### PR TITLE
Fix: illegible text on auth pages in dark mode

### DIFF
--- a/web/app/cli-auth/page.tsx
+++ b/web/app/cli-auth/page.tsx
@@ -250,7 +250,7 @@ function CliAuthContent() {
                       }
                     }
                   }}
-                  className="w-full px-4 py-3 text-2xl text-center font-mono tracking-widest border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+                  className="w-full px-4 py-3 text-2xl text-center font-mono tracking-widest bg-background text-text-primary border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                   placeholder="XXXX-XXXX"
                   maxLength={9}
                   disabled={status === 'validating' || status === 'authorizing'}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -11,6 +11,14 @@
   --primary: #c026d3;
   --primary-hover: #a21caf;
 
+  /* Theme colors — adapt in dark mode */
+  --background: #ffffff;
+  --card: #f8fafc;
+  --card-hover: #f1f5f9;
+  --border: #e2e8f0;
+  --text-primary: #0f172a;
+  --text-secondary: #64748b;
+
   /* Plotly chart colors (read via JavaScript) */
   --plot-bg: #ffffff;
   --plot-paper: #f8fafc;
@@ -44,6 +52,14 @@
   --primary-hover: #f0abfc;
   --background-start-rgb: 15, 23, 42;
   --background-end-rgb: 15, 23, 42;
+
+  /* Theme colors — dark mode */
+  --background: #0f172a;
+  --card: #1e293b;
+  --card-hover: #334155;
+  --border: #334155;
+  --text-primary: #f1f5f9;
+  --text-secondary: #94a3b8;
 
   --plot-bg: #0f172a;
   --plot-paper: #1e293b;

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -51,7 +51,7 @@ export default function RootLayout({
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
       </head>
-      <body className={`${roboto.variable} ${robotoMono.variable} font-sans antialiased min-h-screen flex flex-col bg-background dark:bg-slate-900 text-text-primary dark:text-slate-100`}>
+      <body className={`${roboto.variable} ${robotoMono.variable} font-sans antialiased min-h-screen flex flex-col bg-background text-text-primary`}>
         <QueryProvider>
           <AuthProvider>
             <ThemeProvider>

--- a/web/app/request-access/page.tsx
+++ b/web/app/request-access/page.tsx
@@ -171,7 +171,7 @@ export default function RequestAccessPage() {
                 type="text"
                 value={fullName}
                 onChange={(e) => setFullName(e.target.value)}
-                className="w-full px-4 py-2 bg-background text-text-primary border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:bg-slate-900"
+                className="w-full px-4 py-2 bg-background text-text-primary border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                 placeholder="Jane Doe"
                 required
                 minLength={2}
@@ -188,7 +188,7 @@ export default function RequestAccessPage() {
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                className="w-full px-4 py-2 bg-background text-text-primary border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:bg-slate-900"
+                className="w-full px-4 py-2 bg-background text-text-primary border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                 placeholder="your.email@example.com"
                 required
                 disabled={loading}

--- a/web/app/request-access/status/page.tsx
+++ b/web/app/request-access/status/page.tsx
@@ -126,7 +126,7 @@ export default function RequestStatusPage() {
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                className="w-full px-4 py-2 bg-background text-text-primary border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:bg-slate-900"
+                className="w-full px-4 py-2 bg-background text-text-primary border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                 placeholder="your.email@example.com"
                 required
                 disabled={loading}

--- a/web/app/welcome/page.tsx
+++ b/web/app/welcome/page.tsx
@@ -238,7 +238,7 @@ export default function WelcomePage() {
                 type="text"
                 value={fullName}
                 onChange={(e) => setFullName(e.target.value)}
-                className="w-full px-4 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+                className="w-full px-4 py-2 bg-background text-text-primary border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                 placeholder="Jane Doe"
                 required
                 disabled={saving}
@@ -261,7 +261,7 @@ export default function WelcomePage() {
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                className="w-full px-4 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+                className="w-full px-4 py-2 bg-background text-text-primary border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                 placeholder="Enter a password (min. 6 characters)"
                 minLength={6}
                 required
@@ -282,7 +282,7 @@ export default function WelcomePage() {
                 type="password"
                 value={confirmPassword}
                 onChange={(e) => setConfirmPassword(e.target.value)}
-                className="w-full px-4 py-2 border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+                className="w-full px-4 py-2 bg-background text-text-primary border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
                 placeholder="Confirm your password"
                 minLength={6}
                 required

--- a/web/components/auth/ChangeEmailForm.tsx
+++ b/web/components/auth/ChangeEmailForm.tsx
@@ -189,7 +189,7 @@ export const ChangeEmailForm: React.FC = () => {
               type="email"
               value={newEmail}
               onChange={(e) => setNewEmail(e.target.value)}
-              className="w-full px-4 py-2 bg-background text-text-primary border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:bg-slate-900"
+              className="w-full px-4 py-2 bg-background text-text-primary border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
               placeholder="your.new.email@example.com"
               required
               disabled={loading}
@@ -205,7 +205,7 @@ export const ChangeEmailForm: React.FC = () => {
               type="email"
               value={confirmEmail}
               onChange={(e) => setConfirmEmail(e.target.value)}
-              className="w-full px-4 py-2 bg-background text-text-primary border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:bg-slate-900"
+              className="w-full px-4 py-2 bg-background text-text-primary border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
               placeholder="your.new.email@example.com"
               required
               disabled={loading}

--- a/web/components/auth/ForgotPasswordForm.tsx
+++ b/web/components/auth/ForgotPasswordForm.tsx
@@ -123,7 +123,7 @@ export const ForgotPasswordForm: React.FC = () => {
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="w-full px-4 py-2 bg-background text-text-primary border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:bg-slate-900"
+              className="w-full px-4 py-2 bg-background text-text-primary border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
               placeholder="your.email@example.com"
               required
               disabled={loading}

--- a/web/components/auth/LoginForm.tsx
+++ b/web/components/auth/LoginForm.tsx
@@ -171,7 +171,7 @@ export const LoginForm: React.FC = () => {
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="w-full px-4 py-2 bg-background text-text-primary border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:bg-slate-900"
+            className="w-full px-4 py-2 bg-background text-text-primary border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
             placeholder="your.email@example.com"
             required
             disabled={loading}
@@ -195,7 +195,7 @@ export const LoginForm: React.FC = () => {
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="w-full px-4 py-2 bg-background text-text-primary border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:bg-slate-900"
+            className="w-full px-4 py-2 bg-background text-text-primary border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
             placeholder="••••••••"
             required
             minLength={6}

--- a/web/components/auth/ResetPasswordForm.tsx
+++ b/web/components/auth/ResetPasswordForm.tsx
@@ -272,7 +272,7 @@ export const ResetPasswordForm: React.FC = () => {
               type={showPassword ? 'text' : 'password'}
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="w-full px-4 py-2 pr-10 bg-background text-text-primary border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:bg-slate-900"
+              className="w-full px-4 py-2 pr-10 bg-background text-text-primary border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
               placeholder="Enter new password"
               required
               minLength={8}
@@ -301,7 +301,7 @@ export const ResetPasswordForm: React.FC = () => {
               type={showConfirmPassword ? 'text' : 'password'}
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}
-              className="w-full px-4 py-2 pr-10 bg-background text-text-primary border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary dark:bg-slate-900"
+              className="w-full px-4 py-2 pr-10 bg-background text-text-primary border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
               placeholder="Confirm new password"
               required
               minLength={8}

--- a/web/components/ui/Button.tsx
+++ b/web/components/ui/Button.tsx
@@ -14,12 +14,12 @@ export const Button: React.FC<ButtonProps> = ({
   disabled,
   ...props
 }) => {
-  const baseClasses = 'inline-flex items-center justify-center whitespace-nowrap rounded-lg font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-slate-900';
+  const baseClasses = 'inline-flex items-center justify-center whitespace-nowrap rounded-lg font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-background';
 
   const variantClasses = {
     primary: 'bg-primary hover:bg-primary-hover text-white focus:ring-primary',
-    secondary: 'border-2 border-border dark:border-slate-600 hover:border-text-secondary dark:hover:border-slate-500 text-text-primary dark:text-slate-100 bg-background dark:bg-slate-800',
-    ghost: 'text-text-primary dark:text-slate-100 hover:bg-card dark:hover:bg-slate-700',
+    secondary: 'border-2 border-border hover:border-text-secondary text-text-primary bg-card',
+    ghost: 'text-text-primary hover:bg-card',
   };
 
   const disabledClasses = 'opacity-50 cursor-not-allowed pointer-events-none';

--- a/web/components/ui/Card.tsx
+++ b/web/components/ui/Card.tsx
@@ -12,8 +12,8 @@ export const Card: React.FC<CardProps> = ({ children, className = '', hover = fa
     <div
       id={id}
       className={`
-        bg-card dark:bg-slate-800 rounded-card border border-border dark:border-slate-700 shadow-sm
-        ${hover ? 'hover:bg-card-hover dark:hover:bg-slate-700 transition-colors cursor-pointer' : ''}
+        bg-card rounded-card border border-border shadow-sm
+        ${hover ? 'hover:bg-card-hover transition-colors cursor-pointer' : ''}
         ${className}
       `}
     >

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -13,13 +13,13 @@ const config: Config = {
         primary: 'var(--primary)',
         'primary-hover': 'var(--primary-hover)',
         header: '#475569',       // Dark slate header
-        background: '#ffffff',
-        card: '#f8fafc',         // Light card background
-        'card-hover': '#f1f5f9',
-        border: '#e2e8f0',       // Subtle borders
+        background: 'var(--background)',
+        card: 'var(--card)',
+        'card-hover': 'var(--card-hover)',
+        border: 'var(--border)',
         text: {
-          primary: '#0f172a',
-          secondary: '#64748b',
+          primary: 'var(--text-primary)',
+          secondary: 'var(--text-secondary)',
         }
       },
       fontFamily: {


### PR DESCRIPTION
Closes #10

## What was the bug?
On login, signup, forgot-password, reset-password, welcome, and CLI auth pages, text was illegible in dark mode — dark grey/black text rendered against dark backgrounds.

## Root cause
The Tailwind theme colors (`text-primary`, `text-secondary`, `background`, `card`, `border`) were hardcoded as light-mode hex values in `tailwind.config.ts`. Unlike `--primary` which was already a CSS variable, these colors had no dark-mode adaptation. Components relied on scattered `dark:` Tailwind overrides, but many elements (especially text labels and headings using `text-text-primary`) had none.

Additionally, inputs on the welcome page and CLI auth page were missing `bg-background` and `text-text-primary` classes entirely.

## What I changed
- **`globals.css`**: Added CSS custom properties for `--background`, `--card`, `--card-hover`, `--border`, `--text-primary`, `--text-secondary` with proper dark-mode values in the `.dark` selector
- **`tailwind.config.ts`**: Changed all hardcoded color values to reference the new CSS variables
- **`Card.tsx`** / **`Button.tsx`**: Removed now-redundant `dark:` overrides (handled automatically by CSS variables)
- **Auth form inputs**: Removed redundant `dark:bg-slate-900` overrides across LoginForm, ForgotPasswordForm, ResetPasswordForm, ChangeEmailForm, request-access pages
- **`welcome/page.tsx`**: Added missing `bg-background text-text-primary` to name/password inputs
- **`cli-auth/page.tsx`**: Added missing `bg-background text-text-primary` to code input
- **`layout.tsx`**: Simplified body classes (removed redundant `dark:` overrides)

## Testing
- `npm run build` passes with no new warnings
- All theme colors now automatically adapt between light and dark mode via CSS variables, matching the existing pattern used for `--primary`

🤖 Generated with [Claude Code](https://claude.com/claude-code)