### PR TITLE
feat: sync redshift slider to inspection override box

### DIFF
--- a/web/components/spectra/SpectrumPlot.tsx
+++ b/web/components/spectra/SpectrumPlot.tsx
@@ -89,6 +89,7 @@ interface SpectrumPlotProps {
   initialRedshift?: number | null;
   inspectionMode?: boolean;
   getCachedData?: (fitsPath: string) => CachedSpectrumData | undefined;
+  onRedshiftChange?: (value: number) => void;
 }
 
 export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
@@ -96,7 +97,8 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
   grating,
   initialRedshift,
   inspectionMode = false,
-  getCachedData
+  getCachedData,
+  onRedshiftChange,
 }) => {
   const { spectrumPreferences, accentColorHex } = usePreferences();
   const { resolvedTheme } = useTheme();
@@ -732,6 +734,7 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
                 if (!isNaN(parsed) && parsed >= 0 && parsed <= 15) {
                   setRedshift(parsed);
                   setRedshiftInput(parsed.toFixed(4));
+                  onRedshiftChange?.(parsed);
                 } else {
                   setRedshiftInput(redshift.toFixed(4));
                 }
@@ -750,6 +753,7 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
                 const newValue = parseFloat(e.target.value);
                 setRedshift(newValue);
                 setRedshiftInput(newValue.toFixed(4));
+                onRedshiftChange?.(newValue);
               }}
               min={0}
               max={15}

--- a/web/components/spectra/inspection/InspectionModeOverlay.tsx
+++ b/web/components/spectra/inspection/InspectionModeOverlay.tsx
@@ -335,6 +335,20 @@ export const InspectionModeOverlay: React.FC<InspectionModeOverlayProps> = ({
     return () => document.removeEventListener('keydown', handler);
   }, [canEdit, inspectionState, handleNext, handlePrev, handleSave, handleClose, handleCycleGrating, showHelp]);
 
+  // Sync slider redshift changes to inspection state (debounced for performance)
+  const sliderDebounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const handleRedshiftSliderChange = useCallback((value: number) => {
+    clearTimeout(sliderDebounceRef.current);
+    sliderDebounceRef.current = setTimeout(() => {
+      inspectionState.setRedshiftInspected(value.toFixed(4));
+    }, 100);
+  }, [inspectionState]);
+
+  // Clean up slider debounce timer
+  useEffect(() => {
+    return () => clearTimeout(sliderDebounceRef.current);
+  }, []);
+
   // Current redshift for emission lines
   const currentRedshift = inspectionState.currentRedshift ?? 0;
 
@@ -440,6 +454,7 @@ export const InspectionModeOverlay: React.FC<InspectionModeOverlayProps> = ({
                 initialRedshift={currentRedshift}
                 inspectionMode={true}
                 getCachedData={getCachedGrating}
+                onRedshiftChange={canEdit ? handleRedshiftSliderChange : undefined}
               />
             </div>
           )}

--- a/web/components/spectra/inspection/RedshiftSection.tsx
+++ b/web/components/spectra/inspection/RedshiftSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useRef, useImperativeHandle, forwardRef } from 'react';
+import { RotateCcw } from 'lucide-react';
 import type { InspectionState } from '@/lib/hooks/useInspectionState';
 
 interface RedshiftSectionProps {
@@ -23,14 +24,37 @@ export const RedshiftSection = forwardRef<RedshiftSectionHandle, RedshiftSection
   const [localRedshift, setLocalRedshift] = useState(state.redshiftInspected);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
-  // Sync inspection state back to local state on navigation (resetKey change).
-  // Also cancels any pending debounce to prevent stale values leaking across objects.
+  // Track whether the last change was from local input (typing) vs external (slider)
+  const isLocalChangeRef = useRef(false);
+  const [isSliderSync, setIsSliderSync] = useState(false);
+  const sliderSyncTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const prevResetKeyRef = useRef(state.resetKey);
+
+  // Sync inspection state back to local state on navigation (resetKey change)
+  // or external updates (slider). Detects source to apply highlight.
   useEffect(() => {
     clearTimeout(debounceTimerRef.current);
+    const isNavigation = state.resetKey !== prevResetKeyRef.current;
+    prevResetKeyRef.current = state.resetKey;
+
+    if (!isNavigation && !isLocalChangeRef.current && state.redshiftInspected !== '' && state.redshiftInspected !== localRedshift) {
+      // External change (slider sync) — highlight the override input
+      setIsSliderSync(true);
+      clearTimeout(sliderSyncTimerRef.current);
+      sliderSyncTimerRef.current = setTimeout(() => setIsSliderSync(false), 1500);
+    } else if (isNavigation) {
+      setIsSliderSync(false);
+    }
+
+    isLocalChangeRef.current = false;
     setLocalRedshift(state.redshiftInspected);
+  // localRedshift is intentionally excluded — we only want to react to external state changes
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.redshiftInspected, state.resetKey]);
 
   const handleChange = (value: string) => {
+    isLocalChangeRef.current = true;
+    setIsSliderSync(false);
     setLocalRedshift(value);
     clearTimeout(debounceTimerRef.current);
     debounceTimerRef.current = setTimeout(() => {
@@ -38,9 +62,20 @@ export const RedshiftSection = forwardRef<RedshiftSectionHandle, RedshiftSection
     }, 300);
   };
 
-  // Clean up timer on unmount
+  const handleReset = () => {
+    isLocalChangeRef.current = true;
+    setIsSliderSync(false);
+    setLocalRedshift('');
+    clearTimeout(debounceTimerRef.current);
+    state.setRedshiftInspected('');
+  };
+
+  // Clean up timers on unmount
   useEffect(() => {
-    return () => clearTimeout(debounceTimerRef.current);
+    return () => {
+      clearTimeout(debounceTimerRef.current);
+      clearTimeout(sliderSyncTimerRef.current);
+    };
   }, []);
 
   // Expose method to immediately flush pending debounced changes
@@ -90,9 +125,21 @@ export const RedshiftSection = forwardRef<RedshiftSectionHandle, RedshiftSection
 
         {/* Override column */}
         <div>
-          <label className="text-xs text-text-secondary dark:text-slate-400 block mb-1">
-            Override:
-          </label>
+          <div className="flex items-center justify-between mb-1">
+            <label className="text-xs text-text-secondary dark:text-slate-400">
+              Override:
+            </label>
+            {localRedshift && canEdit && (
+              <button
+                onClick={handleReset}
+                className="flex items-center gap-0.5 text-xs text-primary hover:text-primary-hover transition-colors"
+                title="Reset to auto-fit redshift"
+              >
+                <RotateCcw className="w-3 h-3" />
+                Reset
+              </button>
+            )}
+          </div>
           <input
             ref={redshiftInputRef}
             type="number"
@@ -101,10 +148,13 @@ export const RedshiftSection = forwardRef<RedshiftSectionHandle, RedshiftSection
             onChange={(e) => handleChange(e.target.value)}
             placeholder="auto"
             disabled={!canEdit}
-            className="w-full px-2 py-1.5 text-sm font-mono border border-border
-                       dark:border-slate-600 rounded bg-background dark:bg-slate-700
+            className={`w-full px-2 py-1.5 text-sm font-mono border rounded bg-background dark:bg-slate-700
                        text-text-primary dark:text-slate-100 focus:outline-none
-                       focus:ring-1 focus:ring-primary disabled:opacity-60"
+                       focus:ring-1 focus:ring-primary disabled:opacity-60 transition-all duration-300
+                       ${isSliderSync
+                         ? 'border-amber-400 dark:border-amber-500 ring-1 ring-amber-400/50 dark:ring-amber-500/50'
+                         : 'border-border dark:border-slate-600'
+                       }`}
             title="Press Z to focus"
           />
         </div>


### PR DESCRIPTION
Closes #13

## What was requested?

In inspection mode, the emission line redshift slider should auto-populate the override text box with a visual highlight, plus a reset button to revert to the auto-fit redshift.

## What I implemented

- **Slider → override sync**: Added `onRedshiftChange` callback to `SpectrumPlot`. In inspection mode, dragging the slider (or editing the plot's `z =` text input) syncs the value back to the inspection state via a 100ms-debounced handler.
- **Amber highlight**: The override input in `RedshiftSection` briefly highlights with an amber ring (1.5s, resets on each update) when its value changes from the slider, distinguishing auto-populated values from manual input.
- **Reset button**: A "Reset" button appears next to the "Override" label when an override is active. Clicking it clears the override, which naturally cascades: `currentRedshift` falls back to `redshift_auto`, which flows down as `initialRedshift` to `SpectrumPlot`, resetting the slider position.

## Design decisions

- **Debounce strategy**: The slider fires `onRedshiftChange` on every step, but `InspectionModeOverlay` debounces at 100ms before pushing to inspection state. This keeps the slider smooth while batching state updates.
- **Highlight detection**: `RedshiftSection` tracks whether changes are from local input (typing) vs external (slider) using a ref. Navigation resets are excluded from highlighting via `resetKey` comparison.
- **Read-only for non-editors**: `onRedshiftChange` is only passed when `canEdit` is true, so viewers can still use the slider for visualization without affecting the override.

## Testing

- `npm run build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)