### PR TITLE
feat: toggle shutter overlay on RGB images

### DIFF
--- a/web/app/spectra/[id]/page.tsx
+++ b/web/app/spectra/[id]/page.tsx
@@ -16,7 +16,7 @@ import { CopyLinkButton } from '@/components/spectra/CopyLinkButton';
 import { CoordinateDisplay } from '@/components/spectra/CoordinateDisplay';
 import { ShowOnMapLink } from '@/components/map/ShowOnMapLink';
 import { ReturnToMapButton } from '@/components/map/ReturnToMapButton';
-import { TileThumbnail } from '@/components/spectra/TileThumbnail';
+import { TileThumbnailWithToggle } from '@/components/spectra/TileThumbnailWithToggle';
 import { NearbyObjects } from '@/components/spectra/NearbyObjects';
 import { SEDPlotViewer } from '@/components/spectra/SEDPlotViewer';
 import { EnterInspectionModeButton } from '@/components/spectra/inspection/EnterInspectionModeButton';
@@ -247,12 +247,11 @@ export default async function SpectrumDetailPage({ params, searchParams }: Spect
 
           {/* Right Column: Tile Cutout with Shutters */}
           <div className="flex-shrink-0" style={{ width: '300px' }}>
-            <TileThumbnail
+            <TileThumbnailWithToggle
               objectId={spectrum.object_id}
               size={600}
               displaySize={300}
               fov={3.2}
-              shutters
               linkToMap={{ field: spectrum.field, ra: spectrum.ra, dec: spectrum.dec }}
             />
           </div>

--- a/web/components/spectra/TileThumbnailWithToggle.tsx
+++ b/web/components/spectra/TileThumbnailWithToggle.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Eye, EyeOff } from 'lucide-react';
+import { TileThumbnail } from './TileThumbnail';
+
+interface TileThumbnailWithToggleProps {
+  objectId: string;
+  size?: number;
+  displaySize?: number;
+  fov?: number;
+  linkToMap?: {
+    field: string;
+    ra: number;
+    dec: number;
+  };
+}
+
+/**
+ * TileThumbnail with a toggle button to show/hide shutter overlays.
+ */
+export const TileThumbnailWithToggle: React.FC<TileThumbnailWithToggleProps> = ({
+  objectId,
+  size = 600,
+  displaySize = 300,
+  fov = 3.2,
+  linkToMap,
+}) => {
+  const [showShutters, setShowShutters] = useState(true);
+
+  return (
+    <div className="space-y-2">
+      <TileThumbnail
+        objectId={objectId}
+        size={size}
+        displaySize={displaySize}
+        fov={fov}
+        shutters={showShutters}
+        linkToMap={linkToMap}
+      />
+      <button
+        onClick={() => setShowShutters((prev) => !prev)}
+        className="flex items-center gap-1.5 text-xs text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200 transition-colors"
+      >
+        {showShutters ? (
+          <EyeOff className="w-3.5 h-3.5" />
+        ) : (
+          <Eye className="w-3.5 h-3.5" />
+        )}
+        {showShutters ? 'Hide shutters' : 'Show shutters'}
+      </button>
+    </div>
+  );
+};


### PR DESCRIPTION
Closes #18

## What was requested?
A button to toggle the shutter overlay on/off for the RGB thumbnail on the NIRSpec object detail page. For objects observed by many programs, the shutters can obscure the actual target.

## What I implemented
- New `TileThumbnailWithToggle` client component that wraps `TileThumbnail` with a show/hide shutters toggle button
- Replaced the static `TileThumbnail` on the detail page with this new component
- Shutters are shown by default (matching current behavior), with a small "Hide shutters" / "Show shutters" button below the image

## Design decisions
- Toggle is a simple text button with an eye icon below the thumbnail rather than an overlay on the image — avoids interfering with the existing click-to-map link
- State is local to the component (not persisted) — shutters default to visible on each page load, which matches the expected behavior
- The `TileThumbnail` component already supported the `shutters` prop, so no API or backend changes were needed

## Testing
- `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)