### PR TITLE
Fix: drop stale get_filtered_object_ids overload breaking map filters

### DIFF
--- a/supabase/migrations/20260320100000_fix_filtered_object_ids_overload.sql
+++ b/supabase/migrations/20260320100000_fix_filtered_object_ids_overload.sql
@@ -1,0 +1,50 @@
+-- Fix: drop the old get_filtered_object_ids overload left behind
+-- when 20260319100000 created the new version with p_updated_since.
+--
+-- The old 34-parameter signature (from 20260316200000_multi_pid_programs)
+-- coexists with the new 35-parameter version (which adds p_updated_since),
+-- causing PostgREST to fail with an ambiguous function error when the
+-- map view calls the RPC directly. This is the same class of bug that
+-- 20260319100001 fixed for get_filtered_objects_paginated.
+
+-- Drop old overload by its exact 34-parameter signature
+DROP FUNCTION IF EXISTS public.get_filtered_object_ids(
+  TEXT[],              -- p_program_slugs
+  TEXT[],              -- p_filter_programs
+  TEXT[],              -- p_fields
+  TEXT[],              -- p_gratings
+  TEXT,                -- p_gratings_mode
+  TEXT[],              -- p_observations
+  INTEGER[],           -- p_redshift_quality
+  DOUBLE PRECISION,    -- p_redshift_min
+  DOUBLE PRECISION,    -- p_redshift_max
+  DOUBLE PRECISION,    -- p_max_snr_min
+  DOUBLE PRECISION,    -- p_max_snr_max
+  DOUBLE PRECISION,    -- p_max_exposure_time_min
+  DOUBLE PRECISION,    -- p_max_exposure_time_max
+  INTEGER,             -- p_spectral_features_include_any
+  INTEGER,             -- p_spectral_features_include_all
+  INTEGER,             -- p_spectral_features_exclude
+  INTEGER,             -- p_object_flags_include_any
+  INTEGER,             -- p_object_flags_include_all
+  INTEGER,             -- p_object_flags_exclude
+  INTEGER,             -- p_dq_flags_include_any
+  INTEGER,             -- p_dq_flags_include_all
+  INTEGER,             -- p_dq_flags_exclude
+  TEXT,                -- p_search
+  BOOLEAN,             -- p_inspected_only
+  TEXT,                -- p_comment_search
+  TEXT,                -- p_comment_search_scope
+  UUID,                -- p_comment_user_id
+  DOUBLE PRECISION,    -- p_coord_ra
+  DOUBLE PRECISION,    -- p_coord_dec
+  DOUBLE PRECISION,    -- p_radius_degrees
+  TEXT,                -- p_sort_column
+  TEXT,                -- p_sort_direction
+  INTEGER,             -- p_page
+  INTEGER              -- p_page_size
+);
+
+-- Now the function name is unique — grant execute on the remaining version
+GRANT EXECUTE ON FUNCTION public.get_filtered_object_ids TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_filtered_object_ids TO service_role;


### PR DESCRIPTION
Closes #22

## What was the bug?
Filtering by program or observation on the map view always showed "Objects: 0 of N" — all filters returned zero results even when matching objects exist in the field.

## Root cause
Migration `20260319100000` added `p_updated_since` to `get_filtered_object_ids` via `CREATE OR REPLACE`, but because the new function has 35 parameters vs the original 34, PostgreSQL treated it as a **new overloaded function** rather than a replacement. With two overloads sharing nearly identical signatures, PostgREST cannot disambiguate them and returns an ambiguous-function error. The map's server action catches this error and returns an empty ID set, so all markers get filtered out.

This is the same class of bug that `20260319100001_fix_paginated_overload.sql` fixed for `get_filtered_objects_paginated` — the companion fix for `get_filtered_object_ids` was missed.

The spectra table was unaffected because it calls `get_filtered_objects_paginated` (which was already fixed), not `get_filtered_object_ids` directly.

## What I changed
- Added migration `20260320100000_fix_filtered_object_ids_overload.sql` that drops the stale 34-parameter overload by its exact type signature, leaving only the correct 35-parameter version with `p_updated_since`
- Re-grants `EXECUTE` to `authenticated` and `service_role` on the now-unique function

## Testing
- `npm run build` passes with no errors
- Fix is a database-only migration (no application code changes), same pattern as the proven fix in `20260319100001`
- After applying, `get_filtered_object_ids` will have a single unambiguous signature, so PostgREST RPC calls from the map view will resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)