### PR TITLE
fix: map last_inspected_by UUID to inspector name in CSV exports

### DIFF
--- a/python/campfire/db/store.py
+++ b/python/campfire/db/store.py
@@ -13,7 +13,7 @@ from typing import Dict, List, Optional, Tuple, Union
 
 
 # Schema version — bump when tables change
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 # Column lists used by both store and export
 OBJECT_COLUMNS = [
@@ -21,7 +21,7 @@ OBJECT_COLUMNS = [
     "ra", "dec", "redshift", "redshift_auto", "redshift_inspected",
     "redshift_quality", "spectral_features", "object_flags", "dq_flags",
     "max_snr", "max_exposure_time",
-    "last_inspected_at", "created_at", "updated_at",
+    "last_inspected_at", "last_inspected_by", "created_at", "updated_at",
 ]
 
 SPECTRA_COLUMNS = [
@@ -36,7 +36,7 @@ OBJECT_EXPORT_COLUMNS = [
     "ra", "dec", "redshift", "redshift_auto", "redshift_inspected",
     "redshift_quality", "spectral_features", "object_flags", "dq_flags",
     "max_snr", "max_exposure_time",
-    "last_inspected_at", "created_at", "updated_at",
+    "last_inspected_at", "last_inspected_by", "created_at", "updated_at",
 ]
 
 SPECTRA_EXPORT_COLUMNS = [
@@ -71,6 +71,7 @@ CREATE TABLE IF NOT EXISTS objects (
     max_snr REAL,
     max_exposure_time REAL,
     last_inspected_at TEXT,
+    last_inspected_by TEXT,
     created_at TEXT,
     updated_at TEXT,
     _synced_at TEXT
@@ -176,6 +177,8 @@ class LocalStore:
             version = self._get_schema_version()
             if version < 3:
                 self._migrate_from_v2()
+            if version < 4:
+                self._migrate_from_v3()
 
     def _get_schema_version(self) -> int:
         """Get current schema version from _meta table."""
@@ -236,6 +239,21 @@ class LocalStore:
         )
         self._conn.commit()
 
+    def _migrate_from_v3(self) -> None:
+        """Migrate from v3 to v4: add last_inspected_by column to objects."""
+        try:
+            self._conn.execute(
+                "ALTER TABLE objects ADD COLUMN last_inspected_by TEXT"
+            )
+        except sqlite3.OperationalError:
+            pass  # Column already exists
+
+        self._conn.execute(
+            "INSERT OR REPLACE INTO _meta (key, value) VALUES ('schema_version', ?)",
+            (str(SCHEMA_VERSION),),
+        )
+        self._conn.commit()
+
     # -------------------------------------------------------------------------
     # Catalog operations
     # -------------------------------------------------------------------------
@@ -265,8 +283,9 @@ class LocalStore:
                      ra, dec, redshift, redshift_auto, redshift_inspected,
                      redshift_quality, spectral_features, object_flags, dq_flags,
                      max_snr, max_exposure_time,
-                     last_inspected_at, created_at, updated_at, _synced_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     last_inspected_at, last_inspected_by,
+                     created_at, updated_at, _synced_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(object_id) DO UPDATE SET
                     program_slug=excluded.program_slug,
                     program_name=excluded.program_name,
@@ -283,6 +302,7 @@ class LocalStore:
                     max_snr=excluded.max_snr,
                     max_exposure_time=excluded.max_exposure_time,
                     last_inspected_at=excluded.last_inspected_at,
+                    last_inspected_by=excluded.last_inspected_by,
                     updated_at=excluded.updated_at,
                     _synced_at=excluded._synced_at
             """, (
@@ -304,6 +324,7 @@ class LocalStore:
                 obj.get("max_snr"),
                 obj.get("max_exposure_time"),
                 obj.get("last_inspected_at"),
+                obj.get("last_inspected_by"),
                 obj.get("created_at"),
                 obj.get("updated_at"),
                 now,

--- a/supabase/migrations/20260323000000_csv_export_inspector_name.sql
+++ b/supabase/migrations/20260323000000_csv_export_inspector_name.sql
@@ -1,0 +1,336 @@
+-- Map last_inspected_by UUID → inspector name in CSV export RPC and sync RPC.
+-- user_profiles.full_name is readable by all authenticated users (RLS policy
+-- "authenticated_select_profiles"), so no SECURITY DEFINER is required.
+
+-- ============================================================
+-- 1. get_csv_export: return inspector name instead of UUID
+-- ============================================================
+
+DROP FUNCTION IF EXISTS public.get_csv_export;
+
+CREATE OR REPLACE FUNCTION public.get_csv_export(
+  p_program_slugs TEXT[],
+  p_filter_programs TEXT[] DEFAULT NULL,
+  p_fields TEXT[] DEFAULT NULL,
+  p_gratings TEXT[] DEFAULT NULL,
+  p_gratings_mode TEXT DEFAULT 'any',
+  p_observations TEXT[] DEFAULT NULL,
+  p_redshift_quality INTEGER[] DEFAULT NULL,
+  p_redshift_min DOUBLE PRECISION DEFAULT NULL,
+  p_redshift_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_snr_min DOUBLE PRECISION DEFAULT NULL,
+  p_max_snr_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_exposure_time_min DOUBLE PRECISION DEFAULT NULL,
+  p_max_exposure_time_max DOUBLE PRECISION DEFAULT NULL,
+  p_spectral_features_include_any INTEGER DEFAULT NULL,
+  p_spectral_features_include_all INTEGER DEFAULT NULL,
+  p_spectral_features_exclude INTEGER DEFAULT NULL,
+  p_object_flags_include_any INTEGER DEFAULT NULL,
+  p_object_flags_include_all INTEGER DEFAULT NULL,
+  p_object_flags_exclude INTEGER DEFAULT NULL,
+  p_dq_flags_include_any INTEGER DEFAULT NULL,
+  p_dq_flags_include_all INTEGER DEFAULT NULL,
+  p_dq_flags_exclude INTEGER DEFAULT NULL,
+  p_search TEXT DEFAULT NULL,
+  p_inspected_only BOOLEAN DEFAULT NULL,
+  p_comment_search TEXT DEFAULT NULL,
+  p_comment_search_scope TEXT DEFAULT NULL,
+  p_comment_user_id UUID DEFAULT NULL,
+  p_coord_ra DOUBLE PRECISION DEFAULT NULL,
+  p_coord_dec DOUBLE PRECISION DEFAULT NULL,
+  p_radius_degrees DOUBLE PRECISION DEFAULT NULL,
+  p_sort_column TEXT DEFAULT 'object_id',
+  p_sort_direction TEXT DEFAULT 'asc'
+)
+RETURNS TABLE(
+  object_id TEXT,
+  field TEXT,
+  ra DOUBLE PRECISION,
+  "dec" DOUBLE PRECISION,
+  redshift NUMERIC,
+  redshift_quality INTEGER,
+  max_snr DOUBLE PRECISION,
+  max_exposure_time DOUBLE PRECISION,
+  num_gratings INTEGER,
+  program_slug TEXT,
+  program_name TEXT,
+  last_inspected_at TIMESTAMPTZ,
+  last_inspected_by TEXT,
+  distance DOUBLE PRECISION,
+  spectral_features INTEGER,
+  object_flags INTEGER,
+  dq_flags INTEGER
+)
+LANGUAGE plpgsql STABLE
+SET plan_cache_mode = 'force_custom_plan'
+AS $$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
+    v_gratings_mode := 'any';
+  END IF;
+
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN
+    p_sort_direction := 'asc';
+  END IF;
+
+  IF NOT (p_sort_column IN ('object_id', 'field', 'observation', 'ra', 'dec', 'redshift', 'redshift_quality', 'max_snr', 'max_exposure_time')
+       OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(
+      SELECT unnest(p_program_slugs)
+      INTERSECT
+      SELECT unnest(p_filter_programs)
+    ) INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  WITH filtered_objects AS (
+    SELECT
+      o.object_id,
+      o.field,
+      o.ra,
+      o.dec,
+      o.redshift,
+      o.redshift_quality,
+      o.max_snr,
+      o.max_exposure_time,
+      (SELECT COUNT(*)::INTEGER FROM spectra s WHERE s.object_id = o.object_id) AS num_gratings,
+      o.program_slug,
+      o.observation,
+      o.last_inspected_at,
+      o.last_inspected_by,
+      CASE
+        WHEN v_coord_search_active THEN
+          2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+            POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+          )))
+        ELSE NULL
+      END AS distance,
+      COALESCE(o.spectral_features, 0) AS spectral_features,
+      COALESCE(o.object_flags, 0) AS object_flags,
+      COALESCE(o.dq_flags, 0) AS dq_flags
+    FROM objects o
+    WHERE
+      o.program_slug = ANY(v_filtered_program_slugs)
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND EXISTS (
+          SELECT 1 FROM spectra gs WHERE gs.object_id = o.object_id AND gs.grating = ANY(p_gratings)
+        ))
+        OR (v_gratings_mode = 'all' AND (
+          SELECT COUNT(DISTINCT gs.grating) FROM spectra gs
+          WHERE gs.object_id = o.object_id AND gs.grating = ANY(p_gratings)
+        ) = array_length(p_gratings, 1))
+        OR (v_gratings_mode = 'none' AND NOT EXISTS (
+          SELECT 1 FROM spectra gs WHERE gs.object_id = o.object_id AND gs.grating = ANY(p_gratings)
+        ))
+      )
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observation = ANY(p_observations))
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_spectral_features_include_any IS NULL OR (COALESCE(o.spectral_features, 0) & p_spectral_features_include_any) != 0)
+      AND (p_spectral_features_include_all IS NULL OR (COALESCE(o.spectral_features, 0) & p_spectral_features_include_all) = p_spectral_features_include_all)
+      AND (p_spectral_features_exclude IS NULL OR (COALESCE(o.spectral_features, 0) & p_spectral_features_exclude) = 0)
+      AND (p_object_flags_include_any IS NULL OR (COALESCE(o.object_flags, 0) & p_object_flags_include_any) != 0)
+      AND (p_object_flags_include_all IS NULL OR (COALESCE(o.object_flags, 0) & p_object_flags_include_all) = p_object_flags_include_all)
+      AND (p_object_flags_exclude IS NULL OR (COALESCE(o.object_flags, 0) & p_object_flags_exclude) = 0)
+      AND (p_dq_flags_include_any IS NULL OR (COALESCE(o.dq_flags, 0) & p_dq_flags_include_any) != 0)
+      AND (p_dq_flags_include_all IS NULL OR (COALESCE(o.dq_flags, 0) & p_dq_flags_include_all) = p_dq_flags_include_all)
+      AND (p_dq_flags_exclude IS NULL OR (COALESCE(o.dq_flags, 0) & p_dq_flags_exclude) = 0)
+      AND (p_search IS NULL OR o.object_id ILIKE '%' || p_search || '%')
+      AND (
+        p_inspected_only IS NULL
+        OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+        OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+      )
+      AND (
+        NOT v_comment_search_active
+        OR EXISTS (
+          SELECT 1 FROM comments c
+          WHERE c.object_id = o.id
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+        )
+      )
+      AND (
+        NOT v_coord_search_active
+        OR (
+          o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+          AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+        )
+      )
+  ),
+  distance_filtered AS (
+    SELECT fo.*
+    FROM filtered_objects fo
+    WHERE NOT v_coord_search_active OR fo.distance <= p_radius_degrees
+  )
+  SELECT
+    df.object_id,
+    df.field,
+    df.ra,
+    df.dec,
+    df.redshift,
+    df.redshift_quality,
+    df.max_snr,
+    df.max_exposure_time,
+    df.num_gratings,
+    df.program_slug,
+    pr.program_name,
+    df.last_inspected_at,
+    up.full_name AS last_inspected_by,
+    df.distance,
+    df.spectral_features,
+    df.object_flags,
+    df.dq_flags
+  FROM distance_filtered df
+  LEFT JOIN programs pr ON pr.slug = df.program_slug
+  LEFT JOIN user_profiles up ON up.user_id = df.last_inspected_by
+  ORDER BY
+    CASE WHEN v_coord_search_active THEN df.distance END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN df.object_id END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'desc' THEN df.object_id END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'asc' THEN df.field END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'desc' THEN df.field END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'observation' AND p_sort_direction = 'asc' THEN df.observation END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'observation' AND p_sort_direction = 'desc' THEN df.observation END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN df.ra END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN df.ra END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN df.dec END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN df.dec END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN df.redshift END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN df.redshift END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN df.redshift_quality END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN df.redshift_quality END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN df.max_snr END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN df.max_snr END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN df.max_exposure_time END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN df.max_exposure_time END DESC NULLS LAST,
+    df.object_id ASC;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_csv_export TO authenticated;
+
+-- ============================================================
+-- 2. get_objects_for_sync: include inspector name for Python client
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.get_objects_for_sync(
+  p_program_slugs TEXT[],
+  p_updated_since TIMESTAMP WITHOUT TIME ZONE DEFAULT NULL,
+  p_limit INTEGER DEFAULT 1000,
+  p_offset INTEGER DEFAULT 0
+)
+RETURNS TABLE(objects JSONB, total_count BIGINT)
+LANGUAGE plpgsql STABLE
+SET plan_cache_mode = 'force_custom_plan'
+AS $$
+BEGIN
+  RETURN QUERY
+  WITH matched AS (
+    SELECT o.id, o.object_id, o.program_slug, o.field, o.observation,
+           o.ra, o.dec, o.redshift, o.redshift_auto, o.redshift_inspected,
+           o.redshift_quality, o.spectral_features, o.object_flags, o.dq_flags,
+           o.max_snr, o.max_exposure_time,
+           o.last_inspected_at, o.last_inspected_by,
+           o.created_at, o.updated_at
+    FROM objects o
+    WHERE o.program_slug = ANY(p_program_slugs)
+      AND (p_updated_since IS NULL OR o.updated_at > p_updated_since)
+    ORDER BY o.object_id
+    LIMIT p_limit OFFSET p_offset
+  ),
+  total AS (
+    SELECT COUNT(*) AS cnt
+    FROM objects o
+    WHERE o.program_slug = ANY(p_program_slugs)
+      AND (p_updated_since IS NULL OR o.updated_at > p_updated_since)
+  )
+  SELECT
+    COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'id', m.id,
+        'object_id', m.object_id,
+        'program_slug', m.program_slug,
+        'program_name', pr.program_name,
+        'field', m.field,
+        'observation', m.observation,
+        'ra', m.ra,
+        'dec', m.dec,
+        'redshift', m.redshift,
+        'redshift_auto', m.redshift_auto,
+        'redshift_inspected', m.redshift_inspected,
+        'redshift_quality', m.redshift_quality,
+        'spectral_features', m.spectral_features,
+        'object_flags', m.object_flags,
+        'dq_flags', m.dq_flags,
+        'max_snr', m.max_snr,
+        'max_exposure_time', m.max_exposure_time,
+        'last_inspected_at', m.last_inspected_at,
+        'last_inspected_by', up.full_name,
+        'created_at', m.created_at,
+        'updated_at', m.updated_at,
+        'spectra', COALESCE(
+          (SELECT jsonb_agg(jsonb_build_object(
+            'id', s.id,
+            'object_id', s.object_id,
+            'grating', s.grating,
+            'fits_path', s.fits_path,
+            'file_hash', s.file_hash,
+            'file_size', s.file_size,
+            'signal_to_noise', s.signal_to_noise,
+            'exposure_time', s.exposure_time,
+            'reduction_version', s.reduction_version
+          )) FROM spectra s WHERE s.object_id = m.object_id),
+          '[]'::jsonb
+        )
+      )
+    ), '[]'::jsonb),
+    COALESCE((SELECT cnt FROM total), 0)::BIGINT
+  FROM matched m
+  LEFT JOIN programs pr ON m.program_slug = pr.slug
+  LEFT JOIN user_profiles up ON up.user_id = m.last_inspected_by;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_objects_for_sync TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_objects_for_sync TO service_role;


### PR DESCRIPTION
Fixes #17

Changes:
- `get_csv_export` RPC: joins `user_profiles` to return inspector full_name instead of UUID
- `get_objects_for_sync` RPC: adds inspector name to JSONB output for Python client
- Python store: adds `last_inspected_by` column to SQLite schema, export columns, and upsert; schema v3→v4 migration

Generated with [Claude Code](https://claude.ai/code)