### PR TITLE
feat: support colons in coordinate search

### DIFF
--- a/web/lib/utils/coordinate-parser.ts
+++ b/web/lib/utils/coordinate-parser.ts
@@ -96,7 +96,7 @@ export function parseCoordinates(coordStr: string): ParsedCoordinates | null {
   // Try parsing second part as Dec
   if (parts[1].includes('d') || parts[1].includes('°') ||
       parts[1].includes("'") || parts[1].includes('"') ||
-      (parts[1].includes(':') && (parts[1].includes('+') || parts[1].includes('-')))) {
+      parts[1].includes(':')) {
     // Sexagesimal Dec
     dec = parseSexagesimalDec(parts[1]);
   } else {


### PR DESCRIPTION
Closes #32

## What was requested?
Support colon-separated sexagesimal coordinates (e.g., `10:02:30.5 02:18:30.5`) in the coordinate search box.

## What I implemented
Colon format was *already* mostly supported — the RA parser (`parseSexagesimalRA`) handles `HH:MM:SS.s` fine, and the Dec parser (`parseSexagesimalDec`) also handles `DD:MM:SS.s`. The bug was in the format-detection logic in `parseCoordinates()`: it only routed the Dec part to the sexagesimal parser when colons were present **and** a `+`/`-` sign was present. Unsigned Dec like `02:18:30.5` fell through to `parseFloat()`, returned NaN, and the whole parse failed.

**Fix:** Remove the sign requirement from the Dec colon detection (line 99 of `coordinate-parser.ts`). If Dec contains `:`, always parse as sexagesimal.

## Design decisions
- The sign requirement was an oversight, not a disambiguation strategy — there's no format where `DD:MM:SS` could be misinterpreted as something else.
- No changes needed to `parseSexagesimalDec()` itself; it already handles unsigned Dec correctly (defaults to positive).

## Testing
- `npm run build` passes
- Verified the parser logic: `10:02:30 02:18:30` now correctly routes both parts to sexagesimal parsers

Generated with Claude Code