### PR TITLE
feat: precision step buttons for redshift slider

### DIFF
--- a/web/components/spectra/PlottingControls.tsx
+++ b/web/components/spectra/PlottingControls.tsx
@@ -3,6 +3,7 @@
  */
 
 import React from 'react';
+import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-react';
 import type { FluxUnit } from './plotting-utils';
 
 interface FluxUnitToggleProps {
@@ -109,9 +110,36 @@ export const RedshiftSliderControl: React.FC<RedshiftSliderControlProps> = ({
     setInputValue(newValue.toFixed(4));
   };
 
+  const nudge = (delta: number) => {
+    const newValue = Math.min(max, Math.max(min, parseFloat((redshift + delta).toFixed(4))));
+    onChange(newValue);
+    setInputValue(newValue.toFixed(4));
+  };
+
+  const stepBtnClass =
+    'p-0.5 rounded text-text-secondary dark:text-slate-400 hover:bg-gray-100 dark:hover:bg-slate-600 hover:text-text-primary dark:hover:text-slate-200 transition-colors disabled:opacity-30 disabled:pointer-events-none';
+
   return (
     <div className="flex items-center gap-2 flex-1 max-w-md">
       <span className="text-sm text-text-secondary dark:text-slate-400">z =</span>
+      <div className="flex items-center gap-0.5">
+        <button
+          onClick={() => nudge(-0.01)}
+          disabled={redshift <= min}
+          className={stepBtnClass}
+          title="-0.01"
+        >
+          <ChevronsLeft size={14} />
+        </button>
+        <button
+          onClick={() => nudge(-0.001)}
+          disabled={redshift <= min}
+          className={stepBtnClass}
+          title="-0.001"
+        >
+          <ChevronLeft size={14} />
+        </button>
+      </div>
       <input
         type="text"
         value={inputValue}
@@ -120,6 +148,24 @@ export const RedshiftSliderControl: React.FC<RedshiftSliderControlProps> = ({
         onKeyDown={handleInputKeyDown}
         className="w-20 px-2 py-1 text-sm border border-border dark:border-slate-600 rounded bg-white dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-primary"
       />
+      <div className="flex items-center gap-0.5">
+        <button
+          onClick={() => nudge(0.001)}
+          disabled={redshift >= max}
+          className={stepBtnClass}
+          title="+0.001"
+        >
+          <ChevronRight size={14} />
+        </button>
+        <button
+          onClick={() => nudge(0.01)}
+          disabled={redshift >= max}
+          className={stepBtnClass}
+          title="+0.01"
+        >
+          <ChevronsRight size={14} />
+        </button>
+      </div>
       <input
         type="range"
         value={redshift}

--- a/web/components/spectra/SpectrumPlot.tsx
+++ b/web/components/spectra/SpectrumPlot.tsx
@@ -9,6 +9,7 @@ import { usePreferences } from '@/lib/contexts/PreferencesContext';
 import { useTheme } from '@/lib/contexts/ThemeContext';
 import type { Colorscale2D, FluxUnit } from '@/lib/types';
 import { getPlotColors, getVisibleEmissionLines, computeYRange, computeNiceRestTicks } from './plotting-utils';
+import { RedshiftSliderControl } from './PlottingControls';
 
 // Dynamic import of Plotly to avoid SSR issues
 const Plot = dynamic(() => import('react-plotly.js'), {
@@ -111,7 +112,6 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
   const [colorscale, setColorscale] = useState<Colorscale2D>(spectrumPreferences.colorscale2D);
   const [showEmissionLines, setShowEmissionLines] = useState(inspectionMode);
   const [redshift, setRedshift] = useState(initialRedshift ?? 0);
-  const [redshiftInput, setRedshiftInput] = useState((initialRedshift ?? 0).toFixed(4));
   const [colorMin, setColorMin] = useState(spectrumPreferences.snrMin);
   const [colorMax, setColorMax] = useState(spectrumPreferences.snrMax);
 
@@ -134,7 +134,6 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
   useEffect(() => {
     if (initialRedshift !== null && initialRedshift !== undefined) {
       setRedshift(initialRedshift);
-      setRedshiftInput(initialRedshift.toFixed(4));
     }
   }, [initialRedshift]);
 
@@ -726,44 +725,13 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
 
         {/* Redshift slider (only shown when emission lines are enabled) */}
         {showEmissionLines && (
-          <div className="flex items-center gap-2 flex-1 max-w-md">
-            <span className="text-sm text-text-secondary dark:text-slate-400">z =</span>
-            <input
-              type="text"
-              value={redshiftInput}
-              onChange={(e) => setRedshiftInput(e.target.value)}
-              onBlur={() => {
-                const parsed = parseFloat(redshiftInput);
-                if (!isNaN(parsed) && parsed >= 0 && parsed <= 15) {
-                  setRedshift(parsed);
-                  setRedshiftInput(parsed.toFixed(4));
-                  onRedshiftChange?.(parsed);
-                } else {
-                  setRedshiftInput(redshift.toFixed(4));
-                }
-              }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  e.currentTarget.blur();
-                }
-              }}
-              className="w-20 px-2 py-1 text-sm border border-border dark:border-slate-600 rounded bg-white dark:bg-slate-800 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-primary"
-            />
-            <input
-              type="range"
-              value={redshift}
-              onChange={(e) => {
-                const newValue = parseFloat(e.target.value);
-                setRedshift(newValue);
-                setRedshiftInput(newValue.toFixed(4));
-                onRedshiftChange?.(newValue);
-              }}
-              min={0}
-              max={15}
-              step={0.01}
-              className="flex-1 h-2 bg-gray-200 dark:bg-slate-600 rounded-lg appearance-none cursor-pointer accent-primary"
-            />
-          </div>
+          <RedshiftSliderControl
+            redshift={redshift}
+            onChange={(z) => {
+              setRedshift(z);
+              onRedshiftChange?.(z);
+            }}
+          />
         )}
       </div>
 


### PR DESCRIPTION
Closes #40

## What was requested?
More precise, fine-grained control on the redshift slider — arrow buttons for dz=0.01 and 0.001 increments.

## What I implemented
- Added chevron step buttons flanking the redshift text input in `RedshiftSliderControl`:
  - `«`/`»` (double chevrons) for ±0.01
  - `‹`/`›` (single chevrons) for ±0.001
- Buttons clamp to min/max range and disable at boundaries
- Tooltips show the step size on hover
- Refactored `SpectrumPlot.tsx` to use the shared `RedshiftSliderControl` component instead of its inline duplicate, so the arrows appear in all three spectrum plot views (SpectrumPlot, MultiSpectrumViewer, RedshiftFitPlot)

## Design decisions
- Step sizes of 0.01 and 0.001 match the issue request. The text input still allows arbitrary precision via direct typing.
- Double chevron = bigger step (0.01), single chevron = smaller step (0.001) — follows standard media-player convention.
- Used `toFixed(4)` rounding in the nudge function to avoid floating-point drift.

## Testing
- `npm run build` passes