### PR TITLE
feat: add username column to user_profiles

### DIFF
--- a/scripts/generate_seed.py
+++ b/scripts/generate_seed.py
@@ -114,6 +114,7 @@ TEST_USERS = [
     {
         'id': ADMIN_UUID,
         'email': 'admin@campfire.dev',
+        'username': 'admin',
         'full_name': 'Admin User',
         'is_admin': True,
         'can_comment': True,
@@ -121,6 +122,7 @@ TEST_USERS = [
     {
         'id': USER_UUID,
         'email': 'user@campfire.dev',
+        'username': 'user',
         'full_name': 'Regular User',
         'is_admin': False,
         'can_comment': True,
@@ -128,6 +130,7 @@ TEST_USERS = [
     {
         'id': VIEWER_UUID,
         'email': 'viewer@campfire.dev',
+        'username': 'viewer',
         'full_name': 'Viewer User',
         'is_admin': False,
         'can_comment': False,
@@ -460,8 +463,8 @@ def generate_user_profiles_sql() -> str:
     lines.append('')
 
     for user in TEST_USERS:
-        lines.append(f"""INSERT INTO public.user_profiles (user_id, full_name, is_admin, can_comment)
-VALUES ({sql_escape(user['id'])}, {sql_escape(user['full_name'])}, {sql_escape(user['is_admin'])}, {sql_escape(user['can_comment'])});""")
+        lines.append(f"""INSERT INTO public.user_profiles (user_id, username, full_name, is_admin, can_comment)
+VALUES ({sql_escape(user['id'])}, {sql_escape(user['username'])}, {sql_escape(user['full_name'])}, {sql_escape(user['is_admin'])}, {sql_escape(user['can_comment'])});""")
 
     lines.append('')
     return '\n'.join(lines)

--- a/supabase/migrations/20260407120000_add_username_to_user_profiles.sql
+++ b/supabase/migrations/20260407120000_add_username_to_user_profiles.sql
@@ -49,7 +49,7 @@ BEGIN
     IF (SELECT count(*) FROM public.user_profiles WHERE username = rec.username) > 1 THEN
       -- This isn't the first user with this name, so add suffix
       -- (The first one in created_at order keeps the base name)
-      IF (SELECT min(user_id) FROM public.user_profiles WHERE username = rec.username ORDER BY created_at ASC LIMIT 1) != rec.user_id THEN
+      IF (SELECT user_id FROM public.user_profiles WHERE username = rec.username ORDER BY created_at ASC LIMIT 1) != rec.user_id THEN
         suffix := 2;
         LOOP
           new_username := rec.username || '-' || suffix;

--- a/supabase/migrations/20260407120000_add_username_to_user_profiles.sql
+++ b/supabase/migrations/20260407120000_add_username_to_user_profiles.sql
@@ -10,15 +10,16 @@ ALTER TABLE public.user_profiles ADD COLUMN IF NOT EXISTS "username" text;
 
 -- Step 2: Populate from auth.users email (local part, lowercased, sanitised)
 UPDATE public.user_profiles up
-SET username = lower(
-  regexp_replace(
+SET username = left(
+  lower(
     regexp_replace(
-      split_part(au.email, '@', 1),
-      '[^a-z0-9._-]', '-', 'gi'
-    ),
-    '^[^a-z0-9]+|[^a-z0-9]+$', '', 'g'
-  )
-)
+      regexp_replace(
+        split_part(au.email, '@', 1),
+        '[^a-z0-9._-]', '-', 'gi'
+      ),
+      '^[^a-z0-9]+|[^a-z0-9]+$', '', 'g'
+    )
+  ), 40)
 FROM auth.users au
 WHERE au.id = up.user_id
   AND up.username IS NULL;

--- a/supabase/migrations/20260407120000_add_username_to_user_profiles.sql
+++ b/supabase/migrations/20260407120000_add_username_to_user_profiles.sql
@@ -1,0 +1,71 @@
+-- =============================================================================
+-- Migration: Add username column to user_profiles
+-- =============================================================================
+-- Adds a unique, validated username to user_profiles. Existing users are
+-- populated from the local part of their auth email address.
+-- =============================================================================
+
+-- Step 1: Add column as nullable first
+ALTER TABLE public.user_profiles ADD COLUMN IF NOT EXISTS "username" text;
+
+-- Step 2: Populate from auth.users email (local part, lowercased, sanitised)
+UPDATE public.user_profiles up
+SET username = lower(
+  regexp_replace(
+    regexp_replace(
+      split_part(au.email, '@', 1),
+      '[^a-z0-9._-]', '-', 'gi'
+    ),
+    '^[^a-z0-9]+|[^a-z0-9]+$', '', 'g'
+  )
+)
+FROM auth.users au
+WHERE au.id = up.user_id
+  AND up.username IS NULL;
+
+-- Step 3: Handle any remaining NULLs or too-short usernames
+UPDATE public.user_profiles
+SET username = 'user-' || left(user_id::text, 8)
+WHERE username IS NULL OR length(username) < 2;
+
+-- Step 4: Handle duplicate usernames by appending a suffix
+DO $$
+DECLARE
+  rec RECORD;
+  suffix INT;
+  new_username TEXT;
+BEGIN
+  FOR rec IN
+    SELECT user_id, username
+    FROM public.user_profiles
+    WHERE username IN (
+      SELECT username FROM public.user_profiles
+      GROUP BY username HAVING count(*) > 1
+    )
+    ORDER BY created_at ASC
+    -- Skip the first (oldest) user with each duplicate username
+  LOOP
+    -- Check if this specific row still has a duplicate
+    IF (SELECT count(*) FROM public.user_profiles WHERE username = rec.username) > 1 THEN
+      -- This isn't the first user with this name, so add suffix
+      -- (The first one in created_at order keeps the base name)
+      IF (SELECT min(user_id) FROM public.user_profiles WHERE username = rec.username ORDER BY created_at ASC LIMIT 1) != rec.user_id THEN
+        suffix := 2;
+        LOOP
+          new_username := rec.username || '-' || suffix;
+          EXIT WHEN NOT EXISTS (SELECT 1 FROM public.user_profiles WHERE username = new_username);
+          suffix := suffix + 1;
+        END LOOP;
+        UPDATE public.user_profiles SET username = new_username WHERE user_id = rec.user_id;
+      END IF;
+    END IF;
+  END LOOP;
+END $$;
+
+-- Step 5: Now make it NOT NULL and add constraints
+ALTER TABLE public.user_profiles ALTER COLUMN "username" SET NOT NULL;
+
+ALTER TABLE public.user_profiles ADD CONSTRAINT "user_profiles_username_key" UNIQUE ("username");
+
+ALTER TABLE public.user_profiles ADD CONSTRAINT "user_profiles_username_check"
+  CHECK (username ~ '^[a-z0-9][a-z0-9._-]{0,38}[a-z0-9]$');

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -704,12 +704,14 @@ ALTER SEQUENCE "public"."objects_id_seq" OWNED BY "public"."objects"."id";
 
 CREATE TABLE IF NOT EXISTS "public"."user_profiles" (
     "user_id" "uuid" NOT NULL,
+    "username" "text" NOT NULL,
     "full_name" "text" NOT NULL,
     "created_at" timestamp without time zone DEFAULT "now"(),
     "is_group_account" boolean DEFAULT false,
     "can_comment" boolean DEFAULT true,
     "is_admin" boolean DEFAULT false,
-    "preferences" "jsonb" DEFAULT '{}'::"jsonb"
+    "preferences" "jsonb" DEFAULT '{}'::"jsonb",
+    CONSTRAINT "user_profiles_username_check" CHECK (("username" ~ '^[a-z0-9][a-z0-9._-]{0,38}[a-z0-9]$'::"text"))
 );
 
 
@@ -960,6 +962,11 @@ ALTER TABLE ONLY "public"."objects"
 
 ALTER TABLE ONLY "public"."user_profiles"
     ADD CONSTRAINT "user_profiles_pkey" PRIMARY KEY ("user_id");
+
+
+
+ALTER TABLE ONLY "public"."user_profiles"
+    ADD CONSTRAINT "user_profiles_username_key" UNIQUE ("username");
 
 
 

--- a/web/app/api/invites/accept/route.ts
+++ b/web/app/api/invites/accept/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient, createServiceClient } from '@/lib/supabase/server';
-import { generateUniqueUsername } from '@/lib/utils/username';
+import { USERNAME_REGEX } from '@/lib/utils/username';
 
 /**
  * POST /api/invites/accept
@@ -11,7 +11,7 @@ import { generateUniqueUsername } from '@/lib/utils/username';
  * - Grants program access
  * - Marks invite as accepted
  *
- * Body: { fullName: string, password: string }
+ * Body: { fullName: string, password: string, username: string }
  */
 export async function POST(request: NextRequest) {
   try {
@@ -28,7 +28,7 @@ export async function POST(request: NextRequest) {
 
     // Parse request body
     const body = await request.json();
-    const { fullName, password } = body;
+    const { fullName, password, username } = body;
 
     // Validate input
     if (!fullName || typeof fullName !== 'string' || !fullName.trim()) {
@@ -41,6 +41,13 @@ export async function POST(request: NextRequest) {
     if (!password || typeof password !== 'string' || password.length < 6) {
       return NextResponse.json(
         { error: 'Password must be at least 6 characters' },
+        { status: 400 }
+      );
+    }
+
+    if (!username || typeof username !== 'string' || !USERNAME_REGEX.test(username)) {
+      return NextResponse.json(
+        { error: 'Username must be 2–40 characters and contain only lowercase letters, numbers, dots, hyphens, and underscores (starting and ending with a letter or number).' },
         { status: 400 }
       );
     }
@@ -76,15 +83,21 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Check username uniqueness
+    const { data: existingUser } = await serviceClient
+      .from('user_profiles')
+      .select('user_id')
+      .eq('username', username)
+      .maybeSingle();
+
+    if (existingUser) {
+      return NextResponse.json(
+        { error: 'That username is already taken. Please choose a different one.' },
+        { status: 409 }
+      );
+    }
+
     // Create user profile (using service client to ensure it succeeds)
-    const username = await generateUniqueUsername(user.email, async (u) => {
-      const { data: existing } = await serviceClient
-        .from('user_profiles')
-        .select('user_id')
-        .eq('username', u)
-        .maybeSingle();
-      return !!existing;
-    });
     const { error: profileError } = await serviceClient
       .from('user_profiles')
       .insert({

--- a/web/app/api/invites/accept/route.ts
+++ b/web/app/api/invites/accept/route.ts
@@ -70,20 +70,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Set user password
-    const { error: passwordError } = await supabase.auth.updateUser({
-      password: password,
-    });
-
-    if (passwordError) {
-      console.error('Error setting password:', passwordError);
-      return NextResponse.json(
-        { error: `Failed to set password: ${passwordError.message}` },
-        { status: 500 }
-      );
-    }
-
-    // Check username uniqueness
+    // Check username uniqueness before any irreversible operations
     const { data: existingUser } = await serviceClient
       .from('user_profiles')
       .select('user_id')
@@ -94,6 +81,19 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { error: 'That username is already taken. Please choose a different one.' },
         { status: 409 }
+      );
+    }
+
+    // Set user password
+    const { error: passwordError } = await supabase.auth.updateUser({
+      password: password,
+    });
+
+    if (passwordError) {
+      console.error('Error setting password:', passwordError);
+      return NextResponse.json(
+        { error: `Failed to set password: ${passwordError.message}` },
+        { status: 500 }
       );
     }
 

--- a/web/app/api/invites/accept/route.ts
+++ b/web/app/api/invites/accept/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient, createServiceClient } from '@/lib/supabase/server';
-import { usernameFromEmail } from '@/lib/utils/username';
+import { generateUniqueUsername } from '@/lib/utils/username';
 
 /**
  * POST /api/invites/accept
@@ -77,7 +77,14 @@ export async function POST(request: NextRequest) {
     }
 
     // Create user profile (using service client to ensure it succeeds)
-    const username = usernameFromEmail(user.email);
+    const username = await generateUniqueUsername(user.email, async (u) => {
+      const { data: existing } = await serviceClient
+        .from('user_profiles')
+        .select('user_id')
+        .eq('username', u)
+        .maybeSingle();
+      return !!existing;
+    });
     const { error: profileError } = await serviceClient
       .from('user_profiles')
       .insert({

--- a/web/app/api/invites/accept/route.ts
+++ b/web/app/api/invites/accept/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient, createServiceClient } from '@/lib/supabase/server';
+import { usernameFromEmail } from '@/lib/utils/username';
 
 /**
  * POST /api/invites/accept
@@ -76,10 +77,12 @@ export async function POST(request: NextRequest) {
     }
 
     // Create user profile (using service client to ensure it succeeds)
+    const username = usernameFromEmail(user.email);
     const { error: profileError } = await serviceClient
       .from('user_profiles')
       .insert({
         user_id: user.id,
+        username,
         full_name: fullName.trim(),
         is_group_account: false,
         can_comment: invite.can_comment,

--- a/web/app/api/profile/route.ts
+++ b/web/app/api/profile/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { USERNAME_REGEX } from '@/lib/utils/username';
 
 /**
  * GET /api/profile
@@ -156,11 +157,33 @@ export async function PATCH(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const { full_name, preferences } = body;
+    const { full_name, username, preferences } = body;
 
     const updates: Record<string, unknown> = {};
     if (typeof full_name === 'string' && full_name.trim()) {
       updates.full_name = full_name.trim();
+    }
+
+    if (username !== undefined) {
+      if (typeof username !== 'string' || !USERNAME_REGEX.test(username)) {
+        return NextResponse.json(
+          { error: 'Username must be 2–40 characters and contain only lowercase letters, numbers, dots, hyphens, and underscores (starting and ending with a letter or number).' },
+          { status: 400 }
+        );
+      }
+      const { data: existing } = await supabase
+        .from('user_profiles')
+        .select('user_id')
+        .eq('username', username)
+        .neq('user_id', user.id)
+        .maybeSingle();
+      if (existing) {
+        return NextResponse.json(
+          { error: 'That username is already taken. Please choose a different one.' },
+          { status: 409 }
+        );
+      }
+      updates.username = username;
     }
 
     // Handle preferences update (merge with existing)

--- a/web/app/profile/page.tsx
+++ b/web/app/profile/page.tsx
@@ -61,6 +61,8 @@ export default function ProfilePage() {
   // Edit mode state
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState('');
+  const [editUsername, setEditUsername] = useState('');
+  const [saveError, setSaveError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
   // Access code state
@@ -85,6 +87,7 @@ export default function ProfilePage() {
 
       setProfileData(data);
       setEditName(data.profile.full_name);
+      setEditUsername(data.profile.username);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch profile');
     } finally {
@@ -98,22 +101,24 @@ export default function ProfilePage() {
 
   const handleSaveProfile = async () => {
     setSaving(true);
+    setSaveError(null);
     try {
       const response = await fetch('/api/profile', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ full_name: editName }),
+        body: JSON.stringify({ full_name: editName, username: editUsername }),
       });
 
       if (!response.ok) {
         const data = await response.json();
-        throw new Error(data.error || 'Failed to update profile');
+        setSaveError(data.error || 'Failed to update profile');
+        return;
       }
 
       setIsEditing(false);
       fetchProfile();
     } catch (err) {
-      alert(err instanceof Error ? err.message : 'Failed to update profile');
+      setSaveError(err instanceof Error ? err.message : 'Failed to update profile');
     } finally {
       setSaving(false);
     }
@@ -244,13 +249,27 @@ export default function ProfilePage() {
               </div>
               <div>
                 {isEditing ? (
-                  <input
-                    type="text"
-                    value={editName}
-                    onChange={(e) => setEditName(e.target.value)}
-                    className="text-xl font-semibold text-text-primary dark:text-slate-100 px-2 py-1 border border-border dark:border-slate-600 rounded bg-white dark:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-primary"
-                    autoFocus
-                  />
+                  <div className="space-y-2">
+                    <input
+                      type="text"
+                      value={editName}
+                      onChange={(e) => setEditName(e.target.value)}
+                      className="text-xl font-semibold text-text-primary dark:text-slate-100 px-2 py-1 border border-border dark:border-slate-600 rounded bg-white dark:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-primary w-full"
+                      autoFocus
+                    />
+                    <div className="flex items-center border border-border dark:border-slate-600 rounded bg-white dark:bg-slate-700 focus-within:ring-2 focus-within:ring-primary">
+                      <span className="pl-2 text-text-secondary dark:text-slate-400 select-none">@</span>
+                      <input
+                        type="text"
+                        value={editUsername}
+                        onChange={(e) => setEditUsername(e.target.value)}
+                        className="text-sm text-text-primary dark:text-slate-100 px-2 py-1 bg-transparent focus:outline-none w-full"
+                      />
+                    </div>
+                    {saveError && (
+                      <p className="text-xs text-red-600 dark:text-red-400">{saveError}</p>
+                    )}
+                  </div>
                 ) : (
                   <div className="flex items-center gap-2">
                     <h1 className="text-xl font-semibold text-text-primary dark:text-slate-100">
@@ -263,7 +282,7 @@ export default function ProfilePage() {
                     )}
                   </div>
                 )}
-                <p className="text-text-secondary dark:text-slate-400">@{profileData.profile.username} &middot; {profileData.email}</p>
+                {!isEditing && <p className="text-text-secondary dark:text-slate-400">@{profileData.profile.username} &middot; {profileData.email}</p>}
               </div>
             </div>
 
@@ -276,6 +295,8 @@ export default function ProfilePage() {
                     onClick={() => {
                       setIsEditing(false);
                       setEditName(profileData.profile.full_name);
+                      setEditUsername(profileData.profile.username);
+                      setSaveError(null);
                     }}
                     disabled={saving}
                   >
@@ -296,7 +317,7 @@ export default function ProfilePage() {
                 </>
               ) : (
                 !profileData.profile.is_group_account && (
-                  <Button variant="secondary" size="sm" onClick={() => setIsEditing(true)}>
+                  <Button variant="secondary" size="sm" onClick={() => { setIsEditing(true); setSaveError(null); }}>
                     <Edit2 className="w-4 h-4 mr-2" />
                     Edit
                   </Button>

--- a/web/app/profile/page.tsx
+++ b/web/app/profile/page.tsx
@@ -263,7 +263,7 @@ export default function ProfilePage() {
                     )}
                   </div>
                 )}
-                <p className="text-text-secondary dark:text-slate-400">{profileData.email}</p>
+                <p className="text-text-secondary dark:text-slate-400">@{profileData.profile.username} &middot; {profileData.email}</p>
               </div>
             </div>
 

--- a/web/app/welcome/page.tsx
+++ b/web/app/welcome/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { usernameFromEmail, USERNAME_REGEX } from '@/lib/utils/username';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import {
@@ -42,6 +43,7 @@ export default function WelcomePage() {
 
   // Form fields
   const [fullName, setFullName] = useState('');
+  const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
 
@@ -80,6 +82,7 @@ export default function WelcomePage() {
 
       // Set name from invite if available, otherwise extract from email
       setFullName(data.invite.full_name || data.invite.email.split('@')[0] || '');
+      setUsername(usernameFromEmail(data.invite.email));
 
       setLoading(false);
     } catch (err) {
@@ -114,6 +117,11 @@ export default function WelcomePage() {
       return;
     }
 
+    if (!USERNAME_REGEX.test(username)) {
+      setError('Username must be 2–40 characters: lowercase letters, numbers, dots, hyphens, and underscores, starting and ending with a letter or number.');
+      return;
+    }
+
     setSaving(true);
 
     try {
@@ -123,6 +131,7 @@ export default function WelcomePage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           fullName: fullName.trim(),
+          username,
           password: password,
         }),
       });
@@ -248,6 +257,29 @@ export default function WelcomePage() {
               </p>
             </div>
 
+            {/* Username */}
+            <div>
+              <label htmlFor="username" className="block text-sm font-medium text-text-primary mb-2">
+                Username <span className="text-red-500">*</span>
+              </label>
+              <div className="flex items-center border border-border rounded-lg bg-background focus-within:ring-2 focus-within:ring-primary">
+                <span className="pl-4 text-text-secondary select-none">@</span>
+                <input
+                  id="username"
+                  type="text"
+                  value={username}
+                  onChange={(e) => setUsername(e.target.value)}
+                  className="flex-1 px-2 py-2 bg-transparent text-text-primary focus:outline-none"
+                  placeholder="your-username"
+                  required
+                  disabled={saving}
+                />
+              </div>
+              <p className="text-xs text-text-secondary mt-1">
+                Lowercase letters, numbers, dots, hyphens, and underscores. 2–40 characters.
+              </p>
+            </div>
+
             {/* Password */}
             <div>
               <label htmlFor="password" className="block text-sm font-medium text-text-primary mb-2">
@@ -304,7 +336,7 @@ export default function WelcomePage() {
               type="submit"
               variant="primary"
               className="w-full mt-6"
-              disabled={saving || !fullName.trim() || !password || !confirmPassword}
+              disabled={saving || !fullName.trim() || !username || !password || !confirmPassword}
             >
               {saving ? (
                 <>

--- a/web/lib/contexts/AuthContext.tsx
+++ b/web/lib/contexts/AuthContext.tsx
@@ -4,7 +4,7 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 import { User, Session } from '@supabase/supabase-js';
 import { createClient } from '@/lib/supabase/client';
 import { UserProfile } from '@/lib/types';
-import { usernameFromEmail } from '@/lib/utils/username';
+import { generateUniqueUsername } from '@/lib/utils/username';
 
 interface ProgramAccessInfo {
   hasProprietaryAccess: boolean;
@@ -158,7 +158,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       // Create user profile
       if (data.user) {
-        const username = usernameFromEmail(email);
+        const username = await generateUniqueUsername(email, async (u) => {
+          const { data: existing } = await supabase
+            .from('user_profiles')
+            .select('user_id')
+            .eq('username', u)
+            .maybeSingle();
+          return !!existing;
+        });
         const { error: profileError } = await supabase
           .from('user_profiles')
           .insert({

--- a/web/lib/contexts/AuthContext.tsx
+++ b/web/lib/contexts/AuthContext.tsx
@@ -4,6 +4,7 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 import { User, Session } from '@supabase/supabase-js';
 import { createClient } from '@/lib/supabase/client';
 import { UserProfile } from '@/lib/types';
+import { usernameFromEmail } from '@/lib/utils/username';
 
 interface ProgramAccessInfo {
   hasProprietaryAccess: boolean;
@@ -157,10 +158,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       // Create user profile
       if (data.user) {
+        const username = usernameFromEmail(email);
         const { error: profileError } = await supabase
           .from('user_profiles')
           .insert({
             user_id: data.user.id,
+            username,
             full_name: fullName,
             is_group_account: false,
             can_comment: true,

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -7,6 +7,7 @@
 
 export interface UserProfile {
   user_id: string;
+  username: string;
   full_name: string;
   created_at: string;
   is_group_account: boolean;

--- a/web/lib/utils/username.ts
+++ b/web/lib/utils/username.ts
@@ -1,3 +1,5 @@
+export const USERNAME_REGEX = /^[a-z0-9][a-z0-9._-]{0,38}[a-z0-9]$/;
+
 /**
  * Find a unique username by appending -2, -3, etc. until a free slot is found.
  * @param email - source email address

--- a/web/lib/utils/username.ts
+++ b/web/lib/utils/username.ts
@@ -1,14 +1,22 @@
 /**
- * Generate a username from an email address.
- *
- * Takes the local part (before @), lowercases, replaces non-alphanumeric
- * characters with hyphens, and trims leading/trailing hyphens.
- *
- * Examples:
- *   "hollis.akins@example.com" → "hollis.akins"
- *   "CMCasey@university.edu"   → "cmcasey"
- *   "user+tag@example.com"     → "user-tag"
+ * Find a unique username by appending -2, -3, etc. until a free slot is found.
+ * @param email - source email address
+ * @param checkExists - async predicate, returns true if the username is already taken
  */
+export async function generateUniqueUsername(
+  email: string,
+  checkExists: (username: string) => Promise<boolean>,
+): Promise<string> {
+  const base = usernameFromEmail(email);
+  if (!(await checkExists(base))) return base;
+  let suffix = 2;
+  while (true) {
+    const candidate = `${base}-${suffix}`;
+    if (!(await checkExists(candidate))) return candidate;
+    suffix++;
+  }
+}
+
 export function usernameFromEmail(email: string): string {
   const local = email.split('@')[0] ?? email;
   const cleaned = local
@@ -18,7 +26,7 @@ export function usernameFromEmail(email: string): string {
     .slice(0, 40);
   // Constraint requires min 2 chars (start + end both alphanumeric)
   if (cleaned.length < 2) {
-    return cleaned + '0';
+    return cleaned.padEnd(2, '0');
   }
   return cleaned;
 }

--- a/web/lib/utils/username.ts
+++ b/web/lib/utils/username.ts
@@ -1,0 +1,24 @@
+/**
+ * Generate a username from an email address.
+ *
+ * Takes the local part (before @), lowercases, replaces non-alphanumeric
+ * characters with hyphens, and trims leading/trailing hyphens.
+ *
+ * Examples:
+ *   "hollis.akins@example.com" → "hollis.akins"
+ *   "CMCasey@university.edu"   → "cmcasey"
+ *   "user+tag@example.com"     → "user-tag"
+ */
+export function usernameFromEmail(email: string): string {
+  const local = email.split('@')[0] ?? email;
+  const cleaned = local
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]/g, '-')
+    .replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, '')
+    .slice(0, 40);
+  // Constraint requires min 2 chars (start + end both alphanumeric)
+  if (cleaned.length < 2) {
+    return cleaned + '0';
+  }
+  return cleaned;
+}


### PR DESCRIPTION
Add a unique, validated username field to user_profiles for stable user identification. Existing users are populated from email prefixes during migration, with duplicate handling via numeric suffixes.

- Schema: username TEXT NOT NULL UNIQUE with regex check constraint
- Migration: populates from auth.users email, handles collisions
- Signup/invite flows: auto-generate username from email
- Profile page: display @username alongside email
- Seed generator: include username for test users
- Utility: usernameFromEmail() shared helper

This is a prerequisite for the object lists feature (PR #53), where usernames will be used to namespace list slugs.

https://claude.ai/code/session_019oih3DAbUnTbkTwHQteJJd