### PR TITLE
Fix: program object count shows 0 for all programs

### DIFF
--- a/web/app/nirspec/programs/[slug]/page.tsx
+++ b/web/app/nirspec/programs/[slug]/page.tsx
@@ -186,7 +186,7 @@ export default function ProgramDetailPage() {
 
         {/* Stat Badges */}
         <div className="flex flex-wrap gap-3">
-          <Badge value={program.object_count.toLocaleString()} label="Objects" compact />
+          <Badge value={program.target_count.toLocaleString()} label="Targets" compact />
           <Badge value={program.gratings.length} label="Gratings" compact />
           <Badge value={program.fields.length} label="Fields" compact />
           <Badge value={program.observations.length} label="Observations" compact />
@@ -213,7 +213,7 @@ export default function ProgramDetailPage() {
                   <tr className="border-b border-border dark:border-slate-700 bg-gray-50 dark:bg-slate-800/50">
                     <th className="text-left px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Observation</th>
                     <th className="text-left px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Field</th>
-                    <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Objects</th>
+                    <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Targets</th>
                     <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Spectra</th>
                     <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Total Size</th>
                     <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400"></th>
@@ -232,7 +232,7 @@ export default function ProgramDetailPage() {
                         {obs.field}
                       </td>
                       <td className="px-4 py-3 text-right text-text-primary dark:text-slate-100">
-                        {obs.object_count.toLocaleString()}
+                        {obs.target_count.toLocaleString()}
                       </td>
                       <td className="px-4 py-3 text-right text-text-primary dark:text-slate-100">
                         {obs.spectrum_count.toLocaleString()}

--- a/web/app/nirspec/programs/page.tsx
+++ b/web/app/nirspec/programs/page.tsx
@@ -67,7 +67,7 @@ function ProgramCard({ program }: { program: ProgramOverview }) {
           )}
           <span className="inline-flex items-center gap-1 px-2.5 py-1 bg-primary/10 text-primary rounded-full text-xs font-medium">
             <Hash className="w-3 h-3" />
-            {program.object_count.toLocaleString()} objects
+            {program.target_count.toLocaleString()} targets
           </span>
           {program.gratings.length > 0 && (
             <span className="inline-flex items-center px-2.5 py-1 bg-blue-50 dark:bg-blue-950 text-blue-700 dark:text-blue-300 rounded-full text-xs font-medium">

--- a/web/components/docs/ProgramDetailContent.tsx
+++ b/web/components/docs/ProgramDetailContent.tsx
@@ -148,7 +148,7 @@ export default function ProgramDetailContent({ programSlug }: { programSlug: str
 
         {/* Stat Badges */}
         <div className="flex flex-wrap gap-3">
-          <Badge value={program.object_count.toLocaleString()} label="Objects" compact />
+          <Badge value={program.target_count.toLocaleString()} label="Targets" compact />
           <Badge value={program.gratings.length} label="Gratings" compact />
           <Badge value={program.fields.length} label="Fields" compact />
           <Badge value={program.observations.length} label="Observations" compact />
@@ -175,7 +175,7 @@ export default function ProgramDetailContent({ programSlug }: { programSlug: str
                   <tr className="border-b border-border dark:border-slate-700 bg-gray-50 dark:bg-slate-800/50">
                     <th className="text-left px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Observation</th>
                     <th className="text-left px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Field</th>
-                    <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Objects</th>
+                    <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Targets</th>
                     <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Spectra</th>
                     <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Total Size</th>
                     <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400"></th>
@@ -194,7 +194,7 @@ export default function ProgramDetailContent({ programSlug }: { programSlug: str
                         {obs.field}
                       </td>
                       <td className="px-4 py-3 text-right text-text-primary dark:text-slate-100">
-                        {obs.object_count.toLocaleString()}
+                        {obs.target_count.toLocaleString()}
                       </td>
                       <td className="px-4 py-3 text-right text-text-primary dark:text-slate-100">
                         {obs.spectrum_count.toLocaleString()}

--- a/web/components/docs/ProgramsContent.tsx
+++ b/web/components/docs/ProgramsContent.tsx
@@ -66,7 +66,7 @@ function ProgramCard({ program }: { program: ProgramOverview }) {
           )}
           <span className="inline-flex items-center gap-1 px-2.5 py-1 bg-primary/10 text-primary rounded-full text-xs font-medium">
             <Hash className="w-3 h-3" />
-            {program.object_count.toLocaleString()} objects
+            {program.target_count.toLocaleString()} targets
           </span>
           {program.gratings.length > 0 && (
             <span className="inline-flex items-center px-2.5 py-1 bg-blue-50 dark:bg-blue-950 text-blue-700 dark:text-blue-300 rounded-full text-xs font-medium">

--- a/web/lib/actions/programs.ts
+++ b/web/lib/actions/programs.ts
@@ -9,7 +9,7 @@ export interface ProgramOverview {
   description: string | null;
   is_public: boolean;
   cycle: number | null;
-  object_count: number;
+  target_count: number;
   gratings: string[];
   fields: string[];
   observations: string[];
@@ -21,7 +21,7 @@ export interface ObservationStat {
   program_slug: string;
   program_name: string;
   field: string;
-  object_count: number;
+  target_count: number;
   spectrum_count: number;
   total_size_bytes: number;
 }
@@ -72,7 +72,7 @@ export async function getProgramsOverview(): Promise<ProgramsOverviewResult> {
         description: p.description,
         is_public: p.is_public,
         cycle: p.cycle ?? null,
-        object_count: Number(p.object_count) || 0,
+        target_count: Number(p.target_count) || 0,
         gratings: p.gratings || [],
         fields: p.fields || [],
         observations: p.observations || [],
@@ -130,7 +130,7 @@ export async function getProgramDetail(programSlug: string): Promise<ProgramDeta
       description: programData.description,
       is_public: programData.is_public,
       cycle: programData.cycle ?? null,
-      object_count: Number(programData.object_count) || 0,
+      target_count: Number(programData.target_count) || 0,
       gratings: programData.gratings || [],
       fields: programData.fields || [],
       observations: programData.observations || [],
@@ -144,7 +144,7 @@ export async function getProgramDetail(programSlug: string): Promise<ProgramDeta
         program_slug: o.program_slug,
         program_name: o.program_name,
         field: o.field,
-        object_count: Number(o.object_count) || 0,
+        target_count: Number(o.target_count) || 0,
         spectrum_count: Number(o.spectrum_count) || 0,
         total_size_bytes: Number(o.total_size_bytes) || 0,
       })

--- a/web/lib/docs/content/api/rest.md
+++ b/web/lib/docs/content/api/rest.md
@@ -164,7 +164,7 @@ List observations with stats.
       "observation": "ember_uds_p4",
       "program_name": "EMBER-UDS",
       "field": "UDS",
-      "object_count": 450,
+      "target_count": 450,
       "spectrum_count": 1350,
       "total_size_bytes": 2147483648
     }


### PR DESCRIPTION
Closes #63

## What was the bug?
The programs page showed 0 objects for every program.

## Root cause
The database RPC functions (`get_programs_overview`, `get_observation_stats`) return a column named `target_count`, but the TypeScript interfaces and mapping code expected `object_count`. Since `Number(undefined)` returns `NaN` and `NaN || 0` evaluates to `0`, every program displayed a count of 0.

## What I changed
- Renamed `object_count` → `target_count` in the `ProgramOverview` and `ObservationStat` interfaces (`web/lib/actions/programs.ts`)
- Updated all field mappings in `getProgramsOverview()` and `getProgramDetail()` to read `target_count` from the RPC response
- Updated UI labels from "objects" to "targets" in:
  - Programs list page (`web/app/nirspec/programs/page.tsx`)
  - Program detail page (`web/app/nirspec/programs/[slug]/page.tsx`)
  - Docs programs components (`web/components/docs/ProgramsContent.tsx`, `ProgramDetailContent.tsx`)
  - REST API docs example (`web/lib/docs/content/api/rest.md`)

## Testing
- `npm run build` passes with no errors

Generated with Claude Code