### PR TITLE
Fix: sync should verify local files

### DIFF
--- a/python/campfire/cli.py
+++ b/python/campfire/cli.py
@@ -445,7 +445,7 @@ def sync_cmd(full: bool, base_url: Optional[str]):
     """
     base_url = base_url or resolve_base_url()
 
-    from .config import meta_dir as _meta_dir
+    from .config import meta_dir as _meta_dir, products_dir as _products_dir
     from .sync import sync_metadata
 
     try:
@@ -484,6 +484,17 @@ def sync_cmd(full: bool, base_url: Optional[str]):
                         f"{result['purged_spectra']} spectra deleted from server.")
         if result.get("sky_objects_purged"):
             click.echo(f"  Removed {result['sky_objects_purged']} sky objects deleted from server.")
+
+        # Verify local files so status reports correct counts immediately
+        pd = _products_dir()
+        if pd.exists():
+            verify = store.verify_local_files(pd, show_progress=True)
+            if verify["cleared"]:
+                click.echo(f"  Detected {verify['cleared']} missing local file(s).")
+            if verify["rehashed"]:
+                click.echo(f"  Re-verified {verify['rehashed']} modified local file(s).")
+            if verify["discovered"]:
+                click.echo(f"  Found {verify['discovered']} existing local file(s).")
 
         if result["stale_count"] > 0:
             click.echo(f"\n⚠ {result['stale_count']} local file(s) have been updated on the server.")
@@ -675,8 +686,7 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
         return
 
     # Reconcile DB with filesystem before planning
-    click.echo("Searching for and verifying local file(s)...")
-    verify = store.verify_local_files(_products_dir())
+    verify = store.verify_local_files(_products_dir(), show_progress=True)
     if verify["cleared"]:
         click.echo(f"  Detected {verify['cleared']} missing local file(s), will re-download.")
     if verify.get("rehashed"):

--- a/python/campfire/db/store.py
+++ b/python/campfire/db/store.py
@@ -744,7 +744,12 @@ class LocalStore:
 
         return result
 
-    def verify_local_files(self, products_dir: Path, observation: Optional[str] = None) -> dict:
+    def verify_local_files(
+        self,
+        products_dir: Path,
+        observation: Optional[str] = None,
+        show_progress: bool = False,
+    ) -> dict:
         """Reconcile database sync state with the local filesystem.
 
         Performs three checks:
@@ -763,6 +768,8 @@ class LocalStore:
             Root products directory (contains ``<obs>/`` subdirs).
         observation : str, optional
             Limit check to a single observation. If None, checks all.
+        show_progress : bool, optional
+            Show a tqdm progress bar during verification. Default False.
 
         Returns
         -------
@@ -786,6 +793,21 @@ class LocalStore:
 
         cleared = 0
         rehashed = 0
+
+        # 2. Discover files that exist but aren't tracked
+        untracked_rows = self._conn.execute(f"""
+            SELECT s.spectra_id, s.fits_path, s.file_hash, o.observation
+            FROM spectra s
+            JOIN targets o ON s.target_id = o.target_id
+            WHERE s.local_path IS NULL AND s.fits_path IS NOT NULL {obs_filter}
+        """, obs_params).fetchall()
+
+        total = len(tracked_rows) + len(untracked_rows)
+        pbar = None
+        if show_progress and total > 0:
+            from tqdm import tqdm
+            pbar = tqdm(total=total, desc="Verifying local files", unit="file")
+
         for row in tracked_rows:
             full_path = products_dir / row["local_path"]
             if not full_path.exists():
@@ -804,6 +826,8 @@ class LocalStore:
                         and stored_size is not None
                         and abs(st.st_mtime - stored_mtime) < 0.001
                         and st.st_size == stored_size):
+                    if pbar:
+                        pbar.update(1)
                     continue  # Fast path: unchanged
                 # Re-hash — mtime/size changed or not yet tracked (pre-v5)
                 new_hash = compute_file_hash(full_path)
@@ -814,14 +838,8 @@ class LocalStore:
                     (new_hash, st.st_mtime, st.st_size, row["spectra_id"]),
                 )
                 rehashed += 1
-
-        # 2. Discover files that exist but aren't tracked
-        untracked_rows = self._conn.execute(f"""
-            SELECT s.spectra_id, s.fits_path, s.file_hash, o.observation
-            FROM spectra s
-            JOIN targets o ON s.target_id = o.target_id
-            WHERE s.local_path IS NULL AND s.fits_path IS NOT NULL {obs_filter}
-        """, obs_params).fetchall()
+            if pbar:
+                pbar.update(1)
 
         discovered = 0
         for row in untracked_rows:
@@ -839,6 +857,11 @@ class LocalStore:
                     (rel_path, actual_hash, st.st_mtime, st.st_size, now, row["spectra_id"]),
                 )
                 discovered += 1
+            if pbar:
+                pbar.update(1)
+
+        if pbar:
+            pbar.close()
 
         if cleared or discovered or rehashed:
             self._conn.commit()


### PR DESCRIPTION
Closes #66

## What was the bug?
After `campfire sync --full`, `campfire status` would report 0 downloaded files because the sync command didn't reconcile the DB with local files on disk. Users had to run `campfire download` (which calls `verify_local_files`) before status would show correct counts.

## Root cause
`verify_local_files()` — which discovers existing local FITS files and updates the DB — was only called in the `download` command, not in `sync`. After a full sync that purges and re-inserts rows, the `local_path` tracking could be lost until the next download.

## What I changed
- **`sync_cmd` (cli.py)**: Added a `verify_local_files()` call after metadata sync completes. Only runs if the products directory exists. Reports discovered/cleared/rehashed counts.
- **`verify_local_files` (store.py)**: Added `show_progress` parameter that shows a tqdm progress bar during file verification (hashing can be slow with many files). Both `sync` and `download` now pass `show_progress=True`.

## Testing
- Verified module imports successfully
- The progress bar covers both tracked-file verification and untracked-file discovery phases