### PR TITLE
Fix: point bagpipes dependency to hollisakins fork

### DIFF
--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "tqdm>=4.65",
     "spectres>=2.2",
     "numba>=0.59",
-    "bagpipes",
+    "bagpipes @ git+https://github.com/hollisakins/bagpipes.git",
     "jhat",
     "snowblind",
     "shapely",


### PR DESCRIPTION
Closes #59

## What was the bug?
The `bagpipes` dependency in `pipeline/pyproject.toml` pointed to the upstream PyPI package instead of the hollisakins fork.

## Root cause
The dependency was specified as `"bagpipes"` (PyPI), which installs the upstream version rather than the forked version at https://github.com/hollisakins/bagpipes.

## What I changed
- Updated `pipeline/pyproject.toml` to use `"bagpipes @ git+https://github.com/hollisakins/bagpipes.git"` instead of `"bagpipes"`

## Testing
- Verified dependency resolution with `pip install -e . --dry-run` — pip correctly clones the fork and resolves metadata