### PR TITLE
feat: Rich output + Textual TUI dashboard for campfire CLI

### DIFF
--- a/python/campfire/auth/device_flow.py
+++ b/python/campfire/auth/device_flow.py
@@ -264,33 +264,41 @@ def run_device_flow(
     TokenResponse
         Access and refresh tokens.
     """
+    from campfire.output import console, print_msg
+
     flow = DeviceFlowAuth(base_url)
 
     # Initiate flow
     device = flow.initiate()
 
     if show_progress:
-        print(f"\nOpening browser to: {device.verification_uri}")
-        print(f"Enter code: {device.user_code}")
-        print("\nWaiting for authorization...", end="", flush=True)
+        print_msg(f"\nOpening browser to: {device.verification_uri}")
+        print_msg(f"Enter code: [bold]{device.user_code}[/bold]")
 
     # Open browser
     if open_browser:
         flow.open_browser(device.verification_uri_complete)
 
-    # Poll for token with progress indicator
-    def on_pending():
+    # Poll for token with status spinner
+    if show_progress and console.is_terminal:
+        with console.status("Waiting for authorization...") as status:
+            tokens = flow.poll_for_token(
+                device.device_code,
+                interval=device.interval,
+                timeout=device.expires_in,
+            )
+    else:
         if show_progress:
-            print(".", end="", flush=True)
+            print_msg("\nWaiting for authorization...")
 
-    tokens = flow.poll_for_token(
-        device.device_code,
-        interval=device.interval,
-        timeout=device.expires_in,
-        on_pending=on_pending,
-    )
+        def on_pending():
+            pass  # Silent in non-tty mode
 
-    if show_progress:
-        print(" done!")
+        tokens = flow.poll_for_token(
+            device.device_code,
+            interval=device.interval,
+            timeout=device.expires_in,
+            on_pending=on_pending,
+        )
 
     return tokens

--- a/python/campfire/cli.py
+++ b/python/campfire/cli.py
@@ -25,6 +25,14 @@ from .auth.credentials import CredentialManager
 from .auth.device_flow import run_device_flow
 from .auth.tokens import TokenManager
 from .exceptions import AuthenticationError
+from .output import (
+    console,
+    make_table,
+    print_error,
+    print_msg,
+    print_success,
+    print_warning,
+)
 
 
 def _require_auth(base_url: str) -> APISession:
@@ -32,8 +40,8 @@ def _require_auth(base_url: str) -> APISession:
     try:
         return APISession(base_url=base_url)
     except AuthenticationError as e:
-        click.echo(f"✗ {e}")
-        click.echo("  Run: campfire login")
+        print_error(str(e))
+        print_msg("  Run: campfire login")
         sys.exit(1)
 
 
@@ -51,17 +59,17 @@ def _open_store():
     try:
         return LocalStore(db_path)
     except SchemaMismatchError as e:
-        click.echo(f"⚠  {e}")
-        click.echo("   The database must be recreated to match the current client version.")
+        print_warning(str(e))
+        print_msg("   The database must be recreated to match the current client version.")
         if click.confirm("   Delete and rebuild on next sync?", default=True):
             db_path.unlink(missing_ok=True)
             # Also remove WAL/SHM files left by SQLite
             db_path.with_suffix(".db-wal").unlink(missing_ok=True)
             db_path.with_suffix(".db-shm").unlink(missing_ok=True)
-            click.echo("   Deleted. Creating fresh database…")
+            print_msg("   Deleted. Creating fresh database…")
             return LocalStore(db_path)
         else:
-            click.echo("   Aborting.")
+            print_msg("   Aborting.")
             sys.exit(1)
 
 
@@ -80,21 +88,27 @@ def _check_client_version(base_url: str) -> None:
         minimum = Version(data.get("minimum", "0.0.0"))
 
         if current < minimum:
-            click.echo(f"\n⚠ campfire v{__version__} is no longer supported "
-                        f"(minimum: v{minimum}). Please update:")
-            click.echo("  pip install -U git+https://github.com/hollisakins/campfire.git#subdirectory=python")
+            print_warning(f"campfire v{__version__} is no longer supported "
+                          f"(minimum: v{minimum}). Please update:")
+            print_msg("  pip install -U git+https://github.com/hollisakins/campfire.git#subdirectory=python")
         elif current < latest:
-            click.echo(f"\n  Update available: v{__version__} → v{latest}")
-            click.echo("  pip install -U git+https://github.com/hollisakins/campfire.git#subdirectory=python")
+            print_msg(f"\n  Update available: v{__version__} → v{latest}")
+            print_msg("  pip install -U git+https://github.com/hollisakins/campfire.git#subdirectory=python")
     except Exception:
         pass  # Never block sync for a version check failure
 
 
-@click.group()
+@click.group(invoke_without_command=True)
 @click.version_option(version="0.3.0", prog_name="campfire")
-def cli():
+@click.pass_context
+def cli(ctx):
     """CAMPFIRE — Python client and deployment tools for NIRSpec spectroscopic data."""
-    pass
+    if ctx.invoked_subcommand is None:
+        if sys.stdout.isatty():
+            from .tui import launch_tui
+            launch_tui()
+        else:
+            click.echo(ctx.get_help())
 
 
 def _register_deploy_group():
@@ -141,18 +155,18 @@ def login(browser: Optional[bool], base_url: Optional[str]):
         existing = creds.load()
         if existing:
             if existing.is_oauth() and existing.user_email:
-                click.echo(f"Already logged in as {existing.user_email}")
+                print_msg(f"Already logged in as {existing.user_email}")
             elif existing.is_api_key():
-                click.echo("Already authenticated with API key")
+                print_msg("Already authenticated with API key")
 
             if not click.confirm("Do you want to re-authenticate?"):
                 return
 
     # Determine authentication method
     if browser is None:
-        click.echo("\nHow would you like to authenticate?")
-        click.echo("  1. Login with web browser (recommended)")
-        click.echo("  2. Paste an API key")
+        print_msg("\nHow would you like to authenticate?")
+        print_msg("  1. Login with web browser (recommended)")
+        print_msg("  2. Paste an API key")
         choice = click.prompt("Choice", type=click.IntRange(1, 2), default=1)
         browser = choice == 1
 
@@ -164,7 +178,7 @@ def login(browser: Optional[bool], base_url: Optional[str]):
 
 def _browser_login(base_url: str, creds: CredentialManager):
     """Handle browser-based OAuth flow."""
-    click.echo("\nStarting browser authentication...")
+    print_msg("\nStarting browser authentication...")
 
     try:
         tokens = run_device_flow(base_url, open_browser=True, show_progress=True)
@@ -180,61 +194,57 @@ def _browser_login(base_url: str, creds: CredentialManager):
             supabase_anon_key=tokens.supabase_anon_key,
         )
 
-        click.echo(f"\n✓ Logged in successfully!")
+        print_success("Logged in successfully!")
         if user_email:
-            click.echo(f"  Authenticated as: {user_email}")
-        click.echo(f"  Credentials saved to: ~/.campfire/credentials")
+            print_msg(f"  Authenticated as: {user_email}")
+        print_msg("  Credentials saved to: ~/.campfire/credentials")
 
     except AuthenticationError as e:
-        click.echo(f"\n✗ Authentication failed: {e}", err=True)
+        print_error(f"Authentication failed: {e}")
         sys.exit(1)
     except KeyboardInterrupt:
-        click.echo("\n\nAuthentication cancelled.")
+        print_msg("\n\nAuthentication cancelled.")
         sys.exit(1)
 
 
 def _api_key_login(base_url: str, creds: CredentialManager):
     """Handle manual API key entry."""
-    click.echo("\nGenerate an API key at:")
-    click.echo(f"  {base_url.replace('/api/v1', '')}/profile/api-keys")
-    click.echo()
+    print_msg("\nGenerate an API key at:")
+    print_msg(f"  {base_url.replace('/api/v1', '')}/profile/api-keys")
+    print_msg()
 
     api_key = click.prompt("Paste your API key", hide_input=True)
 
     if not api_key:
-        click.echo("✗ No API key provided", err=True)
+        print_error("No API key provided")
         sys.exit(1)
 
     if not api_key.startswith("sk_"):
-        click.echo("✗ Invalid API key format (should start with 'sk_')", err=True)
+        print_error("Invalid API key format (should start with 'sk_')")
         sys.exit(1)
 
-    click.echo("Validating...", nl=False)
+    with console.status("Validating..."):
+        try:
+            response = requests.get(
+                f"{base_url}/auth/whoami",
+                headers={"Authorization": f"Bearer {api_key}"},
+                timeout=10,
+            )
 
-    try:
-        response = requests.get(
-            f"{base_url}/auth/whoami",
-            headers={"Authorization": f"Bearer {api_key}"},
-            timeout=10,
-        )
+            if response.status_code == 401:
+                print_error("Invalid API key")
+                sys.exit(1)
 
-        if response.status_code == 401:
-            click.echo(" ✗")
-            click.echo("Invalid API key", err=True)
+            response.raise_for_status()
+
+        except requests.RequestException as e:
+            print_error(f"Failed to validate API key: {e}")
             sys.exit(1)
 
-        response.raise_for_status()
-        click.echo(" ✓")
+    creds.save_api_key(api_key)
 
-        creds.save_api_key(api_key)
-
-        click.echo(f"\n✓ API key saved successfully!")
-        click.echo(f"  Credentials saved to: ~/.campfire/credentials")
-
-    except requests.RequestException as e:
-        click.echo(" ✗")
-        click.echo(f"Failed to validate API key: {e}", err=True)
-        sys.exit(1)
+    print_success("API key saved successfully!")
+    print_msg("  Credentials saved to: ~/.campfire/credentials")
 
 
 def _get_user_email(base_url: str, access_token: str) -> Optional[str]:
@@ -261,7 +271,7 @@ def logout(base_url: Optional[str]):
     creds = CredentialManager()
 
     if not creds.exists():
-        click.echo("Not logged in.")
+        print_msg("Not logged in.")
         return
 
     # Revoke server-side refresh token before deleting local credentials
@@ -277,7 +287,7 @@ def logout(base_url: Optional[str]):
             pass  # Best-effort; still delete local creds
 
     creds.delete()
-    click.echo("✓ Logged out successfully")
+    print_success("Logged out successfully")
 
 
 @cli.command()
@@ -288,18 +298,18 @@ def whoami(base_url: Optional[str]):
     creds = CredentialManager()
 
     if not creds.exists():
-        click.echo("Not logged in. Run: campfire login")
+        print_msg("Not logged in. Run: campfire login")
         sys.exit(1)
 
     loaded = creds.load()
     if not loaded:
-        click.echo("Invalid credentials. Run: campfire login")
+        print_msg("Invalid credentials. Run: campfire login")
         sys.exit(1)
 
     if loaded.is_api_key():
-        click.echo("Authentication: API key")
+        print_msg("Authentication: API key")
         if loaded.api_key:
-            click.echo(f"Key prefix: {loaded.api_key[:20]}...")
+            print_msg(f"Key prefix: {loaded.api_key[:20]}...")
 
         try:
             response = requests.get(
@@ -309,16 +319,16 @@ def whoami(base_url: Optional[str]):
             )
             if response.status_code == 200:
                 data = response.json()
-                click.echo(f"Email: {data.get('email', 'unknown')}")
+                print_msg(f"Email: {data.get('email', 'unknown')}")
         except requests.RequestException:
             pass
 
     elif loaded.is_oauth():
-        click.echo("Authentication: OAuth (device flow)")
+        print_msg("Authentication: OAuth (device flow)")
         if loaded.user_email:
-            click.echo(f"Email: {loaded.user_email}")
+            print_msg(f"Email: {loaded.user_email}")
         if loaded.expires_at:
-            click.echo(f"Token expires: {loaded.expires_at}")
+            print_msg(f"Token expires: {loaded.expires_at}")
 
 
 @cli.command()
@@ -331,8 +341,8 @@ def status(base_url: Optional[str]):
         token_manager = TokenManager(base_url)
 
         if not token_manager.has_credentials():
-            click.echo("✗ No credentials found")
-            click.echo("  Run: campfire login")
+            print_error("No credentials found")
+            print_msg("  Run: campfire login")
             sys.exit(1)
 
         token = token_manager.get_valid_token(auto_refresh=True)
@@ -344,21 +354,21 @@ def status(base_url: Optional[str]):
         )
 
         if response.status_code == 200:
-            click.echo("✓ Credentials valid")
+            print_success("Credentials valid")
             data = response.json()
             if data.get("email"):
-                click.echo(f"  User: {data['email']}")
+                print_msg(f"  User: {data['email']}")
         else:
-            click.echo("✗ Credentials invalid or expired")
-            click.echo("  Run: campfire login")
+            print_error("Credentials invalid or expired")
+            print_msg("  Run: campfire login")
             sys.exit(1)
 
     except AuthenticationError as e:
-        click.echo(f"✗ {e}")
-        click.echo("  Run: campfire login")
+        print_error(str(e))
+        print_msg("  Run: campfire login")
         sys.exit(1)
     except requests.RequestException as e:
-        click.echo(f"✗ Failed to verify credentials: {e}")
+        print_error(f"Failed to verify credentials: {e}")
         sys.exit(1)
 
     # Show catalog and download status
@@ -366,12 +376,12 @@ def status(base_url: Optional[str]):
     from .sync import format_size
 
     data_dir = resolve_data_dir()
-    click.echo()
-    click.echo(f"Data directory: {data_dir}")
+    print_msg()
+    print_msg(f"Data directory: {data_dir}")
 
     db_path = _meta_dir(data_dir) / "campfire.db"
     if not db_path.exists():
-        click.echo("\nNo local catalog. Run: campfire sync")
+        print_msg("\nNo local catalog. Run: campfire sync")
         return
 
     from .db.store import LocalStore, SchemaMismatchError
@@ -379,7 +389,7 @@ def status(base_url: Optional[str]):
     try:
         store = LocalStore(db_path)
     except SchemaMismatchError:
-        click.echo("\n⚠  Local catalog has an outdated schema. Run: campfire sync")
+        print_warning("Local catalog has an outdated schema. Run: campfire sync")
         return
 
     # Catalog stats
@@ -387,14 +397,13 @@ def status(base_url: Optional[str]):
     last_synced = store.get_last_synced_at()
     if last_synced:
         last_str = last_synced[:16].replace("T", " ")
-        click.echo(f"Catalog: {len(obs_list)} observations (last synced {last_str})")
+        print_msg(f"Catalog: {len(obs_list)} observations (last synced {last_str})")
     else:
-        click.echo(f"Catalog: {len(obs_list)} observations")
+        print_msg(f"Catalog: {len(obs_list)} observations")
 
     # Download stats per observation
     if obs_list:
-        click.echo()
-        click.echo(f"  {'OBSERVATION':<25} {'DOWNLOADED':<14} {'SIZE':<12}")
+        table = make_table("OBSERVATION", "DOWNLOADED", "SIZE")
 
         total_downloaded = 0
         total_bytes = 0
@@ -405,20 +414,22 @@ def status(base_url: Optional[str]):
             total_downloaded += downloaded
             total_bytes += stats["total_bytes"]
             if downloaded > 0:
-                click.echo(f"  {obs:<25} {downloaded:<14} {size:<12}")
+                table.add_row(obs, str(downloaded), size)
 
         if total_downloaded == 0:
-            click.echo("  No FITS files downloaded yet. Run: campfire download --obs <name>")
+            print_msg("  No FITS files downloaded yet. Run: campfire download --obs <name>")
+        else:
+            console.print(table)
 
     # Stale files
     stale = store.get_stale_files()
     if stale:
-        click.echo(f"\n⚠ {len(stale)} local file(s) updated on server. Run: campfire download --stale")
+        print_warning(f"{len(stale)} local file(s) updated on server. Run: campfire download --stale")
 
     # Disk usage
     if data_dir.exists():
         total = sum(f.stat().st_size for f in data_dir.rglob("*") if f.is_file())
-        click.echo(f"\nDisk usage: {format_size(total)}")
+        print_msg(f"\nDisk usage: {format_size(total)}")
 
     store.close()
 
@@ -452,7 +463,7 @@ def sync_cmd(full: bool, base_url: Optional[str]):
         api_session = APISession(base_url=base_url)
         api = APIClient(api_session)
     except AuthenticationError as e:
-        click.echo(f"✗ {e}")
+        print_error(str(e))
         sys.exit(1)
 
     store = _open_store()
@@ -460,9 +471,9 @@ def sync_cmd(full: bool, base_url: Optional[str]):
     try:
         is_incremental = not full and store.get_max_updated_at() is not None
         if is_incremental:
-            click.echo("Syncing catalog (updating existing)...")
+            print_msg("Syncing catalog (updating existing)...")
         else:
-            click.echo("Syncing full CAMPFIRE catalog (may take a while)...")
+            print_msg("Syncing full CAMPFIRE catalog (may take a while)...")
 
         result = sync_metadata(
             api, store, _meta_dir(),
@@ -471,39 +482,39 @@ def sync_cmd(full: bool, base_url: Optional[str]):
         )
 
         if result.get("incremental"):
-            click.echo(f"✓ Incremental sync complete: {result['observations']} observations, "
-                        f"{result['targets']} targets, {result['spectra']} spectra, "
-                        f"{result['sky_objects']} sky objects updated.")
+            print_success(f"Incremental sync complete: {result['observations']} observations, "
+                          f"{result['targets']} targets, {result['spectra']} spectra, "
+                          f"{result['sky_objects']} sky objects updated.")
         else:
-            click.echo(f"✓ Full sync complete: {result['observations']} observations, "
-                        f"{result['targets']} targets, {result['spectra']} spectra, "
-                        f"{result['sky_objects']} sky objects.")
+            print_success(f"Full sync complete: {result['observations']} observations, "
+                          f"{result['targets']} targets, {result['spectra']} spectra, "
+                          f"{result['sky_objects']} sky objects.")
 
         if result.get("purged_objects") or result.get("purged_spectra"):
-            click.echo(f"  Removed {result['purged_objects']} targets and "
-                        f"{result['purged_spectra']} spectra deleted from server.")
+            print_msg(f"  Removed {result['purged_objects']} targets and "
+                      f"{result['purged_spectra']} spectra deleted from server.")
         if result.get("sky_objects_purged"):
-            click.echo(f"  Removed {result['sky_objects_purged']} sky objects deleted from server.")
+            print_msg(f"  Removed {result['sky_objects_purged']} sky objects deleted from server.")
 
         # Verify local files so status reports correct counts immediately
         pd = _products_dir()
         if pd.exists():
             verify = store.verify_local_files(pd, show_progress=True)
             if verify["cleared"]:
-                click.echo(f"  Detected {verify['cleared']} missing local file(s).")
+                print_msg(f"  Detected {verify['cleared']} missing local file(s).")
             if verify["rehashed"]:
-                click.echo(f"  Re-verified {verify['rehashed']} modified local file(s).")
+                print_msg(f"  Re-verified {verify['rehashed']} modified local file(s).")
             if verify["discovered"]:
-                click.echo(f"  Found {verify['discovered']} existing local file(s).")
+                print_msg(f"  Found {verify['discovered']} existing local file(s).")
 
         if result["stale_count"] > 0:
-            click.echo(f"\n⚠ {result['stale_count']} local file(s) have been updated on the server.")
-            click.echo("  Run: campfire download --stale")
+            print_warning(f"{result['stale_count']} local file(s) have been updated on the server.")
+            print_msg("  Run: campfire download --stale")
 
         # Check for client updates (non-blocking)
         _check_client_version(base_url)
     except Exception as e:
-        click.echo(f"✗ Sync failed: {e}", err=True)
+        print_error(f"Sync failed: {e}")
         sys.exit(1)
     finally:
         store.close()
@@ -554,7 +565,7 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
         api_session = APISession(base_url=base_url)
         api = APIClient(api_session)
     except AuthenticationError as e:
-        click.echo(f"✗ {e}")
+        print_error(str(e))
         sys.exit(1)
 
     store = _open_store()
@@ -563,14 +574,14 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
     try:
         is_first_sync = store.get_max_updated_at() is None
         if is_first_sync:
-            click.echo("Syncing catalog for the first time...")
+            print_msg("Syncing catalog for the first time...")
         else:
-            click.echo("Syncing catalog...")
+            print_msg("Syncing catalog...")
 
         result = sync_metadata(api, store, _meta_dir(), show_progress=is_first_sync)
 
         if result.get("needs_full_sync"):
-            click.echo("  Local catalog out of sync with server, running full sync...")
+            print_msg("  Local catalog out of sync with server, running full sync...")
             result = sync_metadata(api, store, _meta_dir(), show_progress=True, full=True)
 
         parts = []
@@ -579,16 +590,16 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
         if result.get("purged_objects"):
             parts.append(f"{result['purged_objects']} removed")
         if parts:
-            click.echo(f"  {', '.join(parts)}")
+            print_msg(f"  {', '.join(parts)}")
         else:
-            click.echo("  Up to date.")
+            print_msg("  Up to date.")
     except Exception as e:
-        click.echo(f"  ⚠ Sync failed: {e}", err=True)
-        click.echo("  Continuing with existing catalog data.")
+        print_warning(f"Sync failed: {e}")
+        print_msg("  Continuing with existing catalog data.")
 
     catalog_obs = store.get_synced_observations()
     if not catalog_obs:
-        click.echo("✗ No catalog data.")
+        print_error("No catalog data.")
         store.close()
         sys.exit(1)
 
@@ -597,13 +608,9 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
         summary = store.get_observation_summary()
         store.close()
 
-        lines = []
-        lines.append("")
-        lines.append(f"Available observations ({len(summary)} total):")
-        if len(summary) > 30:
-            lines.append("(scroll with arrow keys, q to quit)")
-        lines.append("")
-        lines.append(f"  {'OBSERVATION':<25} {'PROGRAM':<15} {'FIELD':<10} {'SPECTRA':>8}   LOCAL")
+        print_msg(f"\nAvailable observations ({len(summary)} total):\n")
+
+        table = make_table("OBSERVATION", "PROGRAM", "FIELD", "SPECTRA", "LOCAL")
         for row in summary:
             downloaded = row["downloaded_count"]
             total = row["spectrum_count"]
@@ -613,35 +620,34 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
                 local_str = f"{downloaded}/{total}"
             else:
                 local_str = ""
-            lines.append(
-                f"  {row['observation']:<25} "
-                f"{row['program_slug']:<15} "
-                f"{row['field']:<10} "
-                f"{total:>8}   {local_str}"
+            table.add_row(
+                row["observation"],
+                row["program_slug"],
+                row["field"],
+                str(total),
+                local_str,
             )
 
-        lines.append("")
-        lines.append("Use --obs, --program, or --field to download, or --all for everything.")
-        lines.append("")
-
-        output = "\n".join(lines)
         if len(summary) > 30:
-            click.echo_via_pager(output)
+            with console.pager():
+                console.print(table)
         else:
-            click.echo(output)
+            console.print(table)
+
+        print_msg("\nUse --obs, --program, or --field to download, or --all for everything.")
         return
 
     # Determine which observations to download
     if stale:
         stale_files = store.get_stale_files()
         if not stale_files:
-            click.echo("All local files are up to date.")
+            print_msg("All local files are up to date.")
             store.close()
             return
         # Group stale files by observation
         stale_obs = set(f["observation"] for f in stale_files)
         target_obs = sorted(stale_obs)
-        click.echo(f"Found {len(stale_files)} stale file(s) across {len(target_obs)} observation(s)")
+        print_msg(f"Found {len(stale_files)} stale file(s) across {len(target_obs)} observation(s)")
     else:
         target_obs = set()
 
@@ -651,7 +657,7 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
         if obs_filter:
             for name in obs_filter:
                 if name not in catalog_obs:
-                    click.echo(f"✗ Observation '{name}' not in catalog. Run: campfire sync", err=True)
+                    print_error(f"Observation '{name}' not in catalog. Run: campfire sync")
                     store.close()
                     sys.exit(1)
                 target_obs.add(name)
@@ -663,7 +669,7 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
                 results = store.query_targets(programs=[prog], limit=999999)
                 obs_for_prog = set(r["observation"] for r in results)
                 if not obs_for_prog:
-                    click.echo(f"✗ No observations found for program '{prog}'", err=True)
+                    print_error(f"No observations found for program '{prog}'")
                     store.close()
                     sys.exit(1)
                 target_obs.update(obs_for_prog)
@@ -673,7 +679,7 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
                 results = store.query_targets(fields=[fld], limit=999999)
                 obs_for_field = set(r["observation"] for r in results)
                 if not obs_for_field:
-                    click.echo(f"✗ No observations found for field '{fld}'", err=True)
+                    print_error(f"No observations found for field '{fld}'")
                     store.close()
                     sys.exit(1)
                 target_obs.update(obs_for_field)
@@ -681,22 +687,22 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
         target_obs = sorted(target_obs)
 
     if not target_obs:
-        click.echo("Nothing to download.")
+        print_msg("Nothing to download.")
         store.close()
         return
 
     # Reconcile DB with filesystem before planning
     verify = store.verify_local_files(_products_dir(), show_progress=True)
     if verify["cleared"]:
-        click.echo(f"  Detected {verify['cleared']} missing local file(s), will re-download.")
+        print_msg(f"  Detected {verify['cleared']} missing local file(s), will re-download.")
     if verify.get("rehashed"):
-        click.echo(f"  Re-verified {verify['rehashed']} modified local file(s).")
+        print_msg(f"  Re-verified {verify['rehashed']} modified local file(s).")
     if verify["discovered"]:
-        click.echo(f"  Found {verify['discovered']} existing local file(s), skipping download.")
+        print_msg(f"  Found {verify['discovered']} existing local file(s), skipping download.")
 
     # Compute download plan locally (no HTTP requests)
     grating_list = list(grating_filter) if grating_filter else None
-    click.echo("Checking files...")
+    print_msg("Checking files...")
 
     pending = store.get_pending_downloads(
         observations=list(target_obs),
@@ -711,7 +717,7 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
     for obs in target_obs:
         obs_pending = pending.get(obs, [])
         if not obs_pending:
-            click.echo(f"  {obs}: up to date")
+            print_msg(f"  {obs}: up to date")
             continue
 
         new_count = sum(1 for s in obs_pending if s["status"] == "new")
@@ -723,30 +729,30 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
             parts.append(f"{new_count} new")
         if updated_count:
             parts.append(f"{updated_count} updated")
-        click.echo(f"  {obs}: {', '.join(parts)} ({format_size(download_bytes)})")
+        print_msg(f"  {obs}: {', '.join(parts)} ({format_size(download_bytes)})")
 
         obs_with_downloads.append(obs)
         total_download += download_bytes
         total_files += len(obs_pending)
 
     if total_files == 0:
-        click.echo("\nAll files up to date.")
+        print_msg("\nAll files up to date.")
         store.close()
         return
 
     if dry_run:
-        click.echo(f"\nDry run: would download {total_files} files ({format_size(total_download)})")
+        print_msg(f"\nDry run: would download {total_files} files ({format_size(total_download)})")
         store.close()
         return
 
     if not yes:
-        click.echo(f"\nDownload {total_files} files ({format_size(total_download)})?")
+        print_msg(f"\nDownload {total_files} files ({format_size(total_download)})?")
         if not click.confirm("Proceed?", default=True):
             store.close()
             return
 
     # Execute downloads — only fetch manifests for observations that need them
-    click.echo()
+    print_msg()
     dl_session = create_download_session(max_workers=workers)
     all_stats = []
 
@@ -763,16 +769,16 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
             )
             all_stats.append(stats)
         except Exception as e:
-            click.echo(f"✗ Failed to download {obs}: {e}")
+            print_error(f"Failed to download {obs}: {e}")
 
     # Summary
     total_downloaded = sum(s.get("downloaded", 0) for s in all_stats)
     total_failed = sum(s.get("failed", 0) for s in all_stats)
-    click.echo(f"\n✓ Download complete")
-    click.echo(f"  Files downloaded: {total_downloaded}")
+    print_success("Download complete")
+    print_msg(f"  Files downloaded: {total_downloaded}")
     if total_failed:
-        click.echo(f"  Files failed: {total_failed}")
-    click.echo(f"  Total size: {format_size(total_download)}")
+        print_msg(f"  Files failed: {total_failed}")
+    print_msg(f"  Total size: {format_size(total_download)}")
 
     store.close()
 

--- a/python/campfire/db/store.py
+++ b/python/campfire/db/store.py
@@ -805,8 +805,8 @@ class LocalStore:
         total = len(tracked_rows) + len(untracked_rows)
         pbar = None
         if show_progress and total > 0:
-            from tqdm import tqdm
-            pbar = tqdm(total=total, desc="Verifying local files", unit="file")
+            from campfire.output import progress_bar
+            pbar = progress_bar(total=total, description="Verifying local files")
 
         for row in tracked_rows:
             full_path = products_dir / row["local_path"]

--- a/python/campfire/deploy/cli.py
+++ b/python/campfire/deploy/cli.py
@@ -31,6 +31,7 @@ import click
 import requests
 
 from campfire.deploy.config import load_config, load_programs, resolve_imaging_config, resolve_tiles_dir
+from campfire.output import console
 
 
 class _VariadicOption(click.Option):
@@ -75,7 +76,7 @@ def _check_admin() -> None:
         tm = TokenManager(base_url=base_url)
         token = tm.get_valid_token(auto_refresh=True)
     except Exception:
-        print("Error: Not logged in. Run: campfire login")
+        console.print("Error: Not logged in. Run: campfire login")
         sys.exit(1)
 
     try:
@@ -87,13 +88,13 @@ def _check_admin() -> None:
         resp.raise_for_status()
         data = resp.json()
     except Exception as e:
-        print(f"Error: Failed to verify admin status: {e}")
+        console.print(f"Error: Failed to verify admin status: {e}")
         sys.exit(1)
 
     if not data.get("is_admin"):
-        print(f"Error: Deploy requires admin privileges.")
-        print(f"  Logged in as: {data.get('email', 'unknown')}")
-        print(f"  Contact an administrator to request access.")
+        console.print(f"Error: Deploy requires admin privileges.")
+        console.print(f"  Logged in as: {data.get('email', 'unknown')}")
+        console.print(f"  Contact an administrator to request access.")
         sys.exit(1)
 
 
@@ -149,8 +150,8 @@ def deploy_group(ctx, config_path, obs, dry_run, source_ids, supabase_only,
     # When invoked without a subcommand, --obs is required
     if ctx.invoked_subcommand is None:
         if not obs:
-            print("Error: --obs is required for full deployment.")
-            print("Usage: campfire deploy --obs <observation_name>")
+            console.print("Error: --obs is required for full deployment.")
+            console.print("Usage: campfire deploy --obs <observation_name>")
             sys.exit(1)
 
         config = load_config(config_path)
@@ -300,24 +301,24 @@ def objects(config_path, field, all_fields, dry_run, radius):
 
     if all_fields:
         fields = fetch_distinct_fields(sb)
-        print(f"Found {len(fields)} fields: {', '.join(fields)}")
+        console.print(f"Found {len(fields)} fields: {', '.join(fields)}")
     else:
         fields = [field]
 
     for f in fields:
-        print(f"\nRebuilding objects for field '{f}'...")
+        console.print(f"\nRebuilding objects for field '{f}'...")
         n_obj, n_multi = rebuild_field_objects(
             sb, f, radius=radius, dry_run=dry_run,
         )
         if not dry_run:
-            print(f"  {n_obj} objects ({n_multi} multi-target)")
+            console.print(f"  {n_obj} objects ({n_multi} multi-target)")
 
     if not dry_run:
-        print()
+        console.print()
         refresh_filter_options(sb)
         refresh_programs_overview(sb)
 
-    print("Done.")
+    console.print("Done.")
 
 
 # ---------------------------------------------------------------------------
@@ -332,24 +333,24 @@ def sync_programs(config_path, dry_run):
     programs_config = load_programs()
     program_slugs = list(programs_config.keys())
 
-    print(f"Found {len(program_slugs)} programs in programs.toml")
+    console.print(f"Found {len(program_slugs)} programs in programs.toml")
     for slug, info in programs_config.items():
-        print(f"  {slug}: {info.get('program_name', '?')} (cycle {info.get('cycle', '?')})")
+        console.print(f"  {slug}: {info.get('program_name', '?')} (cycle {info.get('cycle', '?')})")
 
     if dry_run:
-        print("\nDry run — no changes made.")
+        console.print("\nDry run — no changes made.")
         return
 
     config = load_config(config_path)
     sb = get_supabase_client(config)
 
-    print("\nUpserting programs...")
+    console.print("\nUpserting programs...")
     upsert_programs(sb, program_slugs, programs_config)
 
-    print("\nRefreshing materialized view...")
+    console.print("\nRefreshing materialized view...")
     refresh_programs_overview(sb)
 
-    print("Done.")
+    console.print("Done.")
 
 
 # ---------------------------------------------------------------------------

--- a/python/campfire/deploy/deploy.py
+++ b/python/campfire/deploy/deploy.py
@@ -12,7 +12,7 @@ Each public function follows the same pattern:
 import shutil
 from pathlib import Path
 
-from tqdm import tqdm
+from campfire.output import console, track, progress_bar
 
 from campfire.deploy.config import load_observations, load_programs, resolve_field, resolve_imaging_config, resolve_obs_dir
 from campfire.deploy.discover import (
@@ -110,7 +110,7 @@ def deploy_observation(
     if source_ids:
         total = len(summary)
         summary = filter_by_source_ids(summary, source_ids)
-        print(f"Filtered {total} spectra to {len(summary)} matching {len(source_ids)} source IDs")
+        console.print(f"Filtered {total} spectra to {len(summary)} matching {len(source_ids)} source IDs")
 
     field = get_field(summary)
     program_slug = get_program_slug(summary)
@@ -122,12 +122,12 @@ def deploy_observation(
     # Get JWST PID from first row (all rows share the same PID per observation)
     jwst_program_id = int(summary['program_id'][0]) if len(summary) > 0 else 0
 
-    print(f"Observation: {obs_name}")
-    print(f"  Field: {field}")
-    print(f"  Program: {program_slug}")
-    print(f"  Objects: {len(objects)}")
-    print(f"  Spectra: {len(spectra)}")
-    print(f"  Zfit files: {len(zfit_paths)}")
+    console.print(f"Observation: {obs_name}")
+    console.print(f"  Field: {field}")
+    console.print(f"  Program: {program_slug}")
+    console.print(f"  Objects: {len(objects)}")
+    console.print(f"  Spectra: {len(spectra)}")
+    console.print(f"  Zfit files: {len(zfit_paths)}")
 
     # Generate RGB/SED if requested (skips existing files)
     if not dry_run:
@@ -136,13 +136,13 @@ def deploy_observation(
             n = generate_rgb_images(obs_name, obs_dir, field,
                                     source_ids=source_ids)
             if n:
-                print(f"  Generated {n} RGB images")
+                console.print(f"  Generated {n} RGB images")
         if include_sed:
             from campfire.deploy.generate_sed import generate_sed_plots
             n = generate_sed_plots(obs_name, obs_dir, field,
                                    source_ids=source_ids)
             if n:
-                print(f"  Generated {n} SED plots")
+                console.print(f"  Generated {n} SED plots")
 
     # Discover optional file types
     rgb_files = discover_rgb_images(obs_dir) if include_rgb else []
@@ -153,50 +153,50 @@ def deploy_observation(
         sed_files = filter_files_by_source_ids(sed_files, source_ids, obs_name)
 
     if rgb_files:
-        print(f"  RGB images: {len(rgb_files)}")
+        console.print(f"  RGB images: {len(rgb_files)}")
     if sed_files:
-        print(f"  SED plots: {len(sed_files)}")
-    print()
+        console.print(f"  SED plots: {len(sed_files)}")
+    console.print()
 
     # Build set of object_ids with SED plots
     objects_with_sed = extract_object_ids_from_files(sed_files, '_sed.pdf') if sed_files else set()
 
     # --- Dry run ---
     if dry_run:
-        print("=== DRY RUN ===")
+        console.print("=== DRY RUN ===")
         if force_overwrite:
-            print("!! FORCE OVERWRITE: inspection data will be reset")
+            console.print("!! FORCE OVERWRITE: inspection data will be reset")
         if not supabase_only:
-            print(f"Would upload to R2:")
-            print(f"  {len(spec_paths)} FITS files")
-            print(f"  {len(spec_paths)} spectrum JSON files")
+            console.print(f"Would upload to R2:")
+            console.print(f"  {len(spec_paths)} FITS files")
+            console.print(f"  {len(spec_paths)} spectrum JSON files")
             if zfit_paths:
-                print(f"  {len(zfit_paths)} zfit JSON files")
+                console.print(f"  {len(zfit_paths)} zfit JSON files")
             if rgb_files:
-                print(f"  {len(rgb_files)} RGB images")
+                console.print(f"  {len(rgb_files)} RGB images")
             if sed_files:
-                print(f"  {len(sed_files)} SED plots")
-        print(f"Would upsert to Supabase:")
-        print(f"  Program: {program_slug}")
-        print(f"  {len(objects)} object(s)")
-        print(f"  {len(spectra)} spectrum record(s)")
+                console.print(f"  {len(sed_files)} SED plots")
+        console.print(f"Would upsert to Supabase:")
+        console.print(f"  Program: {program_slug}")
+        console.print(f"  {len(objects)} object(s)")
+        console.print(f"  {len(spectra)} spectrum record(s)")
         if include_shutters:
             ecsv_path = discover_shutters_ecsv(obs_dir, obs_name)
             if ecsv_path:
                 shutters_data = load_shutters_ecsv(ecsv_path)
-                print(f"  {len(shutters_data)} shutter record(s)")
+                console.print(f"  {len(shutters_data)} shutter record(s)")
             else:
-                print("  No shutters ECSV found, would skip")
+                console.print("  No shutters ECSV found, would skip")
         else:
-            print("  Shutters: skipped (--no-shutters)")
+            console.print("  Shutters: skipped (--no-shutters)")
         if not force_overwrite:
-            print("  (existing objects: pipeline fields only, inspection data preserved)")
-        print()
-        print("Sample object IDs:")
+            console.print("  (existing objects: pipeline fields only, inspection data preserved)")
+        console.print()
+        console.print("Sample object IDs:")
         for obj in objects[:5]:
-            print(f"  - {obj['object_id']}")
+            console.print(f"  - {obj['object_id']}")
         if len(objects) > 5:
-            print(f"  ... and {len(objects) - 5} more")
+            console.print(f"  ... and {len(objects) - 5} more")
         return
 
     # --- Live deployment ---
@@ -207,25 +207,25 @@ def deploy_observation(
     target_ids = [o['object_id'] for o in objects]
     existing = check_existing_objects(sb, target_ids)
     if existing:
-        print(f"Found {len(existing)} existing objects")
+        console.print(f"Found {len(existing)} existing objects")
         if force_overwrite:
-            print("  FORCE OVERWRITE: inspection data will be RESET!")
+            console.print("  FORCE OVERWRITE: inspection data will be RESET!")
             if not auto_approve:
                 resp = input("  Are you sure? [y/N]: ")
                 if resp.lower() != 'y':
-                    print("Aborted.")
+                    console.print("Aborted.")
                     return
         else:
-            print("  (inspection data preserved)")
+            console.print("  (inspection data preserved)")
             if not auto_approve:
                 resp = input("  Update pipeline data for existing objects? [y/N]: ")
                 if resp.lower() != 'y':
-                    print("Aborted.")
+                    console.print("Aborted.")
                     return
-    print()
+    console.print()
 
     # Upsert program
-    print("Upserting program...")
+    console.print("Upserting program...")
     upsert_programs(sb, [program_slug], programs_config)
 
     # Upsert observation record with definition from observations.toml
@@ -240,7 +240,7 @@ def deploy_observation(
         gratings=obs_gratings if obs_gratings else None,
         data_subdir=obs_data_subdir,
     )
-    print()
+    console.print()
 
     # Generate content and upload
     temp_dir = obs_dir / '.deploy_temp'
@@ -251,8 +251,8 @@ def deploy_observation(
         r2_prefix = f"spectra/{obs_name}"
 
         if not supabase_only:
-            print("Generating content...")
-            for spec_path in tqdm(spec_paths, desc="Processing", unit="file"):
+            console.print("Generating content...")
+            for spec_path in track(spec_paths, description="Processing"):
                 # FITS file
                 upload_tasks.append(UploadTask(spec_path, f"{r2_prefix}/{spec_path.name}", 'application/fits'))
 
@@ -273,27 +273,27 @@ def deploy_observation(
             for sed_path in sed_files:
                 upload_tasks.append(UploadTask(sed_path, f"sed/{obs_name}/{sed_path.name}", 'application/pdf'))
 
-            print(f"Uploading {len(upload_tasks)} files...")
+            console.print(f"Uploading {len(upload_tasks)} files...")
             success, failed, failed_msgs = upload_files_parallel(config, upload_tasks, desc="R2 uploads")
 
             if failed_msgs:
-                print(f"\n  {failed} uploads failed:")
+                console.print(f"\n  {failed} uploads failed:")
                 for msg in failed_msgs[:10]:
-                    print(f"    - {msg}")
+                    console.print(f"    - {msg}")
                 if len(failed_msgs) > 10:
-                    print(f"    ... and {len(failed_msgs) - 10} more")
-            print(f"Uploaded {success}/{len(upload_tasks)} files")
-            print()
+                    console.print(f"    ... and {len(failed_msgs) - 10} more")
+            console.print(f"Uploaded {success}/{len(upload_tasks)} files")
+            console.print()
 
         # Generate thumbnails and enrich spectra records
-        print("Generating thumbnails...")
+        console.print("Generating thumbnails...")
         thumb_map = {}
-        for spec_path in tqdm(spec_paths, desc="Thumbnails", unit="file"):
+        for spec_path in track(spec_paths, description="Thumbnails"):
             try:
                 thumbs = generate_thumbnails_from_fits(spec_path)
                 thumb_map[spec_path.name] = thumbs
             except Exception as e:
-                print(f"  Warning: {spec_path.name}: {e}")
+                console.print(f"  Warning: {spec_path.name}: {e}")
 
         # Enrich spectra records with thumbnails
         for rec in spectra:
@@ -302,37 +302,37 @@ def deploy_observation(
                 rec.update(thumb_map[fits_name])
 
         # Supabase upserts
-        print("Upserting objects...")
+        console.print("Upserting objects...")
         n_obj, new_object_ids, n_quality_reset = batch_upsert_objects(sb, objects, field, force_overwrite, objects_with_sed)
-        print(f"  {n_obj} objects")
+        console.print(f"  {n_obj} objects")
         if n_quality_reset:
-            print(f"  Reset {n_quality_reset} Secure objects (redshift_auto drift > {REDSHIFT_DRIFT_THRESHOLD}, no manual override)")
+            console.print(f"  Reset {n_quality_reset} Secure objects (redshift_auto drift > {REDSHIFT_DRIFT_THRESHOLD}, no manual override)")
 
-        print("Upserting spectra...")
+        console.print("Upserting spectra...")
         n_spec = batch_upsert_spectra(sb, spectra)
-        print(f"  {n_spec} spectra")
+        console.print(f"  {n_spec} spectra")
 
         # Recompute aggregate columns (max_snr, max_exposure_time) in bulk
         target_ids = [o['object_id'] for o in objects]
         n_agg = recompute_target_aggregates(sb, target_ids)
-        print(f"  Recomputed aggregates for {n_agg} targets")
+        console.print(f"  Recomputed aggregates for {n_agg} targets")
 
         # Cross-match propagation for new objects
         if new_object_ids:
-            print("Checking cross-matches...")
+            console.print("Checking cross-matches...")
             n_propagated = propagate_crossmatches(sb, new_object_ids)
             if n_propagated:
-                print(f"  Auto-secured {n_propagated} objects via cross-match")
+                console.print(f"  Auto-secured {n_propagated} objects via cross-match")
             else:
-                print("  No cross-matches found")
+                console.print("  No cross-matches found")
 
         # Rebuild objects table for this field
         from campfire.deploy.objects import rebuild_field_objects
-        print("\nRebuilding objects...")
+        console.print("\nRebuilding objects...")
         n_obj, n_multi = rebuild_field_objects(sb, field)
-        print(f"  {n_obj} objects ({n_multi} multi-target)")
+        console.print(f"  {n_obj} objects ({n_multi} multi-target)")
 
-        print()
+        console.print()
         refresh_filter_options(sb)
         refresh_programs_overview(sb)
 
@@ -343,7 +343,7 @@ def deploy_observation(
             if ecsv_path:
                 shutters_data = load_shutters_ecsv(ecsv_path)
                 n_src = len(set(r['object_id'] for r in shutters_data))
-                print(f"\nDeploying shutters ({len(shutters_data)} records, {n_src} sources)...")
+                console.print(f"\nDeploying shutters ({len(shutters_data)} records, {n_src} sources)...")
 
                 if not skip_astrometry:
                     import tomllib
@@ -356,13 +356,13 @@ def deploy_observation(
                         shutters_data, obs_dir, obs_name, field, imaging_config,
                     )
                     if n_corrected:
-                        print(f"  Astrometry: corrected {n_corrected} shutters "
+                        console.print(f"  Astrometry: corrected {n_corrected} shutters "
                               f"({n_matches} catalog cross-matches)")
 
                 n_shutters = db_deploy_shutters(sb, obs_name, shutters_data)
-                print(f"  Deployed {n_shutters} shutter records")
+                console.print(f"  Deployed {n_shutters} shutter records")
             else:
-                print(f"\nNo shutters ECSV found for {obs_name}, skipping shutter deployment")
+                console.print(f"\nNo shutters ECSV found for {obs_name}, skipping shutter deployment")
 
         # Record deployment provenance
         config_snapshot = _load_config_snapshot(obs_dir, obs_name)
@@ -389,9 +389,9 @@ def deploy_observation(
         )
         if deployment_id:
             update_latest_deployment(sb, obs_name, deployment_id)
-            print(f"\nDeployment #{deployment_id} recorded")
+            console.print(f"\nDeployment #{deployment_id} recorded")
 
-        print()
+        console.print()
         msg = f"Deployed {len(spectra)} spectra from {len(objects)} objects"
         if zfit_paths:
             msg += f" + {len(zfit_paths)} zfit files"
@@ -401,7 +401,7 @@ def deploy_observation(
             msg += f" + {len(sed_files)} SED plots"
         if n_shutters:
             msg += f" + {n_shutters} shutters"
-        print(msg)
+        console.print(msg)
 
     finally:
         if temp_dir.exists():
@@ -431,7 +431,7 @@ def deploy_rgb(
             n = generate_rgb_images(obs_name, obs_dir, field,
                                     overwrite=overwrite, source_ids=source_ids)
             if n:
-                print(f"Generated {n} RGB images")
+                console.print(f"Generated {n} RGB images")
 
     rgb_files = discover_rgb_images(obs_dir)
 
@@ -439,28 +439,28 @@ def deploy_rgb(
         rgb_files = filter_files_by_source_ids(rgb_files, source_ids, obs_name)
 
     if not rgb_files:
-        print("No RGB images found.")
+        console.print("No RGB images found.")
         return
 
-    print(f"Found {len(rgb_files)} RGB images")
+    console.print(f"Found {len(rgb_files)} RGB images")
 
     if dry_run:
-        print("=== DRY RUN ===")
+        console.print("=== DRY RUN ===")
         for path in rgb_files[:5]:
-            print(f"  {path.name} -> rgb/{obs_name}/{path.name}")
+            console.print(f"  {path.name} -> rgb/{obs_name}/{path.name}")
         if len(rgb_files) > 5:
-            print(f"  ... and {len(rgb_files) - 5} more")
+            console.print(f"  ... and {len(rgb_files) - 5} more")
         return
 
     tasks = [UploadTask(p, f"rgb/{obs_name}/{p.name}", 'image/png') for p in rgb_files]
     success, failed, failed_msgs = upload_files_parallel(config, tasks, desc="RGB images")
 
     if failed_msgs:
-        print(f"\n  {failed} failed:")
+        console.print(f"\n  {failed} failed:")
         for msg in failed_msgs[:5]:
-            print(f"    - {msg}")
+            console.print(f"    - {msg}")
 
-    print(f"Uploaded {success}/{len(rgb_files)} RGB images")
+    console.print(f"Uploaded {success}/{len(rgb_files)} RGB images")
 
 
 def deploy_sed(
@@ -482,7 +482,7 @@ def deploy_sed(
             n = generate_sed_plots(obs_name, obs_dir, field,
                                    overwrite=overwrite, source_ids=source_ids)
             if n:
-                print(f"Generated {n} SED plots")
+                console.print(f"Generated {n} SED plots")
 
     sed_files = discover_sed_plots(obs_dir)
 
@@ -490,35 +490,35 @@ def deploy_sed(
         sed_files = filter_files_by_source_ids(sed_files, source_ids, obs_name)
 
     if not sed_files:
-        print("No SED plots found.")
+        console.print("No SED plots found.")
         return
 
     objects_with_sed = extract_object_ids_from_files(sed_files, '_sed.pdf')
-    print(f"Found {len(sed_files)} SED plots ({len(objects_with_sed)} objects)")
+    console.print(f"Found {len(sed_files)} SED plots ({len(objects_with_sed)} objects)")
 
     if dry_run:
-        print("=== DRY RUN ===")
+        console.print("=== DRY RUN ===")
         for path in sed_files[:5]:
-            print(f"  {path.name} -> sed/{obs_name}/{path.name}")
+            console.print(f"  {path.name} -> sed/{obs_name}/{path.name}")
         if len(sed_files) > 5:
-            print(f"  ... and {len(sed_files) - 5} more")
-        print(f"Would set has_sed_plot=true for {len(objects_with_sed)} objects")
+            console.print(f"  ... and {len(sed_files) - 5} more")
+        console.print(f"Would set has_sed_plot=true for {len(objects_with_sed)} objects")
         return
 
     tasks = [UploadTask(p, f"sed/{obs_name}/{p.name}", 'application/pdf') for p in sed_files]
     success, failed, failed_msgs = upload_files_parallel(config, tasks, desc="SED plots")
 
     if failed_msgs:
-        print(f"\n  {failed} failed:")
+        console.print(f"\n  {failed} failed:")
         for msg in failed_msgs[:5]:
-            print(f"    - {msg}")
+            console.print(f"    - {msg}")
 
-    print(f"Uploaded {success}/{len(sed_files)} SED plots")
+    console.print(f"Uploaded {success}/{len(sed_files)} SED plots")
 
     # Update database
     sb = get_supabase_client(config)
     n = update_has_sed_plot(sb, objects_with_sed)
-    print(f"Updated has_sed_plot for {n} objects")
+    console.print(f"Updated has_sed_plot for {n} objects")
 
 
 def deploy_json(
@@ -538,38 +538,38 @@ def deploy_json(
     spec_paths = get_spec_paths(summary, obs_dir)
 
     if not spec_paths:
-        print("No spectrum files found.")
+        console.print("No spectrum files found.")
         return
 
-    print(f"Found {len(spec_paths)} spectrum files")
+    console.print(f"Found {len(spec_paths)} spectrum files")
 
     if dry_run:
-        print("=== DRY RUN ===")
+        console.print("=== DRY RUN ===")
         for path in spec_paths[:5]:
-            print(f"  {path.name} -> spectra/{obs_name}/{path.stem}.json")
+            console.print(f"  {path.name} -> spectra/{obs_name}/{path.stem}.json")
         if len(spec_paths) > 5:
-            print(f"  ... and {len(spec_paths) - 5} more")
+            console.print(f"  ... and {len(spec_paths) - 5} more")
         return
 
     temp_dir = obs_dir / '.deploy_temp'
     temp_dir.mkdir(exist_ok=True)
 
     try:
-        print("Generating JSON files...")
+        console.print("Generating JSON files...")
         tasks = []
-        for path in tqdm(spec_paths, desc="Generating", unit="file"):
+        for path in track(spec_paths, description="Generating"):
             json_path = generate_spectrum_json(path, temp_dir)
             tasks.append(UploadTask(json_path, f"spectra/{obs_name}/{json_path.name}", 'application/json'))
 
-        print("Uploading...")
+        console.print("Uploading...")
         success, failed, failed_msgs = upload_files_parallel(config, tasks, desc="JSON files")
 
         if failed_msgs:
-            print(f"\n  {failed} failed:")
+            console.print(f"\n  {failed} failed:")
             for msg in failed_msgs[:5]:
-                print(f"    - {msg}")
+                console.print(f"    - {msg}")
 
-        print(f"Uploaded {success}/{len(spec_paths)} JSON files")
+        console.print(f"Uploaded {success}/{len(spec_paths)} JSON files")
     finally:
         if temp_dir.exists():
             shutil.rmtree(temp_dir)
@@ -595,18 +595,18 @@ def deploy_zfit(
     objects = get_unique_objects(summary)
     field = get_field(summary)
 
-    print(f"Found {len(zfit_paths)} zfit files for {len(objects)} objects")
+    console.print(f"Found {len(zfit_paths)} zfit files for {len(objects)} objects")
 
     if not zfit_paths:
-        print("No zfit files to deploy.")
+        console.print("No zfit files to deploy.")
         return
 
     if dry_run:
-        print("=== DRY RUN ===")
+        console.print("=== DRY RUN ===")
         if force_overwrite:
-            print("!! FORCE OVERWRITE: inspection data will be reset")
-        print(f"Would upload {len(zfit_paths)} zfit JSON files")
-        print(f"Would update redshift_auto for {len(objects)} objects")
+            console.print("!! FORCE OVERWRITE: inspection data will be reset")
+        console.print(f"Would upload {len(zfit_paths)} zfit JSON files")
+        console.print(f"Would update redshift_auto for {len(objects)} objects")
         return
 
     # Upload zfit JSONs
@@ -614,21 +614,21 @@ def deploy_zfit(
     temp_dir.mkdir(exist_ok=True)
 
     try:
-        print("Generating zfit JSON files...")
+        console.print("Generating zfit JSON files...")
         tasks = []
         for path in zfit_paths:
             json_path = generate_zfit_json(path, temp_dir)
             tasks.append(UploadTask(json_path, f"spectra/{obs_name}/{json_path.name}", 'application/json'))
 
-        print("Uploading...")
+        console.print("Uploading...")
         success, failed, failed_msgs = upload_files_parallel(config, tasks, desc="Zfit JSON")
 
         if failed_msgs:
-            print(f"\n  {failed} failed:")
+            console.print(f"\n  {failed} failed:")
             for msg in failed_msgs[:5]:
-                print(f"    - {msg}")
+                console.print(f"    - {msg}")
 
-        print(f"Uploaded {success}/{len(zfit_paths)} zfit JSON files")
+        console.print(f"Uploaded {success}/{len(zfit_paths)} zfit JSON files")
     finally:
         if temp_dir.exists():
             shutil.rmtree(temp_dir)
@@ -639,21 +639,21 @@ def deploy_zfit(
     if force_overwrite:
         existing = check_existing_objects(sb, [o['object_id'] for o in objects])
         if existing and not auto_approve:
-            print(f"  {len(existing)} objects exist. FORCE OVERWRITE will reset inspection data!")
+            console.print(f"  {len(existing)} objects exist. FORCE OVERWRITE will reset inspection data!")
             resp = input("  Are you sure? [y/N]: ")
             if resp.lower() != 'y':
-                print("Aborted.")
+                console.print("Aborted.")
                 return
 
-    print("Updating objects...")
+    console.print("Updating objects...")
     n, _, n_quality_reset = batch_upsert_objects(sb, objects, field, force_overwrite)
-    print(f"  Updated {n} objects")
+    console.print(f"  Updated {n} objects")
     if n_quality_reset:
-        print(f"  Reset {n_quality_reset} Secure objects (redshift_auto drift)")
+        console.print(f"  Reset {n_quality_reset} Secure objects (redshift_auto drift)")
 
     refresh_filter_options(sb)
     refresh_programs_overview(sb)
-    print(f"Deployed {len(zfit_paths)} zfit files, updated {n} objects")
+    console.print(f"Deployed {len(zfit_paths)} zfit files, updated {n} objects")
 
 
 def deploy_thumbnails(
@@ -673,23 +673,23 @@ def deploy_thumbnails(
     spec_paths = get_spec_paths(summary, obs_dir)
 
     if not spec_paths:
-        print("No spectrum files found.")
+        console.print("No spectrum files found.")
         return
 
-    print(f"Found {len(spec_paths)} spectrum files")
+    console.print(f"Found {len(spec_paths)} spectrum files")
 
     if dry_run:
-        print("=== DRY RUN ===")
-        print(f"Would regenerate thumbnails for {len(spec_paths)} spectra")
+        console.print("=== DRY RUN ===")
+        console.print(f"Would regenerate thumbnails for {len(spec_paths)} spectra")
         return
 
     sb = get_supabase_client(config)
 
-    print("Generating and updating thumbnails...")
+    console.print("Generating and updating thumbnails...")
     updated = 0
     errors = []
 
-    for spec_path in tqdm(spec_paths, desc="Processing", unit="file"):
+    for spec_path in track(spec_paths, description="Processing"):
         try:
             thumbs = generate_thumbnails_from_fits(spec_path)
 
@@ -708,13 +708,13 @@ def deploy_thumbnails(
             errors.append(f"{spec_path.name}: {e}")
 
     if errors:
-        print(f"\n  {len(errors)} errors:")
+        console.print(f"\n  {len(errors)} errors:")
         for msg in errors[:5]:
-            print(f"    - {msg}")
+            console.print(f"    - {msg}")
         if len(errors) > 5:
-            print(f"    ... and {len(errors) - 5} more")
+            console.print(f"    ... and {len(errors) - 5} more")
 
-    print(f"Updated thumbnails for {updated}/{len(spec_paths)} spectra")
+    console.print(f"Updated thumbnails for {updated}/{len(spec_paths)} spectra")
 
 
 def deploy_slits(
@@ -728,24 +728,24 @@ def deploy_slits(
     slits_path = discover_slits_json(obs_dir, obs_name)
 
     if not slits_path:
-        print(f"Error: Slit file not found: {obs_dir / f'{obs_name}_slits.json'}")
-        print(f"Generate it first with: cfpipe nirspec slits --obs {obs_name}")
+        console.print(f"Error: Slit file not found: {obs_dir / f'{obs_name}_slits.json'}")
+        console.print(f"Generate it first with: cfpipe nirspec slits --obs {obs_name}")
         return
 
     slits_data = load_slits_json(slits_path)
-    print(f"Found {len(slits_data)} slit records")
+    console.print(f"Found {len(slits_data)} slit records")
 
     if dry_run:
-        print("=== DRY RUN ===")
-        print(f"Would delete existing slit_regions for '{obs_name}'")
-        print(f"Would insert {len(slits_data)} rows")
+        console.print("=== DRY RUN ===")
+        console.print(f"Would delete existing slit_regions for '{obs_name}'")
+        console.print(f"Would insert {len(slits_data)} rows")
         return
 
     sb = get_supabase_client(config)
 
-    print("Deploying slits...")
+    console.print("Deploying slits...")
     n = db_deploy_slits(sb, obs_name, slits_data)
-    print(f"Deployed {n} slit records for {obs_name}")
+    console.print(f"Deployed {n} slit records for {obs_name}")
 
 
 def deploy_shutters(
@@ -760,24 +760,24 @@ def deploy_shutters(
     ecsv_path = discover_shutters_ecsv(obs_dir, obs_name)
 
     if not ecsv_path:
-        print(f"Error: Shutters file not found: {obs_dir / f'{obs_name}_shutters.ecsv'}")
-        print(f"Generate it first with: cfpipe nirspec summary --obs {obs_name}")
+        console.print(f"Error: Shutters file not found: {obs_dir / f'{obs_name}_shutters.ecsv'}")
+        console.print(f"Generate it first with: cfpipe nirspec summary --obs {obs_name}")
         return
 
     shutters_data = load_shutters_ecsv(ecsv_path)
     n_sources = len(set(r['object_id'] for r in shutters_data))
-    print(f"Found {len(shutters_data)} shutter records ({n_sources} sources)")
+    console.print(f"Found {len(shutters_data)} shutter records ({n_sources} sources)")
 
     # Astrometric correction: align MSA coordinates to imaging reference frame
     if skip_astrometry:
-        print("Skipping astrometry correction (--skip-astrometry)")
+        console.print("Skipping astrometry correction (--skip-astrometry)")
     else:
         import tomllib
         from campfire.deploy.astrometry import correct_shutter_positions
 
         field = resolve_field(obs_name)
         if not field:
-            print("  Could not determine field, skipping astrometry")
+            console.print("  Could not determine field, skipping astrometry")
         else:
             imaging_path = resolve_imaging_config()
             with open(imaging_path, 'rb') as f:
@@ -786,20 +786,20 @@ def deploy_shutters(
                 shutters_data, obs_dir, obs_name, field, imaging_config,
             )
             if n_corrected:
-                print(f"  Astrometry: corrected {n_corrected} shutters "
+                console.print(f"  Astrometry: corrected {n_corrected} shutters "
                       f"({n_matches} catalog cross-matches)")
 
     if dry_run:
-        print("=== DRY RUN ===")
-        print(f"Would delete existing shutters for '{obs_name}'")
-        print(f"Would insert {len(shutters_data)} rows")
+        console.print("=== DRY RUN ===")
+        console.print(f"Would delete existing shutters for '{obs_name}'")
+        console.print(f"Would insert {len(shutters_data)} rows")
         return
 
     sb = get_supabase_client(config)
 
-    print("Deploying shutters...")
+    console.print("Deploying shutters...")
     n = db_deploy_shutters(sb, obs_name, shutters_data)
-    print(f"Deployed {n} shutter records for {obs_name}")
+    console.print(f"Deployed {n} shutter records for {obs_name}")
 
 
 def fetch_config(
@@ -830,7 +830,7 @@ def fetch_config(
     result = fetch_deployment_config(sb, obs_name)
 
     if result is None:
-        print(f"Error: Observation '{obs_name}' not found or has no deployment record.")
+        console.print(f"Error: Observation '{obs_name}' not found or has no deployment record.")
         return
 
     obs_data = result['observation']
@@ -874,14 +874,14 @@ def fetch_config(
     files_written.append(obs_path)
 
     # Summary
-    print(f"Fetched config for '{obs_name}':")
+    console.print(f"Fetched config for '{obs_name}':")
     for p in files_written:
-        print(f"  {p}")
+        console.print(f"  {p}")
 
-    print(f"\nDeployment #{dep_data.get('id')}:")
-    print(f"  Deployed by: {dep_data.get('deployed_by', 'unknown')}")
-    print(f"  Deployed at: {dep_data.get('deployed_at', 'unknown')}")
-    print(f"  Reduced at:  {dep_data.get('reduced_at', 'unknown')}")
-    print(f"  cfpipe:      {dep_data.get('cfpipe_version', 'unknown')}")
-    print(f"  jwst:        {dep_data.get('jwst_version', 'unknown')}")
-    print(f"  CRDS:        {dep_data.get('crds_context', 'unknown')}")
+    console.print(f"\nDeployment #{dep_data.get('id')}:")
+    console.print(f"  Deployed by: {dep_data.get('deployed_by', 'unknown')}")
+    console.print(f"  Deployed at: {dep_data.get('deployed_at', 'unknown')}")
+    console.print(f"  Reduced at:  {dep_data.get('reduced_at', 'unknown')}")
+    console.print(f"  cfpipe:      {dep_data.get('cfpipe_version', 'unknown')}")
+    console.print(f"  jwst:        {dep_data.get('jwst_version', 'unknown')}")
+    console.print(f"  CRDS:        {dep_data.get('crds_context', 'unknown')}")

--- a/python/campfire/deploy/r2.py
+++ b/python/campfire/deploy/r2.py
@@ -16,7 +16,8 @@ from pathlib import Path
 from typing import NamedTuple, Optional
 
 import requests as http_requests
-from tqdm import tqdm
+
+from campfire.output import console, progress_bar
 
 
 class UploadTask(NamedTuple):
@@ -111,7 +112,7 @@ def request_presigned_urls(
             data = resp.json()
             all_urls.update(data['urls'])
         except Exception as e:
-            print(f"  Warning: Presign request failed: {e}")
+            console.print(f"  Warning: Presign request failed: {e}")
             return None
 
     return all_urls
@@ -170,7 +171,7 @@ def upload_files_presigned(
             if task.r2_key in urls
         }
 
-        with tqdm(total=len(future_to_task), desc=desc, unit='file') as pbar:
+        with progress_bar(total=len(future_to_task), description=desc) as pbar:
             for future in as_completed(future_to_task):
                 task = future_to_task[future]
                 try:
@@ -257,7 +258,7 @@ def upload_files_direct(
             for task in tasks
         }
 
-        with tqdm(total=len(tasks), desc=desc, unit='file') as pbar:
+        with progress_bar(total=len(tasks), description=desc) as pbar:
             for future in as_completed(future_to_task):
                 task = future_to_task[future]
                 try:
@@ -358,7 +359,7 @@ def upload_files_parallel(
                 for task in tasks
             }
 
-            with tqdm(total=len(tasks), desc=desc, unit='file') as pbar:
+            with progress_bar(total=len(tasks), description=desc) as pbar:
                 for future in as_completed(future_to_task):
                     task = future_to_task[future]
                     try:

--- a/python/campfire/deploy/tiles.py
+++ b/python/campfire/deploy/tiles.py
@@ -12,8 +12,6 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-from tqdm import tqdm
-
 logger = logging.getLogger(__name__)
 
 

--- a/python/campfire/deploy/tiles_engine.py
+++ b/python/campfire/deploy/tiles_engine.py
@@ -42,11 +42,22 @@ try:
 except ImportError:
     import tomli as tomllib
 
-try:
-    from tqdm import tqdm
-except ImportError:
-    def tqdm(iterable, **kwargs):
-        return iterable
+from campfire.output import track as _track, progress_bar as _progress_bar
+
+
+def tqdm(iterable=None, **kwargs):
+    """Compatibility shim: routes to Rich track() or progress_bar()."""
+    if iterable is not None:
+        return _track(
+            iterable,
+            description=kwargs.get("desc", ""),
+            total=kwargs.get("total"),
+        )
+    # Standalone mode (total= given, no iterable) — return a progress bar
+    return _progress_bar(
+        total=kwargs.get("total"),
+        description=kwargs.get("desc", ""),
+    )
 
 
 # ============================================

--- a/python/campfire/output.py
+++ b/python/campfire/output.py
@@ -1,0 +1,216 @@
+"""
+Rich output utilities for the CAMPFIRE CLI.
+
+Provides styled terminal output with automatic plain-text fallback
+when stdout is not a tty (piped, redirected, or CI).
+
+Usage::
+
+    from campfire.output import console, print_success, print_error, track, progress_bar
+
+    print_success("Sync complete: 42 targets")
+    print_error("Authentication failed")
+
+    for item in track(items, description="Processing"):
+        process(item)
+
+    with progress_bar(total=100, description="Uploading") as pb:
+        for chunk in chunks:
+            upload(chunk)
+            pb.update(1)
+"""
+
+import sys
+
+from rich.console import Console
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    TimeRemainingColumn,
+    track as _rich_track,
+)
+from rich.table import Table
+
+# Shared console instances — Rich auto-detects tty and strips ANSI when piped.
+console = Console(highlight=False)
+error_console = Console(stderr=True, highlight=False)
+
+
+def is_tty() -> bool:
+    """Check if stdout is an interactive terminal."""
+    return console.is_terminal
+
+
+# ---------------------------------------------------------------------------
+# Styled message helpers (replace click.echo with ✓/✗/⚠ glyphs)
+# ---------------------------------------------------------------------------
+
+def print_success(msg: str) -> None:
+    """Print a success message with green ✓."""
+    console.print(f"[green]✓[/green] {msg}")
+
+
+def print_error(msg: str) -> None:
+    """Print an error message with red ✗ to stderr."""
+    error_console.print(f"[red]✗[/red] {msg}")
+
+
+def print_warning(msg: str) -> None:
+    """Print a warning with yellow ⚠."""
+    console.print(f"[yellow]⚠[/yellow]  {msg}")
+
+
+def print_msg(msg: str = "") -> None:
+    """Print a plain message (replaces click.echo / bare print)."""
+    console.print(msg)
+
+
+# ---------------------------------------------------------------------------
+# Tables
+# ---------------------------------------------------------------------------
+
+def make_table(*columns: str, title: str | None = None, padding: tuple = (0, 2)) -> Table:
+    """Create a Rich Table pre-configured with column headers."""
+    table = Table(
+        title=title,
+        show_header=True,
+        header_style="bold",
+        padding=padding,
+        box=None,
+    )
+    for col in columns:
+        table.add_column(col)
+    return table
+
+
+# ---------------------------------------------------------------------------
+# Progress bars (replace tqdm everywhere)
+# ---------------------------------------------------------------------------
+
+_PROGRESS_COLUMNS = (
+    SpinnerColumn(),
+    TextColumn("[progress.description]{task.description}"),
+    BarColumn(),
+    MofNCompleteColumn(),
+    TimeRemainingColumn(),
+)
+
+
+def track(iterable, description: str = "", total: int | None = None):
+    """Drop-in replacement for ``for x in tqdm(iterable, ...)``.
+
+    In non-tty mode, returns the iterable unchanged (no progress display).
+    """
+    if not is_tty():
+        return iterable
+
+    return _rich_track(
+        iterable,
+        description=description,
+        total=total,
+        console=console,
+    )
+
+
+class _NoOpProgressBar:
+    """Silent progress bar for non-tty contexts."""
+
+    def __init__(self, total=None, **kwargs):
+        self.total = total or 0
+        self.n = 0
+
+    def update(self, n=1):
+        self.n += n
+
+    def refresh(self):
+        pass
+
+    def close(self):
+        pass
+
+    def write(self, msg):
+        console.print(msg)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+class _RichProgressBar:
+    """Thin tqdm-like wrapper around ``rich.progress.Progress``.
+
+    Supports both context-manager and standalone (create → update → close)
+    usage, plus dynamic total adjustment via ``.total`` / ``.n`` / ``.refresh()``.
+    """
+
+    def __init__(self, total=None, description="", transient=False):
+        self._progress = Progress(
+            *_PROGRESS_COLUMNS,
+            console=console,
+            transient=transient,
+        )
+        self._description = description
+        self._task_id = None
+        self._started = False
+        self.n = 0
+        self.total = total
+
+    def _ensure_started(self):
+        if not self._started:
+            self._progress.start()
+            self._task_id = self._progress.add_task(
+                self._description, total=self.total,
+            )
+            self._started = True
+
+    def update(self, n=1):
+        self._ensure_started()
+        self.n += n
+        self._progress.advance(self._task_id, n)
+
+    def refresh(self):
+        """Sync the display with current ``.total`` and ``.n`` values."""
+        self._ensure_started()
+        self._progress.update(
+            self._task_id, total=self.total, completed=self.n,
+        )
+
+    def close(self):
+        if self._started:
+            self._progress.stop()
+            self._started = False
+
+    def write(self, msg):
+        """Print a message without disturbing the progress bar."""
+        if self._started:
+            self._progress.console.print(msg)
+        else:
+            console.print(msg)
+
+    def __enter__(self):
+        self._ensure_started()
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
+def progress_bar(total=None, description: str = "", transient: bool = False):
+    """Create a progress bar.
+
+    Returns an object with ``.update(n)``, ``.close()``, settable ``.total``
+    and ``.n``, and ``.refresh()`` for dynamic-total patterns.  Works as a
+    context manager (auto-closes on exit).
+
+    In non-tty mode returns a silent no-op.
+    """
+    if not is_tty():
+        return _NoOpProgressBar(total=total)
+    return _RichProgressBar(
+        total=total, description=description, transient=transient,
+    )

--- a/python/campfire/sync.py
+++ b/python/campfire/sync.py
@@ -11,9 +11,9 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 import requests
-from tqdm import tqdm
 
 from .api.session import create_download_session
+from .output import print_error, progress_bar
 from .exceptions import DownloadError
 
 
@@ -27,10 +27,10 @@ def compute_file_hash(path: Path) -> str:
 
 
 def _make_progress(show, unit, desc):
-    """Create a tqdm progress bar and page-complete callback."""
+    """Create a Rich progress bar and page-complete callback."""
     if not show:
         return None, None
-    pbar = tqdm(unit=unit, desc=desc)
+    pbar = progress_bar(description=desc)
 
     def callback(fetched, total):
         pbar.total = total
@@ -374,7 +374,7 @@ def download_observation(
             for spec in to_download
         }
 
-        with tqdm(total=len(to_download), desc=obs_name, unit="file") as pbar:
+        with progress_bar(total=len(to_download), description=obs_name) as pbar:
             for future in as_completed(future_to_spec):
                 spec = future_to_spec[future]
                 try:
@@ -395,7 +395,7 @@ def download_observation(
                     bytes_downloaded += result.get("file_size") or 0
                 except Exception as e:
                     stats["failed"] += 1
-                    tqdm.write(f"  Failed: {spec['fits_path']}: {e}")
+                    pbar.write(f"  Failed: {spec['fits_path']}: {e}")
                 pbar.update(1)
 
     store.log_sync_complete(log_id, stats["downloaded"], stats["skipped"], bytes_downloaded)

--- a/python/campfire/sync.py
+++ b/python/campfire/sync.py
@@ -13,7 +13,7 @@ from typing import Dict, List, Optional, Tuple
 import requests
 
 from .api.session import create_download_session
-from .output import print_error, progress_bar
+from .output import progress_bar
 from .exceptions import DownloadError
 
 
@@ -297,6 +297,7 @@ def download_observation(
     download_session: Optional[requests.Session] = None,
     manifest: Optional[dict] = None,
     grating_filter: Optional[List[str]] = None,
+    show_progress: bool = True,
 ) -> dict:
     """Download FITS files for a single observation.
 
@@ -320,6 +321,9 @@ def download_observation(
         Pre-fetched manifest (avoids re-fetching if caller already has it).
     grating_filter : list of str, optional
         Only download spectra matching these gratings.
+    show_progress : bool
+        Show a Rich progress bar during download. Set False when called
+        from the Textual TUI to avoid corrupting the display.
 
     Returns
     -------
@@ -374,29 +378,37 @@ def download_observation(
             for spec in to_download
         }
 
-        with progress_bar(total=len(to_download), description=obs_name) as pbar:
-            for future in as_completed(future_to_spec):
-                spec = future_to_spec[future]
-                try:
-                    result = future.result()
-                    store.mark_synced(
-                        result["spectra_id"],
-                        result["target_id"],
-                        obs_name,
-                        result["grating"],
-                        result["fits_path"],
-                        result["local_path"],
-                        result["file_hash"],
-                        result["file_size"],
-                        local_file_mtime=result.get("local_file_mtime"),
-                        local_file_size=result.get("local_file_size"),
-                    )
-                    stats["downloaded"] += 1
-                    bytes_downloaded += result.get("file_size") or 0
-                except Exception as e:
-                    stats["failed"] += 1
+        pbar = progress_bar(total=len(to_download), description=obs_name) if show_progress else None
+        if pbar:
+            pbar._ensure_started()
+
+        for future in as_completed(future_to_spec):
+            spec = future_to_spec[future]
+            try:
+                result = future.result()
+                store.mark_synced(
+                    result["spectra_id"],
+                    result["target_id"],
+                    obs_name,
+                    result["grating"],
+                    result["fits_path"],
+                    result["local_path"],
+                    result["file_hash"],
+                    result["file_size"],
+                    local_file_mtime=result.get("local_file_mtime"),
+                    local_file_size=result.get("local_file_size"),
+                )
+                stats["downloaded"] += 1
+                bytes_downloaded += result.get("file_size") or 0
+            except Exception as e:
+                stats["failed"] += 1
+                if pbar:
                     pbar.write(f"  Failed: {spec['fits_path']}: {e}")
+            if pbar:
                 pbar.update(1)
+
+        if pbar:
+            pbar.close()
 
     store.log_sync_complete(log_id, stats["downloaded"], stats["skipped"], bytes_downloaded)
     return stats

--- a/python/campfire/tui.py
+++ b/python/campfire/tui.py
@@ -46,7 +46,6 @@ def _get_store():
 def _fetch_status_data() -> dict:
     """Collect status data (credentials, catalog, disk usage)."""
     from .auth.credentials import CredentialManager
-    from .config import resolve_data_dir
     from .sync import format_size
 
     result = {
@@ -88,18 +87,14 @@ def _fetch_status_data() -> dict:
         result["stale_count"] = len(store.get_stale_files())
         store.close()
 
-    data_dir = resolve_data_dir()
-    if data_dir.exists():
-        total = sum(f.stat().st_size for f in data_dir.rglob("*") if f.is_file())
-        result["disk_usage"] = format_size(total)
+    # Skip disk usage scan — too slow for large data directories with FITS files.
+    # The CLI `campfire status` can afford the wait; the TUI cannot block on mount.
 
     return result
 
 
 def _fetch_observation_summary() -> list[dict]:
     """Get the observation summary table data."""
-    from .sync import format_size
-
     store = _get_store()
     if not store:
         return []
@@ -205,9 +200,9 @@ class StatusPanel(Static):
     @work(thread=True)
     def refresh_data(self) -> None:
         data = _fetch_status_data()
-        self.app.call_from_thread(self._render, data)
+        self.app.call_from_thread(self._show_status, data)
 
-    def _render(self, data: dict) -> None:
+    def _show_status(self, data: dict) -> None:
         lines = []
         if data["logged_in"]:
             user = data["email"] or "authenticated"

--- a/python/campfire/tui.py
+++ b/python/campfire/tui.py
@@ -168,6 +168,7 @@ def _run_download(obs_name: str, on_status) -> dict | None:
             _products_dir(), store,
             max_workers=4,
             download_session=dl_session,
+            show_progress=False,
         )
         return stats
     except Exception as e:

--- a/python/campfire/tui.py
+++ b/python/campfire/tui.py
@@ -1,0 +1,436 @@
+"""
+Textual TUI dashboard for CAMPFIRE.
+
+Launched when ``campfire`` is run with no arguments in an interactive terminal.
+Provides a status panel, sync controls, and an observation browser with
+inline download triggering.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from rich.text import Text
+from textual import work
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.widgets import (
+    Button,
+    DataTable,
+    Footer,
+    Header,
+    Label,
+    Static,
+)
+
+
+# ---------------------------------------------------------------------------
+# Data helpers (run blocking I/O in thread via asyncio executor)
+# ---------------------------------------------------------------------------
+
+def _get_store():
+    """Open a read-only LocalStore, or None if DB doesn't exist."""
+    from .config import ensure_data_dir, meta_dir
+    from .db.store import LocalStore, SchemaMismatchError
+
+    ensure_data_dir()
+    db_path = meta_dir() / "campfire.db"
+    if not db_path.exists():
+        return None
+    try:
+        return LocalStore(db_path)
+    except SchemaMismatchError:
+        return None
+
+
+def _fetch_status_data() -> dict:
+    """Collect status data (credentials, catalog, disk usage)."""
+    from .auth.credentials import CredentialManager
+    from .config import resolve_data_dir
+    from .sync import format_size
+
+    result = {
+        "logged_in": False,
+        "email": None,
+        "observations": 0,
+        "last_synced": None,
+        "obs_stats": [],
+        "stale_count": 0,
+        "disk_usage": None,
+    }
+
+    creds = CredentialManager()
+    if creds.exists():
+        loaded = creds.load()
+        if loaded:
+            result["logged_in"] = True
+            if loaded.is_oauth() and loaded.user_email:
+                result["email"] = loaded.user_email
+
+    store = _get_store()
+    if store:
+        obs_list = store.get_synced_observations()
+        result["observations"] = len(obs_list)
+
+        last = store.get_last_synced_at()
+        if last:
+            result["last_synced"] = last[:16].replace("T", " ")
+
+        for obs in obs_list:
+            stats = store.get_observation_stats(obs)
+            if stats["synced_count"] > 0:
+                result["obs_stats"].append({
+                    "observation": obs,
+                    "downloaded": stats["synced_count"],
+                    "size": format_size(stats["total_bytes"]),
+                })
+
+        result["stale_count"] = len(store.get_stale_files())
+        store.close()
+
+    data_dir = resolve_data_dir()
+    if data_dir.exists():
+        total = sum(f.stat().st_size for f in data_dir.rglob("*") if f.is_file())
+        result["disk_usage"] = format_size(total)
+
+    return result
+
+
+def _fetch_observation_summary() -> list[dict]:
+    """Get the observation summary table data."""
+    from .sync import format_size
+
+    store = _get_store()
+    if not store:
+        return []
+    summary = store.get_observation_summary()
+    store.close()
+    return summary
+
+
+def _run_sync(on_status) -> dict | None:
+    """Run sync_metadata synchronously (called from a worker thread)."""
+    from .api.session import APISession, resolve_base_url
+    from .api.client import APIClient
+    from .config import meta_dir as _meta_dir
+    from .exceptions import AuthenticationError
+    from .sync import sync_metadata
+
+    base_url = resolve_base_url()
+    try:
+        api_session = APISession(base_url=base_url)
+        api = APIClient(api_session)
+    except AuthenticationError:
+        on_status("Not logged in. Run: campfire login")
+        return None
+
+    store = _get_store()
+    if not store:
+        on_status("No local database. Run: campfire sync first.")
+        return None
+
+    try:
+        on_status("Syncing catalog...")
+        result = sync_metadata(
+            api, store, _meta_dir(),
+            show_progress=False,
+            full=False,
+        )
+        return result
+    except Exception as e:
+        on_status(f"Sync failed: {e}")
+        return None
+    finally:
+        store.close()
+
+
+def _run_download(obs_name: str, on_status) -> dict | None:
+    """Download files for a single observation (called from a worker thread)."""
+    from .api.session import APISession, resolve_base_url, create_download_session
+    from .api.client import APIClient
+    from .config import products_dir as _products_dir
+    from .exceptions import AuthenticationError
+    from .sync import download_observation
+
+    base_url = resolve_base_url()
+    try:
+        api_session = APISession(base_url=base_url)
+        api = APIClient(api_session)
+    except AuthenticationError:
+        on_status("Not logged in.")
+        return None
+
+    store = _get_store()
+    if not store:
+        on_status("No local database.")
+        return None
+
+    try:
+        on_status(f"Downloading {obs_name}...")
+        dl_session = create_download_session(max_workers=4)
+        stats = download_observation(
+            api, obs_name,
+            _products_dir(), store,
+            max_workers=4,
+            download_session=dl_session,
+        )
+        return stats
+    except Exception as e:
+        on_status(f"Download failed: {e}")
+        return None
+    finally:
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# Widgets
+# ---------------------------------------------------------------------------
+
+class StatusPanel(Static):
+    """Displays credential validity, catalog stats, and disk usage."""
+
+    DEFAULT_CSS = """
+    StatusPanel {
+        height: auto;
+        max-height: 12;
+        padding: 0 1;
+        border: solid $primary;
+    }
+    """
+
+    def on_mount(self) -> None:
+        self.loading = True
+        self.refresh_data()
+
+    @work(thread=True)
+    def refresh_data(self) -> None:
+        data = _fetch_status_data()
+        self.app.call_from_thread(self._render, data)
+
+    def _render(self, data: dict) -> None:
+        lines = []
+        if data["logged_in"]:
+            user = data["email"] or "authenticated"
+            lines.append(f"[green]✓[/green] Logged in as {user}")
+        else:
+            lines.append("[red]✗[/red] Not logged in")
+
+        obs_count = data["observations"]
+        last = data["last_synced"]
+        if obs_count:
+            ts = f" (synced {last})" if last else ""
+            lines.append(f"  Catalog: {obs_count} observations{ts}")
+        else:
+            lines.append("  No catalog — run [bold]campfire sync[/bold]")
+
+        if data["stale_count"]:
+            lines.append(f"  [yellow]⚠[/yellow] {data['stale_count']} stale file(s)")
+
+        if data["disk_usage"]:
+            lines.append(f"  Disk usage: {data['disk_usage']}")
+
+        self.update(Text.from_markup("\n".join(lines)))
+        self.loading = False
+
+
+class SyncPanel(Static):
+    """Sync controls: trigger catalog sync and show status."""
+
+    DEFAULT_CSS = """
+    SyncPanel {
+        height: auto;
+        max-height: 6;
+        padding: 0 1;
+        border: solid $accent;
+        layout: horizontal;
+    }
+    SyncPanel Button {
+        margin: 0 2 0 0;
+        min-width: 16;
+    }
+    SyncPanel Label {
+        padding: 1 0;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Button("Sync Catalog", id="sync-btn", variant="primary")
+        yield Label("Press S or click to sync", id="sync-status")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "sync-btn":
+            self._start_sync()
+
+    def _start_sync(self) -> None:
+        btn = self.query_one("#sync-btn", Button)
+        btn.disabled = True
+        self._update_status("Syncing...")
+        self._do_sync()
+
+    @work(thread=True)
+    def _do_sync(self) -> None:
+        def on_status(msg):
+            self.app.call_from_thread(self._update_status, msg)
+
+        result = _run_sync(on_status)
+
+        if result:
+            msg = (f"✓ Synced: {result['targets']} targets, "
+                   f"{result['spectra']} spectra")
+            self.app.call_from_thread(self._sync_done, msg)
+        else:
+            self.app.call_from_thread(self._sync_done, None)
+
+    def _update_status(self, msg: str) -> None:
+        self.query_one("#sync-status", Label).update(msg)
+
+    def _sync_done(self, msg: str | None) -> None:
+        btn = self.query_one("#sync-btn", Button)
+        btn.disabled = False
+        if msg:
+            self._update_status(msg)
+        # Refresh other panels
+        try:
+            self.app.query_one(StatusPanel).refresh_data()
+            self.app.query_one(ObservationBrowser).refresh_data()
+        except Exception:
+            pass
+
+
+class ObservationBrowser(Static):
+    """Scrollable observation table with inline download."""
+
+    DEFAULT_CSS = """
+    ObservationBrowser {
+        height: 1fr;
+        border: solid $surface;
+    }
+    ObservationBrowser DataTable {
+        height: 1fr;
+    }
+    ObservationBrowser #dl-status {
+        height: 1;
+        padding: 0 1;
+        dock: bottom;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield DataTable(id="obs-table")
+        yield Label("", id="dl-status")
+
+    def on_mount(self) -> None:
+        table = self.query_one("#obs-table", DataTable)
+        table.cursor_type = "row"
+        table.add_columns("OBSERVATION", "PROGRAM", "FIELD", "SPECTRA", "LOCAL")
+        self.refresh_data()
+
+    @work(thread=True)
+    def refresh_data(self) -> None:
+        summary = _fetch_observation_summary()
+        self.app.call_from_thread(self._populate, summary)
+
+    def _populate(self, summary: list[dict]) -> None:
+        table = self.query_one("#obs-table", DataTable)
+        table.clear()
+        for row in summary:
+            downloaded = row["downloaded_count"]
+            total = row["spectrum_count"]
+            if downloaded >= total and total > 0:
+                local_str = f"{downloaded} (complete)"
+            elif downloaded > 0:
+                local_str = f"{downloaded}/{total}"
+            else:
+                local_str = ""
+            table.add_row(
+                row["observation"],
+                row["program_slug"],
+                row["field"],
+                str(total),
+                local_str,
+                key=row["observation"],
+            )
+
+    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        """Download files for the selected observation."""
+        obs_name = str(event.row_key.value)
+        status = self.query_one("#dl-status", Label)
+        status.update(f"Downloading {obs_name}...")
+        self._download(obs_name)
+
+    @work(thread=True)
+    def _download(self, obs_name: str) -> None:
+        def on_status(msg):
+            self.app.call_from_thread(
+                self.query_one("#dl-status", Label).update, msg
+            )
+
+        result = _run_download(obs_name, on_status)
+
+        if result:
+            dl = result.get("downloaded", 0)
+            failed = result.get("failed", 0)
+            msg = f"✓ {obs_name}: {dl} downloaded"
+            if failed:
+                msg += f", {failed} failed"
+            self.app.call_from_thread(
+                self.query_one("#dl-status", Label).update, msg
+            )
+            # Refresh to show updated local counts
+            self.refresh_data()
+            try:
+                self.app.query_one(StatusPanel).refresh_data()
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+class CampfireApp(App):
+    """CAMPFIRE interactive dashboard."""
+
+    TITLE = "CAMPFIRE"
+    SUB_TITLE = "NIRSpec Data Portal"
+
+    CSS = """
+    Screen {
+        layout: vertical;
+    }
+    """
+
+    BINDINGS = [
+        Binding("q", "quit", "Quit"),
+        Binding("r", "refresh", "Refresh"),
+        Binding("s", "sync", "Sync"),
+    ]
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield StatusPanel()
+        yield SyncPanel()
+        yield ObservationBrowser()
+        yield Footer()
+
+    def action_refresh(self) -> None:
+        """Refresh all panels."""
+        self.query_one(StatusPanel).refresh_data()
+        self.query_one(ObservationBrowser).refresh_data()
+
+    def action_sync(self) -> None:
+        """Trigger catalog sync."""
+        self.query_one(SyncPanel)._start_sync()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def launch_tui() -> None:
+    """Launch the TUI, or print a message if not in a terminal."""
+    if not sys.stdout.isatty():
+        print("TUI requires an interactive terminal. Run 'campfire --help' for CLI usage.")
+        return
+    app = CampfireApp()
+    app.run()

--- a/python/campfire/tui.py
+++ b/python/campfire/tui.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 import sys
 
 from rich.text import Text
-from textual import work
 from textual.app import App, ComposeResult
+from textual import work
 from textual.binding import Binding
 from textual.widgets import (
     Button,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -29,7 +29,8 @@ dependencies = [
     "requests>=2.28.0",
     "astropy>=6.0",
     "numpy>=1.24.0",
-    "tqdm>=4.65.0",
+    "rich>=13.0",
+    "textual>=0.70.0",
     "packaging",
     "toml>=0.10",
     # Deploy DB operations


### PR DESCRIPTION
## Summary

- **Rich output**: Replace `click.echo`/`tqdm` with Rich across all `campfire` subcommands — styled ✓/✗/⚠ messages, Rich Tables (status, download listing), Rich Progress bars (sync, download, deploy uploads), status spinners (API key validation, auth polling)
- **Textual TUI**: Running `campfire` with no arguments launches an interactive dashboard with status panel, sync controls (button/keybinding), and observation browser (scrollable DataTable with inline download via Enter)
- **Plain fallback**: Both subcommand output and TUI launcher fall back to plain text when stdout is not a tty

### New files
- `python/campfire/output.py` — Rich utilities: `console`, `print_success/error/warning/msg`, `make_table()`, `track()`, `progress_bar()`
- `python/campfire/tui.py` — Textual app with `StatusPanel`, `SyncPanel`, `ObservationBrowser`

### Modified files
- `python/pyproject.toml` — add `rich>=13.0`, `textual>=0.70.0`; remove `tqdm`
- `python/campfire/cli.py` — Rich output for all commands + `invoke_without_command=True` TUI launch
- `python/campfire/sync.py` — tqdm → `progress_bar()`
- `python/campfire/db/store.py` — tqdm → `progress_bar()`
- `python/campfire/auth/device_flow.py` — Rich status spinner for auth polling
- `python/campfire/deploy/deploy.py` — `print()` → `console.print()`, `tqdm` → `track()`
- `python/campfire/deploy/r2.py` — tqdm → `progress_bar()`
- `python/campfire/deploy/cli.py` — `print()` → `console.print()`
- `python/campfire/deploy/tiles.py` — removed unused tqdm import
- `python/campfire/deploy/tiles_engine.py` — tqdm compatibility shim routing to Rich

## Test plan

- [ ] `campfire status` — styled ✓/✗ and Rich table for download stats
- [ ] `campfire sync` — Rich progress bar during catalog pull
- [ ] `campfire download` — Rich table for observation listing, Rich progress for file downloads
- [ ] `campfire status | cat` — plain text, no ANSI codes
- [ ] `campfire` (no args, in terminal) — launches Textual TUI
- [ ] `campfire` (no args, piped) — prints help text
- [ ] `campfire deploy --obs <x> --dry-run` — deploy output via `console.print()`
- [ ] `campfire login` — Rich spinner during auth flow

Generated with Claude Code