### PR TITLE
Add parent object link to spectrum detail page

### DIFF
--- a/web/app/nirspec/targets/[id]/page.tsx
+++ b/web/app/nirspec/targets/[id]/page.tsx
@@ -217,6 +217,18 @@ export default async function SpectrumDetailPage({ params, searchParams }: Spect
                     </Link>
                   </>
                 )}
+                {spectrum.parent_object_id && (
+                  <>
+                    <span>·</span>
+                    <span>Object:</span>
+                    <Link
+                      href={`/nirspec/objects/${encodeURIComponent(spectrum.parent_object_id)}`}
+                      className="inline-flex items-center hover:bg-gray-100 dark:hover:bg-slate-700 px-2 py-1 rounded transition-colors text-text-primary dark:text-slate-100"
+                    >
+                      {spectrum.parent_object_id}
+                    </Link>
+                  </>
+                )}
               </div>
               <div className="flex items-center gap-4">
                 <CoordinateDisplay ra={spectrum.ra} dec={spectrum.dec} />


### PR DESCRIPTION
## Summary
Added a clickable link to the parent object on the spectrum detail page, allowing users to navigate from a spectrum to its associated parent object.

## Key Changes
- Added conditional rendering of parent object information when `spectrum.parent_object_id` exists
- Displays the parent object ID as a linked element with consistent styling (separator, label, and link)
- Link navigates to `/nirspec/objects/{parent_object_id}` with proper URL encoding
- Styled to match existing UI patterns with hover effects and dark mode support

## Implementation Details
- The new section is placed alongside other spectrum metadata links
- Uses the same visual separator (·) and styling conventions as adjacent elements
- Includes responsive hover states and dark mode styling consistent with the rest of the page
- Parent object ID is URL-encoded to handle special characters safely

https://claude.ai/code/session_01Bz8VuRh8pEEtbME8MJXUZB