### PR TITLE
Add list member FK relinking after field object rebuild

### DIFF
--- a/python/campfire/deploy/objects.py
+++ b/python/campfire/deploy/objects.py
@@ -360,6 +360,23 @@ def _set_target_fks(
     return total
 
 
+def _relink_list_members(client: Client, field: str) -> dict:
+    """Re-link object_list_members.object_id after object rebuild.
+
+    List members are keyed by (ra, dec) which survive rebuilds. This
+    updates the object_id FK by spatial cross-matching against the
+    newly created objects (within 0.3 arcsec tolerance).
+
+    Returns dict with keys: relinked, orphaned, orphaned_details.
+    """
+    resp = client.rpc('relink_list_members_for_field', {
+        'p_field': field,
+    }).execute()
+    if isinstance(resp.data, dict):
+        return resp.data
+    return {'relinked': 0, 'orphaned': 0, 'orphaned_details': []}
+
+
 # ---------------------------------------------------------------------------
 # Reporting
 # ---------------------------------------------------------------------------
@@ -454,6 +471,18 @@ def rebuild_field_objects(
     print(f"  Setting target FK references...")
     n_fks = _set_target_fks(client, objects, object_id_to_db_id)
     print(f"    Updated {n_fks} targets")
+
+    print(f"  Re-linking list member FKs...")
+    relink_result = _relink_list_members(client, field)
+    n_relinked = relink_result.get('relinked', 0)
+    n_orphaned = relink_result.get('orphaned', 0)
+    if n_relinked:
+        print(f"    Re-linked {n_relinked} list members")
+    if n_orphaned:
+        print(f"    WARNING: {n_orphaned} orphaned list members (no object within 0.3\"):")
+        for detail in relink_result.get('orphaned_details', []):
+            print(f"      - List \"{detail['list_name']}\": "
+                  f"RA={detail['ra']:.6f}, Dec={detail['dec']:.6f}")
 
     print_rebuild_summary(objects, targets)
 


### PR DESCRIPTION
## Summary
This change adds functionality to re-link foreign keys in the `object_list_members` table after field objects are rebuilt. List members are identified by their (RA, Dec) coordinates which persist across rebuilds, but their `object_id` foreign keys need to be updated to point to the newly created objects.

## Key Changes
- **New function `_relink_list_members()`**: Calls a database RPC procedure (`relink_list_members_for_field`) to perform spatial cross-matching of list members against newly created objects within a 0.3 arcsecond tolerance. Returns statistics on relinked and orphaned members.

- **Integration into `rebuild_field_objects()`**: Added a new step in the rebuild workflow that:
  - Calls the relinking function after target FKs are updated
  - Reports the number of successfully relinked list members
  - Warns about orphaned list members (those without a matching object within tolerance) with detailed information including list name and coordinates

## Implementation Details
- The relinking is performed via RPC call to the database, allowing for efficient spatial queries
- Orphaned members are reported with their list name and precise RA/Dec coordinates to aid in debugging
- The function gracefully handles edge cases by returning default values if the RPC response is not a dictionary

https://claude.ai/code/session_019GFYyCEJbMfDv2Upsvhy9D