### PR TITLE
Batch field object deletion to avoid Supabase timeout

### DIFF
--- a/python/campfire/deploy/objects.py
+++ b/python/campfire/deploy/objects.py
@@ -282,13 +282,46 @@ def build_objects(
 # ---------------------------------------------------------------------------
 
 def _clear_field_objects(client: Client, field: str) -> None:
-    """Null target FKs and delete objects for a field."""
-    # Must null FKs first (FK constraint has no ON DELETE SET NULL)
-    client.table('targets').update(
-        {'object_id': None},
-    ).eq('field', field).not_.is_('object_id', 'null').execute()
+    """Null target FKs and delete objects for a field, in batches.
 
-    client.table('objects').delete().eq('field', field).execute()
+    Large fields (e.g. COSMOS with ~10k targets) exceed Supabase's
+    statement timeout when updated in a single call.  We fetch small
+    batches of IDs and update/delete them individually to stay within
+    the timeout.
+    """
+    # 1. Batch-null the target FK references
+    while True:
+        resp = (
+            client.table('targets')
+            .select('id')
+            .eq('field', field)
+            .not_.is_('object_id', 'null')
+            .order('id')
+            .limit(BATCH_SIZE)
+            .execute()
+        )
+        if not resp.data:
+            break
+        ids = [row['id'] for row in resp.data]
+        client.table('targets').update(
+            {'object_id': None},
+        ).in_('id', ids).execute()
+
+    # 2. Batch-delete objects (ON DELETE SET NULL cascades to
+    #    object_list_members, so large deletes can also time out)
+    while True:
+        resp = (
+            client.table('objects')
+            .select('id')
+            .eq('field', field)
+            .order('id')
+            .limit(BATCH_SIZE)
+            .execute()
+        )
+        if not resp.data:
+            break
+        ids = [row['id'] for row in resp.data]
+        client.table('objects').delete().in_('id', ids).execute()
 
 
 def _insert_objects(


### PR DESCRIPTION
## Summary
Modified `_clear_field_objects()` to process deletions in batches instead of single bulk operations, preventing statement timeouts when clearing large fields with thousands of objects.

## Key Changes
- Refactored target FK nullification to fetch and update objects in `BATCH_SIZE` chunks rather than a single query
- Refactored object deletion to similarly process in batches, fetching IDs first then deleting by ID
- Updated docstring to explain the batching rationale and mention the ON DELETE SET NULL cascade behavior

## Implementation Details
- Uses a loop pattern: fetch a batch of IDs with `.limit(BATCH_SIZE)`, process them, repeat until no more results
- Maintains the original constraint that FKs must be nulled before deletion (no ON DELETE SET NULL on targets.object_id)
- Acknowledges that large cascading deletes can also timeout, hence batching both operations
- Preserves ordering by ID to ensure deterministic batch processing

https://claude.ai/code/session_015AeMDSawEXQm6Z8vbkGts3