### PR TITLE
Add photometry to CSV exports and Python client sync

### DIFF
--- a/python/campfire/api/client.py
+++ b/python/campfire/api/client.py
@@ -376,6 +376,47 @@ class APIClient:
             "/sync/objects", updated_since, on_page_complete,
         )
 
+    def fetch_all_photometry(
+        self,
+        updated_since: Optional[str] = None,
+        on_page_complete: Optional[Callable[[int, int], None]] = None,
+    ) -> Tuple[List[dict], int]:
+        """Fetch all photometry records via the /sync/photometry endpoint.
+
+        Parameters
+        ----------
+        updated_since : str, optional
+            ISO 8601 timestamp. Only fetch records updated after this time.
+        on_page_complete : callable, optional
+            Callback ``(fetched_so_far, total)`` called after each page.
+
+        Returns
+        -------
+        (records, total_count)
+            The fetched photometry records and the total count.
+        """
+        all_items: List[dict] = []
+        offset = 0
+        total_count = 0
+        while True:
+            self._session._ensure_valid_token()
+            params: dict = {"limit": 1000, "offset": offset}
+            if updated_since:
+                params["updated_since"] = updated_since
+            response = self._session.get("/sync/photometry", params=params, timeout=60)
+            _handle_response_error(response, "fetching photometry")
+            data = response.json()
+            items = data.get("data", [])
+            all_items.extend(items)
+            total = data.get("pagination", {}).get("total", 0)
+            total_count = total
+            offset += len(items)
+            if on_page_complete:
+                on_page_complete(offset, total)
+            if offset >= total or not items:
+                break
+        return all_items, total_count
+
     def fetch_tags(self) -> List[dict]:
         """Fetch all tag metadata via the /sync/lists endpoint.
 

--- a/python/campfire/db/export.py
+++ b/python/campfire/db/export.py
@@ -1,11 +1,12 @@
 """CSV catalog export from SQLite database.
 
-Generates targets.csv, spectra.csv, and objects.csv as human-readable export
-artifacts from the LocalStore. These files are written atomically so they're
-always in a consistent state.
+Generates targets.csv, spectra.csv, objects.csv, and photometry.csv as
+human-readable export artifacts from the LocalStore. These files are written
+atomically so they're always in a consistent state.
 """
 
 import csv
+import json
 from pathlib import Path
 from typing import Tuple
 
@@ -14,11 +15,12 @@ from .store import (
     TARGET_EXPORT_COLUMNS,
     SPECTRA_EXPORT_COLUMNS,
     OBJECT_EXPORT_COLUMNS,
+    PHOTOMETRY_EXPORT_COLUMNS,
 )
 
 
 def export_catalogs(store: LocalStore, output_dir: Path) -> Tuple[int, int, int]:
-    """Export targets.csv, spectra.csv, and objects.csv from the local database.
+    """Export targets.csv, spectra.csv, objects.csv, and photometry.csv.
 
     Parameters
     ----------
@@ -82,7 +84,64 @@ def export_catalogs(store: LocalStore, output_dir: Path) -> Tuple[int, int, int]
 
     _atomic_csv_write(output_dir / "objects.csv", OBJECT_EXPORT_COLUMNS, object_rows)
 
+    # Export wide-format photometry
+    _export_photometry_csv(store, output_dir / "photometry.csv")
+
     return len(target_rows), len(spectra_rows), len(object_rows)
+
+
+def _export_photometry_csv(store: LocalStore, path: Path) -> None:
+    """Export photometry as a wide-format CSV with f_/e_ columns per band.
+
+    One row per object-catalog combination. Bands are sorted by wavelength
+    (using the ``wav`` field from the JSONB data). Missing bands get empty cells.
+    """
+    records = store.query_photometry()
+    if not records:
+        # Write empty file with just scalar headers
+        _atomic_csv_write(path, PHOTOMETRY_EXPORT_COLUMNS, [])
+        return
+
+    # First pass: collect all band names with their wavelengths
+    band_wavs: dict = {}
+    for rec in records:
+        phot = rec.get("photometry")
+        if not isinstance(phot, dict):
+            continue
+        bands = phot.get("bands", {})
+        for band_name, band_data in bands.items():
+            if band_name not in band_wavs:
+                wav = band_data.get("wav", float("inf"))
+                band_wavs[band_name] = wav
+
+    # Sort bands by wavelength, then alphabetically for ties
+    sorted_bands = sorted(band_wavs.keys(), key=lambda b: (band_wavs[b], b))
+
+    # Build columns: scalar fields + f_<band>, e_<band> for each band
+    columns = list(PHOTOMETRY_EXPORT_COLUMNS) + [
+        col for b in sorted_bands for col in (f"f_{b}", f"e_{b}")
+    ]
+
+    # Build rows
+    rows = []
+    for rec in records:
+        row = {col: rec.get(col) for col in PHOTOMETRY_EXPORT_COLUMNS}
+
+        phot = rec.get("photometry")
+        bands = phot.get("bands", {}) if isinstance(phot, dict) else {}
+
+        for band_name in sorted_bands:
+            data = bands.get(band_name)
+            if data:
+                row[f"f_{band_name}"] = data.get("flux")
+                row[f"e_{band_name}"] = data.get("flux_err")
+            else:
+                row[f"f_{band_name}"] = None
+                row[f"e_{band_name}"] = None
+
+        rows.append(row)
+
+    _atomic_csv_write(path, columns, rows)
 
 
 def _atomic_csv_write(path: Path, columns: list, rows: list) -> None:

--- a/python/campfire/db/store.py
+++ b/python/campfire/db/store.py
@@ -14,7 +14,7 @@ from typing import Dict, List, Optional, Tuple, Union
 
 # Schema version — bump when tables change.
 # Squashed to v1 on 2026-04-06; existing databases must be deleted and re-synced.
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 # Column lists used by both store and export
 TARGET_COLUMNS = [
@@ -53,6 +53,7 @@ OBJECT_COLUMNS = [
     "programs", "gratings",
     "max_snr", "max_exposure_time",
     "best_redshift", "best_redshift_quality",
+    "has_photometry", "photo_z", "photo_z_err_lo", "photo_z_err_hi",
     "member_target_ids",
     "created_at", "updated_at",
 ]
@@ -63,7 +64,22 @@ OBJECT_EXPORT_COLUMNS = [
     "n_targets", "n_spectra",
     "programs", "gratings",
     "max_snr", "max_exposure_time",
+    "has_photometry", "photo_z", "photo_z_err_lo", "photo_z_err_hi",
     "member_target_ids",
+]
+
+# Columns for the object_photometry table
+PHOTOMETRY_COLUMNS = [
+    "id", "object_id", "field", "catalog_name", "catalog_id",
+    "match_distance_arcsec", "photometry",
+    "photo_z", "photo_z_err_lo", "photo_z_err_hi", "has_pz",
+    "created_at", "updated_at",
+]
+
+PHOTOMETRY_EXPORT_COLUMNS = [
+    "object_id", "field", "catalog_name", "catalog_id",
+    "match_distance_arcsec",
+    "photo_z", "photo_z_err_lo", "photo_z_err_hi",
 ]
 
 
@@ -136,6 +152,10 @@ CREATE TABLE IF NOT EXISTS objects (
     max_exposure_time REAL,
     best_redshift REAL,
     best_redshift_quality INTEGER DEFAULT 0,
+    has_photometry INTEGER DEFAULT 0,
+    photo_z REAL,
+    photo_z_err_lo REAL,
+    photo_z_err_hi REAL,
     member_target_ids TEXT,
     created_at TEXT,
     updated_at TEXT,
@@ -144,6 +164,25 @@ CREATE TABLE IF NOT EXISTS objects (
 
 CREATE INDEX IF NOT EXISTS idx_objects_object_id ON objects(object_id);
 CREATE INDEX IF NOT EXISTS idx_objects_field ON objects(field);
+
+CREATE TABLE IF NOT EXISTS object_photometry (
+    id INTEGER PRIMARY KEY,
+    object_id TEXT,
+    field TEXT,
+    catalog_name TEXT,
+    catalog_id TEXT,
+    match_distance_arcsec REAL,
+    photometry TEXT,
+    photo_z REAL,
+    photo_z_err_lo REAL,
+    photo_z_err_hi REAL,
+    has_pz INTEGER DEFAULT 0,
+    created_at TEXT,
+    updated_at TEXT,
+    _synced_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_ophot_object_id ON object_photometry(object_id);
 
 CREATE TABLE IF NOT EXISTS spectra (
     spectra_id INTEGER PRIMARY KEY,
@@ -1156,9 +1195,10 @@ class LocalStore:
                      n_targets, n_spectra, programs, gratings,
                      max_snr, max_exposure_time,
                      best_redshift, best_redshift_quality,
+                     has_photometry, photo_z, photo_z_err_lo, photo_z_err_hi,
                      member_target_ids,
                      created_at, updated_at, _synced_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(object_id) DO UPDATE SET
                     field=excluded.field,
                     ra=excluded.ra, dec=excluded.dec,
@@ -1170,6 +1210,10 @@ class LocalStore:
                     max_exposure_time=excluded.max_exposure_time,
                     best_redshift=excluded.best_redshift,
                     best_redshift_quality=excluded.best_redshift_quality,
+                    has_photometry=excluded.has_photometry,
+                    photo_z=excluded.photo_z,
+                    photo_z_err_lo=excluded.photo_z_err_lo,
+                    photo_z_err_hi=excluded.photo_z_err_hi,
                     member_target_ids=excluded.member_target_ids,
                     updated_at=excluded.updated_at,
                     _synced_at=excluded._synced_at
@@ -1187,6 +1231,10 @@ class LocalStore:
                 obj.get("max_exposure_time"),
                 obj.get("best_redshift"),
                 obj.get("best_redshift_quality", 0),
+                1 if obj.get("has_photometry") else 0,
+                obj.get("photo_z"),
+                obj.get("photo_z_err_lo"),
+                obj.get("photo_z_err_hi"),
                 member_ids,
                 obj.get("created_at"),
                 obj.get("updated_at"),
@@ -1443,6 +1491,132 @@ class LocalStore:
         purged = cursor.rowcount
         self._conn.commit()
         return purged
+
+    # -------------------------------------------------------------------------
+    # Object photometry operations
+    # -------------------------------------------------------------------------
+
+    def upsert_photometry(self, records: List[dict]) -> int:
+        """Insert or update photometry records from the /sync/photometry endpoint.
+
+        Parameters
+        ----------
+        records : list of dict
+            Photometry records from the sync endpoint.
+
+        Returns
+        -------
+        int
+            Number of records upserted.
+        """
+        import json as _json
+
+        now = datetime.now(timezone.utc).isoformat()
+        count = 0
+
+        for rec in records:
+            phot = rec.get("photometry")
+            if isinstance(phot, dict):
+                phot = _json.dumps(phot)
+
+            self._conn.execute("""
+                INSERT INTO object_photometry
+                    (id, object_id, field, catalog_name, catalog_id,
+                     match_distance_arcsec, photometry,
+                     photo_z, photo_z_err_lo, photo_z_err_hi, has_pz,
+                     created_at, updated_at, _synced_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    object_id=excluded.object_id,
+                    field=excluded.field,
+                    catalog_name=excluded.catalog_name,
+                    catalog_id=excluded.catalog_id,
+                    match_distance_arcsec=excluded.match_distance_arcsec,
+                    photometry=excluded.photometry,
+                    photo_z=excluded.photo_z,
+                    photo_z_err_lo=excluded.photo_z_err_lo,
+                    photo_z_err_hi=excluded.photo_z_err_hi,
+                    has_pz=excluded.has_pz,
+                    updated_at=excluded.updated_at,
+                    _synced_at=excluded._synced_at
+            """, (
+                rec.get("id"),
+                rec.get("object_id"),
+                rec.get("field"),
+                rec.get("catalog_name"),
+                rec.get("catalog_id"),
+                rec.get("match_distance_arcsec"),
+                phot,
+                rec.get("photo_z"),
+                rec.get("photo_z_err_lo"),
+                rec.get("photo_z_err_hi"),
+                1 if rec.get("has_pz") else 0,
+                rec.get("created_at"),
+                rec.get("updated_at"),
+                now,
+            ))
+            count += 1
+
+        self._conn.commit()
+        return count
+
+    def get_max_photometry_updated_at(self) -> Optional[str]:
+        """Get the most recent server-side updated_at for photometry.
+
+        Used for incremental sync of the object_photometry table.
+        """
+        row = self._conn.execute(
+            "SELECT MAX(updated_at) FROM object_photometry"
+        ).fetchone()
+        return row[0] if row and row[0] else None
+
+    def purge_stale_photometry(self, sync_timestamp: str) -> int:
+        """Delete photometry records not seen in the latest full sync.
+
+        Parameters
+        ----------
+        sync_timestamp : str
+            ISO 8601 timestamp from the start of the sync.
+
+        Returns
+        -------
+        int
+            Number of records purged.
+        """
+        cursor = self._conn.execute(
+            "DELETE FROM object_photometry WHERE _synced_at < ?",
+            (sync_timestamp,),
+        )
+        purged = cursor.rowcount
+        self._conn.commit()
+        return purged
+
+    def query_photometry(self) -> List[dict]:
+        """Query all photometry records from local database.
+
+        Returns
+        -------
+        list of dict
+            Photometry records with deserialized JSONB.
+        """
+        import json as _json
+
+        rows = self._conn.execute(
+            "SELECT * FROM object_photometry ORDER BY object_id, catalog_name"
+        ).fetchall()
+
+        results = []
+        for row in rows:
+            rec = dict(row)
+            phot = rec.get("photometry")
+            if isinstance(phot, str):
+                try:
+                    rec["photometry"] = _json.loads(phot)
+                except (ValueError, TypeError):
+                    rec["photometry"] = None
+            results.append(rec)
+
+        return results
 
     # Deprecated aliases (old names → new names)
     upsert_objects = upsert_targets

--- a/python/campfire/sync.py
+++ b/python/campfire/sync.py
@@ -110,6 +110,35 @@ def _sync_objects(api, store, full, show_progress):
     return obj_count, purged
 
 
+def _sync_photometry(api, store, full, show_progress):
+    """Sync object photometry from the server.
+
+    Returns (record_count, purged_count).
+    """
+    updated_since = None
+    if not full:
+        updated_since = store.get_max_photometry_updated_at()
+
+    sync_timestamp = datetime.now(timezone.utc).isoformat()
+
+    pbar, callback = _make_progress(show_progress, "rec", "Photometry")
+
+    all_records, total_count = api.fetch_all_photometry(
+        updated_since=updated_since,
+        on_page_complete=callback,
+    )
+    if pbar:
+        pbar.close()
+
+    rec_count = store.upsert_photometry(all_records)
+
+    purged = 0
+    if updated_since is None:
+        purged = store.purge_stale_photometry(sync_timestamp)
+
+    return rec_count, purged
+
+
 def _sync_tags(api, store, show_progress):
     """Sync tag metadata from the server.
 
@@ -164,13 +193,16 @@ def sync_metadata(
     # 2. Sync sky-objects
     obj_count, obj_purged = _sync_objects(api, store, full, show_progress)
 
-    # 3. Sync tag metadata
+    # 3. Sync photometry
+    phot_count, phot_purged = _sync_photometry(api, store, full, show_progress)
+
+    # 4. Sync tag metadata
     tags_count = _sync_tags(api, store, show_progress)
 
-    # 4. Export CSVs (always full export from SQLite)
+    # 5. Export CSVs (always full export from SQLite)
     export_catalogs(store, meta_dir)
 
-    # 4. Detect stale local files
+    # 6. Detect stale local files
     stale = store.get_stale_files()
 
     result = {
@@ -179,6 +211,8 @@ def sync_metadata(
         "spectra": spec_count,
         "sky_objects": obj_count,
         "sky_objects_purged": obj_purged,
+        "photometry": phot_count,
+        "photometry_purged": phot_purged,
         "tags": tags_count,
         "stale_count": len(stale),
         "stale_files": stale,

--- a/supabase/migrations/20260413173125_add-has-photometry-to-target-functions.sql
+++ b/supabase/migrations/20260413173125_add-has-photometry-to-target-functions.sql
@@ -1,0 +1,1037 @@
+drop function if exists "public"."get_adjacent_targets"(p_current_target_id text, p_program_slugs text[], p_filter_programs text[], p_fields text[], p_gratings text[], p_gratings_mode text, p_observations text[], p_redshift_quality integer[], p_redshift_min double precision, p_redshift_max double precision, p_max_snr_min double precision, p_max_snr_max double precision, p_max_exposure_time_min double precision, p_max_exposure_time_max double precision, p_spectral_features integer, p_dq_flags integer, p_spectral_features_include_any integer, p_spectral_features_include_all integer, p_spectral_features_exclude integer, p_dq_flags_include_any integer, p_dq_flags_include_all integer, p_dq_flags_exclude integer, p_list_ids integer[], p_search text, p_inspected_only boolean, p_comment_search text, p_comment_search_scope text, p_comment_user_id uuid, p_coord_ra double precision, p_coord_dec double precision, p_radius_degrees double precision, p_sort_column text, p_sort_direction text);
+
+drop function if exists "public"."get_csv_export"(p_program_slugs text[], p_filter_programs text[], p_fields text[], p_gratings text[], p_gratings_mode text, p_observations text[], p_redshift_quality integer[], p_redshift_min double precision, p_redshift_max double precision, p_max_snr_min double precision, p_max_snr_max double precision, p_max_exposure_time_min double precision, p_max_exposure_time_max double precision, p_spectral_features_include_any integer, p_spectral_features_include_all integer, p_spectral_features_exclude integer, p_dq_flags_include_any integer, p_dq_flags_include_all integer, p_dq_flags_exclude integer, p_list_ids integer[], p_search text, p_inspected_only boolean, p_comment_search text, p_comment_search_scope text, p_comment_user_id uuid, p_coord_ra double precision, p_coord_dec double precision, p_radius_degrees double precision, p_sort_column text, p_sort_direction text);
+
+drop function if exists "public"."get_csv_export_spectra"(p_program_slugs text[], p_filter_programs text[], p_fields text[], p_gratings text[], p_gratings_mode text, p_observations text[], p_redshift_quality integer[], p_redshift_min double precision, p_redshift_max double precision, p_max_snr_min double precision, p_max_snr_max double precision, p_max_exposure_time_min double precision, p_max_exposure_time_max double precision, p_spectral_features_include_any integer, p_spectral_features_include_all integer, p_spectral_features_exclude integer, p_dq_flags_include_any integer, p_dq_flags_include_all integer, p_dq_flags_exclude integer, p_list_ids integer[], p_search text, p_inspected_only boolean, p_comment_search text, p_comment_search_scope text, p_comment_user_id uuid, p_coord_ra double precision, p_coord_dec double precision, p_radius_degrees double precision, p_sort_column text, p_sort_direction text);
+
+drop function if exists "public"."get_filtered_spectra_paginated"(p_program_slugs text[], p_filter_programs text[], p_fields text[], p_gratings text[], p_gratings_mode text, p_observations text[], p_redshift_quality integer[], p_redshift_min double precision, p_redshift_max double precision, p_max_snr_min double precision, p_max_snr_max double precision, p_max_exposure_time_min double precision, p_max_exposure_time_max double precision, p_spectral_features_include_any integer, p_spectral_features_include_all integer, p_spectral_features_exclude integer, p_dq_flags_include_any integer, p_dq_flags_include_all integer, p_dq_flags_exclude integer, p_list_ids integer[], p_search text, p_inspected_only boolean, p_comment_search text, p_comment_search_scope text, p_comment_user_id uuid, p_coord_ra double precision, p_coord_dec double precision, p_radius_degrees double precision, p_sort_column text, p_sort_direction text, p_page integer, p_page_size integer, p_include_thumbnails boolean);
+
+drop function if exists "public"."get_filtered_target_ids"(p_program_slugs text[], p_filter_programs text[], p_fields text[], p_gratings text[], p_gratings_mode text, p_observations text[], p_redshift_quality integer[], p_redshift_min double precision, p_redshift_max double precision, p_max_snr_min double precision, p_max_snr_max double precision, p_max_exposure_time_min double precision, p_max_exposure_time_max double precision, p_spectral_features_include_any integer, p_spectral_features_include_all integer, p_spectral_features_exclude integer, p_dq_flags_include_any integer, p_dq_flags_include_all integer, p_dq_flags_exclude integer, p_list_ids integer[], p_search text, p_inspected_only boolean, p_comment_search text, p_comment_search_scope text, p_comment_user_id uuid, p_coord_ra double precision, p_coord_dec double precision, p_radius_degrees double precision, p_sort_column text, p_sort_direction text, p_page integer, p_page_size integer, p_updated_since timestamp without time zone);
+
+drop function if exists "public"."get_filtered_targets_paginated"(p_program_slugs text[], p_filter_programs text[], p_fields text[], p_gratings text[], p_gratings_mode text, p_observations text[], p_redshift_quality integer[], p_redshift_min double precision, p_redshift_max double precision, p_max_snr_min double precision, p_max_snr_max double precision, p_max_exposure_time_min double precision, p_max_exposure_time_max double precision, p_spectral_features integer, p_dq_flags integer, p_spectral_features_include_any integer, p_spectral_features_include_all integer, p_spectral_features_exclude integer, p_dq_flags_include_any integer, p_dq_flags_include_all integer, p_dq_flags_exclude integer, p_list_ids integer[], p_search text, p_inspected_only boolean, p_comment_search text, p_comment_search_scope text, p_comment_user_id uuid, p_coord_ra double precision, p_coord_dec double precision, p_radius_degrees double precision, p_sort_column text, p_sort_direction text, p_page integer, p_page_size integer, p_include_thumbnails boolean, p_updated_since timestamp without time zone);
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_adjacent_targets(p_current_target_id text, p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_spectral_features integer DEFAULT NULL::integer, p_dq_flags integer DEFAULT NULL::integer, p_spectral_features_include_any integer DEFAULT NULL::integer, p_spectral_features_include_all integer DEFAULT NULL::integer, p_spectral_features_exclude integer DEFAULT NULL::integer, p_dq_flags_include_any integer DEFAULT NULL::integer, p_dq_flags_include_all integer DEFAULT NULL::integer, p_dq_flags_exclude integer DEFAULT NULL::integer, p_list_ids integer[] DEFAULT NULL::integer[], p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_has_photometry boolean DEFAULT NULL::boolean, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_sort_column text DEFAULT 'target_id'::text, p_sort_direction text DEFAULT 'asc'::text)
+ RETURNS TABLE(prev_target_id text, next_target_id text, current_index bigint, total_count bigint)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_sort_is_text BOOLEAN;
+  v_sf_include_any INTEGER;
+  v_sf_include_all INTEGER;
+  v_sf_exclude INTEGER;
+  v_dq_include_any INTEGER;
+  v_dq_include_all INTEGER;
+  v_dq_exclude INTEGER;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN v_gratings_mode := 'any'; END IF;
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
+  IF NOT (p_sort_column IN ('target_id', 'field', 'observation', 'ra', 'dec', 'redshift', 'redshift_quality', 'max_snr', 'max_exposure_time')
+       OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'target_id';
+  END IF;
+  IF v_coord_search_active THEN p_sort_column := 'distance'; p_sort_direction := 'asc'; END IF;
+  v_sort_is_text := p_sort_column IN ('target_id', 'field', 'observation');
+  v_sf_include_any := COALESCE(p_spectral_features_include_any, p_spectral_features);
+  v_sf_include_all := p_spectral_features_include_all;
+  v_sf_exclude := p_spectral_features_exclude;
+  v_dq_include_any := COALESCE(p_dq_flags_include_any, p_dq_flags);
+  v_dq_include_all := p_dq_flags_include_all;
+  v_dq_exclude := p_dq_flags_exclude;
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs))
+    INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN QUERY SELECT NULL::TEXT, NULL::TEXT, 0::BIGINT, 0::BIGINT;
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  WITH filtered_targets AS MATERIALIZED (
+    SELECT
+      t.target_id,
+      CASE WHEN v_coord_search_active THEN
+        2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(t.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(t.dec)) *
+          POWER(SIN(RADIANS(t.ra - p_coord_ra) / 2), 2)
+        )))
+      ELSE NULL END AS distance,
+      t.field, t.observation, t.ra, t.dec, t.redshift, t.redshift_quality, t.max_snr, t.max_exposure_time
+    FROM targets t
+    WHERE
+      t.program_slug = ANY(v_filtered_program_slugs)
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND EXISTS (SELECT 1 FROM spectra gs WHERE gs.target_id = t.target_id AND gs.grating = ANY(p_gratings)))
+        OR (v_gratings_mode = 'all' AND (SELECT COUNT(DISTINCT gs.grating) FROM spectra gs WHERE gs.target_id = t.target_id AND gs.grating = ANY(p_gratings)) = array_length(p_gratings, 1))
+        OR (v_gratings_mode = 'none' AND NOT EXISTS (SELECT 1 FROM spectra gs WHERE gs.target_id = t.target_id AND gs.grating = ANY(p_gratings)))
+      )
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR t.field = ANY(p_fields))
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR t.observation = ANY(p_observations))
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR t.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR t.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR t.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR t.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR t.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR t.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR t.max_exposure_time <= p_max_exposure_time_max)
+      AND (v_sf_include_any IS NULL OR (COALESCE(t.spectral_features, 0) & v_sf_include_any) != 0)
+      AND (v_sf_include_all IS NULL OR (COALESCE(t.spectral_features, 0) & v_sf_include_all) = v_sf_include_all)
+      AND (v_sf_exclude IS NULL OR (COALESCE(t.spectral_features, 0) & v_sf_exclude) = 0)
+      AND (v_dq_include_any IS NULL OR (COALESCE(t.dq_flags, 0) & v_dq_include_any) != 0)
+      AND (v_dq_include_all IS NULL OR (COALESCE(t.dq_flags, 0) & v_dq_include_all) = v_dq_include_all)
+      AND (v_dq_exclude IS NULL OR (COALESCE(t.dq_flags, 0) & v_dq_exclude) = 0)
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR t.object_id IN (
+          SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_search IS NULL OR t.target_id ILIKE '%' || p_search || '%')
+      AND (p_inspected_only IS NULL
+        OR (p_inspected_only = TRUE AND t.redshift_quality > 0)
+        OR (p_inspected_only = FALSE AND t.redshift_quality = 0))
+      AND (p_has_photometry IS NULL OR EXISTS (SELECT 1 FROM objects o WHERE o.id = t.object_id AND o.has_photometry = p_has_photometry))
+      AND (NOT v_comment_search_active OR EXISTS (
+        SELECT 1 FROM comments c WHERE c.target_id = t.id AND c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (p_comment_search_scope = 'everyone' OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id))
+      ))
+      AND (NOT v_coord_search_active OR (
+        t.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND t.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+      ))
+  ),
+  distance_filtered AS MATERIALIZED (
+    SELECT
+      ft.*,
+      CASE p_sort_column
+        WHEN 'target_id' THEN ft.target_id WHEN 'field' THEN ft.field WHEN 'observation' THEN ft.observation ELSE NULL
+      END AS sort_text,
+      CASE p_sort_column
+        WHEN 'ra' THEN ft.ra WHEN 'dec' THEN ft.dec WHEN 'redshift' THEN ft.redshift::DOUBLE PRECISION
+        WHEN 'redshift_quality' THEN ft.redshift_quality::DOUBLE PRECISION
+        WHEN 'max_snr' THEN ft.max_snr WHEN 'max_exposure_time' THEN ft.max_exposure_time
+        WHEN 'distance' THEN ft.distance ELSE NULL
+      END AS sort_num
+    FROM filtered_targets ft
+    WHERE NOT v_coord_search_active OR ft.distance <= p_radius_degrees
+  ),
+  current_tgt AS (
+    SELECT df.sort_text, df.sort_num, df.target_id FROM distance_filtered df WHERE df.target_id = p_current_target_id
+  )
+  SELECT
+    (SELECT df.target_id FROM distance_filtered df, current_tgt c
+     WHERE CASE WHEN v_sort_is_text THEN
+       (CASE WHEN p_sort_direction = 'asc' THEN df.sort_text < c.sort_text ELSE df.sort_text > c.sort_text END)
+       OR (df.sort_text IS NOT DISTINCT FROM c.sort_text AND df.target_id < c.target_id)
+       OR (df.sort_text IS NOT NULL AND c.sort_text IS NULL)
+     ELSE
+       (CASE WHEN p_sort_direction = 'asc' THEN df.sort_num < c.sort_num ELSE df.sort_num > c.sort_num END)
+       OR (df.sort_num IS NOT DISTINCT FROM c.sort_num AND df.target_id < c.target_id)
+       OR (df.sort_num IS NOT NULL AND c.sort_num IS NULL)
+     END
+     ORDER BY
+       CASE WHEN v_sort_is_text AND p_sort_direction = 'asc' THEN df.sort_text END DESC NULLS FIRST,
+       CASE WHEN v_sort_is_text AND p_sort_direction = 'desc' THEN df.sort_text END ASC NULLS FIRST,
+       CASE WHEN NOT v_sort_is_text AND p_sort_direction = 'asc' THEN df.sort_num END DESC NULLS FIRST,
+       CASE WHEN NOT v_sort_is_text AND p_sort_direction = 'desc' THEN df.sort_num END ASC NULLS FIRST,
+       df.target_id DESC
+     LIMIT 1
+    ) AS prev_target_id,
+    (SELECT df.target_id FROM distance_filtered df, current_tgt c
+     WHERE CASE WHEN v_sort_is_text THEN
+       (CASE WHEN p_sort_direction = 'asc' THEN df.sort_text > c.sort_text ELSE df.sort_text < c.sort_text END)
+       OR (df.sort_text IS NOT DISTINCT FROM c.sort_text AND df.target_id > c.target_id)
+       OR (c.sort_text IS NOT NULL AND df.sort_text IS NULL)
+     ELSE
+       (CASE WHEN p_sort_direction = 'asc' THEN df.sort_num > c.sort_num ELSE df.sort_num < c.sort_num END)
+       OR (df.sort_num IS NOT DISTINCT FROM c.sort_num AND df.target_id > c.target_id)
+       OR (c.sort_num IS NOT NULL AND df.sort_num IS NULL)
+     END
+     ORDER BY
+       CASE WHEN v_sort_is_text AND p_sort_direction = 'asc' THEN df.sort_text END ASC NULLS LAST,
+       CASE WHEN v_sort_is_text AND p_sort_direction = 'desc' THEN df.sort_text END DESC NULLS LAST,
+       CASE WHEN NOT v_sort_is_text AND p_sort_direction = 'asc' THEN df.sort_num END ASC NULLS LAST,
+       CASE WHEN NOT v_sort_is_text AND p_sort_direction = 'desc' THEN df.sort_num END DESC NULLS LAST,
+       df.target_id ASC
+     LIMIT 1
+    ) AS next_target_id,
+    CASE WHEN EXISTS (SELECT 1 FROM current_tgt) THEN (
+      SELECT COUNT(*) + 1
+      FROM distance_filtered df, current_tgt c
+      WHERE CASE WHEN v_sort_is_text THEN
+        (CASE WHEN p_sort_direction = 'asc' THEN df.sort_text < c.sort_text ELSE df.sort_text > c.sort_text END)
+        OR (df.sort_text IS NOT DISTINCT FROM c.sort_text AND df.target_id < c.target_id)
+        OR (df.sort_text IS NOT NULL AND c.sort_text IS NULL)
+      ELSE
+        (CASE WHEN p_sort_direction = 'asc' THEN df.sort_num < c.sort_num ELSE df.sort_num > c.sort_num END)
+        OR (df.sort_num IS NOT DISTINCT FROM c.sort_num AND df.target_id < c.target_id)
+        OR (df.sort_num IS NOT NULL AND c.sort_num IS NULL)
+      END
+    )::BIGINT ELSE 0::BIGINT END AS current_index,
+    (SELECT COUNT(*) FROM distance_filtered)::BIGINT AS total_count;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_csv_export(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_spectral_features_include_any integer DEFAULT NULL::integer, p_spectral_features_include_all integer DEFAULT NULL::integer, p_spectral_features_exclude integer DEFAULT NULL::integer, p_dq_flags_include_any integer DEFAULT NULL::integer, p_dq_flags_include_all integer DEFAULT NULL::integer, p_dq_flags_exclude integer DEFAULT NULL::integer, p_list_ids integer[] DEFAULT NULL::integer[], p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_has_photometry boolean DEFAULT NULL::boolean, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_sort_column text DEFAULT 'target_id'::text, p_sort_direction text DEFAULT 'asc'::text)
+ RETURNS TABLE(target_id text, field text, ra double precision, "dec" double precision, redshift numeric, redshift_quality integer, max_snr double precision, max_exposure_time double precision, num_gratings integer, program_slug text, program_name text, last_inspected_at timestamp with time zone, last_inspected_by text, distance double precision, spectral_features integer, dq_flags integer, lists text)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (p_comment_search IS NOT NULL AND p_comment_search != '' AND p_comment_search_scope IN ('just_me', 'everyone'));
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN v_gratings_mode := 'any'; END IF;
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
+  IF NOT (p_sort_column IN ('target_id', 'field', 'observation', 'ra', 'dec', 'redshift', 'redshift_quality', 'max_snr', 'max_exposure_time')
+       OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'target_id';
+  END IF;
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs)) INTO v_filtered_program_slugs;
+  ELSE v_filtered_program_slugs := p_program_slugs; END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN RETURN; END IF;
+
+  RETURN QUERY
+  WITH filtered_targets AS (
+    SELECT t.target_id, t.field, t.ra, t.dec, t.redshift, t.redshift_quality,
+      t.max_snr, t.max_exposure_time,
+      (SELECT COUNT(*)::INTEGER FROM spectra s WHERE s.target_id = t.target_id) AS num_gratings,
+      t.program_slug, t.observation, t.last_inspected_at, t.last_inspected_by,
+      CASE WHEN v_coord_search_active THEN
+        2 * DEGREES(ASIN(SQRT(POWER(SIN(RADIANS(t.dec - p_coord_dec) / 2), 2) + COS(RADIANS(p_coord_dec)) * COS(RADIANS(t.dec)) * POWER(SIN(RADIANS(t.ra - p_coord_ra) / 2), 2))))
+      ELSE NULL END AS distance,
+      COALESCE(t.spectral_features, 0) AS spectral_features,
+      COALESCE(t.dq_flags, 0) AS dq_flags,
+      (SELECT string_agg(ol.slug, ';' ORDER BY ol.slug)
+       FROM object_list_members olm
+       JOIN object_lists ol ON ol.id = olm.list_id
+       WHERE olm.object_id = t.object_id
+         AND (ol.created_by = auth.uid() OR ol.visibility IN ('public_read', 'public_edit'))) AS lists
+    FROM targets t
+    WHERE t.program_slug = ANY(v_filtered_program_slugs)
+      AND (NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND EXISTS (SELECT 1 FROM spectra gs WHERE gs.target_id = t.target_id AND gs.grating = ANY(p_gratings)))
+        OR (v_gratings_mode = 'all' AND (SELECT COUNT(DISTINCT gs.grating) FROM spectra gs WHERE gs.target_id = t.target_id AND gs.grating = ANY(p_gratings)) = array_length(p_gratings, 1))
+        OR (v_gratings_mode = 'none' AND NOT EXISTS (SELECT 1 FROM spectra gs WHERE gs.target_id = t.target_id AND gs.grating = ANY(p_gratings))))
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR t.field = ANY(p_fields))
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR t.observation = ANY(p_observations))
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR t.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR t.redshift >= p_redshift_min) AND (p_redshift_max IS NULL OR t.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR t.max_snr >= p_max_snr_min) AND (p_max_snr_max IS NULL OR t.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR t.max_exposure_time >= p_max_exposure_time_min) AND (p_max_exposure_time_max IS NULL OR t.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_spectral_features_include_any IS NULL OR (COALESCE(t.spectral_features, 0) & p_spectral_features_include_any) != 0)
+      AND (p_spectral_features_include_all IS NULL OR (COALESCE(t.spectral_features, 0) & p_spectral_features_include_all) = p_spectral_features_include_all)
+      AND (p_spectral_features_exclude IS NULL OR (COALESCE(t.spectral_features, 0) & p_spectral_features_exclude) = 0)
+      AND (p_dq_flags_include_any IS NULL OR (COALESCE(t.dq_flags, 0) & p_dq_flags_include_any) != 0)
+      AND (p_dq_flags_include_all IS NULL OR (COALESCE(t.dq_flags, 0) & p_dq_flags_include_all) = p_dq_flags_include_all)
+      AND (p_dq_flags_exclude IS NULL OR (COALESCE(t.dq_flags, 0) & p_dq_flags_exclude) = 0)
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR t.object_id IN (
+          SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_search IS NULL OR t.target_id ILIKE '%' || p_search || '%')
+      AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND t.redshift_quality > 0) OR (p_inspected_only = FALSE AND t.redshift_quality = 0))
+      AND (p_has_photometry IS NULL OR EXISTS (SELECT 1 FROM objects o WHERE o.id = t.object_id AND o.has_photometry = p_has_photometry))
+      AND (NOT v_comment_search_active OR EXISTS (
+        SELECT 1 FROM comments c WHERE c.target_id = t.id AND c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (p_comment_search_scope = 'everyone' OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id))))
+      AND (NOT v_coord_search_active OR (
+        t.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND t.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)))
+  ),
+  distance_filtered AS (SELECT ft.* FROM filtered_targets ft WHERE NOT v_coord_search_active OR ft.distance <= p_radius_degrees)
+  SELECT df.target_id, df.field, df.ra, df.dec, df.redshift, df.redshift_quality,
+    df.max_snr, df.max_exposure_time, df.num_gratings, df.program_slug,
+    pr.program_name, df.last_inspected_at, up.full_name AS last_inspected_by,
+    df.distance, df.spectral_features, df.dq_flags, df.lists
+  FROM distance_filtered df
+  LEFT JOIN programs pr ON pr.slug = df.program_slug
+  LEFT JOIN user_profiles up ON up.user_id = df.last_inspected_by
+  ORDER BY
+    CASE WHEN v_coord_search_active THEN df.distance END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'target_id' AND p_sort_direction = 'asc' THEN df.target_id END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'target_id' AND p_sort_direction = 'desc' THEN df.target_id END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'asc' THEN df.field END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'desc' THEN df.field END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'observation' AND p_sort_direction = 'asc' THEN df.observation END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'observation' AND p_sort_direction = 'desc' THEN df.observation END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN df.ra END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN df.ra END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN df.dec END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN df.dec END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN df.redshift END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN df.redshift END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN df.redshift_quality END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN df.redshift_quality END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN df.max_snr END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN df.max_snr END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN df.max_exposure_time END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN df.max_exposure_time END DESC NULLS LAST,
+    df.target_id ASC;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_csv_export_spectra(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_spectral_features_include_any integer DEFAULT NULL::integer, p_spectral_features_include_all integer DEFAULT NULL::integer, p_spectral_features_exclude integer DEFAULT NULL::integer, p_dq_flags_include_any integer DEFAULT NULL::integer, p_dq_flags_include_all integer DEFAULT NULL::integer, p_dq_flags_exclude integer DEFAULT NULL::integer, p_list_ids integer[] DEFAULT NULL::integer[], p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_has_photometry boolean DEFAULT NULL::boolean, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_sort_column text DEFAULT 'target_id'::text, p_sort_direction text DEFAULT 'asc'::text)
+ RETURNS TABLE(target_id text, grating text, field text, ra double precision, "dec" double precision, redshift numeric, redshift_quality integer, signal_to_noise double precision, exposure_time double precision, fits_path text, program_slug text, program_name text, last_inspected_at timestamp with time zone, last_inspected_by text, distance double precision, spectral_features integer, dq_flags integer, lists text)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (p_comment_search IS NOT NULL AND p_comment_search != '' AND p_comment_search_scope IN ('just_me', 'everyone'));
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
+  IF NOT (p_sort_column IN ('target_id', 'field', 'observation', 'ra', 'dec', 'redshift', 'redshift_quality', 'signal_to_noise', 'exposure_time', 'grating')
+       OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'target_id';
+  END IF;
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs)) INTO v_filtered_program_slugs;
+  ELSE v_filtered_program_slugs := p_program_slugs; END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN RETURN; END IF;
+
+  RETURN QUERY
+  WITH filtered_spectra AS (
+    SELECT t.target_id, s.grating, t.field, t.ra, t.dec, t.redshift, t.redshift_quality,
+      s.signal_to_noise, s.exposure_time, s.fits_path, t.program_slug, t.observation,
+      t.last_inspected_at, t.last_inspected_by,
+      CASE WHEN v_coord_search_active THEN
+        2 * DEGREES(ASIN(SQRT(POWER(SIN(RADIANS(t.dec - p_coord_dec) / 2), 2) + COS(RADIANS(p_coord_dec)) * COS(RADIANS(t.dec)) * POWER(SIN(RADIANS(t.ra - p_coord_ra) / 2), 2))))
+      ELSE NULL END AS distance,
+      COALESCE(t.spectral_features, 0) AS spectral_features,
+      COALESCE(t.dq_flags, 0) AS dq_flags,
+      (SELECT string_agg(ol.slug, ';' ORDER BY ol.slug)
+       FROM object_list_members olm
+       JOIN object_lists ol ON ol.id = olm.list_id
+       WHERE olm.object_id = t.object_id
+         AND (ol.created_by = auth.uid() OR ol.visibility IN ('public_read', 'public_edit'))) AS lists
+    FROM targets t JOIN spectra s ON s.target_id = t.target_id
+    WHERE t.program_slug = ANY(v_filtered_program_slugs)
+      AND (NOT v_grating_filter_active OR s.grating = ANY(p_gratings))
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR t.field = ANY(p_fields))
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR t.observation = ANY(p_observations))
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR t.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR t.redshift >= p_redshift_min) AND (p_redshift_max IS NULL OR t.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR t.max_snr >= p_max_snr_min) AND (p_max_snr_max IS NULL OR t.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR t.max_exposure_time >= p_max_exposure_time_min) AND (p_max_exposure_time_max IS NULL OR t.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_spectral_features_include_any IS NULL OR (COALESCE(t.spectral_features, 0) & p_spectral_features_include_any) != 0)
+      AND (p_spectral_features_include_all IS NULL OR (COALESCE(t.spectral_features, 0) & p_spectral_features_include_all) = p_spectral_features_include_all)
+      AND (p_spectral_features_exclude IS NULL OR (COALESCE(t.spectral_features, 0) & p_spectral_features_exclude) = 0)
+      AND (p_dq_flags_include_any IS NULL OR (COALESCE(t.dq_flags, 0) & p_dq_flags_include_any) != 0)
+      AND (p_dq_flags_include_all IS NULL OR (COALESCE(t.dq_flags, 0) & p_dq_flags_include_all) = p_dq_flags_include_all)
+      AND (p_dq_flags_exclude IS NULL OR (COALESCE(t.dq_flags, 0) & p_dq_flags_exclude) = 0)
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR t.object_id IN (
+          SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_search IS NULL OR t.target_id ILIKE '%' || p_search || '%')
+      AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND t.redshift_quality > 0) OR (p_inspected_only = FALSE AND t.redshift_quality = 0))
+      AND (p_has_photometry IS NULL OR EXISTS (SELECT 1 FROM objects o WHERE o.id = t.object_id AND o.has_photometry = p_has_photometry))
+      AND (NOT v_comment_search_active OR EXISTS (
+        SELECT 1 FROM comments c WHERE c.target_id = t.id AND c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (p_comment_search_scope = 'everyone' OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id))))
+      AND (NOT v_coord_search_active OR (
+        t.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND t.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)))
+  ),
+  distance_filtered AS (SELECT fs.* FROM filtered_spectra fs WHERE NOT v_coord_search_active OR fs.distance <= p_radius_degrees)
+  SELECT df.target_id, df.grating, df.field, df.ra, df.dec, df.redshift, df.redshift_quality,
+    df.signal_to_noise, df.exposure_time, df.fits_path, df.program_slug,
+    pr.program_name, df.last_inspected_at, up.full_name AS last_inspected_by,
+    df.distance, df.spectral_features, df.dq_flags, df.lists
+  FROM distance_filtered df
+  LEFT JOIN programs pr ON pr.slug = df.program_slug
+  LEFT JOIN user_profiles up ON up.user_id = df.last_inspected_by
+  ORDER BY
+    CASE WHEN v_coord_search_active THEN df.distance END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'target_id' AND p_sort_direction = 'asc' THEN df.target_id END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'target_id' AND p_sort_direction = 'desc' THEN df.target_id END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'asc' THEN df.field END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'desc' THEN df.field END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'observation' AND p_sort_direction = 'asc' THEN df.observation END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'observation' AND p_sort_direction = 'desc' THEN df.observation END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN df.ra END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN df.ra END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN df.dec END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN df.dec END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN df.redshift END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN df.redshift END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN df.redshift_quality END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN df.redshift_quality END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'signal_to_noise' AND p_sort_direction = 'asc' THEN df.signal_to_noise END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'signal_to_noise' AND p_sort_direction = 'desc' THEN df.signal_to_noise END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'exposure_time' AND p_sort_direction = 'asc' THEN df.exposure_time END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'exposure_time' AND p_sort_direction = 'desc' THEN df.exposure_time END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'grating' AND p_sort_direction = 'asc' THEN df.grating END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'grating' AND p_sort_direction = 'desc' THEN df.grating END DESC NULLS LAST,
+    df.target_id ASC, df.grating ASC;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_filtered_spectra_paginated(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_spectral_features_include_any integer DEFAULT NULL::integer, p_spectral_features_include_all integer DEFAULT NULL::integer, p_spectral_features_exclude integer DEFAULT NULL::integer, p_dq_flags_include_any integer DEFAULT NULL::integer, p_dq_flags_include_all integer DEFAULT NULL::integer, p_dq_flags_exclude integer DEFAULT NULL::integer, p_list_ids integer[] DEFAULT NULL::integer[], p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_has_photometry boolean DEFAULT NULL::boolean, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_sort_column text DEFAULT 'target_id'::text, p_sort_direction text DEFAULT 'asc'::text, p_page integer DEFAULT 1, p_page_size integer DEFAULT 50, p_include_thumbnails boolean DEFAULT false)
+ RETURNS TABLE(targets jsonb, total_count bigint, page integer, page_size integer)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_offset INTEGER;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
+    v_gratings_mode := 'any';
+  END IF;
+
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN
+    p_sort_direction := 'asc';
+  END IF;
+
+  IF NOT (p_sort_column IN (
+    'target_id', 'field', 'observation', 'ra', 'dec', 'redshift',
+    'redshift_quality', 'signal_to_noise', 'exposure_time', 'grating'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'target_id';
+  END IF;
+
+  IF v_coord_search_active AND p_sort_column = 'target_id' AND p_sort_direction = 'asc' THEN
+    p_sort_column := 'distance';
+  END IF;
+
+  v_offset := (COALESCE(p_page, 1) - 1) * COALESCE(p_page_size, 50);
+
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(
+      SELECT unnest(p_program_slugs)
+      INTERSECT
+      SELECT unnest(p_filter_programs)
+    ) INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN QUERY SELECT '[]'::jsonb, 0::BIGINT, p_page, p_page_size;
+    RETURN;
+  END IF;
+
+  -- Single-pass CTE: filtered_spectra is referenced by both distance_filtered
+  -- and the count subquery, so PostgreSQL materializes it once.
+  RETURN QUERY
+  WITH filtered_spectra AS (
+    SELECT
+      t.id AS tgt_db_id,
+      t.target_id,
+      t.program_slug,
+      t.field,
+      t.observation,
+      t.ra,
+      t.dec,
+      t.redshift,
+      t.redshift_auto,
+      t.redshift_inspected,
+      t.redshift_quality,
+      COALESCE(t.spectral_features, 0) AS spectral_features,
+      COALESCE(t.dq_flags, 0) AS dq_flags,
+      t.max_snr,
+      t.max_exposure_time,
+      t.last_inspected_at,
+      t.last_inspected_by,
+      t.created_at,
+      t.updated_at,
+      s.id AS spectrum_id,
+      s.grating,
+      s.fits_path,
+      s.signal_to_noise,
+      s.exposure_time,
+      s.file_hash,
+      s.file_size,
+      s.thumbnail_svg_fnu,
+      s.thumbnail_svg_flambda,
+      CASE
+        WHEN v_coord_search_active THEN
+          2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(t.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(t.dec)) *
+            POWER(SIN(RADIANS(t.ra - p_coord_ra) / 2), 2)
+          )))
+        ELSE NULL
+      END AS distance
+    FROM targets t
+    JOIN spectra s ON s.target_id = t.target_id
+    WHERE
+      t.program_slug = ANY(v_filtered_program_slugs)
+      AND (NOT v_grating_filter_active OR s.grating = ANY(p_gratings))
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR t.field = ANY(p_fields))
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR t.observation = ANY(p_observations))
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR t.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR t.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR t.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR s.signal_to_noise >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR s.signal_to_noise <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR s.exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR s.exposure_time <= p_max_exposure_time_max)
+      AND (p_spectral_features_include_any IS NULL OR (COALESCE(t.spectral_features, 0) & p_spectral_features_include_any) != 0)
+      AND (p_spectral_features_include_all IS NULL OR (COALESCE(t.spectral_features, 0) & p_spectral_features_include_all) = p_spectral_features_include_all)
+      AND (p_spectral_features_exclude IS NULL OR (COALESCE(t.spectral_features, 0) & p_spectral_features_exclude) = 0)
+      AND (p_dq_flags_include_any IS NULL OR (COALESCE(t.dq_flags, 0) & p_dq_flags_include_any) != 0)
+      AND (p_dq_flags_include_all IS NULL OR (COALESCE(t.dq_flags, 0) & p_dq_flags_include_all) = p_dq_flags_include_all)
+      AND (p_dq_flags_exclude IS NULL OR (COALESCE(t.dq_flags, 0) & p_dq_flags_exclude) = 0)
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR t.object_id IN (
+          SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_search IS NULL OR t.target_id ILIKE '%' || p_search || '%')
+      AND (
+        p_inspected_only IS NULL
+        OR (p_inspected_only = TRUE AND t.redshift_quality > 0)
+        OR (p_inspected_only = FALSE AND t.redshift_quality = 0)
+      )
+      AND (p_has_photometry IS NULL OR EXISTS (SELECT 1 FROM objects o WHERE o.id = t.object_id AND o.has_photometry = p_has_photometry))
+      AND (
+        NOT v_comment_search_active
+        OR EXISTS (
+          SELECT 1 FROM comments c
+          WHERE c.target_id = t.id
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+        )
+      )
+      AND (
+        NOT v_coord_search_active
+        OR (
+          t.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+          AND t.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+        )
+      )
+  ),
+  distance_filtered AS (
+    SELECT fs.*
+    FROM filtered_spectra fs
+    WHERE NOT v_coord_search_active OR fs.distance <= p_radius_degrees
+  ),
+  page_rows AS (
+    SELECT *, ROW_NUMBER() OVER () as row_num
+    FROM (
+      SELECT * FROM distance_filtered
+      ORDER BY
+        CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN distance END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN distance END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'target_id' AND p_sort_direction = 'asc' THEN target_id END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'target_id' AND p_sort_direction = 'desc' THEN target_id END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN field END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN field END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'observation' AND p_sort_direction = 'asc' THEN observation END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'observation' AND p_sort_direction = 'desc' THEN observation END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN ra END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN ra END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN "dec" END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN "dec" END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN redshift END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN redshift END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN redshift_quality END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN redshift_quality END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'signal_to_noise' AND p_sort_direction = 'asc' THEN signal_to_noise END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'signal_to_noise' AND p_sort_direction = 'desc' THEN signal_to_noise END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'exposure_time' AND p_sort_direction = 'asc' THEN exposure_time END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'exposure_time' AND p_sort_direction = 'desc' THEN exposure_time END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'grating' AND p_sort_direction = 'asc' THEN grating END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'grating' AND p_sort_direction = 'desc' THEN grating END DESC NULLS LAST,
+        target_id ASC, grating ASC
+      LIMIT p_page_size OFFSET v_offset
+    ) sorted_page
+  )
+  SELECT
+    COALESCE(jsonb_agg(jsonb_build_object(
+      'id', r.tgt_db_id,
+      'target_id', r.target_id,
+      'program_slug', r.program_slug,
+      'program_name', pr.program_name,
+      'field', r.field,
+      'observation', r.observation,
+      'ra', r.ra,
+      'dec', r.dec,
+      'redshift', r.redshift,
+      'redshift_auto', r.redshift_auto,
+      'redshift_inspected', r.redshift_inspected,
+      'redshift_quality', r.redshift_quality,
+      'spectral_features', r.spectral_features,
+      'dq_flags', r.dq_flags,
+      'max_snr', r.max_snr,
+      'max_exposure_time', r.max_exposure_time,
+      'last_inspected_at', r.last_inspected_at,
+      'last_inspected_by', r.last_inspected_by,
+      'created_at', r.created_at,
+      'updated_at', r.updated_at,
+      'distance', CASE WHEN v_coord_search_active THEN r.distance ELSE NULL END,
+      'spectra', jsonb_build_array(jsonb_build_object(
+        'id', r.spectrum_id,
+        'target_id', r.target_id,
+        'grating', r.grating,
+        'fits_path', r.fits_path,
+        'signal_to_noise', r.signal_to_noise,
+        'exposure_time', r.exposure_time,
+        'file_hash', r.file_hash,
+        'file_size', r.file_size,
+        'thumbnail_svg_fnu', CASE WHEN p_include_thumbnails THEN r.thumbnail_svg_fnu ELSE NULL END,
+        'thumbnail_svg_flambda', CASE WHEN p_include_thumbnails THEN r.thumbnail_svg_flambda ELSE NULL END
+      ))
+    ) ORDER BY r.row_num), '[]'::jsonb),
+    (SELECT COUNT(*) FROM distance_filtered),
+    p_page,
+    p_page_size
+  FROM page_rows r
+  LEFT JOIN programs pr ON pr.slug = r.program_slug;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_filtered_target_ids(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_spectral_features_include_any integer DEFAULT NULL::integer, p_spectral_features_include_all integer DEFAULT NULL::integer, p_spectral_features_exclude integer DEFAULT NULL::integer, p_dq_flags_include_any integer DEFAULT NULL::integer, p_dq_flags_include_all integer DEFAULT NULL::integer, p_dq_flags_exclude integer DEFAULT NULL::integer, p_list_ids integer[] DEFAULT NULL::integer[], p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_has_photometry boolean DEFAULT NULL::boolean, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_sort_column text DEFAULT 'target_id'::text, p_sort_direction text DEFAULT 'asc'::text, p_page integer DEFAULT NULL::integer, p_page_size integer DEFAULT NULL::integer, p_updated_since timestamp without time zone DEFAULT NULL::timestamp without time zone)
+ RETURNS TABLE(target_id text, distance double precision, row_num bigint, total_count bigint)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_paginate BOOLEAN;
+  v_offset INTEGER;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
+    v_gratings_mode := 'any';
+  END IF;
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN
+    p_sort_direction := 'asc';
+  END IF;
+  IF NOT (p_sort_column IN ('target_id', 'field', 'observation', 'ra', 'dec', 'redshift', 'redshift_quality', 'max_snr', 'max_exposure_time')
+       OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'target_id';
+  END IF;
+  IF v_coord_search_active AND p_sort_column = 'target_id' AND p_sort_direction = 'asc' THEN
+    p_sort_column := 'distance';
+  END IF;
+  v_paginate := (p_page IS NOT NULL AND p_page_size IS NOT NULL);
+  IF v_paginate THEN
+    v_offset := (p_page - 1) * p_page_size;
+  END IF;
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(
+      SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs)
+    ) INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN;
+  END IF;
+
+  -- === Paginated path ===
+  IF v_paginate THEN
+    RETURN QUERY
+    WITH filtered_targets AS (
+      SELECT
+        t.target_id,
+        CASE WHEN v_coord_search_active THEN
+          2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(t.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(t.dec)) *
+            POWER(SIN(RADIANS(t.ra - p_coord_ra) / 2), 2)
+          )))
+        ELSE NULL END AS distance,
+        t.field, t.observation, t.ra, t.dec, t.redshift, t.redshift_quality, t.max_snr, t.max_exposure_time
+      FROM targets t
+      WHERE
+        t.program_slug = ANY(v_filtered_program_slugs)
+        AND (p_updated_since IS NULL OR t.updated_at > p_updated_since)
+        AND (
+          NOT v_grating_filter_active
+          OR (v_gratings_mode = 'any' AND EXISTS (
+            SELECT 1 FROM spectra gs WHERE gs.target_id = t.target_id AND gs.grating = ANY(p_gratings)
+          ))
+          OR (v_gratings_mode = 'all' AND (
+            SELECT COUNT(DISTINCT gs.grating) FROM spectra gs
+            WHERE gs.target_id = t.target_id AND gs.grating = ANY(p_gratings)
+          ) = array_length(p_gratings, 1))
+          OR (v_gratings_mode = 'none' AND NOT EXISTS (
+            SELECT 1 FROM spectra gs WHERE gs.target_id = t.target_id AND gs.grating = ANY(p_gratings)
+          ))
+        )
+        AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR t.field = ANY(p_fields))
+        AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR t.observation = ANY(p_observations))
+        AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR t.redshift_quality = ANY(p_redshift_quality))
+        AND (p_redshift_min IS NULL OR t.redshift >= p_redshift_min)
+        AND (p_redshift_max IS NULL OR t.redshift <= p_redshift_max)
+        AND (p_max_snr_min IS NULL OR t.max_snr >= p_max_snr_min)
+        AND (p_max_snr_max IS NULL OR t.max_snr <= p_max_snr_max)
+        AND (p_max_exposure_time_min IS NULL OR t.max_exposure_time >= p_max_exposure_time_min)
+        AND (p_max_exposure_time_max IS NULL OR t.max_exposure_time <= p_max_exposure_time_max)
+        AND (p_spectral_features_include_any IS NULL OR (COALESCE(t.spectral_features, 0) & p_spectral_features_include_any) != 0)
+        AND (p_spectral_features_include_all IS NULL OR (COALESCE(t.spectral_features, 0) & p_spectral_features_include_all) = p_spectral_features_include_all)
+        AND (p_spectral_features_exclude IS NULL OR (COALESCE(t.spectral_features, 0) & p_spectral_features_exclude) = 0)
+        AND (p_dq_flags_include_any IS NULL OR (COALESCE(t.dq_flags, 0) & p_dq_flags_include_any) != 0)
+        AND (p_dq_flags_include_all IS NULL OR (COALESCE(t.dq_flags, 0) & p_dq_flags_include_all) = p_dq_flags_include_all)
+        AND (p_dq_flags_exclude IS NULL OR (COALESCE(t.dq_flags, 0) & p_dq_flags_exclude) = 0)
+        AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR t.object_id IN (
+            SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+        AND (p_search IS NULL OR t.target_id ILIKE '%' || p_search || '%')
+        AND (
+          p_inspected_only IS NULL
+          OR (p_inspected_only = TRUE AND t.redshift_quality > 0)
+          OR (p_inspected_only = FALSE AND t.redshift_quality = 0)
+        )
+        AND (p_has_photometry IS NULL OR EXISTS (SELECT 1 FROM objects o WHERE o.id = t.object_id AND o.has_photometry = p_has_photometry))
+        AND (
+          NOT v_comment_search_active
+          OR EXISTS (
+            SELECT 1 FROM comments c
+            WHERE c.target_id = t.id AND c.is_deleted = false
+              AND c.content ILIKE '%' || p_comment_search || '%'
+              AND (p_comment_search_scope = 'everyone'
+                   OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id))
+          )
+        )
+        AND (
+          NOT v_coord_search_active
+          OR (t.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+              AND t.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees))
+        )
+    ),
+    distance_filtered AS (
+      SELECT ft.* FROM filtered_targets ft
+      WHERE NOT v_coord_search_active OR ft.distance <= p_radius_degrees
+    )
+    SELECT
+      df.target_id, df.distance,
+      ROW_NUMBER() OVER (
+        ORDER BY
+          CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN df.distance END ASC NULLS LAST,
+          CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN df.distance END DESC NULLS LAST,
+          CASE WHEN p_sort_column = 'target_id' AND p_sort_direction = 'asc' THEN df.target_id END ASC NULLS LAST,
+          CASE WHEN p_sort_column = 'target_id' AND p_sort_direction = 'desc' THEN df.target_id END DESC NULLS LAST,
+          CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN df.field END ASC NULLS LAST,
+          CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN df.field END DESC NULLS LAST,
+          CASE WHEN p_sort_column = 'observation' AND p_sort_direction = 'asc' THEN df.observation END ASC NULLS LAST,
+          CASE WHEN p_sort_column = 'observation' AND p_sort_direction = 'desc' THEN df.observation END DESC NULLS LAST,
+          CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN df.ra END ASC NULLS LAST,
+          CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN df.ra END DESC NULLS LAST,
+          CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN df.dec END ASC NULLS LAST,
+          CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN df.dec END DESC NULLS LAST,
+          CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN df.redshift END ASC NULLS LAST,
+          CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN df.redshift END DESC NULLS LAST,
+          CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN df.redshift_quality END ASC NULLS LAST,
+          CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN df.redshift_quality END DESC NULLS LAST,
+          CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN df.max_snr END ASC NULLS LAST,
+          CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN df.max_snr END DESC NULLS LAST,
+          CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN df.max_exposure_time END ASC NULLS LAST,
+          CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN df.max_exposure_time END DESC NULLS LAST,
+          df.target_id ASC
+      ) AS row_num,
+      (SELECT COUNT(*) FROM distance_filtered)::BIGINT AS total_count
+    FROM distance_filtered df
+    ORDER BY
+      CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN df.distance END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN df.distance END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'target_id' AND p_sort_direction = 'asc' THEN df.target_id END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'target_id' AND p_sort_direction = 'desc' THEN df.target_id END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN df.field END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN df.field END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'observation' AND p_sort_direction = 'asc' THEN df.observation END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'observation' AND p_sort_direction = 'desc' THEN df.observation END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN df.ra END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN df.ra END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN df.dec END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN df.dec END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN df.redshift END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN df.redshift END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN df.redshift_quality END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN df.redshift_quality END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN df.max_snr END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN df.max_snr END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN df.max_exposure_time END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN df.max_exposure_time END DESC NULLS LAST,
+      df.target_id ASC
+    LIMIT p_page_size OFFSET v_offset;
+
+  -- === Full path (all rows) ===
+  ELSE
+    RETURN QUERY
+    WITH filtered_targets AS (
+      SELECT
+        t.target_id,
+        CASE WHEN v_coord_search_active THEN
+          2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(t.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(t.dec)) *
+            POWER(SIN(RADIANS(t.ra - p_coord_ra) / 2), 2)
+          )))
+        ELSE NULL END AS distance,
+        t.field, t.observation, t.ra, t.dec, t.redshift, t.redshift_quality, t.max_snr, t.max_exposure_time
+      FROM targets t
+      WHERE
+        t.program_slug = ANY(v_filtered_program_slugs)
+        AND (p_updated_since IS NULL OR t.updated_at > p_updated_since)
+        AND (
+          NOT v_grating_filter_active
+          OR (v_gratings_mode = 'any' AND EXISTS (
+            SELECT 1 FROM spectra gs WHERE gs.target_id = t.target_id AND gs.grating = ANY(p_gratings)
+          ))
+          OR (v_gratings_mode = 'all' AND (
+            SELECT COUNT(DISTINCT gs.grating) FROM spectra gs
+            WHERE gs.target_id = t.target_id AND gs.grating = ANY(p_gratings)
+          ) = array_length(p_gratings, 1))
+          OR (v_gratings_mode = 'none' AND NOT EXISTS (
+            SELECT 1 FROM spectra gs WHERE gs.target_id = t.target_id AND gs.grating = ANY(p_gratings)
+          ))
+        )
+        AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR t.field = ANY(p_fields))
+        AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR t.observation = ANY(p_observations))
+        AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR t.redshift_quality = ANY(p_redshift_quality))
+        AND (p_redshift_min IS NULL OR t.redshift >= p_redshift_min)
+        AND (p_redshift_max IS NULL OR t.redshift <= p_redshift_max)
+        AND (p_max_snr_min IS NULL OR t.max_snr >= p_max_snr_min)
+        AND (p_max_snr_max IS NULL OR t.max_snr <= p_max_snr_max)
+        AND (p_max_exposure_time_min IS NULL OR t.max_exposure_time >= p_max_exposure_time_min)
+        AND (p_max_exposure_time_max IS NULL OR t.max_exposure_time <= p_max_exposure_time_max)
+        AND (p_spectral_features_include_any IS NULL OR (COALESCE(t.spectral_features, 0) & p_spectral_features_include_any) != 0)
+        AND (p_spectral_features_include_all IS NULL OR (COALESCE(t.spectral_features, 0) & p_spectral_features_include_all) = p_spectral_features_include_all)
+        AND (p_spectral_features_exclude IS NULL OR (COALESCE(t.spectral_features, 0) & p_spectral_features_exclude) = 0)
+        AND (p_dq_flags_include_any IS NULL OR (COALESCE(t.dq_flags, 0) & p_dq_flags_include_any) != 0)
+        AND (p_dq_flags_include_all IS NULL OR (COALESCE(t.dq_flags, 0) & p_dq_flags_include_all) = p_dq_flags_include_all)
+        AND (p_dq_flags_exclude IS NULL OR (COALESCE(t.dq_flags, 0) & p_dq_flags_exclude) = 0)
+        AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR t.object_id IN (
+            SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+        AND (p_search IS NULL OR t.target_id ILIKE '%' || p_search || '%')
+        AND (
+          p_inspected_only IS NULL
+          OR (p_inspected_only = TRUE AND t.redshift_quality > 0)
+          OR (p_inspected_only = FALSE AND t.redshift_quality = 0)
+        )
+        AND (p_has_photometry IS NULL OR EXISTS (SELECT 1 FROM objects o WHERE o.id = t.object_id AND o.has_photometry = p_has_photometry))
+        AND (
+          NOT v_comment_search_active
+          OR EXISTS (
+            SELECT 1 FROM comments c
+            WHERE c.target_id = t.id AND c.is_deleted = false
+              AND c.content ILIKE '%' || p_comment_search || '%'
+              AND (p_comment_search_scope = 'everyone'
+                   OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id))
+          )
+        )
+        AND (
+          NOT v_coord_search_active
+          OR (t.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+              AND t.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees))
+        )
+    ),
+    distance_filtered AS (
+      SELECT ft.* FROM filtered_targets ft
+      WHERE NOT v_coord_search_active OR ft.distance <= p_radius_degrees
+    )
+    SELECT
+      df.target_id, df.distance,
+      ROW_NUMBER() OVER (
+        ORDER BY
+          CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN df.distance END ASC NULLS LAST,
+          CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN df.distance END DESC NULLS LAST,
+          CASE WHEN p_sort_column = 'target_id' AND p_sort_direction = 'asc' THEN df.target_id END ASC NULLS LAST,
+          CASE WHEN p_sort_column = 'target_id' AND p_sort_direction = 'desc' THEN df.target_id END DESC NULLS LAST,
+          CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN df.field END ASC NULLS LAST,
+          CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN df.field END DESC NULLS LAST,
+          CASE WHEN p_sort_column = 'observation' AND p_sort_direction = 'asc' THEN df.observation END ASC NULLS LAST,
+          CASE WHEN p_sort_column = 'observation' AND p_sort_direction = 'desc' THEN df.observation END DESC NULLS LAST,
+          CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN df.ra END ASC NULLS LAST,
+          CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN df.ra END DESC NULLS LAST,
+          CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN df.dec END ASC NULLS LAST,
+          CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN df.dec END DESC NULLS LAST,
+          CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN df.redshift END ASC NULLS LAST,
+          CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN df.redshift END DESC NULLS LAST,
+          CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN df.redshift_quality END ASC NULLS LAST,
+          CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN df.redshift_quality END DESC NULLS LAST,
+          CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN df.max_snr END ASC NULLS LAST,
+          CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN df.max_snr END DESC NULLS LAST,
+          CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN df.max_exposure_time END ASC NULLS LAST,
+          CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN df.max_exposure_time END DESC NULLS LAST,
+          df.target_id ASC
+      ) AS row_num,
+      COUNT(*) OVER () AS total_count
+    FROM distance_filtered df;
+  END IF;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_filtered_targets_paginated(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_spectral_features integer DEFAULT NULL::integer, p_dq_flags integer DEFAULT NULL::integer, p_spectral_features_include_any integer DEFAULT NULL::integer, p_spectral_features_include_all integer DEFAULT NULL::integer, p_spectral_features_exclude integer DEFAULT NULL::integer, p_dq_flags_include_any integer DEFAULT NULL::integer, p_dq_flags_include_all integer DEFAULT NULL::integer, p_dq_flags_exclude integer DEFAULT NULL::integer, p_list_ids integer[] DEFAULT NULL::integer[], p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_has_photometry boolean DEFAULT NULL::boolean, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_sort_column text DEFAULT 'target_id'::text, p_sort_direction text DEFAULT 'asc'::text, p_page integer DEFAULT 1, p_page_size integer DEFAULT 50, p_include_thumbnails boolean DEFAULT false, p_updated_since timestamp without time zone DEFAULT NULL::timestamp without time zone)
+ RETURNS TABLE(targets jsonb, total_count bigint, page integer, page_size integer)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_sf_include_any INTEGER;
+  v_sf_include_all INTEGER;
+  v_sf_exclude INTEGER;
+  v_dq_include_any INTEGER;
+  v_dq_include_all INTEGER;
+  v_dq_exclude INTEGER;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_coord_search_active BOOLEAN;
+BEGIN
+  v_sf_include_any := COALESCE(p_spectral_features_include_any, p_spectral_features);
+  v_sf_include_all := p_spectral_features_include_all;
+  v_sf_exclude := p_spectral_features_exclude;
+  v_dq_include_any := COALESCE(p_dq_flags_include_any, p_dq_flags);
+  v_dq_include_all := p_dq_flags_include_all;
+  v_dq_exclude := p_dq_flags_exclude;
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+
+  RETURN QUERY
+  WITH ids AS (
+    SELECT *
+    FROM public.get_filtered_target_ids(
+      p_program_slugs, p_filter_programs, p_fields, p_gratings, p_gratings_mode,
+      p_observations, p_redshift_quality, p_redshift_min, p_redshift_max,
+      p_max_snr_min, p_max_snr_max, p_max_exposure_time_min, p_max_exposure_time_max,
+      v_sf_include_any, v_sf_include_all, v_sf_exclude,
+      v_dq_include_any, v_dq_include_all, v_dq_exclude,
+      p_list_ids,
+      p_search, p_inspected_only, p_has_photometry,
+      p_comment_search, p_comment_search_scope, p_comment_user_id,
+      p_coord_ra, p_coord_dec, p_radius_degrees,
+      p_sort_column, p_sort_direction,
+      p_page, p_page_size,
+      p_updated_since
+    )
+  ),
+  with_relations AS (
+    SELECT
+      jsonb_build_object(
+        'id', t.id,
+        'target_id', t.target_id,
+        'program_slug', t.program_slug,
+        'program_name', pr.program_name,
+        'field', t.field,
+        'observation', t.observation,
+        'ra', t.ra,
+        'dec', t.dec,
+        'redshift', t.redshift,
+        'redshift_auto', t.redshift_auto,
+        'redshift_inspected', t.redshift_inspected,
+        'redshift_quality', t.redshift_quality,
+        'spectral_features', t.spectral_features,
+        'dq_flags', t.dq_flags,
+        'max_snr', t.max_snr,
+        'max_exposure_time', t.max_exposure_time,
+        'last_inspected_at', t.last_inspected_at,
+        'last_inspected_by', t.last_inspected_by,
+        'created_at', t.created_at,
+        'updated_at', t.updated_at,
+        'distance', CASE WHEN v_coord_search_active THEN ids.distance ELSE NULL END,
+        'spectra', COALESCE(
+          (SELECT jsonb_agg(
+            jsonb_build_object(
+              'id', s.id,
+              'target_id', s.target_id,
+              'grating', s.grating,
+              'fits_path', s.fits_path,
+              'signal_to_noise', s.signal_to_noise,
+              'file_hash', s.file_hash,
+              'file_size', s.file_size,
+              'thumbnail_svg_fnu', CASE WHEN p_include_thumbnails THEN s.thumbnail_svg_fnu ELSE NULL END,
+              'thumbnail_svg_flambda', CASE WHEN p_include_thumbnails THEN s.thumbnail_svg_flambda ELSE NULL END
+            )
+          )
+          FROM spectra s
+          WHERE s.target_id = t.target_id
+            AND (NOT v_grating_filter_active OR v_gratings_mode = 'none' OR s.grating = ANY(p_gratings))
+          ),
+          '[]'::jsonb
+        ),
+        'row_num', ids.row_num
+      ) AS obj_json,
+      ids.total_count,
+      ids.row_num
+    FROM ids
+    JOIN targets t ON t.target_id = ids.target_id
+    LEFT JOIN programs pr ON t.program_slug = pr.slug
+  )
+  SELECT
+    COALESCE(jsonb_agg(wr.obj_json ORDER BY wr.row_num), '[]'::jsonb),
+    COALESCE(MAX(wr.total_count), 0)::BIGINT,
+    p_page,
+    p_page_size
+  FROM with_relations wr;
+END;
+$function$
+;
+
+

--- a/supabase/migrations/20260413194519_add-photometry-to-csv-sync.sql
+++ b/supabase/migrations/20260413194519_add-photometry-to-csv-sync.sql
@@ -1,0 +1,261 @@
+drop function if exists "public"."get_csv_export_objects"(p_program_slugs text[], p_filter_programs text[], p_fields text[], p_gratings text[], p_gratings_mode text, p_redshift_quality integer[], p_redshift_min double precision, p_redshift_max double precision, p_max_snr_min double precision, p_max_snr_max double precision, p_max_exposure_time_min double precision, p_max_exposure_time_max double precision, p_search text, p_inspected_only boolean, p_list_ids integer[], p_coord_ra double precision, p_coord_dec double precision, p_radius_degrees double precision, p_has_photometry boolean, p_photo_z_min double precision, p_photo_z_max double precision, p_sort_column text, p_sort_direction text);
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_photometry_for_sync(p_program_slugs text[], p_updated_since timestamp with time zone DEFAULT NULL::timestamp with time zone, p_limit integer DEFAULT 1000, p_offset integer DEFAULT 0)
+ RETURNS TABLE(photometry_records jsonb, total_count bigint)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+BEGIN
+  RETURN QUERY
+  WITH matched AS (
+    SELECT op.id, o.object_id, op.field, op.catalog_name, op.catalog_id,
+           op.match_distance_arcsec, op.photometry, op.photo_z,
+           op.photo_z_err_lo, op.photo_z_err_hi, op.has_pz,
+           op.created_at, op.updated_at
+    FROM object_photometry op
+    JOIN objects o ON o.id = op.object_id
+    WHERE o.programs && p_program_slugs
+      AND (p_updated_since IS NULL OR op.updated_at > p_updated_since)
+    ORDER BY op.id
+    LIMIT p_limit OFFSET p_offset
+  ),
+  total AS (
+    SELECT COUNT(*) AS cnt
+    FROM object_photometry op
+    JOIN objects o ON o.id = op.object_id
+    WHERE o.programs && p_program_slugs
+      AND (p_updated_since IS NULL OR op.updated_at > p_updated_since)
+  )
+  SELECT
+    COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'id', m.id,
+        'object_id', m.object_id,
+        'field', m.field,
+        'catalog_name', m.catalog_name,
+        'catalog_id', m.catalog_id,
+        'match_distance_arcsec', m.match_distance_arcsec,
+        'photometry', m.photometry,
+        'photo_z', m.photo_z,
+        'photo_z_err_lo', m.photo_z_err_lo,
+        'photo_z_err_hi', m.photo_z_err_hi,
+        'has_pz', m.has_pz,
+        'created_at', m.created_at,
+        'updated_at', m.updated_at
+      )
+    ), '[]'::jsonb),
+    COALESCE((SELECT cnt FROM total), 0)::BIGINT
+  FROM matched m;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_csv_export_objects(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_list_ids integer[] DEFAULT NULL::integer[], p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_has_photometry boolean DEFAULT NULL::boolean, p_photo_z_min double precision DEFAULT NULL::double precision, p_photo_z_max double precision DEFAULT NULL::double precision, p_sort_column text DEFAULT 'object_id'::text, p_sort_direction text DEFAULT 'asc'::text)
+ RETURNS TABLE(object_id text, field text, ra double precision, "dec" double precision, best_redshift double precision, best_redshift_quality integer, n_targets integer, n_spectra integer, programs text, gratings text, max_snr double precision, max_exposure_time double precision, member_target_ids text, distance double precision, lists text, has_photometry boolean, photo_z double precision, photo_z_err_lo double precision, photo_z_err_hi double precision, photometry jsonb)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN v_gratings_mode := 'any'; END IF;
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'best_redshift', 'best_redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time', 'photo_z'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs)) INTO v_filtered_program_slugs;
+  ELSE v_filtered_program_slugs := p_program_slugs; END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN RETURN; END IF;
+
+  RETURN QUERY
+  WITH filtered_objects AS (
+    SELECT o.object_id, o.field, o.ra, o.dec,
+      o.best_redshift, o.best_redshift_quality,
+      o.n_targets, o.n_spectra,
+      array_to_string(o.programs, ';') AS programs,
+      array_to_string(o.gratings, ';') AS gratings,
+      o.max_snr, o.max_exposure_time,
+      (SELECT array_to_string(ARRAY(
+        SELECT t.target_id FROM targets t
+        WHERE t.object_id = o.id AND t.program_slug = ANY(v_filtered_program_slugs)
+        ORDER BY t.target_id
+      ), ';')) AS member_target_ids,
+      CASE WHEN v_coord_search_active THEN
+        2 * DEGREES(ASIN(SQRT(POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) + COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) * POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2))))
+      ELSE NULL END AS distance,
+      (SELECT string_agg(ol.slug, ';' ORDER BY ol.slug)
+       FROM object_list_members olm
+       JOIN object_lists ol ON ol.id = olm.list_id
+       WHERE olm.object_id = o.id
+         AND (ol.created_by = auth.uid() OR ol.visibility IN ('public_read', 'public_edit'))) AS lists,
+      o.has_photometry, o.photo_z, o.photo_z_err_lo, o.photo_z_err_hi,
+      phot.photometry
+    FROM objects o
+    LEFT JOIN LATERAL (
+      SELECT op.photometry FROM object_photometry op
+      WHERE op.object_id = o.id ORDER BY op.updated_at DESC LIMIT 1
+    ) phot ON true
+    WHERE o.programs && v_filtered_program_slugs
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+        OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+        OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+      )
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.best_redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.best_redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.best_redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_search IS NULL OR o.object_id ILIKE '%' || p_search || '%'
+      OR EXISTS (SELECT 1 FROM targets t WHERE t.object_id = o.id AND t.target_id ILIKE '%' || p_search || '%'))
+      AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.best_redshift_quality > 0) OR (p_inspected_only = FALSE AND o.best_redshift_quality = 0))
+      AND (NOT v_coord_search_active OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+      ))
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+      AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+  ),
+  distance_filtered AS (SELECT fo.* FROM filtered_objects fo WHERE NOT v_coord_search_active OR fo.distance <= p_radius_degrees)
+  SELECT df.object_id, df.field, df.ra, df.dec,
+    df.best_redshift, df.best_redshift_quality,
+    df.n_targets, df.n_spectra,
+    df.programs, df.gratings,
+    df.max_snr, df.max_exposure_time,
+    df.member_target_ids, df.distance, df.lists,
+    df.has_photometry, df.photo_z, df.photo_z_err_lo, df.photo_z_err_hi,
+    df.photometry
+  FROM distance_filtered df
+  ORDER BY
+    CASE WHEN v_coord_search_active THEN df.distance END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN df.object_id END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'desc' THEN df.object_id END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'asc' THEN df.field END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'desc' THEN df.field END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN df.ra END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN df.ra END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN df.dec END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN df.dec END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'best_redshift' AND p_sort_direction = 'asc' THEN df.best_redshift END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'best_redshift' AND p_sort_direction = 'desc' THEN df.best_redshift END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'best_redshift_quality' AND p_sort_direction = 'asc' THEN df.best_redshift_quality END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'best_redshift_quality' AND p_sort_direction = 'desc' THEN df.best_redshift_quality END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_targets' AND p_sort_direction = 'asc' THEN df.n_targets END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_targets' AND p_sort_direction = 'desc' THEN df.n_targets END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_spectra' AND p_sort_direction = 'asc' THEN df.n_spectra END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_spectra' AND p_sort_direction = 'desc' THEN df.n_spectra END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN df.max_snr END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN df.max_snr END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN df.max_exposure_time END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN df.max_exposure_time END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'photo_z' AND p_sort_direction = 'asc' THEN df.photo_z END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'photo_z' AND p_sort_direction = 'desc' THEN df.photo_z END DESC NULLS LAST,
+    df.object_id ASC;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_objects_for_sync(p_program_slugs text[], p_user_id uuid DEFAULT NULL::uuid, p_updated_since timestamp with time zone DEFAULT NULL::timestamp with time zone, p_limit integer DEFAULT 1000, p_offset integer DEFAULT 0)
+ RETURNS TABLE(objects jsonb, total_count bigint, total_accessible_count bigint)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+BEGIN
+  RETURN QUERY
+  WITH matched AS (
+    SELECT o.id, o.object_id, o.field, o.ra, o.dec,
+           o.n_targets, o.n_spectra, o.programs, o.gratings,
+           o.max_snr, o.max_exposure_time,
+           o.best_redshift, o.best_redshift_quality,
+           o.has_photometry, o.photo_z, o.photo_z_err_lo, o.photo_z_err_hi,
+           o.created_at, o.updated_at
+    FROM objects o
+    WHERE o.programs && p_program_slugs
+      AND (p_updated_since IS NULL OR o.updated_at > p_updated_since)
+    ORDER BY o.object_id
+    LIMIT p_limit OFFSET p_offset
+  ),
+  total AS (
+    SELECT COUNT(*) AS cnt
+    FROM objects o
+    WHERE o.programs && p_program_slugs
+      AND (p_updated_since IS NULL OR o.updated_at > p_updated_since)
+  ),
+  accessible AS (
+    SELECT COUNT(*) AS cnt
+    FROM objects o
+    WHERE o.programs && p_program_slugs
+  )
+  SELECT
+    COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'id', m.id,
+        'object_id', m.object_id,
+        'field', m.field,
+        'ra', m.ra,
+        'dec', m.dec,
+        'n_targets', m.n_targets,
+        'n_spectra', m.n_spectra,
+        'programs', m.programs,
+        'gratings', m.gratings,
+        'max_snr', m.max_snr,
+        'max_exposure_time', m.max_exposure_time,
+        'best_redshift', m.best_redshift,
+        'best_redshift_quality', m.best_redshift_quality,
+        'has_photometry', m.has_photometry,
+        'photo_z', m.photo_z,
+        'photo_z_err_lo', m.photo_z_err_lo,
+        'photo_z_err_hi', m.photo_z_err_hi,
+        'created_at', m.created_at,
+        'updated_at', m.updated_at,
+        'member_target_ids', COALESCE(
+          (SELECT jsonb_agg(t.target_id ORDER BY t.target_id)
+           FROM targets t
+           WHERE t.object_id = m.id
+             AND t.program_slug = ANY(p_program_slugs)),
+          '[]'::jsonb
+        ),
+        'lists', COALESCE(
+          (SELECT jsonb_agg(ol.slug ORDER BY ol.slug)
+           FROM object_list_members olm
+           JOIN object_lists ol ON ol.id = olm.list_id
+           WHERE olm.object_id = m.id
+             AND (ol.created_by = p_user_id OR ol.visibility IN ('public_read', 'public_edit'))),
+          '[]'::jsonb
+        )
+      )
+    ), '[]'::jsonb),
+    COALESCE((SELECT cnt FROM total), 0)::BIGINT,
+    COALESCE((SELECT cnt FROM accessible), 0)::BIGINT
+  FROM matched m;
+END;
+$function$
+;
+
+GRANT EXECUTE ON FUNCTION public.get_photometry_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_photometry_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER) TO service_role;

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -148,6 +148,7 @@ CREATE OR REPLACE FUNCTION public.get_filtered_target_ids(
   p_list_ids INTEGER[] DEFAULT NULL,
   p_search TEXT DEFAULT NULL,
   p_inspected_only BOOLEAN DEFAULT NULL,
+  p_has_photometry BOOLEAN DEFAULT NULL,
   p_comment_search TEXT DEFAULT NULL,
   p_comment_search_scope TEXT DEFAULT NULL,
   p_comment_user_id UUID DEFAULT NULL,
@@ -264,6 +265,7 @@ BEGIN
           OR (p_inspected_only = TRUE AND t.redshift_quality > 0)
           OR (p_inspected_only = FALSE AND t.redshift_quality = 0)
         )
+        AND (p_has_photometry IS NULL OR EXISTS (SELECT 1 FROM objects o WHERE o.id = t.object_id AND o.has_photometry = p_has_photometry))
         AND (
           NOT v_comment_search_active
           OR EXISTS (
@@ -391,6 +393,7 @@ BEGIN
           OR (p_inspected_only = TRUE AND t.redshift_quality > 0)
           OR (p_inspected_only = FALSE AND t.redshift_quality = 0)
         )
+        AND (p_has_photometry IS NULL OR EXISTS (SELECT 1 FROM objects o WHERE o.id = t.object_id AND o.has_photometry = p_has_photometry))
         AND (
           NOT v_comment_search_active
           OR EXISTS (
@@ -476,6 +479,7 @@ CREATE OR REPLACE FUNCTION public.get_filtered_targets_paginated(
   p_list_ids INTEGER[] DEFAULT NULL,
   p_search TEXT DEFAULT NULL,
   p_inspected_only BOOLEAN DEFAULT NULL,
+  p_has_photometry BOOLEAN DEFAULT NULL,
   p_comment_search TEXT DEFAULT NULL,
   p_comment_search_scope TEXT DEFAULT NULL,
   p_comment_user_id UUID DEFAULT NULL,
@@ -524,7 +528,8 @@ BEGIN
       v_sf_include_any, v_sf_include_all, v_sf_exclude,
       v_dq_include_any, v_dq_include_all, v_dq_exclude,
       p_list_ids,
-      p_search, p_inspected_only, p_comment_search, p_comment_search_scope, p_comment_user_id,
+      p_search, p_inspected_only, p_has_photometry,
+      p_comment_search, p_comment_search_scope, p_comment_user_id,
       p_coord_ra, p_coord_dec, p_radius_degrees,
       p_sort_column, p_sort_direction,
       p_page, p_page_size,
@@ -847,6 +852,7 @@ CREATE OR REPLACE FUNCTION public.get_filtered_spectra_paginated(
   p_list_ids INTEGER[] DEFAULT NULL,
   p_search TEXT DEFAULT NULL,
   p_inspected_only BOOLEAN DEFAULT NULL,
+  p_has_photometry BOOLEAN DEFAULT NULL,
   p_comment_search TEXT DEFAULT NULL,
   p_comment_search_scope TEXT DEFAULT NULL,
   p_comment_user_id UUID DEFAULT NULL,
@@ -989,6 +995,7 @@ BEGIN
         OR (p_inspected_only = TRUE AND t.redshift_quality > 0)
         OR (p_inspected_only = FALSE AND t.redshift_quality = 0)
       )
+      AND (p_has_photometry IS NULL OR EXISTS (SELECT 1 FROM objects o WHERE o.id = t.object_id AND o.has_photometry = p_has_photometry))
       AND (
         NOT v_comment_search_active
         OR EXISTS (
@@ -1545,6 +1552,7 @@ CREATE OR REPLACE FUNCTION public.get_adjacent_targets(
   p_list_ids INTEGER[] DEFAULT NULL,
   p_search TEXT DEFAULT NULL,
   p_inspected_only BOOLEAN DEFAULT NULL,
+  p_has_photometry BOOLEAN DEFAULT NULL,
   p_comment_search TEXT DEFAULT NULL,
   p_comment_search_scope TEXT DEFAULT NULL,
   p_comment_user_id UUID DEFAULT NULL,
@@ -1647,6 +1655,7 @@ BEGIN
       AND (p_inspected_only IS NULL
         OR (p_inspected_only = TRUE AND t.redshift_quality > 0)
         OR (p_inspected_only = FALSE AND t.redshift_quality = 0))
+      AND (p_has_photometry IS NULL OR EXISTS (SELECT 1 FROM objects o WHERE o.id = t.object_id AND o.has_photometry = p_has_photometry))
       AND (NOT v_comment_search_active OR EXISTS (
         SELECT 1 FROM comments c WHERE c.target_id = t.id AND c.is_deleted = false
           AND c.content ILIKE '%' || p_comment_search || '%'
@@ -1945,6 +1954,7 @@ CREATE OR REPLACE FUNCTION public.get_csv_export(
   p_dq_flags_exclude INTEGER DEFAULT NULL,
   p_list_ids INTEGER[] DEFAULT NULL,
   p_search TEXT DEFAULT NULL, p_inspected_only BOOLEAN DEFAULT NULL,
+  p_has_photometry BOOLEAN DEFAULT NULL,
   p_comment_search TEXT DEFAULT NULL, p_comment_search_scope TEXT DEFAULT NULL,
   p_comment_user_id UUID DEFAULT NULL,
   p_coord_ra DOUBLE PRECISION DEFAULT NULL, p_coord_dec DOUBLE PRECISION DEFAULT NULL,
@@ -2023,6 +2033,7 @@ BEGIN
       ))
       AND (p_search IS NULL OR t.target_id ILIKE '%' || p_search || '%')
       AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND t.redshift_quality > 0) OR (p_inspected_only = FALSE AND t.redshift_quality = 0))
+      AND (p_has_photometry IS NULL OR EXISTS (SELECT 1 FROM objects o WHERE o.id = t.object_id AND o.has_photometry = p_has_photometry))
       AND (NOT v_comment_search_active OR EXISTS (
         SELECT 1 FROM comments c WHERE c.target_id = t.id AND c.is_deleted = false
           AND c.content ILIKE '%' || p_comment_search || '%'
@@ -2084,6 +2095,7 @@ CREATE OR REPLACE FUNCTION public.get_csv_export_spectra(
   p_dq_flags_exclude INTEGER DEFAULT NULL,
   p_list_ids INTEGER[] DEFAULT NULL,
   p_search TEXT DEFAULT NULL, p_inspected_only BOOLEAN DEFAULT NULL,
+  p_has_photometry BOOLEAN DEFAULT NULL,
   p_comment_search TEXT DEFAULT NULL, p_comment_search_scope TEXT DEFAULT NULL,
   p_comment_user_id UUID DEFAULT NULL,
   p_coord_ra DOUBLE PRECISION DEFAULT NULL, p_coord_dec DOUBLE PRECISION DEFAULT NULL,
@@ -2154,6 +2166,7 @@ BEGIN
       ))
       AND (p_search IS NULL OR t.target_id ILIKE '%' || p_search || '%')
       AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND t.redshift_quality > 0) OR (p_inspected_only = FALSE AND t.redshift_quality = 0))
+      AND (p_has_photometry IS NULL OR EXISTS (SELECT 1 FROM objects o WHERE o.id = t.object_id AND o.has_photometry = p_has_photometry))
       AND (NOT v_comment_search_active OR EXISTS (
         SELECT 1 FROM comments c WHERE c.target_id = t.id AND c.is_deleted = false
           AND c.content ILIKE '%' || p_comment_search || '%'

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -724,6 +724,7 @@ BEGIN
            o.n_targets, o.n_spectra, o.programs, o.gratings,
            o.max_snr, o.max_exposure_time,
            o.best_redshift, o.best_redshift_quality,
+           o.has_photometry, o.photo_z, o.photo_z_err_lo, o.photo_z_err_hi,
            o.created_at, o.updated_at
     FROM objects o
     WHERE o.programs && p_program_slugs
@@ -758,6 +759,10 @@ BEGIN
         'max_exposure_time', m.max_exposure_time,
         'best_redshift', m.best_redshift,
         'best_redshift_quality', m.best_redshift_quality,
+        'has_photometry', m.has_photometry,
+        'photo_z', m.photo_z,
+        'photo_z_err_lo', m.photo_z_err_lo,
+        'photo_z_err_hi', m.photo_z_err_hi,
         'created_at', m.created_at,
         'updated_at', m.updated_at,
         'member_target_ids', COALESCE(
@@ -785,6 +790,69 @@ $$;
 
 GRANT EXECUTE ON FUNCTION public.get_objects_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER) TO authenticated;
 GRANT EXECUTE ON FUNCTION public.get_objects_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER) TO service_role;
+
+
+-- =============================================================================
+-- get_photometry_for_sync
+-- (bulk fetch for Python client photometry sync)
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.get_photometry_for_sync(
+  p_program_slugs TEXT[],
+  p_updated_since TIMESTAMPTZ DEFAULT NULL,
+  p_limit INTEGER DEFAULT 1000,
+  p_offset INTEGER DEFAULT 0
+)
+RETURNS TABLE(photometry_records JSONB, total_count BIGINT)
+LANGUAGE plpgsql STABLE
+SET plan_cache_mode = 'force_custom_plan'
+AS $$
+BEGIN
+  RETURN QUERY
+  WITH matched AS (
+    SELECT op.id, o.object_id, op.field, op.catalog_name, op.catalog_id,
+           op.match_distance_arcsec, op.photometry, op.photo_z,
+           op.photo_z_err_lo, op.photo_z_err_hi, op.has_pz,
+           op.created_at, op.updated_at
+    FROM object_photometry op
+    JOIN objects o ON o.id = op.object_id
+    WHERE o.programs && p_program_slugs
+      AND (p_updated_since IS NULL OR op.updated_at > p_updated_since)
+    ORDER BY op.id
+    LIMIT p_limit OFFSET p_offset
+  ),
+  total AS (
+    SELECT COUNT(*) AS cnt
+    FROM object_photometry op
+    JOIN objects o ON o.id = op.object_id
+    WHERE o.programs && p_program_slugs
+      AND (p_updated_since IS NULL OR op.updated_at > p_updated_since)
+  )
+  SELECT
+    COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'id', m.id,
+        'object_id', m.object_id,
+        'field', m.field,
+        'catalog_name', m.catalog_name,
+        'catalog_id', m.catalog_id,
+        'match_distance_arcsec', m.match_distance_arcsec,
+        'photometry', m.photometry,
+        'photo_z', m.photo_z,
+        'photo_z_err_lo', m.photo_z_err_lo,
+        'photo_z_err_hi', m.photo_z_err_hi,
+        'has_pz', m.has_pz,
+        'created_at', m.created_at,
+        'updated_at', m.updated_at
+      )
+    ), '[]'::jsonb),
+    COALESCE((SELECT cnt FROM total), 0)::BIGINT
+  FROM matched m;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_photometry_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_photometry_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER) TO service_role;
 
 
 -- =============================================================================
@@ -2240,7 +2308,10 @@ RETURNS TABLE(
   programs TEXT, gratings TEXT,
   max_snr DOUBLE PRECISION, max_exposure_time DOUBLE PRECISION,
   member_target_ids TEXT, distance DOUBLE PRECISION,
-  lists TEXT
+  lists TEXT,
+  has_photometry BOOLEAN, photo_z DOUBLE PRECISION,
+  photo_z_err_lo DOUBLE PRECISION, photo_z_err_hi DOUBLE PRECISION,
+  photometry JSONB
 )
 LANGUAGE plpgsql STABLE SET plan_cache_mode = 'force_custom_plan'
 AS $$
@@ -2257,7 +2328,7 @@ BEGIN
   IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
   IF NOT (p_sort_column IN (
     'object_id', 'field', 'ra', 'dec', 'best_redshift', 'best_redshift_quality',
-    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time'
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time', 'photo_z'
   ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
     p_sort_column := 'object_id';
   END IF;
@@ -2287,8 +2358,14 @@ BEGIN
        FROM object_list_members olm
        JOIN object_lists ol ON ol.id = olm.list_id
        WHERE olm.object_id = o.id
-         AND (ol.created_by = auth.uid() OR ol.visibility IN ('public_read', 'public_edit'))) AS lists
+         AND (ol.created_by = auth.uid() OR ol.visibility IN ('public_read', 'public_edit'))) AS lists,
+      o.has_photometry, o.photo_z, o.photo_z_err_lo, o.photo_z_err_hi,
+      phot.photometry
     FROM objects o
+    LEFT JOIN LATERAL (
+      SELECT op.photometry FROM object_photometry op
+      WHERE op.object_id = o.id ORDER BY op.updated_at DESC LIMIT 1
+    ) phot ON true
     WHERE o.programs && v_filtered_program_slugs
       AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
       AND (
@@ -2325,7 +2402,9 @@ BEGIN
     df.n_targets, df.n_spectra,
     df.programs, df.gratings,
     df.max_snr, df.max_exposure_time,
-    df.member_target_ids, df.distance, df.lists
+    df.member_target_ids, df.distance, df.lists,
+    df.has_photometry, df.photo_z, df.photo_z_err_lo, df.photo_z_err_hi,
+    df.photometry
   FROM distance_filtered df
   ORDER BY
     CASE WHEN v_coord_search_active THEN df.distance END ASC NULLS LAST,
@@ -2349,6 +2428,8 @@ BEGIN
     CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN df.max_snr END DESC NULLS LAST,
     CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN df.max_exposure_time END ASC NULLS LAST,
     CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN df.max_exposure_time END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'photo_z' AND p_sort_direction = 'asc' THEN df.photo_z END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'photo_z' AND p_sort_direction = 'desc' THEN df.photo_z END DESC NULLS LAST,
     df.object_id ASC;
 END;
 $$;

--- a/web/app/api/v1/sync/photometry/route.ts
+++ b/web/app/api/v1/sync/photometry/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { validateAuth } from '@/lib/api-auth';
+import { getAccessiblePrograms } from '@/lib/api-helpers';
+
+/**
+ * GET /api/v1/sync/photometry
+ *
+ * Bulk fetch for Python client photometry sync.
+ * Returns object_photometry records (with JSONB band data) for objects
+ * accessible by the authenticated user, paginated, with optional
+ * incremental filtering via updated_since.
+ *
+ * Query parameters:
+ * - updated_since: ISO 8601 timestamp (only return records updated after this)
+ * - limit: page size (default 1000)
+ * - offset: pagination offset (default 0)
+ */
+export async function GET(request: NextRequest) {
+  const userId = await validateAuth(request);
+
+  if (!userId) {
+    return NextResponse.json(
+      { error: 'Invalid or missing authentication' },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const accessibleProgramSlugs = await getAccessiblePrograms(userId);
+
+    if (accessibleProgramSlugs.length === 0) {
+      return NextResponse.json({
+        data: [],
+        pagination: { total: 0, limit: 0, offset: 0 },
+      });
+    }
+
+    const searchParams = request.nextUrl.searchParams;
+    const limit = parseInt(searchParams.get('limit') || '1000', 10);
+    const offset = parseInt(searchParams.get('offset') || '0', 10);
+    const updatedSince = searchParams.get('updated_since') || null;
+
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+    const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+    const { data, error } = await supabase.rpc('get_photometry_for_sync', {
+      p_program_slugs: accessibleProgramSlugs,
+      p_updated_since: updatedSince,
+      p_limit: limit,
+      p_offset: offset,
+    });
+
+    if (error) {
+      console.error('Error in sync photometry:', error);
+      return NextResponse.json(
+        { error: 'Failed to fetch photometry', details: error.message },
+        { status: 500 }
+      );
+    }
+
+    const result = data?.[0] || { photometry_records: [], total_count: 0 };
+
+    return NextResponse.json({
+      data: result.photometry_records || [],
+      pagination: {
+        total: result.total_count || 0,
+        limit,
+        offset,
+      },
+    });
+  } catch (error) {
+    console.error('Error in API /v1/sync/photometry:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/web/lib/actions/download.ts
+++ b/web/lib/actions/download.ts
@@ -25,6 +25,16 @@ interface DownloadPayload {
   zipFilename: string;
 }
 
+interface PhotometryBands {
+  [band: string]: {
+    flux: number;
+    flux_err: number;
+    wav?: number;
+    wav_min?: number;
+    wav_max?: number;
+  };
+}
+
 interface ObjectsCsvRow {
   object_id: string;
   field: string;
@@ -41,6 +51,11 @@ interface ObjectsCsvRow {
   member_target_ids: string;   // semicolon-separated
   distance: number | null;
   lists: string | null;        // semicolon-separated list slugs
+  has_photometry: boolean;
+  photo_z: number | null;
+  photo_z_err_lo: number | null;
+  photo_z_err_hi: number | null;
+  photometry: { flux_unit: string; bands: PhotometryBands } | null;
 }
 
 interface CsvRow {
@@ -354,9 +369,31 @@ function spectraRowsToCsv(rows: SpectraCsvRow[], includeDistance: boolean): stri
 }
 
 /**
+ * Collect all unique band names from photometry rows, sorted by wavelength
+ */
+function collectSortedBands(rows: ObjectsCsvRow[]): string[] {
+  const bandWavs = new Map<string, number>();
+  for (const row of rows) {
+    if (!row.photometry?.bands) continue;
+    for (const [band, data] of Object.entries(row.photometry.bands)) {
+      if (!bandWavs.has(band) && data.wav != null) {
+        bandWavs.set(band, data.wav);
+      } else if (!bandWavs.has(band)) {
+        bandWavs.set(band, Infinity);
+      }
+    }
+  }
+  return [...bandWavs.entries()]
+    .sort((a, b) => a[1] - b[1] || a[0].localeCompare(b[0]))
+    .map(([band]) => band);
+}
+
+/**
  * Convert objects-mode CSV export rows to CSV string
  */
 function objectsRowsToCsv(rows: ObjectsCsvRow[], includeDistance: boolean): string {
+  const sortedBands = collectSortedBands(rows);
+
   const columns = [
     'object_id',
     'field',
@@ -372,6 +409,11 @@ function objectsRowsToCsv(rows: ObjectsCsvRow[], includeDistance: boolean): stri
     'max_exposure_time',
     'member_target_ids',
     'tags',
+    'has_photometry',
+    'photo_z',
+    'photo_z_err_lo',
+    'photo_z_err_hi',
+    ...sortedBands.flatMap(b => [`f_${b}`, `e_${b}`]),
   ];
 
   if (includeDistance) {
@@ -403,7 +445,22 @@ function objectsRowsToCsv(rows: ObjectsCsvRow[], includeDistance: boolean): stri
       row.max_exposure_time != null ? row.max_exposure_time.toFixed(0) : '',
       escapeCsvValue(row.member_target_ids || ''),
       escapeCsvValue(row.lists || ''),
+      row.has_photometry ? 1 : 0,
+      row.photo_z != null ? row.photo_z.toFixed(6) : '',
+      row.photo_z_err_lo != null ? row.photo_z_err_lo.toFixed(6) : '',
+      row.photo_z_err_hi != null ? row.photo_z_err_hi.toFixed(6) : '',
     );
+
+    // Expand photometry bands
+    const bands = row.photometry?.bands;
+    for (const band of sortedBands) {
+      const data = bands?.[band];
+      if (data) {
+        values.push(data.flux.toFixed(6), data.flux_err.toFixed(6));
+      } else {
+        values.push('', '');
+      }
+    }
 
     csvRows.push(values.join(','));
   }


### PR DESCRIPTION
## Summary
- **Frontend CSV (objects mode):** Now includes `has_photometry`, `photo_z`, `photo_z_err_lo`, `photo_z_err_hi`, and wide-format `f_<band>`/`e_<band>` columns for every photometric band in the result set, sorted by wavelength. Objects without photometry get empty cells.
- **Python client sync:** New `object_photometry` table synced from server via `get_photometry_for_sync` RPC + `/api/v1/sync/photometry` endpoint. Exports wide-format `photometry.csv` alongside existing catalogs. `objects.csv` now includes photo-z summary fields.
- **`get_objects_for_sync` RPC:** Now returns `has_photometry`, `photo_z`, `photo_z_err_lo`, `photo_z_err_hi` so the Python client has photo-z info on the objects table.
- SQLite `SCHEMA_VERSION` bumped to 3 (existing local databases will need `--full` re-sync).

## Test plan
- [ ] `supabase db reset` — migration applies cleanly (verified locally)
- [ ] `npm run build` — no type errors (verified locally)
- [ ] Download CSV from frontend in objects view mode for a field with photometry — confirm band columns appear
- [ ] `campfire sync --full` — confirm `objects.csv` has photo_z columns and `photometry.csv` has wide-format band data
- [ ] Verify Vercel preview deployment builds successfully

Generated with Claude Code