### PR TITLE
Add spectral calibration, stacking, and unit-aware SpectrumData

### DIFF
--- a/python/campfire/__init__.py
+++ b/python/campfire/__init__.py
@@ -6,7 +6,15 @@ from the CAMPFIRE archive (COSMOS Archive of MultiPle-Field Internal Reductions 
 """
 
 from .client import Campfire
-from .models import SpectrumData
+from .models import (
+    SpectrumData,
+    Spectrum,
+    SpectrumCollection,
+    Photometry,
+    Band,
+    Target,
+    Object,
+)
 from .exceptions import (
     CampfireError,
     AuthenticationError,
@@ -34,6 +42,10 @@ def __getattr__(name):
     if name in ("plot_cutout",):
         from . import imaging
         return getattr(imaging, name)
+    if name in ("calibrate_to_photometry", "calibrate_and_stack",
+                 "stack_spectra", "CalibrationResult", "StackResult"):
+        from . import calibration
+        return getattr(calibration, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -41,6 +53,12 @@ __version__ = "0.3.0"
 __all__ = [
     "Campfire",
     "SpectrumData",
+    "Spectrum",
+    "SpectrumCollection",
+    "Photometry",
+    "Band",
+    "Target",
+    "Object",
     # Exceptions
     "CampfireError",
     "AuthenticationError",
@@ -65,4 +83,10 @@ __all__ = [
     "get_emission_lines",
     # Imaging (lazy loaded)
     "plot_cutout",
+    # Calibration & stacking (lazy loaded)
+    "calibrate_to_photometry",
+    "calibrate_and_stack",
+    "stack_spectra",
+    "CalibrationResult",
+    "StackResult",
 ]

--- a/python/campfire/calibration.py
+++ b/python/campfire/calibration.py
@@ -1,0 +1,1084 @@
+"""Spectral calibration and stacking.
+
+Provides utilities for flux-calibrating spectra against photometric
+measurements and stacking multiple spectra of the same object.
+
+Example
+-------
+::
+
+    from campfire.calibration import calibrate_to_photometry, calibrate_and_stack
+
+    cf = Campfire()
+    obj = cf.get_object('J100025.32+021520.1')
+
+    # Single spectrum calibration
+    calib = calibrate_to_photometry(obj.spectra[0], obj.photometry)
+    calib.plot()
+
+    # Calibrate + stack all PRISM spectra
+    prism = obj.spectra[obj.spectra.grating == 'PRISM']
+    stacked = calibrate_and_stack(prism, obj.photometry)
+    stacked.plot()
+"""
+
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Union
+
+import numpy as np
+
+from .models import Photometry, Spectrum, SpectrumCollection, SpectrumData
+
+
+# ---------------------------------------------------------------------------
+# SVO Filter Profile Service — band name → SVO ID mapping
+# ---------------------------------------------------------------------------
+
+SVO_FILTER_MAP = {
+    # JWST NIRCam
+    "f090w": "JWST/NIRCam.F090W",
+    "f115w": "JWST/NIRCam.F115W",
+    "f140m": "JWST/NIRCam.F140M",
+    "f150w": "JWST/NIRCam.F150W",
+    "f182m": "JWST/NIRCam.F182M",
+    "f200w": "JWST/NIRCam.F200W",
+    "f210m": "JWST/NIRCam.F210M",
+    "f250m": "JWST/NIRCam.F250M",
+    "f277w": "JWST/NIRCam.F277W",
+    "f300m": "JWST/NIRCam.F300M",
+    "f335m": "JWST/NIRCam.F335M",
+    "f356w": "JWST/NIRCam.F356W",
+    "f360m": "JWST/NIRCam.F360M",
+    "f410m": "JWST/NIRCam.F410M",
+    "f430m": "JWST/NIRCam.F430M",
+    "f444w": "JWST/NIRCam.F444W",
+    "f460m": "JWST/NIRCam.F460M",
+    "f480m": "JWST/NIRCam.F480M",
+    "f770w": "JWST/NIRCam.F770W",
+    # HST ACS/WFC
+    "f435w": "HST/ACS_WFC.F435W",
+    "f606w": "HST/ACS_WFC.F606W",
+    "f814w": "HST/ACS_WFC.F814W",
+    # HST WFC3/IR
+    "f098m": "HST/WFC3_IR.F098M",
+    # Euclid
+    "vis": "Euclid/VIS.vis",
+    # Ground-based (COSMOS defaults)
+    "u": "CFHT/MegaCam.u",
+    "g": "Subaru/HSC.g",
+    "r": "Subaru/HSC.r",
+    "i": "Subaru/HSC.i",
+    "z": "Subaru/HSC.z",
+    "y": "Subaru/HSC.y",
+    "Y": "Paranal/VISTA.Y",
+    "J": "Paranal/VISTA.J",
+    "H": "Paranal/VISTA.H",
+    "Ks": "Paranal/VISTA.Ks",
+}
+
+SVO_BASE_URL = "http://svo2.cab.inta-csic.es/theory/fps/getdata.php"
+
+# Fallback band edges (microns) from deploy/photometry.py
+_FILTER_EDGES = {
+    "f090w": (0.788550, 1.023550),
+    "f115w": (0.998200, 1.305200),
+    "f140m": (1.304350, 1.505350),
+    "f150w": (1.303790, 1.693790),
+    "f182m": (1.695500, 2.000500),
+    "f200w": (1.723400, 2.258400),
+    "f210m": (1.961600, 2.232600),
+    "f250m": (2.393530, 2.616900),
+    "f277w": (2.365900, 3.216190),
+    "f300m": (2.770356, 3.250592),
+    "f335m": (3.118640, 3.642920),
+    "f356w": (3.070000, 4.078020),
+    "f360m": (3.322680, 3.902360),
+    "f410m": (3.775340, 4.402310),
+    "f430m": (4.122610, 4.444200),
+    "f444w": (3.802370, 5.099550),
+    "f460m": (4.465820, 4.813090),
+    "f480m": (4.582030, 5.088740),
+    "f770w": (6.475000, 8.830000),
+    "f435w": (0.359500, 0.488300),
+    "f606w": (0.462700, 0.717900),
+    "f814w": (0.686800, 0.962600),
+    "f098m": (0.889000, 1.084297),
+    "vis": (0.495885, 0.930629),
+    "u": (0.3100, 0.4000),
+    "g": (0.3950, 0.5600),
+    "r": (0.5500, 0.7000),
+    "i": (0.6900, 0.8400),
+    "z": (0.8200, 1.0000),
+    "y": (0.9300, 1.0600),
+    "Y": (0.9600, 1.0900),
+    "J": (1.1500, 1.3500),
+    "H": (1.4900, 1.8000),
+    "Ks": (1.9900, 2.3200),
+}
+
+
+def _cache_dir() -> Path:
+    """Return (and create) the local filter curve cache directory."""
+    d = Path.home() / ".cache" / "campfire" / "filters"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _download_filter_curve(band: str) -> Optional[tuple]:
+    """Download a filter transmission curve from the SVO Filter Profile Service.
+
+    Returns (wavelength_um, transmission) arrays, or None on failure.
+    """
+    svo_id = SVO_FILTER_MAP.get(band)
+    if svo_id is None:
+        return None
+
+    import requests
+
+    try:
+        resp = requests.get(
+            SVO_BASE_URL,
+            params={"format": "ascii", "id": svo_id},
+            timeout=15,
+        )
+        resp.raise_for_status()
+    except Exception:
+        return None
+
+    # Parse the 2-column ASCII: wavelength (Angstrom), transmission
+    wavelengths = []
+    transmissions = []
+    for line in resp.text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or line.startswith("!"):
+            continue
+        parts = line.split()
+        if len(parts) >= 2:
+            try:
+                w = float(parts[0])
+                t = float(parts[1])
+                wavelengths.append(w)
+                transmissions.append(t)
+            except ValueError:
+                continue
+
+    if len(wavelengths) < 3:
+        return None
+
+    wave_um = np.array(wavelengths) * 1e-4  # Angstrom → micron
+    trans = np.array(transmissions)
+    return wave_um, trans
+
+
+def get_filter_curve(band: str) -> tuple:
+    """Get filter transmission curve (wavelength_um, transmission).
+
+    Checks the local cache first, downloads from SVO if needed,
+    falls back to a top-hat approximation using known band edges.
+
+    Parameters
+    ----------
+    band : str
+        Band name (e.g. ``'f444w'``).
+
+    Returns
+    -------
+    wavelength : np.ndarray
+        Wavelength in microns.
+    transmission : np.ndarray
+        Transmission (0–1).
+    """
+    cache = _cache_dir() / f"{band}.npz"
+
+    # Try cache
+    if cache.exists():
+        data = np.load(cache)
+        return data["wavelength"], data["transmission"]
+
+    # Try SVO download
+    result = _download_filter_curve(band)
+    if result is not None:
+        wave, trans = result
+        np.savez_compressed(cache, wavelength=wave, transmission=trans)
+        return wave, trans
+
+    # Fallback: top-hat from known band edges
+    if band in _FILTER_EDGES:
+        blue, red = _FILTER_EDGES[band]
+        warnings.warn(
+            f"Could not download filter curve for '{band}' from SVO. "
+            f"Using top-hat approximation ({blue:.3f}–{red:.3f} μm).",
+            stacklevel=2,
+        )
+        wave = np.array([blue - 0.001, blue, red, red + 0.001])
+        trans = np.array([0.0, 1.0, 1.0, 0.0])
+        return wave, trans
+
+    raise ValueError(
+        f"Unknown band '{band}': not in SVO_FILTER_MAP or _FILTER_EDGES. "
+        f"Available bands: {sorted(SVO_FILTER_MAP.keys())}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Synthetic photometry
+# ---------------------------------------------------------------------------
+
+def synthetic_photometry(
+    wavelength: np.ndarray,
+    flux: np.ndarray,
+    flux_err: np.ndarray,
+    band: str,
+) -> tuple:
+    """Compute AB synthetic photometry for a single band.
+
+    Uses the standard AB formula for f_ν:
+    ``<f_ν> = ∫ f_ν(λ) T(λ) λ dλ / ∫ T(λ) λ dλ``
+
+    Parameters
+    ----------
+    wavelength : np.ndarray
+        Spectrum wavelength in microns.
+    flux : np.ndarray
+        Spectrum flux density (f_ν) in μJy.
+    flux_err : np.ndarray
+        Flux error in μJy.
+    band : str
+        Band name (e.g. ``'f444w'``).
+
+    Returns
+    -------
+    synth_flux : float
+        Synthetic flux in μJy.
+    synth_err : float
+        Propagated error in μJy.
+    """
+    filt_wave, filt_trans = get_filter_curve(band)
+
+    # Interpolate filter onto spectrum wavelength grid
+    T = np.interp(wavelength, filt_wave, filt_trans, left=0.0, right=0.0)
+
+    # Mask non-finite flux pixels
+    valid = np.isfinite(flux) & np.isfinite(flux_err)
+    T_v = T.copy()
+    T_v[~valid] = 0.0
+    flux_v = np.where(valid, flux, 0.0)
+    err_v = np.where(valid, flux_err, 0.0)
+
+    denom = np.trapz(T_v * wavelength, wavelength)
+    if denom == 0:
+        return np.nan, np.nan
+
+    synth_flux = np.trapz(flux_v * T_v * wavelength, wavelength) / denom
+    synth_err = np.sqrt(np.trapz((err_v * T_v * wavelength) ** 2, wavelength)) / denom
+
+    return float(synth_flux), float(synth_err)
+
+
+# ---------------------------------------------------------------------------
+# CalibrationResult
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CalibrationResult:
+    """Result of spectral calibration to photometry.
+
+    Attributes
+    ----------
+    spectrum : SpectrumData
+        Calibrated spectrum (new object with corrected flux).
+    original : SpectrumData
+        Original uncalibrated spectrum.
+    multiplier : np.ndarray
+        Correction curve applied to flux (same length as wavelength).
+    method : str
+        Calibration method used (``'chebyshev'`` or ``'flat'``).
+    bands_used : list of str
+        Bands that contributed to the fit.
+    observed_flux : np.ndarray
+        Photometric flux for ``bands_used`` (μJy).
+    observed_flux_err : np.ndarray
+        Photometric flux error (μJy).
+    synthetic_flux : np.ndarray
+        Synthetic photometry from original spectrum (μJy).
+    synthetic_flux_err : np.ndarray
+        Synthetic photometry error (μJy).
+    band_wavelengths : np.ndarray
+        Pivot wavelengths for ``bands_used`` (microns).
+    """
+
+    spectrum: SpectrumData
+    original: SpectrumData
+    multiplier: np.ndarray
+    method: str
+    bands_used: List[str]
+    observed_flux: np.ndarray
+    observed_flux_err: np.ndarray
+    synthetic_flux: np.ndarray
+    synthetic_flux_err: np.ndarray
+    band_wavelengths: np.ndarray
+
+    def plot(self, axes=None):
+        """Diagnostic plot showing calibration results.
+
+        Two-panel figure:
+        - **Top**: Before/after spectra with photometric points.
+        - **Bottom**: Calibration multiplier curve with per-band ratios.
+
+        Parameters
+        ----------
+        axes : array-like of matplotlib.axes.Axes, optional
+            Two Axes to draw on. If *None*, a new figure is created.
+
+        Returns
+        -------
+        tuple of matplotlib.axes.Axes
+        """
+        import matplotlib.pyplot as plt
+
+        if axes is None:
+            fig, axes = plt.subplots(
+                2, 1, figsize=(10, 7), height_ratios=[3, 1],
+                sharex=True, constrained_layout=True,
+            )
+
+        ax_spec, ax_mult = axes
+
+        wave = self.original.wavelength
+        valid = np.isfinite(self.original.fnu)
+
+        # Top panel: spectra + photometry
+        ax_spec.plot(
+            wave[valid], self.original.fnu[valid],
+            color="0.5", lw=0.8, alpha=0.7, label="Original",
+        )
+        ax_spec.plot(
+            wave[valid], self.spectrum.fnu[valid],
+            color="C0", lw=1, label="Calibrated",
+        )
+        ax_spec.errorbar(
+            self.band_wavelengths, self.observed_flux,
+            yerr=self.observed_flux_err,
+            fmt="o", color="C3", ms=6, zorder=10, label="Photometry",
+        )
+        # Synthetic photometry of calibrated spectrum
+        synth_after = np.array([
+            synthetic_photometry(wave, self.spectrum.fnu, self.spectrum.fnu_err, b)[0]
+            for b in self.bands_used
+        ])
+        ax_spec.scatter(
+            self.band_wavelengths, synth_after,
+            marker="x", color="C0", s=60, zorder=11, label="Synth (after)",
+        )
+        ax_spec.scatter(
+            self.band_wavelengths, self.synthetic_flux,
+            marker="x", color="0.5", s=40, zorder=9, label="Synth (before)",
+        )
+
+        ax_spec.set_ylabel("f_ν (μJy)")
+        ax_spec.legend(fontsize=8)
+        ax_spec.set_title(
+            f"{self.original.target_id}  {self.original.grating}  —  "
+            f"{self.method} calibration"
+        )
+
+        # Bottom panel: multiplier curve + per-band ratios
+        ax_mult.plot(wave, self.multiplier, color="C0", lw=1.5)
+
+        ratio = self.observed_flux / self.synthetic_flux
+        frac_err = np.sqrt(
+            (self.observed_flux_err / self.observed_flux) ** 2
+            + (self.synthetic_flux_err / self.synthetic_flux) ** 2
+        )
+        ratio_err = ratio * frac_err
+
+        ax_mult.errorbar(
+            self.band_wavelengths, ratio, yerr=ratio_err,
+            fmt="o", color="C3", ms=6, zorder=10,
+        )
+        ax_mult.axhline(1.0, color="0.5", ls="--", lw=0.8)
+        ax_mult.set_xlabel("Wavelength (μm)")
+        ax_mult.set_ylabel("Multiplier")
+
+        return ax_spec, ax_mult
+
+
+# ---------------------------------------------------------------------------
+# Main calibration function
+# ---------------------------------------------------------------------------
+
+def calibrate_to_photometry(
+    spectrum: Union[Spectrum, SpectrumData],
+    photometry: Photometry,
+    method: str = "chebyshev",
+    bands: Optional[List[str]] = None,
+    degree: Optional[int] = None,
+    min_snr: float = 0.5,
+) -> CalibrationResult:
+    """Flux-calibrate a spectrum against broadband photometry.
+
+    Computes synthetic photometry from the spectrum for each band,
+    compares to the observed photometry, and fits a smooth correction
+    curve to bring the spectrum into agreement.
+
+    Parameters
+    ----------
+    spectrum : Spectrum or SpectrumData
+        The spectrum to calibrate. If a :class:`Spectrum` handle,
+        ``.open()`` is called to load the data.
+    photometry : Photometry
+        Broadband photometric measurements (flux in μJy).
+    method : str
+        ``'chebyshev'`` (default) fits a Chebyshev polynomial.
+        ``'flat'`` applies a single scalar correction.
+    bands : list of str, optional
+        Bands to use. Default: auto-select bands overlapping the
+        spectrum with sufficient SNR.
+    degree : int, optional
+        Chebyshev polynomial degree. Default: ``min(3, n_bands - 1)``.
+    min_snr : float
+        Minimum SNR in both spectrum and photometry for a band to
+        be included in the fit (default 0.5).
+
+    Returns
+    -------
+    CalibrationResult
+        Contains the calibrated spectrum, correction curve, and
+        diagnostic data. Call ``.plot()`` for a visual summary.
+    """
+    # Resolve Spectrum → SpectrumData
+    if isinstance(spectrum, Spectrum):
+        spec_data = spectrum.open()
+    else:
+        spec_data = spectrum
+
+    wave = spec_data.wavelength
+    flux = spec_data.fnu
+    flux_err = spec_data.fnu_err
+
+    # Determine which bands to use
+    if bands is None:
+        bands = _auto_select_bands(wave, flux, flux_err, photometry, min_snr)
+    else:
+        # Validate requested bands exist in photometry
+        for b in bands:
+            if b not in photometry.bands:
+                raise ValueError(
+                    f"Band '{b}' not found in photometry. "
+                    f"Available: {', '.join(photometry.bands)}"
+                )
+
+    if len(bands) == 0:
+        raise ValueError(
+            "No bands overlap with the spectrum wavelength range. "
+            "Check that the photometry bands cover the spectral range."
+        )
+
+    # Compute synthetic photometry for each band
+    synth_fluxes = []
+    synth_errs = []
+    obs_fluxes = []
+    obs_errs = []
+    band_waves = []
+
+    for b in bands:
+        sf, se = synthetic_photometry(wave, flux, flux_err, b)
+        band_info = photometry[b]
+        synth_fluxes.append(sf)
+        synth_errs.append(se)
+        obs_fluxes.append(band_info.flux)
+        obs_errs.append(band_info.flux_err)
+        band_waves.append(band_info.wavelength)
+
+    synth_fluxes = np.array(synth_fluxes)
+    synth_errs = np.array(synth_errs)
+    obs_fluxes = np.array(obs_fluxes)
+    obs_errs = np.array(obs_errs)
+    band_waves = np.array(band_waves)
+
+    # Filter out NaN synthetic photometry
+    valid = (
+        np.isfinite(synth_fluxes)
+        & np.isfinite(obs_fluxes)
+        & (synth_fluxes > 0)
+        & (obs_fluxes > 0)
+    )
+    if valid.sum() == 0:
+        raise ValueError(
+            "No valid band ratios could be computed. Synthetic photometry "
+            "returned NaN or zero for all bands."
+        )
+
+    if valid.sum() < len(bands):
+        dropped = [b for b, v in zip(bands, valid) if not v]
+        warnings.warn(
+            f"Dropped bands with invalid synthetic photometry: {dropped}",
+            stacklevel=2,
+        )
+        bands = [b for b, v in zip(bands, valid) if v]
+        synth_fluxes = synth_fluxes[valid]
+        synth_errs = synth_errs[valid]
+        obs_fluxes = obs_fluxes[valid]
+        obs_errs = obs_errs[valid]
+        band_waves = band_waves[valid]
+
+    # Compute correction multiplier
+    if method == "chebyshev":
+        multiplier = _fit_chebyshev(
+            wave, band_waves, obs_fluxes, obs_errs,
+            synth_fluxes, synth_errs, degree,
+        )
+    elif method == "flat":
+        multiplier = _fit_flat(
+            wave, obs_fluxes, obs_errs, synth_fluxes, synth_errs,
+        )
+    else:
+        raise ValueError(f"Unknown method '{method}'. Use 'chebyshev' or 'flat'.")
+
+    # Apply calibration — create new SpectrumData
+    cal_fnu = spec_data.fnu * multiplier
+    cal_fnu_err = spec_data.fnu_err * multiplier
+    cal_flam = spec_data.flam * multiplier
+    cal_flam_err = spec_data.flam_err * multiplier
+
+    calibrated = SpectrumData(
+        wavelength=spec_data.wavelength.copy(),
+        fnu=cal_fnu,
+        fnu_err=cal_fnu_err,
+        header=dict(spec_data.header),
+        grating=spec_data.grating,
+        target_id=spec_data.target_id,
+        flam=cal_flam,
+        flam_err=cal_flam_err,
+        fits_path=spec_data.fits_path,
+    )
+
+    return CalibrationResult(
+        spectrum=calibrated,
+        original=spec_data,
+        multiplier=multiplier,
+        method=method,
+        bands_used=bands,
+        observed_flux=obs_fluxes,
+        observed_flux_err=obs_errs,
+        synthetic_flux=synth_fluxes,
+        synthetic_flux_err=synth_errs,
+        band_wavelengths=band_waves,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _auto_select_bands(
+    wave: np.ndarray,
+    flux: np.ndarray,
+    flux_err: np.ndarray,
+    photometry: Photometry,
+    min_snr: float,
+) -> List[str]:
+    """Select photometry bands that overlap the spectrum with sufficient SNR."""
+    wmin = wave[np.isfinite(flux)].min()
+    wmax = wave[np.isfinite(flux)].max()
+
+    selected = []
+    for b in photometry.bands:
+        # Check band overlaps spectrum
+        if b in _FILTER_EDGES:
+            blue, red = _FILTER_EDGES[b]
+        elif b in SVO_FILTER_MAP:
+            # Use photometry pivot wavelength as rough check
+            band_info = photometry[b]
+            blue = band_info.wavelength * 0.8
+            red = band_info.wavelength * 1.2
+        else:
+            continue
+
+        if red < wmin or blue > wmax:
+            continue
+
+        # Check photometric SNR
+        band_info = photometry[b]
+        if band_info.flux_err > 0 and band_info.flux / band_info.flux_err < min_snr:
+            continue
+
+        # Check synthetic photometry SNR
+        sf, se = synthetic_photometry(wave, flux, flux_err, b)
+        if not np.isfinite(sf) or sf <= 0:
+            continue
+        if se > 0 and sf / se < min_snr:
+            continue
+
+        selected.append(b)
+
+    return selected
+
+
+def _fit_chebyshev(
+    wave: np.ndarray,
+    band_waves: np.ndarray,
+    obs_flux: np.ndarray,
+    obs_err: np.ndarray,
+    synth_flux: np.ndarray,
+    synth_err: np.ndarray,
+    degree: Optional[int],
+) -> np.ndarray:
+    """Fit a Chebyshev polynomial calibration curve."""
+    ratio = obs_flux / synth_flux
+    frac_err = np.sqrt(
+        (obs_err / obs_flux) ** 2 + (synth_err / synth_flux) ** 2
+    )
+    ratio_err = ratio * frac_err
+
+    # Map wavelengths to [-1, 1] using spectrum bounds
+    wmin, wmax = wave.min(), wave.max()
+    cheb_band = (band_waves - wmin) / (wmax - wmin) * 2 - 1
+    cheb_wave = (wave - wmin) / (wmax - wmin) * 2 - 1
+
+    # Auto degree: min(3, n_bands - 1)
+    n = len(band_waves)
+    if degree is None:
+        degree = min(3, n - 1)
+    degree = max(0, min(degree, n - 1))
+
+    # Weighted Chebyshev fit
+    weights = 1.0 / ratio_err
+    coeffs = np.polynomial.chebyshev.chebfit(cheb_band, ratio, degree, w=weights)
+    multiplier = np.polynomial.chebyshev.chebval(cheb_wave, coeffs)
+
+    # Clamp to prevent runaway corrections
+    multiplier = np.clip(multiplier, 0.1, 50.0)
+
+    # Freeze beyond the reddest fitted band (constant extrapolation)
+    red_idx = wave > band_waves.max()
+    if red_idx.any():
+        multiplier[red_idx] = multiplier[~red_idx][-1] if (~red_idx).any() else 1.0
+
+    # Freeze below the bluest fitted band
+    blue_idx = wave < band_waves.min()
+    if blue_idx.any():
+        multiplier[blue_idx] = multiplier[~blue_idx][0] if (~blue_idx).any() else 1.0
+
+    return multiplier
+
+
+def _fit_flat(
+    wave: np.ndarray,
+    obs_flux: np.ndarray,
+    obs_err: np.ndarray,
+    synth_flux: np.ndarray,
+    synth_err: np.ndarray,
+) -> np.ndarray:
+    """Compute a flat (scalar) calibration correction."""
+    ratio = obs_flux / synth_flux
+    frac_err = np.sqrt(
+        (obs_err / obs_flux) ** 2 + (synth_err / synth_flux) ** 2
+    )
+    ratio_err = ratio * frac_err
+
+    # Inverse-variance weighted mean
+    weights = 1.0 / ratio_err**2
+    flat_ratio = np.sum(weights * ratio) / np.sum(weights)
+
+    return np.full_like(wave, flat_ratio)
+
+
+# ---------------------------------------------------------------------------
+# Spectral resampling
+# ---------------------------------------------------------------------------
+
+def _resample(
+    new_wave: np.ndarray,
+    old_wave: np.ndarray,
+    flux: np.ndarray,
+    flux_err: np.ndarray,
+) -> tuple:
+    """Resample a spectrum onto a new wavelength grid.
+
+    Uses ``spectres`` for flux-conserving resampling if installed,
+    otherwise falls back to linear interpolation.
+
+    Returns (resampled_flux, resampled_flux_err).
+    """
+    try:
+        from spectres import spectres
+        new_flux = spectres(new_wave, old_wave, flux, spec_errs=flux_err, fill=np.nan, verbose=False)
+        # spectres returns (flux, err) when spec_errs is given
+        if isinstance(new_flux, tuple):
+            return new_flux[0], new_flux[1]
+        # If only flux returned, resample errors separately
+        new_err = spectres(new_wave, old_wave, flux_err, fill=np.nan, verbose=False)
+        return new_flux, new_err
+    except ImportError:
+        pass
+
+    # Fallback: linear interpolation (set out-of-range to NaN)
+    valid = np.isfinite(flux) & np.isfinite(flux_err)
+    new_flux = np.interp(new_wave, old_wave[valid], flux[valid], left=np.nan, right=np.nan)
+    new_err = np.interp(new_wave, old_wave[valid], flux_err[valid], left=np.nan, right=np.nan)
+    return new_flux, new_err
+
+
+# ---------------------------------------------------------------------------
+# Spectrum stacking
+# ---------------------------------------------------------------------------
+
+def stack_spectra(
+    spectra: List[SpectrumData],
+    method: str = "weighted_mean",
+    wavelength_grid: Optional[np.ndarray] = None,
+) -> SpectrumData:
+    """Stack multiple spectra onto a common wavelength grid.
+
+    Resamples all input spectra to a shared wavelength grid, then
+    combines them using inverse-variance weighting (default) or
+    median.
+
+    Parameters
+    ----------
+    spectra : list of SpectrumData
+        Spectra to stack. Should generally share the same grating.
+    method : str
+        ``'weighted_mean'`` (default): inverse-variance weighted mean.
+        ``'median'``: pixel-wise median (errors from MAD).
+        ``'mean'``: unweighted mean.
+    wavelength_grid : np.ndarray, optional
+        Common wavelength grid (microns). Default: use the grid from
+        the spectrum with the most pixels.
+
+    Returns
+    -------
+    SpectrumData
+        Stacked spectrum. ``target_id`` is taken from the first input;
+        ``grating`` from the first input.
+
+    Raises
+    ------
+    ValueError
+        If fewer than 2 spectra are provided.
+    """
+    if len(spectra) < 2:
+        raise ValueError("Need at least 2 spectra to stack.")
+
+    # Choose reference wavelength grid
+    if wavelength_grid is None:
+        ref = max(spectra, key=lambda s: len(s.wavelength))
+        wavelength_grid = ref.wavelength.copy()
+
+    n_pix = len(wavelength_grid)
+    n_spec = len(spectra)
+
+    # Resample all spectra onto the common grid
+    flux_cube = np.full((n_spec, n_pix), np.nan)
+    err_cube = np.full((n_spec, n_pix), np.nan)
+
+    for i, s in enumerate(spectra):
+        if np.array_equal(s.wavelength, wavelength_grid):
+            flux_cube[i] = s.fnu
+            err_cube[i] = s.fnu_err
+        else:
+            flux_cube[i], err_cube[i] = _resample(
+                wavelength_grid, s.wavelength, s.fnu, s.fnu_err,
+            )
+
+    # Stack
+    if method == "weighted_mean":
+        stacked_flux, stacked_err = _stack_weighted_mean(flux_cube, err_cube)
+    elif method == "median":
+        stacked_flux, stacked_err = _stack_median(flux_cube)
+    elif method == "mean":
+        stacked_flux, stacked_err = _stack_mean(flux_cube, err_cube)
+    else:
+        raise ValueError(
+            f"Unknown stacking method '{method}'. "
+            f"Use 'weighted_mean', 'median', or 'mean'."
+        )
+
+    # Also stack flam
+    flam_cube = np.full((n_spec, n_pix), np.nan)
+    flam_err_cube = np.full((n_spec, n_pix), np.nan)
+    for i, s in enumerate(spectra):
+        if np.array_equal(s.wavelength, wavelength_grid):
+            flam_cube[i] = s.flam
+            flam_err_cube[i] = s.flam_err
+        else:
+            flam_cube[i], flam_err_cube[i] = _resample(
+                wavelength_grid, s.wavelength, s.flam, s.flam_err,
+            )
+    if method == "weighted_mean":
+        stacked_flam, stacked_flam_err = _stack_weighted_mean(flam_cube, flam_err_cube)
+    elif method == "median":
+        stacked_flam, stacked_flam_err = _stack_median(flam_cube)
+    else:
+        stacked_flam, stacked_flam_err = _stack_mean(flam_cube, flam_err_cube)
+
+    # Build merged header
+    header = dict(spectra[0].header)
+    header["NSTACK"] = n_spec
+    header["STACKMTH"] = method
+
+    target_ids = list(dict.fromkeys(s.target_id for s in spectra))
+
+    return SpectrumData(
+        wavelength=wavelength_grid,
+        fnu=stacked_flux,
+        fnu_err=stacked_err,
+        header=header,
+        grating=spectra[0].grating,
+        target_id=" + ".join(target_ids) if len(target_ids) > 1 else target_ids[0],
+        flam=stacked_flam,
+        flam_err=stacked_flam_err,
+    )
+
+
+def _stack_weighted_mean(
+    flux_cube: np.ndarray,
+    err_cube: np.ndarray,
+) -> tuple:
+    """Inverse-variance weighted mean along axis 0."""
+    with np.errstate(divide="ignore", invalid="ignore"):
+        weights = np.where(
+            np.isfinite(flux_cube) & np.isfinite(err_cube) & (err_cube > 0),
+            1.0 / err_cube**2,
+            0.0,
+        )
+    w_sum = np.sum(weights, axis=0)
+    safe = w_sum > 0
+
+    stacked = np.full(flux_cube.shape[1], np.nan)
+    stacked_err = np.full(flux_cube.shape[1], np.nan)
+
+    flux_filled = np.where(np.isfinite(flux_cube), flux_cube, 0.0)
+    stacked[safe] = np.sum(weights * flux_filled, axis=0)[safe] / w_sum[safe]
+    stacked_err[safe] = 1.0 / np.sqrt(w_sum[safe])
+
+    return stacked, stacked_err
+
+
+def _stack_median(flux_cube: np.ndarray) -> tuple:
+    """Median stack with MAD-based error estimate."""
+    stacked = np.nanmedian(flux_cube, axis=0)
+    # MAD → sigma: σ ≈ 1.4826 * MAD
+    mad = np.nanmedian(np.abs(flux_cube - stacked[np.newaxis, :]), axis=0)
+    n_good = np.sum(np.isfinite(flux_cube), axis=0)
+    # Error on median ≈ 1.4826 * MAD / sqrt(n)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        stacked_err = np.where(n_good > 0, 1.4826 * mad / np.sqrt(n_good), np.nan)
+    return stacked, stacked_err
+
+
+def _stack_mean(
+    flux_cube: np.ndarray,
+    err_cube: np.ndarray,
+) -> tuple:
+    """Unweighted mean with propagated errors."""
+    stacked = np.nanmean(flux_cube, axis=0)
+    n_good = np.sum(np.isfinite(flux_cube) & np.isfinite(err_cube), axis=0)
+    err_filled = np.where(np.isfinite(err_cube), err_cube, 0.0)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        stacked_err = np.where(
+            n_good > 0,
+            np.sqrt(np.nansum(err_filled**2, axis=0)) / n_good,
+            np.nan,
+        )
+    return stacked, stacked_err
+
+
+# ---------------------------------------------------------------------------
+# Calibrate + stack convenience
+# ---------------------------------------------------------------------------
+
+@dataclass
+class StackResult:
+    """Result of calibrating and stacking multiple spectra.
+
+    Attributes
+    ----------
+    spectrum : SpectrumData
+        The final stacked spectrum.
+    calibrations : list of CalibrationResult
+        Per-spectrum calibration results (empty if no calibration was
+        performed).
+    input_spectra : list of SpectrumData
+        The individual (calibrated) spectra before stacking.
+    stacking_method : str
+        Stacking method used.
+    """
+
+    spectrum: SpectrumData
+    calibrations: List[CalibrationResult]
+    input_spectra: List[SpectrumData]
+    stacking_method: str
+
+    def plot(self, axes=None):
+        """Diagnostic plot showing stacked spectrum and inputs.
+
+        Three-panel figure:
+        - **Top**: Individual calibrated spectra (translucent) with
+          stacked result overlaid.
+        - **Middle**: Stacked spectrum with error band.
+        - **Bottom**: Per-spectrum calibration multipliers (if available).
+
+        Parameters
+        ----------
+        axes : array-like of matplotlib.axes.Axes, optional
+            Axes to draw on. If *None*, a new figure is created.
+            Pass 2 Axes if no calibrations, 3 if calibrations exist.
+
+        Returns
+        -------
+        tuple of matplotlib.axes.Axes
+        """
+        import matplotlib.pyplot as plt
+
+        has_calibrations = len(self.calibrations) > 0
+        n_panels = 3 if has_calibrations else 2
+
+        if axes is None:
+            ratios = [3, 2, 1] if has_calibrations else [3, 2]
+            fig, axes = plt.subplots(
+                n_panels, 1, figsize=(10, 3 * n_panels),
+                height_ratios=ratios,
+                sharex=True, constrained_layout=True,
+            )
+
+        ax_overlay = axes[0]
+        ax_stacked = axes[1]
+
+        wave = self.spectrum.wavelength
+
+        # Top: individual spectra + stack overlay
+        for i, s in enumerate(self.input_spectra):
+            valid = np.isfinite(s.fnu)
+            ax_overlay.plot(
+                s.wavelength[valid], s.fnu[valid],
+                alpha=0.4, lw=0.7, label=f"Spec {i+1}" if i < 5 else None,
+            )
+        valid = np.isfinite(self.spectrum.fnu)
+        ax_overlay.plot(
+            wave[valid], self.spectrum.fnu[valid],
+            color="black", lw=1.5, label="Stacked",
+        )
+        ax_overlay.set_ylabel("f_ν (μJy)")
+        ax_overlay.legend(fontsize=8)
+        ax_overlay.set_title(
+            f"{self.spectrum.target_id}  {self.spectrum.grating}  —  "
+            f"{self.stacking_method} stack of {len(self.input_spectra)} spectra"
+        )
+
+        # Middle: stacked with error band
+        ax_stacked.plot(
+            wave[valid], self.spectrum.fnu[valid],
+            color="C0", lw=1,
+        )
+        err = self.spectrum.fnu_err
+        ax_stacked.fill_between(
+            wave[valid],
+            self.spectrum.fnu[valid] - err[valid],
+            self.spectrum.fnu[valid] + err[valid],
+            alpha=0.15, color="C0",
+        )
+        ax_stacked.set_ylabel("f_ν (μJy)")
+
+        # Bottom: calibration multipliers
+        if has_calibrations:
+            ax_calib = axes[2]
+            for i, c in enumerate(self.calibrations):
+                ax_calib.plot(
+                    c.original.wavelength, c.multiplier,
+                    alpha=0.7, lw=1, label=f"Spec {i+1}" if i < 5 else None,
+                )
+            ax_calib.axhline(1.0, color="0.5", ls="--", lw=0.8)
+            ax_calib.set_ylabel("Multiplier")
+            ax_calib.legend(fontsize=8)
+
+        axes[-1].set_xlabel("Wavelength (μm)")
+
+        return tuple(axes)
+
+
+def calibrate_and_stack(
+    spectra: Union[SpectrumCollection, List[Spectrum], List[SpectrumData]],
+    photometry: Optional[Photometry] = None,
+    calibration_method: str = "chebyshev",
+    stacking_method: str = "weighted_mean",
+    wavelength_grid: Optional[np.ndarray] = None,
+    **calibration_kwargs,
+) -> StackResult:
+    """Calibrate multiple spectra to photometry and stack them.
+
+    Convenience function that combines :func:`calibrate_to_photometry`
+    and :func:`stack_spectra` into a single call.
+
+    Parameters
+    ----------
+    spectra : SpectrumCollection, list of Spectrum, or list of SpectrumData
+        Spectra to calibrate and stack.
+    photometry : Photometry, optional
+        Photometric measurements. Required unless *spectra* are already
+        :class:`SpectrumData` (in which case stacking is done without
+        calibration).
+    calibration_method : str
+        Passed to :func:`calibrate_to_photometry` as ``method``.
+    stacking_method : str
+        Passed to :func:`stack_spectra` as ``method``.
+    wavelength_grid : np.ndarray, optional
+        Common wavelength grid for stacking.
+    **calibration_kwargs
+        Additional keyword arguments passed to
+        :func:`calibrate_to_photometry` (e.g. ``bands``, ``degree``).
+
+    Returns
+    -------
+    StackResult
+        Contains the stacked spectrum and per-spectrum calibration
+        results. Call ``.plot()`` for a visual summary.
+    """
+    spec_list = list(spectra)
+
+    if not spec_list:
+        raise ValueError("No spectra provided.")
+
+    # Determine if we need calibration
+    calibrations = []
+    calibrated_data = []
+
+    if isinstance(spec_list[0], SpectrumData):
+        # Already loaded — stack directly (no calibration)
+        calibrated_data = spec_list
+    elif photometry is not None:
+        # Calibrate each spectrum
+        for s in spec_list:
+            calib = calibrate_to_photometry(
+                s, photometry,
+                method=calibration_method,
+                **calibration_kwargs,
+            )
+            calibrations.append(calib)
+            calibrated_data.append(calib.spectrum)
+    else:
+        # No photometry — just load and stack uncalibrated
+        for s in spec_list:
+            if isinstance(s, Spectrum):
+                calibrated_data.append(s.open())
+            else:
+                calibrated_data.append(s)
+
+    if len(calibrated_data) < 2:
+        raise ValueError("Need at least 2 spectra to stack.")
+
+    stacked = stack_spectra(
+        calibrated_data,
+        method=stacking_method,
+        wavelength_grid=wavelength_grid,
+    )
+
+    return StackResult(
+        spectrum=stacked,
+        calibrations=calibrations,
+        input_spectra=calibrated_data,
+        stacking_method=stacking_method,
+    )

--- a/python/campfire/calibration.py
+++ b/python/campfire/calibration.py
@@ -1007,7 +1007,7 @@ class StackResult:
 def calibrate_and_stack(
     spectra: Union[SpectrumCollection, List[Spectrum], List[SpectrumData]],
     photometry: Optional[Photometry] = None,
-    calibration_method: str = "chebyshev",
+    method: str = "chebyshev",
     stacking_method: str = "weighted_mean",
     wavelength_grid: Optional[np.ndarray] = None,
     **calibration_kwargs,
@@ -1025,7 +1025,7 @@ def calibrate_and_stack(
         Photometric measurements. Required unless *spectra* are already
         :class:`SpectrumData` (in which case stacking is done without
         calibration).
-    calibration_method : str
+    method : str
         Passed to :func:`calibrate_to_photometry` as ``method``.
     stacking_method : str
         Passed to :func:`stack_spectra` as ``method``.
@@ -1058,7 +1058,7 @@ def calibrate_and_stack(
         for s in spec_list:
             calib = calibrate_to_photometry(
                 s, photometry,
-                method=calibration_method,
+                method=method,
                 **calibration_kwargs,
             )
             calibrations.append(calib)

--- a/python/campfire/calibration.py
+++ b/python/campfire/calibration.py
@@ -272,7 +272,11 @@ def synthetic_photometry(
         return np.nan, np.nan
 
     synth_flux = np.trapz(flux_v * T_v * wavelength, wavelength) / denom
-    synth_err = np.sqrt(np.trapz((err_v * T_v * wavelength) ** 2, wavelength)) / denom
+    dw = np.zeros_like(wavelength)
+    dw[1:-1] = (wavelength[2:] - wavelength[:-2]) / 2.0
+    dw[0] = (wavelength[1] - wavelength[0]) / 2.0
+    dw[-1] = (wavelength[-1] - wavelength[-2]) / 2.0
+    synth_err = np.sqrt(np.sum((err_v * T_v * wavelength * dw) ** 2)) / denom
 
     return float(synth_flux), float(synth_err)
 

--- a/python/campfire/client.py
+++ b/python/campfire/client.py
@@ -1238,6 +1238,7 @@ class Campfire:
             n_targets=raw.get("n_targets", 0),
             n_spectra=raw.get("n_spectra", 0),
             programs=raw.get("programs", []),
+            tags=raw.get("tags", []),
             max_snr=raw.get("max_snr"),
             max_exposure_time=raw.get("max_exposure_time"),
             has_photometry=bool(raw.get("has_photometry")),

--- a/python/campfire/client.py
+++ b/python/campfire/client.py
@@ -25,7 +25,7 @@ from .flags import (
     DQFlags,
     parse_flag_input,
 )
-from .models import SpectrumData
+from .models import SpectrumData, Spectrum, SpectrumCollection, Photometry, Target, Object
 
 __version__ = "0.2.0"
 
@@ -703,13 +703,13 @@ class Campfire:
         Returns
         -------
         SpectrumData
-            Spectrum with .wavelength, .flux, .flux_err, .header attributes.
+            Spectrum with .wavelength, .fnu, .fnu_err, .flam, .flam_err, .header attributes.
 
         Examples
         --------
         >>> cf = Campfire()
         >>> spec = cf.open_spectrum('ember_uds_p4_123456', 'PRISM')
-        >>> print(spec.wavelength.shape, spec.flux.shape)
+        >>> print(spec.wavelength.shape, spec.fnu.shape)
         """
         # Check local store first
         if self._local and self._products_dir:
@@ -874,6 +874,9 @@ class Campfire:
         self,
         fields: Optional[List[str]] = None,
         programs: Optional[List[Union[int, str]]] = None,
+        gratings: Optional[List[str]] = None,
+        tags: Optional[List[str]] = None,
+        has_photometry: Optional[bool] = None,
         redshift_range: Optional[Tuple[float, float]] = None,
         redshift_quality: Optional[List[Union[int, str]]] = None,
         max_snr_range: Optional[Tuple[float, float]] = None,
@@ -897,6 +900,14 @@ class Campfire:
             Field names to filter by.
         programs : list of str, optional
             Program slugs to filter by.
+        gratings : list of str, optional
+            Filter by grating availability (e.g. ['PRISM', 'G395M']).
+            Returns objects that have spectra in any of the given gratings.
+        tags : list of str, optional
+            Filter by tag membership (e.g. ['lrd', 'blagn']).
+            Returns objects in any of the given tags.
+        has_photometry : bool, optional
+            If True, only objects with photometry. If False, only without.
         redshift_range : tuple of (float, float), optional
             (min, max) best redshift range.
         redshift_quality : list of int or str, optional
@@ -927,6 +938,9 @@ class Campfire:
         >>> cf.sync()
         >>> objects = cf.query_objects(redshift_range=(2.0, 6.0))
         >>> print(objects['object_id', 'best_redshift', 'n_targets'])
+        >>>
+        >>> # Objects with PRISM spectra tagged as LRDs
+        >>> lrds = cf.query_objects(gratings=['PRISM'], tags=['lrd'])
         """
         if self._local is None:
             raise ValidationError(
@@ -939,6 +953,8 @@ class Campfire:
             fields = [f.lower() for f in fields]
         if programs:
             programs = [str(p) for p in programs]
+        if gratings:
+            gratings = [g.upper() for g in gratings]
         if redshift_quality:
             redshift_quality = [
                 int(RedshiftQuality(q)) if isinstance(q, str) else q
@@ -948,6 +964,9 @@ class Campfire:
         objects = self._local.query_sky_objects(
             fields=fields,
             programs=programs,
+            gratings=gratings,
+            tags=tags,
+            has_photometry=has_photometry,
             redshift_range=redshift_range,
             redshift_quality=redshift_quality,
             max_snr_range=max_snr_range,
@@ -963,6 +982,314 @@ class Campfire:
             return Table()
 
         return Table(rows=objects)
+
+    def query_spectra(
+        self,
+        target_ids: Optional[List[str]] = None,
+        gratings: Optional[List[str]] = None,
+        programs: Optional[List[str]] = None,
+        fields: Optional[List[str]] = None,
+        observations: Optional[List[str]] = None,
+        snr_range: Optional[Tuple[float, float]] = None,
+        downloaded_only: bool = False,
+        sort: str = "target_id",
+        sort_dir: str = "asc",
+        limit: Optional[int] = None,
+        offset: int = 0,
+    ) -> Table:
+        """
+        Query individual spectra with filters.
+
+        Unlike ``query_targets()`` which returns targets with nested spectra
+        dicts, this returns one row per spectrum — useful for filtering by
+        grating, SNR, or checking which files are locally available.
+
+        Requires a local sync (``cf.sync()``).
+
+        Parameters
+        ----------
+        target_ids : list of str, optional
+            Filter to specific target IDs.
+        gratings : list of str, optional
+            Filter by grating (e.g. ['PRISM', 'G395M']).
+        programs : list of str, optional
+            Filter by program slug.
+        fields : list of str, optional
+            Filter by field name.
+        observations : list of str, optional
+            Filter by observation name.
+        snr_range : tuple of (float, float), optional
+            Signal-to-noise range. Use None for open-ended, e.g. ``(10, None)``.
+        downloaded_only : bool, optional
+            If True, only return spectra with a local FITS file.
+        sort : str, optional
+            Sort column (default: 'target_id').
+        sort_dir : str, optional
+            Sort direction: 'asc' or 'desc'.
+        limit : int, optional
+            Maximum number of results.
+        offset : int, optional
+            Pagination offset.
+
+        Returns
+        -------
+        astropy.table.Table
+            Table with one row per spectrum, including target context columns
+            (program_slug, field, observation, ra, dec, redshift, redshift_quality).
+
+        Examples
+        --------
+        >>> cf = Campfire()
+        >>> # All PRISM spectra
+        >>> prism = cf.query_spectra(gratings=['PRISM'])
+        >>>
+        >>> # High-SNR spectra that are downloaded locally
+        >>> good = cf.query_spectra(snr_range=(10, None), downloaded_only=True)
+        >>>
+        >>> # PRISM spectra for specific targets
+        >>> specs = cf.query_spectra(
+        ...     target_ids=['ember_uds_p4_12345'],
+        ...     gratings=['PRISM'],
+        ... )
+        """
+        if self._local is None:
+            raise ValidationError(
+                "No local catalog. Run cf.sync() first to query spectra."
+            )
+
+        self._log_local_use()
+
+        if gratings:
+            gratings = [g.upper() for g in gratings]
+        if fields:
+            fields = [f.lower() for f in fields]
+        if observations:
+            observations = [o.lower() for o in observations]
+
+        rows = self._local.query_spectra(
+            target_ids=target_ids,
+            gratings=gratings,
+            programs=programs,
+            fields=fields,
+            observations=observations,
+            snr_range=snr_range,
+            downloaded_only=downloaded_only,
+            sort=sort,
+            sort_dir=sort_dir,
+            limit=limit,
+            offset=offset,
+        )
+
+        if len(rows) == 0:
+            return Table()
+
+        return Table(rows=rows)
+
+    def query_photometry(
+        self,
+        object_ids: Optional[List[str]] = None,
+        fields: Optional[List[str]] = None,
+        catalogs: Optional[List[str]] = None,
+        has_photo_z: Optional[bool] = None,
+        limit: Optional[int] = None,
+        offset: int = 0,
+    ) -> Table:
+        """
+        Query photometric catalog cross-matches.
+
+        Returns one row per object-catalog combination. The ``photometry``
+        column contains the band-level flux data as a dict.
+
+        Requires a local sync (``cf.sync()``).
+
+        Parameters
+        ----------
+        object_ids : list of str, optional
+            Filter to specific sky-object IDs.
+        fields : list of str, optional
+            Filter by field name.
+        catalogs : list of str, optional
+            Filter by catalog name.
+        has_photo_z : bool, optional
+            If True, only records with a photometric redshift.
+        limit : int, optional
+            Maximum number of results.
+        offset : int, optional
+            Pagination offset.
+
+        Returns
+        -------
+        astropy.table.Table
+            Table of photometry records.
+
+        Examples
+        --------
+        >>> cf = Campfire()
+        >>> phot = cf.query_photometry(object_ids=['J100025.32+021520.1'])
+        >>> # All records with photo-z
+        >>> pz = cf.query_photometry(has_photo_z=True)
+        """
+        if self._local is None:
+            raise ValidationError(
+                "No local catalog. Run cf.sync() first to query photometry."
+            )
+
+        self._log_local_use()
+
+        if fields:
+            fields = [f.lower() for f in fields]
+
+        rows = self._local.query_photometry(
+            object_ids=object_ids,
+            fields=fields,
+            catalogs=catalogs,
+            has_photo_z=has_photo_z,
+            limit=limit,
+            offset=offset,
+        )
+
+        if len(rows) == 0:
+            return Table()
+
+        return Table(rows=rows)
+
+    def get_object(self, object_id: str) -> Object:
+        """
+        Get a single sky-object with its member targets, spectra, and photometry.
+
+        Returns an :class:`Object` with navigable attributes and
+        numpy-style filtering on spectra::
+
+            obj = cf.get_object('J100025.32+021520.1')
+            prism = obj.spectra[obj.spectra.grating == 'PRISM']
+            prism[0].open()  # -> SpectrumData with wavelength/flux arrays
+
+        Requires a local sync (``cf.sync()``).
+
+        Parameters
+        ----------
+        object_id : str
+            The sky-object ID.
+
+        Returns
+        -------
+        Object
+            Sky-object with ``.targets``, ``.spectra``, and ``.photometry``
+            attributes.
+
+        Raises
+        ------
+        NotFoundError
+            If the object ID is not in the local catalog.
+
+        Examples
+        --------
+        >>> obj = cf.get_object('J100025.32+021520.1')
+        >>> obj.best_redshift
+        3.42
+        >>> obj.spectra[obj.spectra.grating == 'PRISM']
+        SpectrumCollection(2 spectra: PRISM)
+        >>> obj.photometry['f444w']
+        Band(flux=0.42, flux_err=0.03, wavelength=4.44)
+        """
+        if self._local is None:
+            raise ValidationError(
+                "No local catalog. Run cf.sync() first."
+            )
+        self._log_local_use()
+
+        raw = self._local.get_sky_object(object_id)
+        if raw is None:
+            raise NotFoundError(f"Object '{object_id}' not found in local catalog.")
+
+        return self._build_object(raw)
+
+    def _build_object(self, raw: dict) -> Object:
+        """Construct an Object dataclass from a LocalStore dict."""
+        opener = self.open_spectrum
+
+        # Build Target instances
+        targets = [
+            Target.from_dict(t, opener=opener)
+            for t in raw.get("targets", [])
+        ]
+
+        # Flat spectra across all targets
+        all_spectra = [s for t in targets for s in t.spectra]
+        spectra = SpectrumCollection(all_spectra)
+
+        # Build Photometry from the best catalog (most bands)
+        phot_records = raw.get("photometry", [])
+        photometry = None
+        if phot_records:
+            best = max(
+                phot_records,
+                key=lambda r: len((r.get("photometry") or {}).get("bands", {})),
+            )
+            photometry = Photometry.from_record(best)
+
+        return Object(
+            object_id=raw.get("object_id", ""),
+            ra=raw.get("ra", 0.0),
+            dec=raw.get("dec", 0.0),
+            field=raw.get("field", ""),
+            best_redshift=raw.get("best_redshift"),
+            best_redshift_quality=raw.get("best_redshift_quality", 0),
+            n_targets=raw.get("n_targets", 0),
+            n_spectra=raw.get("n_spectra", 0),
+            programs=raw.get("programs", []),
+            max_snr=raw.get("max_snr"),
+            max_exposure_time=raw.get("max_exposure_time"),
+            has_photometry=bool(raw.get("has_photometry")),
+            photo_z=raw.get("photo_z"),
+            photo_z_err_lo=raw.get("photo_z_err_lo"),
+            photo_z_err_hi=raw.get("photo_z_err_hi"),
+            targets=targets,
+            spectra=spectra,
+            photometry=photometry,
+        )
+
+    def get_target(self, target_id: str) -> Target:
+        """
+        Get a single target with its spectra.
+
+        Returns a :class:`Target` with a ``.spectra`` :class:`SpectrumCollection`
+        supporting numpy-style filtering.
+
+        Parameters
+        ----------
+        target_id : str
+            The target ID (e.g. 'ember_uds_p4_12345').
+
+        Returns
+        -------
+        Target
+            Target with ``.spectra`` attribute.
+
+        Raises
+        ------
+        NotFoundError
+            If the target ID is not in the local catalog.
+
+        Examples
+        --------
+        >>> t = cf.get_target('ember_uds_p4_12345')
+        >>> t.redshift
+        3.42
+        >>> t.spectra[t.spectra.grating == 'PRISM'][0].open()
+        SpectrumData(ember_uds_p4_12345, PRISM, 489 pixels, 0.60-5.30 μm)
+        """
+        if self._local is None:
+            raise ValidationError(
+                "No local catalog. Run cf.sync() first."
+            )
+        self._log_local_use()
+
+        raw = self._local.get_object(target_id)
+        if raw is None:
+            raise NotFoundError(f"Target '{target_id}' not found in local catalog.")
+
+        return Target.from_dict(raw, opener=self.open_spectrum)
 
     # -------------------------------------------------------------------------
     # Imaging Methods (cutouts + shutters)

--- a/python/campfire/db/store.py
+++ b/python/campfire/db/store.py
@@ -658,7 +658,7 @@ class LocalStore:
 
         spectra_rows = self._conn.execute(
             """SELECT spectra_id as id, target_id, grating, fits_path,
-                      signal_to_noise, exposure_time, reduction_version
+                      signal_to_noise, exposure_time, reduction_version, local_path
                FROM spectra WHERE target_id = ?""",
             (target_id,),
         ).fetchall()

--- a/python/campfire/db/store.py
+++ b/python/campfire/db/store.py
@@ -1880,6 +1880,13 @@ class LocalStore:
         # Attach photometry records
         obj["photometry"] = self.get_photometry_for_object(object_id)
 
+        # Attach tag slugs
+        tag_rows = self._conn.execute(
+            "SELECT list_slug FROM object_list_memberships WHERE object_id = ?",
+            (object_id,),
+        ).fetchall()
+        obj["tags"] = [r[0] for r in tag_rows]
+
         return obj
 
     def get_targets_for_object(self, object_id: str) -> List[dict]:

--- a/python/campfire/db/store.py
+++ b/python/campfire/db/store.py
@@ -1317,6 +1317,9 @@ class LocalStore:
         self,
         fields: Optional[List[str]] = None,
         programs: Optional[List[str]] = None,
+        gratings: Optional[List[str]] = None,
+        tags: Optional[List[str]] = None,
+        has_photometry: Optional[bool] = None,
         redshift_range: Optional[Tuple[float, float]] = None,
         redshift_quality: Optional[List[int]] = None,
         max_snr_range: Optional[Tuple[float, float]] = None,
@@ -1336,6 +1339,14 @@ class LocalStore:
             Filter by field name.
         programs : list of str, optional
             Filter by program slug (semicolon-separated column).
+        gratings : list of str, optional
+            Filter by grating availability (e.g. ['PRISM']).
+            Matches objects that have any of the given gratings.
+        tags : list of str, optional
+            Filter by tag/list membership (e.g. ['lrd', 'blagn']).
+            Matches objects in any of the given tags.
+        has_photometry : bool, optional
+            If True, only objects with photometry. If False, only without.
         redshift_range : tuple of (min, max), optional
         redshift_quality : list of int, optional
         max_snr_range : tuple of (min, max), optional
@@ -1368,6 +1379,26 @@ class LocalStore:
                 prog_clauses.append("o.programs LIKE ?")
                 params.append(f"%{prog}%")
             where_clauses.append(f"({' OR '.join(prog_clauses)})")
+
+        if gratings:
+            # Gratings stored as semicolon-separated; match any
+            grat_clauses = []
+            for grat in gratings:
+                grat_clauses.append("o.gratings LIKE ?")
+                params.append(f"%{grat}%")
+            where_clauses.append(f"({' OR '.join(grat_clauses)})")
+
+        if tags:
+            placeholders = ",".join("?" * len(tags))
+            where_clauses.append(
+                f"o.object_id IN (SELECT object_id FROM object_list_memberships WHERE list_slug IN ({placeholders}))"
+            )
+            params.extend(tags)
+
+        if has_photometry is True:
+            where_clauses.append("o.has_photometry = 1")
+        elif has_photometry is False:
+            where_clauses.append("o.has_photometry = 0")
 
         if redshift_range:
             where_clauses.append("o.best_redshift >= ? AND o.best_redshift <= ?")
@@ -1456,6 +1487,9 @@ class LocalStore:
             for col in ("programs", "gratings", "member_target_ids"):
                 val = obj.get(col)
                 obj[col] = val.split(";") if val else []
+
+            # Convert has_photometry from int to bool
+            obj["has_photometry"] = bool(obj.get("has_photometry"))
 
             results.append(obj)
 
@@ -1591,23 +1625,333 @@ class LocalStore:
         self._conn.commit()
         return purged
 
-    def query_photometry(self) -> List[dict]:
-        """Query all photometry records from local database.
+    def query_photometry(
+        self,
+        object_ids: Optional[List[str]] = None,
+        fields: Optional[List[str]] = None,
+        catalogs: Optional[List[str]] = None,
+        has_photo_z: Optional[bool] = None,
+        limit: Optional[int] = None,
+        offset: int = 0,
+    ) -> List[dict]:
+        """Query photometry records from local database.
+
+        Parameters
+        ----------
+        object_ids : list of str, optional
+            Filter to specific sky-object IDs.
+        fields : list of str, optional
+            Filter by field name.
+        catalogs : list of str, optional
+            Filter by catalog name.
+        has_photo_z : bool, optional
+            If True, only records with a photometric redshift.
+            If False, only records without.
+        limit, offset : int
 
         Returns
         -------
         list of dict
-            Photometry records with deserialized JSONB.
+            Photometry records with deserialized JSONB photometry column.
+        """
+        import json as _json
+
+        where_clauses: list = []
+        params: list = []
+
+        if object_ids:
+            placeholders = ",".join("?" * len(object_ids))
+            where_clauses.append(f"object_id IN ({placeholders})")
+            params.extend(object_ids)
+
+        if fields:
+            placeholders = ",".join("?" * len(fields))
+            where_clauses.append(f"field IN ({placeholders})")
+            params.extend(fields)
+
+        if catalogs:
+            placeholders = ",".join("?" * len(catalogs))
+            where_clauses.append(f"catalog_name IN ({placeholders})")
+            params.extend(catalogs)
+
+        if has_photo_z is True:
+            where_clauses.append("has_pz = 1")
+        elif has_photo_z is False:
+            where_clauses.append("has_pz = 0")
+
+        where_sql = " AND ".join(where_clauses) if where_clauses else "1=1"
+
+        sql = f"""
+            SELECT * FROM object_photometry
+            WHERE {where_sql}
+            ORDER BY object_id, catalog_name
+        """
+        if limit is not None:
+            sql += " LIMIT ? OFFSET ?"
+            params.extend([limit, offset])
+        elif offset:
+            sql += " LIMIT -1 OFFSET ?"
+            params.append(offset)
+
+        rows = self._conn.execute(sql, params).fetchall()
+
+        results = []
+        for row in rows:
+            rec = dict(row)
+            rec.pop("_synced_at", None)
+            phot = rec.get("photometry")
+            if isinstance(phot, str):
+                try:
+                    rec["photometry"] = _json.loads(phot)
+                except (ValueError, TypeError):
+                    rec["photometry"] = None
+            results.append(rec)
+
+        return results
+
+    # -------------------------------------------------------------------------
+    # Flat spectra queries
+    # -------------------------------------------------------------------------
+
+    def query_spectra(
+        self,
+        target_ids: Optional[List[str]] = None,
+        gratings: Optional[List[str]] = None,
+        programs: Optional[List[str]] = None,
+        fields: Optional[List[str]] = None,
+        observations: Optional[List[str]] = None,
+        snr_range: Optional[Tuple[float, float]] = None,
+        downloaded_only: bool = False,
+        sort: str = "target_id",
+        sort_dir: str = "asc",
+        limit: Optional[int] = None,
+        offset: int = 0,
+    ) -> List[dict]:
+        """Query spectra with filters, returning one row per spectrum.
+
+        Joins to targets for program/field/observation context.
+
+        Parameters
+        ----------
+        target_ids : list of str, optional
+            Filter to specific target IDs.
+        gratings : list of str, optional
+            Filter by grating (e.g. ['PRISM', 'G395M']).
+        programs : list of str, optional
+            Filter by program slug (via targets join).
+        fields : list of str, optional
+            Filter by field name (via targets join).
+        observations : list of str, optional
+            Filter by observation name (via targets join).
+        snr_range : tuple of (min, max), optional
+            Signal-to-noise range. Use None for open-ended, e.g. (10, None).
+        downloaded_only : bool
+            If True, only return spectra with a local file.
+        sort : str
+            Column to sort by.
+        sort_dir : str
+            'asc' or 'desc'.
+        limit, offset : int
+
+        Returns
+        -------
+        list of dict
+            Spectrum rows with target context columns.
+        """
+        where_clauses = []
+        params: list = []
+
+        if target_ids:
+            placeholders = ",".join("?" * len(target_ids))
+            where_clauses.append(f"s.target_id IN ({placeholders})")
+            params.extend(target_ids)
+
+        if gratings:
+            placeholders = ",".join("?" * len(gratings))
+            where_clauses.append(f"s.grating IN ({placeholders})")
+            params.extend(gratings)
+
+        if programs:
+            placeholders = ",".join("?" * len(programs))
+            where_clauses.append(f"t.program_slug IN ({placeholders})")
+            params.extend(programs)
+
+        if fields:
+            placeholders = ",".join("?" * len(fields))
+            where_clauses.append(f"t.field IN ({placeholders})")
+            params.extend(fields)
+
+        if observations:
+            placeholders = ",".join("?" * len(observations))
+            where_clauses.append(f"t.observation IN ({placeholders})")
+            params.extend(observations)
+
+        if snr_range:
+            lo, hi = snr_range
+            if lo is not None:
+                where_clauses.append("s.signal_to_noise >= ?")
+                params.append(lo)
+            if hi is not None:
+                where_clauses.append("s.signal_to_noise <= ?")
+                params.append(hi)
+
+        if downloaded_only:
+            where_clauses.append("s.local_path IS NOT NULL")
+
+        where_sql = " AND ".join(where_clauses) if where_clauses else "1=1"
+
+        allowed_sorts = {
+            "target_id", "grating", "signal_to_noise", "exposure_time",
+            "spectra_id", "field", "observation", "program_slug",
+        }
+        if sort not in allowed_sorts:
+            sort = "target_id"
+        if sort_dir not in ("asc", "desc"):
+            sort_dir = "asc"
+
+        # Map sort columns to qualified names
+        sort_col = f"s.{sort}" if sort in (
+            "target_id", "grating", "signal_to_noise", "exposure_time", "spectra_id",
+        ) else f"t.{sort}"
+
+        sql = f"""
+            SELECT s.spectra_id, s.target_id, s.grating, s.fits_path,
+                   s.signal_to_noise, s.exposure_time, s.reduction_version,
+                   s.local_path,
+                   t.program_slug, t.field, t.observation,
+                   t.ra, t.dec, t.redshift, t.redshift_quality
+            FROM spectra s
+            JOIN targets t ON s.target_id = t.target_id
+            WHERE {where_sql}
+            ORDER BY {sort_col} {sort_dir}
+        """
+        if limit is not None:
+            sql += " LIMIT ? OFFSET ?"
+            params.extend([limit, offset])
+        elif offset:
+            sql += " LIMIT -1 OFFSET ?"
+            params.append(offset)
+
+        rows = self._conn.execute(sql, params).fetchall()
+        return [dict(r) for r in rows]
+
+    # -------------------------------------------------------------------------
+    # Object traversal helpers
+    # -------------------------------------------------------------------------
+
+    def get_sky_object(self, object_id: str) -> Optional[dict]:
+        """Get a single sky-object with its member targets, spectra, and photometry.
+
+        Parameters
+        ----------
+        object_id : str
+            The sky-object ID.
+
+        Returns
+        -------
+        dict or None
+            Object dict with:
+
+            - ``targets``: list of target dicts, each with a ``spectra`` list
+            - ``photometry``: list of photometry record dicts (with deserialized JSON)
+
+            None if not found.
+        """
+        row = self._conn.execute(
+            "SELECT * FROM objects WHERE object_id = ?", (object_id,)
+        ).fetchone()
+        if not row:
+            return None
+
+        obj = dict(row)
+        obj.pop("_synced_at", None)
+
+        # Deserialize semicolon-separated fields
+        for col in ("programs", "gratings", "member_target_ids"):
+            val = obj.get(col)
+            obj[col] = val.split(";") if val else []
+
+        # Convert has_photometry from int to bool
+        obj["has_photometry"] = bool(obj.get("has_photometry"))
+
+        # Attach member targets with their spectra
+        obj["targets"] = self.get_targets_for_object(object_id)
+
+        # Attach photometry records
+        obj["photometry"] = self.get_photometry_for_object(object_id)
+
+        return obj
+
+    def get_targets_for_object(self, object_id: str) -> List[dict]:
+        """Get all member targets for a sky-object, with their spectra.
+
+        Uses the objects.member_target_ids column to find matching targets.
+
+        Parameters
+        ----------
+        object_id : str
+            The sky-object ID.
+
+        Returns
+        -------
+        list of dict
+            Target dicts, each with a 'spectra' key containing spectrum rows.
+        """
+        # Get target IDs from objects table
+        row = self._conn.execute(
+            "SELECT member_target_ids FROM objects WHERE object_id = ?",
+            (object_id,),
+        ).fetchone()
+        if not row or not row[0]:
+            return []
+
+        target_ids = row[0].split(";")
+        placeholders = ",".join("?" * len(target_ids))
+        target_rows = self._conn.execute(
+            f"SELECT * FROM targets WHERE target_id IN ({placeholders})",
+            target_ids,
+        ).fetchall()
+
+        results = []
+        for trow in target_rows:
+            target = dict(trow)
+            target.pop("_synced_at", None)
+
+            spectra_rows = self._conn.execute(
+                """SELECT spectra_id as id, target_id, grating, fits_path,
+                          signal_to_noise, exposure_time, reduction_version, local_path
+                   FROM spectra WHERE target_id = ?""",
+                (target["target_id"],),
+            ).fetchall()
+            target["spectra"] = [dict(s) for s in spectra_rows]
+            results.append(target)
+
+        return results
+
+    def get_photometry_for_object(self, object_id: str) -> List[dict]:
+        """Get photometry records for a sky-object.
+
+        Parameters
+        ----------
+        object_id : str
+            The sky-object ID.
+
+        Returns
+        -------
+        list of dict
+            Photometry records with deserialized JSON photometry column.
         """
         import json as _json
 
         rows = self._conn.execute(
-            "SELECT * FROM object_photometry ORDER BY object_id, catalog_name"
+            "SELECT * FROM object_photometry WHERE object_id = ? ORDER BY catalog_name",
+            (object_id,),
         ).fetchall()
 
         results = []
         for row in rows:
             rec = dict(row)
+            rec.pop("_synced_at", None)
             phot = rec.get("photometry")
             if isinstance(phot, str):
                 try:

--- a/python/campfire/models.py
+++ b/python/campfire/models.py
@@ -769,6 +769,8 @@ class Object:
         Total number of spectra.
     programs : list of str
         Program slugs with data for this object.
+    tags : list of str
+        Tag slugs this object belongs to (e.g. ``['lrd', 'blagn']``).
     targets : list of Target
         Member targets, each with their own spectra.
     spectra : SpectrumCollection
@@ -786,6 +788,7 @@ class Object:
     n_targets: int = 0
     n_spectra: int = 0
     programs: List[str] = dc_field(default_factory=list)
+    tags: List[str] = dc_field(default_factory=list)
     max_snr: Optional[float] = None
     max_exposure_time: Optional[float] = None
     has_photometry: bool = False

--- a/python/campfire/models.py
+++ b/python/campfire/models.py
@@ -1,11 +1,15 @@
 """Data models for the CAMPFIRE Python client."""
 
 import re
-from dataclasses import dataclass, field
+from collections import namedtuple
+from dataclasses import dataclass, field as dc_field
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Dict, List, Optional, TYPE_CHECKING
 
 import numpy as np
+
+if TYPE_CHECKING:
+    from astropy.table import Table
 
 
 @dataclass
@@ -19,14 +23,16 @@ class SpectrumData:
     ----------
     wavelength : np.ndarray
         Wavelength array in microns.
-    flux : np.ndarray
-        Flux density (f_nu) in microjansky.
-    flux_err : np.ndarray
-        Flux density error in microjansky.
-    flam : np.ndarray or None
-        Flux density (f_lambda) in erg/s/cm2/A, if available.
-    flam_err : np.ndarray or None
-        Flux density error (f_lambda), if available.
+    fnu : np.ndarray
+        Flux density f_ν in microjansky (μJy).
+    fnu_err : np.ndarray
+        Flux density error f_ν in microjansky (μJy).
+    flam : np.ndarray
+        Flux density f_λ in erg/s/cm²/Å. Auto-computed from fnu if not
+        provided.
+    flam_err : np.ndarray
+        Flux density error f_λ in erg/s/cm²/Å. Auto-computed from fnu_err
+        if not provided.
     header : dict
         FITS primary header as a dict.
     grating : str
@@ -35,17 +41,32 @@ class SpectrumData:
         CAMPFIRE target ID (e.g., 'ember_cosmos_p1_920424').
     fits_path : str or None
         Local file path if loaded from disk, None if from API.
+    fnu_units : str
+        Unit string for fnu (default ``'uJy'``).
+    flam_units : str
+        Unit string for flam (default ``'erg/s/cm2/A'``).
+    wave_units : str
+        Unit string for wavelength (default ``'um'``).
     """
 
     wavelength: np.ndarray
-    flux: np.ndarray
-    flux_err: np.ndarray
+    fnu: np.ndarray
+    fnu_err: np.ndarray
     header: dict
     grating: str
     target_id: str
-    flam: Optional[np.ndarray] = field(default=None, repr=False)
-    flam_err: Optional[np.ndarray] = field(default=None, repr=False)
+    flam: Optional[np.ndarray] = dc_field(default=None, repr=False)
+    flam_err: Optional[np.ndarray] = dc_field(default=None, repr=False)
     fits_path: Optional[str] = None
+    fnu_units: str = dc_field(default="uJy", repr=False)
+    flam_units: str = dc_field(default="erg/s/cm2/A", repr=False)
+    wave_units: str = dc_field(default="um", repr=False)
+
+    def __post_init__(self):
+        if self.flam is None:
+            self.flam = self.fnu * 2.998e-19 / self.wavelength**2
+        if self.flam_err is None:
+            self.flam_err = self.fnu_err * 2.998e-19 / self.wavelength**2
 
     def __repr__(self) -> str:
         n = len(self.wavelength)
@@ -55,6 +76,64 @@ class SpectrumData:
             f"SpectrumData({self.target_id}, {self.grating}, "
             f"{n} pixels, {wmin:.2f}-{wmax:.2f} μm)"
         )
+
+    def plot(
+        self,
+        flux_unit: str = "fnu",
+        show_errors: bool = True,
+        ax=None,
+        **kwargs,
+    ):
+        """Quick-look matplotlib plot of the spectrum.
+
+        Parameters
+        ----------
+        flux_unit : str
+            ``'fnu'`` for f_ν in μJy (default), ``'flam'`` or
+            ``'flambda'`` for f_λ in erg/s/cm²/Å.
+        show_errors : bool
+            Show shaded 1-sigma error band (default True).
+        ax : matplotlib.axes.Axes, optional
+            Axes to draw on. If *None*, a new figure is created.
+        **kwargs
+            Passed to ``ax.plot()``.
+
+        Returns
+        -------
+        matplotlib.axes.Axes
+        """
+        import matplotlib.pyplot as plt
+
+        if ax is None:
+            _, ax = plt.subplots()
+
+        wave = self.wavelength
+        if flux_unit in ("flam", "flambda"):
+            flux = self.flam
+            flux_err = self.flam_err
+        else:
+            flux = self.fnu
+            flux_err = self.fnu_err
+
+        valid = np.isfinite(flux)
+        w = wave[valid]
+        f = flux[valid]
+
+        line, = ax.step(w, f, where="mid", **kwargs)
+
+        if show_errors:
+            e = flux_err[valid]
+            color = line.get_color()
+            ax.fill_between(w, f - e, f + e, alpha=0.15, color=color, step="mid")
+
+        ax.set_xlabel("Wavelength (μm)")
+        if flux_unit in ("flam", "flambda"):
+            ax.set_ylabel("f_λ (erg/s/cm²/Å)")
+        else:
+            ax.set_ylabel("f_ν (μJy)")
+        ax.set_title(f"{self.target_id}  {self.grating}")
+
+        return ax
 
     @staticmethod
     def _parse_target_id_from_filename(filename: str) -> str:
@@ -175,8 +254,8 @@ class SpectrumData:
 
         return cls(
             wavelength=wavelength,
-            flux=flux,
-            flux_err=flux_err,
+            fnu=flux,
+            fnu_err=flux_err,
             flam=flam,
             flam_err=flam_err,
             header=header,
@@ -184,3 +263,548 @@ class SpectrumData:
             target_id=object_id,
             fits_path=fits_path,
         )
+
+
+# ---------------------------------------------------------------------------
+# Band namedtuple for photometry band access
+# ---------------------------------------------------------------------------
+
+Band = namedtuple("Band", ["flux", "flux_err", "wavelength"])
+
+
+# ---------------------------------------------------------------------------
+# Spectrum (catalog metadata) — lightweight handle to a single spectrum row
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Spectrum:
+    """Catalog metadata for a single spectrum.
+
+    This is the catalog row — target_id, grating, SNR, etc. Call
+    ``.open()`` to load the actual wavelength/flux arrays as a
+    :class:`SpectrumData`.
+
+    Attributes
+    ----------
+    spectra_id : int
+        Unique spectrum ID in the database.
+    target_id : str
+        Parent target ID.
+    grating : str
+        Grating name (e.g. 'PRISM', 'G395M').
+    signal_to_noise : float or None
+        Peak signal-to-noise ratio.
+    exposure_time : float or None
+        Total exposure time in seconds.
+    reduction_version : str or None
+        Pipeline reduction version.
+    fits_path : str or None
+        Remote FITS path.
+    local_path : str or None
+        Local relative path to the downloaded FITS file (None if not downloaded).
+    """
+
+    spectra_id: int
+    target_id: str
+    grating: str
+    signal_to_noise: Optional[float] = None
+    exposure_time: Optional[float] = None
+    reduction_version: Optional[str] = None
+    fits_path: Optional[str] = None
+    local_path: Optional[str] = None
+    _opener: Optional[Callable] = dc_field(default=None, repr=False, compare=False)
+
+    def open(self) -> SpectrumData:
+        """Open this spectrum, returning a :class:`SpectrumData` with flux arrays.
+
+        Reads from local FITS if downloaded, otherwise downloads from the API.
+        Requires the parent :class:`Campfire` client (set automatically when
+        returned by ``cf.get_object()`` or ``cf.get_target()``).
+
+        Returns
+        -------
+        SpectrumData
+        """
+        if self._opener is None:
+            raise RuntimeError(
+                "No client attached. Use cf.get_object() or cf.get_target() "
+                "to get Spectrum instances with .open() support, or call "
+                "cf.open_spectrum(target_id, grating) directly."
+            )
+        return self._opener(self.target_id, self.grating)
+
+    @property
+    def data(self) -> SpectrumData:
+        """Load and return the spectrum data (wavelength, flux, etc.).
+
+        Equivalent to :meth:`open` but reads more naturally as attribute
+        access::
+
+            spec = obj.spectra[0]
+            spec.data.wavelength   # numpy array
+
+        Returns
+        -------
+        SpectrumData
+        """
+        return self.open()
+
+    def plot(self, **kwargs):
+        """Load the spectrum and create a quick-look matplotlib plot.
+
+        All keyword arguments are forwarded to
+        :meth:`SpectrumData.plot`.  See that method for the full
+        parameter list (``flux_unit``, ``show_errors``, ``ax``, etc.).
+
+        Returns
+        -------
+        matplotlib.axes.Axes
+        """
+        return self.open().plot(**kwargs)
+
+    @property
+    def downloaded(self) -> bool:
+        """Whether the FITS file is available locally."""
+        return self.local_path is not None
+
+    def __repr__(self) -> str:
+        snr = f", SNR={self.signal_to_noise:.1f}" if self.signal_to_noise else ""
+        dl = " ✓" if self.downloaded else ""
+        return f"Spectrum({self.target_id}, {self.grating}{snr}{dl})"
+
+
+# ---------------------------------------------------------------------------
+# SpectrumCollection — numpy-style filterable collection of Spectrum objects
+# ---------------------------------------------------------------------------
+
+class SpectrumCollection:
+    """Filterable collection of :class:`Spectrum` objects.
+
+    Supports numpy-style boolean indexing on any attribute::
+
+        prism = obj.spectra[obj.spectra.grating == 'PRISM']
+        high_snr = obj.spectra[obj.spectra.signal_to_noise > 10]
+
+    Integer indexing returns a single :class:`Spectrum`::
+
+        obj.spectra[0]
+
+    Iteration yields individual :class:`Spectrum` instances.
+    """
+
+    def __init__(self, spectra: List[Spectrum]):
+        self._spectra = list(spectra)
+
+    # --- Attribute access returns numpy arrays for filtering ---
+
+    @property
+    def grating(self) -> np.ndarray:
+        return np.array([s.grating for s in self._spectra])
+
+    @property
+    def target_id(self) -> np.ndarray:
+        return np.array([s.target_id for s in self._spectra])
+
+    @property
+    def signal_to_noise(self) -> np.ndarray:
+        return np.array([s.signal_to_noise for s in self._spectra], dtype=float)
+
+    @property
+    def exposure_time(self) -> np.ndarray:
+        return np.array([s.exposure_time for s in self._spectra], dtype=float)
+
+    @property
+    def spectra_id(self) -> np.ndarray:
+        return np.array([s.spectra_id for s in self._spectra])
+
+    @property
+    def downloaded(self) -> np.ndarray:
+        return np.array([s.downloaded for s in self._spectra])
+
+    @property
+    def gratings(self) -> List[str]:
+        """Unique gratings available in this collection."""
+        return sorted(set(s.grating for s in self._spectra))
+
+    # --- Indexing ---
+
+    def __getitem__(self, key):
+        if isinstance(key, (int, np.integer)):
+            return self._spectra[key]
+        if isinstance(key, np.ndarray) and key.dtype == bool:
+            return SpectrumCollection(
+                [s for s, m in zip(self._spectra, key) if m]
+            )
+        if isinstance(key, slice):
+            return SpectrumCollection(self._spectra[key])
+        raise TypeError(f"Unsupported index type: {type(key)}")
+
+    # --- Container protocol ---
+
+    def __len__(self) -> int:
+        return len(self._spectra)
+
+    def __iter__(self):
+        return iter(self._spectra)
+
+    def __bool__(self) -> bool:
+        return len(self._spectra) > 0
+
+    def to_table(self) -> "Table":
+        """Convert to an astropy Table."""
+        from astropy.table import Table as AstropyTable
+
+        if not self._spectra:
+            return AstropyTable()
+        rows = [
+            {
+                "spectra_id": s.spectra_id,
+                "target_id": s.target_id,
+                "grating": s.grating,
+                "signal_to_noise": s.signal_to_noise,
+                "exposure_time": s.exposure_time,
+                "reduction_version": s.reduction_version,
+                "local_path": s.local_path,
+            }
+            for s in self._spectra
+        ]
+        return AstropyTable(rows=rows)
+
+    def __repr__(self) -> str:
+        n = len(self._spectra)
+        if n == 0:
+            return "SpectrumCollection(empty)"
+
+        # Column widths
+        tid_width = max(len(s.target_id) for s in self._spectra)
+        grat_width = max(len(s.grating) for s in self._spectra)
+        tid_width = max(tid_width, len("target_id"))
+        grat_width = max(grat_width, len("grating"))
+
+        header = (
+            f"{'target_id':<{tid_width}}  {'grating':<{grat_width}}"
+            f"  {'SNR':>7}  {'exp_time':>8}  {'local':>5}"
+        )
+        sep = "-" * len(header)
+
+        lines = [f"SpectrumCollection ({n} spectra)", header, sep]
+        for s in self._spectra:
+            snr = f"{s.signal_to_noise:7.1f}" if s.signal_to_noise is not None else "      -"
+            exp = f"{s.exposure_time:8.0f}" if s.exposure_time is not None else "       -"
+            dl = "    Y" if s.downloaded else "    -"
+            lines.append(
+                f"{s.target_id:<{tid_width}}  {s.grating:<{grat_width}}"
+                f"  {snr}  {exp}  {dl}"
+            )
+
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Photometry — flat parallel-array structure for a single object
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Photometry:
+    """Photometric measurements for a sky-object.
+
+    Stores band-level data as parallel arrays for easy plotting and
+    analysis. Individual bands are accessible by name::
+
+        phot = obj.photometry
+        phot['f444w']              # Band(flux=0.42, flux_err=0.03, wavelength=4.44)
+        phot.flux                  # full array
+        plt.errorbar(phot.wavelength, phot.flux, phot.flux_err)
+
+    Attributes
+    ----------
+    bands : list of str
+        Band names in wavelength order.
+    flux : np.ndarray
+        Flux density for each band (microjansky).
+    flux_err : np.ndarray
+        Flux error for each band (microjansky).
+    wavelength : np.ndarray
+        Effective wavelength for each band (microns).
+    flux_unit : str
+        Unit string (typically 'uJy').
+    catalog : str
+        Source catalog name.
+    catalog_id : str or None
+        ID of this object in the source catalog.
+    match_distance_arcsec : float or None
+        Cross-match distance in arcsec.
+    photo_z : float or None
+        Photometric redshift from this catalog.
+    photo_z_err_lo : float or None
+        Photo-z lower error bound.
+    photo_z_err_hi : float or None
+        Photo-z upper error bound.
+    """
+
+    bands: List[str]
+    flux: np.ndarray
+    flux_err: np.ndarray
+    wavelength: np.ndarray
+    flux_unit: str = "uJy"
+    catalog: str = ""
+    catalog_id: Optional[str] = None
+    match_distance_arcsec: Optional[float] = None
+    photo_z: Optional[float] = None
+    photo_z_err_lo: Optional[float] = None
+    photo_z_err_hi: Optional[float] = None
+
+    def __getitem__(self, band_name: str) -> Band:
+        """Get a single band by name.
+
+        Returns
+        -------
+        Band
+            Named tuple with (flux, flux_err, wavelength).
+
+        Raises
+        ------
+        KeyError
+            If band name not found.
+        """
+        try:
+            idx = self.bands.index(band_name)
+        except ValueError:
+            raise KeyError(
+                f"Band '{band_name}' not found. Available: {', '.join(self.bands)}"
+            )
+        return Band(
+            flux=self.flux[idx],
+            flux_err=self.flux_err[idx],
+            wavelength=self.wavelength[idx],
+        )
+
+    def to_table(self) -> "Table":
+        """Convert to an astropy Table.
+
+        Returns a table with columns: band, flux, flux_err, wavelength.
+        """
+        from astropy.table import Table as AstropyTable
+
+        return AstropyTable(
+            {
+                "band": self.bands,
+                "flux": self.flux,
+                "flux_err": self.flux_err,
+                "wavelength": self.wavelength,
+            }
+        )
+
+    def __len__(self) -> int:
+        return len(self.bands)
+
+    def __repr__(self) -> str:
+        n = len(self.bands)
+        cat = f", {self.catalog}" if self.catalog else ""
+        pz = f", photo_z={self.photo_z:.2f}" if self.photo_z is not None else ""
+        return f"Photometry({n} bands{cat}{pz})"
+
+    @classmethod
+    def from_record(cls, record: dict) -> "Photometry":
+        """Build from a store photometry record (with deserialized JSON).
+
+        Parameters
+        ----------
+        record : dict
+            A row from ``LocalStore.get_photometry_for_object()``, with the
+            ``photometry`` key already deserialized from JSON.
+        """
+        phot_data = record.get("photometry") or {}
+        bands_dict = phot_data.get("bands", {})
+
+        # Sort bands by wavelength
+        band_items = sorted(
+            bands_dict.items(),
+            key=lambda kv: kv[1].get("wav", 0) or 0,
+        )
+
+        band_names = [k for k, _ in band_items]
+        flux = np.array([v.get("flux", np.nan) for _, v in band_items])
+        flux_err = np.array([v.get("flux_err", np.nan) for _, v in band_items])
+        wavelength = np.array([v.get("wav", np.nan) for _, v in band_items])
+
+        return cls(
+            bands=band_names,
+            flux=flux,
+            flux_err=flux_err,
+            wavelength=wavelength,
+            flux_unit=phot_data.get("flux_unit", "uJy"),
+            catalog=record.get("catalog_name", ""),
+            catalog_id=record.get("catalog_id"),
+            match_distance_arcsec=record.get("match_distance_arcsec"),
+            photo_z=record.get("photo_z"),
+            photo_z_err_lo=record.get("photo_z_err_lo"),
+            photo_z_err_hi=record.get("photo_z_err_hi"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Target — per-program target with its spectra
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Target:
+    """A per-program, per-observation spectroscopic target.
+
+    Attributes
+    ----------
+    target_id : str
+        Unique target identifier (e.g. 'ember_uds_p4_12345').
+    ra : float
+        Right ascension (degrees).
+    dec : float
+        Declination (degrees).
+    redshift : float or None
+        Best redshift estimate.
+    redshift_quality : int
+        Redshift quality code (0=none, 1=tentative, ..., 4=secure).
+    program_slug : str
+        Program identifier.
+    field : str
+        Field name (e.g. 'cosmos').
+    observation : str
+        Observation name.
+    spectra : SpectrumCollection
+        Spectra associated with this target.
+    """
+
+    target_id: str
+    ra: float
+    dec: float
+    redshift: Optional[float] = None
+    redshift_auto: Optional[float] = None
+    redshift_inspected: Optional[float] = None
+    redshift_quality: int = 0
+    spectral_features: int = 0
+    dq_flags: int = 0
+    program_slug: str = ""
+    program_name: str = ""
+    field: str = ""
+    observation: str = ""
+    max_snr: Optional[float] = None
+    max_exposure_time: Optional[float] = None
+    last_inspected_at: Optional[str] = None
+    last_inspected_by: Optional[str] = None
+    spectra: SpectrumCollection = dc_field(default_factory=lambda: SpectrumCollection([]))
+
+    def __repr__(self) -> str:
+        z = f", z={self.redshift:.4f}" if self.redshift is not None else ""
+        n = len(self.spectra)
+        gratings = ", ".join(self.spectra.gratings) if n else "no spectra"
+        return f"Target({self.target_id}{z}, {gratings})"
+
+    @classmethod
+    def from_dict(
+        cls, d: dict, opener: Optional[Callable] = None
+    ) -> "Target":
+        """Build from a store target dict (with nested spectra list)."""
+        spectra_dicts = d.get("spectra", [])
+        spectra = [
+            Spectrum(
+                spectra_id=s.get("id") or s.get("spectra_id", 0),
+                target_id=s.get("target_id", d.get("target_id", "")),
+                grating=s.get("grating", ""),
+                signal_to_noise=s.get("signal_to_noise"),
+                exposure_time=s.get("exposure_time"),
+                reduction_version=s.get("reduction_version"),
+                fits_path=s.get("fits_path"),
+                local_path=s.get("local_path"),
+                _opener=opener,
+            )
+            for s in spectra_dicts
+        ]
+
+        return cls(
+            target_id=d.get("target_id", ""),
+            ra=d.get("ra", 0.0),
+            dec=d.get("dec", 0.0),
+            redshift=d.get("redshift"),
+            redshift_auto=d.get("redshift_auto"),
+            redshift_inspected=d.get("redshift_inspected"),
+            redshift_quality=d.get("redshift_quality", 0),
+            spectral_features=d.get("spectral_features", 0),
+            dq_flags=d.get("dq_flags", 0),
+            program_slug=d.get("program_slug", ""),
+            program_name=d.get("program_name", ""),
+            field=d.get("field", ""),
+            observation=d.get("observation", ""),
+            max_snr=d.get("max_snr"),
+            max_exposure_time=d.get("max_exposure_time"),
+            last_inspected_at=d.get("last_inspected_at"),
+            last_inspected_by=d.get("last_inspected_by"),
+            spectra=SpectrumCollection(spectra),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Object — cross-program sky-object with full context
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Object:
+    """A sky-object grouping targets across programs.
+
+    Attributes
+    ----------
+    object_id : str
+        Sky-object identifier (e.g. 'J100025.32+021520.1').
+    ra : float
+        Right ascension (degrees).
+    dec : float
+        Declination (degrees).
+    field : str
+        Field name.
+    best_redshift : float or None
+        Best available redshift across member targets.
+    best_redshift_quality : int
+        Quality code of the best redshift.
+    n_targets : int
+        Number of member targets.
+    n_spectra : int
+        Total number of spectra.
+    programs : list of str
+        Program slugs with data for this object.
+    targets : list of Target
+        Member targets, each with their own spectra.
+    spectra : SpectrumCollection
+        All spectra across all member targets.
+    photometry : Photometry or None
+        Photometric data, or None if no photometry available.
+    """
+
+    object_id: str
+    ra: float
+    dec: float
+    field: str = ""
+    best_redshift: Optional[float] = None
+    best_redshift_quality: int = 0
+    n_targets: int = 0
+    n_spectra: int = 0
+    programs: List[str] = dc_field(default_factory=list)
+    max_snr: Optional[float] = None
+    max_exposure_time: Optional[float] = None
+    has_photometry: bool = False
+    photo_z: Optional[float] = None
+    photo_z_err_lo: Optional[float] = None
+    photo_z_err_hi: Optional[float] = None
+    targets: List[Target] = dc_field(default_factory=list, repr=False)
+    spectra: SpectrumCollection = dc_field(
+        default_factory=lambda: SpectrumCollection([]), repr=False
+    )
+    photometry: Optional[Photometry] = dc_field(default=None, repr=False)
+
+    def __repr__(self) -> str:
+        z = f"z={self.best_redshift:.4f}, " if self.best_redshift is not None else ""
+        gratings = ", ".join(self.spectra.gratings) if self.spectra else ""
+        parts = [
+            f"Object({self.object_id}, {z}{self.field})",
+            f"  {self.n_targets} target(s), {self.n_spectra} spectra ({gratings})",
+        ]
+        if self.photometry:
+            parts.append(f"  {self.photometry!r}")
+        return "\n".join(parts)

--- a/python/tests/test_local_first.py
+++ b/python/tests/test_local_first.py
@@ -281,15 +281,15 @@ class TestSpectrumData:
 
         spec = SpectrumData(
             wavelength=wave,
-            flux=flux,
-            flux_err=flux_err,
+            fnu=flux,
+            fnu_err=flux_err,
             header={"OBJECT": "test"},
             grating="PRISM",
             target_id="test_123",
         )
 
         assert spec.wavelength.shape == (100,)
-        assert spec.flux.shape == (100,)
+        assert spec.fnu.shape == (100,)
         assert spec.grating == "PRISM"
         assert spec.target_id == "test_123"
         assert spec.fits_path is None
@@ -299,8 +299,8 @@ class TestSpectrumData:
         wave = np.linspace(0.6, 5.3, 100)
         spec = SpectrumData(
             wavelength=wave,
-            flux=np.ones(100),
-            flux_err=np.zeros(100),
+            fnu=np.ones(100),
+            fnu_err=np.zeros(100),
             header={},
             grating="G395M",
             target_id="obj_456",
@@ -334,8 +334,8 @@ class TestSpectrumData:
         spec = SpectrumData.from_fits(str(fits_path))
 
         assert spec.wavelength.shape == (50,)
-        assert spec.flux.shape == (50,)
-        assert spec.flux_err.shape == (50,)
+        assert spec.fnu.shape == (50,)
+        assert spec.fnu_err.shape == (50,)
         assert spec.target_id == "test_obj"
         assert spec.grating == "PRISM"
         assert spec.fits_path == str(fits_path)

--- a/supabase/migrations/20260414151708_drop-unused-indexes.sql
+++ b/supabase/migrations/20260414151708_drop-unused-indexes.sql
@@ -1,0 +1,31 @@
+drop index if exists "public"."idx_download_log_target_ids";
+
+drop index if exists "public"."idx_flag_audit_log_target_id";
+
+drop index if exists "public"."idx_objects_best_redshift";
+
+drop index if exists "public"."idx_objects_max_exposure_time";
+
+drop index if exists "public"."idx_objects_max_snr";
+
+drop index if exists "public"."idx_objects_photo_z";
+
+drop index if exists "public"."idx_objects_redshift_generated";
+
+drop index if exists "public"."idx_objects_redshift_quality";
+
+drop index if exists "public"."idx_shutters_observation";
+
+drop index if exists "public"."idx_spectra_file_hash";
+
+drop index if exists "public"."idx_spectra_target_id";
+
+drop index if exists "public"."idx_targets_field";
+
+drop index if exists "public"."idx_targets_max_exposure_time";
+
+drop index if exists "public"."idx_targets_max_snr";
+
+drop index if exists "public"."idx_targets_program_slug";
+
+

--- a/supabase/migrations/20260415183059_update-objects-on-list-change.sql
+++ b/supabase/migrations/20260415183059_update-objects-on-list-change.sql
@@ -1,0 +1,34 @@
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.log_list_membership_change()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+    v_object_id INTEGER;
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        v_object_id := NEW.object_id;
+        INSERT INTO list_audit_log (list_id, object_id, user_id, action, ra, dec)
+        VALUES (NEW.list_id, NEW.object_id, auth.uid(), 'add', NEW.ra, NEW.dec);
+    ELSIF TG_OP = 'DELETE' THEN
+        v_object_id := OLD.object_id;
+        INSERT INTO list_audit_log (list_id, object_id, user_id, action, ra, dec)
+        VALUES (OLD.list_id, OLD.object_id, auth.uid(), 'remove', OLD.ra, OLD.dec);
+    END IF;
+
+    -- Bump objects.updated_at so incremental sync picks up tag changes
+    UPDATE objects SET updated_at = NOW() WHERE id = v_object_id;
+
+    IF TG_OP = 'INSERT' THEN
+        RETURN NEW;
+    ELSIF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NULL;
+END;
+$function$
+;
+
+

--- a/supabase/schemas/triggers.sql
+++ b/supabase/schemas/triggers.sql
@@ -106,14 +106,25 @@ DROP FUNCTION IF EXISTS public.log_list_membership_change CASCADE;
 CREATE OR REPLACE FUNCTION public.log_list_membership_change() RETURNS trigger
 LANGUAGE plpgsql SECURITY DEFINER
 AS $$
+DECLARE
+    v_object_id INTEGER;
 BEGIN
     IF TG_OP = 'INSERT' THEN
+        v_object_id := NEW.object_id;
         INSERT INTO list_audit_log (list_id, object_id, user_id, action, ra, dec)
         VALUES (NEW.list_id, NEW.object_id, auth.uid(), 'add', NEW.ra, NEW.dec);
-        RETURN NEW;
     ELSIF TG_OP = 'DELETE' THEN
+        v_object_id := OLD.object_id;
         INSERT INTO list_audit_log (list_id, object_id, user_id, action, ra, dec)
         VALUES (OLD.list_id, OLD.object_id, auth.uid(), 'remove', OLD.ra, OLD.dec);
+    END IF;
+
+    -- Bump objects.updated_at so incremental sync picks up tag changes
+    UPDATE objects SET updated_at = NOW() WHERE id = v_object_id;
+
+    IF TG_OP = 'INSERT' THEN
+        RETURN NEW;
+    ELSIF TG_OP = 'DELETE' THEN
         RETURN OLD;
     END IF;
     RETURN NULL;

--- a/web/lib/docs/content/api/python-client.md
+++ b/web/lib/docs/content/api/python-client.md
@@ -18,7 +18,7 @@ results = cf.query_objects(
 
 # Open a spectrum directly
 spec = cf.open_spectrum('ember_uds_p4_123456', 'PRISM')
-print(spec.wavelength.shape, spec.flux.shape)
+print(spec.wavelength.shape, spec.fnu.shape)
 ```
 
 ---
@@ -262,11 +262,13 @@ spec = cf.open_spectrum(object_id, grating)
 | Attribute | Type | Description |
 |-----------|------|-------------|
 | `wavelength` | np.ndarray | Wavelength in microns |
-| `flux` | np.ndarray | Flux density f_nu in microjansky |
-| `flux_err` | np.ndarray | Flux error in microjansky |
+| `fnu` | np.ndarray | Flux density f_ν in microjansky (μJy) |
+| `fnu_err` | np.ndarray | Flux error f_ν in microjansky (μJy) |
+| `flam` | np.ndarray | Flux density f_λ in erg/s/cm²/Å (auto-computed from fnu if not in FITS) |
+| `flam_err` | np.ndarray | Flux error f_λ in erg/s/cm²/Å |
 | `header` | dict | FITS primary header |
 | `grating` | str | Grating name |
-| `object_id` | str | Object ID |
+| `target_id` | str | Target ID |
 | `fits_path` | str/None | Local file path if from disk |
 
 **Example:**
@@ -279,7 +281,7 @@ print(spec)
 
 # Access arrays directly
 import matplotlib.pyplot as plt
-plt.plot(spec.wavelength, spec.flux)
+plt.plot(spec.wavelength, spec.fnu)
 plt.xlabel('Wavelength (μm)')
 plt.ylabel('f_ν (μJy)')
 


### PR DESCRIPTION
## Summary

- **New `campfire.calibration` module** with `calibrate_to_photometry()` (Chebyshev/flat methods), `stack_spectra()` (weighted mean/median/mean), and `calibrate_and_stack()` convenience function. All return result objects with diagnostic `.plot()` methods.
- **Real filter transmission curves** downloaded from the SVO Filter Profile Service and cached locally as `.npz` files, with top-hat fallback.
- **Unit-aware `SpectrumData`**: renamed `flux`/`flux_err` → `fnu`/`fnu_err`, `flam`/`flam_err` always available (auto-computed from fnu if not in FITS), plus `fnu_units`, `flam_units`, `wave_units` string attributes.
- **`SpectrumData.plot()`** now uses `plt.step(where='mid')` and accepts `flux_unit='flam'`.
- **Expanded client models**: `Spectrum`, `SpectrumCollection`, `Photometry`, `Target`, `Object` with filtering, `.open()`/`.data` accessors, and rich reprs exported from `__init__`.
- **LocalStore query enhancements**: grating, tag, and has_photometry filters for `query_objects()`.

## Test plan

- [x] All 104 existing tests pass
- [x] Manual test: calibrate a spectrum to photometry, inspect diagnostic plot
- [x] Manual test: calibrate + stack multiple PRISM spectra of the same object
- [ ] Verify `spec.flam` is auto-computed when loading from FITS without flam columns

Generated with Claude Code