### PR TITLE
Fix: default $CAMPFIRE_ROOT to ~/campfire when unset in cfpipe

### DIFF
--- a/pipeline/campfire_pipeline/cli.py
+++ b/pipeline/campfire_pipeline/cli.py
@@ -77,7 +77,7 @@ def info(config_path):
 
     campfire_root = os.environ.get('CAMPFIRE_ROOT')
     click.echo()
-    click.echo(f"  CAMPFIRE_ROOT:  {campfire_root or '(not set)'}")
+    click.echo(f"  CAMPFIRE_ROOT:  {campfire_root or '~/campfire (default)'}")
 
     cfg = load_config(config_path)
     setup_environment(cfg)
@@ -128,7 +128,7 @@ INSTRUMENT_DEFAULTS = {
 @click.option('--exp-type', default=None,
               help='Exposure type (default: auto from instrument).')
 @click.option('--download-dir', default=None,
-              help='Download directory (default: $CAMPFIRE_ROOT/raw or ./data).')
+              help='Download directory (default: $CAMPFIRE_ROOT/raw, or ~/campfire/raw if unset).')
 @click.option('--dry-run', is_flag=True,
               help='List files without downloading.')
 @click.option('--token', default=None,
@@ -143,11 +143,8 @@ def download(program, instrument, obs_id, exp_type, download_dir, dry_run, token
         exp_type = INSTRUMENT_DEFAULTS.get(instrument_upper, 'NRS_MSASPEC')
 
     if download_dir is None:
-        campfire_root = os.environ.get('CAMPFIRE_ROOT')
-        if campfire_root:
-            download_dir = os.path.join(campfire_root, 'raw')
-        else:
-            download_dir = 'data'
+        from campfire_pipeline.config import _get_campfire_root
+        download_dir = os.path.join(_get_campfire_root(), 'raw')
 
     token = token or os.environ.get('MAST_API_TOKEN')
 

--- a/pipeline/campfire_pipeline/config.py
+++ b/pipeline/campfire_pipeline/config.py
@@ -3,14 +3,22 @@ Configuration loading and environment setup.
 
 Resolves paths in order:
 1. Explicit paths in config
-2. $CAMPFIRE_ROOT/{raw,products,cache} if env var is set
-3. Raise a clear error
+2. $CAMPFIRE_ROOT/{raw,products,cache} (defaults to ~/campfire if unset)
 """
 
 import os
 from pathlib import Path
 
 import toml
+
+
+# ---------------------------------------------------------------------------
+# CAMPFIRE_ROOT resolution
+# ---------------------------------------------------------------------------
+
+def _get_campfire_root():
+    """Return $CAMPFIRE_ROOT, defaulting to ~/campfire if unset."""
+    return os.environ.get('CAMPFIRE_ROOT') or str(Path.home() / 'campfire')
 
 
 # ---------------------------------------------------------------------------
@@ -69,11 +77,10 @@ def load_config(config_path=None):
             raise FileNotFoundError(f"Config file not found: {config_path}")
         user_path = config_path
     else:
-        campfire_root = os.environ.get('CAMPFIRE_ROOT')
-        if campfire_root:
-            candidate = os.path.join(campfire_root, 'config', 'config.toml')
-            if os.path.isfile(candidate):
-                user_path = candidate
+        campfire_root = _get_campfire_root()
+        candidate = os.path.join(campfire_root, 'config', 'config.toml')
+        if os.path.isfile(candidate):
+            user_path = candidate
         if user_path is None and os.path.isfile('config.toml'):
             user_path = 'config.toml'
 
@@ -112,25 +119,23 @@ def _resolve_path(config_value, campfire_root, default_subdir, label):
         return config_value
     if campfire_root:
         return os.path.join(campfire_root, default_subdir)
-    raise RuntimeError(
-        f"{label}: set [paths].{label} in config.toml or export CAMPFIRE_ROOT"
-    )
+    return os.path.join(_get_campfire_root(), default_subdir)
 
 
 def setup_environment(config):
     """Set environment variables from config file.
 
-    For CRDS_PATH, falls back to $CAMPFIRE_ROOT/cache/crds if not specified
-    in config and $CAMPFIRE_ROOT is set.
+    For CRDS_PATH, priority is:
+    1. Existing $CRDS_PATH in the user's environment
+    2. [environment].CRDS_PATH in config
+    3. $CAMPFIRE_ROOT/cache/crds (CAMPFIRE_ROOT defaults to ~/campfire)
     """
-    campfire_root = os.environ.get('CAMPFIRE_ROOT')
-
     if 'environment' in config:
         env = config['environment']
 
-        # Handle CRDS_PATH fallback before setting env vars
-        if 'CRDS_PATH' not in env and campfire_root:
-            env['CRDS_PATH'] = os.path.join(campfire_root, 'cache', 'crds')
+        # Only set CRDS_PATH fallback if not in config and not already in env
+        if 'CRDS_PATH' not in env and 'CRDS_PATH' not in os.environ:
+            env['CRDS_PATH'] = os.path.join(_get_campfire_root(), 'cache', 'crds')
 
         for key, value in env.items():
             os.environ[key] = str(value)
@@ -142,7 +147,7 @@ def resolve_paths(config):
     Returns dict with keys: data_dir, products_dir.
     """
     paths = config.get('paths', {})
-    campfire_root = os.environ.get('CAMPFIRE_ROOT')
+    campfire_root = _get_campfire_root()
 
     result = {
         'data_dir': _resolve_path(
@@ -185,12 +190,11 @@ def resolve_observations_file(explicit_path=None):
     if explicit_path:
         tried.append(explicit_path)
 
-    campfire_root = os.environ.get('CAMPFIRE_ROOT')
-    if campfire_root:
-        candidate = os.path.join(campfire_root, 'config', 'observations.toml')
-        if os.path.isfile(candidate):
-            return candidate
-        tried.append(candidate)
+    campfire_root = _get_campfire_root()
+    candidate = os.path.join(campfire_root, 'config', 'observations.toml')
+    if os.path.isfile(candidate):
+        return candidate
+    tried.append(candidate)
 
     if os.path.isfile('observations.toml'):
         return 'observations.toml'
@@ -226,12 +230,11 @@ def resolve_fields_file(explicit_path=None):
     if explicit_path:
         tried.append(explicit_path)
 
-    campfire_root = os.environ.get('CAMPFIRE_ROOT')
-    if campfire_root:
-        candidate = os.path.join(campfire_root, 'config', 'fields.toml')
-        if os.path.isfile(candidate):
-            return candidate
-        tried.append(candidate)
+    campfire_root = _get_campfire_root()
+    candidate = os.path.join(campfire_root, 'config', 'fields.toml')
+    if os.path.isfile(candidate):
+        return candidate
+    tried.append(candidate)
 
     if os.path.isfile('fields.toml'):
         return 'fields.toml'
@@ -279,15 +282,14 @@ def resolve_template_grid_paths(config):
     If a path in template_grids.*.file is relative, resolve it relative
     to $CAMPFIRE_ROOT/cache/templates/. Absolute paths are used as-is.
     """
-    campfire_root = os.environ.get('CAMPFIRE_ROOT')
+    campfire_root = _get_campfire_root()
     template_grids = config.get('nirspec', {}).get('template_grids', {})
 
     for name, grid_config in template_grids.items():
         filepath = grid_config.get('file', '')
         if filepath and not os.path.isabs(filepath):
-            if campfire_root:
-                grid_config['file'] = os.path.join(
-                    campfire_root, 'cache', 'templates', filepath)
+            grid_config['file'] = os.path.join(
+                campfire_root, 'cache', 'templates', filepath)
 
     return template_grids
 

--- a/pipeline/campfire_pipeline/config.py
+++ b/pipeline/campfire_pipeline/config.py
@@ -96,19 +96,17 @@ def load_config(config_path=None):
 # Environment and path resolution
 # ---------------------------------------------------------------------------
 
-def _resolve_path(config_value, campfire_root, default_subdir, label):
-    """Resolve a single path from config value or $CAMPFIRE_ROOT.
+def _resolve_path(config_value, campfire_root, default_subdir):
+    """Resolve a single path from config value or CAMPFIRE_ROOT.
 
     Parameters
     ----------
     config_value : str or None
         Explicit path from config (takes priority).
-    campfire_root : str or None
-        Value of $CAMPFIRE_ROOT environment variable.
+    campfire_root : str
+        Resolved CAMPFIRE_ROOT (from ``_get_campfire_root()``).
     default_subdir : str
-        Subdirectory under $CAMPFIRE_ROOT (e.g. 'raw', 'products').
-    label : str
-        Human-readable label for error messages.
+        Subdirectory under CAMPFIRE_ROOT (e.g. 'raw', 'products').
 
     Returns
     -------
@@ -117,9 +115,7 @@ def _resolve_path(config_value, campfire_root, default_subdir, label):
     """
     if config_value:
         return config_value
-    if campfire_root:
-        return os.path.join(campfire_root, default_subdir)
-    return os.path.join(_get_campfire_root(), default_subdir)
+    return os.path.join(campfire_root, default_subdir)
 
 
 def setup_environment(config):
@@ -138,6 +134,8 @@ def setup_environment(config):
             env['CRDS_PATH'] = os.path.join(_get_campfire_root(), 'cache', 'crds')
 
         for key, value in env.items():
+            if key == 'CRDS_PATH' and 'CRDS_PATH' in os.environ:
+                continue
             os.environ[key] = str(value)
 
 
@@ -151,9 +149,9 @@ def resolve_paths(config):
 
     result = {
         'data_dir': _resolve_path(
-            paths.get('data_dir'), campfire_root, 'raw', 'data_dir'),
+            paths.get('data_dir'), campfire_root, 'raw'),
         'products_dir': _resolve_path(
-            paths.get('products_dir'), campfire_root, 'products', 'products_dir'),
+            paths.get('products_dir'), campfire_root, 'products'),
     }
     for d in result.values():
         if d:

--- a/pipeline/campfire_pipeline/nircam/cli.py
+++ b/pipeline/campfire_pipeline/nircam/cli.py
@@ -54,9 +54,8 @@ def _setup(config_path, field_name):
     """
     config = load_config(config_path)
     setup_environment(config)
-    campfire_root = os.environ.get('CAMPFIRE_ROOT')
     field_obj = Field.load(field_name)
-    field_obj.setup_workspace(campfire_root)
+    field_obj.setup_workspace()
     return config, field_obj
 
 

--- a/pipeline/campfire_pipeline/nircam/engine.py
+++ b/pipeline/campfire_pipeline/nircam/engine.py
@@ -25,7 +25,8 @@ class ReductionEngine:
         self.config = load_config(config_path)
         self.config_path = config_path
         setup_environment(self.config)
-        self.campfire_root = os.environ.get('CAMPFIRE_ROOT')
+        from campfire_pipeline.config import _get_campfire_root
+        self.campfire_root = _get_campfire_root()
         log("Initialized NIRCam ReductionEngine")
 
     def get_stage_config(self, stage_name, field):

--- a/pipeline/campfire_pipeline/nircam/engine.py
+++ b/pipeline/campfire_pipeline/nircam/engine.py
@@ -9,7 +9,7 @@ that existing scripts and interactive usage continue to work.
 import os
 
 from campfire_pipeline.config import (
-    load_config, setup_environment, get_nircam_stage_config,
+    _get_campfire_root, load_config, setup_environment, get_nircam_stage_config,
 )
 from campfire_pipeline.common.io import log
 from campfire_pipeline.nircam.field import Field
@@ -25,7 +25,6 @@ class ReductionEngine:
         self.config = load_config(config_path)
         self.config_path = config_path
         setup_environment(self.config)
-        from campfire_pipeline.config import _get_campfire_root
         self.campfire_root = _get_campfire_root()
         log("Initialized NIRCam ReductionEngine")
 

--- a/pipeline/campfire_pipeline/nircam/field.py
+++ b/pipeline/campfire_pipeline/nircam/field.py
@@ -121,11 +121,8 @@ class Field:
             Override $CAMPFIRE_ROOT. If None, reads from environment.
         """
         if campfire_root is None:
-            campfire_root = os.environ.get('CAMPFIRE_ROOT')
-        if not campfire_root:
-            raise RuntimeError(
-                "Cannot set up workspace: export CAMPFIRE_ROOT or pass campfire_root"
-            )
+            from campfire_pipeline.config import _get_campfire_root
+            campfire_root = _get_campfire_root()
 
         self.raw_dir = os.path.join(campfire_root, 'raw', self.data_subdir)
         self.products_dir = os.path.join(campfire_root, 'products', 'nircam', self.name)

--- a/pipeline/campfire_pipeline/nirspec/stage2.py
+++ b/pipeline/campfire_pipeline/nirspec/stage2.py
@@ -50,11 +50,8 @@ def build_empirical_wavecorr():
     from jwst.datamodels import WaveCorrModel
 
     # --- cache check ---
-    campfire_root = os.environ.get('CAMPFIRE_ROOT')
-    if not campfire_root:
-        raise RuntimeError(
-            "CAMPFIRE_ROOT must be set to build empirical wavecorr file"
-        )
+    from campfire_pipeline.config import _get_campfire_root
+    campfire_root = _get_campfire_root()
     cache_dir = os.path.join(campfire_root, 'cache')
     os.makedirs(cache_dir, exist_ok=True)
     out_path = os.path.join(cache_dir, 'jwst_nirspec_wavecorr_jades_dr4_empirical.asdf')

--- a/pipeline/tests/test_config.py
+++ b/pipeline/tests/test_config.py
@@ -4,8 +4,6 @@ import os
 from pathlib import Path
 from unittest import mock
 
-import pytest
-
 from campfire_pipeline.config import (
     _get_campfire_root,
     _resolve_path,
@@ -25,22 +23,23 @@ class TestGetCampfireRoot:
 
 class TestResolvePath:
     def test_config_value_takes_priority(self):
-        result = _resolve_path("/explicit/path", "/root", "raw", "data_dir")
+        result = _resolve_path("/explicit/path", "/root", "raw")
         assert result == "/explicit/path"
 
     def test_campfire_root_used_when_no_config(self):
-        result = _resolve_path(None, "/root", "raw", "data_dir")
+        result = _resolve_path(None, "/root", "raw")
         assert result == "/root/raw"
-
-    def test_falls_back_to_default_root(self):
-        with mock.patch.dict(os.environ, {}, clear=True):
-            result = _resolve_path(None, None, "raw", "data_dir")
-        assert result == os.path.join(str(Path.home() / "campfire"), "raw")
 
 
 class TestSetupEnvironmentCrdsPath:
     def test_respects_existing_crds_path(self):
         config = {"environment": {"CRDS_SERVER_URL": "https://example.com"}}
+        with mock.patch.dict(os.environ, {"CRDS_PATH": "/user/crds"}, clear=False):
+            setup_environment(config)
+            assert os.environ["CRDS_PATH"] == "/user/crds"
+
+    def test_env_crds_path_beats_config(self):
+        config = {"environment": {"CRDS_PATH": "/config/crds"}}
         with mock.patch.dict(os.environ, {"CRDS_PATH": "/user/crds"}, clear=False):
             setup_environment(config)
             assert os.environ["CRDS_PATH"] == "/user/crds"

--- a/pipeline/tests/test_config.py
+++ b/pipeline/tests/test_config.py
@@ -1,0 +1,66 @@
+"""Tests for config path resolution and environment setup."""
+
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from campfire_pipeline.config import (
+    _get_campfire_root,
+    _resolve_path,
+    setup_environment,
+)
+
+
+class TestGetCampfireRoot:
+    def test_returns_env_var_when_set(self):
+        with mock.patch.dict(os.environ, {"CAMPFIRE_ROOT": "/custom/root"}):
+            assert _get_campfire_root() == "/custom/root"
+
+    def test_defaults_to_home_campfire_when_unset(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            assert _get_campfire_root() == str(Path.home() / "campfire")
+
+
+class TestResolvePath:
+    def test_config_value_takes_priority(self):
+        result = _resolve_path("/explicit/path", "/root", "raw", "data_dir")
+        assert result == "/explicit/path"
+
+    def test_campfire_root_used_when_no_config(self):
+        result = _resolve_path(None, "/root", "raw", "data_dir")
+        assert result == "/root/raw"
+
+    def test_falls_back_to_default_root(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            result = _resolve_path(None, None, "raw", "data_dir")
+        assert result == os.path.join(str(Path.home() / "campfire"), "raw")
+
+
+class TestSetupEnvironmentCrdsPath:
+    def test_respects_existing_crds_path(self):
+        config = {"environment": {"CRDS_SERVER_URL": "https://example.com"}}
+        with mock.patch.dict(os.environ, {"CRDS_PATH": "/user/crds"}, clear=False):
+            setup_environment(config)
+            assert os.environ["CRDS_PATH"] == "/user/crds"
+
+    def test_config_crds_path_overrides_default(self):
+        config = {"environment": {"CRDS_PATH": "/config/crds"}}
+        with mock.patch.dict(os.environ, {}, clear=True):
+            setup_environment(config)
+            assert os.environ["CRDS_PATH"] == "/config/crds"
+
+    def test_falls_back_to_campfire_root_cache(self):
+        config = {"environment": {}}
+        env = {"CAMPFIRE_ROOT": "/my/root"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            setup_environment(config)
+            assert os.environ["CRDS_PATH"] == "/my/root/cache/crds"
+
+    def test_falls_back_to_default_root_cache(self):
+        config = {"environment": {}}
+        with mock.patch.dict(os.environ, {}, clear=True):
+            setup_environment(config)
+            expected = os.path.join(str(Path.home() / "campfire"), "cache", "crds")
+            assert os.environ["CRDS_PATH"] == expected


### PR DESCRIPTION
Closes #82

## What was the bug?
When `$CAMPFIRE_ROOT` is unset, `cfpipe` commands either crashed with a `RuntimeError` or used wrong default paths (e.g. `cfpipe download` wrote to `./data` instead of `~/campfire/raw`). The `campfire` Python CLI already defaults to `~/campfire` — the pipeline should match.

## Root cause
Every call site in the pipeline used `os.environ.get('CAMPFIRE_ROOT')` directly and either raised an error or fell back to a hard-coded relative path when the env var was unset. There was no shared fallback to `~/campfire`.

Additionally, `setup_environment()` unconditionally overwrote `$CRDS_PATH` with a default even if the user already had it set in their shell environment.

## What I changed
- Added `_get_campfire_root()` helper in `config.py` that returns `$CAMPFIRE_ROOT` or `~/campfire`
- Replaced all raw `os.environ.get('CAMPFIRE_ROOT')` calls across the pipeline with the helper:
  - `config.py`: `load_config`, `_resolve_path`, `resolve_paths`, `resolve_observations_file`, `resolve_fields_file`, `resolve_template_grid_paths`
  - `cli.py`: download command, info display
  - `nircam/cli.py`, `nircam/engine.py`, `nircam/field.py`
  - `nirspec/stage2.py`
- Fixed `setup_environment()` to respect an existing `$CRDS_PATH` env var before applying defaults (priority: user env → config → CAMPFIRE_ROOT/cache/crds)
- Updated `cfpipe info` to show `~/campfire (default)` when the env var is unset

## Testing
- Added `pipeline/tests/test_config.py` with 9 tests covering:
  - `_get_campfire_root` with and without env var
  - `_resolve_path` priority (config > campfire_root > default)
  - `setup_environment` CRDS_PATH priority (existing env > config > fallback)
- All tests pass