### PR TITLE
Add GitHub link to web portal

### DIFF
--- a/web/components/layout/Footer.tsx
+++ b/web/components/layout/Footer.tsx
@@ -1,4 +1,4 @@
-import { Bug, Lightbulb } from 'lucide-react';
+import { Bug, Github, Lightbulb } from 'lucide-react';
 
 const GITHUB_REPO = 'https://github.com/hollisakins/campfire';
 
@@ -8,6 +8,16 @@ export function Footer() {
       <div className="container mx-auto px-4 py-4 flex flex-col sm:flex-row items-center justify-between gap-2 text-sm text-text-secondary dark:text-slate-400">
         <span>&copy; 2025 Hollis Akins &middot; MIT License</span>
         <div className="flex items-center gap-4">
+          <a
+            href={GITHUB_REPO}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 hover:text-primary transition-colors"
+          >
+            <Github className="w-4 h-4" />
+            GitHub
+          </a>
+          <span className="text-border dark:text-slate-600">|</span>
           <a
             href={`${GITHUB_REPO}/issues/new?template=bug_report.yml`}
             target="_blank"

--- a/web/components/layout/Navigation.tsx
+++ b/web/components/layout/Navigation.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { Flame, LogOut, User, Shield, Sun, Moon, Monitor, ChevronDown } from 'lucide-react';
+import { Flame, LogOut, User, Shield, Sun, Moon, Monitor, ChevronDown, Github } from 'lucide-react';
 import { useAuth } from '@/lib/contexts/AuthContext';
 import { useTheme } from '@/lib/contexts/ThemeContext';
 
@@ -134,6 +134,18 @@ export const Navigation: React.FC = () => {
             >
               <ThemeIcon className="w-4 h-4" />
             </button>
+
+            {/* GitHub */}
+            <a
+              href="https://github.com/hollisakins/campfire"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center text-sm text-gray-300 hover:text-white transition-colors"
+              aria-label="View on GitHub"
+              title="View on GitHub"
+            >
+              <Github className="w-4 h-4" />
+            </a>
 
             {/* User Menu */}
             {user ? (


### PR DESCRIPTION
Closes #81

## What was requested?
Add a link to the GitHub repository from the web portal.

## What I implemented
- **Navbar**: GitHub icon link (lucide `Github`) placed after the theme toggle, before the user menu divider. Icon-only to match the theme toggle style.
- **Footer**: Added a "GitHub" link (with icon) as the first item in the footer links, before "Report a Bug" and "Request a Feature".

## Design decisions
- Navbar uses icon-only (no text label) to keep the top bar clean — matches the theme toggle pattern.
- Footer uses icon + text label to match the existing "Report a Bug" / "Request a Feature" style.
- Both link to `https://github.com/hollisakins/campfire` with `target="_blank"`.

## Testing
- `npm run build` passes cleanly.

Generated with Claude Code