### PR TITLE
Bug fixes for Fixed Slit, z_fitting, plotting, and Fixed Slit handling

### DIFF
--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -6,7 +6,7 @@
 
 [environment]
     CRDS_SERVER_URL = "https://jwst-crds.stsci.edu"
-    # CRDS_CONTEXT = "jwst_1481.pmap"   # uncomment to pin
+    CRDS_CONTEXT = "jwst_1481.pmap"   # uncomment to pin
 
 [paths]
     # Resolved from $CAMPFIRE_ROOT by default. Uncomment to override:

--- a/pipeline/campfire_pipeline/nirspec/plots.py
+++ b/pipeline/campfire_pipeline/nirspec/plots.py
@@ -5,6 +5,8 @@ NIRSpec stage-specific QA plotting.
 import os
 import warnings
 import numpy as np
+import matplotlib
+matplotlib.use('pdf')
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 from astropy.io import fits

--- a/pipeline/campfire_pipeline/nirspec/redshift_fitting.py
+++ b/pipeline/campfire_pipeline/nirspec/redshift_fitting.py
@@ -692,18 +692,11 @@ def fit_redshifts(obs_name, config, source_ids=None, overwrite=False,
             spec_files = actual_spec_files
 
         logger.info(f"Starting redshift fitting for {len(spec_files)} objects using {ncores} cores")
-        if ncores > 1:
-            numba.set_num_threads(1)
-        else:
-            numba.set_num_threads(os.cpu_count() or 1)
+        numba.set_num_threads(ncores)
 
         start_time = time.time()
-        if ncores > 1:
-            with Pool(ncores) as pool:
-                _ = pool.starmap(fit_func, [fit_args_factory(sf) for sf in spec_files])
-        else:
-            for spec_file in spec_files:
-                fit_func(*fit_args_factory(spec_file))
+        for spec_file in spec_files:
+            fit_func(*fit_args_factory(spec_file))
         end_time = time.time()
         logger.info(f"Fit {len(spec_files)} redshifts in {end_time-start_time:.1f}s")
 

--- a/pipeline/campfire_pipeline/nirspec/stage1.py
+++ b/pipeline/campfire_pipeline/nirspec/stage1.py
@@ -195,6 +195,9 @@ def mask_slits(
         meta_model.meta.wcs.bounding_box = generate_compound_bbox(meta_model, slits)
 
         for slitlet in slits:
+            
+            if slitlet.name in ["S200A1", "S200A2", "S400A1", "S1600A1", "S200B1"]:
+                continue #override if fixed slits are present, as these are auto-masked anyways
             bbox = meta_model.meta.wcs.bounding_box[slitlet.name]
             xmin, xmax, ymin, ymax = boundingbox_to_indices(processed_model.data.shape, bbox)
             y_indices, x_indices = np.mgrid[ymin:ymax, xmin:xmax]

--- a/pipeline/campfire_pipeline/nirspec/stage3.py
+++ b/pipeline/campfire_pipeline/nirspec/stage3.py
@@ -497,14 +497,14 @@ def opt_ext_single_source(
         ax_1d_fnu.step(wave, fnu, where='mid', color='k', linewidth=1)
         ax_1d_fnu.fill_between(wave, (fnu - fnu_err), (fnu + fnu_err),
             alpha=0.15, facecolor='k', edgecolor='none', step='mid')
-        ax_1d_fnu.set_ylabel(r'$f_{\nu}$ [μJy]')
+        ax_1d_fnu.set_ylabel(r'$f_{\nu}$ [$\mu$Jy]')
 
         # f_λ plot
         ax_1d_flam.step(wave, flam, where='mid', color='k', linewidth=1)
         ax_1d_flam.fill_between(wave, (flam - flam_err), (flam + flam_err),
             alpha=0.15, facecolor='k', edgecolor='none', step='mid')
         ax_1d_flam.set_ylabel(r'$f_{\lambda}$ [erg s$^{-1}$ cm$^{-2}$ Å$^{-1}$]')
-        ax_1d_flam.set_xlabel('Observed Wavelength [μm]')
+        ax_1d_flam.set_xlabel(r'Observed Wavelength [$\mu$m]')
 
         # Advanced grid and tick styling
         ax_1d_fnu.grid(True, alpha=0.2, linewidth=1, zorder=-1000)
@@ -787,13 +787,13 @@ def combine_per_eg_spectra(
         ax_1d_fnu.step(wave, fnu, where='mid', color='k', linewidth=1)
         ax_1d_fnu.fill_between(wave, fnu - fnu_err, fnu + fnu_err,
             alpha=0.15, facecolor='k', edgecolor='none', step='mid')
-        ax_1d_fnu.set_ylabel(r'$f_{\nu}$ [μJy]')
+        ax_1d_fnu.set_ylabel(r'$f_{\nu}$ [$\mu$Jy]')
 
         ax_1d_flam.step(wave, flam, where='mid', color='k', linewidth=1)
         ax_1d_flam.fill_between(wave, flam - flam_err, flam + flam_err,
             alpha=0.15, facecolor='k', edgecolor='none', step='mid')
         ax_1d_flam.set_ylabel(r'$f_{\lambda}$ [erg s$^{-1}$ cm$^{-2}$ Å$^{-1}$]')
-        ax_1d_flam.set_xlabel('Observed Wavelength [μm]')
+        ax_1d_flam.set_xlabel(r'Observed Wavelength [$\mu$m]')
 
         ax_1d_fnu.grid(True, alpha=0.2, linewidth=1, zorder=-1000)
         ax_1d_flam.grid(True, alpha=0.2, linewidth=1, zorder=-1000)


### PR DESCRIPTION
Added fix to exclude Fixed Slits from custom masking in Stage 1.
Added fix to z_fitting to properly handle nprocesses.
Uncommented CRDS_CONTEXT to fix a bug where no pictureframe reference was queried.
Replaced unicode mu with LaTeX mu to allow a LaTeX backend for matplotlib plots.