### PR TITLE
fix: clarify nod numbering in bkg override file, create in stage2a

### DIFF
--- a/pipeline/campfire_pipeline/nirspec/observation.py
+++ b/pipeline/campfire_pipeline/nirspec/observation.py
@@ -243,12 +243,17 @@ class Observation:
                 # format is like the stuck closed shutter list, e.g., there's
                 # a table for each "root" file name, which
                 # consists of obs/visit/config, e.g. "jw06368001001_03101"
-                # for each source ID, the background shutters to use for 
-                # each nod should be given as a key-value pair in the table; 
+                # for each source ID, the background shutters to use for
+                # each nod should be given as a key-value pair in the table;
                 # for example:""" + """
                 # [jw06368001001_03101]
                 #     12345 = {3=[1]}
                 # (for source 12345, only use nod 1 as background for nod 3)
+                #
+                # NOTE: nod numbers are the exposure sequence numbers from the
+                # FITS filenames (the 3rd underscore-delimited segment), NOT
+                # sequential indices. If a TACONFIRM exposure is 00001, the
+                # first science nod will be 2, not 1.
                 """)
                 f.write(docstring)
 

--- a/pipeline/campfire_pipeline/nirspec/stage2.py
+++ b/pipeline/campfire_pipeline/nirspec/stage2.py
@@ -239,6 +239,9 @@ def run_stage2a(obs, stage_config, source_ids='all', overwrite=False,
     if not obs.directories_setup:
         obs.setup_workspace_directory(data_dir, products_dir, overwrite=False)
 
+    # Ensure the background override file exists so it can be edited before stage2b
+    _ = obs.bkg_overrides
+
     # Pre-fetch CRDS references to avoid multiprocessing race conditions
     if n_processes > 1 and obs.rate_files:
         _prefetch_crds_references(obs.rate_files)


### PR DESCRIPTION
## Summary
- Add a note to the background override TOML comment card clarifying that nod numbers are exposure sequence numbers from FITS filenames (3rd `_`-delimited segment), not sequential indices — important when TACONFIRM exposures shift the numbering.
- Create the override file during stage2a (instead of lazily in stage2b) so it's available for editing between stages.

## Test plan
- [ ] Run stage2a on an observation and verify `_<obs>_nodded_background_overrides.toml` is created
- [ ] Confirm the new note appears in the file header
- [ ] Run stage2b with overrides and verify they still apply correctly

Generated with Claude Code