### PR TITLE
claude/fix-nirspec-dropdown-z-index-F0VtD

### DIFF
--- a/web/components/layout/Navigation.tsx
+++ b/web/components/layout/Navigation.tsx
@@ -37,7 +37,7 @@ function NavDropdown({ link, isActive }: { link: NavLink; isActive: boolean }) {
         <ChevronDown className={`w-3 h-3 transition-transform ${open ? 'rotate-180' : ''}`} />
       </button>
       {open && (
-        <div className="absolute top-full left-0 mt-2 w-44 bg-header dark:bg-slate-800 rounded-lg shadow-lg border border-gray-700 dark:border-slate-700 py-1 z-50">
+        <div className="absolute top-full left-0 mt-2 w-44 bg-header dark:bg-slate-800 rounded-lg shadow-lg border border-gray-700 dark:border-slate-700 py-1 z-[1100]">
           {link.children!.map((child) => (
             <Link
               key={child.href}


### PR DESCRIPTION
The nav dropdown used z-50 which is lower than the map's z-[1000]+
overlays, causing it to appear behind map tiles. Bump to z-[1100].

https://claude.ai/code/session_01RP8pb6htrqQvN1wf332MSR