### PR TITLE
claude/fix-shutter-deploy-requirement-ugzFC

### DIFF
--- a/python/campfire/deploy/cli.py
+++ b/python/campfire/deploy/cli.py
@@ -519,6 +519,10 @@ def tiles(config_path, field, filter_names, dry_run, generate_only,
 
     tile_dir_path = resolve_tiles_dir(tile_dir)
     imaging_config_path = resolve_imaging_config(imaging_config)
+    if imaging_config_path is None:
+        print("Error: No imaging.toml found. Tiles deployment requires imaging.toml.")
+        print("  Use --imaging-config <path> or set $CAMPFIRE_ROOT")
+        raise SystemExit(1)
 
     # Determine which phases to run
     if generate_only:

--- a/python/campfire/deploy/config.py
+++ b/python/campfire/deploy/config.py
@@ -310,7 +310,7 @@ def resolve_tiles_dir(tile_dir: str | None = None) -> Path:
     sys.exit(1)
 
 
-def resolve_imaging_config(imaging_config: str | None = None) -> Path:
+def resolve_imaging_config(imaging_config: str | None = None) -> Path | None:
     """
     Resolve the imaging.toml config path.
 
@@ -318,6 +318,9 @@ def resolve_imaging_config(imaging_config: str | None = None) -> Path:
       1. Explicit --imaging-config argument
       2. $CAMPFIRE_ROOT/config/imaging.toml
       3. ./pipeline/imaging.toml (repo fallback)
+
+    Returns None if no imaging config is found during auto-discovery.
+    Still exits if an explicit path is provided but does not exist.
     """
     if imaging_config:
         p = Path(imaging_config)
@@ -337,9 +340,7 @@ def resolve_imaging_config(imaging_config: str | None = None) -> Path:
     if p.exists():
         return p
 
-    print("Error: No imaging.toml found.")
-    print("  Use --imaging-config <path> or set $CAMPFIRE_ROOT")
-    sys.exit(1)
+    return None
 
 
 def resolve_photometry_config(photometry_config: str | None = None) -> Path | None:

--- a/python/campfire/deploy/deploy.py
+++ b/python/campfire/deploy/deploy.py
@@ -370,14 +370,17 @@ def deploy_observation(
                     from campfire.deploy.astrometry import correct_shutter_positions
 
                     imaging_path = resolve_imaging_config()
-                    with open(imaging_path, 'rb') as f:
-                        imaging_config = tomllib.load(f)
-                    n_corrected, n_matches = correct_shutter_positions(
-                        shutters_data, obs_dir, obs_name, field, imaging_config,
-                    )
-                    if n_corrected:
-                        print(f"  Astrometry: corrected {n_corrected} shutters "
-                              f"({n_matches} catalog cross-matches)")
+                    if imaging_path is None:
+                        print("  No imaging.toml found, skipping astrometry correction")
+                    else:
+                        with open(imaging_path, 'rb') as f:
+                            imaging_config = tomllib.load(f)
+                        n_corrected, n_matches = correct_shutter_positions(
+                            shutters_data, obs_dir, obs_name, field, imaging_config,
+                        )
+                        if n_corrected:
+                            print(f"  Astrometry: corrected {n_corrected} shutters "
+                                  f"({n_matches} catalog cross-matches)")
 
                 n_shutters = db_deploy_shutters(sb, obs_name, shutters_data)
                 print(f"  Deployed {n_shutters} shutter records")
@@ -802,14 +805,17 @@ def deploy_shutters(
             print("  Could not determine field, skipping astrometry")
         else:
             imaging_path = resolve_imaging_config()
-            with open(imaging_path, 'rb') as f:
-                imaging_config = tomllib.load(f)
-            n_corrected, n_matches = correct_shutter_positions(
-                shutters_data, obs_dir, obs_name, field, imaging_config,
-            )
-            if n_corrected:
-                print(f"  Astrometry: corrected {n_corrected} shutters "
-                      f"({n_matches} catalog cross-matches)")
+            if imaging_path is None:
+                print("  No imaging.toml found, skipping astrometry correction")
+            else:
+                with open(imaging_path, 'rb') as f:
+                    imaging_config = tomllib.load(f)
+                n_corrected, n_matches = correct_shutter_positions(
+                    shutters_data, obs_dir, obs_name, field, imaging_config,
+                )
+                if n_corrected:
+                    print(f"  Astrometry: corrected {n_corrected} shutters "
+                          f"({n_matches} catalog cross-matches)")
 
     if dry_run:
         print("=== DRY RUN ===")

--- a/python/campfire/deploy/tiles.py
+++ b/python/campfire/deploy/tiles.py
@@ -322,6 +322,10 @@ def generate_tiles(
     if imaging_config_path is None:
         from campfire.deploy.config import resolve_imaging_config
         imaging_config_path = resolve_imaging_config()
+    if imaging_config_path is None:
+        print("Error: No imaging.toml found. Tiles deployment requires imaging.toml.")
+        print("  Use --imaging-config <path> or set $CAMPFIRE_ROOT")
+        raise SystemExit(1)
 
     imaging_config = load_imaging_config(imaging_config_path)
 


### PR DESCRIPTION
Instead of hard-exiting when no imaging.toml is found, shutter deployment
now prints a message and skips the astrometric correction step. Tiles
deployment still requires imaging.toml and errors accordingly.

https://claude.ai/code/session_01JAuq4W5Cwju1AhG1o7ggeh