### PR TITLE
Fix objects rebuild wiping all gratings/n_spectra

### DIFF
--- a/python/campfire/deploy/objects.py
+++ b/python/campfire/deploy/objects.py
@@ -101,12 +101,15 @@ def fetch_field_targets(client: Client, field: str) -> list[dict]:
 
 def fetch_spectra_metadata(
     client: Client,
-    target_ids: list[int],
+    target_ids: list[str],
 ) -> dict[str, list[dict]]:
     """Fetch grating, S/N, exposure_time for spectra belonging to the given targets.
 
     Queries spectra directly by target_id in batches to avoid both
     PostgREST FK embedding timeouts and URI-length limits.
+
+    ``target_ids`` must be the text ``targets.target_id`` values, since
+    ``spectra.target_id`` is a TEXT FK to that column (not to ``targets.id``).
     """
     select = 'target_id, grating, signal_to_noise, exposure_time'
     result: dict[str, list[dict]] = defaultdict(list)
@@ -620,8 +623,8 @@ def rebuild_field_objects(
         return 0, 0
 
     print(f"  Fetching spectra metadata...")
-    target_db_ids = [t['id'] for t in targets]
-    spectra_map = fetch_spectra_metadata(client, target_db_ids)
+    target_text_ids = [t['target_id'] for t in targets]
+    spectra_map = fetch_spectra_metadata(client, target_text_ids)
     n_spectra = sum(len(v) for v in spectra_map.values())
     print(f"    {n_spectra} spectra for {len(spectra_map)} targets")
 


### PR DESCRIPTION
## Summary
- `fetch_spectra_metadata` was querying `spectra.target_id` (TEXT, FK to `targets.target_id`) using the integer `targets.id` PKs, so `.in_('target_id', [...])` matched nothing.
- Every rebuilt object got `gratings: []` and `n_spectra: 0`. Any field where rebuild fired after 68ed192 (Apr 16) lost aggregated grating info — surfaced in production after a deploy triggered rebuild.
- Fix: pass the text `target_id` values instead, and update the signature/docstring to reflect the FK.

## Recovery
After merge, for each affected field:
```
campfire deploy objects --field <name>
```
Rebuild is idempotent and will restore gratings/n_spectra from the spectra table.

## Test plan
- [ ] Local: `supabase db reset`, run `campfire deploy objects --field <seeded_field> --local`, confirm `objects.gratings` is non-empty and `n_spectra > 0`.
- [ ] Dry-run against prod: `campfire deploy objects --field <field> --dry-run` — stats should show non-zero spectra per object.
- [ ] Prod rebuild per affected field once merged.

Generated with Claude Code