### PR TITLE
Reconcile skip no-ops + fix MV concurrent refresh

### DIFF
--- a/python/campfire/deploy/reconcile.py
+++ b/python/campfire/deploy/reconcile.py
@@ -146,6 +146,10 @@ class Proposals:
     merges: list[Merge] = dc_field(default_factory=list)
     orphans: list[Orphan] = dc_field(default_factory=list)
     complex_overlaps: list[ComplexOverlap] = dc_field(default_factory=list)
+    # No-op 1:1 matches: cluster and existing object have identical aggregates
+    # and no staleness signal. Skipped in apply_proposals to avoid bumping
+    # updated_at on every row (which would bloat incremental sync cursors).
+    unchanged: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -171,9 +175,13 @@ def fetch_existing_objects(
     offset = 0
     select = (
         'id, object_id, field, ra, dec, is_active, '
-        'redshift_quality, last_inspected_at, max_snr, '
+        'redshift_quality, last_inspected_at, '
         'redshift_inspected, redshift_auto, last_inspected_by, '
-        'last_data_change_at, staleness_reason, version'
+        'last_data_change_at, staleness_reason, version, '
+        # Aggregate columns — used by classify() to detect no-op 1:1 matches
+        # and skip redundant updates (avoids bumping updated_at on every row).
+        'n_targets, n_spectra, programs, gratings, observations, '
+        'max_snr, max_exposure_time'
     )
     while True:
         resp = (
@@ -256,6 +264,32 @@ def build_cluster_aggregates(
         max_exposure_time=max(all_exp) if all_exp else None,
         member_target_db_ids=[m['id'] for m in members],
         member_target_ids={m['target_id'] for m in members},
+    )
+
+
+def _aggregates_match_object(agg: ClusterAggregates, obj: dict) -> bool:
+    """True if the cluster's aggregates equal the existing object's stored aggregates.
+
+    Used by classify() to detect no-op 1:1 matches: the cluster has identical
+    membership AND identical per-spectrum aggregates to the existing object,
+    so there is nothing to write. Skipping these rows avoids bumping
+    objects.updated_at (which is the cursor for incremental sync) on every
+    object in the field just because one observation was redeployed.
+
+    Array columns (programs/gratings/observations) are always sorted by
+    build_cluster_aggregates() before write, so list equality is valid.
+    """
+    return (
+        agg.object_id == obj.get('object_id')
+        and agg.ra == obj.get('ra')
+        and agg.dec == obj.get('dec')
+        and agg.n_targets == obj.get('n_targets')
+        and agg.n_spectra == obj.get('n_spectra')
+        and list(agg.programs) == list(obj.get('programs') or [])
+        and list(agg.gratings) == list(obj.get('gratings') or [])
+        and list(agg.observations) == list(obj.get('observations') or [])
+        and agg.max_snr == obj.get('max_snr')
+        and agg.max_exposure_time == obj.get('max_exposure_time')
     )
 
 
@@ -435,6 +469,21 @@ def classify(
             changed_hashes=changed_hashes,
             spectra_map=spectra_map,
         )
+        # Skip no-op updates: same member set (enforced by the 1:1 guard
+        # above), no reprocessed spectra (staleness is None), and identical
+        # aggregates. Writing these would bump updated_at on every row and
+        # cause every incremental sync to re-pull the full field.
+        # The object must already be active (inactive 1:1 matches need a
+        # reactivation write in apply_proposals).
+        if (
+            staleness is None
+            and obj.get('is_active')
+            and _aggregates_match_object(agg, obj)
+        ):
+            proposals.unchanged += 1
+            handled_clusters.add(ci)
+            handled_objects.add(oid)
+            continue
         proposals.updates.append(
             Update(
                 cluster_idx=ci,
@@ -1306,13 +1355,15 @@ def merge_objects(
 
 def print_summary(field: str, proposals: Proposals, stats: dict[str, int] | None) -> None:
     n_clusters = (
-        len(proposals.updates) + len(proposals.inserts) + len(proposals.revivals)
+        proposals.unchanged
+        + len(proposals.updates) + len(proposals.inserts) + len(proposals.revivals)
         + sum(len(s.daughters) for s in proposals.splits)
         + len(proposals.merges)
     )
     print()
     print(f"  Reconciliation summary ({field}):")
     print(f"    Clusters:        {n_clusters}")
+    print(f"    Unchanged:       {proposals.unchanged}")
     print(f"    Updates:         {len(proposals.updates)}")
     print(f"    Inserts:         {len(proposals.inserts)}")
     print(f"    Revivals:        {len(proposals.revivals)}")

--- a/python/tests/test_reconcile.py
+++ b/python/tests/test_reconcile.py
@@ -184,6 +184,85 @@ def test_batch_upsert_spectra_flags_hash_change():
     assert changed == {('t1', 'prism')}
 
 
+def test_unchanged_1to1_match_is_skipped_not_updated():
+    # Regression: a 1:1 match whose aggregates equal the existing object's
+    # stored aggregates and whose membership is unchanged must NOT be added
+    # to proposals.updates. Otherwise every reconcile run rewrites every
+    # object and bumps updated_at, which bloats incremental sync cursors
+    # downstream.
+    targets = [_target(1, 't1', 150.0, 2.0, 100)]
+    groups = [[0]]
+    obj = _obj(100, 'OBJ-A', 150.0, 2.0)
+    obj.update({
+        'n_targets': 1, 'n_spectra': 0,
+        'programs': ['prog'], 'gratings': [], 'observations': ['obs'],
+        'max_snr': None, 'max_exposure_time': None,
+    })
+    # object_id has to match the IAU name build_cluster_aggregates() will
+    # generate from the centroid, since that is one of the compared fields.
+    from campfire.deploy.objects import generate_iau_name
+    obj['object_id'] = generate_iau_name(150.0, 2.0)
+
+    p = classify(
+        groups=groups, targets=targets, existing_objects=[obj],
+        members_by_obj={100: {'t1'}}, spectra_map={},
+        changed_hashes=set(),
+    )
+
+    assert p.unchanged == 1
+    assert p.updates == []
+    assert p.inserts == []
+
+
+def test_changed_aggregates_still_classified_as_update():
+    # Flip side of the skip: if the aggregates differ (e.g. stored n_spectra
+    # is stale), the cluster must be appended to proposals.updates so the
+    # row gets rewritten. Guards against the skip-helper being too permissive.
+    targets = [_target(1, 't1', 150.0, 2.0, 100)]
+    groups = [[0]]
+    obj = _obj(100, 'OBJ-A', 150.0, 2.0)
+    obj.update({
+        'n_targets': 1, 'n_spectra': 5,  # stale — cluster has 0 spectra
+        'programs': ['prog'], 'gratings': [], 'observations': ['obs'],
+        'max_snr': None, 'max_exposure_time': None,
+    })
+    from campfire.deploy.objects import generate_iau_name
+    obj['object_id'] = generate_iau_name(150.0, 2.0)
+
+    p = classify(
+        groups=groups, targets=targets, existing_objects=[obj],
+        members_by_obj={100: {'t1'}}, spectra_map={},
+        changed_hashes=set(),
+    )
+
+    assert p.unchanged == 0
+    assert len(p.updates) == 1
+
+
+def test_inactive_1to1_match_is_not_skipped():
+    # Inactive 1:1 matches need a reactivation write; they must always
+    # land on proposals.updates regardless of aggregate equality.
+    targets = [_target(1, 't1', 150.0, 2.0, 100)]
+    groups = [[0]]
+    obj = _obj(100, 'OBJ-A', 150.0, 2.0, active=False)
+    obj.update({
+        'n_targets': 1, 'n_spectra': 0,
+        'programs': ['prog'], 'gratings': [], 'observations': ['obs'],
+        'max_snr': None, 'max_exposure_time': None,
+    })
+    from campfire.deploy.objects import generate_iau_name
+    obj['object_id'] = generate_iau_name(150.0, 2.0)
+
+    p = classify(
+        groups=groups, targets=targets, existing_objects=[obj],
+        members_by_obj={100: {'t1'}}, spectra_map={},
+        changed_hashes=set(),
+    )
+
+    assert p.unchanged == 0
+    assert len(p.updates) == 1
+
+
 def test_independent_split_and_merge_both_apply():
     # A → {X, Y} (split), Z ← {B, C} (merge). No cluster overlap.
     targets = [

--- a/supabase/migrations/20260421152754_compute_object_redshift_auto_skip_noops.sql
+++ b/supabase/migrations/20260421152754_compute_object_redshift_auto_skip_noops.sql
@@ -1,0 +1,48 @@
+-- Skip no-op rewrites in compute_object_redshift_auto and bump updated_at
+-- for rows whose redshift_auto actually changes, so get_objects_for_sync
+-- (which uses updated_at > p_updated_since as its delta cursor) picks the
+-- change up on the next client sync. Prior version unconditionally
+-- rewrote every object in the field and did not touch updated_at, which
+-- meant pipeline-driven redshift_auto changes were silently invisible to
+-- incremental sync.
+
+CREATE OR REPLACE FUNCTION public.compute_object_redshift_auto(p_field TEXT)
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  n INTEGER;
+BEGIN
+  WITH computed AS (
+    SELECT o.id,
+           (
+             SELECT s.redshift_auto
+             FROM targets t
+             JOIN spectra s ON s.target_id = t.target_id
+             WHERE t.object_id = o.id
+               AND s.redshift_auto IS NOT NULL
+             ORDER BY
+               CASE
+                 WHEN s.grating = 'PRISM' THEN 0
+                 WHEN s.grating IN ('G140M', 'G235M', 'G395M') THEN 1
+                 WHEN s.grating IN ('G140H', 'G235H', 'G395H') THEN 2
+                 ELSE 3
+               END ASC,
+               s.exposure_time DESC NULLS LAST,
+               s.id ASC
+             LIMIT 1
+           ) AS new_val
+    FROM objects o
+    WHERE o.field = p_field
+  )
+  UPDATE objects o
+  SET redshift_auto = c.new_val,
+      updated_at = NOW()
+  FROM computed c
+  WHERE o.id = c.id
+    AND o.redshift_auto IS DISTINCT FROM c.new_val;
+
+  GET DIAGNOSTICS n = ROW_COUNT;
+  RETURN n;
+END;
+$$;

--- a/supabase/migrations/20260421153229_restore_mv_unique_indexes.sql
+++ b/supabase/migrations/20260421153229_restore_mv_unique_indexes.sql
@@ -1,0 +1,23 @@
+-- Restore unique indexes on mv_filter_options and mv_programs_overview.
+--
+-- Several recent migrations (20260416191221, 20260417013428, 20260417145348)
+-- dropped and recreated these materialized views without recreating their
+-- unique indexes, leaving prod in a state where REFRESH MATERIALIZED VIEW
+-- CONCURRENTLY fails with:
+--   "cannot refresh materialized view ... concurrently"
+--   "Create a unique index with no WHERE clause on one or more columns"
+--
+-- The deploy CLI calls refresh_filter_options() / refresh_programs_overview()
+-- at the end of every deploy, both of which use CONCURRENTLY. With the
+-- indexes missing, the refreshes soft-fail and the MVs go stale until
+-- manually rebuilt.
+--
+-- Root cause is migra's known MV-tracking limitation (see CLAUDE.md). The
+-- canonical index definitions live in supabase/schemas/views.sql — this
+-- migration just re-applies them.
+
+CREATE UNIQUE INDEX IF NOT EXISTS mv_filter_options_id
+    ON public.mv_filter_options USING btree (id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS mv_programs_overview_slug
+    ON public.mv_programs_overview USING btree (slug);

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -2496,6 +2496,12 @@ GRANT EXECUTE ON FUNCTION public.recompute_target_aggregates(TEXT[]) TO service_
 -- via update_object_best_redshift trigger) with a direct one-hop path
 -- (spectra.redshift_auto → objects.redshift_auto at reconciliation time).
 
+-- The CTE + IS DISTINCT FROM guard ensures we only rewrite rows whose
+-- redshift_auto actually changed, and updated_at is bumped in the same
+-- statement so get_objects_for_sync (which uses updated_at as its delta
+-- cursor) picks the change up on the next client sync. Without the bump,
+-- clients would silently miss redshift_auto changes from pipeline reruns.
+-- ROW_COUNT is then the true number of objects whose value changed.
 CREATE OR REPLACE FUNCTION public.compute_object_redshift_auto(p_field TEXT)
 RETURNS INTEGER
 LANGUAGE plpgsql
@@ -2503,25 +2509,34 @@ AS $$
 DECLARE
   n INTEGER;
 BEGIN
-  UPDATE objects o
-  SET redshift_auto = (
-    SELECT s.redshift_auto
-    FROM targets t
-    JOIN spectra s ON s.target_id = t.target_id
-    WHERE t.object_id = o.id
-      AND s.redshift_auto IS NOT NULL
-    ORDER BY
-      CASE
-        WHEN s.grating = 'PRISM' THEN 0
-        WHEN s.grating IN ('G140M', 'G235M', 'G395M') THEN 1
-        WHEN s.grating IN ('G140H', 'G235H', 'G395H') THEN 2
-        ELSE 3
-      END ASC,
-      s.exposure_time DESC NULLS LAST,
-      s.id ASC
-    LIMIT 1
+  WITH computed AS (
+    SELECT o.id,
+           (
+             SELECT s.redshift_auto
+             FROM targets t
+             JOIN spectra s ON s.target_id = t.target_id
+             WHERE t.object_id = o.id
+               AND s.redshift_auto IS NOT NULL
+             ORDER BY
+               CASE
+                 WHEN s.grating = 'PRISM' THEN 0
+                 WHEN s.grating IN ('G140M', 'G235M', 'G395M') THEN 1
+                 WHEN s.grating IN ('G140H', 'G235H', 'G395H') THEN 2
+                 ELSE 3
+               END ASC,
+               s.exposure_time DESC NULLS LAST,
+               s.id ASC
+             LIMIT 1
+           ) AS new_val
+    FROM objects o
+    WHERE o.field = p_field
   )
-  WHERE o.field = p_field;
+  UPDATE objects o
+  SET redshift_auto = c.new_val,
+      updated_at = NOW()
+  FROM computed c
+  WHERE o.id = c.id
+    AND o.redshift_auto IS DISTINCT FROM c.new_val;
 
   GET DIAGNOSTICS n = ROW_COUNT;
   RETURN n;


### PR DESCRIPTION
## Summary

Three deploy-side fixes surfaced by a `campfire deploy --obs zenith_p9 --supabase-only` run on cosmos (~10k objects):

- **reconcile `classify()` now skips no-op 1:1 matches** — pre-fix, every 1:1 (cluster, object) pair went onto `proposals.updates`, causing ~10k sequential UPDATEs and `updated_at` bumps on every object regardless of whether aggregates actually changed. Now only rows with real aggregate drift (or staleness, or reactivation) land on `updates`; the rest are counted as `Proposals.unchanged`.
- **`compute_object_redshift_auto` skips no-op rewrites and bumps `updated_at`** — the RPC ran a blanket UPDATE over every object in the field without setting `updated_at`, which meant pipeline-driven `redshift_auto` changes were silently invisible to `get_objects_for_sync` (uses `updated_at > since` as its delta cursor). Rewritten with a CTE + `IS DISTINCT FROM` guard so only changed rows are rewritten and their `updated_at` advances.
- **Restore unique indexes on `mv_filter_options` / `mv_programs_overview`** — three recent migrations dropped + recreated these MVs without recreating their unique indexes (migra MV-tracking limitation), which broke `REFRESH MATERIALIZED VIEW CONCURRENTLY` in prod. New migration re-applies the index definitions idempotently.

## Test plan

- [x] `pytest tests/test_reconcile.py` — 11 tests pass (3 new regression tests for the skip behavior: unchanged skipped, changed still updates, inactive always updates)
- [x] `supabase db reset` — all migrations apply cleanly on a fresh local DB
- [x] `REFRESH MATERIALIZED VIEW CONCURRENTLY` and `refresh_filter_options()` / `refresh_programs_overview()` both succeed locally post-migration
- [x] `npm run build` — web build passes
- [ ] Supabase preview branch migration check (runs automatically on PR open)
- [ ] `campfire deploy --obs zenith_p9 --supabase-only` against the preview branch — should show `Unchanged: ~9878 / Updates: ~44` in reconcile summary, `Updated ~177 objects` (not 9922) in the redshift_auto pass, and no MV refresh warnings

Generated with Claude Code