### PR TITLE
Needs-review UX: clickable badge, filter, Status column

### DIFF
--- a/supabase/migrations/20260422153719_add_needs_review_filter.sql
+++ b/supabase/migrations/20260422153719_add_needs_review_filter.sql
@@ -1,0 +1,1203 @@
+drop function if exists "public"."get_adjacent_objects"(p_current_object_id text, p_program_slugs text[], p_filter_programs text[], p_fields text[], p_gratings text[], p_gratings_mode text, p_observations text[], p_redshift_quality integer[], p_redshift_min double precision, p_redshift_max double precision, p_max_snr_min double precision, p_max_snr_max double precision, p_max_exposure_time_min double precision, p_max_exposure_time_max double precision, p_search text, p_inspected_only boolean, p_list_ids integer[], p_coord_ra double precision, p_coord_dec double precision, p_radius_degrees double precision, p_sort_column text, p_sort_direction text, p_has_photometry boolean, p_photo_z_min double precision, p_photo_z_max double precision);
+
+drop function if exists "public"."get_csv_export_objects"(p_program_slugs text[], p_filter_programs text[], p_fields text[], p_gratings text[], p_gratings_mode text, p_redshift_quality integer[], p_redshift_min double precision, p_redshift_max double precision, p_max_snr_min double precision, p_max_snr_max double precision, p_max_exposure_time_min double precision, p_max_exposure_time_max double precision, p_search text, p_inspected_only boolean, p_list_ids integer[], p_coord_ra double precision, p_coord_dec double precision, p_radius_degrees double precision, p_has_photometry boolean, p_photo_z_min double precision, p_photo_z_max double precision, p_sort_column text, p_sort_direction text);
+
+drop function if exists "public"."get_csv_export_spectra"(p_program_slugs text[], p_filter_programs text[], p_fields text[], p_gratings text[], p_gratings_mode text, p_observations text[], p_redshift_quality integer[], p_redshift_min double precision, p_redshift_max double precision, p_max_snr_min double precision, p_max_snr_max double precision, p_max_exposure_time_min double precision, p_max_exposure_time_max double precision, p_dq_flags_include_any integer, p_dq_flags_include_all integer, p_dq_flags_exclude integer, p_list_ids integer[], p_search text, p_inspected_only boolean, p_has_photometry boolean, p_comment_search text, p_comment_search_scope text, p_comment_user_id uuid, p_coord_ra double precision, p_coord_dec double precision, p_radius_degrees double precision, p_sort_column text, p_sort_direction text);
+
+drop function if exists "public"."get_filtered_object_ids"(p_program_slugs text[], p_filter_programs text[], p_fields text[], p_gratings text[], p_gratings_mode text, p_redshift_quality integer[], p_redshift_min double precision, p_redshift_max double precision, p_max_snr_min double precision, p_max_snr_max double precision, p_max_exposure_time_min double precision, p_max_exposure_time_max double precision, p_search text, p_inspected_only boolean, p_list_ids integer[], p_coord_ra double precision, p_coord_dec double precision, p_radius_degrees double precision, p_has_photometry boolean, p_photo_z_min double precision, p_photo_z_max double precision);
+
+drop function if exists "public"."get_filtered_objects_paginated"(p_program_slugs text[], p_filter_programs text[], p_fields text[], p_gratings text[], p_gratings_mode text, p_observations text[], p_redshift_quality integer[], p_redshift_min double precision, p_redshift_max double precision, p_max_snr_min double precision, p_max_snr_max double precision, p_max_exposure_time_min double precision, p_max_exposure_time_max double precision, p_search text, p_inspected_only boolean, p_list_ids integer[], p_coord_ra double precision, p_coord_dec double precision, p_radius_degrees double precision, p_has_photometry boolean, p_photo_z_min double precision, p_photo_z_max double precision, p_sort_column text, p_sort_direction text, p_page integer, p_page_size integer);
+
+drop function if exists "public"."get_filtered_spectra_paginated"(p_program_slugs text[], p_filter_programs text[], p_fields text[], p_gratings text[], p_gratings_mode text, p_observations text[], p_redshift_quality integer[], p_redshift_min double precision, p_redshift_max double precision, p_max_snr_min double precision, p_max_snr_max double precision, p_max_exposure_time_min double precision, p_max_exposure_time_max double precision, p_dq_flags_include_any integer, p_dq_flags_include_all integer, p_dq_flags_exclude integer, p_list_ids integer[], p_search text, p_inspected_only boolean, p_has_photometry boolean, p_comment_search text, p_comment_search_scope text, p_comment_user_id uuid, p_coord_ra double precision, p_coord_dec double precision, p_radius_degrees double precision, p_sort_column text, p_sort_direction text, p_page integer, p_page_size integer, p_include_thumbnails boolean);
+
+drop materialized view if exists "public"."mv_filter_options";
+
+drop materialized view if exists "public"."mv_programs_overview";
+
+drop view if exists "public"."spectrum_flag_summary";
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_adjacent_objects(p_current_object_id text, p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_list_ids integer[] DEFAULT NULL::integer[], p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_sort_column text DEFAULT 'object_id'::text, p_sort_direction text DEFAULT 'asc'::text, p_has_photometry boolean DEFAULT NULL::boolean, p_photo_z_min double precision DEFAULT NULL::double precision, p_photo_z_max double precision DEFAULT NULL::double precision)
+ RETURNS TABLE(prev_object_id text, next_object_id text, current_index bigint, total_count bigint)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_sort_is_text BOOLEAN;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN v_gratings_mode := 'any'; END IF;
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+  IF v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN
+    p_sort_column := 'distance';
+    p_sort_direction := 'asc';
+  END IF;
+  v_sort_is_text := p_sort_column IN ('object_id', 'field');
+
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs))
+    INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN QUERY SELECT NULL::TEXT, NULL::TEXT, 0::BIGINT, 0::BIGINT;
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  WITH filtered_objects AS MATERIALIZED (
+    SELECT
+      o.object_id,
+      CASE WHEN v_coord_search_active THEN
+        2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        )))
+      ELSE NULL END AS distance,
+      o.field, o.ra, o.dec, o.redshift, o.redshift_quality,
+      o.n_targets, o.n_spectra, o.max_snr, o.max_exposure_time
+    FROM objects o
+    WHERE
+      o.programs && v_filtered_program_slugs
+      AND o.is_active = true
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+        OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+        OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+      )
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_search IS NULL OR o.object_id ILIKE '%' || p_search || '%'
+        OR EXISTS (SELECT 1 FROM targets t WHERE t.object_id = o.id AND t.target_id ILIKE '%' || p_search || '%'))
+      AND (p_inspected_only IS NULL
+        OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+        OR (p_inspected_only = FALSE AND o.redshift_quality = 0))
+      AND (p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at))))
+      AND (NOT v_coord_search_active OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+      ))
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+      AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+  ),
+  distance_filtered AS MATERIALIZED (
+    SELECT
+      fo.*,
+      CASE p_sort_column
+        WHEN 'object_id' THEN fo.object_id WHEN 'field' THEN fo.field ELSE NULL
+      END AS sort_text,
+      CASE p_sort_column
+        WHEN 'ra' THEN fo.ra WHEN 'dec' THEN fo.dec
+        WHEN 'redshift' THEN fo.redshift
+        WHEN 'redshift_quality' THEN fo.redshift_quality::DOUBLE PRECISION
+        WHEN 'n_targets' THEN fo.n_targets::DOUBLE PRECISION
+        WHEN 'n_spectra' THEN fo.n_spectra::DOUBLE PRECISION
+        WHEN 'max_snr' THEN fo.max_snr WHEN 'max_exposure_time' THEN fo.max_exposure_time
+        WHEN 'distance' THEN fo.distance ELSE NULL
+      END AS sort_num
+    FROM filtered_objects fo
+    WHERE NOT v_coord_search_active OR fo.distance <= p_radius_degrees
+  ),
+  current_obj AS (
+    SELECT df.sort_text, df.sort_num, df.object_id FROM distance_filtered df WHERE df.object_id = p_current_object_id
+  )
+  SELECT
+    (SELECT df.object_id FROM distance_filtered df, current_obj c
+     WHERE CASE WHEN v_sort_is_text THEN
+       (CASE WHEN p_sort_direction = 'asc' THEN df.sort_text < c.sort_text ELSE df.sort_text > c.sort_text END)
+       OR (df.sort_text IS NOT DISTINCT FROM c.sort_text AND df.object_id < c.object_id)
+       OR (df.sort_text IS NOT NULL AND c.sort_text IS NULL)
+     ELSE
+       (CASE WHEN p_sort_direction = 'asc' THEN df.sort_num < c.sort_num ELSE df.sort_num > c.sort_num END)
+       OR (df.sort_num IS NOT DISTINCT FROM c.sort_num AND df.object_id < c.object_id)
+       OR (df.sort_num IS NOT NULL AND c.sort_num IS NULL)
+     END
+     ORDER BY
+       CASE WHEN v_sort_is_text AND p_sort_direction = 'asc' THEN df.sort_text END DESC NULLS FIRST,
+       CASE WHEN v_sort_is_text AND p_sort_direction = 'desc' THEN df.sort_text END ASC NULLS FIRST,
+       CASE WHEN NOT v_sort_is_text AND p_sort_direction = 'asc' THEN df.sort_num END DESC NULLS FIRST,
+       CASE WHEN NOT v_sort_is_text AND p_sort_direction = 'desc' THEN df.sort_num END ASC NULLS FIRST,
+       df.object_id DESC
+     LIMIT 1
+    ) AS prev_object_id,
+    (SELECT df.object_id FROM distance_filtered df, current_obj c
+     WHERE CASE WHEN v_sort_is_text THEN
+       (CASE WHEN p_sort_direction = 'asc' THEN df.sort_text > c.sort_text ELSE df.sort_text < c.sort_text END)
+       OR (df.sort_text IS NOT DISTINCT FROM c.sort_text AND df.object_id > c.object_id)
+       OR (c.sort_text IS NOT NULL AND df.sort_text IS NULL)
+     ELSE
+       (CASE WHEN p_sort_direction = 'asc' THEN df.sort_num > c.sort_num ELSE df.sort_num < c.sort_num END)
+       OR (df.sort_num IS NOT DISTINCT FROM c.sort_num AND df.object_id > c.object_id)
+       OR (c.sort_num IS NOT NULL AND df.sort_num IS NULL)
+     END
+     ORDER BY
+       CASE WHEN v_sort_is_text AND p_sort_direction = 'asc' THEN df.sort_text END ASC NULLS LAST,
+       CASE WHEN v_sort_is_text AND p_sort_direction = 'desc' THEN df.sort_text END DESC NULLS LAST,
+       CASE WHEN NOT v_sort_is_text AND p_sort_direction = 'asc' THEN df.sort_num END ASC NULLS LAST,
+       CASE WHEN NOT v_sort_is_text AND p_sort_direction = 'desc' THEN df.sort_num END DESC NULLS LAST,
+       df.object_id ASC
+     LIMIT 1
+    ) AS next_object_id,
+    CASE WHEN EXISTS (SELECT 1 FROM current_obj) THEN (
+      SELECT COUNT(*) + 1
+      FROM distance_filtered df, current_obj c
+      WHERE CASE WHEN v_sort_is_text THEN
+        (CASE WHEN p_sort_direction = 'asc' THEN df.sort_text < c.sort_text ELSE df.sort_text > c.sort_text END)
+        OR (df.sort_text IS NOT DISTINCT FROM c.sort_text AND df.object_id < c.object_id)
+        OR (df.sort_text IS NOT NULL AND c.sort_text IS NULL)
+      ELSE
+        (CASE WHEN p_sort_direction = 'asc' THEN df.sort_num < c.sort_num ELSE df.sort_num > c.sort_num END)
+        OR (df.sort_num IS NOT DISTINCT FROM c.sort_num AND df.object_id < c.object_id)
+        OR (df.sort_num IS NOT NULL AND c.sort_num IS NULL)
+      END
+    )::BIGINT ELSE 0::BIGINT END AS current_index,
+    (SELECT COUNT(*) FROM distance_filtered)::BIGINT AS total_count;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_csv_export_objects(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_list_ids integer[] DEFAULT NULL::integer[], p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_has_photometry boolean DEFAULT NULL::boolean, p_photo_z_min double precision DEFAULT NULL::double precision, p_photo_z_max double precision DEFAULT NULL::double precision, p_sort_column text DEFAULT 'object_id'::text, p_sort_direction text DEFAULT 'asc'::text)
+ RETURNS TABLE(object_id text, field text, ra double precision, "dec" double precision, redshift numeric, redshift_quality integer, redshift_inspected numeric, redshift_auto double precision, last_inspected_at timestamp with time zone, last_inspected_by text, last_data_change_at timestamp with time zone, staleness_reason text, version integer, n_targets integer, n_spectra integer, programs text, gratings text, max_snr double precision, max_exposure_time double precision, member_target_ids text, distance double precision, lists text, has_photometry boolean, photo_z double precision, photo_z_err_lo double precision, photo_z_err_hi double precision, photometry jsonb)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN v_gratings_mode := 'any'; END IF;
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time', 'photo_z'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs)) INTO v_filtered_program_slugs;
+  ELSE v_filtered_program_slugs := p_program_slugs; END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN RETURN; END IF;
+
+  RETURN QUERY
+  WITH member_targets AS (
+    SELECT t.object_id, string_agg(t.target_id, ';' ORDER BY t.target_id) AS member_target_ids
+    FROM targets t
+    WHERE t.program_slug = ANY(v_filtered_program_slugs)
+    GROUP BY t.object_id
+  ),
+  visible_lists AS (
+    SELECT olm.object_id, string_agg(ol.slug, ';' ORDER BY ol.slug) AS lists
+    FROM object_list_members olm
+    JOIN object_lists ol ON ol.id = olm.list_id
+    WHERE ol.created_by = auth.uid() OR ol.visibility IN ('public_read', 'public_edit')
+    GROUP BY olm.object_id
+  ),
+  filtered_objects AS (
+    SELECT o.object_id, o.field, o.ra, o.dec,
+      o.redshift, o.redshift_quality,
+      o.redshift_inspected, o.redshift_auto,
+      o.last_inspected_at, up.full_name AS last_inspected_by,
+      o.last_data_change_at, o.staleness_reason, o.version,
+      o.n_targets, o.n_spectra,
+      array_to_string(o.programs, ';') AS programs,
+      array_to_string(o.gratings, ';') AS gratings,
+      o.max_snr, o.max_exposure_time,
+      mt.member_target_ids,
+      CASE WHEN v_coord_search_active THEN
+        2 * DEGREES(ASIN(SQRT(POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) + COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) * POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2))))
+      ELSE NULL END AS distance,
+      vl.lists,
+      o.has_photometry, o.photo_z, o.photo_z_err_lo, o.photo_z_err_hi,
+      phot.photometry
+    FROM objects o
+    LEFT JOIN member_targets mt ON mt.object_id = o.id
+    LEFT JOIN visible_lists vl ON vl.object_id = o.id
+    LEFT JOIN user_profiles up ON up.user_id = o.last_inspected_by
+    LEFT JOIN LATERAL (
+      SELECT op.photometry FROM object_photometry op
+      WHERE op.object_id = o.id ORDER BY op.updated_at DESC LIMIT 1
+    ) phot ON true
+    WHERE o.programs && v_filtered_program_slugs
+      AND o.is_active = true
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+        OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+        OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+      )
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_search IS NULL OR o.object_id ILIKE '%' || p_search || '%'
+      OR EXISTS (SELECT 1 FROM targets t WHERE t.object_id = o.id AND t.target_id ILIKE '%' || p_search || '%'))
+      AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.redshift_quality > 0) OR (p_inspected_only = FALSE AND o.redshift_quality = 0))
+      AND (p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at))))
+      AND (NOT v_coord_search_active OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+      ))
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+      AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+  ),
+  distance_filtered AS (SELECT fo.* FROM filtered_objects fo WHERE NOT v_coord_search_active OR fo.distance <= p_radius_degrees)
+  SELECT df.object_id, df.field, df.ra, df.dec,
+    df.redshift, df.redshift_quality,
+    df.redshift_inspected, df.redshift_auto,
+    df.last_inspected_at, df.last_inspected_by,
+    df.last_data_change_at, df.staleness_reason, df.version,
+    df.n_targets, df.n_spectra,
+    df.programs, df.gratings,
+    df.max_snr, df.max_exposure_time,
+    df.member_target_ids, df.distance, df.lists,
+    df.has_photometry, df.photo_z, df.photo_z_err_lo, df.photo_z_err_hi,
+    df.photometry
+  FROM distance_filtered df
+  ORDER BY
+    CASE WHEN v_coord_search_active THEN df.distance END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN df.object_id END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'desc' THEN df.object_id END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'asc' THEN df.field END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'desc' THEN df.field END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN df.ra END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN df.ra END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN df.dec END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN df.dec END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN df.redshift END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN df.redshift END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN df.redshift_quality END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN df.redshift_quality END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_targets' AND p_sort_direction = 'asc' THEN df.n_targets END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_targets' AND p_sort_direction = 'desc' THEN df.n_targets END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_spectra' AND p_sort_direction = 'asc' THEN df.n_spectra END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_spectra' AND p_sort_direction = 'desc' THEN df.n_spectra END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN df.max_snr END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN df.max_snr END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN df.max_exposure_time END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN df.max_exposure_time END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'photo_z' AND p_sort_direction = 'asc' THEN df.photo_z END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'photo_z' AND p_sort_direction = 'desc' THEN df.photo_z END DESC NULLS LAST,
+    df.object_id ASC;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_csv_export_spectra(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_dq_flags_include_any integer DEFAULT NULL::integer, p_dq_flags_include_all integer DEFAULT NULL::integer, p_dq_flags_exclude integer DEFAULT NULL::integer, p_list_ids integer[] DEFAULT NULL::integer[], p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_has_photometry boolean DEFAULT NULL::boolean, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_sort_column text DEFAULT 'target_id'::text, p_sort_direction text DEFAULT 'asc'::text)
+ RETURNS TABLE(spectrum_id text, target_id text, grating text, field text, ra double precision, "dec" double precision, redshift numeric, redshift_quality integer, redshift_auto double precision, signal_to_noise double precision, exposure_time double precision, fits_path text, program_slug text, program_name text, last_inspected_at timestamp with time zone, last_inspected_by text, distance double precision, dq_flags integer, lists text)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (p_comment_search IS NOT NULL AND p_comment_search != '' AND p_comment_search_scope IN ('just_me', 'everyone'));
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
+  IF NOT (p_sort_column IN ('target_id', 'spectrum_id', 'field', 'observation', 'ra', 'dec', 'redshift', 'redshift_quality', 'redshift_auto', 'signal_to_noise', 'exposure_time', 'grating')
+       OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'spectrum_id';
+  END IF;
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs)) INTO v_filtered_program_slugs;
+  ELSE v_filtered_program_slugs := p_program_slugs; END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN RETURN; END IF;
+
+  RETURN QUERY
+  WITH visible_lists AS (
+    SELECT olm.object_id, string_agg(ol.slug, ';' ORDER BY ol.slug) AS lists
+    FROM object_list_members olm
+    JOIN object_lists ol ON ol.id = olm.list_id
+    WHERE ol.created_by = auth.uid() OR ol.visibility IN ('public_read', 'public_edit')
+    GROUP BY olm.object_id
+  ),
+  filtered_spectra AS (
+    SELECT s.spectrum_id, t.target_id, s.grating, t.field, t.ra, t.dec,
+      o.redshift, o.redshift_quality,
+      s.redshift_auto,
+      s.signal_to_noise, s.exposure_time, s.fits_path, t.program_slug, t.observation,
+      o.last_inspected_at, o.last_inspected_by,
+      CASE WHEN v_coord_search_active THEN
+        2 * DEGREES(ASIN(SQRT(POWER(SIN(RADIANS(t.dec - p_coord_dec) / 2), 2) + COS(RADIANS(p_coord_dec)) * COS(RADIANS(t.dec)) * POWER(SIN(RADIANS(t.ra - p_coord_ra) / 2), 2))))
+      ELSE NULL END AS distance,
+      COALESCE(s.dq_flags, 0) AS dq_flags,
+      vl.lists
+    FROM targets t
+    JOIN spectra s ON s.target_id = t.target_id
+    LEFT JOIN objects o ON o.id = t.object_id
+    LEFT JOIN visible_lists vl ON vl.object_id = t.object_id
+    WHERE t.program_slug = ANY(v_filtered_program_slugs)
+      AND (o.id IS NULL OR o.is_active = true)
+      AND (NOT v_grating_filter_active OR s.grating = ANY(p_gratings))
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR t.field = ANY(p_fields))
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR t.observation = ANY(p_observations))
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min) AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR s.signal_to_noise >= p_max_snr_min) AND (p_max_snr_max IS NULL OR s.signal_to_noise <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR s.exposure_time >= p_max_exposure_time_min) AND (p_max_exposure_time_max IS NULL OR s.exposure_time <= p_max_exposure_time_max)
+      AND (p_dq_flags_include_any IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_any) != 0)
+      AND (p_dq_flags_include_all IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_all) = p_dq_flags_include_all)
+      AND (p_dq_flags_exclude IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_exclude) = 0)
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR t.object_id IN (
+          SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_search IS NULL
+           OR t.target_id ILIKE '%' || p_search || '%'
+           OR s.spectrum_id ILIKE '%' || p_search || '%')
+      AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.redshift_quality > 0) OR (p_inspected_only = FALSE AND COALESCE(o.redshift_quality, 0) = 0))
+      AND (p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at))))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (NOT v_comment_search_active OR EXISTS (
+        SELECT 1 FROM comments c WHERE c.target_id = t.id AND c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (p_comment_search_scope = 'everyone' OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id))))
+      AND (NOT v_coord_search_active OR (
+        t.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND t.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)))
+  ),
+  distance_filtered AS (SELECT fs.* FROM filtered_spectra fs WHERE NOT v_coord_search_active OR fs.distance <= p_radius_degrees)
+  SELECT df.spectrum_id, df.target_id, df.grating, df.field, df.ra, df.dec, df.redshift, df.redshift_quality, df.redshift_auto,
+    df.signal_to_noise, df.exposure_time, df.fits_path, df.program_slug,
+    pr.program_name, df.last_inspected_at, up.full_name AS last_inspected_by,
+    df.distance, df.dq_flags, df.lists
+  FROM distance_filtered df
+  LEFT JOIN programs pr ON pr.slug = df.program_slug
+  LEFT JOIN user_profiles up ON up.user_id = df.last_inspected_by
+  ORDER BY
+    CASE WHEN v_coord_search_active THEN df.distance END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'spectrum_id' AND p_sort_direction = 'asc' THEN df.spectrum_id END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'spectrum_id' AND p_sort_direction = 'desc' THEN df.spectrum_id END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'target_id' AND p_sort_direction = 'asc' THEN df.target_id END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'target_id' AND p_sort_direction = 'desc' THEN df.target_id END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'asc' THEN df.field END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'desc' THEN df.field END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'observation' AND p_sort_direction = 'asc' THEN df.observation END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'observation' AND p_sort_direction = 'desc' THEN df.observation END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN df.ra END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN df.ra END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN df.dec END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN df.dec END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN df.redshift END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN df.redshift END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN df.redshift_quality END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN df.redshift_quality END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_auto' AND p_sort_direction = 'asc' THEN df.redshift_auto END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_auto' AND p_sort_direction = 'desc' THEN df.redshift_auto END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'signal_to_noise' AND p_sort_direction = 'asc' THEN df.signal_to_noise END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'signal_to_noise' AND p_sort_direction = 'desc' THEN df.signal_to_noise END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'exposure_time' AND p_sort_direction = 'asc' THEN df.exposure_time END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'exposure_time' AND p_sort_direction = 'desc' THEN df.exposure_time END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'grating' AND p_sort_direction = 'asc' THEN df.grating END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'grating' AND p_sort_direction = 'desc' THEN df.grating END DESC NULLS LAST,
+    df.target_id ASC, df.grating ASC;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_filtered_object_ids(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_list_ids integer[] DEFAULT NULL::integer[], p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_has_photometry boolean DEFAULT NULL::boolean, p_photo_z_min double precision DEFAULT NULL::double precision, p_photo_z_max double precision DEFAULT NULL::double precision)
+ RETURNS TABLE(object_id text)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
+    v_gratings_mode := 'any';
+  END IF;
+
+  -- Intersect user-accessible programs with filter selection
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(
+      SELECT unnest(p_program_slugs)
+      INTERSECT
+      SELECT unnest(p_filter_programs)
+    ) INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT o.object_id
+  FROM objects o
+  WHERE
+    o.programs && v_filtered_program_slugs
+    AND o.is_active = true
+    AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+    AND (
+      NOT v_grating_filter_active
+      OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+      OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+      OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+    )
+    AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+    AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+    AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+    AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+    AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+    AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+    AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+    AND (p_search IS NULL OR o.object_id ILIKE '%' || p_search || '%'
+      OR EXISTS (SELECT 1 FROM targets t WHERE t.object_id = o.id AND t.target_id ILIKE '%' || p_search || '%'))
+    AND (
+      p_inspected_only IS NULL
+      OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+      OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+    )
+    AND (
+      p_needs_review IS NULL
+      OR (p_needs_review = TRUE
+          AND o.staleness_reason IS NOT NULL
+          AND o.last_inspected_at IS NOT NULL
+          AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+      OR (p_needs_review = FALSE
+          AND (o.staleness_reason IS NULL
+               OR o.last_inspected_at IS NULL
+               OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+    )
+    AND (
+      NOT v_coord_search_active
+      OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+        AND 2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) <= p_radius_degrees
+      )
+    )
+    AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+        SELECT olm.object_id FROM object_list_members olm
+        WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+    ))
+  ORDER BY o.object_id;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_filtered_objects_paginated(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_list_ids integer[] DEFAULT NULL::integer[], p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_has_photometry boolean DEFAULT NULL::boolean, p_photo_z_min double precision DEFAULT NULL::double precision, p_photo_z_max double precision DEFAULT NULL::double precision, p_sort_column text DEFAULT 'object_id'::text, p_sort_direction text DEFAULT 'asc'::text, p_page integer DEFAULT 1, p_page_size integer DEFAULT 50)
+ RETURNS TABLE(targets jsonb, total_count bigint, page integer, page_size integer)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_offset INTEGER;
+  v_total_count BIGINT;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
+    v_gratings_mode := 'any';
+  END IF;
+
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN
+    p_sort_direction := 'asc';
+  END IF;
+
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time', 'photo_z'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+
+  IF v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN
+    p_sort_column := 'distance';
+  END IF;
+
+  v_offset := (COALESCE(p_page, 1) - 1) * COALESCE(p_page_size, 50);
+
+  -- Intersect user-accessible programs with filter selection
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(
+      SELECT unnest(p_program_slugs)
+      INTERSECT
+      SELECT unnest(p_filter_programs)
+    ) INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN QUERY SELECT '[]'::jsonb, 0::BIGINT, p_page, p_page_size;
+    RETURN;
+  END IF;
+
+  -- Step 1: count
+  SELECT COUNT(*) INTO v_total_count
+  FROM objects o
+  WHERE
+    -- Access control: object must have at least one accessible program
+    o.programs && v_filtered_program_slugs
+    AND o.is_active = true
+    AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+    AND (
+      NOT v_grating_filter_active
+      OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+      OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+      OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+    )
+    AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+    AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+    AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+    AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+    AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+    AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+    AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+    AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+    AND (p_search IS NULL OR o.object_id ILIKE '%' || p_search || '%'
+      OR EXISTS (SELECT 1 FROM targets t WHERE t.object_id = o.id AND t.target_id ILIKE '%' || p_search || '%'))
+    AND (
+      p_inspected_only IS NULL
+      OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+      OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+    )
+    AND (
+      p_needs_review IS NULL
+      OR (p_needs_review = TRUE
+          AND o.staleness_reason IS NOT NULL
+          AND o.last_inspected_at IS NOT NULL
+          AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+      OR (p_needs_review = FALSE
+          AND (o.staleness_reason IS NULL
+               OR o.last_inspected_at IS NULL
+               OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+    )
+    AND (
+      NOT v_coord_search_active
+      OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+        AND 2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) <= p_radius_degrees
+      )
+    )
+    AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+        SELECT olm.object_id FROM object_list_members olm
+        WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+    ))
+    AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+    AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+    AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max);
+
+  -- Step 2: fetch page
+  RETURN QUERY
+  WITH filtered_objects AS (
+    SELECT
+      o.id,
+      o.object_id,
+      o.field,
+      o.ra,
+      o.dec,
+      o.n_targets,
+      o.n_spectra,
+      o.programs,
+      o.gratings,
+      o.max_snr,
+      o.max_exposure_time,
+      o.redshift,
+      o.redshift_quality,
+      o.redshift_inspected,
+      o.redshift_auto,
+      o.last_inspected_at,
+      o.last_inspected_by,
+      o.last_data_change_at,
+      o.staleness_reason,
+      o.version,
+      o.is_active,
+      o.photo_z,
+      o.has_photometry,
+      o.created_at,
+      CASE
+        WHEN v_coord_search_active THEN
+          2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+            POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+          )))
+        ELSE NULL
+      END AS distance
+    FROM objects o
+    WHERE
+      o.programs && v_filtered_program_slugs
+      AND o.is_active = true
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+        OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+        OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+      )
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_search IS NULL OR o.object_id ILIKE '%' || p_search || '%'
+      OR EXISTS (SELECT 1 FROM targets t WHERE t.object_id = o.id AND t.target_id ILIKE '%' || p_search || '%'))
+      AND (
+        p_inspected_only IS NULL
+        OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+        OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+      )
+      AND (
+        p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+      )
+      AND (
+        NOT v_coord_search_active
+        OR (
+          o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+          AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+          AND 2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+            POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+          ))) <= p_radius_degrees
+        )
+      )
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+      AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+    ORDER BY
+      CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN
+        2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN
+        2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN o.object_id END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'desc' THEN o.object_id END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN o.field END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN o.field END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN o.ra END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN o.ra END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN o.dec END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN o.dec END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN o.redshift END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN o.redshift END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN o.redshift_quality END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN o.redshift_quality END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'asc' THEN o.n_targets END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'desc' THEN o.n_targets END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'asc' THEN o.n_spectra END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'desc' THEN o.n_spectra END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN o.max_snr END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN o.max_snr END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN o.max_exposure_time END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN o.max_exposure_time END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'asc' THEN o.photo_z END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'desc' THEN o.photo_z END DESC NULLS LAST,
+      o.object_id ASC
+    LIMIT p_page_size OFFSET v_offset
+  ),
+  with_members AS (
+    SELECT
+      jsonb_build_object(
+        'id', fo.id,
+        'object_id', fo.object_id,
+        'field', fo.field,
+        'ra', fo.ra,
+        'dec', fo.dec,
+        'n_targets', fo.n_targets,
+        'n_spectra', fo.n_spectra,
+        'programs', fo.programs,
+        'gratings', fo.gratings,
+        'max_snr', fo.max_snr,
+        'max_exposure_time', fo.max_exposure_time,
+        'redshift', fo.redshift,
+        'redshift_quality', fo.redshift_quality,
+        'redshift_inspected', fo.redshift_inspected,
+        'redshift_auto', fo.redshift_auto,
+        'last_inspected_at', fo.last_inspected_at,
+        'last_inspected_by', fo.last_inspected_by,
+        'last_data_change_at', fo.last_data_change_at,
+        'staleness_reason', fo.staleness_reason,
+        'version', fo.version,
+        'is_active', fo.is_active,
+        'photo_z', fo.photo_z,
+        'has_photometry', fo.has_photometry,
+        'created_at', fo.created_at,
+        'distance', fo.distance,
+        -- Phase D: member_targets becomes provenance only (target_id, program,
+        -- observation). Inspection state lives on the object now; redshift_auto
+        -- on targets is retained for transitional UI display until Phase E.
+        'member_targets', COALESCE(
+          (SELECT jsonb_agg(
+            jsonb_build_object(
+              'target_id', t.target_id,
+              'program_slug', t.program_slug,
+              'observation', t.observation,
+              'redshift_auto', t.redshift_auto
+            )
+          )
+          FROM targets t
+          WHERE t.object_id = fo.id
+            AND t.program_slug = ANY(v_filtered_program_slugs)
+          ),
+          '[]'::jsonb
+        ),
+        'lists', COALESCE(
+          (SELECT jsonb_agg(
+            jsonb_build_object(
+              'id', ol.id,
+              'name', ol.name,
+              'slug', ol.slug,
+              'icon', ol.icon,
+              'color', ol.color
+            ) ORDER BY ol.name
+          )
+          FROM object_list_members olm
+          JOIN object_lists ol ON ol.id = olm.list_id
+          WHERE olm.object_id = fo.id),
+          '[]'::jsonb
+        )
+      ) AS obj_json
+    FROM filtered_objects fo
+  )
+  SELECT
+    COALESCE(jsonb_agg(wm.obj_json), '[]'::jsonb),
+    v_total_count,
+    p_page,
+    p_page_size
+  FROM with_members wm;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_filtered_spectra_paginated(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_dq_flags_include_any integer DEFAULT NULL::integer, p_dq_flags_include_all integer DEFAULT NULL::integer, p_dq_flags_exclude integer DEFAULT NULL::integer, p_list_ids integer[] DEFAULT NULL::integer[], p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_has_photometry boolean DEFAULT NULL::boolean, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_sort_column text DEFAULT 'target_id'::text, p_sort_direction text DEFAULT 'asc'::text, p_page integer DEFAULT 1, p_page_size integer DEFAULT 50, p_include_thumbnails boolean DEFAULT false)
+ RETURNS TABLE(targets jsonb, total_count bigint, page integer, page_size integer)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_offset INTEGER;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
+    v_gratings_mode := 'any';
+  END IF;
+
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN
+    p_sort_direction := 'asc';
+  END IF;
+
+  IF NOT (p_sort_column IN (
+    'target_id', 'spectrum_id', 'field', 'observation', 'program_slug', 'ra', 'dec', 'redshift',
+    'redshift_quality', 'redshift_auto', 'signal_to_noise', 'exposure_time', 'grating'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'spectrum_id';
+  END IF;
+
+  IF v_coord_search_active AND p_sort_column IN ('target_id', 'spectrum_id') AND p_sort_direction = 'asc' THEN
+    p_sort_column := 'distance';
+  END IF;
+
+  v_offset := (COALESCE(p_page, 1) - 1) * COALESCE(p_page_size, 50);
+
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(
+      SELECT unnest(p_program_slugs)
+      INTERSECT
+      SELECT unnest(p_filter_programs)
+    ) INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN QUERY SELECT '[]'::jsonb, 0::BIGINT, p_page, p_page_size;
+    RETURN;
+  END IF;
+
+  -- Single-pass CTE: filtered_spectra is referenced by both distance_filtered
+  -- and the count subquery, so PostgreSQL materializes it once.
+  RETURN QUERY
+  WITH filtered_spectra AS (
+    SELECT
+      t.id AS tgt_db_id,
+      t.target_id,
+      t.program_slug,
+      t.field,
+      t.observation,
+      t.ra,
+      t.dec,
+      -- Phase D: redshift / redshift_quality / inspected flags now live on the
+      -- parent object. LEFT JOIN so spectra whose target has no object FK
+      -- (shouldn't happen post-reconcile, but safe) still appear.
+      o.redshift,
+      o.redshift_quality,
+      o.redshift_inspected,
+      o.last_inspected_at,
+      o.last_inspected_by,
+      o.is_active AS object_is_active,
+      o.has_photometry AS object_has_photometry,
+      o.object_id AS parent_object_id,
+      t.max_snr,
+      t.max_exposure_time,
+      t.created_at,
+      t.updated_at,
+      s.id AS spectrum_pk,
+      s.spectrum_id,
+      s.grating,
+      s.fits_path,
+      s.signal_to_noise,
+      s.exposure_time,
+      s.redshift_auto,
+      COALESCE(s.dq_flags, 0) AS dq_flags,
+      s.file_hash,
+      s.file_size,
+      s.thumbnail_svg_fnu,
+      s.thumbnail_svg_flambda,
+      CASE
+        WHEN v_coord_search_active THEN
+          2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(t.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(t.dec)) *
+            POWER(SIN(RADIANS(t.ra - p_coord_ra) / 2), 2)
+          )))
+        ELSE NULL
+      END AS distance
+    FROM targets t
+    JOIN spectra s ON s.target_id = t.target_id
+    LEFT JOIN objects o ON o.id = t.object_id
+    WHERE
+      t.program_slug = ANY(v_filtered_program_slugs)
+      -- Hide spectra whose parent object was soft-deleted.
+      AND (o.id IS NULL OR o.is_active = true)
+      AND (NOT v_grating_filter_active OR s.grating = ANY(p_gratings))
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR t.field = ANY(p_fields))
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR t.observation = ANY(p_observations))
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR s.signal_to_noise >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR s.signal_to_noise <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR s.exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR s.exposure_time <= p_max_exposure_time_max)
+      AND (p_dq_flags_include_any IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_any) != 0)
+      AND (p_dq_flags_include_all IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_all) = p_dq_flags_include_all)
+      AND (p_dq_flags_exclude IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_exclude) = 0)
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR t.object_id IN (
+          SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_search IS NULL
+           OR t.target_id ILIKE '%' || p_search || '%'
+           OR s.spectrum_id ILIKE '%' || p_search || '%')
+      AND (
+        p_inspected_only IS NULL
+        OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+        OR (p_inspected_only = FALSE AND COALESCE(o.redshift_quality, 0) = 0)
+      )
+      AND (
+        p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+      )
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (
+        NOT v_comment_search_active
+        OR EXISTS (
+          SELECT 1 FROM comments c
+          WHERE c.target_id = t.id
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+        )
+      )
+      AND (
+        NOT v_coord_search_active
+        OR (
+          t.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+          AND t.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+        )
+      )
+  ),
+  distance_filtered AS (
+    SELECT fs.*
+    FROM filtered_spectra fs
+    WHERE NOT v_coord_search_active OR fs.distance <= p_radius_degrees
+  ),
+  page_rows AS (
+    SELECT *, ROW_NUMBER() OVER () as row_num
+    FROM (
+      SELECT * FROM distance_filtered
+      ORDER BY
+        CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN distance END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN distance END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'target_id' AND p_sort_direction = 'asc' THEN target_id END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'target_id' AND p_sort_direction = 'desc' THEN target_id END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'spectrum_id' AND p_sort_direction = 'asc' THEN spectrum_id END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'spectrum_id' AND p_sort_direction = 'desc' THEN spectrum_id END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN field END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN field END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'observation' AND p_sort_direction = 'asc' THEN observation END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'observation' AND p_sort_direction = 'desc' THEN observation END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'program_slug' AND p_sort_direction = 'asc' THEN program_slug END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'program_slug' AND p_sort_direction = 'desc' THEN program_slug END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN ra END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN ra END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN "dec" END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN "dec" END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN redshift END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN redshift END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN redshift_quality END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN redshift_quality END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift_auto' AND p_sort_direction = 'asc' THEN redshift_auto END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift_auto' AND p_sort_direction = 'desc' THEN redshift_auto END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'signal_to_noise' AND p_sort_direction = 'asc' THEN signal_to_noise END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'signal_to_noise' AND p_sort_direction = 'desc' THEN signal_to_noise END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'exposure_time' AND p_sort_direction = 'asc' THEN exposure_time END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'exposure_time' AND p_sort_direction = 'desc' THEN exposure_time END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'grating' AND p_sort_direction = 'asc' THEN grating END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'grating' AND p_sort_direction = 'desc' THEN grating END DESC NULLS LAST,
+        target_id ASC, grating ASC
+      LIMIT p_page_size OFFSET v_offset
+    ) sorted_page
+  )
+  SELECT
+    COALESCE(jsonb_agg(jsonb_build_object(
+      'id', r.tgt_db_id,
+      'target_id', r.target_id,
+      'parent_object_id', r.parent_object_id,
+      'program_slug', r.program_slug,
+      'program_name', pr.program_name,
+      'field', r.field,
+      'observation', r.observation,
+      'ra', r.ra,
+      'dec', r.dec,
+      -- Phase D: redshift fields are object-level reads
+      'redshift', r.redshift,
+      'redshift_inspected', r.redshift_inspected,
+      'redshift_quality', r.redshift_quality,
+      'last_inspected_at', r.last_inspected_at,
+      'last_inspected_by', r.last_inspected_by,
+      'max_snr', r.max_snr,
+      'max_exposure_time', r.max_exposure_time,
+      'created_at', r.created_at,
+      'updated_at', r.updated_at,
+      'distance', CASE WHEN v_coord_search_active THEN r.distance ELSE NULL END,
+      'spectra', jsonb_build_array(jsonb_build_object(
+        'id', r.spectrum_pk,
+        'spectrum_id', r.spectrum_id,
+        'target_id', r.target_id,
+        'grating', r.grating,
+        'fits_path', r.fits_path,
+        'signal_to_noise', r.signal_to_noise,
+        'exposure_time', r.exposure_time,
+        -- Phase D: per-spectrum auto-z and DQ
+        'redshift_auto', r.redshift_auto,
+        'dq_flags', r.dq_flags,
+        'file_hash', r.file_hash,
+        'file_size', r.file_size,
+        'thumbnail_svg_fnu', CASE WHEN p_include_thumbnails THEN r.thumbnail_svg_fnu ELSE NULL END,
+        'thumbnail_svg_flambda', CASE WHEN p_include_thumbnails THEN r.thumbnail_svg_flambda ELSE NULL END
+      ))
+    ) ORDER BY r.row_num), '[]'::jsonb),
+    (SELECT COUNT(*) FROM distance_filtered),
+    p_page,
+    p_page_size
+  FROM page_rows r
+  LEFT JOIN programs pr ON pr.slug = r.program_slug;
+END;
+$function$
+;
+
+create materialized view "public"."mv_filter_options" as  SELECT 1 AS id,
+    ARRAY( SELECT DISTINCT targets.field
+           FROM public.targets
+          ORDER BY targets.field) AS fields,
+    ARRAY( SELECT DISTINCT targets.observation
+           FROM public.targets
+          WHERE (targets.observation IS NOT NULL)
+          ORDER BY targets.observation) AS observations,
+    ARRAY( SELECT DISTINCT spectra.grating
+           FROM public.spectra
+          ORDER BY spectra.grating) AS gratings;
+
+
+create materialized view "public"."mv_programs_overview" as  SELECT p.slug,
+    p.program_name,
+    p.pi_name,
+    p.description,
+    p.is_public,
+    p.cycle,
+    COALESCE(stats.target_count, (0)::bigint) AS target_count,
+    COALESCE(stats.gratings, ARRAY[]::text[]) AS gratings,
+    COALESCE(stats.fields, ARRAY[]::text[]) AS fields,
+    COALESCE(stats.observations, ARRAY[]::text[]) AS observations,
+    COALESCE(pids.jwst_pids, ARRAY[]::integer[]) AS jwst_pids
+   FROM ((public.programs p
+     LEFT JOIN ( SELECT t.program_slug,
+            count(DISTINCT t.target_id) AS target_count,
+            array_agg(DISTINCT s.grating ORDER BY s.grating) FILTER (WHERE (s.grating IS NOT NULL)) AS gratings,
+            array_agg(DISTINCT t.field ORDER BY t.field) AS fields,
+            array_agg(DISTINCT t.observation ORDER BY t.observation) AS observations
+           FROM (public.targets t
+             LEFT JOIN public.spectra s ON ((s.target_id = t.target_id)))
+          GROUP BY t.program_slug) stats ON ((p.slug = stats.program_slug)))
+     LEFT JOIN ( SELECT observations.program_slug,
+            array_agg(DISTINCT observations.jwst_program_id ORDER BY observations.jwst_program_id) AS jwst_pids
+           FROM public.observations
+          GROUP BY observations.program_slug) pids ON ((p.slug = pids.program_slug)));
+
+
+create or replace view "public"."spectrum_flag_summary" as  SELECT s.id,
+    s.target_id,
+    s.grating,
+    array_agg(DISTINCT fd.label) FILTER (WHERE ((fd.category = 'dq_flags'::text) AND ((s.dq_flags & fd.value) > 0))) AS dq_flags_labels
+   FROM (public.spectra s
+     CROSS JOIN public.flag_definitions fd)
+  GROUP BY s.id, s.target_id, s.grating;
+
+-- Restore unique indexes and grants on the recreated materialized views (not
+-- tracked by migra — dropped above as a dependency of the function DROPs).
+CREATE UNIQUE INDEX mv_filter_options_id ON public.mv_filter_options USING btree (id);
+GRANT ALL ON TABLE public.mv_filter_options TO anon;
+GRANT ALL ON TABLE public.mv_filter_options TO authenticated;
+GRANT ALL ON TABLE public.mv_filter_options TO service_role;
+
+CREATE UNIQUE INDEX mv_programs_overview_slug ON public.mv_programs_overview (slug);
+GRANT SELECT ON public.mv_programs_overview TO authenticated;
+
+
+

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -141,6 +141,14 @@ CREATE OR REPLACE FUNCTION public.get_objects_for_sync(
 RETURNS TABLE(objects JSONB, total_count BIGINT, total_accessible_count BIGINT)
 LANGUAGE plpgsql STABLE
 SET plan_cache_mode = 'force_custom_plan'
+-- OFFSET-based pagination is linear in offset: a deep-page request
+-- (e.g. OFFSET 29000 on a 30k-row catalog) must materialize the ordered
+-- scan up to that point plus run three aggregate CTEs, and started
+-- tipping past the default service_role timeout around page ~29 of a
+-- --full sync. Bumped to 120s so deep pages finish while the paginator
+-- is still offset-based; a future change should switch this RPC to
+-- keyset pagination (WHERE object_id > cursor) and then drop this SET.
+SET statement_timeout = '120s'
 AS $$
 BEGIN
   RETURN QUERY
@@ -289,6 +297,9 @@ CREATE OR REPLACE FUNCTION public.get_spectra_for_sync(
 RETURNS TABLE(spectra JSONB, total_count BIGINT, total_accessible_count BIGINT)
 LANGUAGE plpgsql STABLE
 SET plan_cache_mode = 'force_custom_plan'
+-- Mirrors get_objects_for_sync: offset-based pagination is linear in
+-- offset, so deep --full-sync pages can tip past the default timeout.
+SET statement_timeout = '120s'
 AS $$
 BEGIN
   RETURN QUERY
@@ -376,6 +387,9 @@ CREATE OR REPLACE FUNCTION public.get_photometry_for_sync(
 RETURNS TABLE(photometry_records JSONB, total_count BIGINT)
 LANGUAGE plpgsql STABLE
 SET plan_cache_mode = 'force_custom_plan'
+-- Mirrors get_objects_for_sync: offset-based pagination is linear in
+-- offset, so deep --full-sync pages can tip past the default timeout.
+SET statement_timeout = '120s'
 AS $$
 BEGIN
   RETURN QUERY
@@ -503,6 +517,7 @@ CREATE OR REPLACE FUNCTION public.get_filtered_spectra_paginated(
   p_list_ids INTEGER[] DEFAULT NULL,
   p_search TEXT DEFAULT NULL,
   p_inspected_only BOOLEAN DEFAULT NULL,
+  p_needs_review BOOLEAN DEFAULT NULL,
   p_has_photometry BOOLEAN DEFAULT NULL,
   p_comment_search TEXT DEFAULT NULL,
   p_comment_search_scope TEXT DEFAULT NULL,
@@ -654,6 +669,17 @@ BEGIN
         OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
         OR (p_inspected_only = FALSE AND COALESCE(o.redshift_quality, 0) = 0)
       )
+      AND (
+        p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+      )
       AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
       AND (
         NOT v_comment_search_active
@@ -790,6 +816,7 @@ CREATE OR REPLACE FUNCTION public.get_filtered_objects_paginated(
   p_max_exposure_time_max DOUBLE PRECISION DEFAULT NULL,
   p_search TEXT DEFAULT NULL,
   p_inspected_only BOOLEAN DEFAULT NULL,
+  p_needs_review BOOLEAN DEFAULT NULL,
   p_list_ids INTEGER[] DEFAULT NULL,
   p_coord_ra DOUBLE PRECISION DEFAULT NULL,
   p_coord_dec DOUBLE PRECISION DEFAULT NULL,
@@ -884,6 +911,17 @@ BEGIN
       OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
     )
     AND (
+      p_needs_review IS NULL
+      OR (p_needs_review = TRUE
+          AND o.staleness_reason IS NOT NULL
+          AND o.last_inspected_at IS NOT NULL
+          AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+      OR (p_needs_review = FALSE
+          AND (o.staleness_reason IS NULL
+               OR o.last_inspected_at IS NULL
+               OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+    )
+    AND (
       NOT v_coord_search_active
       OR (
         o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
@@ -965,6 +1003,17 @@ BEGIN
         p_inspected_only IS NULL
         OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
         OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+      )
+      AND (
+        p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
       )
       AND (
         NOT v_coord_search_active
@@ -1120,6 +1169,7 @@ CREATE OR REPLACE FUNCTION public.get_filtered_object_ids(
   p_max_exposure_time_max DOUBLE PRECISION DEFAULT NULL,
   p_search TEXT DEFAULT NULL,
   p_inspected_only BOOLEAN DEFAULT NULL,
+  p_needs_review BOOLEAN DEFAULT NULL,
   p_list_ids INTEGER[] DEFAULT NULL,
   p_coord_ra DOUBLE PRECISION DEFAULT NULL,
   p_coord_dec DOUBLE PRECISION DEFAULT NULL,
@@ -1188,6 +1238,17 @@ BEGIN
       OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
     )
     AND (
+      p_needs_review IS NULL
+      OR (p_needs_review = TRUE
+          AND o.staleness_reason IS NOT NULL
+          AND o.last_inspected_at IS NOT NULL
+          AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+      OR (p_needs_review = FALSE
+          AND (o.staleness_reason IS NULL
+               OR o.last_inspected_at IS NULL
+               OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+    )
+    AND (
       NOT v_coord_search_active
       OR (
         o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
@@ -1233,6 +1294,7 @@ CREATE OR REPLACE FUNCTION public.get_adjacent_objects(
   p_max_exposure_time_max DOUBLE PRECISION DEFAULT NULL,
   p_search TEXT DEFAULT NULL,
   p_inspected_only BOOLEAN DEFAULT NULL,
+  p_needs_review BOOLEAN DEFAULT NULL,
   p_list_ids INTEGER[] DEFAULT NULL,
   p_coord_ra DOUBLE PRECISION DEFAULT NULL,
   p_coord_dec DOUBLE PRECISION DEFAULT NULL,
@@ -1319,6 +1381,15 @@ BEGIN
       AND (p_inspected_only IS NULL
         OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
         OR (p_inspected_only = FALSE AND o.redshift_quality = 0))
+      AND (p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at))))
       AND (NOT v_coord_search_active OR (
         o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
         AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
@@ -1440,6 +1511,7 @@ CREATE OR REPLACE FUNCTION public.get_csv_export_spectra(
   p_dq_flags_exclude INTEGER DEFAULT NULL,
   p_list_ids INTEGER[] DEFAULT NULL,
   p_search TEXT DEFAULT NULL, p_inspected_only BOOLEAN DEFAULT NULL,
+  p_needs_review BOOLEAN DEFAULT NULL,
   p_has_photometry BOOLEAN DEFAULT NULL,
   p_comment_search TEXT DEFAULT NULL, p_comment_search_scope TEXT DEFAULT NULL,
   p_comment_user_id UUID DEFAULT NULL,
@@ -1519,6 +1591,15 @@ BEGIN
            OR t.target_id ILIKE '%' || p_search || '%'
            OR s.spectrum_id ILIKE '%' || p_search || '%')
       AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.redshift_quality > 0) OR (p_inspected_only = FALSE AND COALESCE(o.redshift_quality, 0) = 0))
+      AND (p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at))))
       AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
       AND (NOT v_comment_search_active OR EXISTS (
         SELECT 1 FROM comments c WHERE c.target_id = t.id AND c.is_deleted = false
@@ -1594,6 +1675,7 @@ CREATE OR REPLACE FUNCTION public.get_csv_export_objects(
   p_max_snr_min DOUBLE PRECISION DEFAULT NULL, p_max_snr_max DOUBLE PRECISION DEFAULT NULL,
   p_max_exposure_time_min DOUBLE PRECISION DEFAULT NULL, p_max_exposure_time_max DOUBLE PRECISION DEFAULT NULL,
   p_search TEXT DEFAULT NULL, p_inspected_only BOOLEAN DEFAULT NULL,
+  p_needs_review BOOLEAN DEFAULT NULL,
   p_list_ids INTEGER[] DEFAULT NULL,
   p_coord_ra DOUBLE PRECISION DEFAULT NULL, p_coord_dec DOUBLE PRECISION DEFAULT NULL,
   p_radius_degrees DOUBLE PRECISION DEFAULT NULL,
@@ -1699,6 +1781,15 @@ BEGIN
       AND (p_search IS NULL OR o.object_id ILIKE '%' || p_search || '%'
       OR EXISTS (SELECT 1 FROM targets t WHERE t.object_id = o.id AND t.target_id ILIKE '%' || p_search || '%'))
       AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.redshift_quality > 0) OR (p_inspected_only = FALSE AND o.redshift_quality = 0))
+      AND (p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at))))
       AND (NOT v_coord_search_active OR (
         o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
         AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
@@ -2502,6 +2593,18 @@ GRANT EXECUTE ON FUNCTION public.recompute_target_aggregates(TEXT[]) TO service_
 -- cursor) picks the change up on the next client sync. Without the bump,
 -- clients would silently miss redshift_auto changes from pipeline reruns.
 -- ROW_COUNT is then the true number of objects whose value changed.
+--
+-- Implicit sign-off preservation: when an inspector committed a quality flag
+-- (redshift_quality >= 2) without entering a numeric override
+-- (redshift_inspected IS NULL), the generated ``redshift`` column resolves to
+-- whatever ``redshift_auto`` currently holds. Letting this function silently
+-- overwrite redshift_auto would silently move the object's displayed redshift
+-- out from under the sign-off. Instead, for any such object whose redshift_auto
+-- is about to change, we promote the OLD redshift_auto into redshift_inspected
+-- (pinning the generated redshift to what the inspector actually reviewed) and
+-- flag ``staleness_reason = 'reprocessed'`` so the UI surfaces a "Needs Review"
+-- badge. Inspectors can then reaffirm (no-op) or clear redshift_inspected to
+-- accept the new auto-fit.
 CREATE OR REPLACE FUNCTION public.compute_object_redshift_auto(p_field TEXT)
 RETURNS INTEGER
 LANGUAGE plpgsql
@@ -2511,6 +2614,9 @@ DECLARE
 BEGIN
   WITH computed AS (
     SELECT o.id,
+           o.redshift_auto AS old_auto,
+           o.redshift_inspected AS old_inspected,
+           o.redshift_quality AS quality,
            (
              SELECT s.redshift_auto
              FROM targets t
@@ -2533,6 +2639,30 @@ BEGIN
   )
   UPDATE objects o
   SET redshift_auto = c.new_val,
+      redshift_inspected = CASE
+        WHEN c.quality >= 2
+             AND c.old_inspected IS NULL
+             AND c.old_auto IS NOT NULL
+             AND c.new_val IS DISTINCT FROM c.old_auto
+        THEN c.old_auto::numeric
+        ELSE o.redshift_inspected
+      END,
+      staleness_reason = CASE
+        WHEN c.quality >= 2
+             AND c.old_inspected IS NULL
+             AND c.old_auto IS NOT NULL
+             AND c.new_val IS DISTINCT FROM c.old_auto
+        THEN 'reprocessed'
+        ELSE o.staleness_reason
+      END,
+      last_data_change_at = CASE
+        WHEN c.quality >= 2
+             AND c.old_inspected IS NULL
+             AND c.old_auto IS NOT NULL
+             AND c.new_val IS DISTINCT FROM c.old_auto
+        THEN NOW()
+        ELSE o.last_data_change_at
+      END,
       updated_at = NOW()
   FROM computed c
   WHERE o.id = c.id

--- a/web/app/api/v1/objects/route.ts
+++ b/web/app/api/v1/objects/route.ts
@@ -60,6 +60,11 @@ export async function GET(request: NextRequest) {
       ? inspectedOnlyParam.toLowerCase() === 'true'
       : null;
 
+    const needsReviewParam = searchParams.get('needs_review');
+    const needsReview = needsReviewParam
+      ? needsReviewParam.toLowerCase() === 'true'
+      : null;
+
     const hasPhotometryParam = searchParams.get('has_photometry');
     const hasPhotometry = hasPhotometryParam
       ? hasPhotometryParam.toLowerCase() === 'true'
@@ -95,6 +100,7 @@ export async function GET(request: NextRequest) {
       p_max_exposure_time_max: searchParams.get('max_exposure_time_max') ? parseFloat(searchParams.get('max_exposure_time_max')!) : null,
       p_search: searchParams.get('search') || null,
       p_inspected_only: inspectedOnly,
+      p_needs_review: needsReview,
       p_list_ids: listIds,
       p_coord_ra: coordRa,
       p_coord_dec: coordDec,

--- a/web/app/api/v1/spectra/list/route.ts
+++ b/web/app/api/v1/spectra/list/route.ts
@@ -70,6 +70,11 @@ export async function GET(request: NextRequest) {
       ? inspectedOnlyParam.toLowerCase() === 'true'
       : null;
 
+    const needsReviewParam = searchParams.get('needs_review');
+    const needsReview = needsReviewParam
+      ? needsReviewParam.toLowerCase() === 'true'
+      : null;
+
     const hasPhotometryParam = searchParams.get('has_photometry');
     const hasPhotometry = hasPhotometryParam
       ? hasPhotometryParam.toLowerCase() === 'true'
@@ -110,6 +115,7 @@ export async function GET(request: NextRequest) {
       p_list_ids: listIds,
       p_search: searchParams.get('search') || null,
       p_inspected_only: inspectedOnly,
+      p_needs_review: needsReview,
       p_has_photometry: hasPhotometry,
       p_comment_search: null,
       p_comment_search_scope: null,

--- a/web/components/spectra/SpectraFilterBar.tsx
+++ b/web/components/spectra/SpectraFilterBar.tsx
@@ -169,6 +169,7 @@ export const SpectraFilterBar: React.FC<SpectraFilterBarProps> = ({
     filters.redshift_quality.length > 0 ||
     filters.redshift_min !== null ||
     filters.redshift_max !== null ||
+    filters.needs_review !== null ||
     filters.search.length > 0 ||
     panelFilterCount > 0;
 
@@ -296,13 +297,18 @@ export const SpectraFilterBar: React.FC<SpectraFilterBarProps> = ({
           precision={2}
         />
 
-        {/* Quality filter with "All inspected" shortcut */}
+        {/* Quality filter with "All inspected" shortcut and "Needs review only" toggle */}
         <FilterChip
           label="Quality"
           options={qualityOptions}
           selected={filters.redshift_quality}
           onChange={(selected) => updateFilter('redshift_quality', selected as number[])}
           shortcut={{ label: 'All inspected', values: INSPECTED_QUALITY_VALUES }}
+          extraCheckbox={{
+            label: 'Needs review only',
+            checked: filters.needs_review === true,
+            onChange: (checked) => updateFilter('needs_review', checked ? true : null),
+          }}
         />
 
         {/* Divider */}

--- a/web/components/spectra/SpectraTable.tsx
+++ b/web/components/spectra/SpectraTable.tsx
@@ -75,7 +75,6 @@ const SPECTRA_COLUMN_TO_SERVER: Record<string, SortColumn> = {
 // Column visibility configuration — objects mode (unique sky positions).
 const OBJECTS_COLUMNS: ColumnDefinition[] = [
   { id: 'target_id', label: 'Object ID', alwaysVisible: true },
-  { id: 'staleness', label: 'Review', defaultVisible: true },
   { id: 'field', label: 'Field', defaultVisible: true },
   { id: 'ra', label: 'RA', defaultVisible: true },
   { id: 'dec', label: 'Dec', defaultVisible: true },
@@ -90,6 +89,7 @@ const OBJECTS_COLUMNS: ColumnDefinition[] = [
   { id: 'obj_lists', label: 'Tags', defaultVisible: false },
   { id: 'max_snr', label: 'Max S/N', defaultVisible: true },
   { id: 'max_exposure_time', label: 'Max Exp. Time', defaultVisible: false },
+  { id: 'staleness', label: 'Status', defaultVisible: false },
 ];
 
 // Map TanStack Table column IDs to server column names — objects mode.
@@ -379,21 +379,6 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
         ),
         enableSorting: false,
       },
-      // Needs Review staleness column (objects mode only).
-      ...(isObjectsMode ? [{
-        id: 'staleness',
-        minSize: 110,
-        header: () => <span className="normal-case">Review</span>,
-        cell: ({ row }: { row: { original: SpectrumTarget } }) => (
-          <StalenessBadge
-            reason={row.original.staleness_reason ?? null}
-            lastInspectedAt={row.original.last_inspected_at ?? null}
-            lastDataChangeAt={row.original.last_data_change_at ?? null}
-            compact
-          />
-        ),
-        enableSorting: false,
-      } satisfies ColumnDef<SpectrumTarget>] : []),
       // Objects mode: Object ID column (links to object detail page).
       ...(isObjectsMode ? [{
         accessorKey: 'target_id' as const,
@@ -844,13 +829,33 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
         ),
         enableSorting: false,
       } satisfies ColumnDef<SpectrumTarget>] : []),
+      // Status column (objects mode only). Hidden by default; auto-revealed
+      // when the "Needs review only" filter is on.
+      ...(isObjectsMode ? [{
+        id: 'staleness',
+        minSize: 110,
+        header: () => <>Status</>,
+        cell: ({ row }: { row: { original: SpectrumTarget } }) => (
+          <StalenessBadge
+            reason={row.original.staleness_reason ?? null}
+            lastInspectedAt={row.original.last_inspected_at ?? null}
+            lastDataChangeAt={row.original.last_data_change_at ?? null}
+            compact
+          />
+        ),
+        enableSorting: false,
+      } satisfies ColumnDef<SpectrumTarget>] : []),
     ],
     [hasCoordinateSearch, currentFilterParams, isSpectraMode, isObjectsMode]
   );
 
-  // Convert column visibility state to TanStack Table format
+  // Convert column visibility state to TanStack Table format.
+  // When the "Needs review only" filter is on, force-show the Status column
+  // regardless of the user's saved preference — otherwise filtering down to
+  // a queue of needs-review objects would hide the reason for the filter.
   const tableColumnVisibility = useMemo<VisibilityState>(() => {
     const visibility: VisibilityState = {};
+    const forceStatusVisible = filters?.needs_review === true;
     columnConfig.forEach(col => {
       // Distance column is special - only include in visibility state when coordinate search is active
       // (avoids TanStack Table warning about referencing a non-existent column)
@@ -858,12 +863,14 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
         if (hasCoordinateSearch) {
           visibility[col.id] = columnVisibility[col.id] !== false;
         }
+      } else if (col.id === 'staleness' && forceStatusVisible) {
+        visibility[col.id] = true;
       } else {
         visibility[col.id] = columnVisibility[col.id] !== false;
       }
     });
     return visibility;
-  }, [columnVisibility, hasCoordinateSearch, columnConfig]);
+  }, [columnVisibility, hasCoordinateSearch, columnConfig, filters?.needs_review]);
 
   // Internal pagination state for client-side mode
   const [internalPagination, setInternalPagination] = useState({

--- a/web/components/spectra/StalenessBadge.tsx
+++ b/web/components/spectra/StalenessBadge.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { AlertTriangle } from 'lucide-react';
 import type { ObjectDetail } from '@/lib/types';
 
@@ -18,6 +18,15 @@ interface StalenessBadgeProps {
   lastInspectedAt: string | null;
   lastDataChangeAt: string | null;
   compact?: boolean;
+  /** When present alongside `version`, enables the click-to-open popover with a
+   *  "Mark as reviewed" action. Omit (or pass `compact`) for a static badge. */
+  objectId?: number;
+  version?: number;
+  /** Current user has can_comment — controls whether the action button is shown. */
+  canMarkReviewed?: boolean;
+  /** Fired after a successful PATCH so the parent can update local state and
+   *  hide the badge without a full refetch. */
+  onReviewed?: (next: { last_inspected_at: string; version: number }) => void;
 }
 
 export const StalenessBadge: React.FC<StalenessBadgeProps> = ({
@@ -25,14 +34,39 @@ export const StalenessBadge: React.FC<StalenessBadgeProps> = ({
   lastInspectedAt,
   lastDataChangeAt,
   compact = false,
+  objectId,
+  version,
+  canMarkReviewed = false,
+  onReviewed,
 }) => {
-  if (!reason || !lastInspectedAt) return null;
+  const [open, setOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
 
-  if (lastDataChangeAt && new Date(lastDataChangeAt) <= new Date(lastInspectedAt)) {
-    return null;
-  }
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [open]);
+
+  if (!reason || !lastInspectedAt) return null;
+  if (lastDataChangeAt && new Date(lastDataChangeAt) <= new Date(lastInspectedAt)) return null;
 
   const tooltip = REASON_COPY[reason];
+  const interactive = !compact && typeof objectId === 'number' && typeof version === 'number';
 
   if (compact) {
     return (
@@ -46,13 +80,83 @@ export const StalenessBadge: React.FC<StalenessBadgeProps> = ({
     );
   }
 
+  if (!interactive) {
+    return (
+      <span
+        className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-sm font-medium bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-300 border border-amber-200 dark:border-amber-800/50"
+        title={tooltip}
+      >
+        <AlertTriangle className="w-4 h-4" />
+        Needs Review
+      </span>
+    );
+  }
+
+  const handleMarkReviewed = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/objects/${objectId}/inspect`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ expected_version: version }),
+      });
+      const data = await res.json();
+      if (res.status === 409) {
+        setError('Another user changed this object — refresh to see the latest.');
+        return;
+      }
+      if (!res.ok) {
+        setError(data?.error || 'Failed to mark as reviewed.');
+        return;
+      }
+      const updated = data?.object;
+      const next = {
+        last_inspected_at: updated?.last_inspected_at ?? new Date().toISOString(),
+        version: updated?.version ?? version,
+      };
+      onReviewed?.(next);
+      setOpen(false);
+    } catch {
+      setError('Network error. Try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   return (
-    <span
-      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-sm font-medium bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-300 border border-amber-200 dark:border-amber-800/50"
-      title={tooltip}
-    >
-      <AlertTriangle className="w-4 h-4" />
-      Needs Review
-    </span>
+    <div ref={containerRef} className="relative inline-block">
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-sm font-medium bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-300 border border-amber-200 dark:border-amber-800/50 hover:bg-amber-200 dark:hover:bg-amber-900/60 transition-colors"
+      >
+        <AlertTriangle className="w-4 h-4" />
+        Needs Review
+      </button>
+      {open && (
+        <div className="absolute left-0 top-full mt-1.5 z-50 w-72 p-3 bg-background dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg shadow-lg">
+          <p className="text-sm text-text-primary dark:text-slate-200 mb-3">{tooltip}</p>
+          {error && (
+            <p className="text-xs text-red-600 dark:text-red-400 mb-2">{error}</p>
+          )}
+          {canMarkReviewed ? (
+            <button
+              type="button"
+              onClick={handleMarkReviewed}
+              disabled={submitting}
+              className="w-full px-3 py-1.5 text-sm font-medium rounded-md bg-primary text-white hover:bg-primary-hover disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+            >
+              {submitting ? 'Marking…' : 'Mark as reviewed'}
+            </button>
+          ) : (
+            <p className="text-xs text-text-secondary dark:text-slate-400">
+              You do not have permission to mark objects as reviewed.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
   );
 };

--- a/web/components/spectra/UnifiedObjectPage.tsx
+++ b/web/components/spectra/UnifiedObjectPage.tsx
@@ -22,6 +22,7 @@ import { PhotometrySED } from './PhotometrySED';
 import { ObjectComments } from './ObjectComments';
 import { NearbyObjects } from './NearbyObjects';
 import { StalenessBadge } from './StalenessBadge';
+import { useAuth } from '@/lib/contexts/AuthContext';
 
 interface UnifiedObjectPageProps {
   object: ObjectDetail;
@@ -34,6 +35,12 @@ function buildInitialVisibility(members: ObjectMemberTarget[]): Record<number, b
 }
 
 export const UnifiedObjectPage: React.FC<UnifiedObjectPageProps> = ({ object }) => {
+  const { userProfile } = useAuth();
+  // Local override for last_inspected_at so the "Mark as reviewed" action in
+  // the StalenessBadge can hide the badge without a full refetch. Reset on
+  // object change (see navigation effect below).
+  const [lastInspectedOverride, setLastInspectedOverride] = useState<string | null>(null);
+
   const colors = useMemo(() => {
     const c: Record<string, string> = {};
     object.member_targets.forEach((m, i) => {
@@ -192,6 +199,7 @@ export const UnifiedObjectPage: React.FC<UnifiedObjectPageProps> = ({ object }) 
       inspection.resetState(initialInspection);
       setExpandedSpectra(new Set());
       setSpectrumVisibility(buildInitialVisibility(object.member_targets));
+      setLastInspectedOverride(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [object.id]);
@@ -270,8 +278,12 @@ export const UnifiedObjectPage: React.FC<UnifiedObjectPageProps> = ({ object }) 
               </h1>
               <StalenessBadge
                 reason={object.staleness_reason}
-                lastInspectedAt={object.last_inspected_at}
+                lastInspectedAt={lastInspectedOverride ?? object.last_inspected_at}
                 lastDataChangeAt={object.last_data_change_at}
+                objectId={object.id}
+                version={inspection.version}
+                canMarkReviewed={!!userProfile?.can_comment}
+                onReviewed={({ last_inspected_at }) => setLastInspectedOverride(last_inspected_at)}
               />
               {!object.is_active && (
                 <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-200 dark:bg-slate-700 text-text-secondary dark:text-slate-300">

--- a/web/components/ui/FilterChip.tsx
+++ b/web/components/ui/FilterChip.tsx
@@ -84,6 +84,12 @@ interface FooterLink {
   href: string;
 }
 
+interface ExtraCheckbox {
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
 interface FilterChipProps {
   label: string;
   options: FilterOption[];
@@ -97,6 +103,9 @@ interface FilterChipProps {
   footerLink?: FooterLink;
   /** Direction dropdown opens. Default 'bottom'. Use 'top' when chip is near bottom of viewport. */
   dropdownPlacement?: 'bottom' | 'top';
+  /** Optional toggleable checkbox rendered below the options list, for filters that are
+   *  conceptually related to the main filter but aren't one of its discrete values. */
+  extraCheckbox?: ExtraCheckbox;
 }
 
 export const FilterChip: React.FC<FilterChipProps> = ({
@@ -111,6 +120,7 @@ export const FilterChip: React.FC<FilterChipProps> = ({
   searchable = false,
   footerLink,
   dropdownPlacement = 'bottom',
+  extraCheckbox,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
@@ -167,11 +177,13 @@ export const FilterChip: React.FC<FilterChipProps> = ({
   const handleClear = (e: React.MouseEvent) => {
     e.stopPropagation();
     onChange([]);
+    if (extraCheckbox?.checked) extraCheckbox.onChange(false);
   };
 
-  const isActive = selected.length > 0;
+  const activeCount = selected.length + (extraCheckbox?.checked ? 1 : 0);
+  const isActive = activeCount > 0;
   const displayText = isActive
-    ? `${label} (${selected.length})`
+    ? `${label} (${activeCount})`
     : label;
 
   return (
@@ -276,6 +288,28 @@ export const FilterChip: React.FC<FilterChipProps> = ({
             </div>
           </div>
 
+          {/* Extra checkbox (e.g., "Needs review only" for the Quality filter) */}
+          {extraCheckbox && (
+            <div className="border-t border-border dark:border-slate-700 p-1">
+              <button
+                onClick={() => extraCheckbox.onChange(!extraCheckbox.checked)}
+                className="w-full flex items-center gap-3 px-3 py-2 text-sm text-left hover:bg-card-hover dark:hover:bg-slate-700 rounded-md transition-colors"
+              >
+                <div
+                  className={`
+                    w-4 h-4 rounded border flex items-center justify-center flex-shrink-0 transition-all duration-200
+                    ${extraCheckbox.checked ? 'bg-primary border-primary scale-110' : 'border-border dark:border-slate-600'}
+                  `}
+                >
+                  {extraCheckbox.checked && <Check className="w-3 h-3 text-white" />}
+                </div>
+                <span className={extraCheckbox.checked ? 'text-text-primary dark:text-slate-100' : 'text-text-secondary dark:text-slate-400'}>
+                  {extraCheckbox.label}
+                </span>
+              </button>
+            </div>
+          )}
+
           {/* Shortcut button */}
           {shortcut && (
             <div className="border-t border-border dark:border-slate-700 p-2">
@@ -291,11 +325,12 @@ export const FilterChip: React.FC<FilterChipProps> = ({
           )}
 
           {/* Clear all button */}
-          {multiSelect && selected.length > 0 && (
+          {multiSelect && (selected.length > 0 || extraCheckbox?.checked) && (
             <div className={`${shortcut ? 'px-2 pb-2' : 'border-t border-border dark:border-slate-700 p-2'}`}>
               <button
                 onClick={() => {
                   onChange([]);
+                  if (extraCheckbox?.checked) extraCheckbox.onChange(false);
                   setIsOpen(false);
                 }}
                 className="w-full px-3 py-1.5 text-sm text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200 hover:bg-card dark:hover:bg-slate-700 rounded-md text-left transition-colors"

--- a/web/lib/actions/filter-params.ts
+++ b/web/lib/actions/filter-params.ts
@@ -37,6 +37,7 @@ export interface FilterOptions {
   list_ids: number[];
   dq_flags: number[];
   inspected_only: boolean | null;
+  needs_review: boolean | null;
   has_photometry: boolean | null;
   search: string;
   search_scope: SearchScope;
@@ -60,6 +61,7 @@ export const DEFAULT_FILTERS: FilterOptions = {
   list_ids: [],
   dq_flags: [],
   inspected_only: null,
+  needs_review: null,
   has_photometry: null,
   search: '',
   search_scope: 'target_id',
@@ -95,6 +97,7 @@ export interface FilterRpcParams {
   p_dq_flags_exclude: number | null;
   p_search: string | null;
   p_inspected_only: boolean | null;
+  p_needs_review: boolean | null;
   p_has_photometry: boolean | null;
   p_coord_ra: number | null;
   p_coord_dec: number | null;
@@ -170,6 +173,7 @@ export function buildFilterParams(
     p_dq_flags_exclude: dqMode === 'none' ? dqFlagsMask : null,
     p_search: targetIdSearch,
     p_inspected_only: filters?.inspected_only ?? null,
+    p_needs_review: filters?.needs_review ?? null,
     p_has_photometry: filters?.has_photometry ?? null,
     p_coord_ra: coordRa,
     p_coord_dec: coordDec,

--- a/web/lib/actions/map.ts
+++ b/web/lib/actions/map.ts
@@ -258,6 +258,7 @@ export async function getFilteredObjectIds(
       p_max_exposure_time_max: baseParams.p_max_exposure_time_max,
       p_search: baseParams.p_search,
       p_inspected_only: baseParams.p_inspected_only,
+      p_needs_review: baseParams.p_needs_review,
       p_has_photometry: baseParams.p_has_photometry,
       p_list_ids: baseParams.p_list_ids,
       p_coord_ra: baseParams.p_coord_ra,

--- a/web/lib/actions/spectra.ts
+++ b/web/lib/actions/spectra.ts
@@ -121,6 +121,7 @@ export async function getSpectra(
         p_max_exposure_time_max: rpcParams.p_max_exposure_time_max,
         p_search: rpcParams.p_search,
         p_inspected_only: rpcParams.p_inspected_only,
+        p_needs_review: rpcParams.p_needs_review,
         p_has_photometry: rpcParams.p_has_photometry,
         p_list_ids: rpcParams.p_list_ids,
         p_coord_ra: rpcParams.p_coord_ra,

--- a/web/lib/utils/url-params.ts
+++ b/web/lib/utils/url-params.ts
@@ -82,6 +82,7 @@ export function parseFiltersFromURL(searchParams: URLSearchParams): AdvancedFilt
     list_ids: parseNumberArray('tags'),
     dq_flags: parseNumberArray('dq_flags'),
     inspected_only: parseBoolean('inspected'),
+    needs_review: parseBoolean('needs_review'),
     has_photometry: parseBoolean('has_photometry'),
     search: searchParams.get('search') || '',
     search_scope: searchScope,
@@ -188,6 +189,9 @@ export function filtersToURLParams(
   }
   if (filters.inspected_only !== null) {
     params.set('inspected', filters.inspected_only.toString());
+  }
+  if (filters.needs_review !== null) {
+    params.set('needs_review', filters.needs_review.toString());
   }
   if (filters.has_photometry !== null) {
     params.set('has_photometry', filters.has_photometry.toString());


### PR DESCRIPTION
## Summary

- Detail-page **Needs Review** badge is now clickable — opens a small popover showing the reason and a "Mark as reviewed" button that PATCHes the existing `/api/objects/[id]/inspect` endpoint with just `expected_version`. `last_inspected_at` advances; the badge hides without a refetch. 409/permission states handled inline; compact (table) badge stays static.
- New **"Needs review only"** checkbox inside the Quality filter dropdown, backed by a new `p_needs_review BOOLEAN` param added to the 6 list/CSV/adjacency RPCs. Predicate mirrors the badge's visibility logic so filter results match what's badged.
- Objects-mode **Review** column renamed to **Status**, moved to the end of the column list, and hidden by default. When the filter is on, `tableColumnVisibility` force-shows the column without touching the user's saved preference in localStorage.
- `FilterChip` gains an optional `extraCheckbox` slot (generic — reusable for future "related but not an option" sub-filters inside other chips).

## Implementation notes

- Schema change is in `supabase/schemas/functions.sql`; generated migration `20260422153719_add_needs_review_filter.sql` drops/recreates the 6 affected RPCs. Migra also drops the dependent materialized views; I appended the `CREATE UNIQUE INDEX` + `GRANT` restoration at the tail (per the known migra limitation called out in CLAUDE.md).
- "Mark as reviewed" sends `{ expected_version }` only. The `bump_object_version` trigger only fires on redshift field changes, so this path doesn't bump the version — no extra 409s for concurrent redshift editors.
- New `needs_review: boolean | null` plumbed through `FilterOptions` → `FilterRpcParams` → `buildFilterParams` → URL params → all call-sites (objects + spectra paginated, map, CSV export, object ID list, adjacent-objects, /api/v1 routes).

## Test plan

- [ ] `supabase db reset` applies migration cleanly on preview branch
- [ ] Open a seeded needs-review object, click badge → popover shows reason, "Mark as reviewed" hides badge without reload
- [ ] Two-tab concurrency: mark reviewed in one, refresh blocked in the other with 409 message
- [ ] Sign in as `viewer@campfire.dev` (no `can_comment`) → popover shows reason only, no button
- [ ] Objects list: check "Needs review only" under Quality → list filters, Status column auto-appears, `?needs_review=true` in URL
- [ ] Clear filter → Status column hides again (user prefs untouched)
- [ ] CSV export / map filter honor `needs_review` on the wire
- [ ] `npm run build` clean

Generated with Claude Code