### PR TITLE
Preserve implicit redshift sign-offs; bump sync RPC timeouts

### DIFF
--- a/scripts/compare_best_redshift.py
+++ b/scripts/compare_best_redshift.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""
+Compare legacy ``objects.best_redshift`` (frozen after PR #99) against the new
+``objects.redshift`` generated column.
+
+PR #99 dropped the trigger that maintained ``best_redshift`` but kept the
+column, so its stored values reflect the pre-migration consensus. The new
+``redshift`` column is derived from ``redshift_inspected`` / ``redshift_auto``
+/ ``redshift_quality`` at the object level, with ``redshift_auto`` now picked
+by grating-priority (PRISM > medium > high-res) rather than per-target.
+
+Usage:
+    python scripts/compare_best_redshift.py
+    python scripts/compare_best_redshift.py --threshold 0.05
+    python scripts/compare_best_redshift.py --output diffs.csv
+    python scripts/compare_best_redshift.py --include-null-new
+    python scripts/compare_best_redshift.py --local
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import sys
+from pathlib import Path
+
+# Make the unified campfire package importable without requiring an editable
+# install, mirroring redeploy_redshifts.py.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "python"))
+
+from campfire.deploy.config import load_config
+from campfire.deploy.supabase import get_supabase_client
+
+PAGE_SIZE = 1000
+
+COLUMNS = (
+    "id, object_id, field, ra, dec, "
+    "best_redshift, best_redshift_quality, "
+    "redshift, redshift_auto, redshift_inspected, redshift_quality, "
+    "staleness_reason, last_inspected_at, last_data_change_at, "
+    "n_targets, n_spectra, gratings"
+)
+
+
+def needs_review(row: dict) -> bool:
+    """Mirror StalenessBadge logic (web/components/spectra/StalenessBadge.tsx).
+
+    The UI shows a "Needs Review" badge when all three hold:
+      1. staleness_reason is set
+      2. last_inspected_at is set (i.e. it has actually been inspected)
+      3. last_data_change_at is later than last_inspected_at
+    """
+    reason = row.get("staleness_reason")
+    last_inspected = row.get("last_inspected_at")
+    last_data_change = row.get("last_data_change_at")
+    if not reason or not last_inspected:
+        return False
+    if not last_data_change:
+        return False
+    return last_data_change > last_inspected
+
+
+def fetch_all_objects(supabase) -> list[dict]:
+    """Page through objects where best_redshift is set."""
+    rows: list[dict] = []
+    offset = 0
+    while True:
+        resp = (
+            supabase.table("objects")
+            .select(COLUMNS)
+            .not_.is_("best_redshift", "null")
+            .order("id")
+            .range(offset, offset + PAGE_SIZE - 1)
+            .execute()
+        )
+        batch = resp.data or []
+        rows.extend(batch)
+        if len(batch) < PAGE_SIZE:
+            break
+        offset += PAGE_SIZE
+        print(f"  fetched {len(rows)} objects...", file=sys.stderr)
+    return rows
+
+
+def classify(row: dict, threshold: float, include_null_new: bool):
+    old = row.get("best_redshift")
+    new = row.get("redshift")
+
+    if old is None:
+        return None  # should not happen — filtered out server-side
+
+    if new is None:
+        if include_null_new:
+            return ("null_new", float("inf"))
+        return None
+
+    dz = float(new) - float(old)
+    if abs(dz) > threshold:
+        return ("diff", dz)
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--threshold", type=float, default=0.1,
+        help="|redshift - best_redshift| threshold for flagging (default 0.1).",
+    )
+    parser.add_argument(
+        "--include-null-new", action="store_true",
+        help="Also report objects whose new redshift is NULL (e.g. quality=1 Impossible).",
+    )
+    parser.add_argument(
+        "--output", type=Path, default=None,
+        help="Optional CSV path to write the flagged rows to.",
+    )
+    parser.add_argument(
+        "--local", action="store_true",
+        help="Query local Supabase instead of production.",
+    )
+    parser.add_argument(
+        "--config", type=str, default=None,
+        help="Override deploy config TOML path.",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None,
+        help="Stop after printing N flagged rows to the terminal (CSV still gets all).",
+    )
+    args = parser.parse_args()
+
+    config = load_config(args.config, local=args.local)
+    supabase = get_supabase_client(config)
+
+    target_url = config["supabase"]["url"]
+    print(f"Querying {target_url} ...")
+
+    rows = fetch_all_objects(supabase)
+    print(f"Fetched {len(rows)} objects with best_redshift IS NOT NULL.")
+
+    flagged: list[tuple[dict, str, float]] = []
+    for row in rows:
+        verdict = classify(row, args.threshold, args.include_null_new)
+        if verdict is None:
+            continue
+        kind, dz = verdict
+        flagged.append((row, kind, dz))
+
+    # Sort: largest absolute delta first, null_new at the top
+    flagged.sort(key=lambda x: (x[1] != "null_new", -abs(x[2]) if x[2] != float("inf") else 0))
+
+    print()
+    print(
+        f"Flagged {len(flagged)} / {len(rows)} objects "
+        f"(|dz| > {args.threshold}"
+        f"{', including NULL-new' if args.include_null_new else ''})."
+    )
+
+    if not flagged:
+        return
+
+    # Terminal report
+    hdr = (
+        f"{'id':>7} {'object_id':<22} {'field':<18} "
+        f"{'old_bz':>8} {'old_q':>5} "
+        f"{'new_z':>8} {'new_q':>5} {'dz':>8} {'z_auto':>8} "
+        f"{'z_insp':>8} {'rev':<4} {'staleness':<22}"
+    )
+    print()
+    print(hdr)
+    print("-" * len(hdr))
+
+    printed = 0
+    for row, kind, dz in flagged:
+        if args.limit is not None and printed >= args.limit:
+            remaining = len(flagged) - printed
+            print(f"... {remaining} more rows not shown (raise --limit or use --output).")
+            break
+
+        def fmt(v, spec=">8.4f"):
+            return format(v, spec) if v is not None else "—".rjust(8)
+
+        dz_str = "NULL" if kind == "null_new" else f"{dz:>+8.4f}"
+        review = "YES" if needs_review(row) else ""
+        print(
+            f"{row['id']:>7} {str(row.get('object_id') or ''):<22} "
+            f"{str(row.get('field') or ''):<18} "
+            f"{fmt(row.get('best_redshift')):>8} "
+            f"{(row.get('best_redshift_quality') if row.get('best_redshift_quality') is not None else '—')!s:>5} "
+            f"{fmt(row.get('redshift')):>8} "
+            f"{(row.get('redshift_quality') if row.get('redshift_quality') is not None else '—')!s:>5} "
+            f"{dz_str:>8} "
+            f"{fmt(row.get('redshift_auto')):>8} "
+            f"{fmt(row.get('redshift_inspected')):>8} "
+            f"{review:<4} "
+            f"{str(row.get('staleness_reason') or ''):<22}"
+        )
+        printed += 1
+
+    if args.output:
+        fieldnames = [
+            "id", "object_id", "field", "ra", "dec",
+            "best_redshift", "best_redshift_quality",
+            "redshift", "redshift_auto", "redshift_inspected", "redshift_quality",
+            "delta_z", "kind", "needs_review",
+            "staleness_reason", "last_inspected_at", "last_data_change_at",
+            "n_targets", "n_spectra", "gratings",
+        ]
+        with open(args.output, "w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=fieldnames)
+            w.writeheader()
+            for row, kind, dz in flagged:
+                out = {k: row.get(k) for k in fieldnames if k in row}
+                out["delta_z"] = "" if kind == "null_new" else f"{dz:.6f}"
+                out["kind"] = kind
+                out["needs_review"] = "yes" if needs_review(row) else "no"
+                w.writerow(out)
+        print()
+        print(f"Wrote {len(flagged)} rows to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repair_implicit_signoff_redshifts.py
+++ b/scripts/repair_implicit_signoff_redshifts.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""
+One-time repair: preserve implicit sign-offs lost across the Phase D migration.
+
+Context
+-------
+Pre-Phase-D, inspectors often signed off on an object by stamping a quality flag
+without typing a numeric override. The legacy ``update_object_best_redshift``
+trigger froze ``objects.best_redshift`` at ``COALESCE(target.redshift_inspected,
+target.redshift_auto)`` for the chosen member target at the moment of the
+inspection.
+
+The Phase D migration copied ``redshift_quality`` / ``redshift_inspected`` to
+the object but made the generated ``redshift`` column depend on
+``objects.redshift_auto``. Any reprocessing that changed the per-spectrum
+``redshift_auto`` after the original sign-off silently moves the object's
+``redshift``, without updating quality — so the database advertises a
+Tentative/Probable/Secure tag on a number nobody reviewed.
+
+This script identifies those affected objects and pins the old signed-off
+value into ``redshift_inspected`` so the generated ``redshift`` returns to
+what the inspector actually approved. It also sets ``staleness_reason =
+'reprocessed'`` and ``last_data_change_at = NOW()`` so the UI surfaces a
+"Needs Review" badge on every repaired row.
+
+Affected set
+------------
+    objects.best_redshift IS NOT NULL
+    AND objects.best_redshift_quality >= 2
+    AND objects.redshift_inspected IS NULL
+    AND (objects.redshift IS NULL
+         OR ABS(objects.redshift::float8 - objects.best_redshift) > 1e-4)
+
+Quality = 1 (Impossible) is intentionally excluded — the generated redshift is
+NULL by design and there's nothing to restore.
+
+Usage
+-----
+    python scripts/repair_implicit_signoff_redshifts.py              # dry run
+    python scripts/repair_implicit_signoff_redshifts.py --apply      # write
+    python scripts/repair_implicit_signoff_redshifts.py --local      # local DB
+    python scripts/repair_implicit_signoff_redshifts.py --output plan.csv
+
+Requires service-role credentials (to bypass the non-admin column-scope trigger
+on the objects table). ``campfire login`` JWTs will NOT work.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "python"))
+
+from campfire.deploy.config import load_config
+from campfire.deploy.supabase import get_supabase_client
+
+PAGE_SIZE = 1000
+EPSILON = 0.03  # floating-point tolerance; precision of stored numeric(10,6) is 1e-6
+
+COLUMNS = (
+    "id, object_id, field, "
+    "best_redshift, best_redshift_quality, "
+    "redshift, redshift_auto, redshift_inspected, redshift_quality, "
+    "staleness_reason, last_inspected_at, last_data_change_at, version"
+)
+
+
+def is_affected(row: dict) -> bool:
+    best = row.get("best_redshift")
+    bq = row.get("best_redshift_quality")
+    inspected = row.get("redshift_inspected")
+    z = row.get("redshift")
+    if best is None or bq is None or bq < 2:
+        return False
+    if inspected is not None:
+        return False
+    if z is None:
+        return True
+    try:
+        return abs(float(z) - float(best)) > EPSILON
+    except (TypeError, ValueError):
+        return True
+
+
+def fetch_candidates(supabase) -> list[dict]:
+    """Pull every object with best_redshift_quality >= 2 and redshift_inspected NULL.
+
+    We filter affected-ness client-side so we can also report the near-miss
+    "same number" rows for inspection. The server filters the cheap predicates.
+    """
+    rows: list[dict] = []
+    offset = 0
+    while True:
+        resp = (
+            supabase.table("objects")
+            .select(COLUMNS)
+            .gte("best_redshift_quality", 2)
+            .not_.is_("best_redshift", "null")
+            .is_("redshift_inspected", "null")
+            .order("id")
+            .range(offset, offset + PAGE_SIZE - 1)
+            .execute()
+        )
+        batch = resp.data or []
+        rows.extend(batch)
+        if len(batch) < PAGE_SIZE:
+            break
+        offset += PAGE_SIZE
+        print(f"  fetched {len(rows)} candidate rows...", file=sys.stderr)
+    return rows
+
+
+def print_plan(affected: list[dict], limit: int | None):
+    if not affected:
+        print("No affected objects — nothing to repair.")
+        return
+
+    hdr = (
+        f"{'id':>7} {'object_id':<22} {'field':<18} "
+        f"{'best_bz':>9} {'best_q':>6} {'cur_z':>9} {'cur_q':>5} "
+        f"{'cur_auto':>9} {'ver':>4}"
+    )
+    print()
+    print(hdr)
+    print("-" * len(hdr))
+
+    shown = 0
+    for r in affected:
+        if limit is not None and shown >= limit:
+            print(f"... {len(affected) - shown} more rows not shown.")
+            break
+        def fmt(v):
+            return f"{float(v):>9.4f}" if v is not None else "—".rjust(9)
+        print(
+            f"{r['id']:>7} {str(r.get('object_id') or ''):<22} "
+            f"{str(r.get('field') or ''):<18} "
+            f"{fmt(r.get('best_redshift'))} "
+            f"{(r.get('best_redshift_quality') or 0):>6} "
+            f"{fmt(r.get('redshift'))} "
+            f"{(r.get('redshift_quality') or 0):>5} "
+            f"{fmt(r.get('redshift_auto'))} "
+            f"{(r.get('version') or 0):>4}"
+        )
+        shown += 1
+
+
+def write_csv(affected: list[dict], path: Path):
+    fieldnames = [
+        "id", "object_id", "field",
+        "best_redshift", "best_redshift_quality",
+        "redshift", "redshift_auto", "redshift_inspected", "redshift_quality",
+        "staleness_reason", "last_inspected_at", "last_data_change_at", "version",
+    ]
+    with open(path, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames)
+        w.writeheader()
+        for r in affected:
+            w.writerow({k: r.get(k) for k in fieldnames})
+    print(f"Wrote {len(affected)} planned updates to {path}")
+
+
+def apply_repairs(supabase, affected: list[dict], batch_size: int):
+    """Apply updates in batches. Each row update touches redshift_inspected
+    (which fires bump_object_version + log_object_inspection_changes) plus
+    staleness_reason / last_data_change_at (non-inspection fields, gated by
+    enforce_object_user_update_scope — service role bypasses)."""
+    now = datetime.now(timezone.utc).isoformat()
+    applied = 0
+    failed = 0
+    batch: list[dict] = []
+
+    def flush():
+        nonlocal applied, failed
+        if not batch:
+            return
+        # Per-row update — PostgREST UPSERT would require every row share the
+        # same column set, which it does, but would also create rows if an id
+        # disappeared. A per-row PATCH is safer.
+        for upd in batch:
+            try:
+                (
+                    supabase.table("objects")
+                    .update({
+                        "redshift_inspected": upd["redshift_inspected"],
+                        "staleness_reason": "reprocessed",
+                        "last_data_change_at": now,
+                    })
+                    .eq("id", upd["id"])
+                    .execute()
+                )
+                applied += 1
+            except Exception as exc:
+                failed += 1
+                print(f"  FAILED id={upd['id']}: {exc}", file=sys.stderr)
+        batch.clear()
+
+    for r in affected:
+        batch.append({
+            "id": r["id"],
+            "redshift_inspected": float(r["best_redshift"]),
+        })
+        if len(batch) >= batch_size:
+            flush()
+            print(f"  applied {applied} / {len(affected)}...", file=sys.stderr)
+
+    flush()
+    print(f"Applied {applied} repairs. {failed} failures.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--apply", action="store_true",
+                        help="Actually write the repairs. Default is dry-run.")
+    parser.add_argument("--output", type=Path, default=None,
+                        help="Write the plan to CSV.")
+    parser.add_argument("--limit", type=int, default=50,
+                        help="Terminal row cap (CSV and --apply still process all). Default 50.")
+    parser.add_argument("--batch-size", type=int, default=200,
+                        help="Apply batch size. Default 200.")
+    parser.add_argument("--local", action="store_true",
+                        help="Run against the local Supabase instance.")
+    parser.add_argument("--config", type=str, default=None,
+                        help="Override deploy config TOML path.")
+    args = parser.parse_args()
+
+    config = load_config(args.config, local=args.local)
+    if not config.get("supabase", {}).get("service_role_key"):
+        print("Error: service-role credentials required.", file=sys.stderr)
+        print("       This script updates staleness_reason / last_data_change_at,", file=sys.stderr)
+        print("       which the non-admin column-scope trigger forbids.", file=sys.stderr)
+        print("       Set CAMPFIRE_SUPABASE_SERVICE_ROLE_KEY or use --local.", file=sys.stderr)
+        sys.exit(2)
+
+    supabase = get_supabase_client(config)
+    print(f"Querying {config['supabase']['url']} ...")
+
+    candidates = fetch_candidates(supabase)
+    affected = [r for r in candidates if is_affected(r)]
+    unchanged = len(candidates) - len(affected)
+
+    print(
+        f"{len(candidates)} candidates (quality>=2, best_redshift set, no redshift_inspected). "
+        f"{len(affected)} affected, {unchanged} match their best_redshift (no repair needed)."
+    )
+
+    # Break down by best_redshift_quality for visibility
+    buckets: dict[int, int] = {}
+    for r in affected:
+        buckets[r["best_redshift_quality"]] = buckets.get(r["best_redshift_quality"], 0) + 1
+    if buckets:
+        print("Affected by old quality:")
+        for q in sorted(buckets):
+            label = {2: "Tentative", 3: "Probable", 4: "Secure"}.get(q, f"q={q}")
+            print(f"  {label:<10} (q={q}): {buckets[q]}")
+
+    print_plan(affected, args.limit)
+
+    if args.output:
+        write_csv(affected, args.output)
+
+    if not args.apply:
+        print()
+        print("DRY RUN — no changes written. Re-run with --apply to execute.")
+        return
+
+    if not affected:
+        return
+
+    print()
+    confirm = input(f"Apply {len(affected)} repairs to {config['supabase']['url']}? [yes/NO] ")
+    if confirm.strip().lower() != "yes":
+        print("Aborted.")
+        return
+
+    apply_repairs(supabase, affected, args.batch_size)
+
+
+if __name__ == "__main__":
+    main()

--- a/supabase/migrations/20260423160000_bump_sync_rpc_timeout.sql
+++ b/supabase/migrations/20260423160000_bump_sync_rpc_timeout.sql
@@ -1,0 +1,26 @@
+-- Raise statement_timeout on the three /sync/* RPCs.
+--
+-- OFFSET-based pagination is linear in offset: each page has to scan and
+-- order up to `offset + limit` rows before returning. On a 30k-object
+-- catalog the final `--full` sync page (offset=29000) was tipping past
+-- the default service_role statement timeout, failing with SQLSTATE
+-- 57014 ("canceling statement due to statement timeout"). The per-page
+-- aggregate CTEs in get_objects_for_sync add to the floor.
+--
+-- Raising the per-function timeout to 120s unblocks the current Python
+-- client without a client-side change. The right fix is to switch these
+-- RPCs to keyset pagination (WHERE object_id > cursor ORDER BY ...),
+-- which is O(log N + limit) per page; that change can follow in a
+-- separate PR and this SET can be dropped at that point.
+
+ALTER FUNCTION public.get_objects_for_sync(
+  text[], uuid, timestamptz, integer, integer, boolean
+) SET statement_timeout TO '120s';
+
+ALTER FUNCTION public.get_spectra_for_sync(
+  text[], uuid, timestamptz, integer, integer, boolean
+) SET statement_timeout TO '120s';
+
+ALTER FUNCTION public.get_photometry_for_sync(
+  text[], timestamptz, integer, integer
+) SET statement_timeout TO '120s';

--- a/supabase/migrations/20260423180000_compute_object_redshift_auto_preserve_signoffs.sql
+++ b/supabase/migrations/20260423180000_compute_object_redshift_auto_preserve_signoffs.sql
@@ -1,0 +1,89 @@
+-- compute_object_redshift_auto: preserve implicit sign-offs when the auto-fit
+-- changes under an already-inspected object.
+--
+-- Previously this function silently overwrote objects.redshift_auto whenever
+-- the best member spectrum produced a new value. For objects where an
+-- inspector had committed a quality flag without entering a numeric override
+-- (redshift_quality >= 2 AND redshift_inspected IS NULL), the generated
+-- ``redshift`` column simply tracked redshift_auto — meaning reprocessing
+-- could silently move the object's displayed redshift off the value the
+-- inspector actually reviewed, while keeping the quality flag intact.
+--
+-- New behavior: when such a sign-off exists AND the auto-fit is about to
+-- change, we first promote the OLD redshift_auto into redshift_inspected
+-- (pinning the generated redshift to what was reviewed) and flag
+-- ``staleness_reason = 'reprocessed'`` so the UI surfaces a "Needs Review"
+-- badge. Uninspected objects (quality = 0), explicit-override objects
+-- (redshift_inspected IS NOT NULL), and Impossible objects (quality = 1,
+-- generated redshift is already NULL) are unaffected.
+--
+-- See scripts/repair_implicit_signoff_redshifts.py for the one-time cleanup
+-- of sign-offs already lost in Phase D.1 / post-migration re-deploys.
+
+CREATE OR REPLACE FUNCTION public.compute_object_redshift_auto(p_field TEXT)
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  n INTEGER;
+BEGIN
+  WITH computed AS (
+    SELECT o.id,
+           o.redshift_auto AS old_auto,
+           o.redshift_inspected AS old_inspected,
+           o.redshift_quality AS quality,
+           (
+             SELECT s.redshift_auto
+             FROM targets t
+             JOIN spectra s ON s.target_id = t.target_id
+             WHERE t.object_id = o.id
+               AND s.redshift_auto IS NOT NULL
+             ORDER BY
+               CASE
+                 WHEN s.grating = 'PRISM' THEN 0
+                 WHEN s.grating IN ('G140M', 'G235M', 'G395M') THEN 1
+                 WHEN s.grating IN ('G140H', 'G235H', 'G395H') THEN 2
+                 ELSE 3
+               END ASC,
+               s.exposure_time DESC NULLS LAST,
+               s.id ASC
+             LIMIT 1
+           ) AS new_val
+    FROM objects o
+    WHERE o.field = p_field
+  )
+  UPDATE objects o
+  SET redshift_auto = c.new_val,
+      redshift_inspected = CASE
+        WHEN c.quality >= 2
+             AND c.old_inspected IS NULL
+             AND c.old_auto IS NOT NULL
+             AND c.new_val IS DISTINCT FROM c.old_auto
+        THEN c.old_auto::numeric
+        ELSE o.redshift_inspected
+      END,
+      staleness_reason = CASE
+        WHEN c.quality >= 2
+             AND c.old_inspected IS NULL
+             AND c.old_auto IS NOT NULL
+             AND c.new_val IS DISTINCT FROM c.old_auto
+        THEN 'reprocessed'
+        ELSE o.staleness_reason
+      END,
+      last_data_change_at = CASE
+        WHEN c.quality >= 2
+             AND c.old_inspected IS NULL
+             AND c.old_auto IS NOT NULL
+             AND c.new_val IS DISTINCT FROM c.old_auto
+        THEN NOW()
+        ELSE o.last_data_change_at
+      END,
+      updated_at = NOW()
+  FROM computed c
+  WHERE o.id = c.id
+    AND o.redshift_auto IS DISTINCT FROM c.new_val;
+
+  GET DIAGNOSTICS n = ROW_COUNT;
+  RETURN n;
+END;
+$$;


### PR DESCRIPTION
## Summary
- **Preserve implicit sign-offs on reprocess** (`compute_object_redshift_auto`): when an object has a sign-off (quality>=2, `redshift_inspected IS NULL`) and the auto-fit is about to change, the old `redshift_auto` is promoted into `redshift_inspected` and `staleness_reason='reprocessed'` is set so the UI surfaces a Needs Review badge. Previously the displayed redshift could silently drift out from under an inspector's review. Schema source-of-truth (`supabase/schemas/functions.sql`) already carries this body — this migration just syncs production.
- **Bump statement_timeout to 120s on `get_objects_for_sync` / `get_spectra_for_sync` / `get_photometry_for_sync`**: deep offset pages on a 30k-object catalog were tipping past the default service_role timeout. Keyset pagination is the proper fix; this unblocks the Python client in the meantime.
- **`scripts/repair_implicit_signoff_redshifts.py`**: one-time cleanup for sign-offs already lost across Phase D re-deploys. Pins the legacy `best_redshift` into `redshift_inspected` and flags `staleness_reason='reprocessed'`.
- **`scripts/compare_best_redshift.py`**: diagnostic comparing legacy `best_redshift` vs. the new generated `redshift` column; used to scope the repair.

## Test plan
- [ ] Supabase preview branch applies both migrations cleanly against the seeded DB
- [ ] `compare_best_redshift.py --local` runs against the preview DB and produces expected diff counts
- [ ] `repair_implicit_signoff_redshifts.py` dry-run on production lists only rows matching the affected set (quality>=2, `redshift_inspected IS NULL`, redshift drift)
- [ ] After merge: trigger a re-deploy on a field with known implicit sign-offs; verify `redshift_inspected` is populated and Needs Review badge appears

Generated with Claude Code