### PR TITLE
Simplify redshift column names in objects CSV export

### DIFF
--- a/web/lib/actions/download.ts
+++ b/web/lib/actions/download.ts
@@ -40,8 +40,8 @@ interface ObjectsCsvRow {
   field: string;
   ra: number;
   dec: number;
-  best_redshift: number | null;
-  best_redshift_quality: number;
+  redshift: number | null;
+  redshift_quality: number;
   n_targets: number;
   n_spectra: number;
   programs: string;            // semicolon-separated
@@ -279,8 +279,8 @@ function objectsRowsToCsv(rows: ObjectsCsvRow[], includeDistance: boolean): stri
     'field',
     'ra',
     'dec',
-    'best_redshift',
-    'best_redshift_quality',
+    'redshift',
+    'redshift_quality',
     'n_observations',
     'n_spectra',
     'programs',
@@ -315,8 +315,8 @@ function objectsRowsToCsv(rows: ObjectsCsvRow[], includeDistance: boolean): stri
     }
 
     values.push(
-      row.best_redshift != null ? row.best_redshift.toFixed(6) : '',
-      row.best_redshift_quality,
+      row.redshift != null ? row.redshift.toFixed(6) : '',
+      row.redshift_quality,
       row.n_targets,
       row.n_spectra,
       escapeCsvValue(row.programs || ''),


### PR DESCRIPTION
## Summary
Renamed redshift-related column names in the objects CSV export to use simpler, more concise naming conventions.

## Changes
- Renamed `best_redshift` to `redshift` in the `ObjectsCsvRow` interface and CSV output
- Renamed `best_redshift_quality` to `redshift_quality` in the `ObjectsCsvRow` interface and CSV output
- Updated all references in the `objectsRowsToCsv()` function to use the new column names

## Details
This change simplifies the CSV column headers and internal field names by removing the "best_" prefix, making the naming more straightforward while maintaining the same functionality. The change affects both the TypeScript interface definition and the CSV generation logic.

https://claude.ai/code/session_01YFF1QSpnE812BLPjYVUGdB