### PR TITLE
feat: derive reduction_version from git commit hash

### DIFF
--- a/pipeline/campfire_pipeline/cli.py
+++ b/pipeline/campfire_pipeline/cli.py
@@ -85,7 +85,8 @@ def info(config_path):
     cfg = load_config(config_path)
     setup_environment(cfg)
 
-    version = cfg.get('pipeline', {}).get('version', 'unknown')
+    from campfire_pipeline.common.version import get_reduction_version
+    version = get_reduction_version(cfg)
     click.echo(f"  Pipeline ver:   {version}")
 
     # CRDS settings

--- a/pipeline/campfire_pipeline/common/version.py
+++ b/pipeline/campfire_pipeline/common/version.py
@@ -1,0 +1,61 @@
+"""Resolve the reduction version string embedded in pipeline outputs."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import campfire_pipeline
+
+
+def _run_git(args: list[str], cwd: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ['git', *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    return result.stdout.strip() or None
+
+
+def _repo_root() -> Path:
+    # campfire_pipeline/__init__.py lives at <repo>/pipeline/campfire_pipeline/
+    return Path(campfire_pipeline.__file__).resolve().parent.parent.parent
+
+
+def _git_version() -> str | None:
+    repo = _repo_root()
+    if not (repo / '.git').exists():
+        return None
+    commit = _run_git(['rev-parse', '--short=12', 'HEAD'], repo)
+    if not commit:
+        return None
+    dirty = _run_git(['status', '--porcelain'], repo)
+    return f'{commit}-dirty' if dirty else commit
+
+
+def get_reduction_version(config: dict | None = None) -> str:
+    """Return the reduction version string to embed in pipeline outputs.
+
+    Resolution order:
+    1. ``config['pipeline']['version']`` if explicitly set (escape hatch).
+    2. Short git commit hash of the campfire repo, with ``-dirty`` suffix
+       when the working tree has uncommitted changes.
+    3. Fallback ``v{__version__}-nogit`` when git metadata is unavailable
+       (e.g., installed from an sdist).
+    """
+    if config is not None:
+        override = config.get('pipeline', {}).get('version')
+        if override:
+            return override
+
+    git_ver = _git_version()
+    if git_ver:
+        return git_ver
+
+    return f'v{campfire_pipeline.__version__}-nogit'

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -2,7 +2,10 @@
 # Export with: cfpipe config > my_config.toml
 
 [pipeline]
-    version = "v0.3"
+    # Reduction version is auto-computed as the campfire git commit hash
+    # (with '-dirty' suffix if the working tree has uncommitted changes).
+    # Uncomment to pin a specific version string instead:
+    # version = "v0.3"
 
 [environment]
     CRDS_SERVER_URL = "https://jwst-crds.stsci.edu"

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -4,8 +4,8 @@
 [pipeline]
     # Reduction version is auto-computed as the campfire git commit hash
     # (with '-dirty' suffix if the working tree has uncommitted changes).
-    # Uncomment to pin a specific version string instead:
-    # version = "v0.3"
+    # Uncomment to pin a specific version string instead, e.g.:
+    # version = "release-v1.0"
 
 [environment]
     CRDS_SERVER_URL = "https://jwst-crds.stsci.edu"

--- a/pipeline/campfire_pipeline/nirspec/cli.py
+++ b/pipeline/campfire_pipeline/nirspec/cli.py
@@ -325,7 +325,8 @@ def _run_summary(cfg, obs_obj):
         write_shutters_ecsv,
     )
 
-    version = cfg.get('pipeline', {}).get('version', 'unknown')
+    from campfire_pipeline.common.version import get_reduction_version
+    version = get_reduction_version(cfg)
     consensus_config = cfg.get('nirspec', {}).get('redshift_consensus', {})
     obs_dir = Path(obs_obj.workspace_dir)
     summary_table = generate_observation_summary(obs_obj.name, obs_dir,

--- a/pipeline/campfire_pipeline/nirspec/engine.py
+++ b/pipeline/campfire_pipeline/nirspec/engine.py
@@ -104,7 +104,8 @@ class ReductionEngine:
             write_effective_config,
             write_summary_ecsv,
         )
-        version = self.config.get('pipeline', {}).get('version', 'unknown')
+        from campfire_pipeline.common.version import get_reduction_version
+        version = get_reduction_version(self.config)
         consensus_config = self.config.get('nirspec', {}).get('redshift_consensus', {})
         obs_dir = Path(obs.workspace_dir)
         summary = generate_observation_summary(obs.name, obs_dir,

--- a/pipeline/campfire_pipeline/nirspec/stage3.py
+++ b/pipeline/campfire_pipeline/nirspec/stage3.py
@@ -41,7 +41,8 @@ def run_stage3(obs, stage_config, config, source_ids='all', n_processes=1,
     from campfire_pipeline.common.parallel import dispatch
     from campfire_pipeline.nirspec.observation import Observation
 
-    version = config.get('pipeline', {}).get('version', 'unknown')
+    from campfire_pipeline.common.version import get_reduction_version
+    version = get_reduction_version(config)
     log(f"Stage 3 config for {obs.name}: {stage_config}")
 
     bkg_subtraction_method = stage_config.get('method', 'nodded')
@@ -338,7 +339,7 @@ def opt_ext_single_source(
             continue
 
     ph['CMPFRTIM'] = (str(datetime.now()), 'Date/time of CAMPFIRE reduction')
-    ph['CMPFRVER'] = (version, 'Version of CAMPFIRE reduction')
+    ph['CMPFRVER'] = (version, 'CAMPFIRE git commit (or pinned version)')
 
     primary = fits.PrimaryHDU(header=ph)
 
@@ -568,7 +569,7 @@ def combine_per_eg_spectra(
         except KeyError:
             continue
     ph['CMPFRTIM'] = (str(datetime.now()), 'Date/time of CAMPFIRE reduction')
-    ph['CMPFRVER'] = (version, 'Version of CAMPFIRE reduction')
+    ph['CMPFRVER'] = (version, 'CAMPFIRE git commit (or pinned version)')
     ph['CMPFRSTG'] = ('stage3-1d', 'CAMPFIRE stage that produced this file')
     ph['NCOMBINE'] = (len(per_eg_spec_files), 'Number of per-exp_group spectra combined')
     primary = fits.PrimaryHDU(header=ph)


### PR DESCRIPTION
Closes #101

## What was requested?
Store the pipeline reduction version as a hash of the campfire commit used to reduce the data, instead of the hardcoded `"v0.3"` string in `config_default.toml`.

## What I implemented
- New helper `campfire_pipeline.common.version.get_reduction_version(config)` that:
  - Returns an explicit `config['pipeline']['version']` if the user pinned one (escape hatch).
  - Otherwise resolves the campfire repo's short git commit hash via `git rev-parse --short=12 HEAD`, appending `-dirty` when the working tree has uncommitted changes.
  - Falls back to `v{__version__}-nogit` when run from an installation without `.git` metadata (e.g., sdist install).
- Replaced the four `cfg.get('pipeline', {}).get('version', 'unknown')` call sites (`cli.py`, `nirspec/cli.py`, `nirspec/engine.py`, `nirspec/stage3.py`) with the helper.
- Removed the hardcoded `version = "v0.3"` default from `config_default.toml`, leaving the field commented as an optional override.
- Updated the `CMPFRVER` FITS header comment to reflect the new meaning.

## Design decisions
- **Short hash (12 chars) rather than full 40.** Keeps the FITS header and UI readable while staying well beyond the collision threshold for a single repo's history.
- **`-dirty` suffix on unclean working trees.** Without this, a commit hash silently lies about what code actually ran. Matches the `git describe --dirty` convention.
- **Config override retained.** Useful for tagged releases, CI fixtures, or ad-hoc reruns where provenance should point to a named version rather than a commit. Removing it would have been a gratuitous regression; keeping it is one extra check.
- **Resolved the repo root via `Path(campfire_pipeline.__file__).parent.parent.parent`.** Package lives at `<repo>/pipeline/campfire_pipeline/`, so this is stable regardless of install location. Falls back cleanly when `.git` is absent.

## Testing
- `cd pipeline && pytest tests/` — 22 passed.
- `cfpipe info` prints `Pipeline ver:   4a0a834128cf-dirty` on the current tree (verified hash matches `git rev-parse --short=12 HEAD`).
- Verified three-way resolution of the helper (no config, empty config, explicit override) with a quick REPL check.

Generated with Claude Code