### PR TITLE
Pin redshift at sign-off time to prevent reprocessing drift

### DIFF
--- a/supabase/migrations/20260425000000_pin_redshift_on_signoff.sql
+++ b/supabase/migrations/20260425000000_pin_redshift_on_signoff.sql
@@ -1,0 +1,656 @@
+-- =============================================================================
+-- Pin redshift at sign-off time
+-- =============================================================================
+-- Adds objects.inspected_used_auto + a BEFORE INSERT/UPDATE trigger that
+-- promotes redshift_auto into redshift_inspected the moment an inspector
+-- commits quality >= 2 without typing a numeric override. The displayed
+-- redshift (the generated `redshift` column) is therefore stable across
+-- reprocessing for every signed-off object.
+--
+-- Companion changes:
+--   * compute_object_redshift_auto loses its post-hoc auto-promotion (the
+--     trigger handles it at write time) but keeps a relaxed staleness signal:
+--     any signed-off object whose redshift_auto changed is flagged
+--     'reprocessed' so inspectors see a "Needs Review" badge.
+--   * enforce_object_user_update_scope rejects direct non-admin writes to
+--     inspected_used_auto (the trigger is the only legitimate writer).
+--   * get_objects_for_sync and get_filtered_objects_paginated surface the
+--     new column so the UI can avoid showing an "(overridden)" hint when
+--     the inspector merely accepted the auto-fit.
+-- =============================================================================
+
+
+-- 1. Column + one-time backfill ------------------------------------------------
+
+ALTER TABLE public.objects
+  ADD COLUMN IF NOT EXISTS inspected_used_auto boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.objects.inspected_used_auto IS
+  'True when redshift_inspected was auto-pinned from redshift_auto at sign-off (implicit sign-off path). False for explicit user-typed overrides and for uninspected/impossible rows. Maintained exclusively by the pin_redshift_on_signoff trigger; the UI uses this to avoid showing an "(overridden)" hint when the inspector merely accepted the auto-fit.';
+
+-- Backfill existing implicit sign-offs so the invariant
+--   quality >= 2 ==> redshift_inspected IS NOT NULL
+-- holds before the trigger is installed. Without this, the first reprocess
+-- would still walk the displayed redshift for legacy rows.
+UPDATE public.objects
+SET redshift_inspected = redshift_auto::numeric,
+    inspected_used_auto = true
+WHERE redshift_quality >= 2
+  AND redshift_inspected IS NULL
+  AND redshift_auto IS NOT NULL;
+
+
+-- 2. pin_redshift_on_signoff trigger function ---------------------------------
+
+CREATE OR REPLACE FUNCTION public.pin_redshift_on_signoff() RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NEW.redshift_quality >= 2 THEN
+        IF NEW.redshift_inspected IS NULL AND NEW.redshift_auto IS NOT NULL THEN
+            NEW.redshift_inspected := NEW.redshift_auto::numeric;
+            NEW.inspected_used_auto := true;
+        ELSIF TG_OP = 'UPDATE'
+              AND NEW.redshift_inspected IS NOT NULL
+              AND NEW.redshift_inspected IS DISTINCT FROM OLD.redshift_inspected THEN
+            NEW.inspected_used_auto := false;
+        ELSIF TG_OP = 'INSERT' AND NEW.redshift_inspected IS NOT NULL THEN
+            NEW.inspected_used_auto := false;
+        END IF;
+    ELSE
+        NEW.redshift_inspected := NULL;
+        NEW.inspected_used_auto := false;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+
+-- 3. Register the trigger -----------------------------------------------------
+
+DROP TRIGGER IF EXISTS pin_redshift_on_signoff_trigger ON public.objects;
+CREATE TRIGGER pin_redshift_on_signoff_trigger
+  BEFORE INSERT OR UPDATE OF redshift_inspected, redshift_quality ON public.objects
+  FOR EACH ROW EXECUTE FUNCTION public.pin_redshift_on_signoff();
+
+
+-- 4. enforce_object_user_update_scope: reject direct writes to the new column
+--    The pin trigger is the only legitimate writer for non-admin sessions.
+
+CREATE OR REPLACE FUNCTION public.enforce_object_user_update_scope() RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+BEGIN
+    IF auth.uid() IS NULL OR public.is_admin() THEN
+        RETURN NEW;
+    END IF;
+
+    IF OLD.object_id IS DISTINCT FROM NEW.object_id
+       OR OLD.field IS DISTINCT FROM NEW.field
+       OR OLD.ra IS DISTINCT FROM NEW.ra
+       OR OLD.dec IS DISTINCT FROM NEW.dec
+       OR OLD.n_targets IS DISTINCT FROM NEW.n_targets
+       OR OLD.n_spectra IS DISTINCT FROM NEW.n_spectra
+       OR OLD.programs IS DISTINCT FROM NEW.programs
+       OR OLD.gratings IS DISTINCT FROM NEW.gratings
+       OR OLD.observations IS DISTINCT FROM NEW.observations
+       OR OLD.max_snr IS DISTINCT FROM NEW.max_snr
+       OR OLD.max_exposure_time IS DISTINCT FROM NEW.max_exposure_time
+       OR OLD.best_redshift IS DISTINCT FROM NEW.best_redshift
+       OR OLD.best_redshift_quality IS DISTINCT FROM NEW.best_redshift_quality
+       OR OLD.photo_z IS DISTINCT FROM NEW.photo_z
+       OR OLD.photo_z_err_lo IS DISTINCT FROM NEW.photo_z_err_lo
+       OR OLD.photo_z_err_hi IS DISTINCT FROM NEW.photo_z_err_hi
+       OR OLD.has_photometry IS DISTINCT FROM NEW.has_photometry
+       OR OLD.redshift_auto IS DISTINCT FROM NEW.redshift_auto
+       OR OLD.last_data_change_at IS DISTINCT FROM NEW.last_data_change_at
+       OR OLD.staleness_reason IS DISTINCT FROM NEW.staleness_reason
+       OR OLD.inspected_used_auto IS DISTINCT FROM NEW.inspected_used_auto
+       OR OLD.is_active IS DISTINCT FROM NEW.is_active
+       OR OLD.created_at IS DISTINCT FROM NEW.created_at
+    THEN
+        RAISE EXCEPTION 'Non-admin updates to objects may only change inspection fields (redshift_inspected, redshift_quality, last_inspected_at, last_inspected_by)'
+            USING ERRCODE = '42501';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+
+-- 5. compute_object_redshift_auto: drop the post-hoc auto-promotion -----------
+--    The pin trigger now handles sign-off pinning at write time, so this
+--    function only updates redshift_auto and flags reprocessed staleness for
+--    any signed-off object whose auto-fit changed (regardless of whether
+--    redshift_inspected is NULL or set — the displayed redshift is pinned
+--    either way, but the inspector should see the badge).
+
+CREATE OR REPLACE FUNCTION public.compute_object_redshift_auto(p_field TEXT)
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  n INTEGER;
+BEGIN
+  WITH computed AS (
+    SELECT o.id,
+           o.redshift_auto AS old_auto,
+           o.redshift_quality AS quality,
+           (
+             SELECT s.redshift_auto
+             FROM targets t
+             JOIN spectra s ON s.target_id = t.target_id
+             WHERE t.object_id = o.id
+               AND s.redshift_auto IS NOT NULL
+             ORDER BY
+               CASE
+                 WHEN s.grating = 'PRISM' THEN 0
+                 WHEN s.grating IN ('G140M', 'G235M', 'G395M') THEN 1
+                 WHEN s.grating IN ('G140H', 'G235H', 'G395H') THEN 2
+                 ELSE 3
+               END ASC,
+               s.exposure_time DESC NULLS LAST,
+               s.id ASC
+             LIMIT 1
+           ) AS new_val
+    FROM objects o
+    WHERE o.field = p_field
+  )
+  UPDATE objects o
+  SET redshift_auto = c.new_val,
+      staleness_reason = CASE
+        WHEN c.quality >= 2
+             AND c.old_auto IS DISTINCT FROM c.new_val
+        THEN 'reprocessed'
+        ELSE o.staleness_reason
+      END,
+      last_data_change_at = CASE
+        WHEN c.quality >= 2
+             AND c.old_auto IS DISTINCT FROM c.new_val
+        THEN NOW()
+        ELSE o.last_data_change_at
+      END,
+      updated_at = NOW()
+  FROM computed c
+  WHERE o.id = c.id
+    AND o.redshift_auto IS DISTINCT FROM c.new_val;
+
+  GET DIAGNOSTICS n = ROW_COUNT;
+  RETURN n;
+END;
+$$;
+
+
+-- 6. get_objects_for_sync: surface inspected_used_auto in the JSONB payload --
+
+CREATE OR REPLACE FUNCTION public.get_objects_for_sync(
+  p_program_slugs TEXT[],
+  p_user_id UUID DEFAULT NULL,
+  p_updated_since TIMESTAMPTZ DEFAULT NULL,
+  p_limit INTEGER DEFAULT 1000,
+  p_offset INTEGER DEFAULT 0,
+  p_include_counts BOOLEAN DEFAULT TRUE
+)
+RETURNS TABLE(objects JSONB, total_count BIGINT, total_accessible_count BIGINT)
+LANGUAGE plpgsql STABLE
+SET plan_cache_mode = 'force_custom_plan'
+SET statement_timeout = '120s'
+AS $$
+BEGIN
+  RETURN QUERY
+  WITH matched AS MATERIALIZED (
+    SELECT o.id, o.object_id, o.field, o.ra, o.dec,
+           o.n_targets, o.n_spectra, o.programs, o.gratings,
+           o.max_snr, o.max_exposure_time,
+           o.redshift, o.redshift_quality,
+           o.redshift_inspected, o.redshift_auto,
+           o.inspected_used_auto,
+           o.last_inspected_at, o.last_inspected_by,
+           o.last_data_change_at, o.staleness_reason,
+           o.version, o.is_active,
+           o.has_photometry, o.photo_z, o.photo_z_err_lo, o.photo_z_err_hi,
+           o.created_at, o.updated_at
+    FROM objects o
+    WHERE o.programs && p_program_slugs
+      AND o.is_active = true
+      AND (p_updated_since IS NULL OR o.updated_at > p_updated_since)
+    ORDER BY o.object_id
+    LIMIT p_limit OFFSET p_offset
+  ),
+  member_targets_agg AS (
+    SELECT t.object_id,
+           jsonb_agg(t.target_id ORDER BY t.target_id) AS target_ids
+    FROM targets t
+    WHERE t.object_id IN (SELECT id FROM matched)
+      AND t.program_slug = ANY(p_program_slugs)
+    GROUP BY t.object_id
+  ),
+  spectra_agg AS (
+    SELECT t.object_id,
+           jsonb_agg(jsonb_build_object(
+             'id', s.id,
+             'target_id', s.target_id,
+             'grating', s.grating,
+             'signal_to_noise', s.signal_to_noise,
+             'exposure_time', s.exposure_time,
+             'redshift_auto', s.redshift_auto,
+             'dq_flags', s.dq_flags
+           ) ORDER BY s.target_id, s.grating) AS spectra
+    FROM spectra s
+    JOIN targets t ON t.target_id = s.target_id
+    WHERE t.object_id IN (SELECT id FROM matched)
+      AND t.program_slug = ANY(p_program_slugs)
+    GROUP BY t.object_id
+  ),
+  lists_agg AS (
+    SELECT olm.object_id,
+           jsonb_agg(ol.slug ORDER BY ol.slug) AS list_slugs
+    FROM object_list_members olm
+    JOIN object_lists ol ON ol.id = olm.list_id
+    WHERE olm.object_id IN (SELECT id FROM matched)
+      AND (ol.created_by = p_user_id
+           OR ol.visibility IN ('public_read', 'public_edit'))
+    GROUP BY olm.object_id
+  ),
+  total AS (
+    SELECT COUNT(*) AS cnt
+    FROM objects o
+    WHERE p_include_counts
+      AND o.programs && p_program_slugs
+      AND o.is_active = true
+      AND (p_updated_since IS NULL OR o.updated_at > p_updated_since)
+  ),
+  accessible AS (
+    SELECT COUNT(*) AS cnt
+    FROM objects o
+    WHERE p_include_counts
+      AND o.programs && p_program_slugs
+      AND o.is_active = true
+  )
+  SELECT
+    COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'id', m.id,
+        'object_id', m.object_id,
+        'field', m.field,
+        'ra', m.ra,
+        'dec', m.dec,
+        'n_targets', m.n_targets,
+        'n_spectra', m.n_spectra,
+        'programs', m.programs,
+        'gratings', m.gratings,
+        'max_snr', m.max_snr,
+        'max_exposure_time', m.max_exposure_time,
+        'redshift', m.redshift,
+        'redshift_quality', m.redshift_quality,
+        'redshift_inspected', m.redshift_inspected,
+        'redshift_auto', m.redshift_auto,
+        'inspected_used_auto', m.inspected_used_auto,
+        'last_inspected_at', m.last_inspected_at,
+        'last_inspected_by', m.last_inspected_by,
+        'last_data_change_at', m.last_data_change_at,
+        'staleness_reason', m.staleness_reason,
+        'version', m.version,
+        'is_active', m.is_active,
+        'has_photometry', m.has_photometry,
+        'photo_z', m.photo_z,
+        'photo_z_err_lo', m.photo_z_err_lo,
+        'photo_z_err_hi', m.photo_z_err_hi,
+        'created_at', m.created_at,
+        'updated_at', m.updated_at,
+        'member_target_ids', COALESCE(mt.target_ids, '[]'::jsonb),
+        'spectra',           COALESCE(sp.spectra,    '[]'::jsonb),
+        'lists',             COALESCE(la.list_slugs, '[]'::jsonb)
+      )
+    ), '[]'::jsonb),
+    COALESCE((SELECT cnt FROM total), 0)::BIGINT,
+    COALESCE((SELECT cnt FROM accessible), 0)::BIGINT
+  FROM matched m
+  LEFT JOIN member_targets_agg mt ON mt.object_id = m.id
+  LEFT JOIN spectra_agg         sp ON sp.object_id = m.id
+  LEFT JOIN lists_agg           la ON la.object_id = m.id;
+END;
+$$;
+
+
+-- 7. get_filtered_objects_paginated: surface inspected_used_auto -------------
+
+CREATE OR REPLACE FUNCTION public.get_filtered_objects_paginated(
+  p_program_slugs TEXT[],
+  p_filter_programs TEXT[] DEFAULT NULL,
+  p_fields TEXT[] DEFAULT NULL,
+  p_gratings TEXT[] DEFAULT NULL,
+  p_gratings_mode TEXT DEFAULT 'any',
+  p_observations TEXT[] DEFAULT NULL,
+  p_redshift_quality INTEGER[] DEFAULT NULL,
+  p_redshift_min DOUBLE PRECISION DEFAULT NULL,
+  p_redshift_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_snr_min DOUBLE PRECISION DEFAULT NULL,
+  p_max_snr_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_exposure_time_min DOUBLE PRECISION DEFAULT NULL,
+  p_max_exposure_time_max DOUBLE PRECISION DEFAULT NULL,
+  p_search TEXT DEFAULT NULL,
+  p_inspected_only BOOLEAN DEFAULT NULL,
+  p_needs_review BOOLEAN DEFAULT NULL,
+  p_list_ids INTEGER[] DEFAULT NULL,
+  p_coord_ra DOUBLE PRECISION DEFAULT NULL,
+  p_coord_dec DOUBLE PRECISION DEFAULT NULL,
+  p_radius_degrees DOUBLE PRECISION DEFAULT NULL,
+  p_has_photometry BOOLEAN DEFAULT NULL,
+  p_photo_z_min DOUBLE PRECISION DEFAULT NULL,
+  p_photo_z_max DOUBLE PRECISION DEFAULT NULL,
+  p_sort_column TEXT DEFAULT 'object_id',
+  p_sort_direction TEXT DEFAULT 'asc',
+  p_page INTEGER DEFAULT 1,
+  p_page_size INTEGER DEFAULT 50
+)
+RETURNS TABLE(targets JSONB, total_count BIGINT, page INTEGER, page_size INTEGER)
+LANGUAGE plpgsql STABLE
+SET plan_cache_mode = 'force_custom_plan'
+AS $$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_offset INTEGER;
+  v_total_count BIGINT;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
+    v_gratings_mode := 'any';
+  END IF;
+
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN
+    p_sort_direction := 'asc';
+  END IF;
+
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time', 'photo_z'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+
+  IF v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN
+    p_sort_column := 'distance';
+  END IF;
+
+  v_offset := (COALESCE(p_page, 1) - 1) * COALESCE(p_page_size, 50);
+
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(
+      SELECT unnest(p_program_slugs)
+      INTERSECT
+      SELECT unnest(p_filter_programs)
+    ) INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN QUERY SELECT '[]'::jsonb, 0::BIGINT, p_page, p_page_size;
+    RETURN;
+  END IF;
+
+  SELECT COUNT(*) INTO v_total_count
+  FROM objects o
+  WHERE
+    o.programs && v_filtered_program_slugs
+    AND o.is_active = true
+    AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+    AND (
+      NOT v_grating_filter_active
+      OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+      OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+      OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+    )
+    AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+    AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+    AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+    AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+    AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+    AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+    AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+    AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+    AND (p_search IS NULL OR o.object_id ILIKE '%' || p_search || '%'
+      OR EXISTS (SELECT 1 FROM targets t WHERE t.object_id = o.id AND t.target_id ILIKE '%' || p_search || '%'))
+    AND (
+      p_inspected_only IS NULL
+      OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+      OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+    )
+    AND (
+      p_needs_review IS NULL
+      OR (p_needs_review = TRUE
+          AND o.staleness_reason IS NOT NULL
+          AND o.last_inspected_at IS NOT NULL
+          AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+      OR (p_needs_review = FALSE
+          AND (o.staleness_reason IS NULL
+               OR o.last_inspected_at IS NULL
+               OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+    )
+    AND (
+      NOT v_coord_search_active
+      OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+        AND 2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) <= p_radius_degrees
+      )
+    )
+    AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+        SELECT olm.object_id FROM object_list_members olm
+        WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+    ))
+    AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+    AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+    AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max);
+
+  RETURN QUERY
+  WITH filtered_objects AS (
+    SELECT
+      o.id,
+      o.object_id,
+      o.field,
+      o.ra,
+      o.dec,
+      o.n_targets,
+      o.n_spectra,
+      o.programs,
+      o.gratings,
+      o.max_snr,
+      o.max_exposure_time,
+      o.redshift,
+      o.redshift_quality,
+      o.redshift_inspected,
+      o.redshift_auto,
+      o.inspected_used_auto,
+      o.last_inspected_at,
+      o.last_inspected_by,
+      o.last_data_change_at,
+      o.staleness_reason,
+      o.version,
+      o.is_active,
+      o.photo_z,
+      o.has_photometry,
+      o.created_at,
+      CASE
+        WHEN v_coord_search_active THEN
+          2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+            POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+          )))
+        ELSE NULL
+      END AS distance
+    FROM objects o
+    WHERE
+      o.programs && v_filtered_program_slugs
+      AND o.is_active = true
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+        OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+        OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+      )
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_search IS NULL OR o.object_id ILIKE '%' || p_search || '%'
+      OR EXISTS (SELECT 1 FROM targets t WHERE t.object_id = o.id AND t.target_id ILIKE '%' || p_search || '%'))
+      AND (
+        p_inspected_only IS NULL
+        OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+        OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+      )
+      AND (
+        p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+      )
+      AND (
+        NOT v_coord_search_active
+        OR (
+          o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+          AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+          AND 2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+            POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+          ))) <= p_radius_degrees
+        )
+      )
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+      AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+    ORDER BY
+      CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN
+        2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN
+        2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN o.object_id END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'desc' THEN o.object_id END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN o.field END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN o.field END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN o.ra END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN o.ra END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN o.dec END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN o.dec END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN o.redshift END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN o.redshift END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN o.redshift_quality END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN o.redshift_quality END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'asc' THEN o.n_targets END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'desc' THEN o.n_targets END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'asc' THEN o.n_spectra END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'desc' THEN o.n_spectra END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN o.max_snr END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN o.max_snr END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN o.max_exposure_time END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN o.max_exposure_time END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'asc' THEN o.photo_z END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'desc' THEN o.photo_z END DESC NULLS LAST,
+      o.object_id ASC
+    LIMIT p_page_size OFFSET v_offset
+  ),
+  with_members AS (
+    SELECT
+      jsonb_build_object(
+        'id', fo.id,
+        'object_id', fo.object_id,
+        'field', fo.field,
+        'ra', fo.ra,
+        'dec', fo.dec,
+        'n_targets', fo.n_targets,
+        'n_spectra', fo.n_spectra,
+        'programs', fo.programs,
+        'gratings', fo.gratings,
+        'max_snr', fo.max_snr,
+        'max_exposure_time', fo.max_exposure_time,
+        'redshift', fo.redshift,
+        'redshift_quality', fo.redshift_quality,
+        'redshift_inspected', fo.redshift_inspected,
+        'redshift_auto', fo.redshift_auto,
+        'inspected_used_auto', fo.inspected_used_auto,
+        'last_inspected_at', fo.last_inspected_at,
+        'last_inspected_by', fo.last_inspected_by,
+        'last_data_change_at', fo.last_data_change_at,
+        'staleness_reason', fo.staleness_reason,
+        'version', fo.version,
+        'is_active', fo.is_active,
+        'photo_z', fo.photo_z,
+        'has_photometry', fo.has_photometry,
+        'created_at', fo.created_at,
+        'distance', fo.distance,
+        'member_targets', COALESCE(
+          (SELECT jsonb_agg(
+            jsonb_build_object(
+              'target_id', t.target_id,
+              'program_slug', t.program_slug,
+              'observation', t.observation,
+              'redshift_auto', t.redshift_auto
+            )
+          )
+          FROM targets t
+          WHERE t.object_id = fo.id
+            AND t.program_slug = ANY(v_filtered_program_slugs)
+          ),
+          '[]'::jsonb
+        ),
+        'lists', COALESCE(
+          (SELECT jsonb_agg(
+            jsonb_build_object(
+              'id', ol.id,
+              'name', ol.name,
+              'slug', ol.slug,
+              'icon', ol.icon,
+              'color', ol.color
+            ) ORDER BY ol.name
+          )
+          FROM object_list_members olm
+          JOIN object_lists ol ON ol.id = olm.list_id
+          WHERE olm.object_id = fo.id),
+          '[]'::jsonb
+        )
+      ) AS obj_json
+    FROM filtered_objects fo
+  )
+  SELECT
+    COALESCE(jsonb_agg(wm.obj_json), '[]'::jsonb),
+    v_total_count,
+    p_page,
+    p_page_size
+  FROM with_members wm;
+END;
+$$;

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -160,6 +160,7 @@ BEGIN
            o.max_snr, o.max_exposure_time,
            o.redshift, o.redshift_quality,
            o.redshift_inspected, o.redshift_auto,
+           o.inspected_used_auto,
            o.last_inspected_at, o.last_inspected_by,
            o.last_data_change_at, o.staleness_reason,
            o.version, o.is_active,
@@ -247,6 +248,7 @@ BEGIN
         'redshift_quality', m.redshift_quality,
         'redshift_inspected', m.redshift_inspected,
         'redshift_auto', m.redshift_auto,
+        'inspected_used_auto', m.inspected_used_auto,
         'last_inspected_at', m.last_inspected_at,
         'last_inspected_by', m.last_inspected_by,
         'last_data_change_at', m.last_data_change_at,
@@ -960,6 +962,7 @@ BEGIN
       o.redshift_quality,
       o.redshift_inspected,
       o.redshift_auto,
+      o.inspected_used_auto,
       o.last_inspected_at,
       o.last_inspected_by,
       o.last_data_change_at,
@@ -1090,6 +1093,7 @@ BEGIN
         'redshift_quality', fo.redshift_quality,
         'redshift_inspected', fo.redshift_inspected,
         'redshift_auto', fo.redshift_auto,
+        'inspected_used_auto', fo.inspected_used_auto,
         'last_inspected_at', fo.last_inspected_at,
         'last_inspected_by', fo.last_inspected_by,
         'last_data_change_at', fo.last_data_change_at,
@@ -2594,17 +2598,20 @@ GRANT EXECUTE ON FUNCTION public.recompute_target_aggregates(TEXT[]) TO service_
 -- clients would silently miss redshift_auto changes from pipeline reruns.
 -- ROW_COUNT is then the true number of objects whose value changed.
 --
--- Implicit sign-off preservation: when an inspector committed a quality flag
--- (redshift_quality >= 2) without entering a numeric override
--- (redshift_inspected IS NULL), the generated ``redshift`` column resolves to
--- whatever ``redshift_auto`` currently holds. Letting this function silently
--- overwrite redshift_auto would silently move the object's displayed redshift
--- out from under the sign-off. Instead, for any such object whose redshift_auto
--- is about to change, we promote the OLD redshift_auto into redshift_inspected
--- (pinning the generated redshift to what the inspector actually reviewed) and
--- flag ``staleness_reason = 'reprocessed'`` so the UI surfaces a "Needs Review"
--- badge. Inspectors can then reaffirm (no-op) or clear redshift_inspected to
--- accept the new auto-fit.
+-- Sign-off pinning is now handled at write time by the
+-- pin_redshift_on_signoff trigger: any object reaching quality >= 2 with
+-- redshift_inspected = NULL has its current redshift_auto promoted into
+-- redshift_inspected and inspected_used_auto = true. The displayed redshift
+-- (the generated `redshift` column) is therefore stable across reprocessing
+-- for every signed-off object — this function never has to worry about
+-- moving a value out from under an inspector.
+--
+-- Staleness signal: when redshift_auto changes for an already-signed-off
+-- object (quality >= 2), we still flag staleness_reason='reprocessed' and
+-- bump last_data_change_at so the UI surfaces a "Needs Review" badge.
+-- The pinned displayed redshift is unchanged, but the inspector should
+-- know the underlying fit shifted in case they want to update their
+-- override or reaffirm the existing one.
 CREATE OR REPLACE FUNCTION public.compute_object_redshift_auto(p_field TEXT)
 RETURNS INTEGER
 LANGUAGE plpgsql
@@ -2615,7 +2622,6 @@ BEGIN
   WITH computed AS (
     SELECT o.id,
            o.redshift_auto AS old_auto,
-           o.redshift_inspected AS old_inspected,
            o.redshift_quality AS quality,
            (
              SELECT s.redshift_auto
@@ -2639,27 +2645,15 @@ BEGIN
   )
   UPDATE objects o
   SET redshift_auto = c.new_val,
-      redshift_inspected = CASE
-        WHEN c.quality >= 2
-             AND c.old_inspected IS NULL
-             AND c.old_auto IS NOT NULL
-             AND c.new_val IS DISTINCT FROM c.old_auto
-        THEN c.old_auto::numeric
-        ELSE o.redshift_inspected
-      END,
       staleness_reason = CASE
         WHEN c.quality >= 2
-             AND c.old_inspected IS NULL
-             AND c.old_auto IS NOT NULL
-             AND c.new_val IS DISTINCT FROM c.old_auto
+             AND c.old_auto IS DISTINCT FROM c.new_val
         THEN 'reprocessed'
         ELSE o.staleness_reason
       END,
       last_data_change_at = CASE
         WHEN c.quality >= 2
-             AND c.old_inspected IS NULL
-             AND c.old_auto IS NOT NULL
-             AND c.new_val IS DISTINCT FROM c.old_auto
+             AND c.old_auto IS DISTINCT FROM c.new_val
         THEN NOW()
         ELSE o.last_data_change_at
       END,

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -467,6 +467,7 @@ CREATE TABLE IF NOT EXISTS "public"."objects" (
     "redshift_auto" double precision,
     "redshift_inspected" numeric(10,6),
     "redshift_quality" integer NOT NULL DEFAULT 0,
+    "inspected_used_auto" boolean NOT NULL DEFAULT false,
     "redshift" numeric(10,6) GENERATED ALWAYS AS (
         CASE
             WHEN ("redshift_quality" = 1) THEN NULL::double precision
@@ -491,7 +492,10 @@ COMMENT ON TABLE "public"."objects" IS 'Unique sky positions cross-matched acros
 COMMENT ON COLUMN "public"."objects"."redshift_auto" IS 'Phase A: per-object auto-fit redshift, computed post-reconciliation by compute_object_redshift_auto() from the best member spectrum under a grating-priority hierarchy (PRISM > medium > high-res, tiebreak on exposure_time). Empty until Phase D migration.';
 
 
-COMMENT ON COLUMN "public"."objects"."redshift_inspected" IS 'Phase A: user-set redshift override at the object level. Empty until Phase D migration.';
+COMMENT ON COLUMN "public"."objects"."redshift_inspected" IS 'Phase A: user-set redshift override at the object level. Empty until Phase D migration. After the pin-on-signoff migration, also populated automatically (= redshift_auto, with inspected_used_auto = true) when an inspector commits a quality flag without typing a numeric override — this stabilizes the displayed redshift across reprocessing.';
+
+
+COMMENT ON COLUMN "public"."objects"."inspected_used_auto" IS 'True when redshift_inspected was auto-pinned from redshift_auto at sign-off (implicit sign-off path). False for explicit user-typed overrides and for uninspected/impossible rows. Maintained exclusively by the pin_redshift_on_signoff trigger; the UI uses this to avoid showing an "(overridden)" hint when the inspector merely accepted the auto-fit.';
 
 
 COMMENT ON COLUMN "public"."objects"."redshift_quality" IS 'Phase A: 0=uninspected, 1=Impossible, 2=Tentative, 3=Probable, 4=Secure. Default 0. Empty until Phase D migration.';

--- a/supabase/schemas/triggers.sql
+++ b/supabase/schemas/triggers.sql
@@ -130,6 +130,7 @@ BEGIN
        OR OLD.redshift_auto IS DISTINCT FROM NEW.redshift_auto
        OR OLD.last_data_change_at IS DISTINCT FROM NEW.last_data_change_at
        OR OLD.staleness_reason IS DISTINCT FROM NEW.staleness_reason
+       OR OLD.inspected_used_auto IS DISTINCT FROM NEW.inspected_used_auto
        OR OLD.is_active IS DISTINCT FROM NEW.is_active
        OR OLD.created_at IS DISTINCT FROM NEW.created_at
     THEN
@@ -137,6 +138,66 @@ BEGIN
             USING ERRCODE = '42501';  -- insufficient_privilege
     END IF;
 
+    RETURN NEW;
+END;
+$$;
+
+
+-- 4b. pin_redshift_on_signoff
+--     Pins the displayed redshift at the moment an inspector signs off.
+--
+--     The generated `redshift` column is COALESCE(redshift_inspected, redshift_auto)
+--     (when quality != 1). If an inspector commits quality >= 2 without entering
+--     a numeric override, the displayed redshift falls through to redshift_auto
+--     — which compute_object_redshift_auto() can move under their feet on the
+--     next reprocess. This trigger eliminates that "implicit sign-off" failure
+--     mode by promoting the current redshift_auto into redshift_inspected at
+--     sign-off time, recording inspected_used_auto = true so the UI knows the
+--     value wasn't typed.
+--
+--     Cases handled (only fires on inspector-driven UPDATEs by being scoped to
+--     OF redshift_inspected, redshift_quality — reconcile-driven redshift_auto
+--     bumps don't trip it):
+--       - quality >= 2 AND inspected IS NULL AND auto IS NOT NULL:
+--           pin → inspected = auto, used_auto = true
+--       - quality >= 2 AND inspected changes to a NEW non-null value:
+--           explicit override → used_auto = false
+--       - quality < 2 (uninspected or Impossible):
+--           drop the pin → inspected = NULL, used_auto = false
+--
+--     Trigger ordering: PostgreSQL fires BEFORE triggers in alphabetical order,
+--     so on UPDATE we get bump → enforce → pin → track. enforce runs before
+--     pin can mutate inspected_used_auto, so it correctly rejects direct
+--     non-admin writes to the column. track runs after pin, so the audit log
+--     captures the final NEW.redshift_inspected value (matches what's stored).
+DROP FUNCTION IF EXISTS public.pin_redshift_on_signoff CASCADE;
+
+CREATE OR REPLACE FUNCTION public.pin_redshift_on_signoff() RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NEW.redshift_quality >= 2 THEN
+        IF NEW.redshift_inspected IS NULL AND NEW.redshift_auto IS NOT NULL THEN
+            -- Implicit sign-off: pin to the current auto-fit so reprocessing
+            -- can't silently move the displayed redshift.
+            NEW.redshift_inspected := NEW.redshift_auto::numeric;
+            NEW.inspected_used_auto := true;
+        ELSIF TG_OP = 'UPDATE'
+              AND NEW.redshift_inspected IS NOT NULL
+              AND NEW.redshift_inspected IS DISTINCT FROM OLD.redshift_inspected THEN
+            -- Explicit override (newly typed or changed): clear the auto flag.
+            NEW.inspected_used_auto := false;
+        ELSIF TG_OP = 'INSERT' AND NEW.redshift_inspected IS NOT NULL THEN
+            -- Initial insert with an explicit override.
+            NEW.inspected_used_auto := false;
+        END IF;
+    ELSE
+        -- quality < 2: object is uninspected or Impossible. Drop the pin so
+        -- redshift_inspected reflects "no user override" again. The generated
+        -- redshift column handles Impossible (quality=1 → NULL) on its own.
+        NEW.redshift_inspected := NULL;
+        NEW.inspected_used_auto := false;
+    END IF;
     RETURN NEW;
 END;
 $$;
@@ -276,6 +337,15 @@ DROP TRIGGER IF EXISTS enforce_object_user_update_scope_trigger ON public.object
 CREATE TRIGGER enforce_object_user_update_scope_trigger
   BEFORE UPDATE ON public.objects
   FOR EACH ROW EXECUTE FUNCTION public.enforce_object_user_update_scope();
+
+-- Pin the displayed redshift at sign-off time. Scoped to inspector-driven
+-- columns so reconcile-driven redshift_auto updates don't fire it. Fires
+-- alphabetically after enforce_object_user_update_scope so any auto-pinning
+-- it does is invisible to the column-scope check (which has already passed).
+DROP TRIGGER IF EXISTS pin_redshift_on_signoff_trigger ON public.objects;
+CREATE TRIGGER pin_redshift_on_signoff_trigger
+  BEFORE INSERT OR UPDATE OF redshift_inspected, redshift_quality ON public.objects
+  FOR EACH ROW EXECUTE FUNCTION public.pin_redshift_on_signoff();
 
 
 -- Per-spectrum DQ flag changes

--- a/web/components/spectra/UnifiedObjectPage.tsx
+++ b/web/components/spectra/UnifiedObjectPage.tsx
@@ -184,10 +184,11 @@ export const UnifiedObjectPage: React.FC<UnifiedObjectPageProps> = ({ object }) 
     redshift_auto: object.redshift_auto,
     redshift_inspected: object.redshift_inspected,
     redshift_quality: object.redshift_quality,
+    inspected_used_auto: object.inspected_used_auto,
     last_inspected_at: object.last_inspected_at,
     last_inspected_by: object.last_inspected_by,
     version: object.version,
-  }), [object.redshift_auto, object.redshift_inspected, object.redshift_quality, object.last_inspected_at, object.last_inspected_by, object.version]);
+  }), [object.redshift_auto, object.redshift_inspected, object.redshift_quality, object.inspected_used_auto, object.last_inspected_at, object.last_inspected_by, object.version]);
 
   const inspection = useInspectionState(object.id, initialInspection);
 

--- a/web/components/spectra/inspection/DashboardPanel.tsx
+++ b/web/components/spectra/inspection/DashboardPanel.tsx
@@ -62,6 +62,7 @@ export const DashboardPanel: React.FC<DashboardPanelProps> = ({
           state={inspectionState}
           canEdit={canEdit}
           redshiftAuto={object.redshift_auto}
+          redshiftInspected={object.redshift_inspected}
           redshiftInputRef={redshiftInputRef}
         />
         <QualitySection state={inspectionState} canEdit={canEdit} />

--- a/web/components/spectra/inspection/InspectionModeOverlay.tsx
+++ b/web/components/spectra/inspection/InspectionModeOverlay.tsx
@@ -70,6 +70,7 @@ function inspectionInitialFromObject(o: ObjectDetail): InspectionInitialData {
     redshift_auto: o.redshift_auto,
     redshift_inspected: o.redshift_inspected,
     redshift_quality: o.redshift_quality,
+    inspected_used_auto: o.inspected_used_auto,
     last_inspected_at: o.last_inspected_at,
     last_inspected_by: o.last_inspected_by,
     version: o.version,

--- a/web/components/spectra/inspection/RedshiftSection.tsx
+++ b/web/components/spectra/inspection/RedshiftSection.tsx
@@ -8,6 +8,11 @@ interface RedshiftSectionProps {
   state: InspectionState;
   canEdit: boolean;
   redshiftAuto: number | null;
+  /** Stored redshift_inspected (may have been pinned at sign-off). Used as
+   *  the "Current" display fallback when the override input is empty so the
+   *  panel shows the inspector's pinned value rather than a freshly
+   *  reprocessed auto-fit. */
+  redshiftInspected: number | null;
   redshiftInputRef?: React.RefObject<HTMLInputElement | null>;
 }
 
@@ -19,6 +24,7 @@ export const RedshiftSection = forwardRef<RedshiftSectionHandle, RedshiftSection
   state,
   canEdit,
   redshiftAuto,
+  redshiftInspected,
   redshiftInputRef,
 }, ref) => {
   const [localRedshift, setLocalRedshift] = useState(state.redshiftInspected);
@@ -88,8 +94,13 @@ export const RedshiftSection = forwardRef<RedshiftSectionHandle, RedshiftSection
     },
   }), [localRedshift, state]);
 
-  // Calculate current redshift
-  const currentRedshift = localRedshift ? parseFloat(localRedshift) : redshiftAuto;
+  // Calculate current redshift. When the override input is empty, prefer the
+  // stored redshift_inspected (which may be a pinned auto value from sign-off)
+  // so the "Current" display matches what's persisted. Mirrors the COALESCE in
+  // the objects.redshift generated column.
+  const currentRedshift = localRedshift
+    ? parseFloat(localRedshift)
+    : (redshiftInspected ?? redshiftAuto);
 
   return (
     <div className="p-4 border-b border-border dark:border-slate-700">

--- a/web/lib/actions/spectra.ts
+++ b/web/lib/actions/spectra.ts
@@ -528,6 +528,7 @@ export async function getObjectById(objectId: string): Promise<{
       redshift_quality: obj.redshift_quality ?? 0,
       redshift_inspected: obj.redshift_inspected ?? null,
       redshift_auto: obj.redshift_auto ?? null,
+      inspected_used_auto: obj.inspected_used_auto ?? false,
       last_inspected_at: obj.last_inspected_at ?? null,
       last_inspected_by: obj.last_inspected_by ?? null,
       last_data_change_at: obj.last_data_change_at ?? null,

--- a/web/lib/hooks/useInspectionState.ts
+++ b/web/lib/hooks/useInspectionState.ts
@@ -15,10 +15,22 @@ export interface InspectionInitialData {
   redshift_auto: number | null;
   redshift_inspected: number | null;
   redshift_quality: number;
+  /** True when redshift_inspected was auto-pinned from redshift_auto at
+   * sign-off. When true, the override input renders empty (the inspector
+   * didn't type anything) even though redshift_inspected has a value. */
+  inspected_used_auto: boolean;
   last_inspected_at: string | null;
   last_inspected_by: string | null;
   /** Required for the optimistic-locking save path. Defaults to 1. */
   version?: number;
+}
+
+/** Reduce InspectionInitialData to the string the override input should
+ *  display: empty for auto-pinned sign-offs (the user didn't type anything),
+ *  the formatted number for explicit overrides. */
+function initialOverrideString(data: InspectionInitialData): string {
+  if (data.inspected_used_auto) return '';
+  return data.redshift_inspected?.toString() ?? '';
 }
 
 export interface SaveIfDirtyResult {
@@ -70,7 +82,7 @@ export function useInspectionState(
   initialData: InspectionInitialData,
 ): InspectionState {
   const [redshiftInspected, _setRedshiftInspected] = useState<string>(
-    initialData.redshift_inspected?.toString() ?? ''
+    initialOverrideString(initialData)
   );
   const [redshiftQuality, _setRedshiftQuality] = useState(initialData.redshift_quality);
 
@@ -85,7 +97,7 @@ export function useInspectionState(
 
   // Refs hold the always-current values (state lags by a render).
   const valuesRef = useRef({
-    redshiftInspected: initialData.redshift_inspected?.toString() ?? '',
+    redshiftInspected: initialOverrideString(initialData),
     redshiftQuality: initialData.redshift_quality,
   });
   const initialDataRef = useRef(initialData);
@@ -107,11 +119,14 @@ export function useInspectionState(
     _setRedshiftQuality(value);
   }, []);
 
+  // Compare the form string against what initial display SHOULD be, not the
+  // raw init.redshift_inspected. For auto-pinned sign-offs the initial display
+  // is empty even though redshift_inspected has a value; without this guard
+  // the form would always look dirty after the pin trigger lands.
   const hasChanges = useMemo(() => {
-    const currentRedshiftInspected = redshiftInspected === '' ? null : parseFloat(redshiftInspected);
     const init = initialDataRef.current;
     return (
-      currentRedshiftInspected !== init.redshift_inspected ||
+      redshiftInspected !== initialOverrideString(init) ||
       redshiftQuality !== init.redshift_quality
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -120,16 +135,19 @@ export function useInspectionState(
   const isDirty = useCallback((): boolean => {
     const v = valuesRef.current;
     const init = initialDataRef.current;
-    const currentRI = v.redshiftInspected === '' ? null : parseFloat(v.redshiftInspected);
     return (
-      currentRI !== init.redshift_inspected ||
+      v.redshiftInspected !== initialOverrideString(init) ||
       v.redshiftQuality !== init.redshift_quality
     );
   }, []);
 
+  // Fall back to the stored redshift_inspected (which may have been pinned by
+  // pin_redshift_on_signoff at sign-off time) before redshift_auto, so signed-
+  // off objects display their pinned value rather than the latest auto-fit
+  // when the form override is empty. Mirrors the COALESCE in objects.redshift.
   const currentRedshift = redshiftInspected
     ? parseFloat(redshiftInspected)
-    : initialData.redshift_auto;
+    : (initialData.redshift_inspected ?? initialData.redshift_auto);
 
   const save = useCallback(async (): Promise<{ success: boolean; conflict?: boolean; version?: number }> => {
     if (savingRef.current) {
@@ -184,12 +202,34 @@ export function useInspectionState(
       versionRef.current = newVersion;
       setVersion(newVersion);
 
+      // Read post-trigger state from the server response: the
+      // pin_redshift_on_signoff trigger may have promoted redshift_auto into
+      // redshift_inspected and set inspected_used_auto=true if the user
+      // signed off with an empty override. Falling back to optimistic
+      // synthesis would mark the form dirty on the next render.
+      const serverObj = data.object;
+      const persistedInspected: number | null =
+        serverObj?.redshift_inspected !== undefined
+          ? (serverObj.redshift_inspected === null ? null : Number(serverObj.redshift_inspected))
+          : (v.redshiftInspected === '' ? null : parseFloat(v.redshiftInspected));
+      const persistedUsedAuto: boolean =
+        typeof serverObj?.inspected_used_auto === 'boolean'
+          ? serverObj.inspected_used_auto
+          : initialDataRef.current.inspected_used_auto;
+
       initialDataRef.current = {
         ...initialDataRef.current,
-        redshift_inspected: v.redshiftInspected === '' ? null : parseFloat(v.redshiftInspected),
+        redshift_inspected: persistedInspected,
         redshift_quality: v.redshiftQuality,
+        inspected_used_auto: persistedUsedAuto,
         version: newVersion,
       };
+
+      // Re-sync the form string to the new initial display so an empty input
+      // after a pin-promotion stays empty (not "dirty against 2.30").
+      const newOverrideStr = initialOverrideString(initialDataRef.current);
+      valuesRef.current.redshiftInspected = newOverrideStr;
+      _setRedshiftInspected(newOverrideStr);
 
       setSaveSuccess(true);
       setSaveCount(c => c + 1);
@@ -228,12 +268,13 @@ export function useInspectionState(
 
   const resetState = useCallback((newData: InspectionInitialData) => {
     initialDataRef.current = newData;
+    const overrideStr = initialOverrideString(newData);
     valuesRef.current = {
-      redshiftInspected: newData.redshift_inspected?.toString() ?? '',
+      redshiftInspected: overrideStr,
       redshiftQuality: newData.redshift_quality,
     };
     versionRef.current = newData.version ?? 1;
-    _setRedshiftInspected(newData.redshift_inspected?.toString() ?? '');
+    _setRedshiftInspected(overrideStr);
     _setRedshiftQuality(newData.redshift_quality);
     setVersion(newData.version ?? 1);
     setSaveSuccess(false);

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -382,6 +382,12 @@ export interface ObjectDetail {
   redshift_quality: number;
   redshift_inspected: number | null;
   redshift_auto: number | null;
+  // True when redshift_inspected was auto-pinned from redshift_auto at sign-off
+  // (inspector accepted the auto-fit rather than typing a number). The UI
+  // suppresses the "(overridden)" hint and shows an empty override input when
+  // this is true. False for explicit user-typed overrides and for
+  // uninspected/impossible rows.
+  inspected_used_auto: boolean;
   last_inspected_at: string | null;
   last_inspected_by: string | null;
   last_data_change_at: string | null;


### PR DESCRIPTION
## Summary

This change implements a database trigger-based mechanism to pin the displayed redshift value at the moment an inspector signs off on an object, preventing the value from silently changing during subsequent data reprocessing. The solution introduces a new `inspected_used_auto` column and a `pin_redshift_on_signoff` trigger that automatically promotes `redshift_auto` into `redshift_inspected` when an inspector commits a quality flag without typing a numeric override.

## Key Changes

**Database Schema & Triggers:**
- Added `inspected_used_auto` boolean column to `objects` table to track whether `redshift_inspected` was auto-pinned from `redshift_auto` at sign-off time
- Created `pin_redshift_on_signoff()` trigger function that fires on `redshift_inspected` or `redshift_quality` updates to:
  - Auto-pin `redshift_auto` → `redshift_inspected` when quality ≥ 2 and no explicit override exists
  - Mark `inspected_used_auto = false` when an explicit numeric override is entered
  - Clear the pin when quality drops below 2 (uninspected/Impossible)
- Updated `enforce_object_user_update_scope()` to reject direct non-admin writes to `inspected_used_auto` (only the trigger can modify it)
- Backfilled existing implicit sign-offs to establish the invariant that quality ≥ 2 implies `redshift_inspected IS NOT NULL`

**Redshift Auto-Computation:**
- Modified `compute_object_redshift_auto()` to remove post-hoc auto-promotion logic (now handled by trigger at write time)
- Relaxed staleness signaling: flags `staleness_reason = 'reprocessed'` for any signed-off object whose `redshift_auto` changed, prompting a "Needs Review" badge in the UI

**API Functions:**
- Updated `get_objects_for_sync()` and `get_filtered_objects_paginated()` to surface `inspected_used_auto` in JSONB payloads so the UI can avoid showing "(overridden)" hints for auto-pinned values

**Frontend State Management:**
- Added `inspected_used_auto` to `InspectionInitialData` interface
- Created `initialOverrideString()` helper that returns empty string for auto-pinned sign-offs (inspector didn't type anything) and the formatted number for explicit overrides
- Updated `useInspectionState()` to initialize the override input correctly and compare against the intended display value rather than raw `redshift_inspected`
- Modified `RedshiftSection` to accept `redshiftInspected` prop for fallback display when override input is empty, ensuring pinned values are shown rather than freshly reprocessed auto-fits

**Type Updates:**
- Added `inspected_used_auto` field to `ObjectDetail` type and related interfaces

## Implementation Details

The trigger ordering is critical: PostgreSQL fires BEFORE triggers alphabetically, so on UPDATE the sequence is `bump_redshift_auto` → `enforce_object_user_update_scope` → `pin_redshift_on_signoff` → `track_object_changes`. This ensures:
- `enforce` runs before `pin` can mutate `inspected_used_auto`, correctly rejecting direct non-admin writes
- `track` runs after `pin`, capturing the final pinned value in the audit log

The solution preserves the invariant that the displayed redshift (generated column `COALESCE(redshift_inspected, redshift_auto)`) remains stable across reprocessing for every signed-off object, while still allowing inspectors to see a "Needs Review" badge when underlying data changes.

https://claude.ai/code/session_01BY9cGFnVqt6w9ffaiYhnfw