### PR TITLE
Upsert photometry at deploy time, restricted to changed objects

### DIFF
--- a/python/campfire/deploy/cli.py
+++ b/python/campfire/deploy/cli.py
@@ -169,6 +169,8 @@ def source_ids_option(f):
 @click.option('--rgb', is_flag=True, help='Include RGB image deployment (skipped by default).')
 @click.option('--no-sed', is_flag=True, help='Skip SED plot deployment.')
 @click.option('--no-shutters', is_flag=True, help='Skip shutter deployment.')
+@click.option('--no-photometry', is_flag=True,
+              help='Skip photometry upsert after objects reconcile.')
 @click.option('--skip-astrometry', is_flag=True,
               help='Skip astrometric correction for shutters (deploy raw MSA positions).')
 @click.option('--local', is_flag=True,
@@ -176,7 +178,7 @@ def source_ids_option(f):
 @click.pass_context
 def deploy_group(ctx, config_path, obs, dry_run, source_ids, supabase_only,
                  force_overwrite, auto_approve, rgb, no_sed, no_shutters,
-                 skip_astrometry, local):
+                 no_photometry, skip_astrometry, local):
     """Deploy CAMPFIRE pipeline products to Supabase + R2."""
     ctx.ensure_object(dict)
     ctx.obj['local'] = local
@@ -204,6 +206,7 @@ def deploy_group(ctx, config_path, obs, dry_run, source_ids, supabase_only,
                 include_rgb=rgb,
                 include_sed=not no_sed,
                 include_shutters=not no_shutters,
+                include_photometry=not no_photometry,
                 skip_astrometry=skip_astrometry,
                 source_ids=list(source_ids) if source_ids else None,
                 auto_approve=auto_approve,
@@ -213,17 +216,33 @@ def deploy_group(ctx, config_path, obs, dry_run, source_ids, supabase_only,
                 fields_needing_rebuild.add(result['field'])
 
         if multi and not dry_run and fields_needing_rebuild:
-            # Deferred multi-obs path: run reconcile once per field at the end.
-            # Trade-off: changed_hashes from each observation's upsert aren't
-            # threaded through here, so 'reprocessed' staleness won't be
-            # detected for multi-obs deploys. Acceptable — per-obs deploys
-            # (the common case) get full detection via deploy_observation.
+            # Deferred multi-obs path: run reconcile (and photometry) once per
+            # field at the end. Trade-off: changed_hashes from each observation's
+            # upsert aren't threaded through here, so 'reprocessed' staleness
+            # won't be detected for multi-obs deploys. Acceptable — per-obs
+            # deploys (the common case) get full detection via deploy_observation.
             from campfire.deploy.reconcile import reconcile_field_objects
 
             sb = get_supabase_client(config)
+            phot_path = None
+            if not no_photometry:
+                from campfire.deploy.config import resolve_photometry_config
+                phot_path = resolve_photometry_config(None)
+
             for field in sorted(fields_needing_rebuild):
                 print(f"\nReconciling objects for field '{field}'...")
-                reconcile_field_objects(sb, field, abort_on_split_merge=True)
+                _, _, changed_ids = reconcile_field_objects(
+                    sb, field, abort_on_split_merge=True,
+                )
+
+                if phot_path is not None and changed_ids:
+                    from campfire.deploy.photometry import deploy_field_photometry
+                    print(f"\nDeploying photometry for {len(changed_ids)} "
+                          f"changed objects in '{field}'...")
+                    deploy_field_photometry(
+                        sb, field, phot_path, config,
+                        restrict_to_object_db_ids=changed_ids,
+                    )
 
             print()
             refresh_filter_options(sb)
@@ -438,7 +457,8 @@ def objects_reconcile(ctx, config_path, field, all_fields, dry_run, radius, yes,
         print(f"\nReconciling objects for field '{f}'...")
         reconcile_field_objects(
             sb, f, radius=radius, dry_run=dry_run, yes=yes,
-        )
+        )  # standalone reconcile: changed_ids discarded; photometry refresh
+        # is operator-driven via `campfire deploy photometry` if needed.
 
     if not dry_run:
         print()
@@ -608,10 +628,14 @@ def objects_rebuild(ctx, config_path, field, all_fields, dry_run, radius, force,
               help='Show stats without making changes.')
 @click.option('--no-photoz', is_flag=True,
               help='Skip photo-z extraction and P(z) sidecar upload.')
+@click.option('--prune', is_flag=True,
+              help='Delete photometry rows whose (catalog_name, catalog_id) '
+                   'is no longer in the catalog (cleanup after upstream '
+                   'catalog regeneration).')
 @click.option('--local', is_flag=True,
               help='Use local Supabase (127.0.0.1:54321).')
 @click.pass_context
-def photometry(ctx, config_path, field, photometry_config, dry_run, no_photoz, local):
+def photometry(ctx, config_path, field, photometry_config, dry_run, no_photoz, prune, local):
     """Deploy photometric catalog data for a field."""
     from campfire.deploy.photometry import deploy_field_photometry
 
@@ -629,6 +653,7 @@ def photometry(ctx, config_path, field, photometry_config, dry_run, no_photoz, l
         sb, field, phot_config_path, config,
         include_photoz=not no_photoz,
         dry_run=dry_run,
+        prune=prune,
     )
 
     print(f"\n{'='*60}")

--- a/python/campfire/deploy/deploy.py
+++ b/python/campfire/deploy/deploy.py
@@ -97,6 +97,7 @@ def deploy_observation(
     include_rgb: bool = False,
     include_sed: bool = True,
     include_shutters: bool = True,
+    include_photometry: bool = True,
     skip_astrometry: bool = False,
     source_ids: list[int] | None = None,
     auto_approve: bool = False,
@@ -197,6 +198,15 @@ def deploy_observation(
                 print("  No shutters ECSV found, would skip")
         else:
             print("  Shutters: skipped (--no-shutters)")
+        if include_photometry:
+            from campfire.deploy.config import resolve_photometry_config
+            phot_path = resolve_photometry_config(None)
+            if phot_path is not None:
+                print(f"  Photometry: would deploy for changed objects after reconcile (count TBD)")
+            else:
+                print("  Photometry: no photometry.toml found, would skip")
+        else:
+            print("  Photometry: skipped (--no-photometry)")
         if not force_overwrite:
             print("  (existing objects: pipeline fields only, inspection data preserved)")
         print()
@@ -336,7 +346,7 @@ def deploy_observation(
         else:
             from campfire.deploy.reconcile import reconcile_field_objects
             print("\nReconciling objects...")
-            n_clusters, _stats = reconcile_field_objects(
+            n_clusters, _stats, changed_ids = reconcile_field_objects(
                 sb, field,
                 changed_hashes=changed_hashes,
                 abort_on_split_merge=True,
@@ -346,6 +356,22 @@ def deploy_observation(
             print()
             refresh_filter_options(sb)
             refresh_programs_overview(sb)
+
+            # Photometry: cross-match the field's catalog and upsert rows
+            # for objects touched by reconcile. Skipped silently if no
+            # photometry config exists for the field, or the change set is
+            # empty (early-exit inside deploy_field_photometry).
+            if include_photometry and changed_ids:
+                from campfire.deploy.config import resolve_photometry_config
+                from campfire.deploy.photometry import deploy_field_photometry
+                phot_path = resolve_photometry_config(None)
+                if phot_path is not None:
+                    print(f"\nDeploying photometry for {len(changed_ids)} "
+                          f"changed objects...")
+                    deploy_field_photometry(
+                        sb, field, phot_path, config,
+                        restrict_to_object_db_ids=changed_ids,
+                    )
 
         # Deploy shutters
         n_shutters = 0

--- a/python/campfire/deploy/photometry.py
+++ b/python/campfire/deploy/photometry.py
@@ -370,36 +370,79 @@ def _fetch_field_objects(client: Client, field: str) -> list[dict]:
     return all_objects
 
 
-def _clear_field_photometry(client: Client, field: str) -> int:
-    """Delete existing photometry for a field. Returns count deleted."""
-    total = 0
-    while True:
-        resp = (
-            client.table('object_photometry')
-            .select('id')
-            .eq('field', field)
-            .order('id')
-            .limit(BATCH_SIZE)
-            .execute()
-        )
-        if not resp.data:
-            break
-        ids = [row['id'] for row in resp.data]
-        client.table('object_photometry').delete().in_('id', ids).execute()
-        total += len(ids)
-    return total
+def _upsert_photometry(client: Client, records: list[dict]) -> int:
+    """Batch-upsert photometry records on (field, catalog_name, catalog_id).
 
-
-def _insert_photometry(
-    client: Client,
-    records: list[dict],
-) -> int:
-    """Batch-insert photometry records. Returns count inserted."""
+    Returns count upserted.
+    """
     total = 0
     for i in range(0, len(records), BATCH_SIZE):
         batch = records[i:i + BATCH_SIZE]
-        client.table('object_photometry').insert(batch).execute()
+        client.table('object_photometry').upsert(
+            batch, on_conflict='field,catalog_name,catalog_id',
+        ).execute()
         total += len(batch)
+    return total
+
+
+def _delete_photometry_for_objects(
+    client: Client, field: str, object_db_ids: set[int],
+) -> int:
+    """Delete photometry rows for the given object DB ids in a field.
+
+    Used for orphan cleanup when a changed object no longer matches any
+    catalog source (e.g., centroid drifted out of match radius).
+    """
+    if not object_db_ids:
+        return 0
+    ids = list(object_db_ids)
+    total = 0
+    for i in range(0, len(ids), BATCH_SIZE):
+        chunk = ids[i:i + BATCH_SIZE]
+        resp = (
+            client.table('object_photometry')
+            .delete()
+            .eq('field', field)
+            .in_('object_id', chunk)
+            .execute()
+        )
+        total += len(resp.data) if resp.data else 0
+    return total
+
+
+def _prune_photometry(
+    client: Client, field: str, kept_keys: set[tuple[str, str]],
+) -> int:
+    """Delete photometry rows whose (catalog_name, catalog_id) is not in
+    *kept_keys*. Used for upstream catalog regeneration cleanup.
+    """
+    total = 0
+    page_size = 1000
+    offset = 0
+    to_delete: list[int] = []
+    while True:
+        resp = (
+            client.table('object_photometry')
+            .select('id, catalog_name, catalog_id')
+            .eq('field', field)
+            .order('id')
+            .range(offset, offset + page_size - 1)
+            .execute()
+        )
+        rows = resp.data
+        if not rows:
+            break
+        for r in rows:
+            if (r['catalog_name'], r['catalog_id']) not in kept_keys:
+                to_delete.append(r['id'])
+        if len(rows) < page_size:
+            break
+        offset += page_size
+
+    for i in range(0, len(to_delete), BATCH_SIZE):
+        chunk = to_delete[i:i + BATCH_SIZE]
+        client.table('object_photometry').delete().in_('id', chunk).execute()
+        total += len(chunk)
     return total
 
 
@@ -415,9 +458,15 @@ def deploy_field_photometry(
     *,
     include_photoz: bool = True,
     dry_run: bool = False,
+    restrict_to_object_db_ids: set[int] | None = None,
+    prune: bool = False,
 ) -> dict:
     """
-    Full photometry deploy for a field.
+    Photometry deploy for a field.
+
+    Cross-matches the configured photometric catalog against object centroids
+    in the field, upserts `object_photometry` rows on
+    `(field, catalog_name, catalog_id)`, and uploads P(z) sidecars to R2.
 
     Args:
         client: Supabase client (service role)
@@ -426,10 +475,23 @@ def deploy_field_photometry(
         deploy_config: Deploy config dict (for R2 upload credentials)
         include_photoz: Whether to extract photo-z and upload P(z) sidecars
         dry_run: Print stats without writing
+        restrict_to_object_db_ids: When set, limits upserts and sidecar uploads
+            to rows whose `object_id` is in this set. Cross-matching still runs
+            against the full field for correct global dedup. When `None`, the
+            full field is processed (standalone CLI behavior). An empty set
+            triggers an early exit before any catalog/photo-z load.
+        prune: When True (and `restrict_to_object_db_ids` is None), after
+            upsert delete rows whose `(catalog_name, catalog_id)` is not in
+            the current match set. Used to clean up after upstream catalog
+            regenerations.
 
     Returns:
         Dict with keys: n_objects, n_matched, n_bands, n_pz
     """
+    # Empty restriction: nothing to do, skip all I/O.
+    if restrict_to_object_db_ids is not None and not restrict_to_object_db_ids:
+        return {'n_objects': 0, 'n_matched': 0, 'n_bands': 0, 'n_pz': 0}
+
     field_config = load_field_config(photometry_config_path, field)
     if field_config is None:
         print(f"  No photometry config for field '{field}'. Skipping.")
@@ -451,16 +513,8 @@ def deploy_field_photometry(
     catalog = Table.read(catalog_path, format=fmt if fmt != 'fits' else None)
     print(f"    {len(catalog)} sources, {len(band_config)} bands configured")
 
-    # Pre-load photo-z data
-    photoz: PhotozData | None = None
-    if include_photoz and photoz_config:
-        photoz_file = photoz_config.get('file')
-        if photoz_file and Path(photoz_file).exists():
-            photoz = PhotozData(photoz_config)
-        else:
-            print(f"  WARNING: Photo-z file not found: {photoz_file}")
-    elif include_photoz and not photoz_config:
-        print(f"  No [photoz] config for field '{field}'. Skipping photo-z.")
+    # Photo-z is loaded lazily after cross-match (only if any kept match
+    # would actually use it — Lazy.jl FITS load is expensive).
 
     # Fetch objects
     print(f"  Fetching objects for field '{field}'...")
@@ -481,15 +535,28 @@ def deploy_field_photometry(
     print(f"    {len(matches)} matches out of {len(objects)} objects")
 
     if dry_run:
+        if restrict_to_object_db_ids is not None:
+            n_kept_dry = sum(
+                1 for obj_idx, _, _ in matches
+                if objects[obj_idx]['id'] in restrict_to_object_db_ids
+            )
+            print(f"    Restricted to {n_kept_dry} matches "
+                  f"({len(restrict_to_object_db_ids)} changed objects)")
+            n_reported = n_kept_dry
+        else:
+            n_reported = len(matches)
         return {
             'n_objects': len(objects),
-            'n_matched': len(matches),
+            'n_matched': n_reported,
             'n_bands': len(band_config),
             'n_pz': 0,
         }
 
     # De-duplicate: when multiple objects match the same catalog source,
-    # keep only the closest match (unique constraint on field+catalog_name+catalog_id)
+    # keep only the closest match (unique constraint on field+catalog_name+catalog_id).
+    # Dedup runs against the *full* match set (not just restricted ids) so the
+    # catalog-source → closest-object mapping stays globally correct even when
+    # only a subset of objects is being upserted.
     matches.sort(key=lambda m: m[2])  # sort by distance
     seen_cat_idx: set[int] = set()
     unique_matches = []
@@ -502,14 +569,43 @@ def deploy_field_photometry(
               f"(kept closest match per catalog source)")
     matches = unique_matches
 
-    # Build records + P(z) sidecars
+    # Partition: kept = matches we will upsert + upload sidecars for.
+    if restrict_to_object_db_ids is not None:
+        kept_matches = [
+            m for m in matches
+            if objects[m[0]]['id'] in restrict_to_object_db_ids
+        ]
+        print(f"    Restricted to {len(kept_matches)} matches "
+              f"for {len(restrict_to_object_db_ids)} changed objects")
+    else:
+        kept_matches = matches
+
+    # Track which restricted objects produced no match — orphan cleanup target.
+    matched_restricted_ids: set[int] = (
+        {objects[m[0]]['id'] for m in kept_matches}
+        if restrict_to_object_db_ids is not None else set()
+    )
+
+    # Lazy photo-z load: only pay the FITS load if we actually have rows to
+    # process. Skipped entirely when kept_matches is empty.
+    photoz: PhotozData | None = None
+    if include_photoz and kept_matches and photoz_config:
+        photoz_file = photoz_config.get('file')
+        if photoz_file and Path(photoz_file).exists():
+            photoz = PhotozData(photoz_config)
+        else:
+            print(f"  WARNING: Photo-z file not found: {photoz_file}")
+    elif include_photoz and kept_matches and not photoz_config:
+        print(f"  No [photoz] config for field '{field}'. Skipping photo-z.")
+
+    # Build records + P(z) sidecars (only for kept matches)
     now = datetime.now(timezone.utc).isoformat()
     records = []
     upload_tasks: list[UploadTask] = []
     n_pz = 0
     tmpdir = tempfile.mkdtemp(prefix='campfire_pz_')
 
-    for obj_idx, cat_idx, dist in matches:
+    for obj_idx, cat_idx, dist in kept_matches:
         obj = objects[obj_idx]
         cat_row = {col: catalog[col][cat_idx] for col in catalog.colnames}
         # Catalog ID: use the raw value for photo-z lookup (usually int),
@@ -574,14 +670,34 @@ def deploy_field_photometry(
             for err in errors[:5]:
                 print(f"      {err}")
 
-    # Write to database
-    print(f"  Clearing existing photometry for field '{field}'...")
-    n_deleted = _clear_field_photometry(client, field)
-    if n_deleted:
-        print(f"    Deleted {n_deleted} existing rows")
+    # Orphan cleanup: changed objects that no longer match any catalog source
+    # need their existing photometry rows removed. (Only meaningful in the
+    # restricted path; the full-field path uses --prune for sweeps instead.)
+    if restrict_to_object_db_ids is not None:
+        orphan_ids = restrict_to_object_db_ids - matched_restricted_ids
+        if orphan_ids:
+            print(f"  Removing photometry for {len(orphan_ids)} unmatched objects...")
+            n_orphans = _delete_photometry_for_objects(client, field, orphan_ids)
+            if n_orphans:
+                print(f"    Deleted {n_orphans} orphaned rows")
 
-    print(f"  Inserting {len(records)} photometry rows...")
-    _insert_photometry(client, records)
+    if records:
+        print(f"  Upserting {len(records)} photometry rows...")
+        _upsert_photometry(client, records)
+    else:
+        print(f"  No photometry rows to upsert.")
+
+    if prune and restrict_to_object_db_ids is None:
+        # Build kept_keys from the *full* match set, not just kept_matches.
+        kept_keys: set[tuple[str, str]] = set()
+        for obj_idx, cat_idx, _ in matches:
+            cat_id_raw = catalog[id_col][cat_idx] if id_col in catalog.colnames else cat_idx
+            cat_id_str = str(cat_id_raw)
+            kept_keys.add((catalog_name, cat_id_str))
+        print(f"  Pruning rows not in current catalog match set...")
+        n_pruned = _prune_photometry(client, field, kept_keys)
+        if n_pruned:
+            print(f"    Pruned {n_pruned} stale rows")
 
     # Sync denormalized columns to objects
     print(f"  Syncing photo_z to objects table...")
@@ -595,7 +711,7 @@ def deploy_field_photometry(
 
     return {
         'n_objects': len(objects),
-        'n_matched': len(matches),
+        'n_matched': len(kept_matches),
         'n_bands': len(band_config),
         'n_pz': n_pz,
     }

--- a/python/campfire/deploy/photometry.py
+++ b/python/campfire/deploy/photometry.py
@@ -385,36 +385,95 @@ def _upsert_photometry(client: Client, records: list[dict]) -> int:
     return total
 
 
-def _delete_photometry_for_objects(
-    client: Client, field: str, object_db_ids: set[int],
-) -> int:
-    """Delete photometry rows for the given object DB ids in a field.
+def _reconcile_existing_rows(
+    client: Client,
+    field: str,
+    catalog_name: str,
+    restricted_object_db_ids: set[int],
+    upsert_keys: set[tuple[int, str]],
+    key_to_obj: dict[tuple[str, str], tuple[int, float, float]],
+    now: str,
+) -> tuple[int, int]:
+    """Reconcile existing photometry rows owned by restricted objects against
+    the current deduped match set.
 
-    Used for orphan cleanup when a changed object no longer matches any
-    catalog source (e.g., centroid drifted out of match radius).
+    For each existing DB row whose `object_id` is in *restricted_object_db_ids*:
+
+    - If the row's catalog source is being re-upserted by the current run
+      (key in *upsert_keys*) → no action; the upsert handles it.
+    - Else if the row's catalog source is matched to a different object now
+      (key in *key_to_obj* but points elsewhere) → re-route: update the FK
+      in place. No R2 upload — photo_z and payload are unchanged.
+    - Else (catalog source absent from current match set) → delete. Genuine
+      orphan: catalog source removed upstream, or all candidate centroids
+      drifted out of match radius.
+
+    Scoped to a single catalog_name so multi-catalog fields are not
+    cross-contaminated.
+
+    Returns (n_deleted, n_rerouted).
     """
-    if not object_db_ids:
-        return 0
-    ids = list(object_db_ids)
-    total = 0
+    if not restricted_object_db_ids:
+        return 0, 0
+
+    ids = list(restricted_object_db_ids)
+    existing: list[dict] = []
     for i in range(0, len(ids), BATCH_SIZE):
         chunk = ids[i:i + BATCH_SIZE]
         resp = (
             client.table('object_photometry')
-            .delete()
+            .select('id, object_id, catalog_name, catalog_id')
             .eq('field', field)
+            .eq('catalog_name', catalog_name)
             .in_('object_id', chunk)
             .execute()
         )
-        total += len(resp.data) if resp.data else 0
-    return total
+        if resp.data:
+            existing.extend(resp.data)
+
+    rows_to_delete: list[int] = []
+    reroutes: list[tuple[int, int, float, float]] = []
+    for r in existing:
+        if (r['object_id'], r['catalog_id']) in upsert_keys:
+            continue  # current run will upsert this row
+        new = key_to_obj.get((r['catalog_name'], r['catalog_id']))
+        if new is None:
+            rows_to_delete.append(r['id'])
+            continue
+        new_id, new_ra, new_dec = new
+        if new_id != r['object_id']:
+            reroutes.append((r['id'], new_id, new_ra, new_dec))
+        # else: dedup still points to same object but row isn't in upsert_keys.
+        # Shouldn't happen in normal flow, but harmless — leave as-is.
+
+    for row_id, new_id, new_ra, new_dec in reroutes:
+        client.table('object_photometry').update({
+            'object_id': new_id,
+            'ra': new_ra,
+            'dec': new_dec,
+            'updated_at': now,
+        }).eq('id', row_id).execute()
+
+    n_deleted = 0
+    for i in range(0, len(rows_to_delete), BATCH_SIZE):
+        chunk = rows_to_delete[i:i + BATCH_SIZE]
+        client.table('object_photometry').delete().in_('id', chunk).execute()
+        n_deleted += len(chunk)
+
+    return n_deleted, len(reroutes)
 
 
 def _prune_photometry(
-    client: Client, field: str, kept_keys: set[tuple[str, str]],
+    client: Client,
+    field: str,
+    catalog_name: str,
+    kept_catalog_ids: set[str],
 ) -> int:
-    """Delete photometry rows whose (catalog_name, catalog_id) is not in
-    *kept_keys*. Used for upstream catalog regeneration cleanup.
+    """Delete photometry rows for *catalog_name* in *field* whose
+    catalog_id is not in *kept_catalog_ids*.
+
+    Scoped to a single catalog so other catalogs deployed to the same
+    field are untouched.
     """
     total = 0
     page_size = 1000
@@ -423,8 +482,9 @@ def _prune_photometry(
     while True:
         resp = (
             client.table('object_photometry')
-            .select('id, catalog_name, catalog_id')
+            .select('id, catalog_id')
             .eq('field', field)
+            .eq('catalog_name', catalog_name)
             .order('id')
             .range(offset, offset + page_size - 1)
             .execute()
@@ -433,7 +493,7 @@ def _prune_photometry(
         if not rows:
             break
         for r in rows:
-            if (r['catalog_name'], r['catalog_id']) not in kept_keys:
+            if r['catalog_id'] not in kept_catalog_ids:
                 to_delete.append(r['id'])
         if len(rows) < page_size:
             break
@@ -580,12 +640,6 @@ def deploy_field_photometry(
     else:
         kept_matches = matches
 
-    # Track which restricted objects produced no match — orphan cleanup target.
-    matched_restricted_ids: set[int] = (
-        {objects[m[0]]['id'] for m in kept_matches}
-        if restrict_to_object_db_ids is not None else set()
-    )
-
     # Lazy photo-z load: only pay the FITS load if we actually have rows to
     # process. Skipped entirely when kept_matches is empty.
     photoz: PhotozData | None = None
@@ -670,16 +724,36 @@ def deploy_field_photometry(
             for err in errors[:5]:
                 print(f"      {err}")
 
-    # Orphan cleanup: changed objects that no longer match any catalog source
-    # need their existing photometry rows removed. (Only meaningful in the
-    # restricted path; the full-field path uses --prune for sweeps instead.)
-    if restrict_to_object_db_ids is not None:
-        orphan_ids = restrict_to_object_db_ids - matched_restricted_ids
-        if orphan_ids:
-            print(f"  Removing photometry for {len(orphan_ids)} unmatched objects...")
-            n_orphans = _delete_photometry_for_objects(client, field, orphan_ids)
-            if n_orphans:
-                print(f"    Deleted {n_orphans} orphaned rows")
+    # Build a (catalog_name, catalog_id) → (obj_db_id, ra, dec) map from the
+    # *full* deduped match set. Used both for existing-row reconciliation
+    # (re-route vs. delete) and for --prune (which catalog_ids are still
+    # present).
+    key_to_obj: dict[tuple[str, str], tuple[int, float, float]] = {}
+    for obj_idx, cat_idx, _ in matches:
+        cat_id_raw = catalog[id_col][cat_idx] if id_col in catalog.colnames else cat_idx
+        cat_id_str = str(cat_id_raw)
+        obj = objects[obj_idx]
+        key_to_obj[(catalog_name, cat_id_str)] = (obj['id'], obj['ra'], obj['dec'])
+
+    # Reconcile existing rows owned by restricted objects against the new
+    # match set. This catches three cases that pure upsert misses:
+    #   1. Object lost a catalog source it used to own (centroid drift) and
+    #      no other object now owns it → delete.
+    #   2. Object lost a source that dedup re-assigned to an unchanged object
+    #      → re-route the FK in place (no R2 upload).
+    #   3. Object's prior row is being re-upserted by this run → no action.
+    if restrict_to_object_db_ids is not None and restrict_to_object_db_ids:
+        upsert_keys: set[tuple[int, str]] = {
+            (rec['object_id'], rec['catalog_id']) for rec in records
+        }
+        n_deleted, n_rerouted = _reconcile_existing_rows(
+            client, field, catalog_name,
+            restrict_to_object_db_ids, upsert_keys, key_to_obj, now,
+        )
+        if n_rerouted:
+            print(f"    Re-routed {n_rerouted} photometry rows to new owners")
+        if n_deleted:
+            print(f"    Deleted {n_deleted} orphaned rows (no catalog match)")
 
     if records:
         print(f"  Upserting {len(records)} photometry rows...")
@@ -688,14 +762,9 @@ def deploy_field_photometry(
         print(f"  No photometry rows to upsert.")
 
     if prune and restrict_to_object_db_ids is None:
-        # Build kept_keys from the *full* match set, not just kept_matches.
-        kept_keys: set[tuple[str, str]] = set()
-        for obj_idx, cat_idx, _ in matches:
-            cat_id_raw = catalog[id_col][cat_idx] if id_col in catalog.colnames else cat_idx
-            cat_id_str = str(cat_id_raw)
-            kept_keys.add((catalog_name, cat_id_str))
-        print(f"  Pruning rows not in current catalog match set...")
-        n_pruned = _prune_photometry(client, field, kept_keys)
+        kept_catalog_ids = {cat_id for (_cn, cat_id) in key_to_obj.keys()}
+        print(f"  Pruning rows in catalog '{catalog_name}' not in current match set...")
+        n_pruned = _prune_photometry(client, field, catalog_name, kept_catalog_ids)
         if n_pruned:
             print(f"    Pruned {n_pruned} stale rows")
 

--- a/python/campfire/deploy/reconcile.py
+++ b/python/campfire/deploy/reconcile.py
@@ -725,8 +725,16 @@ def confirm_proposals(
 
 def apply_proposals(
     client: Client, field: str, proposals: Proposals,
-) -> dict[str, int]:
-    """Execute the reconciliation against Supabase. Returns a stats dict."""
+) -> tuple[dict[str, int], set[int]]:
+    """Execute the reconciliation against Supabase.
+
+    Returns:
+        (stats, changed_object_db_ids). The set contains the union of
+        object DB ids that were inserted, revived, updated, split (parent
+        plus daughters), or merged (survivor). Soft-deleted orphans and
+        merge losers are excluded — downstream consumers (e.g. photometry)
+        don't need to re-process them.
+    """
     if proposals.complex_overlaps:
         raise RuntimeError(
             f"apply_proposals called with {len(proposals.complex_overlaps)} "
@@ -742,6 +750,8 @@ def apply_proposals(
 
     # Track (cluster_idx → object_db_id) for FK assignment at the end.
     cluster_to_object_db_id: dict[int, int] = {}
+    # Track touched object DB ids (returned for downstream consumers).
+    changed_ids: set[int] = set()
 
     # 1. Inserts — brand-new objects.
     if proposals.inserts:
@@ -752,6 +762,7 @@ def apply_proposals(
         ids = _insert_objects(client, new_records)
         for p, oid in zip(proposals.inserts, ids):
             cluster_to_object_db_id[p.cluster_idx] = oid
+            changed_ids.add(oid)
         stats['inserted'] += len(ids)
 
     # 2. Revivals — reactivate inactive objects, re-set centroid + aggregates.
@@ -773,6 +784,7 @@ def apply_proposals(
             'updated_at': now,
         }).eq('id', r.object['id']).execute()
         cluster_to_object_db_id[r.cluster_idx] = r.object['id']
+        changed_ids.add(r.object['id'])
         stats['revived'] += 1
 
     # 3. Updates — refresh aggregates on matched objects, set staleness if any.
@@ -791,6 +803,7 @@ def apply_proposals(
             stats['reactivated'] += 1
         client.table('objects').update(patch).eq('id', u.object['id']).execute()
         cluster_to_object_db_id[u.cluster_idx] = u.object['id']
+        changed_ids.add(u.object['id'])
         stats['updated'] += 1
         if u.staleness_reason:
             stats[f'staleness_{u.staleness_reason}'] += 1
@@ -821,6 +834,7 @@ def apply_proposals(
             client, s.object['id'], original_centroid,
             [(nid, (d.ra, d.dec)) for nid, d in zip(new_object_db_ids, s.daughters)],
         )
+        changed_ids.update(new_object_db_ids)
         stats['split'] += 1
         stats['inserted'] += len(s.daughters) - 1
 
@@ -832,6 +846,7 @@ def apply_proposals(
         patch['staleness_reason'] = 'membership_changed'
         client.table('objects').update(patch).eq('id', m.survivor['id']).execute()
         cluster_to_object_db_id[m.cluster_idx] = m.survivor['id']
+        changed_ids.add(m.survivor['id'])
         # Absorb state from losers, then soft-delete them.
         for loser in m.losers:
             _absorb_loser_state(client, loser_id=loser['id'], survivor_id=m.survivor['id'])
@@ -879,7 +894,7 @@ def apply_proposals(
             }).execute()
         stats['target_fks_set'] += len(pairs)
 
-    return dict(stats)
+    return dict(stats), changed_ids
 
 
 # ---------------------------------------------------------------------------
@@ -1396,7 +1411,7 @@ def reconcile_field_objects(
     yes: bool = False,
     abort_on_split_merge: bool = False,
     changed_hashes: set[tuple[str, str]] | None = None,
-) -> tuple[int, dict[str, int]]:
+) -> tuple[int, dict[str, int], set[int]]:
     """Incrementally reconcile the objects table for a field.
 
     Args:
@@ -1411,7 +1426,11 @@ def reconcile_field_objects(
             standalone reconcile (no upsert ran).
 
     Returns:
-        (n_clusters, stats_dict). On dry_run, stats is empty.
+        (n_clusters, stats_dict, changed_object_db_ids). The third element is
+        the union of object DB ids touched (inserted, revived, updated, split,
+        merged-survivor) — useful for downstream consumers like photometry
+        deploy that only need to re-process changed objects. Empty on dry_run
+        and on no-targets early returns.
     """
     if changed_hashes is None:
         changed_hashes = set()
@@ -1427,7 +1446,7 @@ def reconcile_field_objects(
     if not targets:
         if dry_run:
             print("  Dry run: would soft-delete all objects.")
-            return 0, {}
+            return 0, {}, set()
         if existing_objects:
             print(f"  No targets remain — soft-deleting {len(existing_objects)} object(s).")
             now = datetime.now(timezone.utc).isoformat()
@@ -1439,7 +1458,7 @@ def reconcile_field_objects(
                         'staleness_reason': 'membership_changed',
                         'updated_at': now,
                     }).eq('id', obj['id']).execute()
-        return 0, {'soft_deleted': sum(1 for o in existing_objects if o.get('is_active'))}
+        return 0, {'soft_deleted': sum(1 for o in existing_objects if o.get('is_active'))}, set()
 
     print(f"  Fetching spectra metadata...")
     target_ids_str = [t['target_id'] for t in targets]
@@ -1464,7 +1483,7 @@ def reconcile_field_objects(
 
     if dry_run:
         confirm_proposals(proposals, yes=True, dry_run=True)
-        return len(groups), {}
+        return len(groups), {}, set()
 
     confirm_proposals(
         proposals, yes=yes, dry_run=False,
@@ -1472,11 +1491,11 @@ def reconcile_field_objects(
     )
 
     print(f"  Applying...")
-    stats = apply_proposals(client, field, proposals)
+    stats, changed_ids = apply_proposals(client, field, proposals)
 
     print(f"  Computing object redshift_auto from member spectra...")
     n_recomputed = compute_object_redshift_auto(client, field)
     stats['redshift_auto_set'] = n_recomputed
     print(f"    Updated {n_recomputed} objects")
 
-    return len(groups), stats
+    return len(groups), stats, changed_ids


### PR DESCRIPTION
## Summary
- Photometry deploy moves from a standalone wipe-and-rebuild pass to an incremental upsert that runs in `deploy_observation()` after object reconciliation. Now that object DB ids are stable across deploys, there's no reason to wipe per-field photometry on every refresh.
- `reconcile_field_objects` now returns the set of object DB ids it touched (inserts, revivals, updates, splits, merges); `deploy_field_photometry` accepts an optional `restrict_to_object_db_ids` and only upserts rows / uploads P(z) sidecars for those objects.
- `_clear_field_photometry + _insert_photometry` replaced by a single upsert on the existing `UNIQUE(field, catalog_name, catalog_id)` key. New `--no-photometry` top-level flag and `--prune` flag on the standalone photometry subcommand.

## Behavior
- **Per-obs deploy**: after reconcile, photometry deploys only for the changed objects. Empty change set → early-exit before any catalog/photo-z FITS load (the dominant cost).
- **Multi-obs deploy** (`--obs A --obs B` same field): per-field reconcile + photometry both run once at the end of the deferred cleanup loop.
- **Standalone CLI** (`campfire deploy photometry --field X`): unchanged surface area; behaves like a full-field upsert. `--prune` cleans up rows whose `(catalog_name, catalog_id)` is no longer in the catalog (e.g., after upstream catalog regeneration).
- **Cross-match scope**: always runs against the full field even when restricted, so the catalog-source → closest-object dedup stays globally correct.
- **Centroid drift**: changed objects that no longer match any catalog source get their existing `object_photometry` rows deleted (orphan cleanup).

## Test plan
- [x] `campfire deploy photometry --field cosmos --local` first-time insert (9 rows for 9 objects)
- [x] Idempotent re-run: same row ids preserved, `created_at` preserved, `updated_at` bumped — proves no wipe-rebuild
- [x] Empty restriction: function early-exits without loading the 1.17M-row COSMOS catalog
- [x] Restricted to `{11, 12}`: only those 2 rows get fresh `updated_at`; other 7 untouched
- [x] `--prune` deletes a row with bogus `catalog_id`
- [x] `--no-photometry` registers in CLI; `deploy_observation(include_photometry=False)` skips the block
- [ ] End-to-end `campfire deploy --obs <cosmos_obs>` against production data

Generated with Claude Code