### PR TITLE
Fix: inspection mode now respects table view sorting

### DIFF
--- a/supabase/migrations/20260427235329_add_sort_to_get_filtered_object_ids.sql
+++ b/supabase/migrations/20260427235329_add_sort_to_get_filtered_object_ids.sql
@@ -1,0 +1,170 @@
+-- Add p_sort_column / p_sort_direction to get_filtered_object_ids so the
+-- inspection-mode queue (and any other caller that wants a stable, sorted ID
+-- list) can request results in a non-default order. Previously the function
+-- was hard-coded to ORDER BY object_id, which meant inspection mode ignored
+-- the sort selected in the table view it was launched from (issue #115).
+
+CREATE OR REPLACE FUNCTION public.get_filtered_object_ids(
+  p_program_slugs TEXT[],
+  p_filter_programs TEXT[] DEFAULT NULL,
+  p_fields TEXT[] DEFAULT NULL,
+  p_gratings TEXT[] DEFAULT NULL,
+  p_gratings_mode TEXT DEFAULT 'any',
+  p_redshift_quality INTEGER[] DEFAULT NULL,
+  p_redshift_min DOUBLE PRECISION DEFAULT NULL,
+  p_redshift_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_snr_min DOUBLE PRECISION DEFAULT NULL,
+  p_max_snr_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_exposure_time_min DOUBLE PRECISION DEFAULT NULL,
+  p_max_exposure_time_max DOUBLE PRECISION DEFAULT NULL,
+  p_search TEXT DEFAULT NULL,
+  p_inspected_only BOOLEAN DEFAULT NULL,
+  p_needs_review BOOLEAN DEFAULT NULL,
+  p_list_ids INTEGER[] DEFAULT NULL,
+  p_coord_ra DOUBLE PRECISION DEFAULT NULL,
+  p_coord_dec DOUBLE PRECISION DEFAULT NULL,
+  p_radius_degrees DOUBLE PRECISION DEFAULT NULL,
+  p_has_photometry BOOLEAN DEFAULT NULL,
+  p_photo_z_min DOUBLE PRECISION DEFAULT NULL,
+  p_photo_z_max DOUBLE PRECISION DEFAULT NULL,
+  p_sort_column TEXT DEFAULT 'object_id',
+  p_sort_direction TEXT DEFAULT 'asc'
+)
+RETURNS TABLE(object_id TEXT)
+LANGUAGE plpgsql STABLE
+SET plan_cache_mode = 'force_custom_plan'
+AS $$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
+    v_gratings_mode := 'any';
+  END IF;
+
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN
+    p_sort_direction := 'asc';
+  END IF;
+
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time', 'photo_z'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+
+  -- Intersect user-accessible programs with filter selection
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(
+      SELECT unnest(p_program_slugs)
+      INTERSECT
+      SELECT unnest(p_filter_programs)
+    ) INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT o.object_id
+  FROM objects o
+  WHERE
+    o.programs && v_filtered_program_slugs
+    AND o.is_active = true
+    AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+    AND (
+      NOT v_grating_filter_active
+      OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+      OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+      OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+    )
+    AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+    AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+    AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+    AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+    AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+    AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+    AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+    AND (p_search IS NULL OR o.object_id ILIKE '%' || p_search || '%'
+      OR EXISTS (SELECT 1 FROM targets t WHERE t.object_id = o.id AND t.target_id ILIKE '%' || p_search || '%'))
+    AND (
+      p_inspected_only IS NULL
+      OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+      OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+    )
+    AND (
+      p_needs_review IS NULL
+      OR (p_needs_review = TRUE
+          AND o.staleness_reason IS NOT NULL
+          AND o.last_inspected_at IS NOT NULL
+          AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+      OR (p_needs_review = FALSE
+          AND (o.staleness_reason IS NULL
+               OR o.last_inspected_at IS NULL
+               OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+    )
+    AND (
+      NOT v_coord_search_active
+      OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+        AND 2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) <= p_radius_degrees
+      )
+    )
+    AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+        SELECT olm.object_id FROM object_list_members olm
+        WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+    ))
+  ORDER BY
+    CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN
+      2 * DEGREES(ASIN(SQRT(
+        POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+        COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+        POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+      ))) END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN
+      2 * DEGREES(ASIN(SQRT(
+        POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+        COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+        POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+      ))) END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN o.object_id END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'desc' THEN o.object_id END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN o.field END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN o.field END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN o.ra END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN o.ra END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN o.dec END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN o.dec END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN o.redshift END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN o.redshift END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN o.redshift_quality END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN o.redshift_quality END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'asc' THEN o.n_targets END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'desc' THEN o.n_targets END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'asc' THEN o.n_spectra END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'desc' THEN o.n_spectra END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN o.max_snr END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN o.max_snr END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN o.max_exposure_time END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN o.max_exposure_time END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'asc' THEN o.photo_z END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'desc' THEN o.photo_z END DESC NULLS LAST,
+    o.object_id ASC;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_filtered_object_ids TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_filtered_object_ids TO service_role;

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -1180,7 +1180,9 @@ CREATE OR REPLACE FUNCTION public.get_filtered_object_ids(
   p_radius_degrees DOUBLE PRECISION DEFAULT NULL,
   p_has_photometry BOOLEAN DEFAULT NULL,
   p_photo_z_min DOUBLE PRECISION DEFAULT NULL,
-  p_photo_z_max DOUBLE PRECISION DEFAULT NULL
+  p_photo_z_max DOUBLE PRECISION DEFAULT NULL,
+  p_sort_column TEXT DEFAULT 'object_id',
+  p_sort_direction TEXT DEFAULT 'asc'
 )
 RETURNS TABLE(object_id TEXT)
 LANGUAGE plpgsql STABLE
@@ -1197,6 +1199,17 @@ BEGIN
   v_gratings_mode := COALESCE(p_gratings_mode, 'any');
   IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
     v_gratings_mode := 'any';
+  END IF;
+
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN
+    p_sort_direction := 'asc';
+  END IF;
+
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time', 'photo_z'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
   END IF;
 
   -- Intersect user-accessible programs with filter selection
@@ -1268,7 +1281,42 @@ BEGIN
         SELECT olm.object_id FROM object_list_members olm
         WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
     ))
-  ORDER BY o.object_id;
+  ORDER BY
+    CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN
+      2 * DEGREES(ASIN(SQRT(
+        POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+        COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+        POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+      ))) END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN
+      2 * DEGREES(ASIN(SQRT(
+        POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+        COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+        POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+      ))) END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN o.object_id END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'desc' THEN o.object_id END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN o.field END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN o.field END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN o.ra END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN o.ra END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN o.dec END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN o.dec END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN o.redshift END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN o.redshift END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN o.redshift_quality END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN o.redshift_quality END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'asc' THEN o.n_targets END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'desc' THEN o.n_targets END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'asc' THEN o.n_spectra END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'desc' THEN o.n_spectra END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN o.max_snr END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN o.max_snr END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN o.max_exposure_time END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN o.max_exposure_time END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'asc' THEN o.photo_z END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'desc' THEN o.photo_z END DESC NULLS LAST,
+    o.object_id ASC;
 END;
 $$;
 

--- a/web/app/inspect/page.tsx
+++ b/web/app/inspect/page.tsx
@@ -6,7 +6,7 @@ import { Loader2 } from 'lucide-react';
 import { InspectionModeOverlay } from '@/components/spectra/inspection/InspectionModeOverlay';
 import { useAuth } from '@/lib/contexts/AuthContext';
 import { getObjectById } from '@/lib/actions/spectra';
-import { parseFiltersFromURL } from '@/lib/utils/url-params';
+import { parseFiltersFromURL, parseSortingFromURL } from '@/lib/utils/url-params';
 import type { ObjectDetail } from '@/lib/types';
 
 function InspectPageInner() {
@@ -21,6 +21,7 @@ function InspectPageInner() {
   urlParams.delete('start');
   const filterStr = urlParams.toString();
   const filters = parseFiltersFromURL(urlParams);
+  const { sortColumn, sortDirection } = parseSortingFromURL(urlParams, 'objects');
 
   const [object, setObject] = useState<ObjectDetail | null>(null);
   const [loading, setLoading] = useState(true);
@@ -97,6 +98,8 @@ function InspectPageInner() {
       object={object}
       filterStr={filterStr}
       filters={filters}
+      sortColumn={sortColumn}
+      sortDirection={sortDirection}
     />
   );
 }

--- a/web/components/spectra/inspection/InspectionModeOverlay.tsx
+++ b/web/components/spectra/inspection/InspectionModeOverlay.tsx
@@ -12,6 +12,7 @@ import { SpectrumPlot } from '../SpectrumPlot';
 import { useInspectionState, type InspectionInitialData } from '@/lib/hooks/useInspectionState';
 import { useAuth } from '@/lib/contexts/AuthContext';
 import type { FilterOptions } from '@/lib/actions/spectra';
+import type { SortColumn, SortDirection } from '@/lib/actions/spectra-types';
 import { GRATINGS, type ObjectDetail, type Spectrum } from '@/lib/types';
 import { useSpectrumDataCache } from '@/lib/hooks/useSpectrumDataCache';
 import { useMultiObjectCache } from '@/lib/hooks/useMultiObjectCache';
@@ -23,6 +24,8 @@ interface InspectionModeOverlayProps {
   object: ObjectDetail;
   filterStr: string;
   filters: Partial<FilterOptions>;
+  sortColumn: SortColumn;
+  sortDirection: SortDirection;
 }
 
 interface TabSpec {
@@ -81,6 +84,8 @@ export const InspectionModeOverlay: React.FC<InspectionModeOverlayProps> = ({
   object,
   filterStr,
   filters,
+  sortColumn,
+  sortDirection,
 }) => {
   const router = useRouter();
   const { user, userProfile } = useAuth();
@@ -111,6 +116,8 @@ export const InspectionModeOverlay: React.FC<InspectionModeOverlayProps> = ({
   const queue = useInspectionQueue({
     initialObjectId: object.object_id,
     filters,
+    sortColumn,
+    sortDirection,
   });
 
   const { navigateTo, fetchObject, prefetchObject, isNavigating, navigationError, setNavigationError } = useObjectNavigation();

--- a/web/lib/actions/spectra.ts
+++ b/web/lib/actions/spectra.ts
@@ -707,14 +707,18 @@ export async function getFilterOptions(): Promise<FilterOptionsResult> {
 
 /**
  * Fetch all matching object IDs (IAU names) for the inspection queue.
- * Returns a stable snapshot ordered by object_id.
+ * Returns a stable snapshot ordered by the requested sort column (defaulting
+ * to object_id ascending) so inspection mode steps through targets in the
+ * same order as the table view it was launched from.
  * If no redshift_quality filter is set, implicitly filters to quality=0 (uninspected).
  *
- * Backed by `get_filtered_object_ids`; sort/observation/feature/DQ filters
- * aren't supported at this lightweight tier.
+ * Backed by `get_filtered_object_ids`; observation/feature/DQ filters aren't
+ * supported at this lightweight tier.
  */
 export async function getInspectionQueueIds(
   filters?: Partial<FilterOptions>,
+  sortColumn: SortColumn = 'object_id',
+  sortDirection: SortDirection = 'asc',
 ): Promise<{ ids: string[]; error?: string }> {
   const supabase = await createClient();
 
@@ -743,8 +747,7 @@ export async function getInspectionQueueIds(
 
     const baseRpcParams = buildFilterParams(filters, accessibleProgramSlugs, user.id);
 
-    // Strip params not accepted by get_filtered_object_ids (target-only filters
-    // and ordering hints — the objects RPC returns rows in object_id order).
+    // Strip params not accepted by get_filtered_object_ids (target-only filters).
     /* eslint-disable @typescript-eslint/no-unused-vars */
     const {
       p_observations: _obs,
@@ -764,6 +767,8 @@ export async function getInspectionQueueIds(
       {
         ...objectParams,
         p_redshift_quality: qualityFilter,
+        p_sort_column: sortColumn,
+        p_sort_direction: sortDirection,
       },
     );
 

--- a/web/lib/hooks/useInspectionQueue.ts
+++ b/web/lib/hooks/useInspectionQueue.ts
@@ -2,11 +2,14 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { getInspectionQueueIds, type FilterOptions } from '@/lib/actions/spectra';
+import type { SortColumn, SortDirection } from '@/lib/actions/spectra-types';
 
 interface UseInspectionQueueOptions {
   /** IAU object_id of the entry point (start parameter from /inspect URL). */
   initialObjectId: string;
   filters: Partial<FilterOptions>;
+  sortColumn?: SortColumn;
+  sortDirection?: SortDirection;
 }
 
 interface InspectionQueueState {
@@ -36,7 +39,7 @@ export function useInspectionQueue(options: UseInspectionQueueOptions): Inspecti
   /** Get the first object ID in the queue (for redirect) */
   firstId: string | null;
 } {
-  const { initialObjectId, filters } = options;
+  const { initialObjectId, filters, sortColumn, sortDirection } = options;
 
   const [ids, setIds] = useState<string[]>([]);
   const [index, setIndex] = useState(-1);
@@ -49,7 +52,7 @@ export function useInspectionQueue(options: UseInspectionQueueOptions): Inspecti
 
     async function fetchQueue() {
       try {
-        const result = await getInspectionQueueIds(filters);
+        const result = await getInspectionQueueIds(filters, sortColumn, sortDirection);
 
         if (cancelled) return;
 


### PR DESCRIPTION
Closes #115

## What was the bug?
Launching inspection mode from a table view sorted by, e.g., redshift would step through objects in `object_id` (alphabetical) order instead, silently dropping the user's chosen ordering.

## Root cause
The `get_filtered_object_ids` RPC that backs the inspection queue was hard-coded to `ORDER BY o.object_id`. The TypeScript layer mirrored that limitation: `getInspectionQueueIds` accepted no sort parameters, the `useInspectionQueue` hook didn't pass any, and `/inspect` never parsed `sort` / `dir` from the incoming URL — even though the table view already serializes those into the inspection-mode link via `currentFilterParams`.

## What I changed
- `supabase/schemas/functions.sql` + new migration `20260427235329_add_sort_to_get_filtered_object_ids.sql`: add `p_sort_column` / `p_sort_direction` to `get_filtered_object_ids`, with the same whitelist (`object_id`, `field`, `ra`, `dec`, `redshift`, `redshift_quality`, `n_targets`, `n_spectra`, `max_snr`, `max_exposure_time`, `photo_z`, plus `distance` when a coord search is active) and `CASE WHEN`-style ORDER BY used by `get_filtered_objects_paginated`.
- `web/lib/actions/spectra.ts`: `getInspectionQueueIds` now takes `sortColumn` / `sortDirection` and forwards them to the RPC.
- `web/lib/hooks/useInspectionQueue.ts`: accepts and passes the sort props through.
- `web/components/spectra/inspection/InspectionModeOverlay.tsx`: accepts sort props and feeds them to the queue hook.
- `web/app/inspect/page.tsx`: parses `parseSortingFromURL(urlParams, 'objects')` and passes to the overlay.

## Testing
- `npm run build` in `web/` — TypeScript and lint pass cleanly with no errors related to these changes (the static-prerender step fails locally because Supabase env vars aren't set, which is unrelated).
- The Supabase preview branch CI on this PR will validate that the migration applies cleanly against the current schema and that the seed data still loads.

Generated with Claude Code