### PR TITLE
feat: surface NIRSpec pointing metadata on programs page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,7 @@ cd python && pip install -e ".[deploy]"
 campfire deploy --obs <obs_name>                         # full deploy
 campfire deploy --obs <obs_name> --dry-run               # validate only
 campfire deploy rgb --obs <obs_name>                     # RGB cutouts only
+campfire deploy pointings --obs <obs_name>               # pointings JSONB backfill
 campfire deploy tiles --field cosmos --filter f444w      # map tiles
 campfire deploy sync-programs                            # upsert from programs.toml
 ```

--- a/pipeline/campfire_pipeline/metadata/pointings.py
+++ b/pipeline/campfire_pipeline/metadata/pointings.py
@@ -1,0 +1,227 @@
+"""
+Generate pointings ECSV with one row per NIRSpec MSA pointing.
+
+A "pointing" is one MSA design at one nominal sky position, identified by
+MSAMETID (a stable integer in the cal-file primary header). Sub-arcsec
+dithers within an MSAMETID are collapsed; truly distinct MSA designs in a
+single observation (e.g. ceers1, uncover1) yield separate rows.
+
+Each row carries pointing geometry, exposure aggregates, and a 4-quadrant
+sky footprint computed via JWST_FOV_plotter.
+"""
+
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+from astropy.io import fits
+from astropy.table import Table
+
+from campfire_pipeline.common.io import log
+
+
+def generate_pointings_table(obs_name, obs_dir, field):
+    """Generate a pointings table for an observation.
+
+    Reads cal-file headers in obs_dir, deduplicates exposures across
+    per-source copies via (visit, exp_spec, exp_num, detector), groups
+    unique exposures by MSAMETID, and aggregates per-pointing metadata
+    plus a 4-quadrant footprint per pointing.
+
+    Parameters
+    ----------
+    obs_name : str
+    obs_dir : Path or str
+    field : str
+
+    Returns
+    -------
+    astropy.table.Table
+        Columns: msametid, msametfl, ra_center, dec_center, pa_aper,
+        gratings, filters, jwst_program, jwst_obs_ids, n_exposures,
+        n_dithers, exptime_total, date_obs_start, date_obs_end,
+        footprint (4 x 4 x 2 array of [RA, Dec] corners).
+    """
+    obs_dir = Path(obs_dir)
+    cal_files = sorted(obs_dir.glob('*_cal.fits'))
+    if not cal_files:
+        log(f"No cal files found in {obs_dir}; skipping pointings")
+        return Table()
+
+    # Dedup exposures across per-source copies.
+    # Cal-file naming: jw{visit}_{expspec}_{expnum}_{detector}_{srcid}_cal.fits
+    # The first four parts identify a unique exposure on a unique detector chip.
+    seen = {}
+    for cal_file in cal_files:
+        parts = cal_file.stem.split('_')
+        if len(parts) < 5:
+            continue
+        key = '_'.join(parts[:4])
+        if key not in seen:
+            seen[key] = cal_file
+
+    if not seen:
+        log(f"No valid cal files to read in {obs_dir}")
+        return Table()
+
+    # Read headers from one cal file per unique exposure
+    exposures = []
+    for key, cal_file in sorted(seen.items()):
+        try:
+            h0 = fits.getheader(cal_file, ext=0)
+            h1 = fits.getheader(cal_file, ext=1)
+        except Exception as e:
+            log(f"Warning: failed to read headers from {cal_file.name}: {e}")
+            continue
+
+        msametid = h0.get('MSAMETID')
+        if msametid is None:
+            continue
+
+        exposures.append({
+            'key': key,
+            'msametid': int(msametid),
+            'msametfl': _strip_source_suffix(h0.get('MSAMETFL', '')),
+            'jwst_program': int(h0.get('PROGRAM', 0)),
+            'observtn': h0.get('OBSERVTN', ''),
+            'visit_id': h0.get('VISIT_ID', ''),
+            'grating': h0.get('GRATING', ''),
+            'filter': h0.get('FILTER', ''),
+            'exptime': float(h0.get('EFFEXPTM', 0.0)),
+            'date_obs': h0.get('DATE-OBS', ''),
+            'patt_num': h0.get('PATT_NUM'),
+            'numdthpt': h0.get('NUMDTHPT'),
+            'ra_ref': float(h1.get('RA_REF', 0.0)),
+            'dec_ref': float(h1.get('DEC_REF', 0.0)),
+            'pa_aper': float(h1.get('PA_APER', 0.0)),
+            'detector': key.split('_')[-1],
+        })
+
+    if not exposures:
+        return Table()
+
+    # Group by MSAMETID. Each group is one pointing.
+    groups = defaultdict(list)
+    for exp in exposures:
+        groups[exp['msametid']].append(exp)
+
+    rows = []
+    for msametid, exps in sorted(groups.items()):
+        ra_center = float(np.mean([e['ra_ref'] for e in exps]))
+        dec_center = float(np.mean([e['dec_ref'] for e in exps]))
+        pa_aper = float(np.mean([e['pa_aper'] for e in exps]))
+
+        # Each (visit, exp_spec, exp_num) is one MSA exposure; the two
+        # detectors (nrs1, nrs2) record the same exposure simultaneously,
+        # so collapse them for n_exposures and exptime accounting.
+        unique_exps = {}
+        for e in exps:
+            exp_key = '_'.join(e['key'].split('_')[:3])
+            if exp_key not in unique_exps:
+                unique_exps[exp_key] = e
+        n_exposures = len(unique_exps)
+        exptime_total = float(sum(e['exptime'] for e in unique_exps.values()))
+
+        n_dithers = len({e['patt_num'] for e in exps if e['patt_num']})
+        gratings = sorted({e['grating'] for e in exps if e['grating']})
+        filters = sorted({e['filter'] for e in exps if e['filter']})
+        obs_ids = sorted({e['observtn'] for e in exps if e['observtn']})
+        dates = sorted({e['date_obs'] for e in exps if e['date_obs']})
+        msametfls = sorted({e['msametfl'] for e in exps if e['msametfl']})
+        jwst_program = exps[0]['jwst_program']
+
+        try:
+            footprint = _compute_msa_footprint(ra_center, dec_center, pa_aper)
+        except Exception as e:
+            log(f"Warning: failed to compute footprint for MSAMETID={msametid}: {e}")
+            footprint = np.zeros((4, 4, 2))
+
+        rows.append({
+            'msametid': msametid,
+            'msametfl': msametfls[0] if msametfls else '',
+            'ra_center': ra_center,
+            'dec_center': dec_center,
+            'pa_aper': pa_aper,
+            'gratings': ';'.join(gratings),
+            'filters': ';'.join(filters),
+            'jwst_program': jwst_program,
+            'jwst_obs_ids': ';'.join(obs_ids),
+            'n_exposures': n_exposures,
+            'n_dithers': n_dithers,
+            'exptime_total': exptime_total,
+            'date_obs_start': dates[0] if dates else '',
+            'date_obs_end': dates[-1] if dates else '',
+            'footprint': footprint,
+        })
+
+    if not rows:
+        return Table()
+
+    table = Table(rows=rows, names=list(rows[0].keys()))
+    table.meta['obs_name'] = obs_name
+    table.meta['field'] = field
+
+    log(f"Generated pointings table: {len(table)} pointings for {obs_name}")
+    return table
+
+
+def write_pointings_ecsv(table, obs_dir, obs_name):
+    """Write the pointings table to an ECSV file."""
+    obs_dir = Path(obs_dir)
+    output_path = obs_dir / f"{obs_name}_pointings.ecsv"
+    table.write(output_path, format='ascii.ecsv', overwrite=True)
+    log(f"Wrote pointings ECSV: {output_path} ({len(table)} rows)")
+    return output_path
+
+
+def _strip_source_suffix(msametfl):
+    """Strip per-source suffix from MSAMETFL.
+
+    Stage2 writes per-source copies named like
+    jw{visit}_{expspec}_{expnum}_{detector}_msa_{srcid}.fits;
+    return the stem without the trailing _{srcid}.
+    """
+    if not msametfl:
+        return ''
+    stem = Path(msametfl).stem
+    parts = stem.split('_')
+    # Pattern: ..._msa_<srcid>
+    if len(parts) >= 2 and parts[-2] == 'msa' and parts[-1].isdigit():
+        return '_'.join(parts[:-1]) + '.fits'
+    return msametfl
+
+
+def _compute_msa_footprint(ra, dec, pa_aper):
+    """Compute 4-quadrant NIRSpec MSA sky footprint.
+
+    Uses JWST_FOV_plotter.radec_FOV with NIRSpec as the reference
+    instrument and pa_aper as the rotation angle. Returns an array
+    of shape (4, 4, 2) — four quadrants, each with four [RA, Dec]
+    corners.
+    """
+    from JWST_FOV_plotter.plotter import radec_FOV
+
+    df = radec_FOV(
+        ra, dec,
+        ref_instr='NIRSpec',
+        rot=pa_aper,
+        instr_to_plot=['NIRSpec'],
+        NIRSpec_MSA=True,
+        NIRSpec_IFU=False,
+        NIRSpec_fixed_slits=False,
+        NIRCam_long_wl=False, NIRCam_short_wl=False, NIRCam_coron=False,
+        MIRI_imag=False, MIRI_IFU=False, MIRI_4QPM=False,
+        MIRI_Lyot=False, MIRI_slit=False,
+        NIRISS_WFSS=False, NIRISS_AMI=False,
+    )
+
+    df = df[df['Aperture'].str.startswith('NRS_FULL_MSA')].sort_values('Aperture')
+    if len(df) != 4:
+        raise ValueError(f"Expected 4 MSA quadrants, got {len(df)}")
+
+    footprint = np.zeros((4, 4, 2))
+    for i, (_, row) in enumerate(df.iterrows()):
+        for j in range(4):
+            footprint[i, j, 0] = row[f'RA_{j+1}']
+            footprint[i, j, 1] = row[f'DEC_{j+1}']
+    return footprint

--- a/pipeline/campfire_pipeline/metadata/pointings.py
+++ b/pipeline/campfire_pipeline/metadata/pointings.py
@@ -106,6 +106,7 @@ def generate_pointings_table(obs_name, obs_dir, field):
         groups[exp['msametid']].append(exp)
 
     rows = []
+    skipped = []
     for msametid, exps in sorted(groups.items()):
         ra_center = float(np.mean([e['ra_ref'] for e in exps]))
         dec_center = float(np.mean([e['dec_ref'] for e in exps]))
@@ -133,8 +134,9 @@ def generate_pointings_table(obs_name, obs_dir, field):
         try:
             footprint = _compute_msa_footprint(ra_center, dec_center, pa_aper)
         except Exception as e:
-            log(f"Warning: failed to compute footprint for MSAMETID={msametid}: {e}")
-            footprint = np.zeros((4, 4, 2))
+            log(f"Warning: failed to compute footprint for MSAMETID={msametid}: {e}; skipping pointing")
+            skipped.append((msametid, str(e)))
+            continue
 
         rows.append({
             'msametid': msametid,
@@ -154,7 +156,15 @@ def generate_pointings_table(obs_name, obs_dir, field):
             'footprint': footprint,
         })
 
+    if skipped:
+        log(
+            f"WARNING: skipped {len(skipped)} pointing(s) in {obs_name} due to "
+            f"footprint computation failures: "
+            + ", ".join(f"MSAMETID={mid} ({err})" for mid, err in skipped)
+        )
+
     if not rows:
+        log(f"WARNING: no valid pointings produced for {obs_name} (all skipped)")
         return Table()
 
     table = Table(rows=rows, names=list(rows[0].keys()))

--- a/pipeline/campfire_pipeline/nirspec/cli.py
+++ b/pipeline/campfire_pipeline/nirspec/cli.py
@@ -324,6 +324,10 @@ def _run_summary(cfg, obs_obj):
         generate_shutters_table,
         write_shutters_ecsv,
     )
+    from campfire_pipeline.metadata.pointings import (
+        generate_pointings_table,
+        write_pointings_ecsv,
+    )
 
     from campfire_pipeline.common.version import get_reduction_version
     version = get_reduction_version(cfg)
@@ -349,6 +353,13 @@ def _run_summary(cfg, obs_obj):
         write_shutters_ecsv(shutters_table, obs_dir, obs_obj.name)
     else:
         log(f"No shutters generated for {obs_obj.name}")
+
+    # Generate pointings ECSV
+    pointings_table = generate_pointings_table(obs_obj.name, obs_dir, obs_obj.field)
+    if len(pointings_table) > 0:
+        write_pointings_ecsv(pointings_table, obs_dir, obs_obj.name)
+    else:
+        log(f"No pointings generated for {obs_obj.name}")
 
 
 @main.command()

--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "snowblind",
     "shapely",
     "photutils>=1.13",
+    "JWST_FOV_plotter>=0.4",
 ]
 
 [project.scripts]

--- a/python/campfire/deploy/cli.py
+++ b/python/campfire/deploy/cli.py
@@ -74,6 +74,7 @@ def _parse_source_ids(ctx, param, value):
 from campfire.deploy.deploy import (
     deploy_json,
     deploy_observation,
+    deploy_pointings,
     deploy_rgb,
     deploy_sed,
     deploy_shutters,
@@ -357,6 +358,20 @@ def shutters(ctx, config_path, obs, dry_run, local, skip_astrometry):
     for obs_name in obs:
         deploy_shutters(obs_name, config, dry_run=dry_run,
                         skip_astrometry=skip_astrometry)
+
+
+@deploy_group.command()
+@shared_options
+@click.pass_context
+def pointings(ctx, config_path, obs, dry_run, local):
+    """Deploy pointings ECSV to observations.pointings (JSONB).
+
+    Backfills an existing observation row with pointing metadata from
+    {obs}_pointings.ecsv without rerunning a full `campfire deploy`.
+    """
+    config = load_config(config_path, local=_resolve_local(ctx, local))
+    for obs_name in obs:
+        deploy_pointings(obs_name, config, dry_run=dry_run)
 
 
 # ---------------------------------------------------------------------------

--- a/python/campfire/deploy/deploy.py
+++ b/python/campfire/deploy/deploy.py
@@ -865,6 +865,44 @@ def deploy_shutters(
     print(f"Deployed {n} shutter records for {obs_name}")
 
 
+def deploy_pointings(
+    obs_name: str,
+    config: dict,
+    *,
+    dry_run: bool = False,
+) -> None:
+    """Deploy pointings ECSV data to observations.pointings (JSONB).
+
+    Useful for backfilling existing observations without rerunning a
+    full `campfire deploy`. The observations row must already exist —
+    run `campfire deploy --obs <name>` first if it doesn't.
+    """
+    obs_dir = resolve_obs_dir(obs_name)
+    ecsv_path = discover_pointings_ecsv(obs_dir, obs_name)
+
+    if not ecsv_path:
+        print(f"Error: Pointings file not found: {obs_dir / f'{obs_name}_pointings.ecsv'}")
+        print(f"Generate it first by rerunning the pipeline summary for {obs_name}.")
+        return
+
+    pointings_data = load_pointings_ecsv(ecsv_path)
+    print(f"Found {len(pointings_data)} pointing(s) for {obs_name}")
+
+    if dry_run:
+        print("=== DRY RUN ===")
+        print(f"Would update observations.pointings for '{obs_name}' "
+              f"with {len(pointings_data)} entries")
+        return
+
+    sb = get_supabase_client(config)
+    n_updated = update_observation_pointings(sb, obs_name, pointings_data)
+    if n_updated == 0:
+        print(f"Error: observation '{obs_name}' not found in database.")
+        print(f"  Run 'campfire deploy --obs {obs_name}' first to create the row.")
+        return
+    print(f"Deployed {len(pointings_data)} pointing(s) for {obs_name}")
+
+
 def fetch_config(
     obs_name: str,
     config: dict,

--- a/python/campfire/deploy/deploy.py
+++ b/python/campfire/deploy/deploy.py
@@ -16,12 +16,14 @@ from tqdm import tqdm
 
 from campfire.deploy.config import load_observations, load_programs, resolve_field, resolve_imaging_config, resolve_obs_dir
 from campfire.deploy.discover import (
+    discover_pointings_ecsv,
     discover_rgb_images,
     discover_sed_plots,
     discover_shutters_ecsv,
     discover_slits_json,
     extract_object_ids_from_files,
     filter_files_by_source_ids,
+    load_pointings_ecsv,
     load_shutters_ecsv,
     load_slits_json,
 )
@@ -46,6 +48,7 @@ from campfire.deploy.supabase import (
     refresh_programs_overview,
     update_has_sed_plot,
     update_latest_deployment,
+    update_observation_pointings,
     upsert_observation,
     upsert_programs,
 )
@@ -198,6 +201,12 @@ def deploy_observation(
                 print("  No shutters ECSV found, would skip")
         else:
             print("  Shutters: skipped (--no-shutters)")
+        pointings_path = discover_pointings_ecsv(obs_dir, obs_name)
+        if pointings_path:
+            pointings_data = load_pointings_ecsv(pointings_path)
+            print(f"  {len(pointings_data)} pointing(s)")
+        else:
+            print("  No pointings ECSV found, would skip")
         if include_photometry:
             from campfire.deploy.config import resolve_photometry_config
             phot_path = resolve_photometry_config(None)
@@ -372,6 +381,15 @@ def deploy_observation(
                         sb, field, phot_path, config,
                         restrict_to_object_db_ids=changed_ids,
                     )
+
+        # Deploy pointings (JSONB on observations)
+        pointings_ecsv = discover_pointings_ecsv(obs_dir, obs_name)
+        if pointings_ecsv:
+            pointings_data = load_pointings_ecsv(pointings_ecsv)
+            update_observation_pointings(sb, obs_name, pointings_data)
+            print(f"\nDeployed {len(pointings_data)} pointing(s) for {obs_name}")
+        else:
+            print(f"\nNo pointings ECSV found for {obs_name}, skipping pointings deployment")
 
         # Deploy shutters
         n_shutters = 0

--- a/python/campfire/deploy/discover.py
+++ b/python/campfire/deploy/discover.py
@@ -116,6 +116,55 @@ def load_shutters_ecsv(ecsv_path: Path) -> list[dict]:
     return records
 
 
+def discover_pointings_ecsv(obs_dir: Path, obs_name: str) -> Path | None:
+    """Find the pointings ECSV file, or None if absent."""
+    ecsv_path = obs_dir / f'{obs_name}_pointings.ecsv'
+    return ecsv_path if ecsv_path.exists() else None
+
+
+def load_pointings_ecsv(ecsv_path: Path) -> list[dict]:
+    """Load pointings ECSV and return JSONB-ready dicts.
+
+    Each dict represents one MSA pointing with geometry, exposure
+    aggregates, and a 4-quadrant footprint. Semicolon-joined string
+    columns (gratings, filters, jwst_obs_ids) are split back into lists.
+    The footprint column (4 x 4 x 2 numpy array) becomes a nested list
+    of [ra, dec] corners.
+    """
+    from astropy.table import Table
+
+    table = Table.read(ecsv_path, format='ascii.ecsv')
+
+    records = []
+    for row in table:
+        gratings_s = str(row['gratings']) if row['gratings'] else ''
+        filters_s = str(row['filters']) if row['filters'] else ''
+        obs_ids_s = str(row['jwst_obs_ids']) if row['jwst_obs_ids'] else ''
+        footprint = row['footprint']
+        records.append({
+            'msametid': int(row['msametid']),
+            'msametfl': str(row['msametfl']),
+            'ra_center': float(row['ra_center']),
+            'dec_center': float(row['dec_center']),
+            'pa_aper': float(row['pa_aper']),
+            'gratings': [g for g in gratings_s.split(';') if g],
+            'filters': [f for f in filters_s.split(';') if f],
+            'jwst_program': int(row['jwst_program']),
+            'jwst_obs_ids': [o for o in obs_ids_s.split(';') if o],
+            'n_exposures': int(row['n_exposures']),
+            'n_dithers': int(row['n_dithers']),
+            'exptime_total': float(row['exptime_total']),
+            'date_obs_start': str(row['date_obs_start']),
+            'date_obs_end': str(row['date_obs_end']),
+            'footprint': [
+                [[float(footprint[i, j, 0]), float(footprint[i, j, 1])]
+                 for j in range(footprint.shape[1])]
+                for i in range(footprint.shape[0])
+            ],
+        })
+    return records
+
+
 def filter_files_by_source_ids(
     files: list[Path],
     source_ids: list[int],

--- a/python/campfire/deploy/supabase.py
+++ b/python/campfire/deploy/supabase.py
@@ -237,9 +237,18 @@ def update_observation_pointings(
     client: Client,
     obs_name: str,
     pointings: list[dict],
-) -> None:
-    """Write the JSONB pointings array for an observation."""
-    client.table('observations').update({'pointings': pointings}).eq('name', obs_name).execute()
+) -> int:
+    """Write the JSONB pointings array for an observation.
+
+    Returns the number of rows updated (0 if no observation row matches).
+    """
+    response = (
+        client.table('observations')
+        .update({'pointings': pointings})
+        .eq('name', obs_name)
+        .execute()
+    )
+    return len(response.data or [])
 
 
 def batch_upsert_objects(

--- a/python/campfire/deploy/supabase.py
+++ b/python/campfire/deploy/supabase.py
@@ -233,6 +233,15 @@ def upsert_observation(
     client.table('observations').upsert(data, on_conflict='name').execute()
 
 
+def update_observation_pointings(
+    client: Client,
+    obs_name: str,
+    pointings: list[dict],
+) -> None:
+    """Write the JSONB pointings array for an observation."""
+    client.table('observations').update({'pointings': pointings}).eq('name', obs_name).execute()
+
+
 def batch_upsert_objects(
     client: Client,
     objects: list[dict],

--- a/supabase/migrations/20260430165649_add_observations_pointings.sql
+++ b/supabase/migrations/20260430165649_add_observations_pointings.sql
@@ -1,0 +1,33 @@
+-- Add JSONB pointings column to observations and surface it via get_observation_stats.
+-- Each observation's pointings array contains one entry per NIRSpec MSA pointing
+-- (grouped by MSAMETID + nominal pointing center) with geometry, exposure
+-- aggregates, and a 4-quadrant sky footprint. Populated at deploy time from
+-- {obs_name}_pointings.ecsv.
+
+alter table "public"."observations" add column "pointings" jsonb;
+
+drop function if exists "public"."get_observation_stats"(p_program_slugs text[]);
+
+create or replace function "public"."get_observation_stats"(p_program_slugs text[])
+returns table(
+  observation text, program_slug text, program_name text, field text,
+  target_count bigint, spectrum_count bigint, total_size_bytes bigint,
+  pointings jsonb
+) language sql stable as $$
+  select t.observation, t.program_slug, p.program_name, t.field,
+    count(distinct t.target_id) as target_count,
+    count(s.id) as spectrum_count,
+    coalesce(sum(s.file_size), 0)::bigint as total_size_bytes,
+    o.pointings
+  from targets t
+  join programs p on p.slug = t.program_slug
+  left join spectra s on s.target_id = t.target_id
+  left join observations o on o.name = t.observation
+  where t.program_slug = any(p_program_slugs)
+  group by t.observation, t.program_slug, p.program_name, t.field, o.pointings
+  order by t.observation;
+$$;
+
+grant execute on function "public"."get_observation_stats"(p_program_slugs text[]) to authenticated;
+grant execute on function "public"."get_observation_stats"(p_program_slugs text[]) to anon;
+grant execute on function "public"."get_observation_stats"(p_program_slugs text[]) to service_role;

--- a/supabase/migrations/20260430165649_add_observations_pointings.sql
+++ b/supabase/migrations/20260430165649_add_observations_pointings.sql
@@ -8,24 +8,33 @@ alter table "public"."observations" add column "pointings" jsonb;
 
 drop function if exists "public"."get_observation_stats"(p_program_slugs text[]);
 
+-- Aggregate stats first, then LEFT JOIN observations once for the JSONB
+-- payload. Keeps the GROUP BY key as cheap text/uuid columns so adding more
+-- per-observation metadata (additional JSONB or array columns) doesn't drag
+-- through the targets x spectra cross product.
 create or replace function "public"."get_observation_stats"(p_program_slugs text[])
 returns table(
   observation text, program_slug text, program_name text, field text,
   target_count bigint, spectrum_count bigint, total_size_bytes bigint,
   pointings jsonb
 ) language sql stable as $$
-  select t.observation, t.program_slug, p.program_name, t.field,
-    count(distinct t.target_id) as target_count,
-    count(s.id) as spectrum_count,
-    coalesce(sum(s.file_size), 0)::bigint as total_size_bytes,
+  with stats as (
+    select t.observation, t.program_slug, p.program_name, t.field,
+      count(distinct t.target_id) as target_count,
+      count(s.id) as spectrum_count,
+      coalesce(sum(s.file_size), 0)::bigint as total_size_bytes
+    from targets t
+    join programs p on p.slug = t.program_slug
+    left join spectra s on s.target_id = t.target_id
+    where t.program_slug = any(p_program_slugs)
+    group by t.observation, t.program_slug, p.program_name, t.field
+  )
+  select s.observation, s.program_slug, s.program_name, s.field,
+    s.target_count, s.spectrum_count, s.total_size_bytes,
     o.pointings
-  from targets t
-  join programs p on p.slug = t.program_slug
-  left join spectra s on s.target_id = t.target_id
-  left join observations o on o.name = t.observation
-  where t.program_slug = any(p_program_slugs)
-  group by t.observation, t.program_slug, p.program_name, t.field, o.pointings
-  order by t.observation;
+  from stats s
+  left join observations o on o.name = s.observation
+  order by s.observation;
 $$;
 
 grant execute on function "public"."get_observation_stats"(p_program_slugs text[]) to authenticated;

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -1889,24 +1889,33 @@ GRANT EXECUTE ON FUNCTION public.refresh_programs_overview TO authenticated;
 -- get_observation_stats
 -- =============================================================================
 
+-- Aggregate stats first, then LEFT JOIN observations once for the JSONB
+-- payload. Keeps the GROUP BY key as cheap text/uuid columns so adding more
+-- per-observation metadata (additional JSONB or array columns) doesn't drag
+-- through the targets x spectra cross product.
 CREATE OR REPLACE FUNCTION public.get_observation_stats(p_program_slugs text[])
 RETURNS TABLE(
   observation text, program_slug text, program_name text, field text,
   target_count bigint, spectrum_count bigint, total_size_bytes bigint,
   pointings jsonb
 ) LANGUAGE sql STABLE AS $$
-  SELECT t.observation, t.program_slug, p.program_name, t.field,
-    COUNT(DISTINCT t.target_id) AS target_count,
-    COUNT(s.id) AS spectrum_count,
-    COALESCE(SUM(s.file_size), 0)::bigint AS total_size_bytes,
+  WITH stats AS (
+    SELECT t.observation, t.program_slug, p.program_name, t.field,
+      COUNT(DISTINCT t.target_id) AS target_count,
+      COUNT(s.id) AS spectrum_count,
+      COALESCE(SUM(s.file_size), 0)::bigint AS total_size_bytes
+    FROM targets t
+    JOIN programs p ON p.slug = t.program_slug
+    LEFT JOIN spectra s ON s.target_id = t.target_id
+    WHERE t.program_slug = ANY(p_program_slugs)
+    GROUP BY t.observation, t.program_slug, p.program_name, t.field
+  )
+  SELECT s.observation, s.program_slug, s.program_name, s.field,
+    s.target_count, s.spectrum_count, s.total_size_bytes,
     o.pointings
-  FROM targets t
-  JOIN programs p ON p.slug = t.program_slug
-  LEFT JOIN spectra s ON s.target_id = t.target_id
-  LEFT JOIN observations o ON o.name = t.observation
-  WHERE t.program_slug = ANY(p_program_slugs)
-  GROUP BY t.observation, t.program_slug, p.program_name, t.field, o.pointings
-  ORDER BY t.observation;
+  FROM stats s
+  LEFT JOIN observations o ON o.name = s.observation
+  ORDER BY s.observation;
 $$;
 
 GRANT EXECUTE ON FUNCTION public.get_observation_stats TO authenticated;

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -1892,17 +1892,20 @@ GRANT EXECUTE ON FUNCTION public.refresh_programs_overview TO authenticated;
 CREATE OR REPLACE FUNCTION public.get_observation_stats(p_program_slugs text[])
 RETURNS TABLE(
   observation text, program_slug text, program_name text, field text,
-  target_count bigint, spectrum_count bigint, total_size_bytes bigint
+  target_count bigint, spectrum_count bigint, total_size_bytes bigint,
+  pointings jsonb
 ) LANGUAGE sql STABLE AS $$
   SELECT t.observation, t.program_slug, p.program_name, t.field,
     COUNT(DISTINCT t.target_id) AS target_count,
     COUNT(s.id) AS spectrum_count,
-    COALESCE(SUM(s.file_size), 0)::bigint AS total_size_bytes
+    COALESCE(SUM(s.file_size), 0)::bigint AS total_size_bytes,
+    o.pointings
   FROM targets t
   JOIN programs p ON p.slug = t.program_slug
   LEFT JOIN spectra s ON s.target_id = t.target_id
+  LEFT JOIN observations o ON o.name = t.observation
   WHERE t.program_slug = ANY(p_program_slugs)
-  GROUP BY t.observation, t.program_slug, p.program_name, t.field
+  GROUP BY t.observation, t.program_slug, p.program_name, t.field, o.pointings
   ORDER BY t.observation;
 $$;
 

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -608,7 +608,8 @@ CREATE TABLE IF NOT EXISTS "public"."observations" (
     "latest_deployment_id" integer,
     "file_globs" "text"[] NOT NULL DEFAULT '{}',
     "gratings" "text"[] NOT NULL DEFAULT '{}',
-    "data_subdir" "text"
+    "data_subdir" "text",
+    "pointings" "jsonb"
 );
 
 

--- a/web/app/nirspec/programs/[slug]/page.tsx
+++ b/web/app/nirspec/programs/[slug]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
@@ -8,8 +8,10 @@ import { Badge } from '@/components/ui/Badge';
 import { Card } from '@/components/ui/Card';
 import { MarkdownRenderer } from '@/components/docs';
 import { useProgramDetailQuery } from '@/lib/hooks/useProgramsQuery';
-import { LogIn, Loader2, Telescope, ExternalLink, ArrowRight, AlertCircle } from 'lucide-react';
+import { LogIn, Loader2, Telescope, ExternalLink, ArrowRight, AlertCircle, ChevronRight, ChevronDown, Download } from 'lucide-react';
 import { useAuth } from '@/lib/contexts/AuthContext';
+import { pointingsToCsv, pointingsToDs9, flattenPointings, downloadBlob } from '@/lib/pointings';
+import type { Pointing } from '@/lib/actions/programs';
 
 // Editorial content registry — add imports as markdown files are authored
 import ember from '@/lib/docs/content/programs/7076.md';
@@ -34,6 +36,40 @@ export default function ProgramDetailPage() {
   const observations = data?.observations ?? [];
   const error = data?.error ?? null;
   const loading = isLoading;
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const toggleExpanded = (obsName: string) => {
+    setExpanded(prev => {
+      const next = new Set(prev);
+      if (next.has(obsName)) next.delete(obsName);
+      else next.add(obsName);
+      return next;
+    });
+  };
+
+  const totalPointings = observations.reduce((acc, o) => acc + (o.pointings?.length ?? 0), 0);
+
+  const downloadAllCsv = () => {
+    const rows = flattenPointings(observations);
+    if (rows.length === 0) return;
+    downloadBlob(pointingsToCsv(rows), `${programSlug}_pointings.csv`, 'text/csv');
+  };
+
+  const downloadAllDs9 = () => {
+    const rows = flattenPointings(observations);
+    if (rows.length === 0) return;
+    downloadBlob(pointingsToDs9(rows), `${programSlug}_pointings.reg`, 'text/plain');
+  };
+
+  const downloadObsCsv = (obsName: string, pointings: Pointing[]) => {
+    const rows = flattenPointings([{ observation: obsName, pointings }]);
+    downloadBlob(pointingsToCsv(rows), `${obsName}_pointings.csv`, 'text/csv');
+  };
+
+  const downloadObsDs9 = (obsName: string, pointings: Pointing[]) => {
+    const rows = flattenPointings([{ observation: obsName, pointings }]);
+    downloadBlob(pointingsToDs9(rows), `${obsName}_pointings.reg`, 'text/plain');
+  };
 
   // Auth gate
   if (!authLoading && !user) {
@@ -203,16 +239,40 @@ export default function ProgramDetailPage() {
       {/* Observations Table */}
       {observations.length > 0 && (
         <div className="mb-8">
-          <h2 className="text-lg font-semibold text-text-primary dark:text-slate-100 mb-4">
-            Observations
-          </h2>
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-semibold text-text-primary dark:text-slate-100">
+              Observations
+            </h2>
+            {totalPointings > 0 && (
+              <div className="flex gap-2 text-xs">
+                <button
+                  onClick={downloadAllCsv}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-text-secondary dark:text-slate-400 hover:text-primary border border-border dark:border-slate-700 rounded transition-colors"
+                  title={`Download all ${totalPointings} pointings as CSV`}
+                >
+                  <Download className="w-3.5 h-3.5" />
+                  Pointings CSV
+                </button>
+                <button
+                  onClick={downloadAllDs9}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-text-secondary dark:text-slate-400 hover:text-primary border border-border dark:border-slate-700 rounded transition-colors"
+                  title={`Download all ${totalPointings} pointings as DS9 region file`}
+                >
+                  <Download className="w-3.5 h-3.5" />
+                  Pointings DS9
+                </button>
+              </div>
+            )}
+          </div>
           <Card className="overflow-hidden">
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b border-border dark:border-slate-700 bg-gray-50 dark:bg-slate-800/50">
+                    <th className="px-2 py-3 w-8"></th>
                     <th className="text-left px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Observation</th>
                     <th className="text-left px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Field</th>
+                    <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Pointings</th>
                     <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Targets</th>
                     <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Spectra</th>
                     <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Total Size</th>
@@ -220,37 +280,74 @@ export default function ProgramDetailPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {observations.map((obs) => (
-                    <tr
-                      key={obs.observation}
-                      className="border-b border-border dark:border-slate-700 last:border-b-0 hover:bg-gray-50 dark:hover:bg-slate-800/30 transition-colors"
-                    >
-                      <td className="px-4 py-3 text-text-primary dark:text-slate-100 font-medium">
-                        {obs.observation}
-                      </td>
-                      <td className="px-4 py-3 text-text-secondary dark:text-slate-400">
-                        {obs.field}
-                      </td>
-                      <td className="px-4 py-3 text-right text-text-primary dark:text-slate-100">
-                        {obs.target_count.toLocaleString()}
-                      </td>
-                      <td className="px-4 py-3 text-right text-text-primary dark:text-slate-100">
-                        {obs.spectrum_count.toLocaleString()}
-                      </td>
-                      <td className="px-4 py-3 text-right text-text-secondary dark:text-slate-400">
-                        {formatBytes(obs.total_size_bytes)}
-                      </td>
-                      <td className="px-4 py-3 text-right">
-                        <Link
-                          href={`/nirspec?programs=${program.slug}&observations=${obs.observation}`}
-                          className="text-primary hover:text-primary-hover transition-colors"
-                          title="View spectra"
+                  {observations.map((obs) => {
+                    const hasPointings = obs.pointings != null && obs.pointings.length > 0;
+                    const isExpanded = expanded.has(obs.observation);
+                    return (
+                      <React.Fragment key={obs.observation}>
+                        <tr
+                          className="border-b border-border dark:border-slate-700 last:border-b-0 hover:bg-gray-50 dark:hover:bg-slate-800/30 transition-colors"
                         >
-                          <ArrowRight className="w-4 h-4" />
-                        </Link>
-                      </td>
-                    </tr>
-                  ))}
+                          <td className="px-2 py-3 text-center">
+                            {hasPointings ? (
+                              <button
+                                onClick={() => toggleExpanded(obs.observation)}
+                                className="text-text-secondary hover:text-primary transition-colors"
+                                title={isExpanded ? 'Collapse pointings' : 'Show pointings'}
+                              >
+                                {isExpanded ? (
+                                  <ChevronDown className="w-4 h-4" />
+                                ) : (
+                                  <ChevronRight className="w-4 h-4" />
+                                )}
+                              </button>
+                            ) : (
+                              <span className="text-text-secondary/40">—</span>
+                            )}
+                          </td>
+                          <td className="px-4 py-3 text-text-primary dark:text-slate-100 font-medium">
+                            {obs.observation}
+                          </td>
+                          <td className="px-4 py-3 text-text-secondary dark:text-slate-400">
+                            {obs.field}
+                          </td>
+                          <td className="px-4 py-3 text-right text-text-primary dark:text-slate-100">
+                            {hasPointings ? obs.pointings!.length : '—'}
+                          </td>
+                          <td className="px-4 py-3 text-right text-text-primary dark:text-slate-100">
+                            {obs.target_count.toLocaleString()}
+                          </td>
+                          <td className="px-4 py-3 text-right text-text-primary dark:text-slate-100">
+                            {obs.spectrum_count.toLocaleString()}
+                          </td>
+                          <td className="px-4 py-3 text-right text-text-secondary dark:text-slate-400">
+                            {formatBytes(obs.total_size_bytes)}
+                          </td>
+                          <td className="px-4 py-3 text-right">
+                            <Link
+                              href={`/nirspec?programs=${program.slug}&observations=${obs.observation}`}
+                              className="text-primary hover:text-primary-hover transition-colors"
+                              title="View spectra"
+                            >
+                              <ArrowRight className="w-4 h-4" />
+                            </Link>
+                          </td>
+                        </tr>
+                        {isExpanded && hasPointings && (
+                          <tr className="border-b border-border dark:border-slate-700 bg-gray-50/50 dark:bg-slate-800/20">
+                            <td colSpan={8} className="px-4 py-3">
+                              <PointingsSubtable
+                                obsName={obs.observation}
+                                pointings={obs.pointings!}
+                                onDownloadCsv={() => downloadObsCsv(obs.observation, obs.pointings!)}
+                                onDownloadDs9={() => downloadObsDs9(obs.observation, obs.pointings!)}
+                              />
+                            </td>
+                          </tr>
+                        )}
+                      </React.Fragment>
+                    );
+                  })}
                 </tbody>
               </table>
             </div>
@@ -267,6 +364,89 @@ export default function ProgramDetailPage() {
           View all spectra from this program
           <ArrowRight className="w-4 h-4" />
         </Link>
+      </div>
+    </div>
+  );
+}
+
+interface PointingsSubtableProps {
+  obsName: string;
+  pointings: Pointing[];
+  onDownloadCsv: () => void;
+  onDownloadDs9: () => void;
+}
+
+function PointingsSubtable({ pointings, onDownloadCsv, onDownloadDs9 }: PointingsSubtableProps) {
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wide">
+          Pointings ({pointings.length})
+        </span>
+        <div className="flex gap-2">
+          <button
+            onClick={onDownloadCsv}
+            className="inline-flex items-center gap-1 px-2 py-1 text-xs text-text-secondary dark:text-slate-400 hover:text-primary border border-border dark:border-slate-700 rounded transition-colors"
+            title="Download these pointings as CSV"
+          >
+            <Download className="w-3 h-3" />
+            CSV
+          </button>
+          <button
+            onClick={onDownloadDs9}
+            className="inline-flex items-center gap-1 px-2 py-1 text-xs text-text-secondary dark:text-slate-400 hover:text-primary border border-border dark:border-slate-700 rounded transition-colors"
+            title="Download these pointings as DS9 region file"
+          >
+            <Download className="w-3 h-3" />
+            DS9
+          </button>
+        </div>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b border-border/60 dark:border-slate-700/60 text-text-secondary dark:text-slate-400">
+              <th className="text-left px-2 py-2 font-medium">MSA Design</th>
+              <th className="text-right px-2 py-2 font-medium">RA</th>
+              <th className="text-right px-2 py-2 font-medium">Dec</th>
+              <th className="text-right px-2 py-2 font-medium">PA</th>
+              <th className="text-left px-2 py-2 font-medium">Gratings</th>
+              <th className="text-right px-2 py-2 font-medium">Dithers</th>
+              <th className="text-right px-2 py-2 font-medium">Exptime</th>
+              <th className="text-left px-2 py-2 font-medium">Date</th>
+            </tr>
+          </thead>
+          <tbody>
+            {pointings.map((p) => (
+              <tr key={p.msametid} className="border-b border-border/30 dark:border-slate-700/30 last:border-b-0">
+                <td className="px-2 py-1.5 text-text-primary dark:text-slate-100 font-mono">
+                  {p.msametid}
+                </td>
+                <td className="px-2 py-1.5 text-right text-text-primary dark:text-slate-100 font-mono">
+                  {p.ra_center.toFixed(5)}
+                </td>
+                <td className="px-2 py-1.5 text-right text-text-primary dark:text-slate-100 font-mono">
+                  {p.dec_center.toFixed(5)}
+                </td>
+                <td className="px-2 py-1.5 text-right text-text-primary dark:text-slate-100 font-mono">
+                  {p.pa_aper.toFixed(2)}
+                </td>
+                <td className="px-2 py-1.5 text-text-secondary dark:text-slate-400">
+                  {p.gratings.join(', ')}
+                </td>
+                <td className="px-2 py-1.5 text-right text-text-primary dark:text-slate-100">
+                  {p.n_dithers}
+                </td>
+                <td className="px-2 py-1.5 text-right text-text-secondary dark:text-slate-400">
+                  {p.exptime_total.toFixed(0)}s
+                </td>
+                <td className="px-2 py-1.5 text-text-secondary dark:text-slate-400">
+                  {p.date_obs_start}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </div>
     </div>
   );

--- a/web/app/nirspec/programs/[slug]/page.tsx
+++ b/web/app/nirspec/programs/[slug]/page.tsx
@@ -11,7 +11,7 @@ import { useProgramDetailQuery } from '@/lib/hooks/useProgramsQuery';
 import { LogIn, Loader2, Telescope, ExternalLink, ArrowRight, AlertCircle, ChevronRight, ChevronDown, Download } from 'lucide-react';
 import { useAuth } from '@/lib/contexts/AuthContext';
 import { pointingsToCsv, pointingsToDs9, flattenPointings, downloadBlob } from '@/lib/pointings';
-import type { Pointing } from '@/lib/actions/programs';
+import type { Pointing } from '@/lib/types';
 
 // Editorial content registry — add imports as markdown files are authored
 import ember from '@/lib/docs/content/programs/7076.md';

--- a/web/lib/actions/programs.ts
+++ b/web/lib/actions/programs.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { createClient } from '@/lib/supabase/server';
+import type { Pointing } from '@/lib/types';
 
 export interface ProgramOverview {
   slug: string;
@@ -14,24 +15,6 @@ export interface ProgramOverview {
   fields: string[];
   observations: string[];
   jwst_pids: number[];
-}
-
-export interface Pointing {
-  msametid: number;
-  msametfl: string;
-  ra_center: number;
-  dec_center: number;
-  pa_aper: number;
-  gratings: string[];
-  filters: string[];
-  jwst_program: number;
-  jwst_obs_ids: string[];
-  n_exposures: number;
-  n_dithers: number;
-  exptime_total: number;
-  date_obs_start: string;
-  date_obs_end: string;
-  footprint: number[][][]; // 4 quadrants × 4 corners × [ra, dec]
 }
 
 export interface ObservationStat {

--- a/web/lib/actions/programs.ts
+++ b/web/lib/actions/programs.ts
@@ -16,6 +16,24 @@ export interface ProgramOverview {
   jwst_pids: number[];
 }
 
+export interface Pointing {
+  msametid: number;
+  msametfl: string;
+  ra_center: number;
+  dec_center: number;
+  pa_aper: number;
+  gratings: string[];
+  filters: string[];
+  jwst_program: number;
+  jwst_obs_ids: string[];
+  n_exposures: number;
+  n_dithers: number;
+  exptime_total: number;
+  date_obs_start: string;
+  date_obs_end: string;
+  footprint: number[][][]; // 4 quadrants × 4 corners × [ra, dec]
+}
+
 export interface ObservationStat {
   observation: string;
   program_slug: string;
@@ -24,6 +42,7 @@ export interface ObservationStat {
   target_count: number;
   spectrum_count: number;
   total_size_bytes: number;
+  pointings: Pointing[] | null;
 }
 
 export interface ProgramsOverviewResult {
@@ -147,6 +166,7 @@ export async function getProgramDetail(programSlug: string): Promise<ProgramDeta
         target_count: Number(o.target_count) || 0,
         spectrum_count: Number(o.spectrum_count) || 0,
         total_size_bytes: Number(o.total_size_bytes) || 0,
+        pointings: (o.pointings as Pointing[] | null) ?? null,
       })
     );
 

--- a/web/lib/pointings.ts
+++ b/web/lib/pointings.ts
@@ -1,0 +1,87 @@
+/**
+ * Client-side serializers for NIRSpec pointing metadata.
+ *
+ * Exports CSV (flat tabular) and DS9 region file (4-quadrant polygons)
+ * formats. Both run entirely in the browser from the JSONB pointings
+ * array — no server round-trip.
+ */
+
+import type { Pointing } from '@/lib/actions/programs';
+
+interface PointingRow extends Pointing {
+  observation: string;
+}
+
+const CSV_COLUMNS: Array<{ key: keyof PointingRow; header: string }> = [
+  { key: 'observation', header: 'observation' },
+  { key: 'msametid', header: 'msametid' },
+  { key: 'msametfl', header: 'msametfl' },
+  { key: 'jwst_program', header: 'jwst_program' },
+  { key: 'jwst_obs_ids', header: 'jwst_obs_ids' },
+  { key: 'ra_center', header: 'ra_center_deg' },
+  { key: 'dec_center', header: 'dec_center_deg' },
+  { key: 'pa_aper', header: 'pa_aper_deg' },
+  { key: 'gratings', header: 'gratings' },
+  { key: 'filters', header: 'filters' },
+  { key: 'n_exposures', header: 'n_exposures' },
+  { key: 'n_dithers', header: 'n_dithers' },
+  { key: 'exptime_total', header: 'exptime_total_s' },
+  { key: 'date_obs_start', header: 'date_obs_start' },
+  { key: 'date_obs_end', header: 'date_obs_end' },
+];
+
+function csvEscape(value: unknown): string {
+  if (value == null) return '';
+  let s: string;
+  if (Array.isArray(value)) s = value.join(';');
+  else s = String(value);
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+export function pointingsToCsv(rows: PointingRow[]): string {
+  const header = CSV_COLUMNS.map(c => c.header).join(',');
+  const lines = rows.map(r => CSV_COLUMNS.map(c => csvEscape(r[c.key])).join(','));
+  return [header, ...lines].join('\n') + '\n';
+}
+
+export function pointingsToDs9(rows: PointingRow[]): string {
+  const lines: string[] = ['# Region file format: DS9', 'icrs'];
+  for (const r of rows) {
+    const tag = `${r.observation}_msametid${r.msametid}`;
+    lines.push(`# composite ${r.ra_center} ${r.dec_center} ||| tag={${tag}}`);
+    for (let q = 0; q < r.footprint.length; q++) {
+      const corners = r.footprint[q];
+      const coords = corners.map(([ra, dec]) => `${ra},${dec}`).join(',');
+      lines.push(`polygon(${coords}) # tag={${tag}} text={Q${q + 1}}`);
+    }
+  }
+  return lines.join('\n') + '\n';
+}
+
+export function flattenPointings(
+  observations: Array<{ observation: string; pointings: Pointing[] | null }>,
+): PointingRow[] {
+  const rows: PointingRow[] = [];
+  for (const obs of observations) {
+    if (!obs.pointings) continue;
+    for (const p of obs.pointings) {
+      rows.push({ ...p, observation: obs.observation });
+    }
+  }
+  return rows;
+}
+
+export function downloadBlob(content: string, filename: string, mimeType: string) {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/web/lib/pointings.ts
+++ b/web/lib/pointings.ts
@@ -6,7 +6,7 @@
  * array — no server round-trip.
  */
 
-import type { Pointing } from '@/lib/actions/programs';
+import type { Pointing } from '@/lib/types';
 
 interface PointingRow extends Pointing {
   observation: string;

--- a/web/lib/pointings.ts
+++ b/web/lib/pointings.ts
@@ -51,7 +51,7 @@ export function pointingsToDs9(rows: PointingRow[]): string {
   const lines: string[] = ['# Region file format: DS9', 'icrs'];
   for (const r of rows) {
     const tag = `${r.observation}_msametid${r.msametid}`;
-    lines.push(`# composite ${r.ra_center} ${r.dec_center} ||| tag={${tag}}`);
+    lines.push(`# composite ${r.ra_center} ${r.dec_center} ${r.pa_aper} ||| tag={${tag}}`);
     for (let q = 0; q < r.footprint.length; q++) {
       const corners = r.footprint[q];
       const coords = corners.map(([ra, dec]) => `${ra},${dec}`).join(',');

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -286,6 +286,25 @@ export interface NircamImage {
   file_size?: number; // in bytes, if available
 }
 
+// One entry in observations.pointings — a NIRSpec MSA pointing.
+export interface Pointing {
+  msametid: number;
+  msametfl: string;
+  ra_center: number;
+  dec_center: number;
+  pa_aper: number;
+  gratings: string[];
+  filters: string[];
+  jwst_program: number;
+  jwst_obs_ids: string[];
+  n_exposures: number;
+  n_dithers: number;
+  exptime_total: number;
+  date_obs_start: string;
+  date_obs_end: string;
+  footprint: number[][][]; // 4 quadrants × 4 corners × [ra, dec]
+}
+
 // ============================================
 // Frontend-specific Types
 // ============================================


### PR DESCRIPTION
## Summary

Captures per-MSA-design pointing metadata (RA/Dec center, PA, dither/exposure aggregates, 4-quadrant sky footprint) at reduction time and exposes it on program detail pages so collaborators can map survey footprints without having to ask. Use case: a colleague wanted NIRSpec pointing centers and PAs for footprint mapping; this generalizes that need so all program/observation metadata is self-serve.

### Pipeline (`pipeline/`)
- New `campfire_pipeline/metadata/pointings.py`: reads `*_cal.fits` headers from the workspace, dedupes per-source copies via `(visit, exp_spec, exp_num, detector)`, groups unique exposures by **MSAMETID** (the stable MSA design ID — per-source MSAMETFL is augmented with source IDs and unsuitable as a key), and aggregates one row per pointing.
- Footprint = 4 polygons (one per MSA quadrant) computed via `JWST_FOV_plotter.radec_FOV(ref_instr='NIRSpec', rot=PA_APER)`. Stored as a `(4, 4, 2)` array in the ECSV.
- Hooked into `_run_summary` in `nirspec/cli.py`, alongside shutters generation. Writes `{obs_name}_pointings.ecsv`.

### Schema
- New `pointings JSONB` column on `observations`.
- `get_observation_stats` extended to return `pointings` (LEFT JOINs `observations` so NULL passes through cleanly for older deploys).
- Migration `20260430165649_add_observations_pointings.sql` is hand-written (the auto-generated diff was 600+ lines of unrelated drift; the manual version is ~25 lines and only touches column + RPC).

### Deploy (`python/campfire/deploy/`)
- `discover.py`: `discover_pointings_ecsv` + `load_pointings_ecsv` (decodes the nested footprint array into JSON-serializable lists).
- `supabase.py`: `update_observation_pointings` writes the JSONB array.
- `deploy.py`: upsert step inserted between reconcile and shutters deployment, with dry-run preview.

### Web (`web/`)
- `lib/pointings.ts`: pure-client CSV (16-column flat table) and DS9 region file (`polygon(...)` per quadrant, tagged by `obs_msametid<N>`) serializers.
- `lib/actions/programs.ts`: new `Pointing` type, RPC mapping returns `pointings | null`.
- `app/nirspec/programs/[slug]/page.tsx`: chevron column + expandable rows, per-observation `PointingsSubtable` (MSA Design / RA / Dec / PA / Gratings / Dithers / Exptime / Date) with per-observation **CSV** / **DS9** download buttons, and program-level **Pointings CSV** / **Pointings DS9** buttons that flat-map across all observations. Em-dash for observations without pointings (NULL in DB).

### Data model rationale

JSONB array on `observations` (not a child table) because: each observation can contain 1–N pointings (most are 1; ceers1 / uncover1 have several distinct MSA designs); volume is small (hundreds of pointings total); the data is read-as-a-blob 99% of the time. Grouping key is **MSAMETID** + nominal pointing center; sub-arcsec dithers within an MSAMETID collapse, but truly distinct MSA designs in a single CAMPFIRE observation yield separate rows.

## Test plan

- [x] Pipeline: ran `generate_pointings_table` on `zenith_p11` (3 distinct MSA designs) → 3 pointings, ECSV round-trips, footprint shape `(4, 4, 2)` per row.
- [x] Schema: `supabase db reset` applies migration cleanly; `\d observations` shows `pointings` column.
- [x] Deploy: `update_observation_pointings` writes JSONB to local Supabase; `get_observation_stats` RPC returns it.
- [x] Web build (`cd web && npm run build`) passes.
- [x] UI: navigated to `/nirspec/programs/canucs` with seeded pointings on 2 observations; chevron expands sub-table; em-dash for unseeded rows.
- [x] CSV download: 6 rows across both observations, 16 columns; per-observation download correctly scoped to 3 rows.
- [x] DS9 download: 24 polygons (6 pointings × 4 quadrants), DS9-format header.
- [ ] Run `cfpipe nirspec` end-to-end on a multi-pointing observation (e.g. ceers1) to confirm the ECSV is written from the real reduction flow.
- [ ] Run `campfire deploy --obs <multi-pointing> --local` to confirm the upsert step doesn't break existing deployments.
- [ ] Open Supabase preview branch on this PR; confirm migration applies and seed loads without error.

Generated with Claude Code