### PR TITLE
Link uncals instead of copying

### DIFF
--- a/pipeline/campfire_pipeline/nirspec/observation.py
+++ b/pipeline/campfire_pipeline/nirspec/observation.py
@@ -152,22 +152,20 @@ class Observation:
             rate_file = uncal_file.replace('_uncal.fits', '_rate.fits').replace(self.raw_dir, self.workspace_dir)
             self.rate_files.append(rate_file)
 
-    def copy_uncal_files(self, overwrite=False):
+    def symlink_uncal_files(self, overwrite=False):
 
         log(self.rate_files)
         if all([os.path.exists(f) for f in self.rate_files]) and not overwrite:
             log('All rate files already exist, and overwrite=False! No new rate files will be generated.')
             return False
-            
-        # Copy rate files to workspace and track MSA meta files needed
-        copied_files = []
+
+        # Symlink uncal files into workspace and track MSA meta files needed
         for src_file in self.uncal_files:
             dst_file = os.path.join(self.workspace_dir, os.path.basename(src_file))
             rate_file = dst_file.replace('_uncal.fits', '_rate.fits')
             if not os.path.exists(dst_file) and (not os.path.exists(rate_file) or overwrite):
                 log(f"Linking {os.path.basename(src_file)} to workspace")
                 os.symlink(src_file, dst_file)
-            copied_files.append(dst_file)
 
         for msa_meta_file in self.msa_meta_files:
             dst_msa_meta_file = os.path.join(self.workspace_dir, os.path.basename(msa_meta_file))

--- a/pipeline/campfire_pipeline/nirspec/observation.py
+++ b/pipeline/campfire_pipeline/nirspec/observation.py
@@ -156,7 +156,7 @@ class Observation:
 
         log(self.rate_files)
         if all([os.path.exists(f) for f in self.rate_files]) and not overwrite:
-            log('All rate files already exist, and overwrite=False! aborting stage1')
+            log('All rate files already exist, and overwrite=False! No new rate files will be generated.')
             return False
             
         # Copy rate files to workspace and track MSA meta files needed

--- a/pipeline/campfire_pipeline/nirspec/observation.py
+++ b/pipeline/campfire_pipeline/nirspec/observation.py
@@ -155,10 +155,10 @@ class Observation:
     def copy_uncal_files(self, overwrite=False):
 
         log(self.rate_files)
-        if all([os.path.exists(f) and os.path.exists(f.replace('_rate.fits', '_bkg.fits')) for f in self.rate_files]) and not overwrite:
-            log('All rate files and bkg files already exist, and overwrite=False! aborting stage1')
+        if all([os.path.exists(f) for f in self.rate_files]) and not overwrite:
+            log('All rate files already exist, and overwrite=False! aborting stage1')
             return False
-
+            
         # Copy rate files to workspace and track MSA meta files needed
         copied_files = []
         for src_file in self.uncal_files:

--- a/pipeline/campfire_pipeline/nirspec/observation.py
+++ b/pipeline/campfire_pipeline/nirspec/observation.py
@@ -155,8 +155,8 @@ class Observation:
     def copy_uncal_files(self, overwrite=False):
 
         log(self.rate_files)
-        if all([os.path.exists(f) for f in self.rate_files]) and not overwrite:
-            log('All rate files already exist, and overwrite=False! aborting stage1')
+        if all([os.path.exists(f) and os.path.exists(f.replace('_rate.fits', '_bkg.fits')) for f in self.rate_files]) and not overwrite:
+            log('All rate files and bkg files already exist, and overwrite=False! aborting stage1')
             return False
 
         # Copy rate files to workspace and track MSA meta files needed

--- a/pipeline/campfire_pipeline/nirspec/observation.py
+++ b/pipeline/campfire_pipeline/nirspec/observation.py
@@ -165,8 +165,8 @@ class Observation:
             dst_file = os.path.join(self.workspace_dir, os.path.basename(src_file))
             rate_file = dst_file.replace('_uncal.fits', '_rate.fits')
             if not os.path.exists(dst_file) and (not os.path.exists(rate_file) or overwrite):
-                log(f"Copying {os.path.basename(src_file)} to workspace")
-                shutil.copy2(src_file, dst_file)
+                log(f"Linking {os.path.basename(src_file)} to workspace")
+                os.symlink(src_file, dst_file)
             copied_files.append(dst_file)
 
         for msa_meta_file in self.msa_meta_files:

--- a/pipeline/campfire_pipeline/nirspec/stage1.py
+++ b/pipeline/campfire_pipeline/nirspec/stage1.py
@@ -88,11 +88,12 @@ def run_stage1(obs, stage_config, n_processes=1, overwrite=False, data_dir=None,
     if missing:
         for f in sorted(missing):
             log(f"WARNING: Detector1Pipeline did not produce {os.path.basename(f)} — skipping background subtraction for this file")
+
+    rates_to_subtract = rate_files
     if not overwrite:
-        rates_to_subtract = [f for f in rate_files if not os.path.exists(f.replace('_rate.fits', '_bkg.fits'))]
-    else: 
-        rates_to_subtract = rate_files
-    if n_processes > 1 and rates_to_process:
+        rates_to_subtract = [f for f in rates_to_subtract if not os.path.exists(f.replace('_rate.fits', '_bkg.fits'))]
+
+    if n_processes > 1 and rates_to_subtract:
         _prefetch_crds_references(rates_to_subtract)
     dispatch(
         subtract_background_from_rate_file,

--- a/pipeline/campfire_pipeline/nirspec/stage1.py
+++ b/pipeline/campfire_pipeline/nirspec/stage1.py
@@ -37,7 +37,7 @@ def run_stage1(obs, stage_config, n_processes=1, overwrite=False, data_dir=None,
         obs.setup_workspace_directory(data_dir, products_dir, overwrite=overwrite)
 
     obs.discover_raw_files()
-    obs.copy_uncal_files(overwrite=overwrite)
+    obs.symlink_uncal_files(overwrite=overwrite)
 
     uncal_files = obs.glob("_uncal.fits")
     if not overwrite:

--- a/pipeline/campfire_pipeline/nirspec/stage1.py
+++ b/pipeline/campfire_pipeline/nirspec/stage1.py
@@ -79,17 +79,9 @@ def run_stage1(obs, stage_config, n_processes=1, overwrite=False, data_dir=None,
         plot=stage_config.get('plot', True),
         save_backup=False,
     )
-    expected_rate_files = [
-        os.path.join(obs.workspace_dir, f.replace('_uncal.fits', '_rate.fits'))
-        for f in uncal_files
-    ]
-    rate_files = [f for f in expected_rate_files if os.path.exists(f)]
-    missing = set(expected_rate_files) - set(rate_files)
-    if missing:
-        for f in sorted(missing):
-            log(f"WARNING: Detector1Pipeline did not produce {os.path.basename(f)} — skipping background subtraction for this file")
 
-    rates_to_subtract = rate_files
+    # Grab all rate files (in case there are some that didn't have background subtraction run on them!)
+    rates_to_subtract = obs.glob("_rate.fits")
     if not overwrite:
         rates_to_subtract = [f for f in rates_to_subtract if not os.path.exists(f.replace('_rate.fits', '_bkg.fits'))]
 

--- a/pipeline/campfire_pipeline/nirspec/stage1.py
+++ b/pipeline/campfire_pipeline/nirspec/stage1.py
@@ -41,9 +41,9 @@ def run_stage1(obs, stage_config, n_processes=1, overwrite=False, data_dir=None,
 
     uncal_files = obs.glob("_uncal.fits")
     if not overwrite:
-        uncal_files = [f for f in uncal_files if not os.path.exists(f.replace('_uncal.fits', '_rate.fits'))]
-
-    uncal_files = [os.path.basename(f) for f in uncal_files]
+        uncals_to_process = [os.path.basename(f) for f in uncal_files if not os.path.exists(f.replace('_uncal.fits', '_rate.fits'))]
+    else: 
+        uncals_to_process = [os.path.basename(f) for f in uncal_files]
 
     kwargs = dict(
         do_clean_flicker_noise=stage_config['do_clean_flicker_noise'],
@@ -53,14 +53,14 @@ def run_stage1(obs, stage_config, n_processes=1, overwrite=False, data_dir=None,
     )
 
     # Phase 1: Run Detector1Pipeline on all uncal files
-    if n_processes > 1 and uncal_files:
+    if n_processes > 1 and uncals_to_process:
         _prefetch_detector1_references(
-            [os.path.join(obs.workspace_dir, f) for f in uncal_files],
+            [os.path.join(obs.workspace_dir, f) for f in uncals_to_process],
             mask_science_regions=stage_config['do_clean_flicker_noise'] and stage_config['mask_science_regions'],
         )
     dispatch(
         run_stage1_single_uncal,
-        uncal_files,
+        uncals_to_process,
         n_processes=n_processes,
         workspace_dir=obs.workspace_dir,
         **kwargs,
@@ -79,10 +79,9 @@ def run_stage1(obs, stage_config, n_processes=1, overwrite=False, data_dir=None,
         plot=stage_config.get('plot', True),
         save_backup=False,
     )
-    all_uncal_files = [os.path.basename(f) for f in obs.glob("_uncal.fits")]
     expected_rate_files = [
         os.path.join(obs.workspace_dir, f.replace('_uncal.fits', '_rate.fits'))
-        for f in all_uncal_files
+        for f in uncal_files
     ]
     rate_files = [f for f in expected_rate_files if os.path.exists(f)]
     missing = set(expected_rate_files) - set(rate_files)
@@ -90,12 +89,14 @@ def run_stage1(obs, stage_config, n_processes=1, overwrite=False, data_dir=None,
         for f in sorted(missing):
             log(f"WARNING: Detector1Pipeline did not produce {os.path.basename(f)} — skipping background subtraction for this file")
     if not overwrite:
-        rate_files = [f for f in rate_files if not os.path.exists(f.replace('_rate.fits', '_bkg.fits'))]
-    if n_processes > 1 and rate_files:
-        _prefetch_crds_references(rate_files)
+        rates_to_subtract = [f for f in rate_files if not os.path.exists(f.replace('_rate.fits', '_bkg.fits'))]
+    else: 
+        rates_to_subtract = rate_files
+    if n_processes > 1 and rates_to_process:
+        _prefetch_crds_references(rates_to_subtract)
     dispatch(
         subtract_background_from_rate_file,
-        rate_files,
+        rates_to_subtract,
         n_processes=n_processes,
         **bkg_kwargs,
     )

--- a/pipeline/campfire_pipeline/nirspec/stage1.py
+++ b/pipeline/campfire_pipeline/nirspec/stage1.py
@@ -79,15 +79,18 @@ def run_stage1(obs, stage_config, n_processes=1, overwrite=False, data_dir=None,
         plot=stage_config.get('plot', True),
         save_backup=False,
     )
+    all_uncal_files = [os.path.basename(f) for f in obs.glob("_uncal.fits")]
     expected_rate_files = [
         os.path.join(obs.workspace_dir, f.replace('_uncal.fits', '_rate.fits'))
-        for f in uncal_files
+        for f in all_uncal_files
     ]
     rate_files = [f for f in expected_rate_files if os.path.exists(f)]
     missing = set(expected_rate_files) - set(rate_files)
     if missing:
         for f in sorted(missing):
             log(f"WARNING: Detector1Pipeline did not produce {os.path.basename(f)} — skipping background subtraction for this file")
+    if not overwrite:
+        rate_files = [f for f in rate_files if not os.path.exists(f.replace('_rate.fits', '_bkg.fits'))]
     if n_processes > 1 and rate_files:
         _prefetch_crds_references(rate_files)
     dispatch(


### PR DESCRIPTION
Create symlinks for uncal files instead of copying them to the workspace. 
Tested successfully with PID 1181. 
Closes #119 and #121