### PR TITLE
perf(map): single-shot RPCs + use inspection redshift_quality for markers

### DIFF
--- a/supabase/migrations/20260501184255_optimize_map_field_rpcs.sql
+++ b/supabase/migrations/20260501184255_optimize_map_field_rpcs.sql
@@ -1,0 +1,69 @@
+-- Map viewer performance: replace paginated table queries with single-shot
+-- RPCs. The previous PostgREST select on objects/shutters paginated at
+-- 1000 rows/page (sequential round-trips) and embedded targets(target_id)
+-- for the slit-filter bridge — both very expensive on COSMOS-sized fields
+-- (~10K objects, ~30-50K shutters → 2-3 min total). The RPCs return all
+-- rows in one call and aggregate member_target_ids server-side.
+
+CREATE OR REPLACE FUNCTION public.get_field_object_markers(p_field TEXT)
+RETURNS TABLE (
+  object_id           TEXT,
+  ra                  DOUBLE PRECISION,
+  "dec"               DOUBLE PRECISION,
+  redshift            DOUBLE PRECISION,
+  redshift_quality    INTEGER,
+  field               TEXT,
+  n_targets           INTEGER,
+  n_spectra           INTEGER,
+  programs            TEXT[],
+  member_target_ids   TEXT[]
+)
+LANGUAGE sql STABLE
+AS $$
+  SELECT
+    o.object_id,
+    o.ra,
+    o.dec,
+    o.redshift::double precision,
+    o.redshift_quality,
+    o.field,
+    o.n_targets,
+    o.n_spectra,
+    o.programs,
+    COALESCE(
+      (SELECT array_agg(t.target_id ORDER BY t.target_id)
+         FROM public.targets t
+        WHERE t.object_id = o.id),
+      ARRAY[]::TEXT[]
+    ) AS member_target_ids
+  FROM public.objects o
+  WHERE o.field = p_field
+    AND o.is_active
+  ORDER BY o.object_id;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_field_object_markers TO authenticated;
+
+
+CREATE OR REPLACE FUNCTION public.get_field_shutters(p_field TEXT)
+RETURNS TABLE (
+  object_id        TEXT,
+  source_id        INTEGER,
+  center_ra        DOUBLE PRECISION,
+  center_dec       DOUBLE PRECISION,
+  position_angle   DOUBLE PRECISION,
+  shutter_idx      SMALLINT,
+  dither_id        SMALLINT,
+  shutter_state    TEXT,
+  observation      TEXT
+)
+LANGUAGE sql STABLE
+AS $$
+  SELECT s.object_id, s.source_id, s.center_ra, s.center_dec,
+         s.position_angle, s.shutter_idx, s.dither_id, s.shutter_state, s.observation
+  FROM public.shutters s
+  WHERE s.field = p_field
+  ORDER BY s.object_id;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_field_shutters TO authenticated;

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -1994,6 +1994,84 @@ $$;
 
 
 -- =============================================================================
+-- get_field_object_markers
+-- =============================================================================
+-- Single-shot fetch of every object in a field for the map viewer. Replaces
+-- the paginated PostgREST select that capped at 1000 rows/page and embedded
+-- targets(target_id) for the slit-filter bridge — both very expensive on
+-- COSMOS-sized fields. RLS on objects still applies (SECURITY INVOKER).
+
+CREATE OR REPLACE FUNCTION public.get_field_object_markers(p_field TEXT)
+RETURNS TABLE (
+  object_id           TEXT,
+  ra                  DOUBLE PRECISION,
+  "dec"               DOUBLE PRECISION,
+  redshift            DOUBLE PRECISION,
+  redshift_quality    INTEGER,
+  field               TEXT,
+  n_targets           INTEGER,
+  n_spectra           INTEGER,
+  programs            TEXT[],
+  member_target_ids   TEXT[]
+)
+LANGUAGE sql STABLE
+AS $$
+  SELECT
+    o.object_id,
+    o.ra,
+    o.dec,
+    o.redshift::double precision,
+    o.redshift_quality,
+    o.field,
+    o.n_targets,
+    o.n_spectra,
+    o.programs,
+    COALESCE(
+      (SELECT array_agg(t.target_id ORDER BY t.target_id)
+         FROM public.targets t
+        WHERE t.object_id = o.id),
+      ARRAY[]::TEXT[]
+    ) AS member_target_ids
+  FROM public.objects o
+  WHERE o.field = p_field
+    AND o.is_active
+  ORDER BY o.object_id;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_field_object_markers TO authenticated;
+
+
+-- =============================================================================
+-- get_field_shutters
+-- =============================================================================
+-- Single-shot fetch of every shutter in a field for the map viewer. Shutters
+-- are public to authenticated users, so SECURITY INVOKER is fine.
+
+CREATE OR REPLACE FUNCTION public.get_field_shutters(p_field TEXT)
+RETURNS TABLE (
+  object_id        TEXT,
+  source_id        INTEGER,
+  center_ra        DOUBLE PRECISION,
+  center_dec       DOUBLE PRECISION,
+  position_angle   DOUBLE PRECISION,
+  shutter_idx      SMALLINT,
+  dither_id        SMALLINT,
+  shutter_state    TEXT,
+  observation      TEXT
+)
+LANGUAGE sql STABLE
+AS $$
+  SELECT s.object_id, s.source_id, s.center_ra, s.center_dec,
+         s.position_angle, s.shutter_idx, s.dither_id, s.shutter_state, s.observation
+  FROM public.shutters s
+  WHERE s.field = p_field
+  ORDER BY s.object_id;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_field_shutters TO authenticated;
+
+
+-- =============================================================================
 -- increment_tile_version
 -- =============================================================================
 

--- a/web/components/map/CanvasMarkerLayer.tsx
+++ b/web/components/map/CanvasMarkerLayer.tsx
@@ -80,7 +80,7 @@ export function CanvasMarkerLayer({
       return {
         marker: m,
         latLng: L.latLng(y, x), // Leaflet: lat=y, lng=x
-        color: QUALITY_COLORS[m.best_redshift_quality] || QUALITY_COLORS[0],
+        color: QUALITY_COLORS[m.redshift_quality] || QUALITY_COLORS[0],
         isHighlighted: m.object_id === highlightObjectId,
       };
     });
@@ -206,7 +206,7 @@ export function CanvasMarkerLayer({
           continue; // Draw highlighted marker last, on top
         }
 
-        const q = item.marker.best_redshift_quality;
+        const q = item.marker.redshift_quality;
         let group = groups.get(q);
         if (!group) {
           group = [];

--- a/web/components/map/MapViewer.tsx
+++ b/web/components/map/MapViewer.tsx
@@ -410,7 +410,7 @@ export function MapViewer({
 
         {/* Popup for clicked marker (standalone, rendered by React) */}
         {popupState && (() => {
-          const qualityLabel = QUALITY_LABELS.find(q => q.value === popupState.marker.best_redshift_quality);
+          const qualityLabel = QUALITY_LABELS.find(q => q.value === popupState.marker.redshift_quality);
           return (
             <Popup
               position={popupState.latLng}
@@ -427,8 +427,8 @@ export function MapViewer({
                   </Link>
                 </div>
                 <div className="space-y-0.5 text-xs">
-                  {popupState.marker.best_redshift !== null && (
-                    <div>z = {popupState.marker.best_redshift.toFixed(4)}</div>
+                  {popupState.marker.redshift !== null && (
+                    <div>z = {popupState.marker.redshift.toFixed(4)}</div>
                   )}
                   <div>
                     Quality: {qualityLabel?.icon} {qualityLabel?.label || 'Unknown'}

--- a/web/lib/actions/map.ts
+++ b/web/lib/actions/map.ts
@@ -47,8 +47,8 @@ export interface MapObjectMarker {
   object_id: string;
   ra: number;
   dec: number;
-  best_redshift: number | null;
-  best_redshift_quality: number;
+  redshift: number | null;
+  redshift_quality: number;
   field: string;
   n_targets: number;
   n_spectra: number;
@@ -165,51 +165,28 @@ export async function getFieldMarkers(
 
 /**
  * Fetch all objects for a field with member target IDs (for slit filter bridge).
+ *
+ * Uses get_field_object_markers RPC for a single round-trip — replaces the
+ * old paginated PostgREST select that fired N×1000-row pages and embedded
+ * targets(target_id), which made COSMOS take ~2-3 minutes. The RPC
+ * aggregates member_target_ids server-side and returns inspection-driven
+ * `redshift` / `redshift_quality` (not the legacy deploy-time `best_*`
+ * columns, which never reflected user inspections).
  */
 export async function getFieldObjectMarkers(
   field: string
 ): Promise<MapObjectMarkersResult> {
   const supabase = await createClient();
 
-  // Supabase embedded resources: objects → targets via FK
-  const { data, error } = await paginateQuery<{
-    object_id: string;
-    ra: number;
-    dec: number;
-    best_redshift: number | null;
-    best_redshift_quality: number;
-    field: string;
-    n_targets: number;
-    n_spectra: number;
-    programs: string[];
-    targets: { target_id: string }[];
-  }>(
-    () => supabase
-      .from('objects')
-      .select('object_id, ra, dec, best_redshift, best_redshift_quality, field, n_targets, n_spectra, programs, targets(target_id)')
-      .eq('field', field)
-      .order('object_id'),
-    1000,
-  );
+  const { data, error } = await supabase.rpc('get_field_object_markers', {
+    p_field: field,
+  });
 
   if (error) {
     return { markers: [], error: error.message };
   }
 
-  const markers: MapObjectMarker[] = data.map(row => ({
-    object_id: row.object_id,
-    ra: row.ra,
-    dec: row.dec,
-    best_redshift: row.best_redshift,
-    best_redshift_quality: row.best_redshift_quality,
-    field: row.field,
-    n_targets: row.n_targets,
-    n_spectra: row.n_spectra,
-    programs: row.programs,
-    member_target_ids: row.targets.map(t => t.target_id),
-  }));
-
-  return { markers };
+  return { markers: (data || []) as MapObjectMarker[] };
 }
 
 /**
@@ -333,26 +310,21 @@ export async function getNearbyShutters(
 }
 
 /**
- * Fetch all shutters for a field, paginating to get past Supabase row limits.
- * Used by the full map viewer.
+ * Fetch all shutters for a field via RPC (single round-trip).
+ * Used by the full map viewer; replaces a 1000-row-per-page PostgREST select.
  */
 export async function getFieldShutters(
   field: string
 ): Promise<ShuttersResult> {
   const supabase = await createClient();
 
-  const { data, error } = await paginateQuery<Shutter>(
-    () => supabase
-      .from('shutters')
-      .select('object_id, source_id, center_ra, center_dec, position_angle, shutter_idx, dither_id, shutter_state, observation')
-      .eq('field', field)
-      .order('object_id'),
-    1000,
-  );
+  const { data, error } = await supabase.rpc('get_field_shutters', {
+    p_field: field,
+  });
 
   if (error) {
-    return { shutters: data, error: error.message };
+    return { shutters: [], error: error.message };
   }
 
-  return { shutters: data };
+  return { shutters: (data || []) as Shutter[] };
 }

--- a/web/lib/hooks/useInspectionState.ts
+++ b/web/lib/hooks/useInspectionState.ts
@@ -1,6 +1,8 @@
 'use client';
 
 import { useState, useCallback, useRef, useMemo } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import type { MapObjectMarker } from '@/lib/actions/map';
 
 /**
  * Object-level inspection state.
@@ -81,6 +83,7 @@ export function useInspectionState(
   objectDbId: number,
   initialData: InspectionInitialData,
 ): InspectionState {
+  const queryClient = useQueryClient();
   const [redshiftInspected, _setRedshiftInspected] = useState<string>(
     initialOverrideString(initialData)
   );
@@ -202,6 +205,27 @@ export function useInspectionState(
       versionRef.current = newVersion;
       setVersion(newVersion);
 
+      // Patch the map marker cache so the marker recolors instantly without
+      // waiting for the 10-min staleTime in useFieldObjectMarkers. We have
+      // the post-trigger row in data.object — use redshift_quality and the
+      // generated redshift column directly.
+      if (data.object?.object_id && data.object?.field) {
+        const objectIdToPatch: string = data.object.object_id;
+        const fieldToPatch: string = data.object.field;
+        const newQuality: number = data.object.redshift_quality ?? 0;
+        const newRedshift: number | null = data.object.redshift !== undefined
+          ? (data.object.redshift === null ? null : Number(data.object.redshift))
+          : null;
+        queryClient.setQueryData<MapObjectMarker[]>(
+          ['fieldObjectMarkers', fieldToPatch],
+          (old) => old?.map(m =>
+            m.object_id === objectIdToPatch
+              ? { ...m, redshift_quality: newQuality, redshift: newRedshift }
+              : m,
+          ),
+        );
+      }
+
       // Read post-trigger state from the server response: the
       // pin_redshift_on_signoff trigger may have promoted redshift_auto into
       // redshift_inspected and set inspected_used_auto=true if the user
@@ -242,7 +266,7 @@ export function useInspectionState(
       savingRef.current = false;
       setSaving(false);
     }
-  }, []);
+  }, [queryClient]);
 
   const saveIfDirty = useCallback(async (): Promise<SaveIfDirtyResult> => {
     if (savingRef.current) {


### PR DESCRIPTION
## Summary

Two related fixes for the NIRCam map viewer.

**Bug: marker color never reflected new inspections.**
Markers were colored by `objects.best_redshift_quality`, a deploy-time aggregate set by `campfire deploy objects` from member spectra. No trigger ever syncs it from `redshift_quality` (which is what `/api/objects/[id]/inspect` writes), so the only way colors changed was a re-deploy. Switched the marker source field to `redshift_quality` (and the generated `redshift` column for the popup) — the value the user actually edits.

**Perf: COSMOS markers/shutters took ~2–3 min to load.**
`getFieldObjectMarkers` and `getFieldShutters` paginated PostgREST selects at 1000 rows/page with sequential round-trips, and the marker query also embedded `targets(target_id)` for the slit-filter bridge. Replaced with single-shot RPCs that aggregate `member_target_ids` server-side. Both `SECURITY INVOKER` so existing RLS still applies.

**Bonus: optimistic marker update on inspection save.**
After a successful PATCH, `useInspectionState` now patches the `['fieldObjectMarkers', field]` React Query cache by `object_id` with the post-trigger `redshift_quality` and `redshift` from the response. Marker recolors instantly — no waiting for the 10-min `staleTime`.

### Out of scope

`best_redshift_quality` is still referenced from filter RPCs, list views, the spectra/objects table, and CSV export. Same staleness problem applies there. Worth a follow-up issue to migrate those off the legacy column entirely.

## Test plan

- [ ] Local: `supabase db reset` applies the new migration cleanly.
- [ ] Local: `get_field_object_markers('cosmos')` returns rows with `redshift_quality` / `redshift` (smoke-tested against seed).
- [ ] Local: `npm run build` passes.
- [ ] Production COSMOS: confirm markers + shutters load in seconds rather than minutes.
- [ ] Production: open the map, edit an object's quality in the inspector, save → marker recolors immediately on return to the map.

Generated with Claude Code