### PR TITLE
Implement parallel downloads with concurrent.futures and tqdm

### DIFF
--- a/pipeline/campfire_pipeline/cli.py
+++ b/pipeline/campfire_pipeline/cli.py
@@ -137,9 +137,9 @@ INSTRUMENT_DEFAULTS = {
               help='List files without downloading.')
 @click.option('--token', default=None,
               help='MAST API token for proprietary data. Falls back to $MAST_API_TOKEN env var.')
-@click.option('--workers', '-w', type=int, default=4, show_default=True,
+@click.option('--processes', '-p', type=int, default=4, show_default=True,
               help='Number of parallel download streams.')
-def download(program, instrument, obs_id, exp_type, download_dir, dry_run, token, workers):
+def download(program, instrument, obs_id, exp_type, download_dir, dry_run, token, processes):
     """Download raw JWST data from MAST.
 
     Auxiliary metafiles (e.g. NIRSpec MSA metadata) are fetched first so
@@ -158,8 +158,8 @@ def download(program, instrument, obs_id, exp_type, download_dir, dry_run, token
 
     token = token or os.environ.get('MAST_API_TOKEN')
 
-    if workers < 1:
-        raise click.BadParameter('--workers must be >= 1')
+    if processes < 1:
+        raise click.BadParameter('--processes must be >= 1')
 
     try:
         download_jwst_data(
@@ -170,7 +170,7 @@ def download(program, instrument, obs_id, exp_type, download_dir, dry_run, token
             dry_run=dry_run,
             obs_id=obs_id,
             token=token,
-            workers=workers,
+            workers=processes,
         )
     except KeyboardInterrupt:
         click.echo("\n\nInterrupted. Re-run to resume (existing files will be skipped).")

--- a/pipeline/campfire_pipeline/cli.py
+++ b/pipeline/campfire_pipeline/cli.py
@@ -137,8 +137,14 @@ INSTRUMENT_DEFAULTS = {
               help='List files without downloading.')
 @click.option('--token', default=None,
               help='MAST API token for proprietary data. Falls back to $MAST_API_TOKEN env var.')
-def download(program, instrument, obs_id, exp_type, download_dir, dry_run, token):
-    """Download raw JWST data from MAST."""
+@click.option('--workers', '-w', type=int, default=4, show_default=True,
+              help='Number of parallel download streams.')
+def download(program, instrument, obs_id, exp_type, download_dir, dry_run, token, workers):
+    """Download raw JWST data from MAST.
+
+    Auxiliary metafiles (e.g. NIRSpec MSA metadata) are fetched first so
+    reduction can begin while uncal files are still downloading.
+    """
     from campfire_pipeline.common.query import download_jwst_data
 
     instrument_upper = instrument.upper()
@@ -152,6 +158,9 @@ def download(program, instrument, obs_id, exp_type, download_dir, dry_run, token
 
     token = token or os.environ.get('MAST_API_TOKEN')
 
+    if workers < 1:
+        raise click.BadParameter('--workers must be >= 1')
+
     try:
         download_jwst_data(
             program_id=program,
@@ -161,6 +170,7 @@ def download(program, instrument, obs_id, exp_type, download_dir, dry_run, token
             dry_run=dry_run,
             obs_id=obs_id,
             token=token,
+            workers=workers,
         )
     except KeyboardInterrupt:
         click.echo("\n\nInterrupted. Re-run to resume (existing files will be skipped).")

--- a/pipeline/campfire_pipeline/common/query.py
+++ b/pipeline/campfire_pipeline/common/query.py
@@ -13,11 +13,13 @@ Usage:
 """
 
 import argparse
+import concurrent.futures
 import sys
-import time
+import threading
 from pathlib import Path
 
 import requests
+from tqdm import tqdm
 
 BASE_URL = "https://mast.stsci.edu/search/jwst/api/v0.1"
 
@@ -129,72 +131,121 @@ def format_size(size_bytes):
     return f"{size_bytes} B"
 
 
-def progress_bar(fraction, width=30):
-    """Render a progress bar string like [████████░░░░░░░░░░]."""
-    filled = int(width * fraction)
-    return f"[{'█' * filled}{'░' * (width - filled)}]"
+def _download_one(file_info, output_dir, token, pbar, pbar_lock):
+    """Download a single file, updating the shared byte-progress bar.
 
-
-def format_speed(bytes_per_sec):
-    """Format download speed as human-readable string."""
-    if bytes_per_sec >= 1024 ** 2:
-        return f"{bytes_per_sec / 1024 ** 2:.1f} MB/s"
-    if bytes_per_sec >= 1024:
-        return f"{bytes_per_sec / 1024:.0f} KB/s"
-    return f"{bytes_per_sec:.0f} B/s"
-
-
-def download_file(uri, output_path, size, index, total, token=None):
-    """Download a single file with progress bar and speed.
-
-    Returns 'downloaded' or 'error'.
+    Returns ('downloaded' | 'error', filename, error_message_or_None).
     """
-    label = f"  [{index}/{total}]"
-    name = output_path.name
-    size_str = format_size(size)
+    filename = file_info["filename"]
+    output_path = output_dir / filename
+    tmp_path = output_path.with_suffix(".tmp")
     headers = {"Authorization": f"token {token}"} if token else {}
 
     try:
         resp = requests.get(
             f"{BASE_URL}/retrieve_product",
-            params={"product_name": uri},
+            params={"product_name": file_info["uri"]},
             stream=True,
             headers=headers,
+            timeout=60,
         )
         resp.raise_for_status()
 
-        tmp_path = output_path.with_suffix(".tmp")
-        downloaded = 0
-        t_start = time.monotonic()
-
         with open(tmp_path, "wb") as f:
             for chunk in resp.iter_content(chunk_size=1024 * 1024):
+                if not chunk:
+                    continue
                 f.write(chunk)
-                downloaded += len(chunk)
-                elapsed = time.monotonic() - t_start
-                speed = downloaded / elapsed if elapsed > 0 else 0
-                frac = downloaded / size if size > 0 else 0
-                bar = progress_bar(frac)
-                line = f"\r{label} {name}  {bar} {format_size(downloaded)}/{size_str}  {format_speed(speed)}"
-                print(line, end="", flush=True)
+                with pbar_lock:
+                    pbar.update(len(chunk))
 
         tmp_path.rename(output_path)
-        elapsed = time.monotonic() - t_start
-        speed = size / elapsed if elapsed > 0 else 0
-        print(f"\r{label} {name}  {size_str}  done in {elapsed:.0f}s ({format_speed(speed)})" + " " * 20)
-        return "downloaded"
+        return "downloaded", filename, None
 
     except (requests.RequestException, OSError) as e:
-        print(f"\r{label} {name}  ERROR: {e}" + " " * 40)
-        tmp_path = output_path.with_suffix(".tmp")
         if tmp_path.exists():
-            tmp_path.unlink()
-        return "error"
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+        return "error", filename, str(e)
+
+
+def download_files(files, output_dir, token=None, workers=4, desc="downloading"):
+    """Download a list of files concurrently with a single aggregate progress bar.
+
+    Parameters
+    ----------
+    files : list of dict
+        Each dict has 'filename', 'uri', and 'size'.
+    output_dir : Path
+        Destination directory (must already exist).
+    token : str or None
+        MAST API token for authentication.
+    workers : int
+        Number of parallel download streams.
+    desc : str
+        Label shown in the progress bar.
+
+    Returns the number of files that errored.
+    """
+    if not files:
+        return 0
+
+    total_size = sum(f["size"] for f in files)
+    pbar_lock = threading.Lock()
+    errors = 0
+
+    workers = max(1, min(workers, len(files)))
+
+    with tqdm(
+        total=total_size,
+        unit="B",
+        unit_scale=True,
+        unit_divisor=1024,
+        desc=f"  {desc}",
+        dynamic_ncols=True,
+    ) as pbar:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as ex:
+            futures = [
+                ex.submit(_download_one, f, output_dir, token, pbar, pbar_lock)
+                for f in files
+            ]
+            try:
+                for future in concurrent.futures.as_completed(futures):
+                    status, name, err = future.result()
+                    if status == "error":
+                        errors += 1
+                        tqdm.write(f"    ERROR {name}: {err}")
+            except KeyboardInterrupt:
+                for fut in futures:
+                    fut.cancel()
+                raise
+
+    return errors
+
+
+def _split_existing(files, output_dir):
+    """Partition files into (to_download, to_skip) based on what's on disk."""
+    to_download = []
+    to_skip = []
+    for f in files:
+        path = output_dir / f["filename"]
+        if path.exists() and path.stat().st_size == f["size"]:
+            to_skip.append(f)
+        else:
+            to_download.append(f)
+    return to_download, to_skip
 
 
 def download_jwst_data(program_id, instrument="NIRSPEC", exp_type="NRS_MSASPEC",
-                       download_dir="data", dry_run=False, obs_id=None, token=None):
+                       download_dir="data", dry_run=False, obs_id=None, token=None,
+                       workers=4):
     """Download JWST level 1b data for a program.
+
+    Auxiliary metadata files (e.g. NIRSpec MSA metafiles) are downloaded
+    first, so reduction can begin while the larger uncal files are still
+    being fetched.
 
     Parameters
     ----------
@@ -212,6 +263,8 @@ def download_jwst_data(program_id, instrument="NIRSPEC", exp_type="NRS_MSASPEC",
         JWST observation number to filter by (e.g. 1, 2, 3).
     token : str or None
         MAST API token for accessing proprietary data.
+    workers : int
+        Number of parallel download streams (default 4).
     """
     if token:
         print("Using MAST API token for authentication.")
@@ -229,7 +282,7 @@ def download_jwst_data(program_id, instrument="NIRSPEC", exp_type="NRS_MSASPEC",
 
     # Step 3: Filter
     uncal_files, aux_files = filter_products(products, instrument)
-    all_files = uncal_files + aux_files
+    all_files = aux_files + uncal_files
     total_size = sum(f["size"] for f in all_files)
 
     print()
@@ -242,14 +295,11 @@ def download_jwst_data(program_id, instrument="NIRSPEC", exp_type="NRS_MSASPEC",
 
     # Check which files already exist
     output_dir = Path(download_dir) / str(program_id)
-    to_download = []
-    to_skip = []
-    for f in all_files:
-        path = output_dir / f["filename"]
-        if path.exists() and path.stat().st_size == f["size"]:
-            to_skip.append(f)
-        else:
-            to_download.append(f)
+    aux_to_dl, aux_skip = _split_existing(aux_files, output_dir)
+    uncal_to_dl, uncal_skip = _split_existing(uncal_files, output_dir)
+
+    to_skip = aux_skip + uncal_skip
+    to_download = aux_to_dl + uncal_to_dl
 
     if to_skip:
         skip_size = sum(f["size"] for f in to_skip)
@@ -270,7 +320,6 @@ def download_jwst_data(program_id, instrument="NIRSPEC", exp_type="NRS_MSASPEC",
                 print(f"  {f['filename']:55s}  {format_size(f['size']):>10s}  (exists)")
         return
 
-    # Step 4: Download
     if not to_download:
         print("\nNothing to download — all files already exist.")
         return
@@ -279,14 +328,24 @@ def download_jwst_data(program_id, instrument="NIRSPEC", exp_type="NRS_MSASPEC",
     dl_size = sum(f["size"] for f in to_download)
 
     print()
-    print(f"Downloading {len(to_download)} files ({format_size(dl_size)}) to {output_dir}/")
+    print(f"Downloading {len(to_download)} files ({format_size(dl_size)}) to {output_dir}/ "
+          f"with {workers} parallel stream{'s' if workers != 1 else ''}")
 
     errors = 0
-    for i, f in enumerate(to_download, 1):
-        output_path = output_dir / f["filename"]
-        result = download_file(f["uri"], output_path, f["size"], i, len(to_download), token=token)
-        if result == "error":
-            errors += 1
+
+    # Step 4a: Aux/MSA metafiles first so reduction can start early
+    if aux_to_dl:
+        print(f"\nFetching {len(aux_to_dl)} metafile(s) first...")
+        errors += download_files(
+            aux_to_dl, output_dir, token=token, workers=workers, desc="metafiles",
+        )
+
+    # Step 4b: Uncal data files
+    if uncal_to_dl:
+        print(f"\nFetching {len(uncal_to_dl)} uncal file(s)...")
+        errors += download_files(
+            uncal_to_dl, output_dir, token=token, workers=workers, desc="uncal    ",
+        )
 
     print()
     downloaded = len(to_download) - errors
@@ -294,7 +353,8 @@ def download_jwst_data(program_id, instrument="NIRSPEC", exp_type="NRS_MSASPEC",
     print(f"Location: {output_dir}/")
 
 
-def download_nirspec_uncal(program_id, download_dir="data", exp_type="NRS_MSASPEC", dry_run=False):
+def download_nirspec_uncal(program_id, download_dir="data", exp_type="NRS_MSASPEC",
+                           dry_run=False, workers=4):
     """Backwards-compatible wrapper for download_jwst_data()."""
     download_jwst_data(
         program_id=program_id,
@@ -302,6 +362,7 @@ def download_nirspec_uncal(program_id, download_dir="data", exp_type="NRS_MSASPE
         exp_type=exp_type,
         download_dir=download_dir,
         dry_run=dry_run,
+        workers=workers,
     )
 
 
@@ -322,15 +383,18 @@ Examples:
     parser.add_argument("--download-dir", default="data", help="Base directory for downloads (default: data)")
     parser.add_argument("--dry-run", action="store_true", help="List files without downloading")
     parser.add_argument("--exp-type", default="NRS_MSASPEC", help="NIRSpec exposure type (default: NRS_MSASPEC)")
+    parser.add_argument("--workers", type=int, default=4, help="Parallel download streams (default: 4)")
 
     args = parser.parse_args()
 
     try:
-        download_nirspec_uncal(
+        download_jwst_data(
             program_id=args.program,
-            download_dir=args.download_dir,
+            instrument="NIRSPEC",
             exp_type=args.exp_type,
+            download_dir=args.download_dir,
             dry_run=args.dry_run,
+            workers=args.workers,
         )
     except requests.HTTPError as e:
         print(f"\nAPI error: {e}", file=sys.stderr)

--- a/pipeline/campfire_pipeline/common/query.py
+++ b/pipeline/campfire_pipeline/common/query.py
@@ -218,8 +218,7 @@ def download_files(files, output_dir, token=None, workers=4, desc="downloading")
                         errors += 1
                         tqdm.write(f"    ERROR {name}: {err}")
             except KeyboardInterrupt:
-                for fut in futures:
-                    fut.cancel()
+                ex.shutdown(wait=False, cancel_futures=True)
                 raise
 
     return errors

--- a/pipeline/campfire_pipeline/common/query.py
+++ b/pipeline/campfire_pipeline/common/query.py
@@ -383,7 +383,7 @@ Examples:
     parser.add_argument("--download-dir", default="data", help="Base directory for downloads (default: data)")
     parser.add_argument("--dry-run", action="store_true", help="List files without downloading")
     parser.add_argument("--exp-type", default="NRS_MSASPEC", help="NIRSpec exposure type (default: NRS_MSASPEC)")
-    parser.add_argument("--workers", type=int, default=4, help="Parallel download streams (default: 4)")
+    parser.add_argument("-p", "--processes", type=int, default=4, help="Parallel download streams (default: 4)")
 
     args = parser.parse_args()
 
@@ -394,7 +394,7 @@ Examples:
             exp_type=args.exp_type,
             download_dir=args.download_dir,
             dry_run=args.dry_run,
-            workers=args.workers,
+            workers=args.processes,
         )
     except requests.HTTPError as e:
         print(f"\nAPI error: {e}", file=sys.stderr)


### PR DESCRIPTION
## Summary
Refactored the JWST data download functionality to support parallel downloads using thread pools and a unified progress bar, replacing the previous sequential download approach with per-file progress tracking.

## Key Changes

- **Parallel download architecture**: Replaced sequential `download_file()` with `_download_one()` worker function and new `download_files()` coordinator that uses `concurrent.futures.ThreadPoolExecutor` for concurrent downloads
- **Unified progress tracking**: Replaced custom progress bar implementation with `tqdm` library for a single aggregate byte-progress bar across all parallel downloads, eliminating per-file status lines
- **Configurable concurrency**: Added `workers` parameter (default 4) to `download_jwst_data()`, `download_nirspec_uncal()`, and CLI to control the number of parallel download streams
- **Improved file handling**: 
  - Added `_split_existing()` helper to partition files into download/skip lists
  - Separated auxiliary metadata files from uncal data files in download order
  - Better error handling with cleanup of partial `.tmp` files
  - Added request timeout (60s) to prevent hanging connections
- **Prioritized metadata downloads**: Auxiliary/MSA metafiles now download first so data reduction can begin while larger uncal files are still being fetched
- **CLI enhancements**: 
  - Added `-p/--processes` flag to control parallel streams
  - Updated help text to document the metadata-first download strategy
  - Added validation for processes parameter (must be >= 1)
- **Dependency updates**: Added `tqdm` import for progress bar functionality; removed `time` module usage

## Implementation Details

- Thread-safe progress bar updates using `threading.Lock` to prevent race conditions
- Graceful handling of `KeyboardInterrupt` with future cancellation
- Per-file error reporting via `tqdm.write()` to avoid corrupting the progress bar
- Maintains backward compatibility through wrapper functions

https://claude.ai/code/session_011qj5cJenMu39XWb9quQ9Jv