### PR TITLE
Surface deployment provenance and derive gratings from spectra

### DIFF
--- a/supabase/migrations/20260503180000_metadata_observations_provenance.sql
+++ b/supabase/migrations/20260503180000_metadata_observations_provenance.sql
@@ -1,0 +1,140 @@
+-- Surface reduction user (deployed_by) on the metadata page and derive
+-- gratings from the spectra table.
+--
+-- - get_observations_overview: drop+recreate; add deployed_by_username and
+--   deployed_by_full_name (joined via user_profiles), and derive gratings
+--   from spectra when present (falling back to observations.gratings, which
+--   may be empty for observations whose deploy didn't go through
+--   observations.toml).
+-- - get_observation_stats: same deployed_by_* additions for the program
+--   detail page.
+--
+-- Function bodies are hand-authored (not generated via `supabase db diff`)
+-- to keep the migration small; both schemas/functions.sql and this file are
+-- kept in sync.
+
+
+set check_function_bodies = off;
+
+
+DROP FUNCTION IF EXISTS public.get_observations_overview(text[]);
+
+CREATE OR REPLACE FUNCTION public.get_observations_overview(p_program_slugs text[])
+ RETURNS TABLE(observation text, program_slug text, program_name text, field text, cycle integer, gratings text[], pointing_count integer, pointings jsonb, target_count bigint, spectrum_count bigint, total_size_bytes bigint, reduction_version text, crds_context text, cfpipe_version text, jwst_version text, reduced_at timestamp with time zone, deployed_at timestamp with time zone, deployed_by_username text, deployed_by_full_name text, n_patches_since_full integer, last_patch_at timestamp with time zone)
+ LANGUAGE sql
+ STABLE
+AS $function$
+  WITH stats AS (
+    SELECT t.observation, t.program_slug,
+      COUNT(DISTINCT t.target_id) AS target_count,
+      COUNT(s.id) AS spectrum_count,
+      COALESCE(SUM(s.file_size), 0)::bigint AS total_size_bytes,
+      ARRAY_AGG(DISTINCT s.grating ORDER BY s.grating)
+        FILTER (WHERE s.grating IS NOT NULL) AS gratings
+    FROM public.targets t
+    LEFT JOIN public.spectra s ON s.target_id = t.target_id
+    WHERE t.program_slug = ANY(p_program_slugs)
+    GROUP BY t.observation, t.program_slug
+  )
+  SELECT
+    o.name AS observation,
+    o.program_slug,
+    p.program_name,
+    o.field,
+    p.cycle,
+    CASE
+      WHEN COALESCE(array_length(s.gratings, 1), 0) > 0 THEN s.gratings
+      ELSE COALESCE(o.gratings, ARRAY[]::text[])
+    END AS gratings,
+    COALESCE(jsonb_array_length(o.pointings), 0) AS pointing_count,
+    o.pointings,
+    COALESCE(s.target_count, 0)::bigint AS target_count,
+    COALESCE(s.spectrum_count, 0)::bigint AS spectrum_count,
+    COALESCE(s.total_size_bytes, 0)::bigint AS total_size_bytes,
+    full_dep.reduction_version, full_dep.crds_context,
+    full_dep.cfpipe_version, full_dep.jwst_version,
+    full_dep.reduced_at, full_dep.deployed_at,
+    full_dep.deployed_by_username, full_dep.deployed_by_full_name,
+    COALESCE(patches.n_patches, 0)::integer AS n_patches_since_full,
+    patches.last_patch_at
+  FROM public.observations o
+  JOIN public.programs p ON p.slug = o.program_slug
+  LEFT JOIN stats s ON s.observation = o.name AND s.program_slug = o.program_slug
+  LEFT JOIN LATERAL (
+    SELECT d.reduction_version, d.crds_context, d.cfpipe_version, d.jwst_version,
+           d.reduced_at, d.deployed_at,
+           up.username AS deployed_by_username,
+           up.full_name AS deployed_by_full_name
+    FROM public.deployments d
+    LEFT JOIN public.user_profiles up ON up.user_id = d.deployed_by
+    WHERE d.observation = o.name AND d.source_ids_filter IS NULL
+    ORDER BY d.deployed_at DESC
+    LIMIT 1
+  ) full_dep ON true
+  LEFT JOIN LATERAL (
+    SELECT COUNT(*)::integer AS n_patches, MAX(d.deployed_at) AS last_patch_at
+    FROM public.deployments d
+    WHERE d.observation = o.name
+      AND d.source_ids_filter IS NOT NULL
+      AND (full_dep.deployed_at IS NULL OR d.deployed_at > full_dep.deployed_at)
+  ) patches ON true
+  WHERE o.program_slug = ANY(p_program_slugs)
+  ORDER BY o.program_slug, o.name;
+$function$
+;
+
+
+DROP FUNCTION IF EXISTS public.get_observation_stats(text[]);
+
+CREATE OR REPLACE FUNCTION public.get_observation_stats(p_program_slugs text[])
+ RETURNS TABLE(observation text, program_slug text, program_name text, field text, target_count bigint, spectrum_count bigint, total_size_bytes bigint, pointings jsonb, reduction_version text, crds_context text, cfpipe_version text, jwst_version text, reduced_at timestamp with time zone, deployed_at timestamp with time zone, deployed_by_username text, deployed_by_full_name text, n_patches_since_full integer, last_patch_at timestamp with time zone)
+ LANGUAGE sql
+ STABLE
+AS $function$
+  WITH stats AS (
+    SELECT t.observation, t.program_slug, p.program_name, t.field,
+      COUNT(DISTINCT t.target_id) AS target_count,
+      COUNT(s.id) AS spectrum_count,
+      COALESCE(SUM(s.file_size), 0)::bigint AS total_size_bytes
+    FROM public.targets t
+    JOIN public.programs p ON p.slug = t.program_slug
+    LEFT JOIN public.spectra s ON s.target_id = t.target_id
+    WHERE t.program_slug = ANY(p_program_slugs)
+    GROUP BY t.observation, t.program_slug, p.program_name, t.field
+  )
+  SELECT s.observation, s.program_slug, s.program_name, s.field,
+    s.target_count, s.spectrum_count, s.total_size_bytes,
+    o.pointings,
+    full_dep.reduction_version, full_dep.crds_context,
+    full_dep.cfpipe_version, full_dep.jwst_version,
+    full_dep.reduced_at, full_dep.deployed_at,
+    full_dep.deployed_by_username, full_dep.deployed_by_full_name,
+    COALESCE(patches.n_patches, 0)::integer AS n_patches_since_full,
+    patches.last_patch_at
+  FROM stats s
+  LEFT JOIN public.observations o ON o.name = s.observation
+  LEFT JOIN LATERAL (
+    SELECT d.reduction_version, d.crds_context, d.cfpipe_version, d.jwst_version,
+           d.reduced_at, d.deployed_at,
+           up.username AS deployed_by_username,
+           up.full_name AS deployed_by_full_name
+    FROM public.deployments d
+    LEFT JOIN public.user_profiles up ON up.user_id = d.deployed_by
+    WHERE d.observation = s.observation AND d.source_ids_filter IS NULL
+    ORDER BY d.deployed_at DESC
+    LIMIT 1
+  ) full_dep ON true
+  LEFT JOIN LATERAL (
+    SELECT COUNT(*)::integer AS n_patches, MAX(d.deployed_at) AS last_patch_at
+    FROM public.deployments d
+    WHERE d.observation = s.observation
+      AND d.source_ids_filter IS NOT NULL
+      AND (full_dep.deployed_at IS NULL OR d.deployed_at > full_dep.deployed_at)
+  ) patches ON true
+  ORDER BY s.observation;
+$function$
+;
+
+
+GRANT EXECUTE ON FUNCTION public.get_observations_overview(text[]) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_observation_stats(text[]) TO authenticated;

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -1957,6 +1957,7 @@ RETURNS TABLE(
   pointings jsonb,
   reduction_version text, crds_context text, cfpipe_version text, jwst_version text,
   reduced_at timestamptz, deployed_at timestamptz,
+  deployed_by_username text, deployed_by_full_name text,
   n_patches_since_full integer, last_patch_at timestamptz
 ) LANGUAGE sql STABLE AS $$
   WITH stats AS (
@@ -1976,14 +1977,18 @@ RETURNS TABLE(
     full_dep.reduction_version, full_dep.crds_context,
     full_dep.cfpipe_version, full_dep.jwst_version,
     full_dep.reduced_at, full_dep.deployed_at,
+    full_dep.deployed_by_username, full_dep.deployed_by_full_name,
     COALESCE(patches.n_patches, 0)::integer AS n_patches_since_full,
     patches.last_patch_at
   FROM stats s
   LEFT JOIN observations o ON o.name = s.observation
   LEFT JOIN LATERAL (
     SELECT d.reduction_version, d.crds_context, d.cfpipe_version, d.jwst_version,
-           d.reduced_at, d.deployed_at
+           d.reduced_at, d.deployed_at,
+           up.username AS deployed_by_username,
+           up.full_name AS deployed_by_full_name
     FROM public.deployments d
+    LEFT JOIN public.user_profiles up ON up.user_id = d.deployed_by
     WHERE d.observation = s.observation AND d.source_ids_filter IS NULL
     ORDER BY d.deployed_at DESC
     LIMIT 1
@@ -2009,6 +2014,15 @@ GRANT EXECUTE ON FUNCTION public.get_observation_stats TO authenticated;
 -- tab. Caller passes the accessible program slug list (public + explicit
 -- access), matching the get_observation_stats pattern; filtering happens in
 -- SQL so the targets/spectra aggregate doesn't scan inaccessible rows.
+--
+-- Gratings are derived from the spectra table (the actual deployed data),
+-- with observations.gratings as a fallback when no spectra exist yet — the
+-- observations.gratings column is populated from observations.toml at deploy
+-- time and is empty for observations that haven't gone through that path.
+--
+-- deployed_by_username / deployed_by_full_name come from user_profiles via
+-- the latest full deployment so the metadata page can show who reduced each
+-- observation without an extra client-side join.
 DROP FUNCTION IF EXISTS public.get_observations_overview();
 DROP FUNCTION IF EXISTS public.get_observations_overview(text[]);
 
@@ -2019,13 +2033,16 @@ RETURNS TABLE(
   target_count bigint, spectrum_count bigint, total_size_bytes bigint,
   reduction_version text, crds_context text, cfpipe_version text, jwst_version text,
   reduced_at timestamptz, deployed_at timestamptz,
+  deployed_by_username text, deployed_by_full_name text,
   n_patches_since_full integer, last_patch_at timestamptz
 ) LANGUAGE sql STABLE AS $$
   WITH stats AS (
     SELECT t.observation, t.program_slug,
       COUNT(DISTINCT t.target_id) AS target_count,
       COUNT(s.id) AS spectrum_count,
-      COALESCE(SUM(s.file_size), 0)::bigint AS total_size_bytes
+      COALESCE(SUM(s.file_size), 0)::bigint AS total_size_bytes,
+      ARRAY_AGG(DISTINCT s.grating ORDER BY s.grating)
+        FILTER (WHERE s.grating IS NOT NULL) AS gratings
     FROM public.targets t
     LEFT JOIN public.spectra s ON s.target_id = t.target_id
     WHERE t.program_slug = ANY(p_program_slugs)
@@ -2037,7 +2054,10 @@ RETURNS TABLE(
     p.program_name,
     o.field,
     p.cycle,
-    COALESCE(o.gratings, ARRAY[]::text[]) AS gratings,
+    CASE
+      WHEN COALESCE(array_length(s.gratings, 1), 0) > 0 THEN s.gratings
+      ELSE COALESCE(o.gratings, ARRAY[]::text[])
+    END AS gratings,
     COALESCE(jsonb_array_length(o.pointings), 0) AS pointing_count,
     o.pointings,
     COALESCE(s.target_count, 0)::bigint AS target_count,
@@ -2046,6 +2066,7 @@ RETURNS TABLE(
     full_dep.reduction_version, full_dep.crds_context,
     full_dep.cfpipe_version, full_dep.jwst_version,
     full_dep.reduced_at, full_dep.deployed_at,
+    full_dep.deployed_by_username, full_dep.deployed_by_full_name,
     COALESCE(patches.n_patches, 0)::integer AS n_patches_since_full,
     patches.last_patch_at
   FROM public.observations o
@@ -2053,8 +2074,11 @@ RETURNS TABLE(
   LEFT JOIN stats s ON s.observation = o.name AND s.program_slug = o.program_slug
   LEFT JOIN LATERAL (
     SELECT d.reduction_version, d.crds_context, d.cfpipe_version, d.jwst_version,
-           d.reduced_at, d.deployed_at
+           d.reduced_at, d.deployed_at,
+           up.username AS deployed_by_username,
+           up.full_name AS deployed_by_full_name
     FROM public.deployments d
+    LEFT JOIN public.user_profiles up ON up.user_id = d.deployed_by
     WHERE d.observation = o.name AND d.source_ids_filter IS NULL
     ORDER BY d.deployed_at DESC
     LIMIT 1

--- a/web/app/nirspec/metadata/page.tsx
+++ b/web/app/nirspec/metadata/page.tsx
@@ -257,6 +257,8 @@ function MetadataPageContent() {
         <MetadataSearchBar
           programs={programs}
           observations={observations}
+          value={filters.search}
+          onChange={(search) => setFilters((prev) => ({ ...prev, search }))}
           onSelectObservation={(name) =>
             setFilters((prev) => ({ ...prev, tab: 'observations', search: name }))
           }

--- a/web/components/metadata/MetadataFilterBar.tsx
+++ b/web/components/metadata/MetadataFilterBar.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useMemo } from 'react';
-import { Search, X } from 'lucide-react';
 import { FilterChip, type FilterOption } from '@/components/ui/FilterChip';
 import type {
   MetadataFilters,
@@ -109,31 +108,6 @@ export const MetadataFilterBar: React.FC<MetadataFilterBarProps> = ({
 
   return (
     <div className="flex flex-wrap items-center gap-2 mb-4">
-      {/* Free-text search */}
-      <div className="relative flex-1 min-w-[200px] max-w-md">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-secondary dark:text-slate-500" />
-        <input
-          type="text"
-          value={filters.search}
-          onChange={(e) => update({ search: e.target.value })}
-          placeholder={
-            tab === 'programs'
-              ? 'Search programs, slug, PI, JWST PID…'
-              : 'Search observation, program, field…'
-          }
-          className="w-full pl-9 pr-9 py-1.5 text-sm border border-border dark:border-slate-700 rounded-md bg-background dark:bg-slate-900 text-text-primary dark:text-slate-100 placeholder:text-text-secondary dark:placeholder:text-slate-500 focus:outline-none focus:ring-1 focus:ring-primary"
-        />
-        {filters.search && (
-          <button
-            onClick={() => update({ search: '' })}
-            className="absolute right-2 top-1/2 -translate-y-1/2 text-text-secondary dark:text-slate-500 hover:text-text-primary dark:hover:text-slate-200"
-            aria-label="Clear search"
-          >
-            <X className="w-4 h-4" />
-          </button>
-        )}
-      </div>
-
       {tab === 'programs' && (
         <>
           <FilterChip

--- a/web/components/metadata/MetadataSearchBar.tsx
+++ b/web/components/metadata/MetadataSearchBar.tsx
@@ -20,6 +20,13 @@ interface SearchResult {
 interface MetadataSearchBarProps {
   programs: ProgramOverview[];
   observations: ObservationOverview[];
+  /**
+   * Current search text. Controlled so it stays in sync with the filter
+   * state (typing here drives `filters.search` directly — there is no
+   * second search bar in the filter row).
+   */
+  value: string;
+  onChange: (value: string) => void;
   onSelectObservation: (obsName: string) => void;
   onSelectPi: (piName: string) => void;
 }
@@ -34,11 +41,12 @@ function matches(haystack: string | number | null | undefined, needle: string): 
 export const MetadataSearchBar: React.FC<MetadataSearchBarProps> = ({
   programs,
   observations,
+  value,
+  onChange,
   onSelectObservation,
   onSelectPi,
 }) => {
   const router = useRouter();
-  const [value, setValue] = useState('');
   const [open, setOpen] = useState(false);
   const [highlight, setHighlight] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -112,7 +120,7 @@ export const MetadataSearchBar: React.FC<MetadataSearchBarProps> = ({
   }, [value]);
 
   const select = (r: SearchResult) => {
-    setValue('');
+    onChange('');
     setOpen(false);
     if (r.kind === 'program' && r.programSlug) {
       router.push(`/nirspec/metadata/programs/${r.programSlug}`);
@@ -149,7 +157,7 @@ export const MetadataSearchBar: React.FC<MetadataSearchBarProps> = ({
         type="text"
         value={value}
         onChange={(e) => {
-          setValue(e.target.value);
+          onChange(e.target.value);
           setOpen(true);
         }}
         onFocus={() => setOpen(true)}
@@ -160,7 +168,7 @@ export const MetadataSearchBar: React.FC<MetadataSearchBarProps> = ({
       {value && (
         <button
           onClick={() => {
-            setValue('');
+            onChange('');
             setOpen(false);
           }}
           className="absolute right-3 top-1/2 -translate-y-1/2 text-text-secondary dark:text-slate-500 hover:text-text-primary dark:hover:text-slate-200"

--- a/web/components/metadata/ObservationsTable.tsx
+++ b/web/components/metadata/ObservationsTable.tsx
@@ -33,6 +33,9 @@ const COLUMN_DEFS: ColumnDefinition[] = [
   { id: 'spectrum_count', label: 'Spectra', defaultVisible: true },
   { id: 'total_size_bytes', label: 'Size', defaultVisible: true },
   { id: 'reduction', label: 'Reduction', defaultVisible: true },
+  { id: 'jwst_version', label: 'JWST', defaultVisible: false },
+  { id: 'crds_context', label: 'CRDS', defaultVisible: false },
+  { id: 'reduced_by', label: 'Reduced by', defaultVisible: false },
 ];
 
 function formatBytes(bytes: number): string {
@@ -181,6 +184,49 @@ export const ObservationsTable: React.FC<ObservationsTableProps> = ({
         header: 'Reduction',
         enableSorting: true,
         cell: ({ row }) => <ProvenanceCell provenance={row.original} />,
+      },
+      {
+        id: 'jwst_version',
+        accessorKey: 'jwst_version',
+        header: 'JWST',
+        enableSorting: true,
+        cell: ({ getValue }) => (
+          <span className="text-xs font-mono text-text-secondary dark:text-slate-400">
+            {String(getValue() || '—')}
+          </span>
+        ),
+      },
+      {
+        id: 'crds_context',
+        accessorKey: 'crds_context',
+        header: 'CRDS',
+        enableSorting: true,
+        cell: ({ getValue }) => (
+          <span className="text-xs font-mono text-text-secondary dark:text-slate-400">
+            {String(getValue() || '—')}
+          </span>
+        ),
+      },
+      {
+        id: 'reduced_by',
+        accessorFn: (r) => r.deployed_by_username || r.deployed_by_full_name || '',
+        header: 'Reduced by',
+        enableSorting: true,
+        cell: ({ row }) => {
+          const username = row.original.deployed_by_username;
+          const fullName = row.original.deployed_by_full_name;
+          if (!username && !fullName) {
+            return <span className="text-xs text-text-secondary dark:text-slate-500">—</span>;
+          }
+          return (
+            <span
+              className="text-xs text-text-secondary dark:text-slate-400"
+              title={fullName ?? undefined}
+            >
+              {username ?? fullName}
+            </span>
+          );
+        },
       },
     ],
     []

--- a/web/components/metadata/ProvenanceCell.tsx
+++ b/web/components/metadata/ProvenanceCell.tsx
@@ -44,6 +44,8 @@ export const ProvenanceCell: React.FC<ProvenanceCellProps> = ({ provenance, comp
     jwst_version,
     reduced_at,
     deployed_at,
+    deployed_by_username,
+    deployed_by_full_name,
     n_patches_since_full,
     last_patch_at,
   } = provenance;
@@ -106,6 +108,10 @@ export const ProvenanceCell: React.FC<ProvenanceCellProps> = ({ provenance, comp
             <dd className="font-mono text-text-primary dark:text-slate-100">{formatTimestamp(reduced_at)}</dd>
             <dt>Deployed</dt>
             <dd className="font-mono text-text-primary dark:text-slate-100">{formatTimestamp(deployed_at)}</dd>
+            <dt>By</dt>
+            <dd className="text-text-primary dark:text-slate-100" title={deployed_by_full_name ?? undefined}>
+              {deployed_by_username ?? deployed_by_full_name ?? '—'}
+            </dd>
           </dl>
           {n_patches_since_full > 0 && (
             <div className="mt-3 pt-2 border-t border-border dark:border-slate-700">

--- a/web/lib/actions/programs.ts
+++ b/web/lib/actions/programs.ts
@@ -29,6 +29,8 @@ export interface ObservationProvenance {
   jwst_version: string | null;
   reduced_at: string | null;
   deployed_at: string | null;
+  deployed_by_username: string | null;
+  deployed_by_full_name: string | null;
   n_patches_since_full: number;
   last_patch_at: string | null;
 }
@@ -213,6 +215,8 @@ export async function getProgramDetail(programSlug: string): Promise<ProgramDeta
         jwst_version: o.jwst_version ?? null,
         reduced_at: o.reduced_at ?? null,
         deployed_at: o.deployed_at ?? null,
+        deployed_by_username: o.deployed_by_username ?? null,
+        deployed_by_full_name: o.deployed_by_full_name ?? null,
         n_patches_since_full: Number(o.n_patches_since_full) || 0,
         last_patch_at: o.last_patch_at ?? null,
       })
@@ -282,6 +286,8 @@ export async function getObservationsOverview(): Promise<ObservationsOverviewRes
         jwst_version: o.jwst_version ?? null,
         reduced_at: o.reduced_at ?? null,
         deployed_at: o.deployed_at ?? null,
+        deployed_by_username: o.deployed_by_username ?? null,
+        deployed_by_full_name: o.deployed_by_full_name ?? null,
         n_patches_since_full: Number(o.n_patches_since_full) || 0,
         last_patch_at: o.last_patch_at ?? null,
       }));


### PR DESCRIPTION
## Summary
This PR enhances the metadata pages by surfacing who reduced each observation and improving grating information accuracy. It adds deployment provenance (username and full name) to observation metadata and derives gratings from actual spectra data rather than relying solely on deployment configuration.

## Key Changes

**Database Functions**
- Updated `get_observations_overview()` and `get_observation_stats()` to join with `user_profiles` via the `deployments` table, exposing `deployed_by_username` and `deployed_by_full_name`
- Modified `get_observations_overview()` to derive gratings from the `spectra` table (actual deployed data) with fallback to `observations.gratings` for observations without spectra yet
- Added migration file to keep schema definitions in sync with hand-authored function bodies

**UI Components**
- Added three new optional columns to the observations table: JWST version, CRDS context, and "Reduced by" (username with full name tooltip)
- Updated `ProvenanceCell` to display the deployment user information in the provenance details popup
- Refactored `MetadataSearchBar` to accept controlled `value` and `onChange` props, syncing with filter state
- Removed duplicate search input from `MetadataFilterBar` (search now lives only in the search bar component)

**Type Updates**
- Extended `ObservationProvenance` interface with `deployed_by_username` and `deployed_by_full_name` fields
- Updated data mapping in `getProgramDetail()` and `getObservationsOverview()` to include new provenance fields

## Implementation Details
- Gratings fallback logic: uses spectra-derived gratings when available (non-empty array), otherwise falls back to `observations.gratings` which may be empty for observations that haven't gone through the `observations.toml` deployment path
- Search bar is now a controlled component, eliminating state duplication and keeping it in sync with the filter bar's search state
- New columns default to hidden (`defaultVisible: false`) to avoid cluttering the default view
- User information is displayed with a tooltip showing the full name on hover

https://claude.ai/code/session_01B1i5rY7eANH6tdih7DVDD6