### PR TITLE
Fix: scope pipeline CMPFRVER dirty check to pipeline/

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -44,6 +44,11 @@ Release procedure: edit the `## Unreleased` section below, then run
   rather than a raw monorepo git short SHA.
 - Added `scripts/release-pipeline.sh` and the `/pipeline-release` Claude Code
   slash command to drive the tag-and-push workflow.
+- Scoped the `CMPFRVER` dirty-flag check to `pipeline/`, so edits in `web/`,
+  `python/`, `supabase/`, etc. no longer flip `+dDATE` on the pipeline
+  version string (#135). `git describe --dirty` checks the whole working
+  tree; we now call `git describe` (no `--dirty`) and pair it with a
+  pipeline-scoped `git status --porcelain -- pipeline`.
 
 ## v0.3.0 — legacy
 

--- a/pipeline/campfire_pipeline/common/version.py
+++ b/pipeline/campfire_pipeline/common/version.py
@@ -12,13 +12,16 @@ Resolution order (first that succeeds wins):
    lookup against installed package metadata.
 5. ``"0.0.0+unknown"`` — sentinel.
 
-The translation from ``git describe`` to PEP 440:
+The translation from ``git describe`` to PEP 440 (dirty flag below comes
+from a pipeline-scoped ``git status --porcelain -- pipeline``, not from
+``git describe --dirty``, which would be tripped by edits anywhere in the
+monorepo):
 
-    pipeline-v0.4.0                    -> 0.4.0
-    pipeline-v0.4.0-3-g7f4e2c1         -> 0.4.1.dev3+g7f4e2c1
-    pipeline-v0.4.0-3-g7f4e2c1-dirty   -> 0.4.1.dev3+g7f4e2c1.d20260504
-    pipeline-v0.4.0-0-g7f4e2c1-dirty   -> 0.4.0+d20260504
-    (no matching tag yet)              -> 0.0.0.dev0+g7f4e2c1[.d20260504]
+    pipeline-v0.4.0           clean -> 0.4.0
+    pipeline-v0.4.0-3-g7f4e2c1 clean -> 0.4.1.dev3+g7f4e2c1
+    pipeline-v0.4.0-3-g7f4e2c1 dirty -> 0.4.1.dev3+g7f4e2c1.d20260504
+    pipeline-v0.4.0-0-g7f4e2c1 dirty -> 0.4.0+d20260504
+    (no matching tag yet)            -> 0.0.0.dev0+g7f4e2c1[.d20260504]
 """
 
 from __future__ import annotations
@@ -34,8 +37,7 @@ import campfire_pipeline
 
 _DESCRIBE_RE = re.compile(
     r'^pipeline-v(?P<base>\d+\.\d+\.\d+)'
-    r'(?:-(?P<distance>\d+)-g(?P<sha>[0-9a-f]+))?'
-    r'(?P<dirty>-dirty)?$'
+    r'(?:-(?P<distance>\d+)-g(?P<sha>[0-9a-f]+))?$'
 )
 
 
@@ -68,7 +70,7 @@ def _today_local_segment() -> str:
     return datetime.now(timezone.utc).strftime('d%Y%m%d')
 
 
-def _describe_to_pep440(described: str) -> str | None:
+def _describe_to_pep440(described: str, dirty: bool) -> str | None:
     m = _DESCRIBE_RE.match(described)
     if not m:
         return None
@@ -76,7 +78,6 @@ def _describe_to_pep440(described: str) -> str | None:
     base = m.group('base')
     distance = int(m.group('distance') or 0)
     sha = m.group('sha')
-    dirty = bool(m.group('dirty'))
 
     if distance == 0:
         version = base
@@ -94,25 +95,29 @@ def _describe_to_pep440(described: str) -> str | None:
     return version
 
 
+def _pipeline_dirty(repo: Path) -> bool:
+    # `git describe --dirty` checks the entire working tree; we only care
+    # about edits to pipeline/ since that's what the version string scopes.
+    return bool(_run_git(['status', '--porcelain', '--', 'pipeline'], repo))
+
+
 def _git_version() -> str | None:
     repo = _repo_root()
     if not (repo / '.git').exists():
         return None
 
     described = _run_git(
-        ['describe', '--tags', '--long', '--dirty', '--match', 'pipeline-v*'],
+        ['describe', '--tags', '--long', '--match', 'pipeline-v*'],
         repo,
     )
     if described:
-        return _describe_to_pep440(described)
+        return _describe_to_pep440(described, _pipeline_dirty(repo))
 
     # No matching tag yet — synthesize a 0.0.0.dev0 string from HEAD.
     sha = _run_git(['rev-parse', '--short=7', 'HEAD'], repo)
     if not sha:
         return None
-    dirty_local = _today_local_segment() if _run_git(
-        ['status', '--porcelain', '--', 'pipeline'], repo
-    ) else None
+    dirty_local = _today_local_segment() if _pipeline_dirty(repo) else None
     local = f"g{sha}" + (f".{dirty_local}" if dirty_local else "")
     return f"0.0.0.dev0+{local}"
 

--- a/pipeline/tests/test_version.py
+++ b/pipeline/tests/test_version.py
@@ -1,0 +1,117 @@
+"""Tests for pipeline version string resolution."""
+
+from unittest import mock
+
+from campfire_pipeline.common import version as version_mod
+
+
+class TestDescribeToPep440:
+    def test_exact_tag_clean(self):
+        assert version_mod._describe_to_pep440('pipeline-v0.4.0', dirty=False) == '0.4.0'
+
+    def test_exact_tag_dirty(self):
+        with mock.patch.object(version_mod, '_today_local_segment', return_value='d20260504'):
+            assert (
+                version_mod._describe_to_pep440('pipeline-v0.4.0', dirty=True)
+                == '0.4.0+d20260504'
+            )
+
+    def test_post_tag_clean(self):
+        assert (
+            version_mod._describe_to_pep440('pipeline-v0.4.0-3-g7f4e2c1', dirty=False)
+            == '0.4.1.dev3+g7f4e2c1'
+        )
+
+    def test_post_tag_dirty(self):
+        with mock.patch.object(version_mod, '_today_local_segment', return_value='d20260504'):
+            assert (
+                version_mod._describe_to_pep440('pipeline-v0.4.0-3-g7f4e2c1', dirty=True)
+                == '0.4.1.dev3+g7f4e2c1.d20260504'
+            )
+
+    def test_unparseable_returns_none(self):
+        assert version_mod._describe_to_pep440('not-a-pipeline-tag', dirty=False) is None
+
+
+class TestGitVersion:
+    """Regression tests for #135 — pipeline-scoped dirty check.
+
+    The bug: `git describe --dirty` checks the entire working tree, so edits
+    to web/, python/, supabase/ flipped the pipeline version's dirty flag
+    even when no pipeline file changed.
+    """
+
+    def test_describe_invocation_has_no_dirty_flag(self, tmp_path):
+        """`git describe --dirty` must not be used (whole-tree dirty leak)."""
+        repo = tmp_path
+        (repo / '.git').mkdir()
+
+        captured: list[list[str]] = []
+
+        def fake_run_git(args, cwd):
+            captured.append(args)
+            if args[0] == 'describe':
+                return 'pipeline-v0.4.0-0-g7f4e2c1'
+            if args[0] == 'status':
+                return ''  # clean
+            return None
+
+        with (
+            mock.patch.object(version_mod, '_repo_root', return_value=repo),
+            mock.patch.object(version_mod, '_run_git', side_effect=fake_run_git),
+        ):
+            result = version_mod._git_version()
+
+        describe_calls = [c for c in captured if c[0] == 'describe']
+        assert describe_calls, 'expected at least one git describe call'
+        for call in describe_calls:
+            assert '--dirty' not in call, f'`--dirty` leaks whole-tree state: {call}'
+
+        assert result == '0.4.0'
+
+    def test_dirty_check_is_pipeline_scoped(self, tmp_path):
+        """Dirty check must pass `-- pipeline` to git status."""
+        repo = tmp_path
+        (repo / '.git').mkdir()
+
+        captured: list[list[str]] = []
+
+        def fake_run_git(args, cwd):
+            captured.append(args)
+            if args[0] == 'describe':
+                return 'pipeline-v0.4.0-0-g7f4e2c1'
+            if args[0] == 'status':
+                return ''  # clean
+            return None
+
+        with (
+            mock.patch.object(version_mod, '_repo_root', return_value=repo),
+            mock.patch.object(version_mod, '_run_git', side_effect=fake_run_git),
+        ):
+            version_mod._git_version()
+
+        status_calls = [c for c in captured if c[0] == 'status']
+        assert status_calls, 'expected a git status call to check dirtiness'
+        for call in status_calls:
+            assert '--' in call and 'pipeline' in call, (
+                f'status call must be scoped to pipeline/: {call}'
+            )
+
+    def test_pipeline_dirty_appends_local_segment(self, tmp_path):
+        """When pipeline files are dirty, the local segment fires."""
+        repo = tmp_path
+        (repo / '.git').mkdir()
+
+        def fake_run_git(args, cwd):
+            if args[0] == 'describe':
+                return 'pipeline-v0.4.0-0-g7f4e2c1'
+            if args[0] == 'status':
+                return ' M pipeline/campfire_pipeline/common/version.py'
+            return None
+
+        with (
+            mock.patch.object(version_mod, '_repo_root', return_value=repo),
+            mock.patch.object(version_mod, '_run_git', side_effect=fake_run_git),
+            mock.patch.object(version_mod, '_today_local_segment', return_value='d20260504'),
+        ):
+            assert version_mod._git_version() == '0.4.0+d20260504'


### PR DESCRIPTION
Closes #135

## What was the bug?
After the setuptools-scm migration (#133), edits to `web/`, `python/`, `supabase/`, etc. would flip the `.d20260504` local segment on the pipeline version string (`CMPFRVER`), tripping the warn-and-confirm prompt in `campfire deploy` for what is factually a clean release-tagged pipeline run.

## Root cause
`git describe --dirty` checks the **entire** working tree — there's no path filter. The `pipeline-v*` tag filter correctly scoped the base version, dev counter, and SHA to the pipeline subpackage, but the dirty check leaked monorepo state into the pipeline version.

## What I changed
- `pipeline/campfire_pipeline/common/version.py`:
  - Drop `--dirty` from the `git describe` invocation.
  - Add a small `_pipeline_dirty(repo)` helper that runs `git status --porcelain -- pipeline`.
  - Refactor `_describe_to_pep440` to take an explicit `dirty: bool` arg instead of parsing `-dirty` out of the describe string.
  - Drop the `(?P<dirty>-dirty)?` group from `_DESCRIBE_RE`.
  - Update the module docstring to call out the pipeline-scoped dirty check.
- `pipeline/CHANGELOG.md`: Infrastructure entry under Unreleased.
- `pipeline/tests/test_version.py` (new): unit tests for `_describe_to_pep440` (clean/dirty × exact-tag/post-tag) plus regression tests asserting (a) `--dirty` never appears in describe args and (b) the status call is scoped with `-- pipeline`.

## Testing
- `pytest tests/test_version.py -v` — 8 new tests pass.
- `pytest tests/` — full pipeline suite, 55 passed.
- Manual smoke: with the new code, `_git_version()` returns `0.4.0` when only `web/` is dirty (mocked) and `0.4.0+d20260504` when `pipeline/` is dirty.

Generated with Claude Code