### PR TITLE
Fix: show observation column in Redshift Fit Summary

### DIFF
--- a/web/components/spectra/RedshiftFitSummary.tsx
+++ b/web/components/spectra/RedshiftFitSummary.tsx
@@ -7,12 +7,13 @@ import type { RedshiftFitData } from '@/app/api/redshift-fit/route';
 import type { Spectrum } from '@/lib/types';
 
 interface RedshiftFitSummaryProps {
-  spectra: Spectrum[];
+  spectra: (Spectrum & { observation?: string })[];
   redshift_auto: number | null;
 }
 
 interface GratingFit {
   grating: string;
+  observation?: string;
   fitsPath: string;
   redshift?: number;
   chi2Min?: number;
@@ -32,6 +33,7 @@ export const RedshiftFitSummary: React.FC<RedshiftFitSummaryProps> = ({
     // Initialize loading state for all gratings
     const initialFits: GratingFit[] = spectra.map(s => ({
       grating: s.grating,
+      observation: s.observation,
       fitsPath: s.fits_path,
       isUsedForAuto: false, // Will be determined after loading
       loading: true,
@@ -142,6 +144,9 @@ export const RedshiftFitSummary: React.FC<RedshiftFitSummaryProps> = ({
           <thead>
             <tr className="border-b border-border dark:border-slate-700">
               <th className="text-left py-2 px-3 text-sm font-medium text-text-secondary dark:text-slate-400">
+                Observation
+              </th>
+              <th className="text-left py-2 px-3 text-sm font-medium text-text-secondary dark:text-slate-400">
                 Grating
               </th>
               <th className="text-right py-2 px-3 text-sm font-medium text-text-secondary dark:text-slate-400">
@@ -166,6 +171,9 @@ export const RedshiftFitSummary: React.FC<RedshiftFitSummaryProps> = ({
                   fit.isUsedForAuto ? 'bg-green-50 dark:bg-green-950' : ''
                 }`}
               >
+                <td className="py-2 px-3 text-sm text-text-primary dark:text-slate-100">
+                  {fit.observation ?? <span className="text-text-secondary dark:text-slate-400">—</span>}
+                </td>
                 <td className="py-2 px-3 text-sm font-medium text-text-primary dark:text-slate-100">
                   {fit.grating}
                 </td>

--- a/web/components/spectra/UnifiedObjectPage.tsx
+++ b/web/components/spectra/UnifiedObjectPage.tsx
@@ -169,8 +169,13 @@ export const UnifiedObjectPage: React.FC<UnifiedObjectPageProps> = ({ object }) 
   );
 
   // Section 3 — flat list of all member spectra for object-level redshift fit summary.
-  const allMemberSpectra: Spectrum[] = useMemo(
-    () => object.member_targets.flatMap(m => m.spectra),
+  // Each spectrum is annotated with its parent member's observation so the summary
+  // table can show which obs each fit came from.
+  const allMemberSpectra: (Spectrum & { observation: string })[] = useMemo(
+    () =>
+      object.member_targets.flatMap(m =>
+        m.spectra.map(s => ({ ...s, observation: m.observation }))
+      ),
     [object.member_targets]
   );
 


### PR DESCRIPTION
Closes #130

## What was the bug?
On the object detail page, the "Redshift Fit Summary" card listed each per-grating fit but didn't indicate which observation it came from, making it hard to disambiguate fits when an object has spectra from multiple observations.

## Root cause
`UnifiedObjectPage` flattened `member_targets[].spectra` into `allMemberSpectra` and dropped the parent member's `observation` field along the way, so `RedshiftFitSummary` never had the data it would need to display it.

## What I changed
- `web/components/spectra/UnifiedObjectPage.tsx`: when flattening member spectra for the summary card, annotate each spectrum with its parent member's `observation`.
- `web/components/spectra/RedshiftFitSummary.tsx`: widen the `spectra` prop to accept the optional `observation`, carry it through `GratingFit`, and render a new "Observation" column as the first column of the per-grating table.

## Testing
- `npx tsc --noEmit` in `web/` — passes cleanly.
- `npm run build` — compiles successfully (the only failure is unrelated static-page prerendering for `/forgot-password` due to missing Supabase env vars in this environment, which is pre-existing).


---
_Generated by [Claude Code](https://claude.ai/code/session_01YJpbVMxwUdMtKwA8Yf81jb)_