### PR TITLE
fix(nircam): proxy preview PNGs through /api/nircam-preview

### DIFF
--- a/web/app/admin/nircam/[id]/page.tsx
+++ b/web/app/admin/nircam/[id]/page.tsx
@@ -15,7 +15,12 @@ import type { NircamExposure, MaskRegionsPayload } from '@/lib/types';
 import { stageBadgeClasses } from '@/lib/nircam-stages';
 import MaskEditor from '@/components/nircam/MaskEditor';
 
-const CDN_BASE = process.env.NEXT_PUBLIC_CDN_BASE_URL || '';
+// PNGs live in R2 under nircam/exposures/<field>/<filter>/...; the
+// /api/nircam-preview proxy handles auth and streams them same-origin.
+function previewUrl(r2Key: string | null): string | null {
+  if (!r2Key) return null;
+  return `/api/nircam-preview?key=${encodeURIComponent(r2Key)}`;
+}
 
 export default function ExposureDetailPage() {
   const params = useParams();
@@ -103,10 +108,8 @@ export default function ExposureDetailPage() {
     );
   }
 
-  const pngUrl = exposure.png_path ? `${CDN_BASE}/${exposure.png_path}` : null;
-  const fullPngUrl = exposure.full_png_path
-    ? `${CDN_BASE}/${exposure.full_png_path}`
-    : null;
+  const pngUrl = previewUrl(exposure.png_path);
+  const fullPngUrl = previewUrl(exposure.full_png_path);
   const editorAvailable = Boolean(
     fullPngUrl && exposure.image_width && exposure.image_height
   );

--- a/web/app/api/nircam-preview/route.ts
+++ b/web/app/api/nircam-preview/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest } from 'next/server';
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+import { r2Client } from '@/lib/r2';
+import { createClient } from '@/lib/supabase/server';
+
+/**
+ * GET /api/nircam-preview?key=<r2_key>
+ *
+ * Admin-only proxy for NIRCam exposure preview PNGs (both `_preview.png`
+ * thumbnails and `_full.png` editor canvases). The R2 bucket isn't
+ * served via a public URL for these objects, so the editor and admin
+ * table fetch them through this same-origin endpoint.
+ *
+ * `key` must start with `nircam/exposures/` — this prevents the route
+ * from being abused as an arbitrary R2 read endpoint.
+ */
+export async function GET(request: NextRequest) {
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  const { data: profile } = await supabase
+    .from('user_profiles')
+    .select('is_admin')
+    .eq('user_id', user.id)
+    .single();
+
+  if (!profile?.is_admin) {
+    return new Response('Forbidden', { status: 403 });
+  }
+
+  const key = request.nextUrl.searchParams.get('key');
+  if (!key || !key.startsWith('nircam/exposures/') || key.includes('..')) {
+    return new Response('Invalid key', { status: 400 });
+  }
+
+  try {
+    const obj = await r2Client.send(new GetObjectCommand({
+      Bucket: process.env.R2_BUCKET_NAME,
+      Key: key,
+    }));
+
+    if (!obj.Body) {
+      return new Response('Not Found', { status: 404 });
+    }
+
+    return new Response(obj.Body.transformToWebStream(), {
+      status: 200,
+      headers: {
+        'Content-Type': obj.ContentType || 'image/png',
+        // Previews are immutable per `_preview.png` / `_full.png` rebuild
+        // (the pipeline's CFP_PREV stamp gates regeneration). Long-cache
+        // the response; the editor invalidates by reloading the page.
+        'Cache-Control': 'private, max-age=3600, stale-while-revalidate=86400',
+      },
+    });
+  } catch (err: unknown) {
+    const e = err as { $metadata?: { httpStatusCode?: number }; name?: string };
+    if (e?.name === 'NoSuchKey' || e?.$metadata?.httpStatusCode === 404) {
+      return new Response('Not Found', { status: 404 });
+    }
+    console.error('nircam-preview proxy error:', err);
+    return new Response('Internal Error', { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- Editor & thumbnails on `/admin/nircam/[id]` were building URLs as `${NEXT_PUBLIC_CDN_BASE_URL}/${png_path}`. In production that env var is the app's own origin, so the requests went to `https://campfire.hollisakins.com/nircam/exposures/...` — which has no route and 404s. The canvas's `bg-black` showed through.
- Adds a same-origin admin-only proxy route `GET /api/nircam-preview?key=<r2_key>` that streams the PNG from R2.
- `[id]/page.tsx` now builds URLs as `/api/nircam-preview?key=...`. `MaskEditor` is URL-agnostic, so unchanged.

Safety:
- `is_admin` gate (matches the rest of `/admin/nircam` server actions).
- Key must start with `nircam/exposures/` and must not contain `..` — can't be used as an arbitrary R2 read endpoint.
- 1h private cache (`Cache-Control: private, max-age=3600, stale-while-revalidate=86400`); previews regenerate when the pipeline rewrites them, and the page reload picks them up.

## Test plan
- [ ] Visit `/admin/nircam/<id>` for an exposure with `full_png_path` populated → editor renders the PNG (no longer black).
- [ ] Network tab confirms 200 from `/api/nircam-preview?key=...` with `Content-Type: image/png`.
- [ ] Same URL hit while logged out → 401; while logged in as non-admin → 403.
- [ ] Bad key (`?key=foo` or `?key=nircam/exposures/../etc`) → 400.
- [ ] Missing key in R2 → 404.

Generated with Claude Code