### PR TITLE
feat(nircam): exposure-table nav + keyboard shortcuts; zoom no longer scrolls page

### DIFF
--- a/web/app/admin/nircam/[id]/page.tsx
+++ b/web/app/admin/nircam/[id]/page.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
-import { Loader2, ArrowLeft, Save, Check } from 'lucide-react';
+import {
+  Loader2, ArrowLeft, Save, Check, ChevronLeft, ChevronRight, Keyboard,
+} from 'lucide-react';
 import {
   getNircamExposureById,
   updateExposureReview,
@@ -14,6 +16,7 @@ import {
 import type { NircamExposure, MaskRegionsPayload } from '@/lib/types';
 import { stageBadgeClasses } from '@/lib/nircam-stages';
 import MaskEditor from '@/components/nircam/MaskEditor';
+import { lookupNircamNav, type NircamNavLookup } from '@/lib/nircam-nav-cache';
 
 // PNGs live in R2 under nircam/exposures/<field>/<filter>/...; the
 // /api/nircam-preview proxy handles auth and streams them same-origin.
@@ -39,6 +42,12 @@ export default function ExposureDetailPage() {
   const [correction, setCorrection] = useState<string>('none');
   const [notes, setNotes] = useState<string>('');
 
+  // Sibling-exposure nav (from sessionStorage cache populated by the list).
+  // Re-derived on every id change; null when there's no cache (direct entry).
+  const [nav, setNav] = useState<NircamNavLookup | null>(null);
+  const [showHelp, setShowHelp] = useState(false);
+  useEffect(() => { setNav(lookupNircamNav(id)); }, [id]);
+
   const fetchExposure = useCallback(async () => {
     setLoading(true);
     setError(null);
@@ -60,34 +69,82 @@ export default function ExposureDetailPage() {
     fetchExposure();
   }, [fetchExposure]);
 
-  const handleSave = async () => {
-    setSaving(true);
-    setSaved(false);
-    setError(null);
-
-    const result = await updateExposureReview(id, {
-      review_status: reviewStatus as NircamExposure['review_status'],
-      masking: masking as NircamExposure['masking'],
-      correction: correction as NircamExposure['correction'],
-      notes: notes || undefined,
-    });
-
-    if (result.error) {
-      setError(result.error);
-    } else if (result.exposure) {
-      setExposure(result.exposure);
-      setSaved(true);
-      setTimeout(() => setSaved(false), 2000);
-    }
-    setSaving(false);
-  };
-
-  const hasChanges = exposure && (
+  const hasChanges = !!(exposure && (
     reviewStatus !== exposure.review_status ||
     masking !== exposure.masking ||
     correction !== exposure.correction ||
     notes !== (exposure.notes || '')
-  );
+  ));
+
+  // Latest-state ref so the keyboard handler doesn't capture stale closures.
+  const stateRef = useRef({ reviewStatus, masking, correction, notes, hasChanges });
+  stateRef.current = { reviewStatus, masking, correction, notes, hasChanges };
+
+  const handleSave = useCallback(async (): Promise<{ ok: boolean }> => {
+    const s = stateRef.current;
+    setSaving(true);
+    setSaved(false);
+    setError(null);
+    const result = await updateExposureReview(id, {
+      review_status: s.reviewStatus as NircamExposure['review_status'],
+      masking: s.masking as NircamExposure['masking'],
+      correction: s.correction as NircamExposure['correction'],
+      notes: s.notes || undefined,
+    });
+    setSaving(false);
+    if (result.error) {
+      setError(result.error);
+      return { ok: false };
+    }
+    if (result.exposure) setExposure(result.exposure);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+    return { ok: true };
+  }, [id]);
+
+  // Auto-save on nav: mirror inspection mode — flush dirty triage so the
+  // operator can blast through a queue with arrow keys without losing state.
+  const goTo = useCallback(async (targetId: number | null) => {
+    if (targetId == null) return;
+    if (stateRef.current.hasChanges) {
+      const result = await handleSave();
+      if (!result.ok) return; // don't navigate on a save failure
+    }
+    router.push(`/admin/nircam/${targetId}`);
+  }, [handleSave, router]);
+
+  const handleNext = useCallback(() => goTo(nav?.next ?? null), [goTo, nav]);
+  const handlePrev = useCallback(() => goTo(nav?.prev ?? null), [goTo, nav]);
+
+  // Global keyboard shortcuts (mirrors web/components/spectra/inspection
+  // pattern). Skip when an input has focus so users can type in notes etc.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const t = e.target as HTMLElement;
+      const isInput = t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.tagName === 'SELECT';
+      if (e.key === 'Escape' && isInput) { t.blur(); return; }
+      if (isInput) return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      switch (e.key) {
+        case '1': e.preventDefault(); setReviewStatus('pending');  break;
+        case '2': e.preventDefault(); setReviewStatus('approved'); break;
+        case '3': e.preventDefault(); setReviewStatus('excluded'); break;
+        case 'ArrowRight':
+        case 'n':
+        case 'N': e.preventDefault(); handleNext(); break;
+        case 'ArrowLeft':
+        case 'p':
+        case 'P': e.preventDefault(); handlePrev(); break;
+        case 's':
+        case 'S': e.preventDefault(); handleSave(); break;
+        case '?': e.preventDefault(); setShowHelp(prev => !prev); break;
+        case 'Escape': if (showHelp) setShowHelp(false); break;
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [handleNext, handlePrev, handleSave, showHelp]);
 
   if (loading) {
     return (
@@ -124,18 +181,69 @@ export default function ExposureDetailPage() {
     <div>
       {/* Header */}
       <div className="flex items-center gap-3 mb-6">
-        <button onClick={() => router.push('/admin/nircam')} className="text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-100">
+        <button onClick={() => router.push('/admin/nircam')} className="text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-100" title="Back to list">
           <ArrowLeft className="w-5 h-5" />
         </button>
-        <div>
-          <h1 className="text-xl font-semibold font-mono text-text-primary dark:text-slate-100">
+        <div className="flex-1 min-w-0">
+          <h1 className="text-xl font-semibold font-mono text-text-primary dark:text-slate-100 truncate">
             {exposure.filename}
           </h1>
           <p className="text-sm text-text-secondary dark:text-slate-400">
             {exposure.field} / {exposure.filter} / {exposure.detector}
           </p>
         </div>
+        {nav && (
+          <div className="flex items-center gap-1 text-sm text-text-secondary dark:text-slate-400">
+            <button
+              onClick={handlePrev}
+              disabled={nav.prev == null}
+              title="Previous (← / P)"
+              className="p-1.5 rounded hover:bg-surface-hover dark:hover:bg-slate-800 disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              <ChevronLeft className="w-5 h-5" />
+            </button>
+            <span className="font-mono tabular-nums text-xs px-1">
+              {nav.index} / {nav.total}
+            </span>
+            <button
+              onClick={handleNext}
+              disabled={nav.next == null}
+              title="Next (→ / N)"
+              className="p-1.5 rounded hover:bg-surface-hover dark:hover:bg-slate-800 disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              <ChevronRight className="w-5 h-5" />
+            </button>
+          </div>
+        )}
+        <button
+          onClick={() => setShowHelp(prev => !prev)}
+          title="Keyboard shortcuts (?)"
+          className="p-1.5 rounded text-text-secondary dark:text-slate-400 hover:bg-surface-hover dark:hover:bg-slate-800"
+        >
+          <Keyboard className="w-5 h-5" />
+        </button>
       </div>
+
+      {showHelp && (
+        <div className="mb-6 rounded-lg border border-border dark:border-slate-700 bg-card dark:bg-slate-900 p-4">
+          <div className="flex items-center justify-between mb-2">
+            <h2 className="text-sm font-semibold text-text-primary dark:text-slate-100">Keyboard shortcuts</h2>
+            <button onClick={() => setShowHelp(false)} className="text-xs text-text-secondary dark:text-slate-400 hover:underline">close</button>
+          </div>
+          <dl className="grid grid-cols-2 gap-x-6 gap-y-1 text-sm">
+            <div className="flex justify-between"><dt>Next exposure</dt><dd className="font-mono text-text-secondary dark:text-slate-400">→ or N</dd></div>
+            <div className="flex justify-between"><dt>Previous</dt><dd className="font-mono text-text-secondary dark:text-slate-400">← or P</dd></div>
+            <div className="flex justify-between"><dt>Mark pending</dt><dd className="font-mono text-text-secondary dark:text-slate-400">1</dd></div>
+            <div className="flex justify-between"><dt>Mark approved</dt><dd className="font-mono text-text-secondary dark:text-slate-400">2</dd></div>
+            <div className="flex justify-between"><dt>Mark excluded</dt><dd className="font-mono text-text-secondary dark:text-slate-400">3</dd></div>
+            <div className="flex justify-between"><dt>Save</dt><dd className="font-mono text-text-secondary dark:text-slate-400">S</dd></div>
+            <div className="flex justify-between"><dt>Help</dt><dd className="font-mono text-text-secondary dark:text-slate-400">?</dd></div>
+          </dl>
+          <p className="mt-2 text-xs text-text-secondary dark:text-slate-400">
+            Navigation auto-saves the triage panel if there are unsaved changes. Mask edits save separately from the editor toolbar.
+          </p>
+        </div>
+      )}
 
       {error && (
         <div className="bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-900 rounded-lg p-4 mb-6">

--- a/web/app/admin/nircam/page.tsx
+++ b/web/app/admin/nircam/page.tsx
@@ -20,6 +20,7 @@ import {
   NIRCAM_STAGES,
   STAGE_COLUMN_KEYS,
 } from '@/lib/nircam-stages';
+import { setNircamNav } from '@/lib/nircam-nav-cache';
 
 // ---------------------------------------------------------------------------
 // Status badge helpers
@@ -389,11 +390,17 @@ export default function AdminNircamPage() {
                 </td>
               </tr>
             ) : (
-              exposures.map((exp) => (
+              exposures.map((exp) => {
+                // Saving the cache on every click means the detail page's
+                // prev/next reflects the current filter state at the moment
+                // the user entered it, even if filters change later.
+                const onRowEnter = () => setNircamNav(exposures.map(e => e.id));
+                return (
                 <tr key={exp.id} className="hover:bg-card/50 dark:hover:bg-slate-700/50">
                   <td className="px-4 py-3">
                     <Link
                       href={`/admin/nircam/${exp.id}`}
+                      onClick={onRowEnter}
                       className="text-sm font-mono text-primary hover:underline"
                     >
                       {exp.filename}
@@ -406,12 +413,13 @@ export default function AdminNircamPage() {
                   <td className="px-4 py-3"><ActionBadge status={exp.masking} label="mask" /></td>
                   <td className="px-4 py-3"><ActionBadge status={exp.correction} label="corr" /></td>
                   <td className="px-4 py-3 text-right">
-                    <Link href={`/admin/nircam/${exp.id}`}>
+                    <Link href={`/admin/nircam/${exp.id}`} onClick={onRowEnter}>
                       <ChevronRight className="w-4 h-4 text-text-secondary dark:text-slate-400" />
                     </Link>
                   </td>
                 </tr>
-              ))
+                );
+              })
             )}
           </tbody>
         </table>

--- a/web/components/nircam/MaskEditor.tsx
+++ b/web/components/nircam/MaskEditor.tsx
@@ -154,21 +154,39 @@ export default function MaskEditor({
   }, [scale, translate]);
 
   // ----- wheel zoom (cursor-anchored) -----
-  const onWheel = useCallback((e: React.WheelEvent) => {
-    e.preventDefault();
-    if (!containerRef.current) return;
-    const rect = containerRef.current.getBoundingClientRect();
-    const mx = e.clientX - rect.left;
-    const my = e.clientY - rect.top;
-    const factor = Math.exp(-e.deltaY * 0.0015);
-    const newScale = Math.max(0.05, Math.min(20, scale * factor));
-    // Keep the PNG point under the cursor stationary:
-    //   client = translate + svg * scale
-    //   solve translate_new so (mx, my) maps to the same svg point.
-    const svgPt = { x: (mx - translate[0]) / scale, y: (my - translate[1]) / scale };
-    setTranslate([mx - svgPt.x * newScale, my - svgPt.y * newScale]);
-    setScale(newScale);
-  }, [scale, translate]);
+  // React's onWheel is registered as a *passive* listener since React 17, so
+  // e.preventDefault() is silently ignored and the page scrolls underneath.
+  // Attach the listener manually with { passive: false } so the zoom owns
+  // the wheel events when the cursor is over the canvas.
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) return;
+    const handler = (e: WheelEvent) => {
+      e.preventDefault();
+      const rect = node.getBoundingClientRect();
+      const mx = e.clientX - rect.left;
+      const my = e.clientY - rect.top;
+      const factor = Math.exp(-e.deltaY * 0.0015);
+      // Functional updates — wheel events fire faster than React renders, so
+      // closing over `scale`/`translate` from the last render would drop
+      // intermediate ticks.
+      setScale((prevScale) => {
+        const newScale = Math.max(0.05, Math.min(20, prevScale * factor));
+        setTranslate(([tx, ty]) => {
+          // Keep the PNG point under the cursor stationary:
+          //   client = translate + svg * scale
+          const svgPt = {
+            x: (mx - tx) / prevScale,
+            y: (my - ty) / prevScale,
+          };
+          return [mx - svgPt.x * newScale, my - svgPt.y * newScale];
+        });
+        return newScale;
+      });
+    };
+    node.addEventListener('wheel', handler, { passive: false });
+    return () => node.removeEventListener('wheel', handler);
+  }, []);
 
   const finalizeDraft = useCallback(() => {
     if (draftVertices.length < 3) {
@@ -322,7 +340,6 @@ export default function MaskEditor({
       <div
         ref={containerRef}
         className={`flex-1 relative overflow-hidden bg-black select-none ${cursorClass}`}
-        onWheel={onWheel}
         onPointerDown={onPointerDown}
         onPointerMove={onPointerMove}
         onPointerUp={onPointerUp}

--- a/web/lib/nircam-nav-cache.ts
+++ b/web/lib/nircam-nav-cache.ts
@@ -1,0 +1,61 @@
+/**
+ * SessionStorage-backed nav cache for the /admin/nircam exposure detail page.
+ *
+ * The list page is single-fetch (no pagination), so this is much simpler
+ * than the generic [[navigation-cache]]: store the visible filtered ID
+ * order on row click, look up neighbors on the detail page.
+ *
+ * Cache lives ~30 min and is invalidated when the user changes filters
+ * (the list page rewrites it on every fetch + click).
+ */
+
+const KEY = 'campfire_nircam_nav';
+const TTL_MS = 30 * 60 * 1000;
+
+interface Cache {
+  ids: number[];
+  ts: number;
+}
+
+export function setNircamNav(ids: number[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    sessionStorage.setItem(KEY, JSON.stringify({ ids, ts: Date.now() } as Cache));
+  } catch {
+    /* storage full or disabled — silent: nav still works, just no prev/next */
+  }
+}
+
+export function getNircamNav(): Cache | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = sessionStorage.getItem(KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Cache;
+    if (!parsed?.ids?.length) return null;
+    if (Date.now() - parsed.ts > TTL_MS) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export interface NircamNavLookup {
+  prev: number | null;
+  next: number | null;
+  index: number;  // 1-based
+  total: number;
+}
+
+export function lookupNircamNav(id: number): NircamNavLookup | null {
+  const cache = getNircamNav();
+  if (!cache) return null;
+  const idx = cache.ids.indexOf(id);
+  if (idx === -1) return null;
+  return {
+    prev: idx > 0 ? cache.ids[idx - 1] : null,
+    next: idx < cache.ids.length - 1 ? cache.ids[idx + 1] : null,
+    index: idx + 1,
+    total: cache.ids.length,
+  };
+}


### PR DESCRIPTION
## Summary
Triage-flow improvements for `/admin/nircam`. Bundled with one editor fix.

**Navigation**
- New tiny `web/lib/nircam-nav-cache.ts`: sessionStorage-backed cache (30 min TTL) holding the filtered exposure-id order. Mirrors the pattern of `web/lib/navigation-cache.ts` but specialized for the single-fetch admin/nircam list (no pagination dance).
- List page writes the visible IDs into the cache on row click.
- Detail page header gets prev/next chevrons + "X / Y" position indicator. Disabled at boundary or when there is no cache (direct entry).

**Keyboard shortcuts** (mirrors `web/components/spectra/inspection` patterns)
- `←` / `P` and `→` / `N` — prev / next exposure (auto-saves dirty triage before navigating, so a save failure stops the nav)
- `1` / `2` / `3` — set `review_status` to `pending` / `approved` / `excluded`
- `S` — save triage
- `?` — toggle a help panel listing the bindings
- Skipped when an `<input>` / `<textarea>` / `<select>` has focus, so typing notes is unaffected.

**Editor bug fix bundled in (~5 LoC):** `MaskEditor`'s wheel handler was registered as React's default *passive* listener since React 17, so `e.preventDefault()` was silently ignored and zoom scrolled the parent page. Attached manually with `{ passive: false }`. Functional `setScale` / `setTranslate` updaters so faster-than-render wheel ticks don't drop intermediate state.

## Test plan
- [ ] Filter the admin nircam list → click an exposure → header shows `2 / N` (or wherever you clicked); chevrons work, position increments.
- [ ] Press `→`, `N`, `←`, `P` → navigates; with unsaved triage, a save fires before nav.
- [ ] Press `1` / `2` / `3` → status pill changes; `S` saves; `?` toggles help.
- [ ] Focus the notes textarea → `1`/`N`/`?` etc. type into the field instead of triggering shortcuts.
- [ ] Scroll wheel inside the mask editor → image zooms; the page itself does NOT scroll.
- [ ] Direct-link entry (`/admin/nircam/<id>` without going through the list) → no nav UI shown, keyboard shortcuts still work for status/save (next/prev are no-ops).

Generated with Claude Code