### PR TITLE
perf(nircam): eager exposure cache + sibling PNG warm-load

### DIFF
--- a/web/app/admin/nircam/[id]/page.tsx
+++ b/web/app/admin/nircam/[id]/page.tsx
@@ -17,6 +17,11 @@ import type { NircamExposure, MaskRegionsPayload } from '@/lib/types';
 import { stageBadgeClasses } from '@/lib/nircam-stages';
 import MaskEditor from '@/components/nircam/MaskEditor';
 import { lookupNircamNav, type NircamNavLookup } from '@/lib/nircam-nav-cache';
+import {
+  getCachedExposure,
+  setCachedExposure,
+  prefetchPreviewPng,
+} from '@/lib/nircam-exposure-cache';
 
 // PNGs live in R2 under nircam/exposures/<field>/<filter>/...; the
 // /api/nircam-preview proxy handles auth and streams them same-origin.
@@ -31,6 +36,7 @@ export default function ExposureDetailPage() {
   const id = Number(params.id);
 
   const [exposure, setExposure] = useState<NircamExposure | null>(null);
+  const [exposureForId, setExposureForId] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
@@ -48,26 +54,73 @@ export default function ExposureDetailPage() {
   const [showHelp, setShowHelp] = useState(false);
   useEffect(() => { setNav(lookupNircamNav(id)); }, [id]);
 
-  const fetchExposure = useCallback(async () => {
-    setLoading(true);
+  // When the route id changes, reset state synchronously from the in-memory
+  // cache so the new exposure paints in the same frame as the URL change —
+  // no spinner, no flash of the previous exposure. The server is hit in the
+  // background to revalidate. (React's "set state during render" pattern,
+  // bounded by the exposureForId guard so we don't loop.)
+  if (exposureForId !== id) {
+    const cached = getCachedExposure(id);
+    setExposureForId(id);
+    setExposure(cached);
+    setReviewStatus(cached?.review_status || 'pending');
+    setMasking(cached?.masking || 'none');
+    setCorrection(cached?.correction || 'none');
+    setNotes(cached?.notes || '');
+    setLoading(!cached);
     setError(null);
+    setSaved(false);
+  }
 
-    const result = await getNircamExposureById(id);
-    if (result.error) {
-      setError(result.error);
-    } else if (result.exposure) {
-      setExposure(result.exposure);
-      setReviewStatus(result.exposure.review_status);
-      setMasking(result.exposure.masking);
-      setCorrection(result.exposure.correction);
-      setNotes(result.exposure.notes || '');
-    }
-    setLoading(false);
+  // Background revalidation against the DB on every id change. Auto-save on
+  // navigation has already flushed any dirty triage state, so it's safe to
+  // overwrite the editable fields with the freshly-fetched values.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const result = await getNircamExposureById(id);
+      if (cancelled) return;
+      if (result.error) {
+        setError(result.error);
+        setLoading(false);
+        return;
+      }
+      if (result.exposure) {
+        setCachedExposure(result.exposure);
+        setExposure(result.exposure);
+        setReviewStatus(result.exposure.review_status);
+        setMasking(result.exposure.masking);
+        setCorrection(result.exposure.correction);
+        setNotes(result.exposure.notes || '');
+      }
+      setLoading(false);
+    })();
+    return () => { cancelled = true; };
   }, [id]);
 
+  // Prefetch sibling exposures (data + warm PNG cache) so prev/next paints
+  // instantly. Fires after both `exposure` and `nav` are known. PNG fetches
+  // go through the same /api/nircam-preview proxy the editor uses, so they
+  // populate the same browser-cache bucket.
   useEffect(() => {
-    fetchExposure();
-  }, [fetchExposure]);
+    if (!nav) return;
+    for (const sibId of [nav.next, nav.prev]) {
+      if (sibId == null) continue;
+      const cached = getCachedExposure(sibId);
+      if (cached) {
+        prefetchPreviewPng(previewUrl(cached.full_png_path));
+        prefetchPreviewPng(previewUrl(cached.png_path));
+        continue;
+      }
+      getNircamExposureById(sibId).then((res) => {
+        if (res.exposure) {
+          setCachedExposure(res.exposure);
+          prefetchPreviewPng(previewUrl(res.exposure.full_png_path));
+          prefetchPreviewPng(previewUrl(res.exposure.png_path));
+        }
+      });
+    }
+  }, [exposure, nav]);
 
   const hasChanges = !!(exposure && (
     reviewStatus !== exposure.review_status ||
@@ -96,7 +149,10 @@ export default function ExposureDetailPage() {
       setError(result.error);
       return { ok: false };
     }
-    if (result.exposure) setExposure(result.exposure);
+    if (result.exposure) {
+      setCachedExposure(result.exposure);
+      setExposure(result.exposure);
+    }
     setSaved(true);
     setTimeout(() => setSaved(false), 2000);
     return { ok: true };
@@ -173,7 +229,10 @@ export default function ExposureDetailPage() {
 
   const handleSaveMasks = async (regions: MaskRegionsPayload) => {
     const res = await saveExposureMaskRegions(exposure.id, regions);
-    if (res.exposure) setExposure(res.exposure);
+    if (res.exposure) {
+      setCachedExposure(res.exposure);
+      setExposure(res.exposure);
+    }
     return { error: res.error };
   };
 

--- a/web/app/admin/nircam/page.tsx
+++ b/web/app/admin/nircam/page.tsx
@@ -235,8 +235,8 @@ export default function AdminNircamPage() {
   const [progress, setProgress] = useState<ReductionProgress[]>([]);
   const [exposures, setExposures] = useState<NircamExposure[]>([]);
   const [excluded, setExcluded] = useState<ExcludedExposure[]>([]);
-  const [filterOptions, setFilterOptions] = useState<{ fields: string[]; filters: string[]; stages: string[] }>({
-    fields: [], filters: [], stages: [],
+  const [filterOptions, setFilterOptions] = useState<{ fields: string[]; filters: string[]; detectors: string[]; stages: string[] }>({
+    fields: [], filters: [], detectors: [], stages: [],
   });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -244,6 +244,7 @@ export default function AdminNircamPage() {
   // Filters
   const [selectedField, setSelectedField] = useState<string>('');
   const [selectedFilter, setSelectedFilter] = useState<string>('');
+  const [selectedDetector, setSelectedDetector] = useState<string>('');
   const [selectedReview, setSelectedReview] = useState<string>('');
   const [selectedStage, setSelectedStage] = useState<string>('');
 
@@ -257,6 +258,7 @@ export default function AdminNircamPage() {
         getNircamExposures({
           field: selectedField || undefined,
           filter: selectedFilter || undefined,
+          detector: selectedDetector || undefined,
           reviewStatus: selectedReview || undefined,
           stage: selectedStage || undefined,
         }),
@@ -278,7 +280,7 @@ export default function AdminNircamPage() {
     } finally {
       setLoading(false);
     }
-  }, [selectedField, selectedFilter, selectedReview, selectedStage]);
+  }, [selectedField, selectedFilter, selectedDetector, selectedReview, selectedStage]);
 
   useEffect(() => {
     fetchData();
@@ -340,6 +342,14 @@ export default function AdminNircamPage() {
           {filterOptions.filters.map(f => <option key={f} value={f}>{f}</option>)}
         </select>
         <select
+          value={selectedDetector}
+          onChange={(e) => setSelectedDetector(e.target.value)}
+          className="text-sm border border-border dark:border-slate-600 rounded-lg px-3 py-1.5 bg-white dark:bg-slate-800 text-text-primary dark:text-slate-100"
+        >
+          <option value="">All detectors</option>
+          {filterOptions.detectors.map(d => <option key={d} value={d}>{d}</option>)}
+        </select>
+        <select
           value={selectedStage}
           onChange={(e) => setSelectedStage(e.target.value)}
           className="text-sm border border-border dark:border-slate-600 rounded-lg px-3 py-1.5 bg-white dark:bg-slate-800 text-text-primary dark:text-slate-100"
@@ -357,9 +367,9 @@ export default function AdminNircamPage() {
           <option value="approved">Approved</option>
           <option value="excluded">Excluded</option>
         </select>
-        {(selectedField || selectedFilter || selectedStage || selectedReview) && (
+        {(selectedField || selectedFilter || selectedDetector || selectedStage || selectedReview) && (
           <button
-            onClick={() => { setSelectedField(''); setSelectedFilter(''); setSelectedStage(''); setSelectedReview(''); }}
+            onClick={() => { setSelectedField(''); setSelectedFilter(''); setSelectedDetector(''); setSelectedStage(''); setSelectedReview(''); }}
             className="text-sm text-primary hover:underline"
           >
             Clear filters

--- a/web/lib/actions/nircam-exposures.ts
+++ b/web/lib/actions/nircam-exposures.ts
@@ -34,6 +34,7 @@ export interface ExposuresResult {
 export async function getNircamExposures(params?: {
   field?: string;
   filter?: string;
+  detector?: string;
   reviewStatus?: string;
   stage?: string;
 }): Promise<ExposuresResult> {
@@ -49,6 +50,7 @@ export async function getNircamExposures(params?: {
 
     if (params?.field) query = query.eq('field', params.field);
     if (params?.filter) query = query.eq('filter', params.filter);
+    if (params?.detector) query = query.eq('detector', params.detector);
     if (params?.reviewStatus) query = query.eq('review_status', params.reviewStatus);
     if (params?.stage) query = query.eq('stage', params.stage);
 
@@ -282,6 +284,7 @@ export async function getExcludedExposures(): Promise<{
 export async function getExposureFilterOptions(): Promise<{
   fields: string[];
   filters: string[];
+  detectors: string[];
   stages: string[];
   error?: string;
 }> {
@@ -290,22 +293,24 @@ export async function getExposureFilterOptions(): Promise<{
 
     const { data, error } = await supabase
       .from('nircam_exposures')
-      .select('field, filter, stage');
+      .select('field, filter, detector, stage');
 
     if (error) {
-      return { fields: [], filters: [], stages: [], error: error.message };
+      return { fields: [], filters: [], detectors: [], stages: [], error: error.message };
     }
 
     const rows = data || [];
     return {
       fields: [...new Set(rows.map(r => r.field))].sort(),
       filters: [...new Set(rows.map(r => r.filter))].sort(),
+      detectors: [...new Set(rows.map(r => r.detector))].sort(),
       stages: [...new Set(rows.map(r => r.stage))].sort(),
     };
   } catch (err) {
     return {
       fields: [],
       filters: [],
+      detectors: [],
       stages: [],
       error: err instanceof Error ? err.message : 'Failed to fetch filter options',
     };

--- a/web/lib/nircam-exposure-cache.ts
+++ b/web/lib/nircam-exposure-cache.ts
@@ -1,0 +1,43 @@
+/**
+ * In-memory exposure cache for the /admin/nircam triage flow.
+ *
+ * Lives at module scope (per browser-tab session). Keyed by exposure id so
+ * the detail page can render instantly when the user steps to a sibling
+ * via prev/next, while a background re-fetch revalidates against the DB.
+ *
+ * Intentionally simple: no LRU eviction, no TTL — admin sessions are short
+ * and a few hundred row rows of cached state is well under any browser memory
+ * budget. The cache is dropped on full reload (refresh, navigate-away).
+ */
+
+import type { NircamExposure } from '@/lib/types';
+
+const cache = new Map<number, NircamExposure>();
+
+export function getCachedExposure(id: number): NircamExposure | null {
+  return cache.get(id) ?? null;
+}
+
+export function setCachedExposure(exp: NircamExposure): void {
+  cache.set(exp.id, exp);
+}
+
+export function clearExposureCache(): void {
+  cache.clear();
+}
+
+/**
+ * Warm browser HTTP cache for a preview PNG so the next render of an
+ * <img src=...> is paint-instant. Returns immediately; the fetch continues
+ * in the background and lands in the same cache the eventual <img> will use.
+ */
+export function prefetchPreviewPng(url: string | null): void {
+  if (!url || typeof window === 'undefined') return;
+  // new Image() triggers a normal HTTP fetch from the renderer with the
+  // browser's image cache; safer than fetch() (which can land in a different
+  // bucket depending on credentials/mode and miss when the <img> later
+  // tries to use it).
+  const img = new Image();
+  img.decoding = 'async';
+  img.src = url;
+}


### PR DESCRIPTION
## Summary
Eliminates the spinner blink when stepping prev/next through `/admin/nircam` exposures.

**`web/lib/nircam-exposure-cache.ts`** — tiny module-scope cache:
- `getCachedExposure(id) / setCachedExposure(exp)` — `Map<number, NircamExposure>` (no LRU/TTL; admin sessions are short, drops on tab close).
- `prefetchPreviewPng(url)` — asks the browser to warm its image-cache via `new Image()`. Same URL the editor's `<img>` later requests, so it lands in the same cache bucket.

**Detail page wiring**:
- On route id change, **synchronously** prime state from the cache before paint (React "set state during render" pattern, guarded by `exposureForId !== id`). The new exposure paints in the same frame as the URL change — no flash of the old exposure, no loader spinner.
- Background re-fetch revalidates against the DB. Auto-save-on-nav already flushes dirty triage, so it's safe to overwrite the editable fields with the freshly-fetched values.
- Save responses (both triage and mask saves) write through the cache, so the next time the user steps back to the row they see their own edits, not the stale snapshot.
- After load, prefetch `nav.next` + `nav.prev` data and warm-load their preview PNGs through the same `/api/nircam-preview` proxy. Idempotent — guarded by `getCachedExposure` short-circuit.

## Test plan
- [ ] Open the table, click any exposure → renders normally (cold cache, spinner OK).
- [ ] Press `→` / `N` → next exposure paints without a spinner and without a frame of the previous exposure's PNG.
- [ ] Same for `←` / `P`.
- [ ] Edit triage on exposure A, navigate to B (auto-save fires), navigate back to A → the new triage values show, not the pre-save ones.
- [ ] Network tab on a navigation: the only `/api/nircam-preview` request is the revalidation of the *current* exposure; the next/prev PNGs were already loaded during the previous page's prefetch.
- [ ] Direct entry (`/admin/nircam/<id>` without going through the list) → still loads with spinner (cold cache, no nav, no prefetch — same as before).

Generated with Claude Code