### PR TITLE
chore: gitignore .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ logs/
 # Temporary files
 *.tmp
 .cache/
+
+# Claude Code per-user state
+.claude/


### PR DESCRIPTION
## Summary

Adds `.claude/` to `.gitignore` so Claude Code's per-user state files (e.g. `scheduled_tasks.lock`) don't show up as untracked in `git status`.

Generated with Claude Code