### PR TITLE
chore: rewrite /pipeline-release for synthesized tag body + gh release

### DIFF
--- a/.claude/commands/pipeline-release.md
+++ b/.claude/commands/pipeline-release.md
@@ -6,6 +6,12 @@ Optional argument: target version (e.g. `0.4.0`). If omitted, recommend one.
 
 Target: $ARGUMENTS
 
+`scripts/release-pipeline.sh` exists as a faster path with a **verbatim**
+Unreleased section as the tag body. This slash command performs the same
+operations by hand so the tag annotation can be a **synthesized** summary
+instead — useful when the Unreleased section is too long or too granular
+to make a useful `git show` view.
+
 ## Process
 
 Walk through the steps below in order. Do NOT skip the inspection/confirmation
@@ -14,7 +20,7 @@ output values, so they warrant care.
 
 ### 1. Verify pre-conditions (read-only)
 
-Without running the release script yet, confirm:
+Before mutating any state, confirm:
 
 - Current branch is `main`
 - Working tree is clean (`git status --porcelain` is empty)
@@ -24,16 +30,16 @@ Without running the release script yet, confirm:
 If any check fails, surface the specific issue and stop. Do not attempt to
 auto-fix (e.g. don't auto-commit dirty files; don't switch branches).
 
-### 2. Show the user the Unreleased changelog content
+### 2. Synthesize the unreleased changes
 
-Read `pipeline/CHANGELOG.md`, extract the `## Unreleased` section, and show
-it verbatim with a `pipeline/CHANGELOG.md:<line>` reference so the user can
-navigate. Note the categories present (Calibration / Algorithm / Infrastructure).
+Read `pipeline/CHANGELOG.md`, extract the `## Unreleased` section, and synthesize 
+the unreleased changes to present to the user. Note the categories present 
+(Calibration / Algorithm / Infrastructure) and the scope of the changes across 
+the pipeline (e.g., NIRCam vs. NIRSpec). 
 
 ### 3. Recommend a version bump
 
-Read the rules from `CLAUDE.md` (the "Pipeline Versioning" section, once it
-exists — until then, use the rules in `pipeline/CHANGELOG.md`):
+Read the rules from `CLAUDE.md`:
 
 - **Calibration** present → MINOR bump (or MAJOR if it's also a breaking format change)
 - **Algorithm** present → MINOR if additive, MAJOR if breaking
@@ -43,8 +49,6 @@ Find the most recent existing release tag:
 ```
 git describe --abbrev=0 --tags --match 'pipeline-v*' 2>/dev/null
 ```
-If no tag exists, the first release should be `0.4.0` (since `__version__`
-was last manually set to `"0.3.0"` and we're moving to scm-driven versioning).
 
 Propose a new version with a one-sentence rationale. If the user supplied a
 version in `$ARGUMENTS`, use that instead and skip recommendation — but still
@@ -56,33 +60,67 @@ Show the planned release inputs:
 - New version number
 - Resulting tag name (`pipeline-v<X.Y.Z>`)
 - Commit message that will be used (`release(pipeline): vX.Y.Z`)
-- Tag annotation body (the changelog entries)
+- Tag annotation body (the synthesized changelog entries)
 
 Ask the user to confirm before running anything that mutates git state.
 
-### 5. Run the release script (no push)
+### 5. Apply the release locally (no push)
 
+Four sub-steps. Stop on the first failure and surface it to the user.
+
+**a. Rewrite the changelog.** Keep `## Unreleased` as a permanent marker
+and insert a `## v<X.Y.Z> — YYYY-MM-DD` heading immediately below it (date
+in UTC, `date -u +%Y-%m-%d`). Use Edit anchored on `## Unreleased` plus the
+first sub-heading underneath (typically `### Calibration` or `### Algorithm`)
+to scope the change.
+
+**b. Commit the changelog.**
 ```
-bash scripts/release-pipeline.sh <X.Y.Z>
-```
-
-This rewrites the changelog, commits, and tags **locally only**. Show the
-script output. Verify with `git log --oneline -1` and
-`git tag --list 'pipeline-v*' --sort=-creatordate | head -3`.
-
-### 6. Confirm before pushing
-
-Pushing `main` and a tag is publicly visible and effectively immutable.
-Ask the user explicitly whether to push. Do not push without explicit confirmation
-even if the user said "yes" earlier in the session — confirm at this step.
-
-If confirmed:
-```
-git push origin main && git push origin pipeline-v<X.Y.Z>
+git add pipeline/CHANGELOG.md
+git commit -m "release(pipeline): v<X.Y.Z>"
 ```
 
-(Or re-run the script with `--push`, but at this point the local commit and
-tag already exist, so a direct push is cleaner.)
+**c. Write the synthesized tag annotation body to a temp file** (e.g.
+`/tmp/pipeline-v<X.Y.Z>-tagmsg.txt`) via the Write tool. Using a file rather
+than passing `-m` avoids two footguns observed previously:
+- `git tag -a -m` defaults to `--cleanup=strip`, which removes lines
+  beginning with `#` as comments — silently eating
+  `### Calibration` / `### Algorithm` / `### Infrastructure` headings.
+- Shell quoting of backticks inside a heredoc is fragile; a file sidesteps
+  it entirely (single-quoted `'EOF'` heredocs leak escaped backticks
+  through as literal `\``).
+
+**d. Create the annotated tag and clean up.**
+```
+git tag -a pipeline-v<X.Y.Z> --cleanup=verbatim -F /tmp/pipeline-v<X.Y.Z>-tagmsg.txt
+rm /tmp/pipeline-v<X.Y.Z>-tagmsg.txt
+```
+
+Verify with `git log --oneline -1`, `git tag --list 'pipeline-v*' --sort=-creatordate | head -3`,
+and `git show --no-patch pipeline-v<X.Y.Z>`. Spot-check the rendered body:
+section headings present, backticks render as backticks (not literal
+`\``). If anything looks wrong, `git tag -d` and recreate — the tag is not
+yet pushed and is freely re-doable.
+
+### 6. Confirm before pushing and creating the GitHub Release
+
+Pushing `main`, the tag, and the Release are all publicly visible and
+effectively immutable. Ask the user explicitly whether to publish. Do not
+proceed without explicit confirmation even if the user said "yes" earlier in
+the session — confirm at this step.
+
+If confirmed, run all three:
+```
+git push origin main
+git push origin pipeline-v<X.Y.Z>
+gh release create pipeline-v<X.Y.Z> --title "pipeline v<X.Y.Z>" --notes-from-tag
+```
+
+`--notes-from-tag` reuses the annotated tag's body as the Release notes,
+keeping the tag as the single source of truth (no drift between the two
+stores). The Release lands at
+`github.com/hollisakins/campfire/releases/tag/pipeline-v<X.Y.Z>` —
+report the URL back to the user.
 
 ### 7. Post-release reminders
 
@@ -96,10 +134,14 @@ Tell the user:
 
 ## Constraints
 
-- Never amend an existing release commit or tag.
+- Never amend an existing release commit or tag (once pushed, the tag is
+  effectively immutable; before push, prefer `git tag -d` + recreate over
+  amending).
 - Never push `--force` to `main`.
-- If the script's preflight checks fail, do not bypass them by editing the
-  script or the working tree — surface the actual issue to the user.
+- If a preflight check fails, do not bypass it (e.g. by editing files or
+  skipping checks) — surface the actual issue to the user. Unrelated dirty
+  files can be stashed (`git stash push -- <path>`) and popped after the
+  release.
 - If the user has uncommitted changelog edits, ask them to commit those on a
   PR first (the changelog rollover happens *during* the release, on a release
   commit; arbitrary unreleased edits should not be folded into it).


### PR DESCRIPTION
## Summary

- Reworks the `/pipeline-release` slash command to drive the release by hand instead of invoking `scripts/release-pipeline.sh`, so the tag annotation can be a synthesized summary grouped by Calibration / Algorithm / Infrastructure rather than the (now ~880-line) verbatim Unreleased section.
- Adds a `gh release create --notes-from-tag` step after the push so the publish flow lands a discoverable GitHub Release page in addition to the git tag.
- Records two footguns hit during the v0.5.0 release for future runs: `git tag -a -m` defaults to `--cleanup=strip` (silently strips `### ...` headings), and single-quoted heredocs leak escaped backticks as literal `\``. The slash command now writes the tag body to a temp file and uses `git tag -a --cleanup=verbatim -F <file>`.

`scripts/release-pipeline.sh` is unchanged and remains available for the fast / verbatim path.

## Test plan

- [x] v0.5.0 was released using this manual flow (tag, push, GitHub Release at github.com/hollisakins/campfire/releases/tag/pipeline-v0.5.0) — section headings and backticks render cleanly.
- [ ] Next pipeline release follows the rewritten slash command end-to-end.

Generated with Claude Code