### PR TITLE
fix(sync): handle reconcile-renamed object_id without UNIQUE failure

### DIFF
--- a/python/campfire/db/store.py
+++ b/python/campfire/db/store.py
@@ -283,9 +283,15 @@ class LocalStore:
             observations = ";".join(obj.get("observations") or [])
             member_ids = ";".join(str(m) for m in (obj.get("member_target_ids") or []))
 
+            # INSERT OR REPLACE: reconciliation on the server can rewrite
+            # either side of the (id, object_id) pair without touching the
+            # other (e.g. a sub-arcsec ra/dec shift bumps the IAU name but
+            # keeps the row id), so a single ON CONFLICT clause can't catch
+            # the crossed case. There are no local-only columns on objects,
+            # so wholesale replacement is safe.
             self._conn.execute(
                 """
-                INSERT INTO objects
+                INSERT OR REPLACE INTO objects
                     (id, object_id, field, ra, dec,
                      n_targets, n_spectra, programs, gratings, observations,
                      member_target_ids, max_snr, max_exposure_time,
@@ -296,33 +302,6 @@ class LocalStore:
                      created_at, updated_at, _synced_at)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
                         ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(object_id) DO UPDATE SET
-                    field=excluded.field,
-                    ra=excluded.ra, dec=excluded.dec,
-                    n_targets=excluded.n_targets,
-                    n_spectra=excluded.n_spectra,
-                    programs=excluded.programs,
-                    gratings=excluded.gratings,
-                    observations=excluded.observations,
-                    member_target_ids=excluded.member_target_ids,
-                    max_snr=excluded.max_snr,
-                    max_exposure_time=excluded.max_exposure_time,
-                    redshift=excluded.redshift,
-                    redshift_auto=excluded.redshift_auto,
-                    redshift_inspected=excluded.redshift_inspected,
-                    redshift_quality=excluded.redshift_quality,
-                    last_inspected_at=excluded.last_inspected_at,
-                    last_inspected_by=excluded.last_inspected_by,
-                    last_data_change_at=excluded.last_data_change_at,
-                    staleness_reason=excluded.staleness_reason,
-                    version=excluded.version,
-                    is_active=excluded.is_active,
-                    has_photometry=excluded.has_photometry,
-                    photo_z=excluded.photo_z,
-                    photo_z_err_lo=excluded.photo_z_err_lo,
-                    photo_z_err_hi=excluded.photo_z_err_hi,
-                    updated_at=excluded.updated_at,
-                    _synced_at=excluded._synced_at
                 """,
                 (
                     obj.get("id"),

--- a/python/tests/test_store.py
+++ b/python/tests/test_store.py
@@ -162,6 +162,20 @@ class TestUpsertObjects:
         assert obj["redshift_quality"] == 3
         assert len(obj["spectra"]) == 2
 
+    def test_upsert_renamed_object_id(self, store, sample_objects):
+        """Server reconcile can rewrite object_id while keeping the same id —
+        e.g. sub-arcsec ra/dec shifts changing the IAU name's last digit.
+        The upsert must overwrite the stale row, not raise UNIQUE failures."""
+        store.upsert_objects(sample_objects)
+        renamed = dict(sample_objects[0])
+        renamed["object_id"] = "CAMPFIRE-J0001+0002"  # same id=1, new name
+        store.upsert_objects([renamed])
+        rows = store.query_objects()
+        assert len(rows) == 2
+        ids = {r["object_id"] for r in rows}
+        assert "CAMPFIRE-J0001+0001" not in ids
+        assert "CAMPFIRE-J0001+0002" in ids
+
 
 class TestQueryObjects:
     def test_query_all(self, store, sample_objects):


### PR DESCRIPTION
## Summary
- `campfire sync --full` was failing with `UNIQUE constraint failed: objects.id` mid-upsert (after the progress bar completed at 32942/32942 objects). Confirmed against `/sync/objects`: the remote DB is healthy — no duplicate ids server-side.
- Root cause is client-side: server reconciliation can rewrite an object's IAU `object_id` (a sub-arcsec ra/dec shift bumps the last decimal of the name) while keeping the same internal `id`. The local SQLite cache still has the old name at that id, so the previous `ON CONFLICT(object_id) DO UPDATE` clause never fired and SQLite fell through to a plain INSERT, tripping the primary-key constraint. Reproduced on a copy of a real cache for 4 objects in the COSMOS field (e.g. `id=187644` flipping between `J141920.68+525257.7` and `J141920.69+525257.7`).
- Switched `upsert_objects` to `INSERT OR REPLACE`. The `objects` table has no local-only columns (unlike `spectra`'s `local_path`/`local_file_hash`/`synced_at`), so wholesale replacement is safe and covers both id- and object_id-side conflicts in one shot.

## Test plan
- [x] Added `test_upsert_renamed_object_id` regression test — same `id`, new `object_id` overwrites the stale row.
- [x] Existing `tests/test_store.py` still passes (35/35).
- [x] Reproduced the failure on a cloned snapshot of `~/campfire/meta/campfire.db` by forcing the crossed-id state, then verified the patched upsert resolves it cleanly.
- [ ] User to re-run `campfire sync --full` on the affected machine post-merge.

Generated with Claude Code