### PR TITLE
fix(client): warn loudly when local CAMPFIRE catalog can't be opened

### DIFF
--- a/python/campfire/client.py
+++ b/python/campfire/client.py
@@ -2,6 +2,8 @@
 
 import hashlib
 import logging
+import os
+import warnings
 from pathlib import Path
 from typing import Iterator, List, Optional, Tuple, Union
 
@@ -84,19 +86,53 @@ class Campfire:
         self._local_logged = False
         self._api_download_count = 0
 
-        resolved_dir = self._resolve_data_dir(data_dir)
-        if resolved_dir:
-            meta_dir = resolved_dir / "meta"
-            db_path = meta_dir / "campfire.db"
-            if db_path.exists():
-                from .db.store import LocalStore, SchemaMismatchError
-                try:
-                    self._local = LocalStore(db_path)
-                except SchemaMismatchError:
-                    self._local = None
-                else:
-                    self._products_dir = resolved_dir / "products"
-                    self._meta_dir = meta_dir
+        self._open_local_catalog(data_dir)
+
+    def _open_local_catalog(self, data_dir: Optional[Union[str, Path]]) -> None:
+        """Attempt to open the local SQLite catalog; warn if it can't be used.
+
+        Without a local catalog, queries fall back to the remote API and
+        ``get_object`` returns no embedded spectra — a common source of
+        confusion when ``$CAMPFIRE_ROOT`` points somewhere stale (e.g.
+        a path that exists on another machine but not this one).
+        """
+        from .config import resolve_data_dir
+
+        if data_dir:
+            resolved = Path(data_dir).expanduser()
+            source = f"data_dir={str(data_dir)!r}"
+        else:
+            env = os.environ.get("CAMPFIRE_ROOT")
+            resolved = resolve_data_dir()
+            source = f"$CAMPFIRE_ROOT={env!r}" if env else f"default {resolved}"
+
+        db_path = resolved / "meta" / "campfire.db"
+        reason: Optional[str] = None
+
+        if not db_path.exists():
+            reason = f"no campfire.db at {db_path} (from {source})"
+        else:
+            from .db.store import LocalStore, SchemaMismatchError
+            try:
+                self._local = LocalStore(db_path)
+            except SchemaMismatchError as exc:
+                reason = (
+                    f"local catalog at {db_path} has schema v{exc.found_version}, "
+                    f"client expects v{exc.expected_version} — "
+                    f"run `campfire sync --full` to rebuild"
+                )
+            else:
+                self._products_dir = resolved / "products"
+                self._meta_dir = resolved / "meta"
+
+        if self._local is None:
+            warnings.warn(
+                f"No local CAMPFIRE catalog ({reason}); "
+                f"falling back to remote API. Some methods (e.g. "
+                f"`get_object().spectra`) return less data over the API. "
+                f"Run `campfire sync` to enable local-first queries.",
+                stacklevel=3,
+            )
 
     @staticmethod
     def _resolve_data_dir(data_dir: Optional[Union[str, Path]]) -> Optional[Path]:

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -1,5 +1,7 @@
 """Tests for CAMPFIRE API client."""
 
+import warnings
+
 import pytest
 from unittest.mock import Mock, patch
 
@@ -196,7 +198,9 @@ class TestImagingMethods:
     def test_get_cutout_object_id_param(self, mock_api_session, tmp_path):
         mock_api_session.get.return_value = _make_mock_response(json_data={})
         mock_api_session.get.return_value.content = b"PNGDATA"
-        with patch("campfire.config.resolve_data_dir", return_value=tmp_path):
+        with patch("campfire.config.resolve_data_dir", return_value=tmp_path), \
+                warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
             client = Campfire()
             client.get_cutout("CAMPFIRE-J0001+0001", fov=3.0, cache=False)
         params = mock_api_session.get.call_args.kwargs.get("params", {})
@@ -206,7 +210,9 @@ class TestImagingMethods:
         mock_api_session.get.return_value = _make_mock_response(
             json_data={"shutters": [], "meta": {}}
         )
-        with patch("campfire.config.resolve_data_dir", return_value=tmp_path):
+        with patch("campfire.config.resolve_data_dir", return_value=tmp_path), \
+                warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
             client = Campfire()
             client.get_shutters("CAMPFIRE-J0001+0001", fov=3.0, cache=False)
         params = mock_api_session.get.call_args.kwargs.get("params", {})

--- a/python/tests/test_local_first.py
+++ b/python/tests/test_local_first.py
@@ -1,6 +1,7 @@
 """Tests for local-first routing in Campfire client and SpectrumData model."""
 
 import io
+import warnings
 import numpy as np
 import pytest
 from unittest.mock import MagicMock, Mock, patch
@@ -153,8 +154,47 @@ class TestLocalFirstQueryObjects:
     def test_no_local_store(self):
         with patch("campfire.client.APISession") as MockSession:
             MockSession.return_value.base_url = "https://test.com/api/v1"
-            client = Campfire(data_dir="/nonexistent/path")
+            with pytest.warns(UserWarning, match="No local CAMPFIRE catalog"):
+                client = Campfire(data_dir="/nonexistent/path")
             assert client.is_local is False
+
+    def test_warning_names_data_dir_source(self):
+        with patch("campfire.client.APISession") as MockSession:
+            MockSession.return_value.base_url = "https://test.com/api/v1"
+            with pytest.warns(UserWarning, match=r"data_dir='/nonexistent/path'"):
+                Campfire(data_dir="/nonexistent/path")
+
+    def test_warning_names_env_var_source(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CAMPFIRE_ROOT", str(tmp_path / "missing"))
+        with patch("campfire.client.APISession") as MockSession:
+            MockSession.return_value.base_url = "https://test.com/api/v1"
+            with pytest.warns(UserWarning, match=r"\$CAMPFIRE_ROOT="):
+                Campfire()
+
+    def test_warning_on_schema_mismatch(self, tmp_path):
+        import sqlite3
+        meta = tmp_path / "meta"
+        meta.mkdir()
+        db_path = meta / "campfire.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("CREATE TABLE _meta (key TEXT PRIMARY KEY, value TEXT)")
+        conn.execute("INSERT INTO _meta VALUES ('schema_version', '0')")
+        conn.commit()
+        conn.close()
+        with patch("campfire.client.APISession") as MockSession:
+            MockSession.return_value.base_url = "https://test.com/api/v1"
+            with pytest.warns(UserWarning, match=r"schema v0"):
+                client = Campfire(data_dir=tmp_path)
+            assert client.is_local is False
+
+    def test_no_warning_when_local_db_present(self, local_store):
+        store, tmp_path = local_store
+        with patch("campfire.client.APISession") as MockSession:
+            MockSession.return_value.base_url = "https://test.com/api/v1"
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                client = Campfire(data_dir=tmp_path)
+            assert client.is_local is True
 
 
 class TestLocalFirstQuerySpectra:


### PR DESCRIPTION
## Summary

- When the local SQLite catalog can't be opened, `Campfire.__init__` silently sets `_local = None` and queries fall back to the remote API. That fallback is mostly fine — except `get_object()` over the API doesn't embed spectra, so `obj.spectra` returns `SpectrumCollection(empty)` with no hint why.
- This bites especially hard when `$CAMPFIRE_ROOT` is set to a path that exists on one machine but not the current one (e.g. shell-config syncing between desktop and laptop).
- Add a `UserWarning` at client construction time that identifies the path tried, the source it came from (`data_dir` arg, `$CAMPFIRE_ROOT`, or default), the failure mode (missing file vs schema mismatch with version numbers), and how to fix it.

## Test plan

- [x] `pytest python/tests/` — 122 passed
- [x] New tests cover: data_dir source, env-var source, schema-mismatch source, and no-warning when the local DB is present
- [x] Reproduces the original case: `CAMPFIRE_ROOT=/bogus/path python -c 'import campfire; campfire.Campfire()'` now prints a clear warning identifying the bad env var and pointing at `campfire sync`

Generated with Claude Code