### PR TITLE
Add program, observation, field, and target_id to Spectrum model

### DIFF
--- a/python/campfire/models.py
+++ b/python/campfire/models.py
@@ -420,6 +420,14 @@ class Spectrum:
         Parent object ID.
     grating : str
         Grating name (e.g. 'PRISM', 'G395M').
+    program : str or None
+        Program slug (e.g. ``'ember'``, ``'rubies'``).
+    observation : str or None
+        Observation name (e.g. ``'ember_cosmos_p1'``).
+    field : str or None
+        Field name (e.g. ``'cosmos'``, ``'uds'``).
+    target_id : str or None
+        Per-program target identifier this spectrum was extracted for.
     signal_to_noise : float or None
         Peak signal-to-noise ratio.
     exposure_time : float or None
@@ -440,6 +448,10 @@ class Spectrum:
     spectrum_id: str
     object_id: str
     grating: str
+    program: Optional[str] = None
+    observation: Optional[str] = None
+    field: Optional[str] = None
+    target_id: Optional[str] = None
     signal_to_noise: Optional[float] = None
     exposure_time: Optional[float] = None
     reduction_version: Optional[str] = None
@@ -497,6 +509,7 @@ class SpectrumCollection:
     Supports numpy-style boolean indexing on any attribute::
 
         prism = obj.spectra[obj.spectra.grating == 'PRISM']
+        ember = obj.spectra[obj.spectra.program == 'ember']
         high_snr = obj.spectra[obj.spectra.signal_to_noise > 10]
 
     Integer indexing returns a single :class:`Spectrum`. Iteration yields
@@ -517,8 +530,24 @@ class SpectrumCollection:
         return np.array([s.object_id for s in self._spectra])
 
     @property
+    def target_id(self) -> np.ndarray:
+        return np.array([s.target_id for s in self._spectra])
+
+    @property
     def grating(self) -> np.ndarray:
         return np.array([s.grating for s in self._spectra])
+
+    @property
+    def program(self) -> np.ndarray:
+        return np.array([s.program for s in self._spectra])
+
+    @property
+    def observation(self) -> np.ndarray:
+        return np.array([s.observation for s in self._spectra])
+
+    @property
+    def field(self) -> np.ndarray:
+        return np.array([s.field for s in self._spectra])
 
     @property
     def signal_to_noise(self) -> np.ndarray:
@@ -529,6 +558,18 @@ class SpectrumCollection:
         return np.array([s.exposure_time for s in self._spectra], dtype=float)
 
     @property
+    def redshift_auto(self) -> np.ndarray:
+        return np.array([s.redshift_auto for s in self._spectra], dtype=float)
+
+    @property
+    def dq_flags(self) -> np.ndarray:
+        return np.array([s.dq_flags for s in self._spectra], dtype=int)
+
+    @property
+    def reduction_version(self) -> np.ndarray:
+        return np.array([s.reduction_version for s in self._spectra])
+
+    @property
     def downloaded(self) -> np.ndarray:
         return np.array([s.downloaded for s in self._spectra])
 
@@ -536,6 +577,21 @@ class SpectrumCollection:
     def gratings(self) -> List[str]:
         """Unique gratings available in this collection."""
         return sorted(set(s.grating for s in self._spectra))
+
+    @property
+    def programs(self) -> List[str]:
+        """Unique programs available in this collection."""
+        return sorted(set(s.program for s in self._spectra if s.program))
+
+    @property
+    def observations(self) -> List[str]:
+        """Unique observations available in this collection."""
+        return sorted(set(s.observation for s in self._spectra if s.observation))
+
+    @property
+    def fields(self) -> List[str]:
+        """Unique fields available in this collection."""
+        return sorted(set(s.field for s in self._spectra if s.field))
 
     # --- Indexing ---
 
@@ -571,10 +627,16 @@ class SpectrumCollection:
             {
                 "spectrum_id": s.spectrum_id,
                 "object_id": s.object_id,
+                "target_id": s.target_id,
+                "program": s.program,
+                "observation": s.observation,
+                "field": s.field,
                 "grating": s.grating,
                 "signal_to_noise": s.signal_to_noise,
                 "exposure_time": s.exposure_time,
                 "reduction_version": s.reduction_version,
+                "redshift_auto": s.redshift_auto,
+                "dq_flags": s.dq_flags,
                 "local_path": s.local_path,
             }
             for s in self._spectra
@@ -724,6 +786,10 @@ class Object:
                 spectrum_id=s.get("spectrum_id") or "",
                 object_id=s.get("object_id") or obj_id,
                 grating=s.get("grating", ""),
+                program=s.get("program") or s.get("program_slug"),
+                observation=s.get("observation"),
+                field=s.get("field"),
+                target_id=s.get("target_id"),
                 signal_to_noise=s.get("signal_to_noise"),
                 exposure_time=s.get("exposure_time"),
                 reduction_version=s.get("reduction_version"),

--- a/python/tests/test_calibration.py
+++ b/python/tests/test_calibration.py
@@ -146,6 +146,35 @@ class TestSpectrumCollection:
         high = col[col.signal_to_noise > 6]
         assert len(high) == 2
 
+    def test_boolean_index_by_program_and_observation(self):
+        spectra = [
+            Spectrum(
+                spectrum_id="s1", object_id="o", grating="PRISM",
+                program="ember", observation="ember_cosmos_p1", field="cosmos",
+            ),
+            Spectrum(
+                spectrum_id="s2", object_id="o", grating="G395M",
+                program="rubies", observation="rubies_uds_p2", field="uds",
+            ),
+            Spectrum(
+                spectrum_id="s3", object_id="o", grating="G395M",
+                program="ember", observation="ember_cosmos_p1", field="cosmos",
+            ),
+        ]
+        col = SpectrumCollection(spectra)
+
+        ember = col[col.program == "ember"]
+        assert len(ember) == 2
+        assert set(ember.spectrum_id) == {"s1", "s3"}
+
+        uds = col[col.field == "uds"]
+        assert len(uds) == 1
+        assert uds[0].spectrum_id == "s2"
+
+        assert col.programs == ["ember", "rubies"]
+        assert col.observations == ["ember_cosmos_p1", "rubies_uds_p2"]
+        assert col.fields == ["cosmos", "uds"]
+
 
 # ---------------------------------------------------------------------------
 # Object.from_dict
@@ -169,6 +198,10 @@ class TestObjectFromDict:
                     "spectrum_id": "ember_cosmos_p1_prism_clear_100",
                     "object_id": "CAMPFIRE-J0001+0001",
                     "grating": "PRISM",
+                    "program_slug": "ember",
+                    "observation": "ember_cosmos_p1",
+                    "field": "cosmos",
+                    "target_id": "t1",
                     "signal_to_noise": 7.0,
                     "exposure_time": 1500.0,
                 },
@@ -176,6 +209,10 @@ class TestObjectFromDict:
                     "spectrum_id": "ember_cosmos_p1_g395m_f290lp_100",
                     "object_id": "CAMPFIRE-J0001+0001",
                     "grating": "G395M",
+                    "program_slug": "ember",
+                    "observation": "ember_cosmos_p1",
+                    "field": "cosmos",
+                    "target_id": "t1",
                     "signal_to_noise": 4.0,
                     "exposure_time": 3000.0,
                 },
@@ -188,6 +225,11 @@ class TestObjectFromDict:
         assert len(obj.spectra) == 2
         assert obj.spectra.gratings == ["G395M", "PRISM"]
         assert obj.photometry is None
+        # program_slug from store rows should be exposed as `.program`
+        assert all(s.program == "ember" for s in obj.spectra)
+        assert obj.spectra[0].observation == "ember_cosmos_p1"
+        assert obj.spectra[0].target_id == "t1"
+        assert len(obj.spectra[obj.spectra.program == "ember"]) == 2
 
     def test_opener_wired(self):
         called = {}


### PR DESCRIPTION
## Summary

Extends the `Spectrum` model and `SpectrumCollection` to expose program metadata (program slug, observation name, field name, and per-program target identifier) that was previously unavailable. This enables filtering and grouping spectra by survey program and observational context.

## Changes

- **Spectrum model**: Added four new optional fields:
  - `program`: Program slug (e.g., `'ember'`, `'rubies'`)
  - `observation`: Observation name (e.g., `'ember_cosmos_p1'`)
  - `field`: Field name (e.g., `'cosmos'`, `'uds'`)
  - `target_id`: Per-program target identifier

- **SpectrumCollection properties**: Added numpy-style array accessors for all four new fields, plus three existing fields that were missing (`redshift_auto`, `dq_flags`, `reduction_version`)

- **SpectrumCollection convenience properties**: Added `programs`, `observations`, and `fields` to return sorted lists of unique values (filtering out `None`)

- **SpectrumCollection.to_table()**: Included all new fields in the table export

- **SpectrumCollection.from_dict()**: Added deserialization logic, with fallback from `program_slug` (legacy key) to `program`

- **Documentation & tests**: Updated docstring example to show filtering by program; added comprehensive test for boolean indexing by program and observation

## Implementation Details

- All new fields are optional (`Optional[str]`) to maintain backward compatibility
- The `from_dict()` method handles both `program` and `program_slug` keys to support existing data sources
- Unique value properties filter out `None` entries before sorting to avoid `None` appearing in the list
- New properties follow the existing pattern of returning numpy arrays for consistency with boolean indexing

https://claude.ai/code/session_01WZYHuQEDvYpeR2gzonN7j4