### PR TITLE
feat(refcat): return ruwe/pm/pmra/pmdec from gaia backend

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -25,6 +25,11 @@ Release procedure: edit the `## Unreleased` section below, then run
 
 ## Unreleased
 
+### Infrastructure
+- `cfpipe nircam refcat query --backend gaia` now also returns `ruwe`, `pm`,
+  `pmra`, and `pmdec` from `gaiadr3.gaia_source`, so downstream consumers can
+  filter on point-source quality (RUWE) or proper motion without re-querying.
+
 ## v0.5.0 — 2026-05-21
 
 ### Calibration

--- a/pipeline/campfire_pipeline/nircam/refcat/query.py
+++ b/pipeline/campfire_pipeline/nircam/refcat/query.py
@@ -85,7 +85,8 @@ def query_gaia(center, radius_deg, *, mag_band="G", mag_max=None,
 
     ra, dec = center
     adql = f"""
-        SELECT ra, dec, {mag_col}, {flux_col}, {flux_err_col}
+        SELECT ra, dec, {mag_col}, {flux_col}, {flux_err_col},
+               ruwe, pm, pmra, pmdec
         FROM gaiadr3.gaia_source
         WHERE 1 = CONTAINS(
             POINT('ICRS', ra, dec),
@@ -107,11 +108,18 @@ def query_gaia(center, radius_deg, *, mag_band="G", mag_max=None,
         mag_err = 2.5 / np.log(10) / snr
 
     keep = np.isfinite(mag) & np.isfinite(mag_err) & (mag_err > 0)
+    # ruwe/pm/pmra/pmdec come back as masked columns when Gaia reports no
+    # value (e.g. 2-parameter solutions). np.asarray(..., dtype=float)
+    # turns masked entries into NaN so consumers see a uniform float array.
     out = Table({
         "RA": np.asarray(result["ra"], dtype=float)[keep],
         "DEC": np.asarray(result["dec"], dtype=float)[keep],
         "mag": mag[keep],
         "mag_err": mag_err[keep],
+        "ruwe": np.asarray(result["ruwe"], dtype=float)[keep],
+        "pm": np.asarray(result["pm"], dtype=float)[keep],
+        "pmra": np.asarray(result["pmra"], dtype=float)[keep],
+        "pmdec": np.asarray(result["pmdec"], dtype=float)[keep],
     })
     return out
 


### PR DESCRIPTION
## Summary
- `cfpipe nircam refcat query --backend gaia` now also returns `ruwe`, `pm`, `pmra`, and `pmdec` from `gaiadr3.gaia_source`, so downstream consumers can filter on point-source quality (RUWE) or proper motion without re-querying.
- Masked entries in Gaia (e.g. 2-parameter solutions where `pm*`/`ruwe` are unset) come through as NaN via `np.asarray(..., dtype=float)`. The existing finite-mag `keep` mask is applied to the new columns too.
- Changelog entry added under Unreleased / Infrastructure (PATCH — no change to pipeline pixel/flux output). `io.py` only validates the canonical 4 columns, and `merge.py` `vstack`s with `metadata_conflicts="silent"`, so extras pass through unchanged.

## Test plan
- [ ] `cfpipe nircam refcat query --field <field> --backend gaia` and confirm the written ECSV has `ruwe`, `pm`, `pmra`, `pmdec` columns
- [ ] Spot-check a row known to have a 2-parameter solution → those columns should be NaN, not raise

Generated with Claude Code