### PR TITLE
fix(pipeline): scope version distance counter to pipeline/ commits

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -25,6 +25,22 @@ Release procedure: edit the `## Unreleased` section below, then run
 
 ## Unreleased
 
+### Infrastructure
+- Pipeline version resolution (`campfire_pipeline.common.version`) now
+  recounts the distance from the last `pipeline-v*.*.*` tag using
+  `git rev-list <tag>..HEAD --count -- pipeline`, so the version stamped
+  onto reduced data (`CMPFRVER`, `spectra.cfpipe_version`) reflects only
+  commits that touched `pipeline/`. Previously the distance came from
+  `git describe --long`, which counts every commit on the branch — any
+  `web/`, `python/`, `supabase/`, or `scripts/` activity bumped a
+  bit-identical reduction from `0.5.0` to `0.5.1.devN+gSHA`, tripping
+  the `campfire deploy` warn-and-confirm prompt for "unreleased" data.
+  The dirty flag was already pipeline-scoped (issue #135); this closes
+  the matching gap for the distance counter. The `setuptools-scm`
+  configuration in `pyproject.toml` is unchanged — it only feeds the
+  build-time stamp in `_version.py`, which the runtime resolver only
+  reads as a last-resort fallback.
+
 ## v0.5.0 — 2026-05-21
 
 ### Calibration

--- a/pipeline/campfire_pipeline/common/version.py
+++ b/pipeline/campfire_pipeline/common/version.py
@@ -12,16 +12,20 @@ Resolution order (first that succeeds wins):
    lookup against installed package metadata.
 5. ``"0.0.0+unknown"`` — sentinel.
 
-The translation from ``git describe`` to PEP 440 (dirty flag below comes
-from a pipeline-scoped ``git status --porcelain -- pipeline``, not from
-``git describe --dirty``, which would be tripped by edits anywhere in the
-monorepo):
+Both the **distance** (``.devN``) and the **dirty flag** are scoped to the
+``pipeline/`` subtree. ``git describe --long``'s commit count and ``git
+describe --dirty``'s working-tree check both span the whole monorepo, so
+unrelated ``web/``, ``python/``, ``supabase/``, and ``scripts/`` activity
+would otherwise bump the version of bit-identical pipeline code. We instead
+use ``git describe --abbrev=0`` to get just the tag, ``git rev-list
+<tag>..HEAD --count -- pipeline`` for distance, and ``git status
+--porcelain -- pipeline`` for the dirty check.
 
-    pipeline-v0.4.0           clean -> 0.4.0
-    pipeline-v0.4.0-3-g7f4e2c1 clean -> 0.4.1.dev3+g7f4e2c1
-    pipeline-v0.4.0-3-g7f4e2c1 dirty -> 0.4.1.dev3+g7f4e2c1.d20260504
-    pipeline-v0.4.0-0-g7f4e2c1 dirty -> 0.4.0+d20260504
-    (no matching tag yet)            -> 0.0.0.dev0+g7f4e2c1[.d20260504]
+    tag pipeline-v0.4.0, 0 pipeline commits since, clean -> 0.4.0
+    tag pipeline-v0.4.0, 3 pipeline commits since, clean -> 0.4.1.dev3+g7f4e2c1
+    tag pipeline-v0.4.0, 3 pipeline commits since, dirty -> 0.4.1.dev3+g7f4e2c1.d20260504
+    tag pipeline-v0.4.0, 0 pipeline commits since, dirty -> 0.4.0+d20260504
+    (no matching tag yet)                                -> 0.0.0.dev0+g7f4e2c1[.d20260504]
 """
 
 from __future__ import annotations
@@ -39,6 +43,7 @@ _DESCRIBE_RE = re.compile(
     r'^pipeline-v(?P<base>\d+\.\d+\.\d+)'
     r'(?:-(?P<distance>\d+)-g(?P<sha>[0-9a-f]+))?$'
 )
+_TAG_RE = re.compile(r'^pipeline-v(?P<base>\d+\.\d+\.\d+)$')
 
 
 def _repo_root() -> Path:
@@ -70,21 +75,13 @@ def _today_local_segment() -> str:
     return datetime.now(timezone.utc).strftime('d%Y%m%d')
 
 
-def _describe_to_pep440(described: str, dirty: bool) -> str | None:
-    m = _DESCRIBE_RE.match(described)
-    if not m:
-        return None
-
-    base = m.group('base')
-    distance = int(m.group('distance') or 0)
-    sha = m.group('sha')
-
+def _build_pep440(base: str, distance: int, sha: str | None, dirty: bool) -> str:
     if distance == 0:
         version = base
         local_parts: list[str] = []
     else:
         version = f"{_bump_patch(base)}.dev{distance}"
-        local_parts = [f"g{sha}"]
+        local_parts = [f"g{sha}"] if sha else []
 
     if dirty:
         local_parts.append(_today_local_segment())
@@ -95,10 +92,43 @@ def _describe_to_pep440(described: str, dirty: bool) -> str | None:
     return version
 
 
+def _describe_to_pep440(described: str, dirty: bool) -> str | None:
+    """Translate a ``git describe --long`` string into a PEP 440 version.
+
+    Retained as a pure parser/formatter for unit tests. The runtime path in
+    :func:`_git_version` does not call this — distance there is recounted
+    scoped to ``pipeline/``, which the raw ``describe --long`` count cannot
+    express.
+    """
+    m = _DESCRIBE_RE.match(described)
+    if not m:
+        return None
+    return _build_pep440(
+        m.group('base'),
+        int(m.group('distance') or 0),
+        m.group('sha'),
+        dirty,
+    )
+
+
 def _pipeline_dirty(repo: Path) -> bool:
     # `git describe --dirty` checks the entire working tree; we only care
     # about edits to pipeline/ since that's what the version string scopes.
     return bool(_run_git(['status', '--porcelain', '--', 'pipeline'], repo))
+
+
+def _pipeline_distance(repo: Path, tag: str) -> int | None:
+    """Commits between *tag* and HEAD that touched ``pipeline/``.
+
+    ``git describe --long`` reports the whole-monorepo count, which would
+    bump ``.devN`` for any ``web/`` or ``python/`` commit even when pipeline
+    code is byte-identical to *tag*. ``rev-list -- pipeline`` reports the
+    count we actually want stamped onto reduced data.
+    """
+    out = _run_git(['rev-list', f'{tag}..HEAD', '--count', '--', 'pipeline'], repo)
+    if out is None or not out.isdigit():
+        return None
+    return int(out)
 
 
 def _git_version() -> str | None:
@@ -106,12 +136,17 @@ def _git_version() -> str | None:
     if not (repo / '.git').exists():
         return None
 
-    described = _run_git(
-        ['describe', '--tags', '--long', '--match', 'pipeline-v*'],
+    tag = _run_git(
+        ['describe', '--tags', '--abbrev=0', '--match', 'pipeline-v*'],
         repo,
     )
-    if described:
-        return _describe_to_pep440(described, _pipeline_dirty(repo))
+    if tag:
+        m = _TAG_RE.match(tag)
+        if not m:
+            return None
+        distance = _pipeline_distance(repo, tag) or 0
+        sha = _run_git(['rev-parse', '--short=7', 'HEAD'], repo) if distance else None
+        return _build_pep440(m.group('base'), distance, sha, _pipeline_dirty(repo))
 
     # No matching tag yet — synthesize a 0.0.0.dev0 string from HEAD.
     sha = _run_git(['rev-parse', '--short=7', 'HEAD'], repo)

--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -45,8 +45,15 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 # Versions come from monorepo git tags of the form `pipeline-vX.Y.Z` only.
-# This isolates the pipeline subpackage version from unrelated commits in
-# `web/`, `python/`, `supabase/`, etc.
+# `tag_regex` isolates the tag *namespace*, but does NOT scope the commit
+# counter — `git describe --long` still reports the full monorepo distance,
+# which would bump `.devN` for unrelated `web/`, `python/`, `supabase/`,
+# `scripts/` commits. This config only fires when setuptools-scm writes
+# `_version.py` at install time (the build-time stamp). The runtime version
+# stamped onto reduced data is computed by
+# `campfire_pipeline.common.version._git_version`, which recounts distance
+# scoped to `pipeline/` via `git rev-list <tag>..HEAD --count -- pipeline`.
+# That is the source of truth for `CMPFRVER` and `spectra.cfpipe_version`.
 root = ".."
 tag_regex = "^pipeline-v(?P<version>\\d+\\.\\d+\\.\\d+)$"
 git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--match", "pipeline-v*"]

--- a/pipeline/tests/test_version.py
+++ b/pipeline/tests/test_version.py
@@ -6,6 +6,8 @@ from campfire_pipeline.common import version as version_mod
 
 
 class TestDescribeToPep440:
+    """Pure parser tests — exercised independently of the runtime path."""
+
     def test_exact_tag_clean(self):
         assert version_mod._describe_to_pep440('pipeline-v0.4.0', dirty=False) == '0.4.0'
 
@@ -33,12 +35,29 @@ class TestDescribeToPep440:
         assert version_mod._describe_to_pep440('not-a-pipeline-tag', dirty=False) is None
 
 
-class TestGitVersion:
-    """Regression tests for #135 — pipeline-scoped dirty check.
+def _fake_git(*, tag='pipeline-v0.4.0', pipeline_distance='0', sha='7f4e2c1', status=''):
+    """Build a `_run_git` mock with controllable per-command return values."""
+    captured: list[list[str]] = []
 
-    The bug: `git describe --dirty` checks the entire working tree, so edits
-    to web/, python/, supabase/ flipped the pipeline version's dirty flag
-    even when no pipeline file changed.
+    def fake_run_git(args, cwd):
+        captured.append(args)
+        if args[0] == 'describe':
+            return tag
+        if args[0] == 'rev-list':
+            return pipeline_distance
+        if args[0] == 'rev-parse':
+            return sha
+        if args[0] == 'status':
+            return status
+        return None
+
+    return fake_run_git, captured
+
+
+class TestGitVersion:
+    """Regression coverage for #135 (dirty-scope) and the pipeline-scoped
+    distance fix that supersedes ``git describe --long``'s monorepo-wide
+    count.
     """
 
     def test_describe_invocation_has_no_dirty_flag(self, tmp_path):
@@ -46,15 +65,7 @@ class TestGitVersion:
         repo = tmp_path
         (repo / '.git').mkdir()
 
-        captured: list[list[str]] = []
-
-        def fake_run_git(args, cwd):
-            captured.append(args)
-            if args[0] == 'describe':
-                return 'pipeline-v0.4.0-0-g7f4e2c1'
-            if args[0] == 'status':
-                return ''  # clean
-            return None
+        fake_run_git, captured = _fake_git()
 
         with (
             mock.patch.object(version_mod, '_repo_root', return_value=repo),
@@ -69,20 +80,35 @@ class TestGitVersion:
 
         assert result == '0.4.0'
 
+    def test_describe_uses_abbrev_zero_not_long(self, tmp_path):
+        """`describe --long` count is monorepo-wide; we must use `--abbrev=0`."""
+        repo = tmp_path
+        (repo / '.git').mkdir()
+
+        fake_run_git, captured = _fake_git()
+
+        with (
+            mock.patch.object(version_mod, '_repo_root', return_value=repo),
+            mock.patch.object(version_mod, '_run_git', side_effect=fake_run_git),
+        ):
+            version_mod._git_version()
+
+        describe_calls = [c for c in captured if c[0] == 'describe']
+        assert describe_calls, 'expected a git describe call'
+        for call in describe_calls:
+            assert '--long' not in call, (
+                f'`--long` would expose monorepo-wide distance count: {call}'
+            )
+            assert '--abbrev=0' in call, (
+                f'expected `--abbrev=0` to suppress distance/sha suffix: {call}'
+            )
+
     def test_dirty_check_is_pipeline_scoped(self, tmp_path):
         """Dirty check must pass `-- pipeline` to git status."""
         repo = tmp_path
         (repo / '.git').mkdir()
 
-        captured: list[list[str]] = []
-
-        def fake_run_git(args, cwd):
-            captured.append(args)
-            if args[0] == 'describe':
-                return 'pipeline-v0.4.0-0-g7f4e2c1'
-            if args[0] == 'status':
-                return ''  # clean
-            return None
+        fake_run_git, captured = _fake_git()
 
         with (
             mock.patch.object(version_mod, '_repo_root', return_value=repo),
@@ -97,17 +123,87 @@ class TestGitVersion:
                 f'status call must be scoped to pipeline/: {call}'
             )
 
+    def test_distance_is_pipeline_scoped(self, tmp_path):
+        """`rev-list -- pipeline` must produce the distance, not `describe --long`."""
+        repo = tmp_path
+        (repo / '.git').mkdir()
+
+        fake_run_git, captured = _fake_git()
+
+        with (
+            mock.patch.object(version_mod, '_repo_root', return_value=repo),
+            mock.patch.object(version_mod, '_run_git', side_effect=fake_run_git),
+        ):
+            version_mod._git_version()
+
+        rev_list_calls = [c for c in captured if c[0] == 'rev-list']
+        assert rev_list_calls, 'expected a `git rev-list` call for pipeline-scoped distance'
+        for call in rev_list_calls:
+            assert '--count' in call, f'rev-list must request --count: {call}'
+            assert '--' in call and 'pipeline' in call, (
+                f'rev-list must be scoped to pipeline/: {call}'
+            )
+            assert 'pipeline-v0.4.0..HEAD' in call, (
+                f'rev-list must use <tag>..HEAD range: {call}'
+            )
+
+    def test_zero_pipeline_commits_returns_clean_tag(self, tmp_path):
+        """0 pipeline commits past the tag -> exact tag version, no .dev / +g."""
+        repo = tmp_path
+        (repo / '.git').mkdir()
+
+        fake_run_git, _ = _fake_git(pipeline_distance='0', status='')
+
+        with (
+            mock.patch.object(version_mod, '_repo_root', return_value=repo),
+            mock.patch.object(version_mod, '_run_git', side_effect=fake_run_git),
+        ):
+            assert version_mod._git_version() == '0.4.0'
+
+    def test_zero_pipeline_commits_even_when_describe_long_would_count_them(self, tmp_path):
+        """The core fix: web/python/scripts commits don't bump the dev counter.
+
+        Simulates a HEAD that's many commits past the tag but where every commit
+        landed outside pipeline/ (rev-list -- pipeline returns 0).
+        """
+        repo = tmp_path
+        (repo / '.git').mkdir()
+
+        fake_run_git, _ = _fake_git(pipeline_distance='0', sha='ff936d6', status='')
+
+        with (
+            mock.patch.object(version_mod, '_repo_root', return_value=repo),
+            mock.patch.object(version_mod, '_run_git', side_effect=fake_run_git),
+        ):
+            result = version_mod._git_version()
+
+        assert result == '0.4.0', (
+            f'commits outside pipeline/ must not bump the version; got {result!r}'
+        )
+
+    def test_pipeline_commits_bump_dev_and_include_sha(self, tmp_path):
+        """Non-zero pipeline-scoped distance bumps patch and appends .devN+gSHA."""
+        repo = tmp_path
+        (repo / '.git').mkdir()
+
+        fake_run_git, _ = _fake_git(pipeline_distance='3', sha='7f4e2c1', status='')
+
+        with (
+            mock.patch.object(version_mod, '_repo_root', return_value=repo),
+            mock.patch.object(version_mod, '_run_git', side_effect=fake_run_git),
+        ):
+            assert version_mod._git_version() == '0.4.1.dev3+g7f4e2c1'
+
     def test_pipeline_dirty_appends_local_segment(self, tmp_path):
         """When pipeline files are dirty, the local segment fires."""
         repo = tmp_path
         (repo / '.git').mkdir()
 
-        def fake_run_git(args, cwd):
-            if args[0] == 'describe':
-                return 'pipeline-v0.4.0-0-g7f4e2c1'
-            if args[0] == 'status':
-                return ' M pipeline/campfire_pipeline/common/version.py'
-            return None
+        fake_run_git, _ = _fake_git(
+            pipeline_distance='0',
+            sha='7f4e2c1',
+            status=' M pipeline/campfire_pipeline/common/version.py',
+        )
 
         with (
             mock.patch.object(version_mod, '_repo_root', return_value=repo),
@@ -115,3 +211,21 @@ class TestGitVersion:
             mock.patch.object(version_mod, '_today_local_segment', return_value='d20260504'),
         ):
             assert version_mod._git_version() == '0.4.0+d20260504'
+
+    def test_pipeline_dirty_with_pipeline_commits(self, tmp_path):
+        """Dirty + non-zero pipeline distance combines both local segments."""
+        repo = tmp_path
+        (repo / '.git').mkdir()
+
+        fake_run_git, _ = _fake_git(
+            pipeline_distance='3',
+            sha='7f4e2c1',
+            status=' M pipeline/foo.py',
+        )
+
+        with (
+            mock.patch.object(version_mod, '_repo_root', return_value=repo),
+            mock.patch.object(version_mod, '_run_git', side_effect=fake_run_git),
+            mock.patch.object(version_mod, '_today_local_segment', return_value='d20260504'),
+        ):
+            assert version_mod._git_version() == '0.4.1.dev3+g7f4e2c1.d20260504'


### PR DESCRIPTION
## Summary
- Runtime version resolver (`campfire_pipeline.common.version._git_version`) now uses `git describe --abbrev=0` + `git rev-list <tag>..HEAD --count -- pipeline` instead of `git describe --long`, so commits outside `pipeline/` no longer bump `.devN` on a byte-identical reduction. Closes the matching gap for the dirty-flag scoping fix from #135.
- Factored a shared `_build_pep440(base, distance, sha, dirty)` helper out of `_describe_to_pep440`; the latter is kept as a pure parser exercised by unit tests.
- Fixed the stale `pyproject.toml` comment that claimed `setuptools-scm` config did the scoping. It does not — `tag_regex` only namespaces tags. The runtime resolver in `common.version` is what scopes distance, and `_version.py` is a last-resort fallback the resolver rarely reads.

## Why
Today, `HEAD` is 8 commits past `pipeline-v0.5.0`, but **zero** of those touch `pipeline/`. A reduction running right now stamps `CMPFRVER` / `spectra.cfpipe_version` as `0.5.1.dev8+gff936d6`, and `campfire deploy` warns about "unreleased" data on every deployment despite the pipeline being byte-identical to v0.5.0. With this change:

| Pipeline-scoped distance | Tree state | Resolved version |
|---|---|---|
| 0 | clean | `0.5.0` (passes deploy release regex) |
| 0 | dirty | `0.5.0+d20260527` |
| 3 | clean | `0.5.1.dev3+g<sha>` |
| 3 | dirty | `0.5.1.dev3+g<sha>.d20260527` |

## Test plan
- [x] `conda run -n campfire python -m pytest tests/test_version.py` — 14/14 pass (5 original parser tests + 9 `_git_version` tests covering describe form, dirty scoping, distance scoping, and combinations)
- [x] Live sanity check: `from campfire_pipeline.common.version import get_reduction_version; print(get_reduction_version())` returns the pipeline-scoped value
- [x] Cross-checked the resolved version against `python/campfire/deploy/deploy.py::_is_release_version` (`^\d+\.\d+\.\d+$`)
- [ ] After merge, cut `pipeline-v0.5.1` so the Unreleased Infrastructure entry ships

Generated with Claude Code