### PR TITLE
fix(supabase): restore MV unique indexes + add CI guard

### DIFF
--- a/.github/workflows/supabase-mv-indexes.yml
+++ b/.github/workflows/supabase-mv-indexes.yml
@@ -1,0 +1,54 @@
+name: Supabase MV index guard
+
+# Asserts that every public materialized view has a unique index after applying
+# all migrations. Without one, REFRESH MATERIALIZED VIEW CONCURRENTLY fails and
+# the deploy CLI's cache refreshes soft-fail (the views go stale). migra does
+# not track MV indexes, so a migra-generated drop/recreate can silently strip
+# them — this guard catches that at PR time.
+
+on:
+  pull_request:
+    paths:
+      - "supabase/migrations/**"
+      - "supabase/schemas/views.sql"
+      - "supabase/schemas/indexes.sql"
+      - "supabase/tests/check_mv_unique_indexes.sql"
+      - ".github/workflows/supabase-mv-indexes.yml"
+
+# Cancel superseded runs on the same PR to save Actions minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-mv-indexes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Start local Postgres
+        run: supabase db start
+
+      - name: Apply migrations
+        # Migrations only (no seed): the MV index invariant is independent of
+        # row data, and skipping the seed keeps this guard fast and focused.
+        run: supabase db reset --no-seed
+
+      - name: Assert materialized views have unique indexes
+        # Fixed local connection string (db.port = 54322 in supabase/config.toml).
+        env:
+          DB_URL: postgresql://postgres:postgres@127.0.0.1:54322/postgres
+        run: |
+          psql "$DB_URL" -v ON_ERROR_STOP=1 \
+            -f supabase/tests/check_mv_unique_indexes.sql

--- a/supabase/migrations/20260529120000_restore_mv_unique_indexes.sql
+++ b/supabase/migrations/20260529120000_restore_mv_unique_indexes.sql
@@ -1,0 +1,25 @@
+-- Restore unique indexes on mv_filter_options and mv_programs_overview (again).
+--
+-- This is a recurrence of the regression first fixed in
+-- 20260421153229_restore_mv_unique_indexes.sql. The migration
+-- 20260513144940_add_nircam_mask_regions.sql dropped and recreated both
+-- materialized views (a migra-generated diff) without recreating their unique
+-- indexes, leaving prod in a state where REFRESH MATERIALIZED VIEW
+-- CONCURRENTLY fails with:
+--   "cannot refresh materialized view ... concurrently"
+--   "Create a unique index with no WHERE clause on one or more columns"
+--
+-- The deploy CLI calls refresh_filter_options() / refresh_programs_overview()
+-- at the end of every deploy, both of which use CONCURRENTLY. With the indexes
+-- missing, the refreshes soft-fail and the MVs go stale until manually rebuilt.
+--
+-- Root cause is migra's known MV-tracking limitation (see CLAUDE.md): any diff
+-- that drops/recreates these MVs silently omits their indexes. The canonical
+-- index definitions live in supabase/schemas/views.sql — this migration just
+-- re-applies them.
+
+CREATE UNIQUE INDEX IF NOT EXISTS mv_filter_options_id
+    ON public.mv_filter_options USING btree (id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS mv_programs_overview_slug
+    ON public.mv_programs_overview USING btree (slug);

--- a/supabase/tests/check_mv_unique_indexes.sql
+++ b/supabase/tests/check_mv_unique_indexes.sql
@@ -1,0 +1,37 @@
+-- Guard: every materialized view in the public schema must have a unique index.
+--
+-- REFRESH MATERIALIZED VIEW CONCURRENTLY requires a unique index on the view.
+-- migra (the engine behind `supabase db diff`) does not track materialized-view
+-- indexes, so any migra-generated migration that drops + recreates an MV will
+-- silently strip its unique index, breaking concurrent refresh in production.
+-- This has regressed twice already (restored by 20260421153229 and
+-- 20260529120000). This assertion catches the next recurrence at PR time.
+--
+-- Run locally:
+--   eval "$(supabase status -o env | grep '^DB_URL=')"
+--   psql "$DB_URL" -v ON_ERROR_STOP=1 -f supabase/tests/check_mv_unique_indexes.sql
+DO $$
+DECLARE
+  missing text;
+BEGIN
+  SELECT string_agg(mv.matviewname, ', ' ORDER BY mv.matviewname)
+  INTO missing
+  FROM pg_matviews mv
+  JOIN pg_class c
+    ON c.relname = mv.matviewname
+   AND c.relnamespace = 'public'::regnamespace
+  WHERE mv.schemaname = 'public'
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_index i
+      WHERE i.indrelid = c.oid
+        AND i.indisunique
+    );
+
+  IF missing IS NOT NULL THEN
+    RAISE EXCEPTION
+      'Materialized view(s) lack a unique index (REFRESH ... CONCURRENTLY will fail): %', missing
+      USING HINT = 'Add CREATE UNIQUE INDEX in supabase/schemas/views.sql AND a migration to restore it.';
+  END IF;
+
+  RAISE NOTICE 'OK: all public materialized views have a unique index.';
+END $$;


### PR DESCRIPTION
## Problem

During deploys, the cache refreshes were soft-failing:

```
Warning: Failed to refresh filter options: cannot refresh materialized view
"public.mv_filter_options" concurrently
Warning: Failed to refresh programs overview: cannot refresh materialized view
"public.mv_programs_overview" concurrently
```

`REFRESH MATERIALIZED VIEW CONCURRENTLY` requires a unique index on the view. Both views are supposed to have one (defined in `supabase/schemas/views.sql`), but production lost them: migration `20260513144940_add_nircam_mask_regions.sql` dropped and recreated both MVs (a migra-generated diff) **without** recreating the unique indexes.

Root cause is migra's known MV-tracking limitation — it doesn't track materialized-view indexes, so any diff that drops/recreates an MV silently strips them. This already regressed once and was fixed in `20260421153229`; this is the same failure recurring.

Impact is **stale cache, not data loss**: underlying tables are fine, but the filter-options and programs-overview caches stay stale after a deploy until manually refreshed.

## Changes

- **Restore migration** (`20260529120000`) — re-creates `mv_filter_options_id` and `mv_programs_overview_slug` (`CREATE UNIQUE INDEX IF NOT EXISTS`, idempotent).
- **Reusable assertion** (`supabase/tests/check_mv_unique_indexes.sql`) — fails if any public materialized view lacks a unique index. Runnable locally.
- **CI guard** (`.github/workflows/supabase-mv-indexes.yml`) — on PRs touching `supabase/migrations/**`, `views.sql`, or `indexes.sql`: starts local Postgres, `supabase db reset --no-seed` (migrations only — the deployment path migra under-tracks), then runs the assertion. Path-scoped + `cancel-in-progress` to keep Actions usage minimal.

The guard catches the *next* migra drop/recreate at PR time instead of in production. It's generic — covers any future materialized view, not just these two.

## After merge

Production won't pick up the index until this migration runs. To un-stale the caches immediately, run once the migration is applied:

```sql
SELECT refresh_filter_options();
SELECT refresh_programs_overview();
```

## Notes

- No schema-file change needed — `views.sql` already defines both indexes correctly; this only repairs the migration/deployment path.
- The new workflow gets its first end-to-end run on this very PR (it touches `supabase/migrations/**`).

Generated with Claude Code