### PR TITLE
fix(pipeline): platform-aware multiprocessing start method

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -25,6 +25,17 @@ Release procedure: edit the `## Unreleased` section below, then run
 
 ## Unreleased
 
+### Infrastructure
+- Multiprocessing start method is now platform-aware: `forkserver` on Linux,
+  `spawn` on macOS. The earlier blanket `forkserver` switch (added to fix
+  `ENOMEM`-at-fork on candide) also forced macOS off its safe `spawn` default,
+  and `forkserver` still `fork()`s its workers — unsafe on macOS, where Apple's
+  threaded frameworks and cv2's `parallel_for_` pool deadlock in the child. The
+  symptom was the NIRSpec stage-1 jump step hanging (`S` / 0% CPU) at "Flagging
+  Snowballs", since stcal's snowball flagging calls into cv2. macOS has no
+  `ENOMEM`-at-fork concern, so `spawn` is both safe and sufficient there;
+  candide keeps `forkserver` and its preload list unchanged.
+
 ## v0.5.1 — 2026-05-27
 
 ### Infrastructure

--- a/pipeline/campfire_pipeline/common/parallel.py
+++ b/pipeline/campfire_pipeline/common/parallel.py
@@ -1,22 +1,37 @@
 """
 Parallel dispatch helper: replaces repeated Pool/serial patterns across stages.
 
-Workers are launched via the ``forkserver`` start method rather than the Linux
-default ``fork``. Forking from a multi-GB parent (e.g. after the persistence
-step's snowblind deep-copies fragment the heap) blows past Linux's per-process
-commit accounting — the kernel must reserve ``parent_RSS × n_workers`` bytes at
-fork time even though copy-on-write means actual usage will be far smaller, and
-``os.fork()`` returns ``ENOMEM`` before any real allocation happens. The
-forkserver helper is launched once early, stays small (~tens of MB plus the
-preloaded modules below), and is what does the per-task forks.
+The start method is platform-aware:
 
-Preloading the heavy scientific imports into the forkserver lets workers
+* **Linux → forkserver.** The Linux default ``fork`` blows past per-process
+  commit accounting when forking from a multi-GB parent (e.g. after the
+  persistence step's snowblind deep-copies fragment the heap): the kernel must
+  reserve ``parent_RSS × n_workers`` bytes at fork time even though
+  copy-on-write means actual usage will be far smaller, and ``os.fork()``
+  returns ``ENOMEM`` before any real allocation happens. The forkserver helper
+  is launched once early, stays small (~tens of MB plus the preloaded modules
+  below), and is what does the per-task forks.
+
+* **macOS → spawn.** ``fork()`` (and therefore ``forkserver``, which forks its
+  workers from the helper) is unsafe on macOS: Apple's threaded frameworks
+  (GCD / Accelerate) and cv2's ``parallel_for_`` pool deadlock in the child.
+  This is why Python defaults macOS to ``spawn``. stcal's snowball flagging
+  (``stcal.jump.jump.flag_large_events``) calls into cv2, so a forked worker
+  hangs (``S`` / 0% CPU) the moment it reaches "Flagging Snowballs". The
+  macOS ENOMEM concern that motivates forkserver on candide does not apply
+  here, so ``spawn`` is both safe and sufficient.
+
+Preloading the heavy scientific imports into the forkserver lets Linux workers
 inherit them via copy-on-write rather than re-importing per pool. ``jhat`` and
 ``tweakreg`` are intentionally absent — importing them touches CRDS singleton
 state in a way that locks the context (see feedback_lazy_jwst_imports), so
-those stay as lazy imports inside the worker functions that need them.
+those stay as lazy imports inside the worker functions that need them. ``stcal``
+and ``snowblind`` are likewise absent: pre-importing cv2 into the forkserver
+helper risks the same half-built-pool deadlock there. (``spawn`` ignores the
+preload list entirely — each worker re-imports from scratch.)
 """
 
+import sys
 from functools import partial
 from multiprocessing import get_context
 from time import sleep
@@ -24,24 +39,25 @@ from time import sleep
 from campfire_pipeline.common.io import log
 
 
-_MP_CTX = get_context('forkserver')
-_MP_CTX.set_forkserver_preload([
-    'numpy',
-    'scipy',
-    'astropy.io.fits',
-    'astropy.wcs',
-    'astropy.table',
-    'jwst',
-    'jwst.datamodels',
-    'stdatamodels',
-    'stdatamodels.jwst',
-    'stcal',
-    'crds',
-    'snowblind',
-    'campfire_pipeline.common.io',
-    'campfire_pipeline.common.cfp',
-    'campfire_pipeline.common.parallel',
-])
+if sys.platform == 'darwin':
+    _MP_CTX = get_context('spawn')
+else:
+    _MP_CTX = get_context('forkserver')
+    _MP_CTX.set_forkserver_preload([
+        'numpy',
+        'scipy',
+        'astropy.io.fits',
+        'astropy.wcs',
+        'astropy.table',
+        'jwst',
+        'jwst.datamodels',
+        'stdatamodels',
+        'stdatamodels.jwst',
+        'crds',
+        'campfire_pipeline.common.io',
+        'campfire_pipeline.common.cfp',
+        'campfire_pipeline.common.parallel',
+    ])
 
 
 class _RetryOnIOError:


### PR DESCRIPTION
## Problem

On macOS, the NIRSpec stage-1 jump step hangs (process in `S` / 0% CPU) at **"Flagging Snowballs"** and never completes.

The cause is the earlier blanket switch to the `forkserver` start method, which was added to fix `ENOMEM`-at-fork on candide (Linux). `forkserver` still `fork()`s its workers from the helper process — and `fork()` is unsafe on macOS, where Apple's threaded frameworks (GCD / Accelerate) and cv2's `parallel_for_` pool deadlock in the child. This is exactly why Python defaults macOS to `spawn`. stcal's snowball flagging (`stcal.jump.jump.flag_large_events`) calls into cv2, so a forked worker deadlocks the moment it reaches that step.

## Fix

Make the start method platform-aware:

- **Linux → `forkserver`** (unchanged) — keeps the candide `ENOMEM`-at-fork fix and its preload list.
- **macOS → `spawn`** — safe and sufficient; macOS has no `ENOMEM`-at-fork concern.

Also drop `stcal` and `snowblind` from the forkserver preload list, so cv2 is never pre-imported into the forkserver helper (which would risk the same half-built-pool deadlock there). `spawn` ignores the preload list entirely.

Consistent with the lazy-jwst-imports discipline — `jhat`/`tweakreg` stay lazy to avoid locking the CRDS context.

## Categorization

**Infrastructure / PATCH** — no change to scientific output for the same input; this only affects how workers are launched per platform. CHANGELOG entry added under `## Unreleased`.

Generated with Claude Code