### PR TITLE
Fix: Inspection mode now respects the observation filter

### DIFF
--- a/supabase/migrations/20260529184316_add_observations_filter_to_get_filtered_object_ids.sql
+++ b/supabase/migrations/20260529184316_add_observations_filter_to_get_filtered_object_ids.sql
@@ -1,0 +1,199 @@
+-- =============================================================================
+-- Migration: Add the observation filter to get_filtered_object_ids.
+-- =============================================================================
+-- get_filtered_object_ids (the lightweight object-id queue used by inspection
+-- mode and the map markers) was the only objects-level RPC missing the
+-- p_observations parameter that its siblings already accept
+-- (get_filtered_objects_paginated, get_adjacent_objects). As a result,
+-- entering inspection mode from an observation-filtered catalog view silently
+-- dropped the observation filter and expanded the queue to every matching
+-- object. (Issue #157)
+--
+-- Adding a defaulted parameter changes the signature, so CREATE OR REPLACE
+-- would create a new overload rather than replace the existing one. We DROP
+-- the current canonical signature first, then CREATE the new version.
+--
+-- The MV/view drop+recreate statements that `supabase db diff` emitted
+-- alongside this change were removed by hand: migra cannot reliably diff
+-- materialized views, and recreating mv_filter_options / mv_programs_overview
+-- here would silently drop the unique indexes restored in
+-- 20260529120000_restore_mv_unique_indexes.sql.
+-- =============================================================================
+
+DROP FUNCTION IF EXISTS public.get_filtered_object_ids(
+  text[], text[], text[], text[], text, integer[],
+  double precision, double precision, double precision, double precision,
+  double precision, double precision,
+  text, boolean, boolean, integer[],
+  double precision, double precision, double precision,
+  boolean, double precision, double precision,
+  text, text, uuid,
+  text, text
+);
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_filtered_object_ids(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_list_ids integer[] DEFAULT NULL::integer[], p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_has_photometry boolean DEFAULT NULL::boolean, p_photo_z_min double precision DEFAULT NULL::double precision, p_photo_z_max double precision DEFAULT NULL::double precision, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_sort_column text DEFAULT 'object_id'::text, p_sort_direction text DEFAULT 'asc'::text)
+ RETURNS TABLE(object_id text)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
+    v_gratings_mode := 'any';
+  END IF;
+
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN
+    p_sort_direction := 'asc';
+  END IF;
+
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time', 'photo_z'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+
+  -- Intersect user-accessible programs with filter selection
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(
+      SELECT unnest(p_program_slugs)
+      INTERSECT
+      SELECT unnest(p_filter_programs)
+    ) INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT o.object_id
+  FROM objects o
+  WHERE
+    o.programs && v_filtered_program_slugs
+    AND o.is_active = true
+    AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+    AND (
+      NOT v_grating_filter_active
+      OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+      OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+      OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+    )
+    AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+    AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+    AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+    AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+    AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+    AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+    AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+    AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+    AND (p_search IS NULL OR o.object_id ILIKE '%' || p_search || '%'
+      OR EXISTS (SELECT 1 FROM targets t WHERE t.object_id = o.id AND t.target_id ILIKE '%' || p_search || '%'))
+    AND (
+      p_inspected_only IS NULL
+      OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+      OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+    )
+    AND (
+      p_needs_review IS NULL
+      OR (p_needs_review = TRUE
+          AND o.staleness_reason IS NOT NULL
+          AND o.last_inspected_at IS NOT NULL
+          AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+      OR (p_needs_review = FALSE
+          AND (o.staleness_reason IS NULL
+               OR o.last_inspected_at IS NULL
+               OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+    )
+    AND (
+      NOT v_coord_search_active
+      OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+        AND 2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) <= p_radius_degrees
+      )
+    )
+    AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+        SELECT olm.object_id FROM object_list_members olm
+        WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+    ))
+    AND (
+      NOT v_comment_search_active
+      OR EXISTS (
+        SELECT 1 FROM comments c
+        WHERE c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (
+            p_comment_search_scope = 'everyone'
+            OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+          )
+          AND (
+            c.object_id = o.id
+            OR c.target_id IN (SELECT t.id FROM targets t WHERE t.object_id = o.id)
+          )
+      )
+    )
+  ORDER BY
+    CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN
+      2 * DEGREES(ASIN(SQRT(
+        POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+        COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+        POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+      ))) END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN
+      2 * DEGREES(ASIN(SQRT(
+        POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+        COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+        POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+      ))) END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN o.object_id END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'desc' THEN o.object_id END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN o.field END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN o.field END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN o.ra END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN o.ra END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN o.dec END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN o.dec END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN o.redshift END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN o.redshift END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN o.redshift_quality END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN o.redshift_quality END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'asc' THEN o.n_targets END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'desc' THEN o.n_targets END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'asc' THEN o.n_spectra END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'desc' THEN o.n_spectra END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN o.max_snr END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN o.max_snr END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN o.max_exposure_time END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN o.max_exposure_time END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'asc' THEN o.photo_z END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'desc' THEN o.photo_z END DESC NULLS LAST,
+    o.object_id ASC;
+END;
+$function$
+;
+
+GRANT EXECUTE ON FUNCTION public.get_filtered_object_ids TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_filtered_object_ids TO service_role;

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -1205,6 +1205,7 @@ CREATE OR REPLACE FUNCTION public.get_filtered_object_ids(
   p_fields TEXT[] DEFAULT NULL,
   p_gratings TEXT[] DEFAULT NULL,
   p_gratings_mode TEXT DEFAULT 'any',
+  p_observations TEXT[] DEFAULT NULL,
   p_redshift_quality INTEGER[] DEFAULT NULL,
   p_redshift_min DOUBLE PRECISION DEFAULT NULL,
   p_redshift_max DOUBLE PRECISION DEFAULT NULL,
@@ -1290,6 +1291,7 @@ BEGIN
       OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
       OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
     )
+    AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
     AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
     AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
     AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)

--- a/web/lib/actions/spectra.ts
+++ b/web/lib/actions/spectra.ts
@@ -715,8 +715,11 @@ export async function getFilterOptions(): Promise<FilterOptionsResult> {
  * same order as the table view it was launched from.
  * If no redshift_quality filter is set, implicitly filters to quality=0 (uninspected).
  *
- * Backed by `get_filtered_object_ids`; observation/feature/DQ filters aren't
- * supported at this lightweight tier.
+ * Backed by `get_filtered_object_ids`; feature/DQ filters aren't supported at
+ * this lightweight tier (they require per-spectrum joins). Observation filtering
+ * is supported via `p_observations` (the objects table carries an aggregated
+ * `observations` array), so the inspection queue stays scoped to the same
+ * observation filter as the table view it was launched from.
  */
 export async function getInspectionQueueIds(
   filters?: Partial<FilterOptions>,
@@ -750,10 +753,11 @@ export async function getInspectionQueueIds(
 
     const baseRpcParams = buildFilterParams(filters, accessibleProgramSlugs, user.id);
 
-    // Strip params not accepted by get_filtered_object_ids (target-only filters).
+    // Strip params not accepted by get_filtered_object_ids (per-spectrum DQ
+    // filters). p_observations IS accepted and must pass through so the queue
+    // respects the observation filter.
     /* eslint-disable @typescript-eslint/no-unused-vars */
     const {
-      p_observations: _obs,
       p_dq_flags_include_any: _dqa,
       p_dq_flags_include_all: _dqb,
       p_dq_flags_exclude: _dqc,


### PR DESCRIPTION
Closes #157

## What was the bug?
Filtering the spectral catalog by observation (e.g. `capers_cosmos_p5`) and then entering inspection mode silently dropped the observation filter — the inspection queue grew to include objects from every observation, not just the filtered one.

## Root cause
`get_filtered_object_ids` (the lightweight object-id RPC backing the inspection queue) was the only objects-level RPC missing the `p_observations` parameter that its siblings (`get_filtered_objects_paginated`, `get_adjacent_objects`) already accept. To compensate, `getInspectionQueueIds` explicitly **stripped** `p_observations` from the params before calling the RPC. The net effect: the observation filter never reached the database, so the queue was scoped only by the remaining filters.

## What I changed
- **`supabase/schemas/functions.sql`** — added `p_observations TEXT[] DEFAULT NULL` to `get_filtered_object_ids`, plus the `o.observations && p_observations` predicate. This is the exact pattern already used by the sibling object RPCs (the `objects` table carries an aggregated `observations` array).
- **`supabase/migrations/20260529184316_add_observations_filter_to_get_filtered_object_ids.sql`** — generated via `supabase db diff`. Because adding a defaulted param changes the signature, the migration drops the current canonical signature and recreates the function (same convention as the prior comment-search migration). The spurious materialized-view / view drop+recreate statements that `db diff` emitted were pruned by hand — migra can't reliably diff MVs, and recreating `mv_filter_options` / `mv_programs_overview` would have silently dropped the unique indexes restored in `20260529120000_restore_mv_unique_indexes.sql`.
- **`web/lib/actions/spectra.ts`** — `getInspectionQueueIds` no longer strips `p_observations`; it now passes through to the RPC. (Per-spectrum DQ filters remain stripped — they need joins the lightweight tier doesn't do.)

## Testing
- `supabase db reset` applies the new migration cleanly; a follow-up `supabase db diff` shows no remaining diff for the function (only the known, pre-existing MV noise).
- Functional check against the seed DB: `get_filtered_object_ids` returns 89 objects unfiltered vs. 3 when scoped to observation `c3po_p1`, confirming the filter is now applied.
- `cd web && npm run build` passes with no errors.

Generated with Claude Code