### PR TITLE
Point cfpipe --version at live git-derived version

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -26,6 +26,12 @@ Release procedure: edit the `## Unreleased` section below, then run
 ## Unreleased
 
 ### Infrastructure
+- `cfpipe --version` now reports the same live, git-derived version as
+  `cfpipe info` (via `get_reduction_version()`) instead of the package
+  metadata frozen at install time. Previously the two could diverge in a
+  checkout — `--version` showed the last-installed tag (e.g. `0.5.1`) while
+  `info` showed the live `0.5.2.devN+g<sha>`. The version stamped into output
+  FITS headers is unchanged; only the `--version` display source moved.
 - Multiprocessing start method is now platform-aware: `forkserver` on Linux,
   `spawn` on macOS. The earlier blanket `forkserver` switch (added to fix
   `ENOMEM`-at-fork on candide) also forced macOS off its safe `spawn` default,

--- a/pipeline/campfire_pipeline/cli.py
+++ b/pipeline/campfire_pipeline/cli.py
@@ -21,6 +21,7 @@ matplotlib.use('Agg')
 import click
 
 from campfire_pipeline.config import load_config, setup_environment, resolve_paths
+from campfire_pipeline.common.version import get_reduction_version
 
 
 # ---------------------------------------------------------------------------
@@ -28,7 +29,7 @@ from campfire_pipeline.config import load_config, setup_environment, resolve_pat
 # ---------------------------------------------------------------------------
 
 @click.group()
-@click.version_option(package_name='campfire-pipeline')
+@click.version_option(version=get_reduction_version(), prog_name='cfpipe')
 def main():
     """CAMPFIRE data reduction pipeline."""
     pass


### PR DESCRIPTION
## Summary

`cfpipe --version` and `cfpipe info` reported different versions in a checkout. `--version` used Click's `package_name='campfire-pipeline'` lookup, which reads package metadata frozen at install time, so it goes stale as pipeline commits accumulate past the last `pipeline-v*` tag. `cfpipe info` resolves the version live via `get_reduction_version()`.

Example divergence:
- `cfpipe info` → `0.5.2.dev1+ga7943a7` (live, git-derived — the value stamped into output FITS)
- `cfpipe --version` → `0.5.1` (last-installed tag from package metadata)

This points Click's `--version` at `get_reduction_version()` so both commands agree and reflect the version actually written into reduced data. `prog_name='cfpipe'` is preserved, so the output format (`cfpipe, version …`) is unchanged.

## Changes
- `pipeline/campfire_pipeline/cli.py`: `--version` now uses `version=get_reduction_version()` instead of `package_name=`.
- `pipeline/CHANGELOG.md`: added an **Infrastructure** entry under `## Unreleased` (PATCH — no scientific output change).

## Testing
The full CLI couldn't be run in the remote container (no `campfire` env / matplotlib), but `cli.py` byte-compiles and `get_reduction_version()` imports and resolves cleanly. Recommend a local `cfpipe --version` vs `cfpipe info` check to confirm they now match.

https://claude.ai/code/session_01KUbAELKQEz1ZZn4SsNWYU8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUbAELKQEz1ZZn4SsNWYU8)_