### PR TITLE
fix(nircam): sanitize per-component variance in campfire drizzle to stop inf-dominated ERR maps

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -25,6 +25,27 @@ Release procedure: edit the `## Unreleased` section below, then run
 
 ## Unreleased
 
+### Algorithm
+- NIRCam campfire-native drizzle (`resample.implementation = "campfire"`): the
+  ERR map no longer fills with `inf`/`nan`. The variance pass summed the three
+  variance components before drizzling, so a single input pixel with a
+  non-finite or negative component (e.g. `var_poisson = inf` at a pixel that is
+  not flagged `DO_NOT_USE`) poisoned `var_total`, and cdriz spread it across
+  every output pixel its kernel touched — `inf` is sticky in the running
+  weighted mean, so one bad input pixel blew up the ERR for all co-located
+  inputs and could dominate a tile. Each variance component is now masked
+  independently with `(var >= 0) & isfinite(var)` before the sum (matching the
+  per-component masking stcal applies in `resample_variance_arrays`): a bad
+  component drops only its own term, so a component that is bad across many
+  inputs (e.g. a flat-field column) degrades gracefully to the surviving terms
+  instead of leaving a NaN hole. A pixel is dropped entirely only where no
+  component is valid, and dropped pixels are excluded from both the variance
+  numerator and its normalizing weight (`outvarw`, now used in place of the SCI
+  weight) so there is no dilution bias. The SCI/WHT pass is unchanged; ERR is
+  bit-identical to before at pixels with no masked components, and only
+  previously-`inf`/`nan` pixels change. The default `jwst` implementation was
+  never affected.
+
 ### Infrastructure
 - `cfpipe --version` now reports the same live, git-derived version as
   `cfpipe info` (via `get_reduction_version()`) instead of the package

--- a/pipeline/campfire_pipeline/nircam/drizzle.py
+++ b/pipeline/campfire_pipeline/nircam/drizzle.py
@@ -5,10 +5,21 @@ NIRCam stage-3 resample (issue #138).
 Structural win over ``stcal.resample.resample.Resample``: the **variance
 trick**. A single persistent accumulator ``outvar`` is filled by drizzling
 ``var_total · wht`` weighted by ``wht``; the final ERR is
-``sqrt(outvar / outwht)``. Replaces stcal's three transient per-component
+``sqrt(outvar / outvarw)``. Replaces stcal's three transient per-component
 variance drizzles plus Python-level full-tile masked accumulator updates
 (~21 s/input × 200 inputs ≈ 70 min/tile of bookkeeping at COSMOS-Web
 scale).
+
+Non-finite or negative input variances are masked *per component* before the
+sum (``_sanitize_variance``) — without this, one input pixel with ``inf``/
+``nan`` variance poisons every output pixel its kernel touches (``inf`` is
+sticky in cdriz's running weighted mean), which is what stcal's per-component
+``isfinite`` masking quietly prevents. A bad component drops only its own term
+(so a component that is bad across many inputs degrades gracefully instead of
+punching a NaN hole); a pixel is dropped entirely only when no component is
+valid. The surviving weight is accumulated in ``outvarw`` and used to normalize
+``outvar``, so excluded pixels bias neither the numerator nor the denominator.
+The SCI/WHT pass is unaffected.
 
 The trick is the canonical kernel-weighted variance estimator
 ``V = (Σᵢ kᵢ wᵢ² varᵢ_total) / (Σᵢ kᵢ wᵢ)²``. This is *not* identical
@@ -194,6 +205,47 @@ def _write_i2d_fits(output_path, sci, err, wht, ctx, output_wcs,
         )
 
 
+def _sanitize_variance(var_rnoise, var_poisson, var_flat, weight):
+    """Sum the variance components for the variance pass, masking per component.
+
+    Each component is validated independently with ``(c >= 0) & isfinite(c)``
+    (the same condition stcal applies per component in
+    ``stcal.resample.resample.resample_variance_arrays``) and contributes 0
+    where it is non-finite or negative. A single bad component — e.g.
+    ``var_poisson = inf`` at a pixel that is *not* flagged ``DO_NOT_USE`` —
+    therefore drops only that term; the pixel keeps its surviving components
+    instead of being discarded wholesale. This matters most when a bad
+    component is correlated across inputs (a flat-field column, a reference
+    region): masking the *summed* variance would zero every input there and
+    punch a NaN hole into the ERR map, whereas per-component masking keeps the
+    good terms (``var_rnoise`` is essentially always finite and positive, so
+    the pixel stays finite).
+
+    Returns ``(var_total, var_weight)``:
+
+    - ``var_total`` is the sum of the validated components — finite and ``>= 0``
+      everywhere, so the ``var·weight`` data array handed to cdriz never carries
+      an ``inf``/``nan``.
+    - ``var_weight`` is the SCI ``weight`` zeroed only at *fully dead* pixels,
+      where no component is valid. Those are dropped from both the variance
+      numerator and its normalizing weight (``outvarw``), so they become
+      ERR = NaN rather than a spurious ERR = 0; everywhere else ``var_weight``
+      equals ``weight``, leaving the SCI/coverage weight untouched.
+
+    Without any masking, one input pixel with ``inf``/``nan`` variance poisons
+    every output pixel its kernel touches (``inf`` is sticky in cdriz's running
+    weighted mean), blowing up the final ERR for all co-located inputs.
+    """
+    var_total = np.zeros(weight.shape, dtype=np.float32)
+    any_valid = np.zeros(weight.shape, dtype=bool)
+    for component in (var_rnoise, var_poisson, var_flat):
+        valid = np.isfinite(component) & (component >= 0)
+        var_total += np.where(valid, component, np.float32(0.0))
+        any_valid |= valid
+    var_weight = np.where(any_valid, weight, np.float32(0.0)).astype(np.float32)
+    return var_total, var_weight
+
+
 def _prepare_drizzle_input(crf_file, output_wcs, out_shape, *,
                            weight_type, good_bits):
     """Open one CRF and prepare the per-input arrays drizzle needs.
@@ -231,10 +283,13 @@ def _prepare_drizzle_input(crf_file, output_wcs, out_shape, *,
             flag_name_map=pixel_flags,
         ).astype(np.float32)
 
-        var_total = (
-            np.asarray(model.var_rnoise, dtype=np.float32)
-            + np.asarray(model.var_poisson, dtype=np.float32)
-            + np.asarray(model.var_flat, dtype=np.float32)
+        # Sum the variance components, masking each independently (see
+        # _sanitize_variance) so one bad component can't poison the ERR map.
+        var_total, var_weight = _sanitize_variance(
+            np.asarray(model.var_rnoise, dtype=np.float32),
+            np.asarray(model.var_poisson, dtype=np.float32),
+            np.asarray(model.var_flat, dtype=np.float32),
+            weight,
         )
 
         xmin, xmax, ymin, ymax = resample_range(
@@ -243,7 +298,7 @@ def _prepare_drizzle_input(crf_file, output_wcs, out_shape, *,
 
     return {
         'data': data, 'err': err,
-        'var_total': var_total, 'weight': weight,
+        'var_total': var_total, 'weight': weight, 'var_weight': var_weight,
         'pixmap': pixmap, 'exptime': exptime,
         'xmin': xmin, 'xmax': xmax, 'ymin': ymin, 'ymax': ymax,
         'in_shape': in_shape, 'input_gwcs': input_gwcs,
@@ -287,9 +342,11 @@ def drizzle_tile(
       writes weighted-mean SCI and weight sum, tracks input contributions
       in the context array).
     - ``outvar`` / ``outvarw`` — variance-trick pass (drizzle ``var·wht``
-      weighted by ``wht``; ``outvarw`` exists only because Drizzle requires
-      an out_wht buffer, its values are discarded and equal ``outwht`` mod
-      float32 accumulation order).
+      weighted by the *masked* variance weight; ``outvarw`` is the running
+      sum of that weight and is used to normalize ``outvar`` into the final
+      variance. It equals ``outwht`` bit-for-bit except at pixels where some
+      input's variance was non-finite/negative and thus excluded from the
+      variance estimate — see ``_prepare_drizzle_input``).
 
     Parameters mirror ``Field.get_tile_wcs`` outputs (``crpix``, ``crval``,
     ``shape``, ``rotation``) and ``[nircam.resample]`` config knobs
@@ -339,21 +396,33 @@ def drizzle_tile(
 
         common = _add_image_kwargs(prep, pixfrac)
         sci_drizzle.add_image(data=prep['data'], **common)
+        # The variance pass uses the *masked* variance weight from
+        # _sanitize_variance (zero only at fully-dead pixels, where no variance
+        # component is valid) so those are excluded from both the numerator and
+        # ``outvarw`` (the denominator). var_total is finite everywhere (bad
+        # components contribute 0), so the ``var·weight`` data array is finite.
+        # ``data`` keeps the unmasked SCI ``weight`` so the numerator carries
+        # the wᵢ² factor; ``weight_map`` carries the masked weight.
         var_drizzle.add_image(
             data=(prep['var_total'] * prep['weight']).astype(np.float32),
-            **common,
+            **dict(common, weight_map=prep['var_weight']),
         )
         log(f"  [{i}/{n_inputs}] drizzled {basename}")
 
     total_exptime = float(sci_drizzle.total_exptime)
 
     # Final ERR. The variance trick gives outvar (per pixel) =
-    # Σwᵢ²kᵢvarᵢ / Σwᵢkᵢ; dividing by outwht (= Σwᵢkᵢ) yields the canonical
-    # weighted variance Σwᵢ²kᵢvarᵢ / (Σwᵢkᵢ)². Pixels with zero weight
+    # Σwᵢ²kᵢvarᵢ / Σwᵢkᵢ; dividing by outvarw (= Σwᵢkᵢ over the inputs with a
+    # valid variance estimate) yields the canonical weighted variance
+    # Σwᵢ²kᵢvarᵢ / (Σwᵢkᵢ)². outvarw is used in place of outwht so that inputs
+    # masked out of the variance estimate are excluded from its normalization
+    # too; at pixels with no masking the two are bit-identical (same inputs,
+    # weights, and pixmap in the same order). Pixels with zero variance weight
     # become ERR = NaN (matches stcal's missing-data convention used by
-    # bkgsub.off_detector via np.isnan(err)).
+    # bkgsub.off_detector via np.isnan(err)) — including pixels that hold flux
+    # but where no contributing input had any valid variance component.
     with np.errstate(divide='ignore', invalid='ignore'):
-        out_var_final = np.where(outwht > 0, outvar / outwht, np.nan)
+        out_var_final = np.where(outvarw > 0, outvar / outvarw, np.nan)
         outerr = np.sqrt(out_var_final).astype(np.float32)
 
     _write_i2d_fits(

--- a/pipeline/tests/test_nircam_drizzle.py
+++ b/pipeline/tests/test_nircam_drizzle.py
@@ -1,0 +1,184 @@
+"""Tests for the campfire-native NIRCam drizzle (`campfire_pipeline.nircam.drizzle`).
+
+Regression coverage for the variance-pass sanitization. Before the fix, the
+variance components were summed before drizzling, so one ``inf``/``nan``/
+negative component propagated into ``var_total * weight``; cdriz spread it
+across every output pixel the kernel touched, and ``inf`` is sticky in the
+running weighted mean — so one bad input pixel blew up the ERR for all
+co-located inputs (inf-dominated ERR maps).
+
+``_sanitize_variance`` masks each component independently with
+``(var >= 0) & isfinite(var)`` (matching stcal's per-component masking), so a
+bad component drops only its own term. A pixel is discarded entirely only when
+*no* component is valid. This degrades gracefully when a component is bad across
+many inputs (a flat-field column, a reference region), where masking the summed
+variance would instead punch a NaN hole in the ERR map.
+
+The integration tests drive the **real** ``drizzle.resample.Drizzle`` (the same
+primitive ``drizzle_tile`` uses) through an identity pixmap, so they reproduce
+the bug and validate the fix deterministically without depending on WCS
+construction.
+"""
+
+import numpy as np
+import pytest
+
+from campfire_pipeline.nircam.drizzle import _sanitize_variance
+
+Drizzle = pytest.importorskip("drizzle.resample").Drizzle
+
+
+# ---------------------------------------------------------------------------
+# unit tests: the per-component masking helper
+# ---------------------------------------------------------------------------
+
+def test_sanitize_variance_sums_clean_components():
+    vr = np.full((1, 3), 1e-3, np.float32)
+    vp = np.full((1, 3), 2e-3, np.float32)
+    vf = np.full((1, 3), 1e-4, np.float32)
+    weight = np.full((1, 3), 7.0, np.float32)
+    var_total, var_weight = _sanitize_variance(vr, vp, vf, weight)
+    np.testing.assert_allclose(var_total, 3.1e-3, rtol=1e-6)
+    np.testing.assert_array_equal(var_weight, weight)
+
+
+def test_sanitize_variance_drops_only_the_bad_component():
+    # col 0 clean; col 1 bad poisson; col 2 negative flat
+    vr = np.array([[1e-3, 1e-3, 1e-3]], np.float32)
+    vp = np.array([[2e-3, np.inf, 2e-3]], np.float32)
+    vf = np.array([[1e-4, 1e-4, -5.0]], np.float32)
+    weight = np.full((1, 3), 10.0, np.float32)
+    var_total, var_weight = _sanitize_variance(vr, vp, vf, weight)
+
+    np.testing.assert_allclose(var_total[0, 0], 3.1e-3, rtol=1e-6)   # all three
+    np.testing.assert_allclose(var_total[0, 1], 1.1e-3, rtol=1e-6)   # poisson dropped
+    np.testing.assert_allclose(var_total[0, 2], 3.0e-3, rtol=1e-6)   # flat dropped
+    assert np.isfinite(var_total).all()
+    # every pixel keeps >= 1 valid component, so the SCI weight is untouched
+    np.testing.assert_array_equal(var_weight, weight)
+
+
+def test_sanitize_variance_drops_pixel_with_no_valid_component():
+    vr = np.array([[1e-3, np.inf]], np.float32)
+    vp = np.array([[2e-3, np.nan]], np.float32)
+    vf = np.array([[1e-4, -1.0]], np.float32)
+    weight = np.full((1, 2), 9.0, np.float32)
+    var_total, var_weight = _sanitize_variance(vr, vp, vf, weight)
+    assert var_weight[0, 0] == 9.0      # has valid components
+    assert var_weight[0, 1] == 0.0      # fully dead -> dropped
+    assert np.isfinite(var_total).all()
+    assert weight[0, 1] == 9.0          # input weight not mutated
+
+
+# ---------------------------------------------------------------------------
+# integration tests: real Drizzle, identity pixmap, the variance trick
+# ---------------------------------------------------------------------------
+
+def _identity_pixmap(ny, nx):
+    iy, ix = np.indices((ny, nx), dtype=np.float64)
+    pm = np.empty((ny, nx, 2), np.float64)
+    pm[..., 0] = ix
+    pm[..., 1] = iy
+    return pm
+
+
+def _drizzle_variance_trick(inputs, shape, *, sanitize):
+    """Mirror drizzle_tile's SCI + variance passes on an identity pixmap.
+
+    ``inputs`` is a list of ``(var_rnoise, var_poisson, var_flat, weight)``.
+    With ``sanitize=False`` this is the pre-fix behaviour (raw sum, shared SCI
+    weight, normalize by the SCI weight); with ``sanitize=True`` it uses the
+    production ``_sanitize_variance`` and normalizes by ``outvarw``.
+    """
+    ny, nx = shape
+    pm = _identity_pixmap(ny, nx)
+    outsci = np.zeros(shape, np.float32); outwht = np.zeros(shape, np.float32)
+    outvar = np.zeros(shape, np.float32); outvarw = np.zeros(shape, np.float32)
+    sci = Drizzle(out_img=outsci, out_wht=outwht, kernel="square",
+                  fillval="INDEF", disable_ctx=True)
+    var = Drizzle(out_img=outvar, out_wht=outvarw, kernel="square",
+                  fillval="INDEF", disable_ctx=True)
+    addkw = dict(exptime=1000.0, pixmap=pm, pixfrac=1.0, in_units="cps",
+                 xmin=0, xmax=nx - 1, ymin=0, ymax=ny - 1)
+    with np.errstate(all="ignore"):
+        for vr, vp, vf, weight in inputs:
+            sci.add_image(data=np.zeros(shape, np.float32), weight_map=weight,
+                          **addkw)
+            if sanitize:
+                var_total, var_weight = _sanitize_variance(vr, vp, vf, weight)
+            else:
+                var_total = (vr + vp + vf).astype(np.float32)   # raw sum
+                var_weight = weight
+            var.add_image(data=(var_total * weight).astype(np.float32),
+                          weight_map=var_weight, **addkw)
+        denom = outvarw if sanitize else outwht
+        err = np.sqrt(np.where(denom > 0, outvar / denom, np.nan)).astype(np.float32)
+    return err, outwht
+
+
+def _const(shape, value):
+    return np.full(shape, value, np.float32)
+
+
+@pytest.mark.parametrize("bad_value", [np.inf, np.nan, -1.0])
+def test_variance_trick_sanitized_vs_raw(bad_value):
+    """One bad variance component at a GOOD pixel in one input: the raw trick
+    produces a non-finite ERR there; the sanitized trick stays finite."""
+    shape = (5, 5)
+    weight = _const(shape, 1000.0)
+    clean = (_const(shape, 1e-3), _const(shape, 2e-3), _const(shape, 1e-4),
+             weight)
+    vp_bad = _const(shape, 2e-3); vp_bad[2, 2] = bad_value
+    bad = (_const(shape, 1e-3), vp_bad, _const(shape, 1e-4), weight)
+    inputs = [clean, bad, clean]
+
+    raw_err, _ = _drizzle_variance_trick(inputs, shape, sanitize=False)
+    san_err, san_wht = _drizzle_variance_trick(inputs, shape, sanitize=True)
+
+    covered = san_wht > 0
+    assert covered[2, 2]
+    assert not np.isfinite(raw_err[2, 2])         # pre-fix: poisoned
+    assert np.isfinite(san_err[covered]).all()    # fixed: all covered finite
+    assert san_err[2, 2] > 0
+    # away from the bad pixel the two agree (masking is local)
+    off = covered.copy(); off[2, 2] = False
+    np.testing.assert_allclose(san_err[off], raw_err[off], rtol=1e-5)
+
+
+def test_per_component_masking_survives_component_bad_across_all_inputs():
+    """A component that is bad in EVERY input at a pixel (e.g. a flat-field
+    column) must still yield a finite ERR from the surviving components — this
+    is the case where masking the summed variance would punch a NaN hole."""
+    shape = (4, 4)
+    weight = _const(shape, 500.0)
+    inputs = []
+    for _ in range(3):
+        vf = _const(shape, 1e-4); vf[1, 1] = np.inf      # flat bad in all inputs
+        inputs.append((_const(shape, 1e-3), _const(shape, 2e-3), vf, weight))
+
+    err, wht = _drizzle_variance_trick(inputs, shape, sanitize=True)
+    assert wht[1, 1] > 0
+    assert np.isfinite(err[1, 1])                         # NOT a NaN hole
+    # ERR reflects rnoise+poisson only (flat dropped), averaged over 3 equal-
+    # weight inputs: V = var_per_input / N for N equal measurements.
+    np.testing.assert_allclose(err[1, 1], np.sqrt((1e-3 + 2e-3) / 3), rtol=1e-3)
+    assert not np.isinf(err).any()
+
+
+def test_variance_trick_all_components_bad_gives_nan_not_inf():
+    """A pixel where no input has any valid variance component has no noise
+    estimate -> ERR is NaN (missing-data convention), never inf or 0."""
+    shape = (4, 4)
+    weight = _const(shape, 500.0)
+    inputs = []
+    for _ in range(2):
+        vr = _const(shape, 1e-3); vr[1, 1] = np.inf
+        vp = _const(shape, 2e-3); vp[1, 1] = np.inf
+        vf = _const(shape, 1e-4); vf[1, 1] = np.inf
+        inputs.append((vr, vp, vf, weight))
+
+    err, wht = _drizzle_variance_trick(inputs, shape, sanitize=True)
+    assert not np.isinf(err).any()
+    assert np.isnan(err[1, 1])
+    other = (wht > 0).copy(); other[1, 1] = False
+    assert np.isfinite(err[other]).all()


### PR DESCRIPTION
## Problem

A colleague reported that NIRCam mosaic ERR maps produced by the campfire-native drizzle (`resample.implementation = "campfire"`) fill with `inf`, sometimes dominating the tile.

**Root cause.** The variance trick summed `var_rnoise + var_poisson + var_flat` into `var_total` and drizzled `var_total · weight` in a single pass, with no finiteness guard:

- A single input pixel with a non-finite/negative component (e.g. `var_poisson = inf` at a pixel that is *not* flagged `DO_NOT_USE`, so it keeps a nonzero ivm weight) makes `var_total` non-finite there.
- cdriz deposits that into every output pixel the kernel touches, and `inf` is **sticky** in the running weighted mean — once an output pixel is `inf`, every subsequent clean input leaves it `inf`. One bad input pixel poisons a whole neighbourhood for all co-located inputs.
- The final `np.where(outwht > 0, …)` guard only caught zero-coverage pixels, not `inf`/`nan` already accumulated in `outvar`.

stcal/jwst avoids this by masking `(var >= 0) & isfinite(var)` **per component** before accumulating (`stcal.resample.resample.resample_variance_arrays`); the trick dropped that guard when it collapsed the three per-component variance drizzles into one.

## Fix

`_sanitize_variance` now validates each component independently and contributes `0` where it is non-finite/negative, so a bad component drops only its own term:

- A component bad across many inputs (e.g. a flat-field column, a reference region) **degrades gracefully** to the surviving terms instead of leaving a NaN hole in the ERR map.
- A pixel is dropped entirely only where **no** component is valid; dropped pixels are excluded from both the variance numerator and its normalizing weight (`outvarw`, now used in place of the SCI `outwht`), so there is no dilution bias.
- The SCI/WHT pass is untouched. ERR is **bit-identical** to before at pixels with no masked components; only previously-`inf`/`nan` pixels change.

### Residual note
A single drizzle cannot give each component its own normalizer, so a *partially*-bad pixel's surviving terms are carried with the full weight (a mild, bounded dilution of the dropped term) rather than excluded from their own normalization the way stcal does per component. Matching that exactly needs three separate variance drizzles — the cost the trick exists to avoid. Graceful degradation was judged the right trade.

## Verification

- **Real rj0911/f444w CRFs** (one input carries `inf var_poisson` at a good pixel): campfire ERR `inf`-on-covered-pixels **9 → 0**, matching the `jwst` implementation (0). Well-covered ERR ratio unchanged (~1.0).
- **New `tests/test_nircam_drizzle.py`** (8 tests, driving the real `drizzle.resample.Drizzle` through an identity pixmap so they reproduce the bug without WCS fragility), including:
  - `test_variance_trick_sanitized_vs_raw[inf/nan/-1]` — raw path is non-finite at the bad pixel, sanitized path stays finite and matches off-pixel.
  - `test_per_component_masking_survives_component_bad_across_all_inputs` — a `var_flat = inf` column in *every* input yields a finite ERR from `rnoise + poisson` (would fail under summed masking).
  - `test_variance_trick_all_components_bad_gives_nan_not_inf` — fully-dead pixel → `NaN`, never `inf`/`0`.
- **Full pipeline suite:** 105 passed.

The default `jwst` implementation was never affected.

## Changelog
Added under `## Unreleased → ### Algorithm` (scientific-output change → MINOR).