### PR TITLE
feat(nirspec): per-group ramp picture-frame + 1/f for jwst 2.0.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,6 @@ dependencies:
   - numba>=0.59
   - pip
   - pip:
-    - jwst>=1.20,<1.21
+    - jwst>=2.0.1,<2.1
     - -e ./pipeline
     - -e ./python

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -25,6 +25,24 @@ Release procedure: edit the `## Unreleased` section below, then run
 
 ## Unreleased
 
+### Calibration
+- Upgraded `jwst` 1.20.2 → 2.0.1 and CRDS context `jwst_1481.pmap` →
+  `jwst_1535.pmap`. This changes pixel/flux values for the same input
+  (calibration-equivalent), and is the umbrella change for the NIRSpec stage-1
+  restructure below.
+- **NIRSpec stage 1 now corrects picture-frame + 1/f per group on the 4D
+  ramp**, replacing the stock jwst `picture_frame` and `clean_flicker_noise`
+  steps. A new `CampfireDetector1Pipeline` (subclass of `Detector1Pipeline`)
+  runs the stock steps through `jump`, then a custom `CampfireRampBkgStep`
+  between `jump` and `ramp_fit` that builds CAMPFIRE's WCS-derived open-slit
+  mask (`mask_slits`) once and subtracts an iterative per-quarter picture-frame
+  template fit + column/row 1/f model (`_iterate_background`) from each group
+  (configured under `[nirspec.stage1.ramp]`). The existing rate-level
+  `subtract_background_from_rate_file` remains as a single-pass residual cleanup
+  and is still where the VAR_RNOISE rescale and manual-mask handling live. jwst
+  2.0's new in-ramp `picture_frame` and spec2 `clean_flicker_noise` (default-on)
+  are both skipped. Pixel values change versus the 1.20.2 reduction.
+
 ### Algorithm
 - NIRCam campfire-native drizzle (`resample.implementation = "campfire"`): the
   ERR map no longer fills with `inf`/`nan`. The variance pass summed the three

--- a/pipeline/campfire_pipeline/config.py
+++ b/pipeline/campfire_pipeline/config.py
@@ -278,10 +278,16 @@ def get_stage_config(stage_name, config, obs):
     Merges two layers (highest priority wins):
         1. Observation-specific overrides  (observations.toml  [obs.stageN])
         2. Config defaults + user overrides (already merged in load_config)
+
+    Uses a deep merge (matching get_nircam_step_config) so a partial per-obs
+    override of a nested sub-table (e.g. [obs.stage1.ramp] or
+    [obs.stage1.override_wavelength_range]) preserves the other keys of that
+    sub-table instead of replacing it wholesale.
     """
-    merged = dict(config.get('nirspec', {}).get(stage_name, {}))
-    merged.update(obs.stage_overrides.get(stage_name, {}))
-    return merged
+    return deep_merge(
+        config.get('nirspec', {}).get(stage_name, {}),
+        obs.stage_overrides.get(stage_name, {}),
+    )
 
 
 def get_nircam_step_config(step_name, config, field):

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -9,7 +9,7 @@
 
 [environment]
     CRDS_SERVER_URL = "https://jwst-crds.stsci.edu"
-    CRDS_CONTEXT = "jwst_1481.pmap"   # uncomment to pin
+    CRDS_CONTEXT = "jwst_1535.pmap"   # uncomment to pin
 
 [paths]
     # Resolved from $CAMPFIRE_ROOT by default. Uncomment to override:
@@ -23,10 +23,14 @@
 # === NIRSpec ===
 
 [nirspec.stage1]
-    do_clean_flicker_noise = true # handled by iterative bkg subtraction
-    mask_science_regions = true
     cleanup_uncal = true
     cleanup_rateints = true
+
+    # --- Phase 2: residual background cleanup on the 2D rate ---
+    # Single-pass picture-frame + 1/f cleanup + VAR_RNOISE rescale, applied to
+    # the rate after the per-group ramp step (below). Manual DS9 masks are
+    # applied here. The same picture-frame template fit + column/row 1/f run as
+    # the ramp step, mopping up whatever residual structure survives in the rate.
     subtract_2d = false
     box_size = 64
     sigma_clip = true
@@ -35,7 +39,7 @@
     col_1f_method = "template" # "median" (flat per-column) or "template" (per-column PF template fit)
     do_row_1f = true # only used for PRISM
     plot = true
-    
+
     [nirspec.stage1.override_wavelength_range] # mask beyond the nominal wavelength range, to cover higher-order spectra
         G140M = [0.70, 2.5]
         G235M = [1.66, 4.0]
@@ -43,6 +47,22 @@
         G140H = [0.70, 2.5]
         G235H = [1.66, 4.0]
         G395H = [2.87, 5.5]
+
+    # --- Phase 1: per-group picture-frame + 1/f on the 4D ramp ---
+    # CampfireRampBkgStep replaces the stock jwst picture_frame and
+    # clean_flicker_noise steps (jwst >= 2.0). Runs between jump and ramp_fit.
+    # Inherits override_wavelength_range above for the slit mask.
+    [nirspec.stage1.ramp]
+        do_picture_frame = true
+        subtract_2d = false
+        box_size = 64
+        sigma_clip = true
+        bkg_estimator = "median"
+        do_col_1f = true
+        col_1f_method = "template"
+        do_row_1f = true # only used for PRISM
+        n_iter = 1 # background fit iterations per group
+        plot = true
 
 [nirspec.masks]
     auto_apply = true   # at stage2a entry, auto re-apply manual masks if they're stale vs the rate file

--- a/pipeline/campfire_pipeline/nirspec/detector1.py
+++ b/pipeline/campfire_pipeline/nirspec/detector1.py
@@ -1,0 +1,318 @@
+"""
+CAMPFIRE NIRSpec Detector1 customization for jwst >= 2.0.
+
+This module defines:
+
+- ``CampfireRampBkgStep`` — a per-group picture-frame + 1/f background
+  correction that runs on the 4D ramp, *replacing* the stock jwst
+  ``picture_frame`` and ``clean_flicker_noise`` steps for NIRSpec full-frame
+  data. It reuses CAMPFIRE's WCS-derived open-slit mask (``mask_slits``) and
+  the shared iterative background model (``_iterate_background``) from
+  ``stage1``.
+- ``CampfireDetector1Pipeline`` — a thin ``Detector1Pipeline`` subclass that
+  inserts ``CampfireRampBkgStep`` between ``jump`` and ``ramp_fit`` and skips
+  the two stock steps it replaces.
+
+This module imports ``jwst`` at import time (it subclasses ``Step`` /
+``Detector1Pipeline``), so it is imported lazily — only from within the
+stage-1 worker — to keep the ``cfpipe`` CLI startup fast.
+"""
+
+import logging
+import os
+
+import numpy as np
+from astropy.io import fits
+
+from jwst.stpipe import Step
+from jwst.pipeline import Detector1Pipeline
+from jwst import datamodels
+
+from campfire_pipeline.nirspec.stage1 import mask_slits, _iterate_background
+
+# jwst 2.0 deprecates Step.log; use a module logger instead.
+logger = logging.getLogger(__name__)
+
+
+# Central horizontal band (rows) always masked as the fixed-slit region.
+# Mirrors the constant used in subtract_background_from_rate_file.
+_FIXED_SLIT_HALFHEIGHT = 100
+
+
+class CampfireRampBkgStep(Step):
+    """Per-group picture-frame + 1/f background correction on the 4D ramp.
+
+    Replaces the stock ``picture_frame`` + ``clean_flicker_noise`` steps for
+    NIRSpec full-frame exposures. Builds CAMPFIRE's open-slit background mask
+    once (WCS-derived, from a draft rate), then for each integration/group
+    subtracts an iterative picture-frame template fit + column/row 1/f model
+    via ``_iterate_background``, operating on the zero-group-subtracted image
+    exactly like the stock picture_frame step.
+
+    Manual (DS9) masks are intentionally NOT applied here — they remain a
+    rate-level concern handled by the phase-2 ``subtract_background_from_rate_file``
+    cleanup pass, which keeps the restorable ``CFBKG`` machinery intact.
+    """
+
+    class_alias = "campfire_bkg"
+
+    spec = """
+        do_picture_frame = boolean(default=True)  # Subtract per-quarter picture-frame template
+        subtract_2d = boolean(default=False)  # Subtract a 2D background
+        box_size = integer(default=64)  # 2D background box size
+        sigma_clip = boolean(default=True)  # Sigma-clip the component fits
+        bkg_estimator = string(default='median')  # 2D background estimator
+        do_col_1f = boolean(default=True)  # Subtract column 1/f
+        do_row_1f = boolean(default=True)  # Subtract row 1/f (PRISM only)
+        col_1f_method = option('median', 'template', default='template')  # Column 1/f method
+        n_iter = integer(default=1)  # Background fit iterations per group
+        plot = boolean(default=True)  # Emit a *_ramp_bkg.pdf diagnostic
+    """
+
+    reference_file_types = ['pictureframe']
+
+    # Per-grating wavelength-range overrides for the slit mask (extends the
+    # masked region to cover higher-order spectra). A dict can't live in the
+    # configobj `spec`, so it's a plain attribute set by the caller.
+    override_wavelength_range = {}
+
+    def process(self, input_data):
+        model = input_data  # in-memory RampModel handed down from the pipeline
+
+        instrument = str(model.meta.instrument.name).upper()
+        subarray = str(getattr(model.meta.subarray, 'name', '') or '').upper()
+        if instrument != 'NIRSPEC' or subarray != 'FULL':
+            logger.warning(
+                'CampfireRampBkgStep applies only to NIRSpec full frame; skipping.')
+            return model
+
+        if not isinstance(model, datamodels.RampModel):
+            logger.warning('CampfireRampBkgStep expects a RampModel; skipping.')
+            return model
+
+        nint, ngroup, ny, nx = model.data.shape
+        if ngroup < 2:
+            logger.warning(
+                'CampfireRampBkgStep cannot run on single-group data; skipping.')
+            return model
+
+        input_dir = self.input_dir or ''
+
+        # --- Build the open-slit background mask once (WCS-derived) ---
+        # make_rate runs a RampFitStep on a copy to get a draft rate the WCS
+        # can be assigned to; the actual per-group fits below use the ramp.
+        from jwst.clean_flicker_noise import clean_flicker_noise as cfn
+        draft = cfn.make_rate(model, input_dir=input_dir)
+        try:
+            slitmask = np.full(draft.data.shape, True)
+            mid = draft.data.shape[0] // 2
+            slitmask[mid - _FIXED_SLIT_HALFHEIGHT:mid + _FIXED_SLIT_HALFHEIGHT, :] = False
+            slitmask = mask_slits(
+                draft, input_dir, slitmask,
+                override_wavelength_range=self.override_wavelength_range,
+            )
+            slitmask[draft.dq > 0] = False
+        finally:
+            draft.close()
+
+        # --- Picture-frame reference template ---
+        use_pictureframe = False
+        template = None
+        if self.do_picture_frame:
+            pf_file = self.get_reference_file(model, 'pictureframe')
+            if pf_file and pf_file.strip().upper() not in ('', 'N/A'):
+                template = fits.getdata(pf_file)
+                use_pictureframe = True
+                logger.info(f'Using pictureframe reference: {pf_file}')
+            else:
+                logger.warning(
+                    'No pictureframe reference available; skipping picture-frame term.')
+
+        do_row_1f = bool(self.do_row_1f) and ('PRISM' in str(model.meta.instrument.grating))
+
+        # --- Diagnostic accumulators (rate-equivalent; no extra ramp fit) ---
+        # Accumulate each component with OLS slope weights over the groups so
+        # the result is a true per-group slope (-> per-second rate after
+        # dividing by group_time), directly comparable to the phase-2 rate
+        # plot. Group 0 carries no correction (anchored at zero), consistent
+        # with fitting on (group - group0). A uniform mean would overstate the
+        # rate by ~ngroup/2; the slope weights are the correct estimator.
+        collect = bool(self.plot)
+        t = np.arange(ngroup, dtype=np.float64)
+        _wnum = t - t.mean()
+        _wden = float(np.sum(_wnum * _wnum))
+        slope_w = (_wnum / _wden) if _wden > 0 else np.zeros_like(_wnum)
+        data_rate = np.zeros((ny, nx), dtype=np.float64) if collect else None
+        comp_rate = ({k: np.zeros((ny, nx), dtype=np.float64)
+                      for k in ('pictureframe', 'bkg2d', 'col', 'row')}
+                     if collect else None)
+        last_mask = slitmask
+
+        # --- Per-group correction loop ---
+        # Mirrors stock picture_frame: fit on (group - zero_group), then
+        # subtract the fitted background from the group in place.
+        for i in range(nint):
+            zero = model.data[i, 0]
+            for g in range(1, ngroup):
+                img = model.data[i, g] - zero
+                bkg_total, mask, components = _iterate_background(
+                    img, slitmask,
+                    n_iter=int(self.n_iter),
+                    do_picture_frame=use_pictureframe, template=template,
+                    subtract_2d=bool(self.subtract_2d), box_size=int(self.box_size),
+                    bkg_estimator=str(self.bkg_estimator), sigma_clip=bool(self.sigma_clip),
+                    do_col_1f=bool(self.do_col_1f), col_1f_method=str(self.col_1f_method),
+                    do_row_1f=do_row_1f, verbose=False,
+                )
+                model.data[i, g] = model.data[i, g] - bkg_total
+
+                if collect:
+                    w = slope_w[g]
+                    data_rate += w * img
+                    for k in comp_rate:
+                        if components[k] is not None:
+                            comp_rate[k] += w * components[k]
+                    last_mask = mask
+
+        # --- Diagnostic plot (Option A: single, rate-equivalent 2D) ---
+        if collect:
+            self._plot_diagnostic(
+                model, data_rate, last_mask, comp_rate, nint,
+                use_pictureframe, do_row_1f,
+            )
+
+        # History note (cal_step has no field for a custom step).
+        from stdatamodels import util as stutil
+        model.history.append(stutil.create_history_entry(
+            'CAMPFIRE per-group picture-frame + 1/f background subtraction'))
+
+        return model
+
+    def _plot_diagnostic(self, model, data_rate, mask, comp_rate, nint,
+                         use_pictureframe, do_row_1f):
+        """Emit ``*_ramp_bkg.pdf`` showing the rate-equivalent correction.
+
+        ``data_rate`` / ``comp_rate`` are slope-weighted sums over groups (one
+        OLS slope per integration); dividing by ``nint`` averages over
+        integrations and by ``group_time`` converts the per-group slope to a
+        per-second rate, so the panels are in the same units as — and directly
+        comparable to — the phase-2 rate-level plot.
+        """
+        from campfire_pipeline.nirspec.plots import plot_bkg_subtraction
+
+        group_time = getattr(model.meta.exposure, 'group_time', None) or 1.0
+        scale = 1.0 / (max(nint, 1) * group_time)
+
+        data = data_rate * scale
+        pf = comp_rate['pictureframe'] * scale if use_pictureframe else None
+        b2 = comp_rate['bkg2d'] * scale if bool(self.subtract_2d) else None
+        col = comp_rate['col'] * scale if bool(self.do_col_1f) else None
+        row = comp_rate['row'] * scale if do_row_1f else None
+
+        base = (model.meta.filename or 'ramp')
+        for suffix in ('_uncal.fits', '_ramp.fits', '.fits'):
+            if base.endswith(suffix):
+                base = base[: -len(suffix)]
+                break
+        out_pdf = os.path.join(self.input_dir or '.', f'{base}_ramp_bkg.pdf')
+
+        try:
+            plot_bkg_subtraction(
+                out_pdf, data, mask,
+                pictureframe_model=pf, bkg2d_model=b2,
+                col_model=col, row_model=row, output_pdf=out_pdf,
+            )
+        except Exception as exc:  # diagnostics must never fail the reduction
+            logger.warning(f'Ramp background diagnostic plot failed: {exc}')
+
+
+class CampfireDetector1Pipeline(Detector1Pipeline):
+    """``Detector1Pipeline`` that runs CAMPFIRE's per-group background step in
+    place of the stock ``picture_frame`` + ``clean_flicker_noise`` steps.
+
+    The ``process`` override mirrors the stock jwst 2.0.x body exactly except
+    that, after ``jump``, NIRSpec full-frame data is corrected by
+    ``self.campfire_bkg`` instead of the stock ``picture_frame`` +
+    ``clean_flicker_noise`` steps. Any other instrument/subarray falls back to
+    the stock steps, so non-NIRSpec data is never silently left uncorrected.
+    """
+
+    step_defs = {**Detector1Pipeline.step_defs, 'campfire_bkg': CampfireRampBkgStep}
+
+    def process(self, input_data):
+        logger.info("Starting CAMPFIRE calwebb_detector1 ...")
+
+        input_data = self.prepare_output(input_data, open_as_type=datamodels.RampModel)
+
+        # propagate output_dir to steps that might need it
+        self.dark_current.output_dir = self.output_dir
+        self.ramp_fit.output_dir = self.output_dir
+
+        instrument = input_data.meta.instrument.name
+        if instrument == "MIRI":
+            # CAMPFIRE only processes NIRSpec, but keep the stock MIRI branch
+            # for parity in case this pipeline is ever pointed at MIRI data.
+            logger.debug("Processing a MIRI exposure")
+            input_data = self.group_scale.run(input_data)
+            input_data = self.dq_init.run(input_data)
+            input_data = self.emicorr.run(input_data)
+            input_data = self.saturation.run(input_data)
+            input_data = self.ipc.run(input_data)
+            input_data = self.firstframe.run(input_data)
+            input_data = self.lastframe.run(input_data)
+            input_data = self.reset.run(input_data)
+            input_data = self.linearity.run(input_data)
+            input_data = self.rscd.run(input_data)
+            input_data = self.dark_current.run(input_data)
+            input_data = self.refpix.run(input_data)
+        else:
+            logger.debug("Processing a Near-IR exposure")
+            input_data = self.group_scale.run(input_data)
+            input_data = self.dq_init.run(input_data)
+            input_data = self.saturation.run(input_data)
+            input_data = self.ipc.run(input_data)
+            input_data = self.superbias.run(input_data)
+            input_data = self.refpix.run(input_data)
+            input_data = self.linearity.run(input_data)
+            if instrument != "NIRSPEC":
+                input_data = self.persistence.run(input_data)
+            input_data = self.dark_current.run(input_data)
+
+        input_data = self.charge_migration.run(input_data)
+        input_data = self.jump.run(input_data)
+
+        # CAMPFIRE per-group picture-frame + 1/f replaces the stock
+        # picture_frame + clean_flicker_noise steps for NIRSpec full-frame data
+        # (the only data CAMPFIRE reduces). For any other instrument/subarray,
+        # fall back to the stock steps so we never silently drop both — the
+        # CampfireRampBkgStep would otherwise no-op (it guards on NIRSpec FULL).
+        subarray = str(getattr(input_data.meta.subarray, 'name', '') or '').upper()
+        if instrument == "NIRSPEC" and subarray == "FULL":
+            input_data = self.campfire_bkg.run(input_data)
+        else:
+            input_data = self.picture_frame.run(input_data)
+            input_data = self.clean_flicker_noise.run(input_data)
+
+        if self.save_calibrated_ramp:
+            self.save_model(input_data, "ramp")
+
+        if self.ramp_fit.skip:
+            input_data = self.ramp_fit.run(input_data)
+            ints_model = None
+        else:
+            input_data, ints_model = self.ramp_fit.run(input_data)
+
+        if input_data is not None:
+            self.gain_scale.suffix = "gain_scale"
+            input_data = self.gain_scale.run(input_data)
+        else:
+            logger.info("NoneType returned from ramp_fit.  Gain Scale step skipped.")
+
+        if ints_model is not None:
+            self.gain_scale.suffix = "gain_scaleints"
+            ints_model = self.gain_scale.run(ints_model)
+            self.save_model(ints_model, "rateints")
+
+        self.setup_output(input_data)
+        logger.info("... ending CAMPFIRE calwebb_detector1")
+        return input_data

--- a/pipeline/campfire_pipeline/nirspec/plots.py
+++ b/pipeline/campfire_pipeline/nirspec/plots.py
@@ -466,7 +466,8 @@ def plot_stage2a_results(files, plot_suffix='nods', stuck_shutters=None):
 
 def plot_bkg_subtraction(rate_file, image_data, mask, *,
                          pictureframe_model=None, pedestal_model=None,
-                         bkg2d_model=None, col_model=None, row_model=None):
+                         bkg2d_model=None, col_model=None, row_model=None,
+                         output_pdf=None):
     """Multi-column diagnostic showing background subtraction stages.
 
     Top row: each background component.  Bottom row: cumulative residual
@@ -475,7 +476,8 @@ def plot_bkg_subtraction(rate_file, image_data, mask, *,
     Parameters
     ----------
     rate_file : str
-        Path to the rate file (used to derive the output PDF path).
+        Path to the rate file (used to derive the output PDF path when
+        ``output_pdf`` is not given).
     image_data : ndarray
         Raw rate image (2D).
     mask : ndarray
@@ -484,6 +486,10 @@ def plot_bkg_subtraction(rate_file, image_data, mask, *,
         Optional background component arrays.
     col_model, row_model : ndarray or None
         Column and row 1/f noise models.
+    output_pdf : str or None
+        Explicit output path for the PDF. If None, derived from ``rate_file``
+        by replacing ``_rate.fits`` with ``_bkg.pdf``. Used by the per-group
+        ramp step to emit ``*_ramp_bkg.pdf``.
     """
     norm = ImageNormalize(image_data[mask], interval=ZScaleInterval())
 
@@ -604,7 +610,7 @@ def plot_bkg_subtraction(rate_file, image_data, mask, *,
         ax[1, i].set_title(col['bottom_title'])
 
     plt.tight_layout()
-    plot_file = rate_file.replace('_rate.fits', '_bkg.pdf')
+    plot_file = output_pdf if output_pdf is not None else rate_file.replace('_rate.fits', '_bkg.pdf')
     log(f'Saving to {plot_file}')
     plt.savefig(plot_file, dpi=_STYLE['dpi'])
     plt.close()

--- a/pipeline/campfire_pipeline/nirspec/stage1.py
+++ b/pipeline/campfire_pipeline/nirspec/stage1.py
@@ -56,25 +56,27 @@ def run_stage1(obs, stage_config, n_processes=1, overwrite=False, data_dir=None,
     else: 
         uncals_to_process = [os.path.basename(f) for f in uncal_files]
 
-    kwargs = dict(
-        do_clean_flicker_noise=stage_config['do_clean_flicker_noise'],
-        mask_science_regions=stage_config['mask_science_regions'],
-        cleanup_uncal=stage_config['cleanup_uncal'],
-        cleanup_rateints=stage_config['cleanup_rateints'],
-    )
+    # Per-group ramp background config (the [nirspec.stage1.ramp] table), used
+    # by CampfireRampBkgStep in place of the stock picture_frame /
+    # clean_flicker_noise steps. The slit-mask wavelength-range overrides are
+    # shared with the phase-2 rate cleanup.
+    ramp_config = dict(stage_config.get('ramp', {}))
+    ramp_config.setdefault(
+        'override_wavelength_range', stage_config.get('override_wavelength_range', {}))
 
-    # Phase 1: Run Detector1Pipeline on all uncal files
+    # Phase 1: Run the CAMPFIRE Detector1 pipeline on all uncal files
     if n_processes > 1 and uncals_to_process:
         _prefetch_detector1_references(
             [os.path.join(obs.workspace_dir, f) for f in uncals_to_process],
-            mask_science_regions=stage_config['do_clean_flicker_noise'] and stage_config['mask_science_regions'],
         )
     dispatch(
         run_stage1_single_uncal,
         uncals_to_process,
         n_processes=n_processes,
         workspace_dir=obs.workspace_dir,
-        **kwargs,
+        ramp_config=ramp_config,
+        cleanup_uncal=stage_config.get('cleanup_uncal', True),
+        cleanup_rateints=stage_config.get('cleanup_rateints', True),
     )
 
     # Phase 2: Background subtraction on resulting rate files
@@ -294,36 +296,46 @@ def mask_slits(
         #     bkg_total += pedestal_model
 
 
-def _prefetch_detector1_references(uncal_files, mask_science_regions=False):
-    """Pre-cache CRDS reference files for Detector1Pipeline to avoid race conditions.
+def _prefetch_detector1_references(uncal_files):
+    """Pre-cache CRDS reference files for the CAMPFIRE Detector1 pipeline to
+    avoid multiprocessing race conditions.
 
     Multiple workers downloading the same CRDS file simultaneously can cause
     one to read a partially-written file. Running CRDS lookups on one file per
     unique detector beforehand ensures everything is cached.
+
+    The WCS / MSA / picture-frame references are always fetched: the per-group
+    ``CampfireRampBkgStep`` builds the open-slit mask (assign_wcs + msaflagopen)
+    and subtracts the picture-frame template in-ramp during phase 1.
     """
     import crds
 
     reftypes = [
         'dark', 'gain', 'ipc', 'linearity', 'mask',
         'readnoise', 'refpix', 'saturation', 'superbias',
+        # WCS + MSA + picture-frame, used by CampfireRampBkgStep:
+        'camera', 'collimator', 'disperser', 'fore', 'fpa',
+        'msa', 'ote', 'wavelengthrange', 'msaoper', 'flat', 'pictureframe',
     ]
-    if mask_science_regions:
-        reftypes += [
-            'camera', 'collimator', 'disperser', 'fore', 'fpa',
-            'msa', 'ote', 'wavelengthrange', 'msaoper', 'flat',
-        ]
 
-    seen_detectors = set()
+    # Dedup on (detector, grating, filter): the WCS references selected by
+    # assign_wcs (disperser, fore) vary by grating/filter, so a multi-grating
+    # observation needs one prefetch per config — not just per detector — or
+    # the non-first gratings' refs race to download in parallel workers.
+    seen_configs = set()
     for uncal_file in uncal_files:
         hdr = fits.getheader(uncal_file)
         det = hdr.get('DETECTOR', 'NRS1')
+        grating = hdr.get('GRATING', 'G140M')
+        filt = hdr.get('FILTER', 'CLEAR')
+        config_key = (det, grating, filt)
 
-        if det in seen_detectors:
+        if config_key in seen_configs:
             continue
-        seen_detectors.add(det)
+        seen_configs.add(config_key)
 
-        log(f"Pre-fetching Detector1Pipeline CRDS references for {det} "
-            f"using {os.path.basename(uncal_file)}")
+        log(f"Pre-fetching Detector1Pipeline CRDS references for "
+            f"{det}/{grating}/{filt} using {os.path.basename(uncal_file)}")
 
         params = {
             "INSTRUME": "NIRSPEC",
@@ -337,12 +349,9 @@ def _prefetch_detector1_references(uncal_files, mask_science_regions=False):
             "SUBSIZE2": hdr.get('SUBSIZE2', 2048),
             "DATE-OBS": hdr.get('DATE-OBS', '2023-01-01'),
             "TIME-OBS": hdr.get('TIME-OBS', '00:00:00'),
+            "FILTER": filt,
+            "GRATING": grating,
         }
-        if mask_science_regions:
-            params.update({
-                "FILTER": hdr.get('FILTER', 'CLEAR'),
-                "GRATING": hdr.get('GRATING', 'G140M'),
-            })
 
         try:
             refs = crds.getreferences(params, reftypes=reftypes, observatory='jwst')
@@ -351,7 +360,7 @@ def _prefetch_detector1_references(uncal_files, mask_science_regions=False):
             log(f"  Cached {len(cached)}/{len(reftypes)} references: "
                 f"{', '.join(sorted(cached))}")
         except Exception as e:
-            log(f"  CRDS prefetch warning for {det}: {e}")
+            log(f"  CRDS prefetch warning for {det}/{grating}/{filt}: {e}")
 
     log("Detector1Pipeline CRDS reference pre-fetch complete")
 
@@ -473,6 +482,203 @@ def _fit_col_template(residual, mask, template, sigma_clip=True,
     return col_model
 
 
+# ---------------------------------------------------------------------------
+# Background-fit building blocks
+#
+# Extracted from subtract_background_from_rate_file so the same picture-frame +
+# 1/f model runs both on a 2D rate (phase-2 cleanup) and per-group on the 4D
+# ramp (CampfireRampBkgStep). Each ``_fit_*`` takes a 2D residual image + a
+# boolean mask (True = background pixel to use) and returns a 2D model to
+# subtract. ``_iterate_background`` is the shared n_iter accumulation loop.
+# ---------------------------------------------------------------------------
+
+
+def _fit_picture_frame(img, mask, template, sigma_clip=True, n_quarters=4, verbose=False):
+    """Per-quarter 2-parameter fit ``data = coeff*template + pedestal``.
+
+    Splits the detector into ``n_quarters`` horizontal bands and fits each
+    independently with iterative 3-sigma (MAD) clipping. Returns a 2D model.
+    """
+    from astropy.stats import median_absolute_deviation
+
+    model = np.zeros_like(img)
+    quarter_height = img.shape[0] // n_quarters
+
+    for i in range(n_quarters):
+        row_start = i * quarter_height
+        row_end = (i + 1) * quarter_height
+
+        q_data = img[row_start:row_end, :]
+        q_mask = mask[row_start:row_end, :]
+        q_template = template[row_start:row_end, :]
+
+        # 2-parameter fit: data = coeff * template + pedestal
+        q_valid = q_data[q_mask]
+        q_templ_valid = q_template[q_mask]
+        A = np.column_stack([q_templ_valid, np.ones_like(q_templ_valid)])
+        (best_coeff, pedestal), _, _, _ = np.linalg.lstsq(A, q_valid, rcond=None)
+
+        # Iterative sigma clipping on the residuals
+        if sigma_clip:
+            for _iteration in range(5):
+                residual = q_valid - (best_coeff * q_templ_valid + pedestal)
+                sigma_mad = median_absolute_deviation(residual)
+                clip_mask = np.abs(residual - np.median(residual)) < 3.0 * sigma_mad
+                if clip_mask.sum() == len(q_valid):
+                    break  # converged, nothing more to clip
+                q_valid = q_valid[clip_mask]
+                q_templ_valid = q_templ_valid[clip_mask]
+                A = np.column_stack([q_templ_valid, np.ones_like(q_templ_valid)])
+                (best_coeff, pedestal), _, _, _ = np.linalg.lstsq(A, q_valid, rcond=None)
+
+        if verbose:
+            log(f'  Quarter {i+1} (rows {row_start}:{row_end}): '
+                f'PF coeff = {best_coeff:.4f}, pedestal = {pedestal:.4f}')
+
+        model[row_start:row_end, :] = best_coeff * q_template + pedestal
+
+    return model
+
+
+def _fit_bkg2d(img, mask, box_size=64, bkg_estimator='median', sigma_clip=True):
+    """2D background via photutils ``Background2D`` over background pixels."""
+    from photutils.background import Background2D, MedianBackground
+    from astropy.stats import SigmaClip
+
+    match bkg_estimator:
+        case 'median':
+            bkg_est = MedianBackground()
+        case _:
+            bkg_est = None
+    sclip = SigmaClip(sigma=3.0, maxiters=5) if sigma_clip else None
+
+    bkg = Background2D(
+        img,
+        box_size=box_size,
+        filter_size=(3, 3),
+        mask=~mask,
+        sigma_clip=sclip,
+        bkg_estimator=bkg_est,
+    )
+    return bkg.background
+
+
+def _fit_col_1f(img, mask, template=None, col_1f_method='template',
+                sigma_clip=True, use_pictureframe=False, verbose=False):
+    """Column 1/f model: per-column PF-template fit (``template`` method) or a
+    flat per-column median. Returns a row-broadcastable / 2D model."""
+    if col_1f_method == 'template' and use_pictureframe:
+        if verbose:
+            log('Subtracting column 1/f via per-column PF template fit')
+        return _fit_col_template(img, mask, template, sigma_clip=sigma_clip)
+
+    if col_1f_method == 'template' and not use_pictureframe and verbose:
+        # Gated on verbose: in the per-group ramp loop this helper is called
+        # once per group*integration, so an ungated warning floods the log.
+        log('WARNING: col_1f_method="template" requested but no PF template '
+            'available; falling back to per-column median')
+    rate_masked = img.copy()
+    rate_masked[~mask] = np.nan
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        col_model = np.nanmedian(rate_masked, axis=0)[np.newaxis, :]
+    col_model[~np.isfinite(col_model)] = 0.0
+    return col_model
+
+
+def _fit_row_1f(img, mask):
+    """Per-row median 1/f model (PRISM only). Returns a column vector."""
+    rate_masked = img.copy()
+    rate_masked[~mask] = np.nan
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        full_row_masked = np.sum(np.isfinite(rate_masked), axis=1) == 0
+        rate_masked[full_row_masked, :] = np.nanmedian(rate_masked)
+        row_model = np.nanmedian(rate_masked, axis=1)[:, np.newaxis]
+    row_model[~np.isfinite(row_model)] = 0.0
+    return row_model
+
+
+def _iterate_background(
+        img, slitmask, *,
+        n_iter=5, n_sigma=2.0, fit_histogram=False,
+        do_picture_frame=False, template=None,
+        subtract_2d=False, box_size=64, bkg_estimator='median', sigma_clip=True,
+        do_col_1f=True, col_1f_method='template', do_row_1f=True,
+        verbose=False,
+    ):
+    """Iterative additive background model for one 2D image.
+
+    Shared core for the phase-2 rate cleanup and the per-group ramp step. On
+    each of ``n_iter`` passes it re-derives the background mask from
+    ``slitmask`` via ``clip_to_background``, then accumulates picture-frame,
+    optional 2D background, and column/row 1/f components into ``bkg_total``.
+
+    Returns ``(bkg_total, mask, components)`` where ``components`` maps
+    ``'pictureframe'``/``'bkg2d'``/``'col'``/``'row'`` to the summed-over-
+    iterations 2D model (or ``None`` if that component was disabled). ``mask``
+    is the final background mask, suitable for the variance-rescale statistics.
+    """
+    from jwst.clean_flicker_noise.clean_flicker_noise import clip_to_background
+
+    bkg_total = np.zeros_like(img)
+    use_pictureframe = do_picture_frame and template is not None
+
+    pf_total = np.zeros_like(img) if use_pictureframe else None
+    bkg2d_total = np.zeros_like(img) if subtract_2d else None
+    col_total = np.zeros_like(img) if do_col_1f else None
+    row_total = np.zeros_like(img) if do_row_1f else None
+
+    mask = slitmask.copy()
+    for j in range(n_iter):
+        if verbose:
+            log(f'Iteration {j+1}/{n_iter}')
+
+        mask = slitmask.copy()
+        clip_to_background(img - bkg_total, mask, sigma_upper=n_sigma,
+                           fit_histogram=fit_histogram, verbose=verbose)
+
+        if use_pictureframe:
+            if verbose:
+                log('Subtracting "picture frame" template (per-quarter fitting)')
+            pf = _fit_picture_frame(img - bkg_total, mask, template,
+                                    sigma_clip=sigma_clip, verbose=verbose)
+            pf_total += pf
+            bkg_total += pf
+
+            # Re-clip mask against the post-PF residual so subsequent steps
+            # (2D background, 1/f) use a mask consistent with the post-PF data.
+            mask = slitmask.copy()
+            clip_to_background(img - bkg_total, mask, sigma_upper=n_sigma,
+                               fit_histogram=fit_histogram, verbose=False)
+
+        if subtract_2d:
+            b2 = _fit_bkg2d(img - bkg_total, mask, box_size=box_size,
+                            bkg_estimator=bkg_estimator, sigma_clip=sigma_clip)
+            bkg_total += b2
+            bkg2d_total += b2
+
+        if do_col_1f:
+            c = _fit_col_1f(img - bkg_total, mask, template=template,
+                            col_1f_method=col_1f_method, sigma_clip=sigma_clip,
+                            use_pictureframe=use_pictureframe, verbose=verbose)
+            bkg_total += c
+            col_total += c
+
+        if do_row_1f:
+            r = _fit_row_1f(img - bkg_total, mask)
+            bkg_total += r
+            row_total += r
+
+    components = {
+        'pictureframe': pf_total,
+        'bkg2d': bkg2d_total,
+        'col': col_total,
+        'row': row_total,
+    }
+    return bkg_total, mask, components
+
+
 def subtract_background_from_rate_file(
         rate_file: str,
         override_wavelength_range: dict = {},
@@ -490,8 +696,6 @@ def subtract_background_from_rate_file(
 
     from stdatamodels import util as stutil
     from jwst.datamodels import ImageModel
-    from jwst.clean_flicker_noise.clean_flicker_noise import _make_processed_rate_image
-    from astropy.stats import median_absolute_deviation
 
     input_dir = os.path.dirname(rate_file)
 
@@ -532,220 +736,27 @@ def subtract_background_from_rate_file(
 
         slitmask[model.dq > 0] = False
 
-        detector = 'nrs2'
-        if 'nrs1' in rate_file:
-            detector = 'nrs1'
-
-        # Initialize background model
-        bkg_total = np.zeros_like(model.data)
-
-        # Track components for plotting
-        pictureframe_model = None
-        pedestal_model = None
-        bkg2d_model = None
-        col_model = None
-        row_model = None
-
         # Look up pictureframe reference via CRDS
         pictureframe_file = _get_pictureframe_file(rate_file)
         use_pictureframe = pictureframe_file is not None
+        pictureframe_template = fits.getdata(pictureframe_file) if use_pictureframe else None
 
-        if use_pictureframe:
-            pictureframe_model_total = np.zeros_like(model.data)
-            pictureframe_template = fits.getdata(pictureframe_file)
-        if subtract_2d:
-            bkg2d_model_total = np.zeros_like(model.data)
-        if do_col_1f:
-            col_model_total = np.zeros_like(model.data)
-        if do_row_1f:
-            row_model_total = np.zeros_like(model.data)
+        bkg_total, mask, components = _iterate_background(
+            model.data, slitmask,
+            n_iter=n_iter, do_picture_frame=use_pictureframe,
+            template=pictureframe_template,
+            subtract_2d=subtract_2d, box_size=box_size,
+            bkg_estimator=bkg_estimator, sigma_clip=sigma_clip,
+            do_col_1f=do_col_1f, col_1f_method=col_1f_method, do_row_1f=do_row_1f,
+            verbose=True,
+        )
 
-
-        from jwst.clean_flicker_noise.clean_flicker_noise import clip_to_background
-        n_sigma, fit_histogram = 2.0, False
-
-        for j in range(n_iter):
-            log(f'Iteration {j+1}/{n_iter}')
-
-            mask = slitmask.copy()
-            clip_to_background(model.data-bkg_total, mask, sigma_upper=n_sigma, fit_histogram=fit_histogram, verbose=True)
-
-            if use_pictureframe:
-                log(f'Subtracting "picture frame" template (per-quarter fitting)')
-                n_quarters = 4
-                quarter_height = 2048 // n_quarters
-
-                pictureframe_model = np.zeros_like(model.data)
-
-                for i in range(n_quarters):
-                    row_start = i * quarter_height
-                    row_end = (i + 1) * quarter_height
-
-                    q_data = model.data[row_start:row_end, :] - bkg_total[row_start:row_end, :]
-                    q_mask = mask[row_start:row_end, :]
-                    q_template = pictureframe_template[row_start:row_end, :]
-
-                    # 2-parameter fit: data = coeff * template + pedestal
-                    q_valid = q_data[q_mask]
-                    q_templ_valid = q_template[q_mask]
-                    A = np.column_stack([q_templ_valid, np.ones_like(q_templ_valid)])
-                    (best_coeff, pedestal), _, _, _ = np.linalg.lstsq(A, q_valid, rcond=None)
-
-                    # Iterative sigma clipping on the residuals
-                    if sigma_clip:
-                        for iteration in range(5):
-                            residual = q_valid - (best_coeff * q_templ_valid + pedestal)
-                            sigma_mad = median_absolute_deviation(residual)
-                            clip_mask = np.abs(residual - np.median(residual)) < 3.0 * sigma_mad
-                            if clip_mask.sum() == len(q_valid):
-                                break  # converged, nothing more to clip
-                            q_valid = q_valid[clip_mask]
-                            q_templ_valid = q_templ_valid[clip_mask]
-                            A = np.column_stack([q_templ_valid, np.ones_like(q_templ_valid)])
-                            (best_coeff, pedestal), _, _, _ = np.linalg.lstsq(A, q_valid, rcond=None)
-
-                    log(f'  Quarter {i+1} (rows {row_start}:{row_end}): '
-                        f'PF coeff = {best_coeff:.4f}, pedestal = {pedestal:.4f}')
-
-                    pictureframe_model[row_start:row_end, :] = best_coeff * q_template + pedestal
-
-                pictureframe_model_total += pictureframe_model
-                bkg_total += pictureframe_model
-
-                # Re-clip mask against updated residual so subsequent steps
-                # (2D background, 1/f) use a mask consistent with the post-PF data
-                mask = slitmask.copy()
-                clip_to_background(model.data-bkg_total, mask, sigma_upper=n_sigma, fit_histogram=fit_histogram, verbose=False)
-
-            # if pictureframe_dir:
-            #     log(f'Subtracting "picture frame" template (global coeff + per-quarter pedestal)')
-            #     n_quarters = 4
-            #     quarter_height = 2048 // n_quarters
-
-            #     pictureframe_model = np.zeros_like(model.data)
-
-            #     residual = (model.data - bkg_total)
-
-            #     # Step 1: Fit a single global coefficient for the template
-            #     global_valid = residual[mask]
-            #     global_templ_valid = pictureframe_template[mask]
-
-            #     A = global_templ_valid[:, np.newaxis]  # single-parameter fit (no constant)
-            #     (best_coeff,), _, _, _ = np.linalg.lstsq(A, global_valid, rcond=None)
-
-            #     if sigma_clip:
-            #         for iteration in range(5):
-            #             resid = global_valid - best_coeff * global_templ_valid
-            #             sigma_mad = median_absolute_deviation(resid)
-            #             clip_mask = np.abs(resid - np.median(resid)) < 3.0 * sigma_mad
-            #             if clip_mask.sum() == len(global_valid):
-            #                 break
-            #             global_valid = global_valid[clip_mask]
-            #             global_templ_valid = global_templ_valid[clip_mask]
-            #             A = global_templ_valid[:, np.newaxis]
-            #             (best_coeff,), _, _, _ = np.linalg.lstsq(A, global_valid, rcond=None)
-
-            #     log(f'  Global PF coeff = {best_coeff:.4f}')
-            #     pictureframe_model = best_coeff * pictureframe_template
-
-            #     # Step 2: Fit per-quarter pedestals on the PF-subtracted residual
-            #     pedestal_model = np.zeros_like(model.data)
-            #     pf_residual = residual - pictureframe_model
-
-            #     for i in range(n_quarters):
-            #         row_start = i * quarter_height
-            #         row_end = (i + 1) * quarter_height
-
-            #         q_resid = pf_residual[row_start:row_end, :]
-            #         q_mask = mask[row_start:row_end, :]
-
-            #         if sigma_clip:
-            #             from astropy.stats import sigma_clipped_stats
-            #             pedestal = sigma_clipped_stats(q_resid[q_mask], sigma=3.0, maxiters=5)[1]
-            #         else:
-            #             pedestal = np.nanmedian(q_resid[q_mask])
-
-            #         log(f'  Quarter {i+1} (rows {row_start}:{row_end}): pedestal = {pedestal:.4f}')
-            #         pedestal_model[row_start:row_end, :] = pedestal
-
-            #     pictureframe_model_total += pictureframe_model
-            #     pedestal_model_total += pedestal_model
-            #     bkg_total += pictureframe_model + pedestal_model
-
-            if subtract_2d:
-                from photutils.background import Background2D, MedianBackground
-                from astropy.stats import SigmaClip
-                match bkg_estimator:
-                    case 'median':
-                        bkg_est = MedianBackground()
-                    case _:
-                        bkg_est = None
-                if sigma_clip:
-                    sclip = SigmaClip(sigma=3.0, maxiters=5)
-                else:
-                    sclip = None
-
-                bkg = Background2D(
-                    model.data - bkg_total,
-                    box_size=box_size,
-                    filter_size=(3,3),
-                    mask=~mask,
-                    sigma_clip=sclip,
-                    bkg_estimator=bkg_est,
-                )
-
-                bkg2d_model = bkg.background
-                bkg_total += bkg2d_model
-                bkg2d_model_total += bkg2d_model
-
-
-            if do_col_1f:
-                if col_1f_method == 'template' and use_pictureframe:
-                    log(f'Subtracting column 1/f via per-column PF template fit')
-                    col_model = _fit_col_template(
-                        model.data - bkg_total, mask, pictureframe_template,
-                        sigma_clip=sigma_clip,
-                    )
-                else:
-                    if col_1f_method == 'template' and not use_pictureframe:
-                        log(f'WARNING: col_1f_method="template" requested but no PF template '
-                            f'available; falling back to per-column median')
-                    rate_masked = (model.data - bkg_total).copy()
-                    rate_masked[~mask] = np.nan
-
-                    with warnings.catch_warnings():
-                        warnings.simplefilter('ignore')
-                        col_model = np.nanmedian(rate_masked, axis=0)[np.newaxis,:]
-                    col_model[~np.isfinite(col_model)] = 0.0
-
-                bkg_total += col_model
-                col_model_total += col_model
-
-            if do_row_1f:
-                rate_masked = (model.data - bkg_total).copy()
-                rate_masked[~mask] = np.nan
-
-                with warnings.catch_warnings():
-                    warnings.simplefilter('ignore')
-                    full_row_masked = np.sum(np.isfinite(rate_masked),axis=1)==0
-                    rate_masked[full_row_masked,:] = np.nanmedian(rate_masked)
-                    row_model = np.nanmedian(rate_masked, axis=1)[:,np.newaxis]
-                row_model[~np.isfinite(row_model)] = 0.0
-
-                bkg_total += row_model
-                row_model_total += row_model
-
-
-        # Point the names the plotting code expects at the totals
-        if use_pictureframe:
-            pictureframe_model = pictureframe_model_total
-            # pedestal_model = pedestal_model_total
-        if subtract_2d:
-            bkg2d_model = bkg2d_model_total
-        if do_col_1f:
-            col_model = col_model_total
-        if do_row_1f:
-            row_model = row_model_total
+        # Names the plotting code expects (pedestal component is unused)
+        pictureframe_model = components['pictureframe']
+        pedestal_model = None
+        bkg2d_model = components['bkg2d']
+        col_model = components['col']
+        row_model = components['row']
 
         if plot:
             from campfire_pipeline.nirspec.plots import plot_bkg_subtraction
@@ -796,43 +807,64 @@ def subtract_background_from_rate_file(
 def run_stage1_single_uncal(
         uncal_file,
         workspace_dir,
-        do_clean_flicker_noise=True,
-        mask_science_regions=True,
+        ramp_config=None,
         cleanup_uncal=True,
         cleanup_rateints=True,
     ):
+    """Run the CAMPFIRE Detector1 pipeline on a single *_uncal.fits file.
+
+    Uses ``CampfireDetector1Pipeline``, which runs the per-group picture-frame
+    + 1/f background step (``CampfireRampBkgStep``) in place of the stock
+    ``picture_frame`` and ``clean_flicker_noise`` steps.
+
+    ``ramp_config`` is the merged ``[nirspec.stage1.ramp]`` table (plus an
+    ``override_wavelength_range`` dict for the slit mask).
     """
-    Runs the JWST Detector1Pipeline on a single *_uncal.fits file.
-    Optionally includes the clean_flicker_noise step.
-    """
+    ramp_config = dict(ramp_config or {})
 
     # Handle directory changes
     prev_cwd = os.getcwd()
-
     os.chdir(workspace_dir)
 
     try:
-        from jwst.pipeline import Detector1Pipeline
+        from campfire_pipeline.nirspec.detector1 import (
+            CampfireDetector1Pipeline, CampfireRampBkgStep,
+        )
+
+        # override_wavelength_range is a dict and can't live in a Step `spec`;
+        # set it as a class attribute (this worker process is isolated, so it
+        # won't race other obs/gratings).
+        CampfireRampBkgStep.override_wavelength_range = (
+            ramp_config.get('override_wavelength_range', {}) or {})
+
+        scalar_keys = (
+            'do_picture_frame', 'subtract_2d', 'box_size', 'sigma_clip',
+            'bkg_estimator', 'do_col_1f', 'do_row_1f', 'col_1f_method',
+            'n_iter', 'plot',
+        )
+        campfire_bkg_steps = {k: ramp_config[k] for k in scalar_keys if k in ramp_config}
+
         steps = {
-                'clean_flicker_noise' :{
-                    'skip': not do_clean_flicker_noise,
-                    'mask_science_regions':mask_science_regions,
-                    'save_mask': False,
-                },
-                'jump': {
-                    'skip': False, # testing, should be False normally
-                    'expand_large_events': True, # testing, should be True normally
-                }
-            }
-        Detector1Pipeline.call(uncal_file,
+            'jump': {
+                'skip': False,
+                'expand_large_events': True,
+            },
+            'campfire_bkg': campfire_bkg_steps,
+        }
+        CampfireDetector1Pipeline.call(
+            uncal_file,
             save_results=True,
+            output_dir=workspace_dir,
             steps=steps,
         )
+
         if cleanup_uncal:
             log(f'Finished Detector1Pipeline for {uncal_file}, removing...')
             os.remove(uncal_file)
         if cleanup_rateints:
-            os.remove(uncal_file.replace('_uncal.fits', '_rateints.fits'))
+            rateints = uncal_file.replace('_uncal.fits', '_rateints.fits')
+            if os.path.exists(rateints):
+                os.remove(rateints)
 
         return 1
 

--- a/pipeline/campfire_pipeline/nirspec/stage2.py
+++ b/pipeline/campfire_pipeline/nirspec/stage2.py
@@ -583,6 +583,11 @@ def run_stage2a_single_rate(
 
 
             steps = {
+                # jwst >= 2.0 runs clean_flicker_noise by default in spec2;
+                # skip it — 1/f is handled by the stage-1 per-group ramp step.
+                'clean_flicker_noise': {
+                    'skip': True,
+                },
                 'extract_1d': {
                     'skip': True,
                 },

--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -4,7 +4,7 @@ description = "JWST data reduction pipeline"
 requires-python = ">=3.12"
 dynamic = ["version"]
 dependencies = [
-    "jwst>=1.20,<1.21",
+    "jwst>=2.0.1,<2.1",
     "astropy>=6.1",
     "numpy>=2.0",
     "scipy>=1.13",

--- a/pipeline/tests/test_stage1_bkg.py
+++ b/pipeline/tests/test_stage1_bkg.py
@@ -1,0 +1,253 @@
+"""Tests for the stage-1 background-fit helpers and stage-1 ramp config.
+
+Targets the pure-Python building blocks extracted from
+``subtract_background_from_rate_file`` (``_fit_picture_frame``,
+``_fit_col_1f``, ``_fit_row_1f``, ``_iterate_background``) on synthetic 2D
+arrays, plus the ``[nirspec.stage1.ramp]`` config wiring. The jwst-dependent
+``_iterate_background`` test is skipped when jwst is unavailable.
+"""
+
+import numpy as np
+import pytest
+
+from campfire_pipeline.nirspec import stage1
+
+
+def _gradient_template(ny=2048, nx=64, seed=0):
+    """Deterministic template with per-pixel variation (ptp > 0 per quarter)."""
+    rng = np.random.default_rng(seed)
+    base = np.linspace(0.0, 1.0, ny)[:, None] + np.linspace(0.0, 0.5, nx)[None, :]
+    return (base + 0.01 * rng.standard_normal((ny, nx))).astype(np.float64)
+
+
+class TestFitPictureFrame:
+    def test_recovers_linear_template_per_quarter(self):
+        template = _gradient_template()
+        mask = np.full(template.shape, True)
+        # Same coeff/pedestal in every quarter -> exact recovery.
+        data = 2.0 * template + 5.0
+        model = stage1._fit_picture_frame(data, mask, template, sigma_clip=False)
+        np.testing.assert_allclose(model, data, rtol=0, atol=1e-6)
+
+    def test_fits_each_quarter_independently(self):
+        template = _gradient_template()
+        mask = np.full(template.shape, True)
+        data = np.zeros_like(template)
+        qh = template.shape[0] // 4
+        coeffs = [1.0, 2.0, 3.0, 4.0]
+        peds = [0.0, 1.0, -2.0, 10.0]
+        for i, (c, p) in enumerate(zip(coeffs, peds)):
+            sl = slice(i * qh, (i + 1) * qh)
+            data[sl, :] = c * template[sl, :] + p
+        model = stage1._fit_picture_frame(data, mask, template, sigma_clip=False)
+        np.testing.assert_allclose(model, data, rtol=0, atol=1e-6)
+
+
+class TestFitCol1f:
+    def test_median_method_returns_column_offsets(self):
+        ny, nx = 100, 20
+        col_offsets = np.arange(nx, dtype=float)
+        data = np.broadcast_to(col_offsets, (ny, nx)).copy()
+        mask = np.full((ny, nx), True)
+        col = stage1._fit_col_1f(data, mask, col_1f_method='median', use_pictureframe=False)
+        assert col.shape == (1, nx)
+        np.testing.assert_allclose(col[0], col_offsets)
+
+    def test_template_without_pictureframe_falls_back_to_median(self):
+        ny, nx = 50, 10
+        data = np.zeros((ny, nx)) + np.arange(nx)
+        mask = np.full((ny, nx), True)
+        # template requested but use_pictureframe=False -> median fallback
+        col = stage1._fit_col_1f(data, mask, template=None,
+                                 col_1f_method='template', use_pictureframe=False)
+        np.testing.assert_allclose(col[0], np.arange(nx))
+
+    def test_masked_pixels_excluded_from_median(self):
+        ny, nx = 40, 4
+        data = np.zeros((ny, nx))
+        data[0, :] = 1000.0  # outlier row
+        mask = np.full((ny, nx), True)
+        mask[0, :] = False   # exclude the outlier
+        col = stage1._fit_col_1f(data, mask, col_1f_method='median', use_pictureframe=False)
+        np.testing.assert_allclose(col[0], np.zeros(nx))
+
+
+class TestFitRow1f:
+    def test_returns_row_offsets(self):
+        ny, nx = 30, 50
+        row_offsets = np.arange(ny, dtype=float)
+        data = np.broadcast_to(row_offsets[:, None], (ny, nx)).copy()
+        mask = np.full((ny, nx), True)
+        row = stage1._fit_row_1f(data, mask)
+        assert row.shape == (ny, 1)
+        np.testing.assert_allclose(row[:, 0], row_offsets)
+
+    def test_fully_masked_row_is_zeroed_or_finite(self):
+        ny, nx = 10, 10
+        data = np.zeros((ny, nx))
+        mask = np.full((ny, nx), True)
+        mask[5, :] = False  # fully masked row
+        row = stage1._fit_row_1f(data, mask)
+        assert np.all(np.isfinite(row))
+
+
+class TestIterateBackground:
+    def test_removes_injected_background(self):
+        pytest.importorskip("jwst")  # _iterate_background uses clip_to_background
+        ny, nx = 2048, 64
+        template = _gradient_template(ny, nx)
+        col = np.linspace(-1, 1, nx)[None, :]
+        row = np.linspace(-0.5, 0.5, ny)[:, None]
+        # Injected background: PF + column + row patterns
+        bkg = 1.5 * template + col + row
+        img = bkg.copy()
+        slitmask = np.full((ny, nx), True)
+
+        bkg_total, mask, components = stage1._iterate_background(
+            img, slitmask, n_iter=3,
+            do_picture_frame=True, template=template,
+            subtract_2d=False, do_col_1f=True, col_1f_method='template',
+            do_row_1f=True, verbose=False,
+        )
+        residual = img - bkg_total
+        # The fit should remove the bulk of the injected structure.
+        assert np.std(residual) < 0.1 * np.std(bkg)
+        assert components['pictureframe'] is not None
+        assert components['col'] is not None
+        assert components['row'] is not None
+        assert components['bkg2d'] is None
+
+    def test_disabled_components_are_none(self):
+        pytest.importorskip("jwst")
+        ny, nx = 2048, 32
+        img = np.zeros((ny, nx))
+        slitmask = np.full((ny, nx), True)
+        bkg_total, mask, components = stage1._iterate_background(
+            img, slitmask, n_iter=1,
+            do_picture_frame=False, template=None,
+            subtract_2d=False, do_col_1f=False, do_row_1f=False,
+        )
+        assert components == {
+            'pictureframe': None, 'bkg2d': None, 'col': None, 'row': None,
+        }
+        np.testing.assert_allclose(bkg_total, 0.0)
+
+
+class _DummyObs:
+    """Minimal stand-in for an Observation with no per-obs stage overrides."""
+    stage_overrides = {}
+
+
+class TestRampConfig:
+    def test_ramp_table_resolves_via_get_stage_config(self):
+        from campfire_pipeline.config import load_config, get_stage_config
+        cfg = load_config()
+        stage_config = get_stage_config('stage1', cfg, _DummyObs())
+        assert 'ramp' in stage_config
+        ramp = stage_config['ramp']
+        for key in ('do_picture_frame', 'do_col_1f', 'do_row_1f',
+                    'col_1f_method', 'n_iter', 'plot'):
+            assert key in ramp
+        assert ramp['n_iter'] == 1
+
+    def test_obsolete_keys_removed(self):
+        from campfire_pipeline.config import load_config
+        cfg = load_config()
+        stage1_cfg = cfg['nirspec']['stage1']
+        assert 'do_clean_flicker_noise' not in stage1_cfg
+        assert 'mask_science_regions' not in stage1_cfg
+
+    def test_partial_ramp_override_preserves_global_keys(self):
+        """A per-obs override of one ramp key must not clobber the rest of the
+        ramp table (deep merge in get_stage_config)."""
+        from campfire_pipeline.config import get_stage_config
+
+        config = {'nirspec': {'stage1': {
+            'plot': True,
+            'ramp': {'do_picture_frame': True, 'box_size': 128,
+                     'bkg_estimator': 'mean', 'n_iter': 1,
+                     'col_1f_method': 'template'},
+        }}}
+
+        class Obs:
+            stage_overrides = {'stage1': {'ramp': {'n_iter': 3}}}
+
+        merged = get_stage_config('stage1', config, Obs())
+        assert merged['ramp']['n_iter'] == 3          # override applied
+        assert merged['ramp']['box_size'] == 128      # global preserved
+        assert merged['ramp']['bkg_estimator'] == 'mean'
+        assert merged['ramp']['do_picture_frame'] is True
+        # the shared config dict must not be mutated
+        assert config['nirspec']['stage1']['ramp']['n_iter'] == 1
+
+    def test_partial_wavelength_override_preserves_other_gratings(self):
+        from campfire_pipeline.config import get_stage_config
+
+        config = {'nirspec': {'stage1': {
+            'override_wavelength_range': {'G140M': [0.7, 2.5], 'G395H': [2.87, 5.5]},
+        }}}
+
+        class Obs:
+            stage_overrides = {'stage1': {'override_wavelength_range': {'G140M': [0.8, 2.4]}}}
+
+        merged = get_stage_config('stage1', config, Obs())
+        assert merged['override_wavelength_range']['G140M'] == [0.8, 2.4]
+        assert merged['override_wavelength_range']['G395H'] == [2.87, 5.5]
+
+
+class TestDiagnosticSlopeWeights:
+    """The ramp diagnostic accumulates with OLS slope weights so the result is
+    a true per-group rate (not a uniform mean, which overstates by ~ngroup/2)."""
+
+    def test_slope_weights_recover_linear_rate(self):
+        ng = 20
+        t = np.arange(ng, dtype=float)
+        wnum = t - t.mean()
+        wden = float(np.sum(wnum * wnum))
+        slope_w = wnum / wden
+
+        b = 3.7  # true per-group rate
+        img = b * t  # zero-subtracted accumulated signal at each group
+        rate = float(np.sum(slope_w * img))
+        np.testing.assert_allclose(rate, b, rtol=1e-12)
+
+        # The old uniform-mean estimator overstates the rate by ~ng/2.
+        uniform_mean = float(np.mean(img[1:]))
+        assert uniform_mean > 5 * b
+
+
+class TestRampStepGuards:
+    """CampfireRampBkgStep self-guards: it only corrects NIRSpec full-frame
+    multi-group ramps and otherwise returns the model untouched."""
+
+    def _ramp(self, shape, instrument='NIRSPEC', subarray='FULL'):
+        RampModel = pytest.importorskip(
+            "stdatamodels.jwst.datamodels", reason="jwst datamodels required"
+        ).RampModel
+        m = RampModel(np.zeros(shape, dtype=np.float32))
+        m.meta.instrument.name = instrument
+        m.meta.subarray.name = subarray
+        return m
+
+    def _step(self):
+        pytest.importorskip("jwst")
+        from campfire_pipeline.nirspec.detector1 import CampfireRampBkgStep
+        return CampfireRampBkgStep()
+
+    def test_non_nirspec_unchanged(self):
+        step = self._step()
+        m = self._ramp((1, 3, 8, 8), instrument='MIRI')
+        out = step.process(m)
+        np.testing.assert_array_equal(out.data, np.zeros((1, 3, 8, 8), np.float32))
+
+    def test_non_full_subarray_unchanged(self):
+        step = self._step()
+        m = self._ramp((1, 3, 8, 8), subarray='SUB512')
+        out = step.process(m)
+        np.testing.assert_array_equal(out.data, np.zeros((1, 3, 8, 8), np.float32))
+
+    def test_single_group_unchanged(self):
+        step = self._step()
+        m = self._ramp((1, 1, 8, 8))
+        out = step.process(m)
+        np.testing.assert_array_equal(out.data, np.zeros((1, 1, 8, 8), np.float32))


### PR DESCRIPTION
## Summary

Migrates NIRSpec stage 1 from `jwst` 1.20.2 → **2.0.1** (CRDS `jwst_1481.pmap` → `jwst_1535.pmap`) and restructures Detector1 processing.

jwst 2.0 added a built-in in-ramp `picture_frame` step and switched spec2 to run `clean_flicker_noise` by default — both overlapping CAMPFIRE's existing corrections. Rather than feed jwst's (coarser) steps, CAMPFIRE **replaces** both with its own picture-frame + 1/f correction, restructured to run **per group on the 4D ramp** (the correct domain for group-varying 1/f), while keeping the existing 2D-rate cleanup pass.

**This changes pixel/flux values for the same input → MINOR / Calibration release.** Not yet validated on real data (see gate below).

## What changed

- **`nirspec/detector1.py` (new):**
  - `CampfireRampBkgStep` — per-group picture-frame template fit + column/row 1/f on the ramp, between `jump` and `ramp_fit`. Builds CAMPFIRE's WCS-derived open-slit mask (`mask_slits`) once from a draft rate; subtracts the iterative model from each group (zero-group-subtracted, like stock `picture_frame`).
  - `CampfireDetector1Pipeline` — `Detector1Pipeline` subclass; faithful `process()` override that swaps stock `picture_frame` + `clean_flicker_noise` for `campfire_bkg` on NIRSpec full-frame data (falls back to stock steps for any other instrument/subarray).
- **`nirspec/stage1.py`:** the four fit blocks + the `n_iter` loop are extracted into shared helpers (`_fit_picture_frame`, `_fit_bkg2d`, `_fit_col_1f`, `_fit_row_1f`, `_iterate_background`) reused by both the ramp step and the unchanged rate-level `subtract_background_from_rate_file` (still does the VAR_RNOISE rescale + manual-mask `CFBKG` handling). Phase-1 CRDS prefetch now keys on `(detector, grating, filter)`.
- **`nirspec/plots.py`:** `plot_bkg_subtraction` gains an `output_pdf` param; the ramp step emits a rate-equivalent `*_ramp_bkg.pdf` (OLS slope-weighted accumulation — true rate units, no extra ramp fit).
- **`nirspec/stage2.py`:** skip the now-default spec2 `clean_flicker_noise`.
- **`config.py`:** `get_stage_config` now deep-merges (partial per-obs `[stage1.ramp]` / `override_wavelength_range` overrides no longer clobber the table).
- **`config_default.toml`:** new `[nirspec.stage1.ramp]` table; removed obsolete `do_clean_flicker_noise` / `mask_science_regions`; CRDS context → `jwst_1535.pmap`.
- **deps:** `jwst>=2.0.1,<2.1` in `environment.yml` + `pipeline/pyproject.toml`.

## Verification done

- 122 pipeline unit tests pass under a fresh `jwst 2.0.1` env, including new coverage for the extracted helpers, the slope-weighted diagnostic estimator, deep-merge config resolution, and the ramp-step guards.
- Adversarial multi-agent review (refactor-equivalence, jwst-2.0.1 API, per-group math, orchestration/config, edge cases) — all surfaced findings fixed (multi-grating prefetch race, deep-merge, diagnostic rate scaling, log flooding, non-NIRSpec fallback).
- NIRCam Detector1 params validated against jwst 2.0.1; lazy-import (fast CLI) preserved; `cfpipe` CLI + config export verified.

## Remaining gate (before merge/tag)

- [ ] **Real-data science comparison**: reduce one PRISM + one grating obs through full stage1+2+3 on `main` (jwst 1.20.2) vs this branch; compare rate images / 1/f residual RMS / extracted spectra.
- [ ] **Double-subtraction check**: confirm phase-2 residual picture-frame coefficients come out small (bulk already removed in-ramp).

Draft until the above pass on the reduction machine.

Generated with Claude Code
