### PR TITLE
feat(pipeline): live TUI/progress renderer for cfpipe run commands

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -47,6 +47,21 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- Live reporting renderer for `run` commands (`cfpipe nirspec run`,
+  `cfpipe nircam run`/`process`/`combine`). Under multiprocessing, each worker
+  previously wrote both `cfpipe`'s own `log()` and JWST/stpipe's stdlib logging
+  straight to the shared terminal, interleaving into unparseable output with no
+  sense of progress. A `ReportingSession` (opened by the `run` CLI commands) now
+  routes every worker's logs, root-logger records, and stdout/stderr onto a
+  single queue drained by one renderer: a `rich` dashboard with progress,
+  per-worker status, and a merged log panel on an interactive terminal, falling
+  back to plain, line-ordered, demultiplexed output when piped/redirected (HPC
+  batch logs). Controlled by `[logging].renderer` (`auto`/`rich`/`plain`/`off`,
+  default `auto`) and `--no-tui`. All parallelism funnels through
+  `common.parallel.dispatch`, which is instrumented at this single chokepoint;
+  the instrumented path uses ordered `pool.imap` so result order (and exception
+  propagation) is unchanged, and behavior is byte-identical to before when no
+  session is active. No change to scientific output.
 - NIRCam campfire-native drizzle (`resample.implementation = "campfire"`): the
   output mosaic i2d now carries the same header metadata as a jwst
   `Image3Pipeline` product. Previously `_write_i2d_fits` built a blank

--- a/pipeline/campfire_pipeline/common/io.py
+++ b/pipeline/campfire_pipeline/common/io.py
@@ -6,9 +6,38 @@ import os
 from datetime import datetime
 
 
+# Pluggable log sink. When ``None`` (the default, and the state in any plain
+# ``cfpipe`` invocation), ``log()`` behaves exactly as it always has: a
+# timestamped ``print`` to stdout. When a reporting session is active it
+# installs a sink here — in the parent process to feed the TUI/plain renderer,
+# and in each worker process (via the pool initializer) to push structured
+# events onto the cross-process queue. The sink is a module global rather than a
+# swapped-out ``log`` function because ``log`` is imported by value in ~60 files;
+# only its *body* can be made pluggable, never its identity.
+_SINK = None
+
+
+def set_sink(sink):
+    """Install (or clear, with ``None``) the active log sink.
+
+    ``sink`` is a callable ``sink(timestamp, args, kwargs)`` where ``args`` and
+    ``kwargs`` are exactly what was passed to :func:`log`.
+    """
+    global _SINK
+    _SINK = sink
+
+
 def log(*args, **kwargs):
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    print(f"[{timestamp}]", *args, **kwargs)
+    sink = _SINK
+    if sink is None:
+        print(f"[{timestamp}]", *args, **kwargs)
+        return
+    try:
+        sink(timestamp, args, kwargs)
+    except Exception:
+        # A misbehaving renderer must never swallow or break a log call.
+        print(f"[{timestamp}]", *args, **kwargs)
 
 
 def atomic_save(model_or_hdul, path, header_updates=None, extra_hdus=None):

--- a/pipeline/campfire_pipeline/common/parallel.py
+++ b/pipeline/campfire_pipeline/common/parallel.py
@@ -31,6 +31,7 @@ helper risks the same half-built-pool deadlock there. (``spawn`` ignores the
 preload list entirely — each worker re-imports from scratch.)
 """
 
+import os
 import sys
 from functools import partial
 from multiprocessing import get_context
@@ -97,7 +98,7 @@ class _RetryOnIOError:
 
 
 def dispatch(func, tasks, n_processes=1, use_starmap=False, retry=False,
-             **kwargs):
+             label=None, **kwargs):
     """Run *func* over *tasks* serially or in parallel.
 
     Parameters
@@ -114,13 +115,16 @@ def dispatch(func, tasks, n_processes=1, use_starmap=False, retry=False,
         If True, each task is unpacked as positional args.
     retry : bool
         If True, wrap worker with retry logic for CRDS file errors.
+    label : str, optional
+        Human-readable name for this batch, shown as a progress group when a
+        reporting session is active. Defaults to ``func.__name__``.
     **kwargs
         Extra keyword arguments bound to *func* via functools.partial.
 
     Returns
     -------
     list
-        Collected return values (one per task).
+        Collected return values (one per task, in task order).
     """
     if retry:
         func = _RetryOnIOError(func)
@@ -129,6 +133,16 @@ def dispatch(func, tasks, n_processes=1, use_starmap=False, retry=False,
         worker = partial(func, **kwargs)
     else:
         worker = func
+
+    # When a reporting session is active, take the instrumented path so the
+    # live renderer gets progress + per-worker status + merged logs. Otherwise
+    # behaviour below is byte-identical to before.
+    from campfire_pipeline.common import reporting
+    session = reporting.active_session()
+    if session is not None:
+        group_label = label or getattr(func, '__name__', 'tasks')
+        return _dispatch_reported(worker, tasks, n_processes, use_starmap,
+                                  session, group_label)
 
     if n_processes > 1:
         log(f"Dispatching {len(tasks)} tasks across {n_processes} workers")
@@ -146,3 +160,44 @@ def dispatch(func, tasks, n_processes=1, use_starmap=False, retry=False,
             else:
                 results.append(worker(task))
         return results
+
+
+def _dispatch_reported(worker, tasks, n_processes, use_starmap, session, label):
+    """Instrumented dispatch: same result list/order/exceptions, plus events.
+
+    Order matters — some callers (e.g. nirspec ``stuck_shutters``) zip results
+    against the input tasks — so the parallel path uses ordered ``pool.imap``,
+    never ``imap_unordered``.
+    """
+    from campfire_pipeline.common import reporting
+
+    gid = session.start_group(label, len(tasks))
+    results = []
+    try:
+        if n_processes > 1:
+            log(f"Dispatching {len(tasks)} tasks across {n_processes} workers")
+            shim = reporting._ReportingShim(worker, use_starmap)
+            with _MP_CTX.Pool(processes=n_processes,
+                              initializer=reporting.worker_init,
+                              initargs=(session.queue,)) as pool:
+                for result in pool.imap(shim, tasks):
+                    results.append(result)
+                    session.advance_group(gid)
+        else:
+            log(f"Processing {len(tasks)} tasks serially")
+            pid = os.getpid()
+            for task in tasks:
+                task_label = reporting._label(task, use_starmap)
+                session.emit((reporting.TASK_START, pid, task_label))
+                try:
+                    result = worker(*task) if use_starmap else worker(task)
+                except BaseException as exc:
+                    session.emit((reporting.TASK_ERROR, pid, task_label,
+                                  repr(exc)))
+                    raise
+                session.emit((reporting.TASK_DONE, pid, task_label))
+                results.append(result)
+                session.advance_group(gid)
+    finally:
+        session.finish_group(gid)
+    return results

--- a/pipeline/campfire_pipeline/common/render.py
+++ b/pipeline/campfire_pipeline/common/render.py
@@ -1,0 +1,252 @@
+"""
+Renderers for the ``cfpipe`` live reporting session.
+
+Two implementations share one interface — ``start()``, ``handle(event)``,
+``tick()``, ``stop()`` — all driven exclusively by the session's drain thread, so
+neither needs internal locking:
+
+* :class:`RichRenderer` — a ``rich.Live`` dashboard with three panels (group
+  progress, per-worker status, merged scrolling log). Used on an interactive TTY.
+* :class:`PlainRenderer` — timestamped, line-ordered, demultiplexed output to the
+  real stdout. Used when piped/redirected (HPC batch logs) or when ``--no-tui`` is
+  passed. Fixes the interleaving problem without any ANSI escapes.
+
+``rich`` is imported lazily inside :class:`RichRenderer` so importing this module
+(and constructing a :class:`PlainRenderer`) never requires it.
+
+Event tuples are documented in :mod:`campfire_pipeline.common.reporting`.
+"""
+
+import sys
+import time
+from collections import deque
+from datetime import datetime
+
+from campfire_pipeline.common.reporting import (
+    GROUP_ADVANCE, GROUP_DONE, GROUP_START, LOG,
+    TASK_DONE, TASK_ERROR, TASK_START,
+)
+
+
+def _now():
+    return datetime.now().strftime("%H:%M:%S")
+
+
+# ---------------------------------------------------------------------------
+# Plain renderer (non-TTY / --no-tui)
+# ---------------------------------------------------------------------------
+
+class PlainRenderer:
+    """Serialised, demultiplexed plain-text output to the real stdout."""
+
+    def __init__(self):
+        self._out = None
+
+    def start(self):
+        # Capture the parent's real stdout once; parent log() now routes through
+        # the session sink, so nothing else competes for this stream.
+        self._out = sys.stdout
+        self._groups = {}
+
+    def _print(self, msg):
+        try:
+            print(msg, file=self._out, flush=True)
+        except Exception:
+            pass
+
+    def handle(self, event):
+        tag = event[0]
+        if tag == LOG:
+            _, _pid, ts, msg = event
+            self._print(f"[{ts}] {msg}")
+        elif tag == GROUP_START:
+            _, gid, label, total = event
+            self._groups[gid] = (label, total)
+            self._print(f"[{_now()}] === {label}: {total} task(s) ===")
+        elif tag == GROUP_DONE:
+            _, gid = event
+            label, total = self._groups.pop(gid, ('?', '?'))
+            self._print(f"[{_now()}] === {label}: done ({total} task(s)) ===")
+        elif tag == TASK_ERROR:
+            _, pid, label, err = event
+            self._print(f"[{_now()}] ERROR [{label}] (pid {pid}): {err}")
+        # TASK_START / TASK_DONE / GROUP_ADVANCE: omitted — too granular for a log
+
+    def tick(self):
+        pass
+
+    def stop(self):
+        try:
+            if self._out is not None:
+                self._out.flush()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Rich renderer (interactive TTY)
+# ---------------------------------------------------------------------------
+
+class RichRenderer:
+    """Three-panel ``rich.Live`` dashboard. Constructed only on a TTY."""
+
+    def __init__(self, log_lines=15):
+        # Import here so a missing/!TTY rich install never blocks plain mode.
+        from rich.console import Console
+        self._Console = Console
+        self.console = Console()
+        self.log_lines = max(3, int(log_lines))
+
+        self._groups = {}     # gid -> {label, total, completed, done}
+        self._group_order = []
+        self._workers = {}    # pid -> {label, started, status}
+        self._logs = deque(maxlen=self.log_lines)
+        self._live = None
+        self._last_refresh = 0.0
+        self._min_interval = 1.0 / 8  # cap redraws at ~8 fps
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def start(self):
+        from rich.live import Live
+        self._live = Live(
+            self._render(), console=self.console,
+            refresh_per_second=8, transient=False,
+            screen=False, auto_refresh=False,
+        )
+        self._live.start()
+
+    def stop(self):
+        if self._live is None:
+            return
+        try:
+            self._live.update(self._render(), refresh=True)
+        except Exception:
+            pass
+        try:
+            self._live.stop()
+        except Exception:
+            pass
+        # Live.stop() restores the cursor; make sure it's visible regardless.
+        try:
+            self.console.show_cursor(True)
+        except Exception:
+            pass
+
+    # -- event handling -----------------------------------------------------
+
+    def handle(self, event):
+        tag = event[0]
+        if tag == LOG:
+            _, pid, ts, msg = event
+            self._logs.append((ts, msg))
+        elif tag == TASK_START:
+            _, pid, label = event
+            self._workers[pid] = {'label': label, 'started': time.monotonic(),
+                                  'status': 'run'}
+        elif tag == TASK_DONE:
+            _, pid, label = event
+            w = self._workers.get(pid)
+            if w is not None:
+                w['status'] = 'idle'
+        elif tag == TASK_ERROR:
+            _, pid, label, err = event
+            w = self._workers.get(pid)
+            if w is not None:
+                w['status'] = 'error'
+            self._logs.append((_now(), f"ERROR [{label}]: {err}"))
+        elif tag == GROUP_START:
+            _, gid, label, total = event
+            self._groups[gid] = {'label': label, 'total': total,
+                                 'completed': 0, 'done': False}
+            self._group_order.append(gid)
+        elif tag == GROUP_ADVANCE:
+            _, gid = event
+            g = self._groups.get(gid)
+            if g is not None:
+                g['completed'] += 1
+        elif tag == GROUP_DONE:
+            _, gid = event
+            g = self._groups.get(gid)
+            if g is not None:
+                g['done'] = True
+        self._maybe_refresh()
+
+    def tick(self):
+        # Periodic redraw so elapsed timers advance without new events.
+        self._maybe_refresh(force=True)
+
+    def _maybe_refresh(self, force=False):
+        now = time.monotonic()
+        if not force and (now - self._last_refresh) < self._min_interval:
+            return
+        self._last_refresh = now
+        if self._live is not None:
+            try:
+                self._live.update(self._render(), refresh=True)
+            except Exception:
+                pass
+
+    # -- rendering ----------------------------------------------------------
+
+    def _bar(self, completed, total, width=24):
+        if total <= 0:
+            return ' ' * width
+        filled = int(width * min(completed, total) / total)
+        return '█' * filled + '░' * (width - filled)
+
+    def _render(self):
+        from rich.console import Group
+        from rich.panel import Panel
+        from rich.table import Table
+        from rich.text import Text
+
+        # --- progress panel: keep the last few groups, summarise finished ---
+        prog = Text()
+        visible = self._group_order[-6:]
+        for gid in visible:
+            g = self._groups[gid]
+            bar = self._bar(g['completed'], g['total'])
+            state = '✓' if g['done'] else ' '
+            prog.append(
+                f"{state} {g['label'][:28]:28} {bar} "
+                f"{g['completed']:>4}/{g['total']:<4}\n"
+            )
+        if not visible:
+            prog.append("(waiting for work…)\n")
+
+        # --- worker panel ---------------------------------------------------
+        wtable = Table.grid(padding=(0, 2))
+        wtable.add_column(justify="right")   # pid
+        wtable.add_column()                  # status
+        wtable.add_column()                  # current task
+        wtable.add_column(justify="right")   # elapsed
+        now = time.monotonic()
+        for pid in sorted(self._workers):
+            w = self._workers[pid]
+            if w['status'] == 'run':
+                elapsed = f"{now - w['started']:5.0f}s"
+                status = "[green]●[/green]"
+            elif w['status'] == 'error':
+                elapsed = ""
+                status = "[red]✗[/red]"
+            else:
+                elapsed = ""
+                status = "[dim]·[/dim]"
+            wtable.add_row(str(pid), status, w['label'][:40], elapsed)
+        if not self._workers:
+            wtable.add_row("", "", "[dim](no active workers)[/dim]", "")
+
+        # --- log panel ------------------------------------------------------
+        logtext = Text()
+        for ts, msg in self._logs:
+            logtext.append(f"[{ts}] ", style="dim")
+            logtext.append(f"{msg}\n")
+        if not self._logs:
+            logtext.append("(no output yet)\n", style="dim")
+
+        return Group(
+            Panel(prog, title="progress", title_align="left"),
+            Panel(wtable, title="workers", title_align="left"),
+            Panel(logtext, title="log", title_align="left"),
+        )

--- a/pipeline/campfire_pipeline/common/reporting.py
+++ b/pipeline/campfire_pipeline/common/reporting.py
@@ -1,0 +1,389 @@
+"""
+Cross-process reporting plumbing for the ``cfpipe`` live renderer.
+
+The pipeline parallelises everything through :func:`campfire_pipeline.common.parallel.dispatch`,
+and both ``cfpipe``'s own :func:`campfire_pipeline.common.io.log` and JWST/stpipe's
+stdlib ``logging`` write straight to the shared terminal — so N workers interleave
+into an unparseable wall of text. This module demultiplexes that:
+
+* A parent-side :class:`ReportingSession` (a context manager opened by the ``run``
+  CLI commands) owns a ``multiprocessing.Manager().Queue()``, a background **drain
+  thread**, and a renderer (rich live display on a TTY, plain merged output
+  otherwise — see :mod:`campfire_pipeline.common.render`).
+* Each worker, via the pool *initializer* (:func:`worker_init`), routes its
+  ``log()`` output, its root-logger records (stpipe), and its ``stdout``/``stderr``
+  onto that queue instead of the terminal.
+* The drain thread is the **single writer** to the renderer; the main process also
+  pushes group-progress events through the same queue, so the renderer never sees
+  concurrent mutation.
+
+Nothing here imports ``rich`` at module load: the renderer is imported lazily by
+the session (parent only), so workers — which import this module via the pool
+initializer — stay lightweight, and ``rich`` never lands in the forkserver
+preload list.
+"""
+
+import io as _io
+import logging
+import os
+import sys
+import threading
+from datetime import datetime
+from multiprocessing import Manager
+from queue import Empty
+
+from campfire_pipeline.common import io as cfio
+
+
+# ---------------------------------------------------------------------------
+# Event protocol — plain tuples on the queue, tagged by these constants
+# ---------------------------------------------------------------------------
+
+TASK_START = 'task_start'      # (TASK_START, pid, label)
+TASK_DONE = 'task_done'        # (TASK_DONE, pid, label)
+TASK_ERROR = 'task_error'      # (TASK_ERROR, pid, label, repr)
+LOG = 'log'                    # (LOG, pid, timestamp, message)
+GROUP_START = 'group_start'    # (GROUP_START, gid, label, total)
+GROUP_ADVANCE = 'group_advance'  # (GROUP_ADVANCE, gid)
+GROUP_DONE = 'group_done'      # (GROUP_DONE, gid)
+
+_STOP = ('__stop__',)          # sentinel pushed by __exit__ to end the drain loop
+
+
+def _now():
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _fmt(args):
+    return ' '.join(str(a) for a in args)
+
+
+# ---------------------------------------------------------------------------
+# Parent-process session singleton
+# ---------------------------------------------------------------------------
+
+_SESSION = None
+
+
+def active_session():
+    """Return the active :class:`ReportingSession`, or ``None``.
+
+    Read by :func:`campfire_pipeline.common.parallel.dispatch` to decide between
+    the instrumented and the default (byte-identical-to-before) paths. Only ever
+    set in the *parent* process; workers never consult it.
+    """
+    return _SESSION
+
+
+# ---------------------------------------------------------------------------
+# Worker-side machinery (runs in pool workers under spawn/forkserver)
+# ---------------------------------------------------------------------------
+
+# Set per worker by worker_init(). Workers share no globals with the parent, so
+# the queue arrives via the pool initializer rather than by inheritance.
+_WORKER_QUEUE = None
+_WORKER_PID = None
+
+
+def _emit(event):
+    """Push an event onto the worker's queue, swallowing any failure.
+
+    Reporting must never break or slow the science path: a full/closed queue
+    silently drops the event rather than raising into pipeline code.
+    """
+    q = _WORKER_QUEUE
+    if q is None:
+        return
+    try:
+        q.put(event)
+    except Exception:
+        pass
+
+
+def _label(task, use_starmap):
+    """Best-effort human label for a task. Total — never raises.
+
+    Tasks are heterogeneous: bare filename strings, source-id ints, astropy
+    row-groups, or (for ``use_starmap``) tuples whose first element is usually a
+    filename. Falls back to the type name, then ``'?'``.
+    """
+    try:
+        head = task[0] if (use_starmap and isinstance(task, (tuple, list))) else task
+        if isinstance(head, str):
+            return os.path.basename(head)
+        if isinstance(head, (int, float)):
+            return str(head)
+        for attr in ('name', 'filename', 'path'):
+            val = getattr(head, attr, None)
+            if isinstance(val, str):
+                return os.path.basename(val)
+        return type(head).__name__
+    except Exception:
+        return '?'
+
+
+def _worker_log_sink(timestamp, args, kwargs):
+    """Sink installed into ``io._SINK`` inside each worker."""
+    _emit((LOG, _WORKER_PID, timestamp, _fmt(args)))
+
+
+class _QueueLoggingHandler(logging.Handler):
+    """Root-logger handler that forwards (stpipe) records onto the queue."""
+
+    def emit(self, record):
+        try:
+            msg = self.format(record)
+        except Exception:
+            return
+        _emit((LOG, _WORKER_PID, _now(), msg))
+
+
+class _StreamToQueue:
+    """File-like shim that forwards a worker's stdout/stderr onto the queue.
+
+    Splits on newlines *and* carriage returns (so ``tqdm``-style progress bars
+    don't accumulate forever), drops blank lines, and delegates ``fileno`` to the
+    real stream so libraries that probe for a descriptor still work.
+    """
+
+    def __init__(self, original):
+        self._original = original
+        self._buf = ''
+
+    def write(self, s):
+        if not s:
+            return
+        self._buf += s
+        while True:
+            nl = self._buf.find('\n')
+            cr = self._buf.find('\r')
+            idx = min(x for x in (nl, cr) if x >= 0) if (nl >= 0 or cr >= 0) else -1
+            if idx < 0:
+                break
+            line = self._buf[:idx].strip()
+            self._buf = self._buf[idx + 1:]
+            if line:
+                _emit((LOG, _WORKER_PID, _now(), line))
+
+    def flush(self):
+        line = self._buf.strip()
+        if line:
+            _emit((LOG, _WORKER_PID, _now(), line))
+        self._buf = ''
+
+    def isatty(self):
+        return False
+
+    def fileno(self):
+        if self._original is not None and hasattr(self._original, 'fileno'):
+            return self._original.fileno()
+        raise _io.UnsupportedOperation('fileno')
+
+
+def worker_init(queue):
+    """Pool initializer — runs once per worker before any task.
+
+    Routes everything the worker would otherwise scatter across the terminal
+    onto *queue*: ``cfpipe`` ``log()`` calls, root-logger records (stpipe), and
+    raw ``stdout``/``stderr``. The root logger's existing handlers are stripped
+    so stpipe's default stderr ``StreamHandler`` can't double-print; redirecting
+    the streams as well catches anything a handler re-adds mid-run.
+    """
+    global _WORKER_QUEUE, _WORKER_PID
+    _WORKER_QUEUE = queue
+    _WORKER_PID = os.getpid()
+
+    # cfpipe's own log() -> queue
+    cfio.set_sink(_worker_log_sink)
+
+    # stpipe / stdlib logging -> queue (replace, don't add, to kill stderr dupes)
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+    qh = _QueueLoggingHandler()
+    qh.setFormatter(logging.Formatter('%(name)s - %(levelname)s - %(message)s'))
+    root.addHandler(qh)
+    root.setLevel(logging.INFO)
+
+    # raw stdout/stderr -> queue (belt-and-suspenders for direct prints)
+    sys.stdout = _StreamToQueue(sys.__stdout__)
+    sys.stderr = _StreamToQueue(sys.__stderr__)
+
+
+class _ReportingShim:
+    """Picklable worker wrapper that brackets each task with start/done events.
+
+    A top-level class (not a closure) so it pickles under ``spawn`` — same
+    constraint that motivates ``_RetryOnIOError`` in ``parallel.py``. Holds only
+    the (already partial-/retry-wrapped) worker and the starmap flag; it reads
+    the queue from the worker global so the queue isn't pickled per task. Return
+    values and exceptions pass through unchanged so dispatch() semantics are
+    preserved exactly.
+    """
+
+    def __init__(self, func, use_starmap):
+        self.func = func
+        self.use_starmap = use_starmap
+
+    def __call__(self, task):
+        pid = os.getpid()
+        label = _label(task, self.use_starmap)
+        _emit((TASK_START, pid, label))
+        try:
+            result = self.func(*task) if self.use_starmap else self.func(task)
+        except BaseException as exc:
+            _emit((TASK_ERROR, pid, label, repr(exc)))
+            raise
+        _emit((TASK_DONE, pid, label))
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Parent-process session
+# ---------------------------------------------------------------------------
+
+class ReportingSession:
+    """Context manager owning the queue, drain thread and renderer.
+
+    Open one around a whole run (per-observation / per-field loop) in the CLI.
+    While active, :func:`active_session` returns it and :func:`dispatch`
+    instruments its pools. On ``off`` mode — or when neither a rich nor plain
+    renderer is wanted — ``__enter__`` is a no-op and behaviour is identical to
+    today.
+    """
+
+    def __init__(self, renderer_mode='auto', log_lines=15):
+        self.renderer_mode = (renderer_mode or 'auto').lower()
+        self.log_lines = int(log_lines)
+        self.active = False
+        self.queue = None
+        self._manager = None
+        self._renderer = None
+        self._drain_thread = None
+        self._group_counter = 0
+        self._group_lock = threading.Lock()
+        self._prev_session = None
+
+    @classmethod
+    def from_config(cls, config, force_plain=False):
+        """Build a session from the merged ``[logging]`` config block.
+
+        ``force_plain`` (wired to ``--no-tui``) downgrades a rich display to the
+        plain merged renderer without disabling reporting entirely.
+        """
+        log_cfg = (config or {}).get('logging', {})
+        mode = log_cfg.get('renderer', 'auto')
+        if force_plain and str(mode).lower() not in ('off',):
+            mode = 'plain'
+        return cls(renderer_mode=mode, log_lines=log_cfg.get('log_lines', 15))
+
+    # -- renderer selection -------------------------------------------------
+
+    def _make_renderer(self):
+        if self.renderer_mode == 'off':
+            return None
+        from campfire_pipeline.common import render
+        if self.renderer_mode == 'plain':
+            return render.PlainRenderer()
+        if self.renderer_mode == 'rich':
+            return render.RichRenderer(log_lines=self.log_lines)
+        # auto: rich on an interactive terminal, plain otherwise
+        if sys.stdout.isatty():
+            try:
+                return render.RichRenderer(log_lines=self.log_lines)
+            except Exception:
+                return render.PlainRenderer()
+        return render.PlainRenderer()
+
+    # -- group progress (called from the main process) ----------------------
+
+    def start_group(self, label, total):
+        with self._group_lock:
+            gid = self._group_counter
+            self._group_counter += 1
+        self.emit((GROUP_START, gid, label, total))
+        return gid
+
+    def advance_group(self, gid):
+        self.emit((GROUP_ADVANCE, gid))
+
+    def finish_group(self, gid):
+        self.emit((GROUP_DONE, gid))
+
+    def emit(self, event):
+        if self.queue is not None:
+            try:
+                self.queue.put(event)
+            except Exception:
+                pass
+
+    # -- parent-side log sink ----------------------------------------------
+
+    def _parent_sink(self, timestamp, args, kwargs):
+        self.emit((LOG, os.getpid(), timestamp, _fmt(args)))
+
+    # -- drain thread -------------------------------------------------------
+
+    def _drain(self):
+        while True:
+            try:
+                event = self.queue.get(timeout=0.2)
+            except Empty:
+                self._safe(self._renderer.tick)
+                continue
+            except (EOFError, OSError, BrokenPipeError):
+                break
+            if event == _STOP:
+                break
+            self._safe(self._renderer.handle, event)
+
+    @staticmethod
+    def _safe(fn, *a):
+        try:
+            fn(*a)
+        except Exception:
+            # A renderer hiccup must never take down the run.
+            pass
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def __enter__(self):
+        renderer = self._make_renderer()
+        if renderer is None:
+            self.active = False
+            return self
+
+        global _SESSION
+        self._prev_session = _SESSION
+        self._renderer = renderer
+        self._manager = Manager()
+        self.queue = self._manager.Queue()
+
+        self._renderer.start()
+        cfio.set_sink(self._parent_sink)
+        self._drain_thread = threading.Thread(target=self._drain, daemon=True)
+        self._drain_thread.start()
+
+        self.active = True
+        _SESSION = self
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if not self.active:
+            return False
+
+        global _SESSION
+        # Restore logging first so teardown chatter prints normally.
+        cfio.set_sink(None)
+        _SESSION = self._prev_session
+
+        try:
+            self.emit(_STOP)
+            if self._drain_thread is not None:
+                self._drain_thread.join(timeout=5.0)
+        finally:
+            self._safe(self._renderer.stop)
+            if self._manager is not None:
+                self._safe(self._manager.shutdown)
+        self.active = False
+        return False  # never suppress the original exception

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -19,6 +19,14 @@
 [logging]
     level = "INFO"
     format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    # Live reporting renderer for `run` commands:
+    #   "auto"  -> rich dashboard on an interactive terminal, plain merged
+    #              output when piped/redirected (HPC batch logs)
+    #   "rich"  -> always use the dashboard
+    #   "plain" -> always use plain merged output (same as --no-tui)
+    #   "off"   -> legacy behavior (no demultiplexing, logs as-is)
+    renderer = "auto"
+    log_lines = 15   # lines kept in the dashboard's scrolling log panel
 
 # === NIRSpec ===
 

--- a/pipeline/campfire_pipeline/nircam/cli.py
+++ b/pipeline/campfire_pipeline/nircam/cli.py
@@ -131,23 +131,31 @@ def main():
 @main.command()
 @common_options
 @processing_options
-def process(config, field, filters, processes, overwrite):
+@click.option('--no-tui', 'no_tui', is_flag=True,
+              help='Disable the live dashboard; stream plain merged logs.')
+def process(config, field, filters, processes, overwrite, no_tui):
     """Run the per-exposure process phase (detector1 → jhat)."""
+    from campfire_pipeline.common.reporting import ReportingSession
     cfg, field_obj = _setup(config, field)
-    run_process(field_obj, cfg,
-                filters=_resolve_filters(filters, field_obj),
-                n_processes=processes, overwrite=overwrite)
+    with ReportingSession.from_config(cfg, force_plain=no_tui):
+        run_process(field_obj, cfg,
+                    filters=_resolve_filters(filters, field_obj),
+                    n_processes=processes, overwrite=overwrite)
 
 
 @main.command()
 @common_options
 @processing_options
-def combine(config, field, filters, processes, overwrite):
+@click.option('--no-tui', 'no_tui', is_flag=True,
+              help='Disable the live dashboard; stream plain merged logs.')
+def combine(config, field, filters, processes, overwrite, no_tui):
     """Run the ensemble combine phase (apply_mask → resample)."""
+    from campfire_pipeline.common.reporting import ReportingSession
     cfg, field_obj = _setup(config, field)
-    run_combine(field_obj, cfg,
-                filters=_resolve_filters(filters, field_obj),
-                n_processes=processes, overwrite=overwrite)
+    with ReportingSession.from_config(cfg, force_plain=no_tui):
+        run_combine(field_obj, cfg,
+                    filters=_resolve_filters(filters, field_obj),
+                    n_processes=processes, overwrite=overwrite)
 
 
 @main.command()
@@ -159,9 +167,12 @@ def combine(config, field, filters, processes, overwrite):
               help='Run the combine phase.')
 @click.option('--all', 'do_all', is_flag=True,
               help='Run both phases.')
+@click.option('--no-tui', 'no_tui', is_flag=True,
+              help='Disable the live dashboard; stream plain merged logs.')
 def run(config, field, filters, processes, overwrite,
-        do_process, do_combine, do_all):
+        do_process, do_combine, do_all, no_tui):
     """Run process and/or combine in one invocation."""
+    from campfire_pipeline.common.reporting import ReportingSession
     if do_all:
         do_process = do_combine = True
     if not (do_process or do_combine):
@@ -172,12 +183,13 @@ def run(config, field, filters, processes, overwrite,
     cfg, field_obj = _setup(config, field)
     filter_list = _resolve_filters(filters, field_obj)
 
-    if do_process:
-        run_process(field_obj, cfg, filters=filter_list,
-                    n_processes=processes, overwrite=overwrite)
-    if do_combine:
-        run_combine(field_obj, cfg, filters=filter_list,
-                    n_processes=processes, overwrite=overwrite)
+    with ReportingSession.from_config(cfg, force_plain=no_tui):
+        if do_process:
+            run_process(field_obj, cfg, filters=filter_list,
+                        n_processes=processes, overwrite=overwrite)
+        if do_combine:
+            run_combine(field_obj, cfg, filters=filter_list,
+                        n_processes=processes, overwrite=overwrite)
 
 
 # ---------------------------------------------------------------------------

--- a/pipeline/campfire_pipeline/nircam/orchestrate.py
+++ b/pipeline/campfire_pipeline/nircam/orchestrate.py
@@ -184,6 +184,7 @@ def _run_detector1(field, config, filtname, n_processes, overwrite, status):
     cfg = get_nircam_step_config('detector1', config, field)
     log(f"detector1: dispatching {len(pending)} files for {filtname}")
     dispatch(detector1_step, pending, n_processes=n_processes,
+             label=f"detector1 ({filtname})",
              field=field, step_config=cfg, overwrite=overwrite,
              status=status)
     new_canonical = [
@@ -232,6 +233,7 @@ def _run_per_exposure(step_name, fn, cfp_key, field, config, filtname,
     cfg = get_nircam_step_config(step_name, config, field)
     log(f"{step_name}: dispatching {len(pending)} exposures for {filtname}")
     dispatch(fn, pending, n_processes=n_processes,
+             label=f"{step_name} ({filtname})",
              field=field, step_config=cfg, overwrite=overwrite,
              status=status)
     status.mark_all(pending, cfp_key)
@@ -254,6 +256,7 @@ def _run_diag_striping(field, config, filtname, n_processes, overwrite, status):
         return
     log(f"diag_striping: dispatching {len(pending)} exposures for {filtname}")
     dispatch(diag_striping_step, pending, n_processes=n_processes,
+             label=f"diag_striping ({filtname})",
              field=field, step_config=cfg, overwrite=overwrite,
              status=status)
     status.mark_all(pending, 'CFP_DIAG')
@@ -291,6 +294,7 @@ def _run_wcs_shift(field, config, filtname, n_processes, overwrite, status):
     cfg['rules'] = rules
     log(f"wcs_shift: dispatching {len(pending)} exposures for {filtname}")
     dispatch(wcs_shift_step, pending, n_processes=n_processes,
+             label=f"wcs_shift ({filtname})",
              field=field, step_config=cfg, overwrite=overwrite,
              status=status)
     status.mark_all(pending, 'CFP_SHFT')
@@ -320,6 +324,7 @@ def _run_bad_pixel(field, config, filtname, n_processes, overwrite, status):
         return
     log(f"bad_pixel: dispatching {len(pending)} exposures for {filtname}")
     dispatch(bad_pixel_step, pending, n_processes=n_processes,
+             label=f"bad_pixel ({filtname})",
              field=field, step_config=cfg, overwrite=overwrite,
              status=status)
     status.mark_all(pending, 'CFP_BPIX')
@@ -429,6 +434,7 @@ def _run_outlier_per_visit(field, cfg, filtname, n_processes, overwrite, status,
     tasks = [(visit, visit_files)
              for visit, visit_files in sorted(pending_visits.items())]
     dispatch(visit_step, tasks, n_processes=n_processes, use_starmap=True,
+             label=f"outlier ({filtname})",
              filter_files=exposures, sregions=sregions,
              field=field, step_config=cfg,
              overwrite=overwrite, status=status)

--- a/pipeline/campfire_pipeline/nirspec/cli.py
+++ b/pipeline/campfire_pipeline/nirspec/cli.py
@@ -484,13 +484,17 @@ def summary(config, obs):
 @click.option('--zfit', 'do_zfit', is_flag=True, help='Run redshift fitting.')
 @click.option('--summary', 'do_summary', is_flag=True, help='Generate summary.')
 @click.option('--all', 'do_all', is_flag=True, help='Run all stages.')
+@click.option('--no-tui', 'no_tui', is_flag=True,
+              help='Disable the live dashboard; stream plain merged logs.')
 def run(config, obs, source_ids, processes, overwrite,
-        do_stage1, do_stage2a, do_stage2b, do_stage3, do_zfit, do_summary, do_all):
+        do_stage1, do_stage2a, do_stage2b, do_stage3, do_zfit, do_summary,
+        do_all, no_tui):
     """Run multiple pipeline stages in sequence."""
     from campfire_pipeline.nirspec.stage1 import run_stage1 as _run_stage1
     from campfire_pipeline.nirspec.stage2 import run_stage2a, run_stage2b
     from campfire_pipeline.nirspec.stage3 import run_stage3 as _run_stage3
     from campfire_pipeline.nirspec.redshift_fitting import fit_redshifts
+    from campfire_pipeline.common.reporting import ReportingSession
 
     if do_all:
         do_stage1 = do_stage2a = do_stage2b = do_stage3 = do_zfit = do_summary = True
@@ -498,7 +502,10 @@ def run(config, obs, source_ids, processes, overwrite,
     if not any([do_stage1, do_stage2a, do_stage2b, do_stage3, do_zfit, do_summary]):
         raise click.UsageError("Specify at least one stage flag, or use --all.")
 
-    for obs_name in obs:
+    session = ReportingSession.from_config(load_config(config),
+                                           force_plain=no_tui)
+    with session:
+      for obs_name in obs:
         cfg, obs_obj, paths = _setup(config, obs_name)
         sids = _resolve_source_ids(source_ids)
 

--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "matplotlib>=3.9",
     "toml>=0.10",
     "click>=8.0",
+    "rich>=13",
     "tqdm>=4.65",
     "spectres>=2.2",
     "numba>=0.59",


### PR DESCRIPTION
## Context

The JWST pipeline (`cfpipe`) emits log output that is hard to follow, and under multiprocessing it's worse: each worker writes both `cfpipe`'s own `log()` **and** JWST/stpipe's stdlib `logging` straight to the shared terminal, so N workers interleave into an unparseable wall of text with no sense of overall progress or per-worker status.

Two facts made this tractable: **all parallelism funnels through one function** (`common.parallel.dispatch`), and **stpipe uses stdlib `logging`** on the root logger (so it can be captured with a `QueueHandler`).

## What this does

A parent-side `ReportingSession` (opened by the `run` CLI commands) owns a Manager queue, a single drain thread, and a renderer. Workers route their `log()`, root-logger records, and `stdout`/`stderr` onto the queue instead of the terminal. The drain thread is the **single writer** to the renderer:

- **Interactive TTY** → a `rich.Live` dashboard: overall/stage progress, per-worker status table, and a merged scrolling log.
- **Piped/redirected (HPC batch)** → plain, line-ordered, demultiplexed output (no ANSI). This alone fixes the interleaving problem.

Controlled by `[logging].renderer` (`auto`/`rich`/`plain`/`off`, default `auto`) and `--no-tui`. Wired for both **NIRSpec** (`run`) and **NIRCam** (`run`/`process`/`combine`), with per-filter progress labels on NIRCam step dispatches.

## Design constraints (the load-bearing bits)

- **`log()`'s signature is frozen** (~430 call sites, imported by value). Only its *body* is made pluggable via a module-level sink — the function is never reassigned.
- **Result order is preserved.** `nirspec/stuck_shutters.py` zips `dispatch()` output against its input, so the instrumented path uses ordered `pool.imap`, **never** `imap_unordered`.
- **stpipe double-output fixed.** The worker initializer strips root-logger handlers, attaches a `QueueHandler`, and redirects `stdout`/`stderr`, so stpipe chatter can't fight the live display.
- **spawn/forkserver safe.** Queue is a `Manager().Queue()` passed via `Pool(initializer=…)`; `rich` is imported lazily in the renderer only, so it never lands in the forkserver preload list and workers stay light.
- **Never masks a pipeline error.** All renderer calls are defensive; on crash/Ctrl-C the `Live` is torn down in `finally` and the sink restored.
- **Byte-identical to before when no session is active** (e.g. `renderer = "off"`, or the non-`run` subcommands).

## Verification

Run in `campfire-jwst-2.0.1` (the `campfire` env isn't on this host):

- ✅ Zero regression: identical results; order preserved across serial / parallel / starmap.
- ✅ `off` mode is a true no-op — no session, no sink installed.
- ✅ Worker exceptions propagate unchanged; session torn down and sink restored (parallel + serial).
- ✅ stpipe-style stdlib logging **and** raw worker `stderr` captured into the merged stream — confirmed they do not leak to the terminal.
- ✅ Both renderers: plain output clean/ordered/ANSI-free; rich dashboard constructs and draws all three panels.

### Worth a manual eyeball
- The `rich.Live` display under a real interactive terminal (forced + verified in non-TTY here, but the live-refresh feel is worth a look).
- A real `Spec2`/`Detector1` run to confirm stpipe doesn't re-add a stderr handler mid-run in practice (the stderr redirect is the belt-and-suspenders for exactly this).

Known minor limitation: `tqdm` bars *inside* workers surface as individual captured log lines rather than an animated bar — acceptable for v1.

## Changelog
Categorized **Infrastructure → PATCH** (no change to scientific output).

Generated with Claude Code