### PR TITLE
Design system + semantic token migration (Phase 1–2, visual no-op)

### DIFF
--- a/docs/claude-design-brief.md
+++ b/docs/claude-design-brief.md
@@ -1,0 +1,90 @@
+# CAMPFIRE — Claude Design Brief (Direction 2: Ember & Dusk)
+
+> This is the **committed** brand brief to seed Claude Design. Unlike
+> `design-system.md` (which explores options), everything here is stated as decided so
+> generated UI stays consistent. Values are *directional* — final hex must pass an AA
+> contrast pass before shipping to code.
+
+## Product
+**CAMPFIRE** — *COSMOS Archive of MultiPle-Field Internal Reductions & Extractions.* A web
+portal where professional astronomers browse, inspect, and quality-assess JWST NIRSpec/
+NIRCam data reductions. Expert users, data-dense work, trust-critical scientific judgments.
+
+## Personality
+**Subtle warmth, felt not noticed.** Calm, precise, quietly confident scientific instrument.
+Warmth lives in neutral *temperature* and craft, never in literal flame/campfire imagery.
+Lean slightly warm of clinical; dense over airy; serious but not cold; restrained — the data
+is the hero.
+
+## Principles
+1. Data is the hero; chrome recedes. 2. Legible at density. 3. Calm, not cold.
+4. Earned color — accent/status mean something. 5. Dark mode is first-class (designed, not
+inverted). 6. Accessible by default (WCAG AA, visible focus, never color-only).
+
+## Typography
+- **UI / body:** Inter (400/500/600/700)
+- **Data / code / all numbers:** JetBrains Mono (400/500), tabular figures — RA/Dec,
+  redshift, S/N, wavelengths are ALWAYS mono.
+- **Scale (rem@16):** xs .75 · sm .875 · base 1 · lg 1.125 · xl 1.25 · 2xl 1.5 · 3xl 1.875.
+  Body line-height 1.55; dense table rows ~1.35. Headings letter-spacing ≈ -.02em.
+
+## Color — LIGHT (warm paper)
+| Token | Hex | Role |
+|---|---|---|
+| background | `#faf7f3` | page |
+| card | `#ffffff` | primary surface (cards pop off the paper) |
+| card-2 | `#f6f1ea` | table header / footer / inset |
+| card-hover | `#f4eee6` | row & control hover |
+| border | `#ece4d9` | hairlines |
+| text | `#211c17` | body / headings |
+| muted | `#736a5f` | labels, meta |
+| primary (ember) | `#d9480f` | default accent |
+| primary-hover | `#e8590c` | accent hover |
+| primary-soft | `rgba(217,72,15,.09)` | active chip / selected bg |
+| ok / warn / bad | `#4d7c0f` / `#b45309` / `#be123c` | quality: secure / tentative / uncertain |
+
+## Color — DARK ("dusk": plum/indigo night, not cold navy)
+| Token | Hex | Role |
+|---|---|---|
+| background | `#16131c` | page |
+| card | `#1f1b27` | surface |
+| card-2 | `#241f2e` | header / footer / inset |
+| card-hover | `#2a2435` | hover |
+| border | `#332c40` | hairlines |
+| text | `#f1ecf6` | body |
+| muted | `#a79db4` | labels, meta |
+| primary (ember) | `#fb923c` | accent (brightened for dark) |
+| primary-hover | `#fdba74` | accent hover |
+| primary-soft | `rgba(251,146,60,.13)` | active bg |
+| ok / warn / bad | `#a3e635` / `#fbbf24` / `#fb7185` | quality |
+
+**Accent system:** ember is the *default*, but keep all user-selectable accents (the
+existing 8: magenta, blue, emerald, red, orange, violet, cyan, lime). Only `--primary` /
+`--primary-hover` swap; everything else is neutral so any accent works.
+
+## Shape, space, motion
+- Radius: cards 16px, controls/buttons/tabs 10–11px, filter chips fully rounded (pill).
+- Elevation: soft layered shadow on cards/popovers; in dark mode lean on border + lighter
+  surface over heavy shadow. Subtle accent *glow* (`0 0 0 3px primary-soft`) on active.
+- Spacing: tight, consistent rhythm (4/6/8/12/16/24). Chrome gets a touch more air than
+  today; tables stay dense.
+- Motion: 120–200ms ease-out; fade/zoom only. No bounce. Respect `prefers-reduced-motion`.
+
+## Components & conventions (keep these)
+Pill filter chips (active = `primary-soft` bg + `primary` border + glow); underline active
+tabs (`primary`); hairline-bordered cards; uppercase tracked micro-labels for metadata;
+visible focus rings everywhere; accent used ONLY on active/selected state; lucide icons,
+consistent stroke. Buttons: primary / secondary / ghost × sm / md / lg.
+
+## Voice (UI copy)
+Plain, precise, scientist-to-scientist. Exact terms ("redshift", "S/N", "NIRSpec G140M")
+over friendly paraphrase. No exclamation marks in chrome. Empty/error states quietly human,
+never cute.
+
+## Canonical reference
+The Targets browse mockup (`docs/design-mockups/direction-2-ember-dusk.html`) — light AND
+dark — is the visual ground truth. Upload screenshots of both as brand reference images.
+
+## Out of scope / do NOT
+Literal campfire/flame motifs beyond the existing small logo mark; cool blue-slate
+neutrals; decorative gradients on content; playful/marketing tone; color-only status.

--- a/docs/design-mockups/direction-1-warm-clinical.html
+++ b/docs/design-mockups/direction-1-warm-clinical.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>CAMPFIRE — Direction 1: Warm Clinical</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&family=Roboto+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+/* DIRECTION 1 — WARM CLINICAL
+   Thesis: change as little as possible. Keep Roboto, keep the structure and density.
+   The ONLY move is neutral temperature: cool slate -> warm stone. Magenta accent kept
+   to prove that warming the grays alone shifts the whole feel. Lowest risk to ship. */
+:root{
+  --bg:#fbfaf8; --card:#f6f4f0; --card-hover:#efece6; --border:#e9e4dc;
+  --text:#1b1a17; --muted:#6c655c;
+  --primary:#c026d3; --primary-soft:rgba(192,38,211,.10);
+  --ok:#4d7c0f; --warn:#b45309; --bad:#b91c1c;
+  --shadow:0 1px 2px rgba(40,33,24,.06);
+  --font:'Roboto',system-ui,sans-serif; --mono:'Roboto Mono',ui-monospace,monospace;
+}
+.dark{
+  --bg:#1a1714; --card:#24201b; --card-hover:#2e2922; --border:#37322a;
+  --text:#f4f1ea; --muted:#a79f95;
+  --primary:#e879f9; --primary-soft:rgba(232,121,249,.14);
+  --ok:#a3e635; --warn:#fbbf24; --bad:#f87171;
+  --shadow:0 1px 2px rgba(0,0,0,.3);
+}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:var(--font);background:var(--bg);color:var(--text);font-size:14px;line-height:1.5;-webkit-font-smoothing:antialiased}
+.mono{font-family:var(--mono);font-variant-numeric:tabular-nums}
+a{color:inherit;text-decoration:none}
+
+/* nav */
+.nav{display:flex;align-items:center;gap:28px;padding:0 24px;height:56px;border-bottom:1px solid var(--border);background:var(--card);position:sticky;top:0;z-index:10}
+.brand{display:flex;align-items:center;gap:9px;font-weight:700;letter-spacing:.02em;font-size:15px}
+.brand svg{display:block}
+.links{display:flex;gap:22px;font-size:13.5px;color:var(--muted)}
+.links a.active{color:var(--text);font-weight:500}
+.links a:hover{color:var(--text)}
+.navright{margin-left:auto;display:flex;align-items:center;gap:14px}
+.iconbtn{width:32px;height:32px;border-radius:8px;border:1px solid var(--border);background:transparent;color:var(--muted);display:grid;place-items:center;cursor:pointer}
+.iconbtn:hover{color:var(--text);background:var(--card-hover)}
+.avatar{width:30px;height:30px;border-radius:50%;background:var(--primary);color:#fff;display:grid;place-items:center;font-size:12px;font-weight:700}
+
+/* page */
+.wrap{max-width:1180px;margin:0 auto;padding:28px 24px 60px}
+.head{display:flex;align-items:flex-end;justify-content:space-between;gap:16px;margin-bottom:20px}
+h1{font-size:26px;font-weight:700;letter-spacing:-.01em}
+.sub{color:var(--muted);font-size:13.5px;margin-top:3px}
+.search{display:flex;align-items:center;gap:8px;background:var(--card);border:1px solid var(--border);border-radius:9px;padding:8px 12px;width:300px;color:var(--muted)}
+.search input{border:0;background:transparent;outline:0;color:var(--text);font:inherit;width:100%}
+
+/* filters */
+.filters{display:flex;flex-wrap:wrap;gap:8px;margin-bottom:18px}
+.chip{display:inline-flex;align-items:center;gap:7px;padding:6px 13px;border-radius:999px;border:1px solid var(--border);background:var(--card);color:var(--muted);font-size:13px;cursor:pointer}
+.chip:hover{background:var(--card-hover);color:var(--text)}
+.chip.on{border-color:var(--primary);background:var(--primary-soft);color:var(--primary);font-weight:500}
+.chip .x{opacity:.6}
+.chip.add{border-style:dashed}
+
+/* table */
+.panel{border:1px solid var(--border);border-radius:12px;overflow:hidden;background:var(--card);box-shadow:var(--shadow)}
+table{width:100%;border-collapse:collapse}
+thead th{text-align:left;font-size:11px;letter-spacing:.07em;text-transform:uppercase;color:var(--muted);font-weight:500;padding:11px 16px;border-bottom:1px solid var(--border)}
+tbody td{padding:12px 16px;border-bottom:1px solid var(--border);font-size:13.5px;vertical-align:middle}
+tbody tr:last-child td{border-bottom:0}
+tbody tr{cursor:pointer}
+tbody tr:hover{background:var(--card-hover)}
+.id{font-weight:500}
+.idsub{color:var(--muted);font-size:12px;margin-top:1px}
+.q{display:inline-flex;align-items:center;gap:6px;font-size:12.5px;font-weight:500}
+.dot{width:8px;height:8px;border-radius:50%}
+.q.secure .dot{background:var(--ok)} .q.secure{color:var(--ok)}
+.q.tent .dot{background:var(--warn)} .q.tent{color:var(--warn)}
+.q.unc .dot{background:var(--bad)} .q.unc{color:var(--bad)}
+.spark{display:block}
+.tag{font-size:11.5px;color:var(--muted);background:var(--bg);border:1px solid var(--border);padding:2px 7px;border-radius:6px;font-family:var(--mono)}
+.foot{display:flex;justify-content:space-between;align-items:center;padding:11px 16px;color:var(--muted);font-size:12.5px}
+.pager{display:flex;gap:4px}
+.pager span{min-width:26px;height:26px;display:grid;place-items:center;border-radius:6px;font-size:12.5px;cursor:pointer}
+.pager span.cur{background:var(--primary);color:#fff}
+.legend{margin-top:34px;color:var(--muted);font-size:12px;text-align:center}
+.label{position:fixed;left:14px;bottom:14px;background:var(--card);border:1px solid var(--border);border-radius:8px;padding:7px 11px;font-size:11.5px;color:var(--muted);box-shadow:var(--shadow)}
+.label b{color:var(--text)}
+</style>
+</head>
+<body>
+<nav class="nav">
+  <span class="brand">
+    <svg width="18" height="20" viewBox="0 0 18 20" fill="none"><path d="M9 1C9 1 3 6 3 11.5C3 15.6 5.7 19 9 19C12.3 19 15 15.6 15 11.5C15 9.5 14 8 14 8C14 8 13 10 11.5 10C11.5 7 9 1 9 1Z" fill="var(--primary)"/><path d="M9 19C7.3 19 6 17.2 6 15.2C6 13 9 11 9 11C9 11 12 13 12 15.2C12 17.2 10.7 19 9 19Z" fill="#fbbf24"/></svg>
+    CAMPFIRE
+  </span>
+  <span class="links">
+    <a class="active">Targets</a><a>Fields</a><a>Programs</a><a>About</a>
+  </span>
+  <span class="navright">
+    <button class="iconbtn" id="toggle" title="Toggle theme">◐</button>
+    <span class="avatar">HA</span>
+  </span>
+</nav>
+
+<div class="wrap">
+  <div class="head">
+    <div>
+      <h1>Targets</h1>
+      <div class="sub">1,284 spectra across 9 programs · COSMOS field</div>
+    </div>
+    <label class="search">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>
+      <input placeholder="Search ID or RA, Dec…">
+    </label>
+  </div>
+
+  <div class="filters">
+    <span class="chip on">Program: 6585 <span class="x">×</span></span>
+    <span class="chip on">z &gt; 5.0 <span class="x">×</span></span>
+    <span class="chip">Quality ▾</span>
+    <span class="chip">Instrument ▾</span>
+    <span class="chip">Grating ▾</span>
+    <span class="chip add">+ Add filter</span>
+  </div>
+
+  <div class="panel">
+    <table>
+      <thead><tr>
+        <th>Target</th><th>R.A.</th><th>Dec.</th><th>Redshift</th><th>Quality</th><th>Grating</th><th>S/N</th><th>Spectrum</th>
+      </tr></thead>
+      <tbody>
+        <tr><td><div class="id">COSMOS-018734</div><div class="idsub">JADES-GS+53.1</div></td><td class="mono">150.07421</td><td class="mono">+2.31884</td><td class="mono">6.241</td><td><span class="q secure"><span class="dot"></span>Secure</span></td><td><span class="tag">G140M</span></td><td class="mono">18.4</td><td><svg class="spark" width="84" height="22"></svg></td></tr>
+        <tr><td><div class="id">COSMOS-021045</div><div class="idsub">—</div></td><td class="mono">150.11903</td><td class="mono">+2.27551</td><td class="mono">7.044</td><td><span class="q secure"><span class="dot"></span>Secure</span></td><td><span class="tag">G235M</span></td><td class="mono">12.1</td><td><svg class="spark" width="84" height="22"></svg></td></tr>
+        <tr><td><div class="id">COSMOS-019982</div><div class="idsub">—</div></td><td class="mono">150.09337</td><td class="mono">+2.30012</td><td class="mono">5.331</td><td><span class="q tent"><span class="dot"></span>Tentative</span></td><td><span class="tag">G140M</span></td><td class="mono">7.8</td><td><svg class="spark" width="84" height="22"></svg></td></tr>
+        <tr><td><div class="id">COSMOS-024418</div><div class="idsub">—</div></td><td class="mono">150.14260</td><td class="mono">+2.41097</td><td class="mono">8.679</td><td><span class="q secure"><span class="dot"></span>Secure</span></td><td><span class="tag">PRISM</span></td><td class="mono">22.6</td><td><svg class="spark" width="84" height="22"></svg></td></tr>
+        <tr><td><div class="id">COSMOS-016590</div><div class="idsub">—</div></td><td class="mono">150.05118</td><td class="mono">+2.18840</td><td class="mono">5.998</td><td><span class="q tent"><span class="dot"></span>Tentative</span></td><td><span class="tag">G235M</span></td><td class="mono">9.3</td><td><svg class="spark" width="84" height="22"></svg></td></tr>
+        <tr><td><div class="id">COSMOS-027731</div><div class="idsub">—</div></td><td class="mono">150.18004</td><td class="mono">+2.49271</td><td class="mono">10.21</td><td><span class="q unc"><span class="dot"></span>Uncertain</span></td><td><span class="tag">PRISM</span></td><td class="mono">4.2</td><td><svg class="spark" width="84" height="22"></svg></td></tr>
+        <tr><td><div class="id">COSMOS-013207</div><div class="idsub">—</div></td><td class="mono">150.02990</td><td class="mono">+2.12663</td><td class="mono">4.770</td><td><span class="q secure"><span class="dot"></span>Secure</span></td><td><span class="tag">G140M</span></td><td class="mono">31.5</td><td><svg class="spark" width="84" height="22"></svg></td></tr>
+        <tr><td><div class="id">COSMOS-022860</div><div class="idsub">—</div></td><td class="mono">150.13351</td><td class="mono">+2.35509</td><td class="mono">6.853</td><td><span class="q secure"><span class="dot"></span>Secure</span></td><td><span class="tag">G235M</span></td><td class="mono">15.0</td><td><svg class="spark" width="84" height="22"></svg></td></tr>
+      </tbody>
+    </table>
+    <div class="foot">
+      <span>1–8 of 1,284</span>
+      <span class="pager"><span>‹</span><span class="cur">1</span><span>2</span><span>3</span><span>…</span><span>161</span><span>›</span></span>
+    </div>
+  </div>
+
+  <div class="legend">Direction 1 · <b>Warm Clinical</b> — Roboto kept, slate neutrals swapped for warm stone, magenta accent retained. Click ◐ to preview dark mode.</div>
+</div>
+
+<div class="label">Direction&nbsp;1 · <b>Warm&nbsp;Clinical</b></div>
+
+<script>
+document.getElementById('toggle').onclick=()=>document.documentElement.classList.toggle('dark');
+// draw little spectrum sparklines with an emission bump
+document.querySelectorAll('.spark').forEach((s,i)=>{
+  const w=84,h=22,pts=[];const peak=14+(i*7)%50;
+  for(let x=0;x<=w;x+=3){let y=h-4-2*Math.sin(x/6+i)-(Math.abs(x-peak)<5?(5-Math.abs(x-peak))*2.4:0);pts.push(x+','+Math.max(2,Math.min(h-2,y)));}
+  s.innerHTML='<polyline fill="none" stroke="var(--muted)" stroke-width="1.2" opacity=".75" points="'+pts.join(' ')+'"/>';
+});
+</script>
+</body>
+</html>

--- a/docs/design-mockups/direction-2-ember-dusk.html
+++ b/docs/design-mockups/direction-2-ember-dusk.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>CAMPFIRE — Direction 2: Ember & Dusk</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+/* DIRECTION 2 — EMBER & DUSK  (the sweet spot)
+   Warmer grotesque (Inter) replaces Roboto for quiet character. A real type scale.
+   Ember/amber becomes the default accent (all 8 still selectable). Light mode = warm
+   paper; dark mode = "dusk" — a plum/indigo-tinted night instead of cold navy, with a
+   whisper of glow on active state. Slightly more air in chrome; tables stay tight. */
+:root{
+  --bg:#faf7f3; --card:#ffffff; --card-2:#f6f1ea; --card-hover:#f4eee6; --border:#ece4d9;
+  --text:#211c17; --muted:#736a5f;
+  --primary:#d9480f; --primary-2:#e8590c; --primary-soft:rgba(217,72,15,.09); --glow:transparent;
+  --ok:#4d7c0f; --warn:#b45309; --bad:#be123c;
+  --shadow:0 1px 2px rgba(60,45,30,.05),0 6px 16px -10px rgba(60,45,30,.12);
+  --font:'Inter',system-ui,sans-serif; --mono:'JetBrains Mono',ui-monospace,monospace;
+}
+.dark{
+  /* dusk: plum/indigo night */
+  --bg:#16131c; --card:#1f1b27; --card-2:#241f2e; --card-hover:#2a2435; --border:#332c40;
+  --text:#f1ecf6; --muted:#a79db4;
+  --primary:#fb923c; --primary-2:#fdba74; --primary-soft:rgba(251,146,60,.13); --glow:0 0 0 3px rgba(251,146,60,.12);
+  --ok:#a3e635; --warn:#fbbf24; --bad:#fb7185;
+  --shadow:0 1px 2px rgba(0,0,0,.35),0 8px 22px -12px rgba(0,0,0,.6);
+}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:var(--font);background:var(--bg);color:var(--text);font-size:14px;line-height:1.55;-webkit-font-smoothing:antialiased;letter-spacing:-.005em}
+.mono{font-family:var(--mono);font-variant-numeric:tabular-nums;letter-spacing:0}
+a{color:inherit;text-decoration:none}
+
+.nav{display:flex;align-items:center;gap:30px;padding:0 26px;height:58px;border-bottom:1px solid var(--border);background:color-mix(in srgb,var(--bg) 70%,transparent);backdrop-filter:blur(8px);position:sticky;top:0;z-index:10}
+.brand{display:flex;align-items:center;gap:10px;font-weight:700;letter-spacing:.04em;font-size:15px}
+.links{display:flex;gap:24px;font-size:14px;color:var(--muted);font-weight:500}
+.links a.active{color:var(--text)} .links a.active{position:relative}
+.links a.active::after{content:"";position:absolute;left:0;right:0;bottom:-19px;height:2px;background:var(--primary);border-radius:2px}
+.links a:hover{color:var(--text)}
+.navright{margin-left:auto;display:flex;align-items:center;gap:14px}
+.iconbtn{width:33px;height:33px;border-radius:9px;border:1px solid var(--border);background:transparent;color:var(--muted);display:grid;place-items:center;cursor:pointer}
+.iconbtn:hover{color:var(--text);background:var(--card-hover)}
+.accentdot{width:14px;height:14px;border-radius:50%;background:var(--primary);box-shadow:0 0 0 3px var(--primary-soft)}
+.avatar{width:31px;height:31px;border-radius:50%;background:linear-gradient(150deg,var(--primary),var(--primary-2));color:#fff;display:grid;place-items:center;font-size:12px;font-weight:700}
+
+.wrap{max-width:1200px;margin:0 auto;padding:34px 26px 70px}
+.head{display:flex;align-items:flex-end;justify-content:space-between;gap:16px;margin-bottom:24px}
+h1{font-size:30px;font-weight:700;letter-spacing:-.02em;line-height:1.1}
+.sub{color:var(--muted);font-size:14px;margin-top:6px}
+.search{display:flex;align-items:center;gap:9px;background:var(--card);border:1px solid var(--border);border-radius:11px;padding:9px 13px;width:320px;color:var(--muted);box-shadow:var(--shadow)}
+.search input{border:0;background:transparent;outline:0;color:var(--text);font:inherit;width:100%}
+
+.filters{display:flex;flex-wrap:wrap;gap:9px;margin-bottom:20px;align-items:center}
+.chip{display:inline-flex;align-items:center;gap:7px;padding:7px 14px;border-radius:999px;border:1px solid var(--border);background:var(--card);color:var(--muted);font-size:13px;font-weight:500;cursor:pointer;transition:.12s}
+.chip:hover{background:var(--card-hover);color:var(--text)}
+.chip.on{border-color:var(--primary);background:var(--primary-soft);color:var(--primary);box-shadow:var(--glow)}
+.chip.add{border-style:dashed}
+.fcount{margin-left:auto;color:var(--muted);font-size:12.5px}
+
+.panel{border:1px solid var(--border);border-radius:16px;overflow:hidden;background:var(--card);box-shadow:var(--shadow)}
+table{width:100%;border-collapse:collapse}
+thead th{text-align:left;font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:var(--muted);font-weight:600;padding:13px 18px;border-bottom:1px solid var(--border);background:var(--card-2)}
+tbody td{padding:13px 18px;border-bottom:1px solid var(--border);font-size:14px;vertical-align:middle}
+tbody tr:last-child td{border-bottom:0}
+tbody tr{cursor:pointer;transition:.1s}
+tbody tr:hover{background:var(--card-hover)}
+.id{font-weight:600} .idsub{color:var(--muted);font-size:12px;margin-top:2px}
+.q{display:inline-flex;align-items:center;gap:7px;font-size:13px;font-weight:600}
+.dot{width:8px;height:8px;border-radius:50%;box-shadow:0 0 0 3px color-mix(in srgb,currentColor 16%,transparent)}
+.q.secure{color:var(--ok)} .q.tent{color:var(--warn)} .q.unc{color:var(--bad)}
+.q .dot{background:currentColor}
+.tag{font-size:11.5px;color:var(--muted);background:var(--card-2);border:1px solid var(--border);padding:3px 9px;border-radius:7px;font-family:var(--mono)}
+.zbig{font-size:15px;font-weight:500}
+.foot{display:flex;justify-content:space-between;align-items:center;padding:13px 18px;color:var(--muted);font-size:13px;background:var(--card-2)}
+.pager{display:flex;gap:5px}
+.pager span{min-width:28px;height:28px;display:grid;place-items:center;border-radius:8px;font-size:13px;cursor:pointer}
+.pager span.cur{background:var(--primary);color:#fff;box-shadow:var(--glow)}
+.legend{margin-top:38px;color:var(--muted);font-size:12.5px;text-align:center}
+.label{position:fixed;left:14px;bottom:14px;background:var(--card);border:1px solid var(--border);border-radius:9px;padding:7px 12px;font-size:11.5px;color:var(--muted);box-shadow:var(--shadow)}
+.label b{color:var(--text)}
+</style>
+</head>
+<body>
+<nav class="nav">
+  <span class="brand">
+    <svg width="18" height="20" viewBox="0 0 18 20" fill="none"><path d="M9 1C9 1 3 6 3 11.5C3 15.6 5.7 19 9 19C12.3 19 15 15.6 15 11.5C15 9.5 14 8 14 8C14 8 13 10 11.5 10C11.5 7 9 1 9 1Z" fill="var(--primary)"/><path d="M9 19C7.3 19 6 17.2 6 15.2C6 13 9 11 9 11C9 11 12 13 12 15.2C12 17.2 10.7 19 9 19Z" fill="var(--primary-2)"/></svg>
+    CAMPFIRE
+  </span>
+  <span class="links"><a class="active">Targets</a><a>Fields</a><a>Programs</a><a>About</a></span>
+  <span class="navright">
+    <span class="accentdot" title="Accent: Ember"></span>
+    <button class="iconbtn" id="toggle" title="Toggle theme">◐</button>
+    <span class="avatar">HA</span>
+  </span>
+</nav>
+
+<div class="wrap">
+  <div class="head">
+    <div>
+      <h1>Targets</h1>
+      <div class="sub">1,284 spectra across 9 programs · COSMOS field</div>
+    </div>
+    <label class="search">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>
+      <input placeholder="Search ID or RA, Dec…">
+    </label>
+  </div>
+
+  <div class="filters">
+    <span class="chip on">Program: 6585 ×</span>
+    <span class="chip on">z &gt; 5.0 ×</span>
+    <span class="chip">Quality ▾</span>
+    <span class="chip">Instrument ▾</span>
+    <span class="chip">Grating ▾</span>
+    <span class="chip add">+ Add filter</span>
+    <span class="fcount">Sorted by redshift ↓</span>
+  </div>
+
+  <div class="panel">
+    <table>
+      <thead><tr>
+        <th>Target</th><th>R.A.</th><th>Dec.</th><th>Redshift</th><th>Quality</th><th>Grating</th><th>S/N</th><th>Spectrum</th>
+      </tr></thead>
+      <tbody>
+        <tr><td><div class="id">COSMOS-027731</div><div class="idsub">candidate z≈10</div></td><td class="mono">150.18004</td><td class="mono">+2.49271</td><td class="mono zbig">10.21</td><td><span class="q unc"><span class="dot"></span>Uncertain</span></td><td><span class="tag">PRISM</span></td><td class="mono">4.2</td><td><svg class="spark" width="90" height="24"></svg></td></tr>
+        <tr><td><div class="id">COSMOS-024418</div><div class="idsub">—</div></td><td class="mono">150.14260</td><td class="mono">+2.41097</td><td class="mono zbig">8.679</td><td><span class="q secure"><span class="dot"></span>Secure</span></td><td><span class="tag">PRISM</span></td><td class="mono">22.6</td><td><svg class="spark" width="90" height="24"></svg></td></tr>
+        <tr><td><div class="id">COSMOS-021045</div><div class="idsub">—</div></td><td class="mono">150.11903</td><td class="mono">+2.27551</td><td class="mono zbig">7.044</td><td><span class="q secure"><span class="dot"></span>Secure</span></td><td><span class="tag">G235M</span></td><td class="mono">12.1</td><td><svg class="spark" width="90" height="24"></svg></td></tr>
+        <tr><td><div class="id">COSMOS-022860</div><div class="idsub">—</div></td><td class="mono">150.13351</td><td class="mono">+2.35509</td><td class="mono zbig">6.853</td><td><span class="q secure"><span class="dot"></span>Secure</span></td><td><span class="tag">G235M</span></td><td class="mono">15.0</td><td><svg class="spark" width="90" height="24"></svg></td></tr>
+        <tr><td><div class="id">COSMOS-018734</div><div class="idsub">JADES-GS+53.1</div></td><td class="mono">150.07421</td><td class="mono">+2.31884</td><td class="mono zbig">6.241</td><td><span class="q secure"><span class="dot"></span>Secure</span></td><td><span class="tag">G140M</span></td><td class="mono">18.4</td><td><svg class="spark" width="90" height="24"></svg></td></tr>
+        <tr><td><div class="id">COSMOS-016590</div><div class="idsub">—</div></td><td class="mono">150.05118</td><td class="mono">+2.18840</td><td class="mono zbig">5.998</td><td><span class="q tent"><span class="dot"></span>Tentative</span></td><td><span class="tag">G235M</span></td><td class="mono">9.3</td><td><svg class="spark" width="90" height="24"></svg></td></tr>
+        <tr><td><div class="id">COSMOS-019982</div><div class="idsub">—</div></td><td class="mono">150.09337</td><td class="mono">+2.30012</td><td class="mono zbig">5.331</td><td><span class="q tent"><span class="dot"></span>Tentative</span></td><td><span class="tag">G140M</span></td><td class="mono">7.8</td><td><svg class="spark" width="90" height="24"></svg></td></tr>
+        <tr><td><div class="id">COSMOS-013207</div><div class="idsub">—</div></td><td class="mono">150.02990</td><td class="mono">+2.12663</td><td class="mono zbig">4.770</td><td><span class="q secure"><span class="dot"></span>Secure</span></td><td><span class="tag">G140M</span></td><td class="mono">31.5</td><td><svg class="spark" width="90" height="24"></svg></td></tr>
+      </tbody>
+    </table>
+    <div class="foot">
+      <span>1–8 of 1,284</span>
+      <span class="pager"><span>‹</span><span class="cur">1</span><span>2</span><span>3</span><span>…</span><span>161</span><span>›</span></span>
+    </div>
+  </div>
+
+  <div class="legend">Direction 2 · <b>Ember &amp; Dusk</b> — Inter + JetBrains Mono, warm paper light mode, plum-tinted "dusk" dark mode, ember default accent with subtle glow. Click ◐ for dark mode (this is where this direction shines).</div>
+</div>
+
+<div class="label">Direction&nbsp;2 · <b>Ember&nbsp;&amp;&nbsp;Dusk</b></div>
+
+<script>
+document.getElementById('toggle').onclick=()=>document.documentElement.classList.toggle('dark');
+document.querySelectorAll('.spark').forEach((s,i)=>{
+  const w=90,h=24,pts=[];const peak=16+(i*9)%56;
+  for(let x=0;x<=w;x+=3){let y=h-4-2*Math.sin(x/6+i)-(Math.abs(x-peak)<6?(6-Math.abs(x-peak))*2.6:0);pts.push(x+','+Math.max(2,Math.min(h-2,y)));}
+  s.innerHTML='<polyline fill="none" stroke="var(--primary)" stroke-width="1.3" opacity=".85" points="'+pts.join(' ')+'"/>';
+});
+</script>
+</body>
+</html>

--- a/docs/design-mockups/direction-3-observatory.html
+++ b/docs/design-mockups/direction-3-observatory.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>CAMPFIRE — Direction 3: Observatory</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+/* DIRECTION 3 — OBSERVATORY  (most expressive, still subtle)
+   Character comes from TYPE, not theming: a warm optical serif (Fraunces) for the
+   wordmark, page titles and object names — evoking classic star-chart / observatory
+   plates — paired with Inter for UI and JetBrains Mono for all data. Warm "paper" light
+   mode; a true deep night-sky dark mode. The most editorial / generous of the three,
+   yet no one would say "campfire" — it just reads as a considered scientific instrument. */
+:root{
+  --bg:#f7f2e9; --paper:#fffdf8; --card-2:#f1ebdd; --card-hover:#f0e9d8; --border:#e6dcc7;
+  --text:#231d13; --muted:#796f5b;
+  --primary:#b54708; --primary-2:#c2410c; --primary-soft:rgba(181,71,8,.08);
+  --ok:#3f6212; --warn:#a16207; --bad:#9f1239;
+  --shadow:0 1px 2px rgba(70,55,25,.06),0 10px 24px -16px rgba(70,55,25,.18);
+  --serif:'Fraunces',Georgia,serif; --ui:'Inter',system-ui,sans-serif; --mono:'JetBrains Mono',ui-monospace,monospace;
+}
+.dark{
+  /* deep night sky */
+  --bg:#0f1118; --paper:#171a24; --card-2:#1b1f2b; --card-hover:#222636; --border:#2a2f3e;
+  --text:#f3efe6; --muted:#9aa0b0;
+  --primary:#fb923c; --primary-2:#fdba74; --primary-soft:rgba(251,146,60,.12);
+  --ok:#a3e635; --warn:#fcd34d; --bad:#fb7185;
+  --shadow:0 1px 2px rgba(0,0,0,.4),0 12px 30px -18px rgba(0,0,0,.7);
+}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:var(--ui);background:
+  radial-gradient(1200px 500px at 80% -10%,var(--primary-soft),transparent 60%),var(--bg);
+  color:var(--text);font-size:14px;line-height:1.55;-webkit-font-smoothing:antialiased}
+.mono{font-family:var(--mono);font-variant-numeric:tabular-nums}
+.serif{font-family:var(--serif)}
+a{color:inherit;text-decoration:none}
+
+.nav{display:flex;align-items:center;gap:32px;padding:0 30px;height:62px;border-bottom:1px solid var(--border);position:sticky;top:0;z-index:10;background:color-mix(in srgb,var(--bg) 72%,transparent);backdrop-filter:blur(8px)}
+.brand{display:flex;align-items:center;gap:11px;font-family:var(--serif);font-weight:600;font-size:19px;letter-spacing:.01em}
+.links{display:flex;gap:26px;font-size:14px;color:var(--muted);font-weight:500}
+.links a.active{color:var(--text)}
+.links a:hover{color:var(--text)}
+.navright{margin-left:auto;display:flex;align-items:center;gap:15px}
+.iconbtn{width:34px;height:34px;border-radius:10px;border:1px solid var(--border);background:transparent;color:var(--muted);display:grid;place-items:center;cursor:pointer}
+.iconbtn:hover{color:var(--text);background:var(--card-hover)}
+.avatar{width:32px;height:32px;border-radius:50%;background:var(--primary);color:#fff;display:grid;place-items:center;font-size:12px;font-weight:600;font-family:var(--ui)}
+
+.wrap{max-width:1220px;margin:0 auto;padding:42px 30px 80px}
+.eyebrow{font-size:11px;letter-spacing:.18em;text-transform:uppercase;color:var(--primary);font-weight:600;margin-bottom:10px}
+.head{display:flex;align-items:flex-end;justify-content:space-between;gap:20px;margin-bottom:30px}
+h1{font-family:var(--serif);font-size:42px;font-weight:500;letter-spacing:-.01em;line-height:1.02}
+.sub{color:var(--muted);font-size:14.5px;margin-top:10px}
+.search{display:flex;align-items:center;gap:9px;background:var(--paper);border:1px solid var(--border);border-radius:12px;padding:10px 14px;width:330px;color:var(--muted);box-shadow:var(--shadow)}
+.search input{border:0;background:transparent;outline:0;color:var(--text);font:inherit;width:100%}
+
+.filters{display:flex;flex-wrap:wrap;gap:10px;margin-bottom:24px;align-items:center}
+.chip{display:inline-flex;align-items:center;gap:7px;padding:8px 15px;border-radius:999px;border:1px solid var(--border);background:var(--paper);color:var(--muted);font-size:13px;font-weight:500;cursor:pointer}
+.chip:hover{background:var(--card-hover);color:var(--text)}
+.chip.on{border-color:var(--primary);background:var(--primary-soft);color:var(--primary)}
+.chip.add{border-style:dashed}
+.fcount{margin-left:auto;color:var(--muted);font-size:12.5px}
+
+.panel{border:1px solid var(--border);border-radius:18px;overflow:hidden;background:var(--paper);box-shadow:var(--shadow)}
+table{width:100%;border-collapse:collapse}
+thead th{text-align:left;font-size:10.5px;letter-spacing:.12em;text-transform:uppercase;color:var(--muted);font-weight:600;padding:15px 22px;border-bottom:1px solid var(--border)}
+tbody td{padding:16px 22px;border-bottom:1px solid var(--border);font-size:14px;vertical-align:middle}
+tbody tr:last-child td{border-bottom:0}
+tbody tr{cursor:pointer}
+tbody tr:hover{background:var(--card-hover)}
+.id{font-family:var(--serif);font-weight:500;font-size:16px}
+.idsub{color:var(--muted);font-size:12px;margin-top:2px}
+.q{display:inline-flex;align-items:center;gap:7px;font-size:12.5px;font-weight:600}
+.dot{width:7px;height:7px;border-radius:50%;background:currentColor}
+.q.secure{color:var(--ok)} .q.tent{color:var(--warn)} .q.unc{color:var(--bad)}
+.tag{font-size:11.5px;color:var(--muted);background:var(--card-2);border:1px solid var(--border);padding:3px 9px;border-radius:7px;font-family:var(--mono)}
+.zbig{font-size:16px;font-weight:500}
+.foot{display:flex;justify-content:space-between;align-items:center;padding:15px 22px;color:var(--muted);font-size:13px}
+.pager{display:flex;gap:5px}
+.pager span{min-width:29px;height:29px;display:grid;place-items:center;border-radius:9px;font-size:13px;cursor:pointer}
+.pager span.cur{background:var(--primary);color:#fff}
+.legend{margin-top:42px;color:var(--muted);font-size:12.5px;text-align:center}
+.label{position:fixed;left:14px;bottom:14px;background:var(--paper);border:1px solid var(--border);border-radius:10px;padding:8px 13px;font-size:11.5px;color:var(--muted);box-shadow:var(--shadow)}
+.label b{color:var(--text);font-family:var(--serif)}
+</style>
+</head>
+<body>
+<nav class="nav">
+  <span class="brand">
+    <svg width="19" height="21" viewBox="0 0 18 20" fill="none"><path d="M9 1C9 1 3 6 3 11.5C3 15.6 5.7 19 9 19C12.3 19 15 15.6 15 11.5C15 9.5 14 8 14 8C14 8 13 10 11.5 10C11.5 7 9 1 9 1Z" fill="var(--primary)"/><path d="M9 19C7.3 19 6 17.2 6 15.2C6 13 9 11 9 11C9 11 12 13 12 15.2C12 17.2 10.7 19 9 19Z" fill="var(--primary-2)"/></svg>
+    Campfire
+  </span>
+  <span class="links"><a class="active">Targets</a><a>Fields</a><a>Programs</a><a>About</a></span>
+  <span class="navright">
+    <button class="iconbtn" id="toggle" title="Toggle theme">◐</button>
+    <span class="avatar">HA</span>
+  </span>
+</nav>
+
+<div class="wrap">
+  <div class="head">
+    <div>
+      <div class="eyebrow">COSMOS · NIRSpec</div>
+      <h1>Targets</h1>
+      <div class="sub">1,284 spectra across 9 programs</div>
+    </div>
+    <label class="search">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>
+      <input placeholder="Search ID or RA, Dec…">
+    </label>
+  </div>
+
+  <div class="filters">
+    <span class="chip on">Program: 6585 ×</span>
+    <span class="chip on">z &gt; 5.0 ×</span>
+    <span class="chip">Quality ▾</span>
+    <span class="chip">Instrument ▾</span>
+    <span class="chip">Grating ▾</span>
+    <span class="chip add">+ Add filter</span>
+    <span class="fcount">Sorted by redshift ↓</span>
+  </div>
+
+  <div class="panel">
+    <table>
+      <thead><tr>
+        <th>Target</th><th>R.A.</th><th>Dec.</th><th>Redshift</th><th>Quality</th><th>Grating</th><th>S/N</th><th>Spectrum</th>
+      </tr></thead>
+      <tbody>
+        <tr><td><div class="id">COSMOS-027731</div><div class="idsub">candidate z≈10</div></td><td class="mono">150.18004</td><td class="mono">+2.49271</td><td class="mono zbig">10.21</td><td><span class="q unc"><span class="dot"></span>Uncertain</span></td><td><span class="tag">PRISM</span></td><td class="mono">4.2</td><td><svg class="spark" width="92" height="24"></svg></td></tr>
+        <tr><td><div class="id">COSMOS-024418</div><div class="idsub">—</div></td><td class="mono">150.14260</td><td class="mono">+2.41097</td><td class="mono zbig">8.679</td><td><span class="q secure"><span class="dot"></span>Secure</span></td><td><span class="tag">PRISM</span></td><td class="mono">22.6</td><td><svg class="spark" width="92" height="24"></svg></td></tr>
+        <tr><td><div class="id">COSMOS-021045</div><div class="idsub">—</div></td><td class="mono">150.11903</td><td class="mono">+2.27551</td><td class="mono zbig">7.044</td><td><span class="q secure"><span class="dot"></span>Secure</span></td><td><span class="tag">G235M</span></td><td class="mono">12.1</td><td><svg class="spark" width="92" height="24"></svg></td></tr>
+        <tr><td><div class="id">COSMOS-022860</div><div class="idsub">—</div></td><td class="mono">150.13351</td><td class="mono">+2.35509</td><td class="mono zbig">6.853</td><td><span class="q secure"><span class="dot"></span>Secure</span></td><td><span class="tag">G235M</span></td><td class="mono">15.0</td><td><svg class="spark" width="92" height="24"></svg></td></tr>
+        <tr><td><div class="id">COSMOS-018734</div><div class="idsub">JADES-GS+53.1</div></td><td class="mono">150.07421</td><td class="mono">+2.31884</td><td class="mono zbig">6.241</td><td><span class="q secure"><span class="dot"></span>Secure</span></td><td><span class="tag">G140M</span></td><td class="mono">18.4</td><td><svg class="spark" width="92" height="24"></svg></td></tr>
+        <tr><td><div class="id">COSMOS-016590</div><div class="idsub">—</div></td><td class="mono">150.05118</td><td class="mono">+2.18840</td><td class="mono zbig">5.998</td><td><span class="q tent"><span class="dot"></span>Tentative</span></td><td><span class="tag">G235M</span></td><td class="mono">9.3</td><td><svg class="spark" width="92" height="24"></svg></td></tr>
+        <tr><td><div class="id">COSMOS-019982</div><div class="idsub">—</div></td><td class="mono">150.09337</td><td class="mono">+2.30012</td><td class="mono zbig">5.331</td><td><span class="q tent"><span class="dot"></span>Tentative</span></td><td><span class="tag">G140M</span></td><td class="mono">7.8</td><td><svg class="spark" width="92" height="24"></svg></td></tr>
+        <tr><td><div class="id">COSMOS-013207</div><div class="idsub">—</div></td><td class="mono">150.02990</td><td class="mono">+2.12663</td><td class="mono zbig">4.770</td><td><span class="q secure"><span class="dot"></span>Secure</span></td><td><span class="tag">G140M</span></td><td class="mono">31.5</td><td><svg class="spark" width="92" height="24"></svg></td></tr>
+      </tbody>
+    </table>
+    <div class="foot">
+      <span>1–8 of 1,284</span>
+      <span class="pager"><span>‹</span><span class="cur">1</span><span>2</span><span>3</span><span>…</span><span>161</span><span>›</span></span>
+    </div>
+  </div>
+
+  <div class="legend">Direction 3 · <b>Observatory</b> — Fraunces serif for the wordmark, titles &amp; object names; Inter for UI; JetBrains Mono for data. Warm paper light mode, deep night-sky dark mode, generous spacing. Click ◐ for dark mode.</div>
+</div>
+
+<div class="label">Direction&nbsp;3 · <b>Observatory</b></div>
+
+<script>
+document.getElementById('toggle').onclick=()=>document.documentElement.classList.toggle('dark');
+document.querySelectorAll('.spark').forEach((s,i)=>{
+  const w=92,h=24,pts=[];const peak=16+(i*9)%58;
+  for(let x=0;x<=w;x+=3){let y=h-4-2*Math.sin(x/6+i)-(Math.abs(x-peak)<6?(6-Math.abs(x-peak))*2.6:0);pts.push(x+','+Math.max(2,Math.min(h-2,y)));}
+  s.innerHTML='<polyline fill="none" stroke="var(--primary)" stroke-width="1.3" opacity=".8" points="'+pts.join(' ')+'"/>';
+});
+</script>
+</body>
+</html>

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,137 @@
+# CAMPFIRE — Design System
+
+> **Status: committed.** This is the single source of truth for CAMPFIRE's visual language.
+> The brand direction is decided (Direction 2 — *Ember & Dusk*); the values below are the
+> implemented target. All chrome color/contrast values are **WCAG AA verified** (see the
+> contrast notes per token). Companion docs: `docs/token-migration-plan.md` (how we get the
+> codebase there) and `docs/design-mockups/` (visual reference).
+
+---
+
+## 1. Product
+**CAMPFIRE** — *COSMOS Archive of MultiPle-Field Internal Reductions & Extractions.* A web
+portal where professional astronomers browse, inspect, and quality-assess JWST NIRSpec/
+NIRCam reductions. Expert users, data-dense work, trust-critical scientific judgments.
+
+## 2. Personality — *subtle warmth, felt not noticed*
+The product should feel calm, precise, and quietly confident. Warmth lives in the
+*temperature* of the neutrals and in craft, **never** in literal flame/campfire imagery.
+Lean slightly warm of clinical; dense over airy; serious but not cold; restrained — the
+data is the hero.
+
+## 3. Principles
+1. Data is the hero; chrome recedes. 2. Legible at density. 3. Calm, not cold. 4. Earned
+color — accent and status mean something. 5. Dark mode is first-class (designed, not
+inverted). 6. Accessible by default (WCAG AA, visible focus, never color-only).
+
+## 4. Decision log
+- **Chosen:** Direction 2 — *Ember & Dusk*. Warm-paper light mode, plum-tinted "dusk" dark
+  mode, ember accent, Inter + JetBrains Mono.
+- **Rejected:** D1 *Warm Clinical* (too timid — keeps generic Roboto); D3 *Observatory*
+  (serif display too expressive for a dense data tool — but its serif-for-object-names idea
+  is parked for possible later use on detail headers).
+
+---
+
+## 5. Color — semantic tokens (the contract)
+
+Components consume **these tokens only** for chrome. Every token carries a light and a dark
+("dusk") value so a single class is correct in both modes — migrating to tokens *removes*
+the manual `dark:` pairs. Source of truth: `web/app/globals.css`, exposed via
+`web/tailwind.config.ts`.
+
+### Surfaces
+| Token | Light | Dark (dusk) | Role |
+|---|---|---|---|
+| `--background` | `#faf7f3` | `#16131c` | page |
+| `--card` | `#ffffff` | `#1f1b27` | primary surface (cards pop off the paper) |
+| `--surface-2` | `#f6f1ea` | `#241f2e` | table header, footer, insets |
+| `--card-hover` | `#f4eee6` | `#2a2435` | row & control hover |
+
+### Borders
+| Token | Light | Dark | Role |
+|---|---|---|---|
+| `--border` | `#ece4d9` | `#332c40` | hairlines, dividers |
+| `--border-strong` | `#ddd2c2` | `#423a52` | emphasized edges, inputs |
+
+### Text  *(AA verified on `--background`)*
+| Token | Light | Dark | Contrast L/D | Role |
+|---|---|---|---|---|
+| `--text-primary` | `#211c17` | `#f1ecf6` | 15.8 / 15.8 | body, headings |
+| `--text-secondary` | `#5c5346` | `#b8aec6` | 7.1 / 8.7 | labels, meta |
+| `--text-tertiary` | `#766a57` | `#8b8398` | 4.95 / 5.1 | muted, placeholder, icons |
+
+### Accent — ember  *(all 8 user accents still selectable; ember is the default)*
+| Token | Light | Dark | Notes |
+|---|---|---|---|
+| `--primary` | `#c63f0c` | `#fb923c` | brand accent; AA as text (4.8/8.1) & as fill w/ white (5.1) |
+| `--primary-hover` | `#ad3408` | `#fdba74` | hover |
+| `--primary-text` | `#b8390a` | `#fb923c` | ember used as inline text/links (AA 5.4) |
+| `--on-primary` | `#ffffff` | `#1a1206` | text/icon ON a primary fill |
+| `--primary-soft` | `rgba(198,63,12,.10)` | `rgba(251,146,60,.14)` | active-chip / selected bg |
+
+> The Direction-2 mockup used `#d9480f`; the implemented `--primary` is nudged one
+> imperceptible step deeper to `#c63f0c` so white button labels and inline links clear AA.
+> **Accent system:** only `--primary*` swap per user choice; everything else is neutral, so
+> all 8 accents work. The 8 stay defined in `web/lib/types.ts`; default changes to ember
+> (add an `ember` entry or promote/retune `orange` — see migration plan §Accent).
+
+### Status — semantic, both modes  *(meaning, not decoration)*
+| Token | Light | Dark | Use |
+|---|---|---|---|
+| `--success` | `#4d7c0f` | `#a3e635` | secure / success |
+| `--warning` | `#b45309` | `#fbbf24` | tentative / caution |
+| `--danger` | `#be123c` | `#fb7185` | uncertain / destructive |
+| `--info` | `#1d4ed8` | `#93c5fd` | informational / links-as-info |
+
+> **Not theme color (do not tokenize as chrome):** spectral emission-line colors
+> (`plotting-utils.ts`), wavelength-domain SED colors (`PhotometrySED.tsx`), spectrum model/
+> profile overlays (`SpectrumPlot.tsx`), redshift-quality + DQ flag colors (`lib/flags.ts`),
+> map markers, the list color picker. These are **scientific encodings** — out of scope for
+> the brand system. (They may later move to a separate `--viz-*` namespace; not now.)
+
+---
+
+## 6. Typography
+- **UI / body:** **Inter** (400/500/600/700), `--font-inter`, `font-sans`.
+- **Data / code / all numbers:** **JetBrains Mono** (400/500), `font-mono`, tabular figures.
+  RA/Dec, redshift, S/N, wavelengths are **always** mono.
+- **Scale (rem @16):** `xs .75 · sm .875 · base 1 · lg 1.125 · xl 1.25 · 2xl 1.5 · 3xl 1.875`.
+  Body line-height 1.55; dense table rows ~1.35. Heading letter-spacing ≈ −0.02em.
+
+## 7. Shape · space · elevation · motion
+- **Radius:** cards `1rem` (`rounded-card`), controls/buttons/tabs `0.625rem`, filter chips
+  pill (`rounded-full`).
+- **Spacing:** tight, consistent rhythm `4/6/8/12/16/24`. Chrome gets slightly more air than
+  today; tables stay dense.
+- **Elevation:** soft layered shadow on cards/popovers; in dark mode prefer border + lighter
+  surface over heavy shadow. Subtle accent glow (`0 0 0 3px var(--primary-soft)`) on active.
+- **Motion:** 120–200ms ease-out; fade/zoom only, no bounce. Respect `prefers-reduced-motion`.
+
+## 8. Components & conventions (preserve)
+Custom components on Tailwind (no shadcn), in `web/components/ui/`. Keep: pill filter chips
+(active = `primary-soft` bg + `primary` border + glow); underline active tabs (`primary`);
+hairline-bordered cards; uppercase tracked micro-labels for metadata; visible focus rings
+everywhere; **accent only on active/selected state**; lucide icons w/ consistent stroke.
+Buttons: `primary | secondary | ghost` × `sm | md | lg`.
+
+## 9. The token contract (rules for all new & migrated code)
+1. **Chrome uses semantic tokens only** — `bg-card`, `text-text-secondary`, `border-border`,
+   etc. **Never** raw `slate-*` / `gray-*` / hex for chrome.
+2. **One class, both modes.** Tokens carry light + dusk values; do not add `dark:` color
+   variants for chrome (delete them on migration).
+3. **Status → status tokens** (`--success/--warning/--danger/--info`), not raw `red-*` etc.
+4. **Scientific/data colors are exempt** (§5 list) and live in their own files; never reused
+   as chrome.
+5. **New color?** Add a semantic token (light + dusk) to `globals.css` + `tailwind.config.ts`
+   — don't inline a hex in a component.
+6. A lint rule enforces 1 & 3 (see migration plan §Guardrail).
+
+## 10. Accessibility
+WCAG AA for text & meaningful UI in both themes (table §5 — re-verify if values change);
+visible focus rings; never color-only signaling (quality also uses label/shape); respect
+`prefers-reduced-motion`; hit targets ≥ ~32px even when dense.
+
+---
+*Implementation status & how the codebase reaches this system:* see
+`docs/token-migration-plan.md`.

--- a/docs/token-migration-plan.md
+++ b/docs/token-migration-plan.md
@@ -1,0 +1,116 @@
+# CAMPFIRE — Token Migration Plan
+
+> One-time refactor to put the codebase on the semantic-token contract in
+> `design-system.md`, so future design iteration is a values change, not a hunt-and-replace.
+> **Companion:** `design-system.md` (the target system + token table).
+
+## Why full migration (not a palette override)
+The neutral chrome is ~96% one Tailwind palette: **`slate` 1,957 usages, `gray` 182**,
+`zinc/neutral/stone` 0 (measured). Tempting to just redefine the `slate` ramp — but the ramp
+is **overloaded across modes**: e.g. `slate-700` is *body text* in light mode and a *dark
+surface* in dark mode. One ramp can't be both warm-brown text and plum-dusk surface. Only
+**semantic tokens**, with independent light/dusk values per role, resolve this. Hence: migrate.
+
+## Strategy: refactor first, restyle second
+Separate the invisible refactor from the visible restyle so each is trivially reviewable.
+
+| Phase | What | Visual effect | Review |
+|---|---|---|---|
+| **1 — Vocabulary** | Add all new tokens (`--surface-2`, `--border-strong`, `--text-tertiary`, `--primary-text`, `--on-primary`, `--primary-soft`, `--success/--warning/--danger/--info`) to `globals.css` + `tailwind.config.ts`, **set to today's cool values** | none | tiny |
+| **2 — Migrate** | Replace raw `slate-*`/`gray-*`/`white`/`black` chrome usages → tokens, directory by directory; **delete now-redundant `dark:` color pairs** | **none** (no-op) — tokens still hold old values | easy: diff should show no visual change |
+| **3 — Restyle** | Flip token *values* to Direction-2 warm/dusk; swap fonts (Inter + JetBrains Mono); set ember default accent | the whole new look, at once | small, high-impact, easy to revert |
+| **4 — Guardrail** | Lint rule + docs so it stays clean | none | tiny |
+
+This is the professional sequence: Phase 2 is a large diff but a visual no-op (low risk);
+Phase 3 is a small diff but the entire restyle (high impact, easy rollback).
+
+## Scope
+
+**In scope (migrate to tokens):** all chrome in `web/components/**`, `web/app/**`,
+`web/lib/**` — backgrounds, surfaces, borders, text, hover, focus, dividers, and *UI* status
+colors.
+
+**Out of scope (leave as-is — scientific/data encodings):**
+- `components/spectra/plotting-utils.ts` — `EMISSION_LINES` (49 line colors)
+- `components/spectra/PhotometrySED.tsx` — wavelength-domain colors
+- `components/spectra/SpectrumPlot.tsx` — model/profile overlay colors (keep accent-derived ones)
+- `lib/flags.ts` — `REDSHIFT_QUALITY`, `DQ_FLAGS` colors
+- `components/map/*` marker colors, `components/lists/ListColorPicker.tsx`
+
+Classify each raw color before migrating: **chrome** → token; **UI status** → status token;
+**scientific/data** → leave. When unsure, it's chrome.
+
+## Mapping table (property × shade → token)
+Mechanical for most usages. Keyed on the CSS property, because the same shade means different
+things as bg vs text vs border. `dark:` counterparts collapse into the single token.
+
+**Surfaces — `bg-*`**
+| Raw (light / its dark pair) | → Token |
+|---|---|
+| `bg-white`, `bg-slate-50` / `dark:bg-slate-900` | `bg-background` |
+| `bg-slate-50/100` cards / `dark:bg-slate-800` | `bg-card` |
+| `bg-slate-100/200` headers, insets / `dark:bg-slate-800/700` | `bg-surface-2` |
+| `bg-slate-100` hover / `dark:bg-slate-700` | `bg-card-hover` |
+
+**Borders — `border-*`, `divide-*`, `ring-*`**
+| `border-slate-200` / `dark:border-slate-700` | `border-border` |
+| `border-slate-300` / `dark:border-slate-600` | `border-border-strong` |
+
+**Text — `text-*`**
+| `text-slate-900/800`, `text-black` / `dark:text-slate-100` | `text-text-primary` |
+| `text-slate-600/500` / `dark:text-slate-300/400` | `text-text-secondary` |
+| `text-slate-400` (placeholder/icons) / `dark:text-slate-500` | `text-text-tertiary` |
+
+**UI status (only when it's status, not data)**
+| `text/bg-green-*` (success) | `*-success` |
+| `text/bg-amber/yellow-*` (caution) | `*-warning` |
+| `text/bg-red-*` (error/destructive) | `*-danger` |
+| `text/bg-blue-*` (info/link) | `*-info` or `*-primary` (if it's an action) |
+
+**Disambiguation rules**
+- `slate-600` text: secondary by default; promote to `text-primary` only if it's a heading/
+  emphasized label.
+- A `bg-slate-50 dark:bg-slate-900` **pair** → one `bg-background` (drop the `dark:`).
+- `white`/`black` on an accent (e.g. button label) → `text-on-primary`, not `text-text-*`.
+
+## Execution order (most leverage first)
+1. **`components/ui/`** — foundational primitives (Button, Card, Badge, Tabs, chips…). Once
+   these are tokenized, everything that composes them inherits correct theming. *(~149 raw)*
+2. **`components/layout/`** — Navigation, Footer, headers *(nav has 12 white/black + 16 raw)*.
+3. **`components/spectra/`** — largest surface *(488 raw across 49 files)*; do sub-batches,
+   skipping the scientific-color files above.
+4. **`metadata/`, `lists/`, `docs/`, `settings/`, `map/`, `auth/`, `app/**`** — remaining.
+5. **`app/prototype/**`** — last / optional (throwaway prototype pages, 72+37 raw).
+
+**Per-file checklist:** classify each color → apply mapping → delete redundant `dark:` pairs
+→ `npm run build` → eyeball the screen in **both** themes. Batch ≈ one directory per PR.
+
+> Tooling: this is a good fit for an agent-per-file or a `Workflow` pipeline using the mapping
+> table as the spec (transform → build-check → visual diff), but each file still needs the
+> chrome-vs-status-vs-data judgment — don't blind-sed.
+
+## Accent decision (do in Phase 3)
+Ember `#c63f0c` isn't one of the current 8 accents (closest is `orange #ea580c`). Either:
+(a) **add** an `ember` entry to `ACCENT_COLORS` and set `DEFAULT_ACCENT_COLOR = 'ember'`, or
+(b) **retune** `orange` to the ember values and default to it. Recommend (a) — keeps the
+existing orange option intact.
+
+## Verification (definition of done)
+- `cd web && npm run build` passes.
+- `rg -o '[a-z-]*slate-[0-9]+' components app lib | wc -l` trends to ~0 (remaining hits are
+  inside the out-of-scope scientific files only).
+- No `dark:(bg|text|border)-(slate|gray)-*` chrome variants remain.
+- Key screens screenshotted light **and** dark (Targets list, object/spectrum page, settings,
+  an admin table) — no regressions in Phase 2; intended new look in Phase 3.
+- Contrast spot-check matches the AA table in `design-system.md`.
+
+## Guardrail (Phase 4)
+Add an ESLint rule (e.g. `eslint-plugin-tailwindcss` `no-restricted` or a custom
+`no-restricted-syntax` on className literals) banning `slate-`/`gray-` and raw hex in
+`className`, with an allowlist for the out-of-scope scientific files. Prevents regression and
+makes the contract self-enforcing.
+
+## Rough sizing
+217 files touched, but heavily front-loaded: `ui/` + `layout/` deliver most of the visible
+win. Phases 1, 3, 4 are each small/hours. Phase 2 is the bulk — parallelizable by directory,
+and the app stays shippable throughout because tokens hold sensible values at every step.

--- a/web/app/admin/activity/page.tsx
+++ b/web/app/admin/activity/page.tsx
@@ -141,7 +141,7 @@ export default function AdminActivityPage() {
       <div className="p-8">
         <div className="flex items-center justify-center py-16">
           <Loader2 className="w-8 h-8 animate-spin text-primary" />
-          <span className="ml-3 text-text-secondary dark:text-slate-400">Loading activity...</span>
+          <span className="ml-3 text-text-secondary">Loading activity...</span>
         </div>
       </div>
     );
@@ -163,8 +163,8 @@ export default function AdminActivityPage() {
     <div className="p-8">
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-semibold text-text-primary dark:text-slate-100">User Activity</h1>
-          <p className="text-sm text-text-secondary dark:text-slate-400 mt-1">
+          <h1 className="text-2xl font-semibold text-text-primary">User Activity</h1>
+          <p className="text-sm text-text-secondary mt-1">
             Recent comments and inspection changes from users
           </p>
         </div>
@@ -202,10 +202,10 @@ export default function AdminActivityPage() {
         {/* Clear all button */}
         {hasActiveFilters && (
           <>
-            <div className="h-6 w-px bg-border dark:bg-slate-700 mx-1" />
+            <div className="h-6 w-px bg-border mx-1" />
             <button
               onClick={handleClearAll}
-              className="inline-flex items-center gap-1 px-3 py-1.5 text-sm text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200 transition-colors"
+              className="inline-flex items-center gap-1 px-3 py-1.5 text-sm text-text-secondary hover:text-text-primary transition-colors"
             >
               <X className="w-3.5 h-3.5" />
               Clear all
@@ -216,50 +216,50 @@ export default function AdminActivityPage() {
 
       {activities.length === 0 ? (
         <Card className="p-8 text-center">
-          <p className="text-text-secondary dark:text-slate-400">No activity yet</p>
+          <p className="text-text-secondary">No activity yet</p>
         </Card>
       ) : (
         <Card className="overflow-hidden">
           <table className="w-full">
-            <thead className="bg-card dark:bg-slate-800 border-b border-border dark:border-slate-700">
+            <thead className="bg-card border-b border-border">
               <tr>
-                <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
                   Type
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
                   User
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
                   Object
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
                   Details
                 </th>
-                <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+                <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
                   Time
                 </th>
               </tr>
             </thead>
-            <tbody className="bg-white dark:bg-slate-800 divide-y divide-border dark:divide-slate-700">
+            <tbody className="bg-card divide-y divide-border">
               {activities.map((activity) => (
-                <tr key={activity.id} className="hover:bg-gray-50 dark:hover:bg-slate-700">
+                <tr key={activity.id} className="hover:bg-card dark:hover:bg-card-hover">
                   <td className="px-6 py-4 whitespace-nowrap">
                     <div className="flex items-center gap-2">
                       {activity.type === 'comment' ? (
                         <>
                           <MessageSquare className="w-4 h-4 text-blue-600 dark:text-blue-400" />
-                          <span className="text-sm text-text-primary dark:text-slate-100">Comment</span>
+                          <span className="text-sm text-text-primary">Comment</span>
                         </>
                       ) : (
                         <>
                           <Edit3 className="w-4 h-4 text-green-600 dark:text-green-400" />
-                          <span className="text-sm text-text-primary dark:text-slate-100">Inspection</span>
+                          <span className="text-sm text-text-primary">Inspection</span>
                         </>
                       )}
                     </div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
-                    <div className="text-sm text-text-primary dark:text-slate-100">
+                    <div className="text-sm text-text-primary">
                       {activity.user_profile?.full_name || 'Unknown User'}
                     </div>
                     {activity.user_profile?.is_group_account && (
@@ -278,7 +278,7 @@ export default function AdminActivityPage() {
                   </td>
                   <td className="px-6 py-4">
                     {activity.type === 'comment' ? (
-                      <div className="text-sm text-text-secondary dark:text-slate-400 max-w-md">
+                      <div className="text-sm text-text-secondary max-w-md">
                         <span className="line-clamp-2">{activity.content}</span>
                         {activity.edited_at && (
                           <span className="text-xs italic ml-1">(edited)</span>
@@ -286,10 +286,10 @@ export default function AdminActivityPage() {
                       </div>
                     ) : (
                       <div className="text-sm">
-                        <span className="text-text-secondary dark:text-slate-400">
+                        <span className="text-text-secondary">
                           {formatFieldName(activity.field_name)}:
                         </span>
-                        <span className="ml-2 text-text-primary dark:text-slate-100">
+                        <span className="ml-2 text-text-primary">
                           {formatActivityField(activity.field_name, activity.old_value)}
                           {' → '}
                           {formatActivityField(activity.field_name, activity.new_value)}
@@ -297,7 +297,7 @@ export default function AdminActivityPage() {
                       </div>
                     )}
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-text-secondary dark:text-slate-400">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-text-secondary">
                     {formatTimestamp(activity.timestamp)}
                   </td>
                 </tr>
@@ -307,8 +307,8 @@ export default function AdminActivityPage() {
 
           {/* Pagination */}
           {data && data.total_count > data.page_size && (
-            <div className="px-6 py-4 border-t border-border dark:border-slate-700 flex items-center justify-between">
-              <div className="text-sm text-text-secondary dark:text-slate-400">
+            <div className="px-6 py-4 border-t border-border flex items-center justify-between">
+              <div className="text-sm text-text-secondary">
                 Showing {(page - 1) * data.page_size + 1} to{' '}
                 {Math.min(page * data.page_size, data.total_count)} of {data.total_count} activities
               </div>

--- a/web/app/admin/codes/page.tsx
+++ b/web/app/admin/codes/page.tsx
@@ -222,7 +222,7 @@ export default function AdminCodesPage() {
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-semibold text-text-primary dark:text-slate-100">Access Codes</h1>
+        <h1 className="text-2xl font-semibold text-text-primary">Access Codes</h1>
         <div className="flex gap-2">
           <Button variant="secondary" size="sm" onClick={fetchCodes}>
             <RefreshCw className="w-4 h-4 mr-2" />
@@ -244,12 +244,12 @@ export default function AdminCodesPage() {
       {/* Create Code Form */}
       {showForm && (
         <Card className="p-6 mb-6">
-          <h2 className="text-lg font-semibold text-text-primary dark:text-slate-100 mb-4">Create New Code</h2>
+          <h2 className="text-lg font-semibold text-text-primary mb-4">Create New Code</h2>
 
           <form onSubmit={handleSubmit} className="space-y-4">
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <label className="block text-sm font-medium text-text-primary dark:text-slate-100 mb-1">
+                <label className="block text-sm font-medium text-text-primary mb-1">
                   Code
                 </label>
                 <div className="flex gap-2">
@@ -258,7 +258,7 @@ export default function AdminCodesPage() {
                     value={formData.code}
                     onChange={(e) => setFormData(prev => ({ ...prev, code: e.target.value.toUpperCase() }))}
                     placeholder="CAMPFIRE-2024"
-                    className="flex-1 px-3 py-2 border border-border dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary font-mono uppercase"
+                    className="flex-1 px-3 py-2 border border-border dark:border-border-strong rounded-lg bg-background dark:bg-card-hover text-text-primary focus:outline-none focus:ring-2 focus:ring-primary font-mono uppercase"
                     required
                   />
                   <Button type="button" variant="secondary" size="sm" onClick={generateRandomCode}>
@@ -268,7 +268,7 @@ export default function AdminCodesPage() {
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-text-primary dark:text-slate-100 mb-1">
+                <label className="block text-sm font-medium text-text-primary mb-1">
                   Description
                 </label>
                 <input
@@ -276,14 +276,14 @@ export default function AdminCodesPage() {
                   value={formData.description}
                   onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
                   placeholder="Core team access"
-                  className="w-full px-3 py-2 border border-border dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary"
+                  className="w-full px-3 py-2 border border-border dark:border-border-strong rounded-lg bg-background dark:bg-card-hover text-text-primary focus:outline-none focus:ring-2 focus:ring-primary"
                 />
               </div>
             </div>
 
             <div className="grid grid-cols-3 gap-4">
               <div>
-                <label className="block text-sm font-medium text-text-primary dark:text-slate-100 mb-1">
+                <label className="block text-sm font-medium text-text-primary mb-1">
                   Access Level
                 </label>
                 <select
@@ -293,7 +293,7 @@ export default function AdminCodesPage() {
                     setFormData(prev => ({ ...prev, grants_all_programs: isAll }));
                     if (isAll) setSelectedPrograms([]);
                   }}
-                  className="w-full px-3 py-2 border border-border dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary"
+                  className="w-full px-3 py-2 border border-border dark:border-border-strong rounded-lg bg-background dark:bg-card-hover text-text-primary focus:outline-none focus:ring-2 focus:ring-primary"
                 >
                   <option value="all">All Programs</option>
                   <option value="specific">Specific Programs</option>
@@ -301,7 +301,7 @@ export default function AdminCodesPage() {
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-text-primary dark:text-slate-100 mb-1">
+                <label className="block text-sm font-medium text-text-primary mb-1">
                   Expires In (days)
                 </label>
                 <input
@@ -310,12 +310,12 @@ export default function AdminCodesPage() {
                   onChange={(e) => setFormData(prev => ({ ...prev, expires_in_days: e.target.value }))}
                   placeholder="Never"
                   min="1"
-                  className="w-full px-3 py-2 border border-border dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary"
+                  className="w-full px-3 py-2 border border-border dark:border-border-strong rounded-lg bg-background dark:bg-card-hover text-text-primary focus:outline-none focus:ring-2 focus:ring-primary"
                 />
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-text-primary dark:text-slate-100 mb-1">
+                <label className="block text-sm font-medium text-text-primary mb-1">
                   Max Uses
                 </label>
                 <input
@@ -324,7 +324,7 @@ export default function AdminCodesPage() {
                   onChange={(e) => setFormData(prev => ({ ...prev, max_uses: e.target.value }))}
                   placeholder="Unlimited"
                   min="1"
-                  className="w-full px-3 py-2 border border-border dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary"
+                  className="w-full px-3 py-2 border border-border dark:border-border-strong rounded-lg bg-background dark:bg-card-hover text-text-primary focus:outline-none focus:ring-2 focus:ring-primary"
                 />
               </div>
             </div>
@@ -370,35 +370,35 @@ export default function AdminCodesPage() {
       {/* Codes List */}
       <Card className="overflow-hidden">
         <table className="w-full">
-          <thead className="bg-card dark:bg-slate-800 border-b border-border dark:border-slate-700">
+          <thead className="bg-card border-b border-border">
             <tr>
-              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
                 Code
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
                 Description
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
                 Access
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
                 Uses
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
                 Expires
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
                 Status
               </th>
-              <th className="px-6 py-3 text-right text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+              <th className="px-6 py-3 text-right text-xs font-medium text-text-secondary uppercase tracking-wider">
                 Actions
               </th>
             </tr>
           </thead>
-          <tbody className="bg-white dark:bg-slate-800 divide-y divide-border dark:divide-slate-700">
+          <tbody className="bg-card divide-y divide-border">
             {codes.length === 0 ? (
               <tr>
-                <td colSpan={7} className="px-6 py-12 text-center text-text-secondary dark:text-slate-400">
+                <td colSpan={7} className="px-6 py-12 text-center text-text-secondary">
                   No access codes yet. Create one to get started.
                 </td>
               </tr>
@@ -407,12 +407,12 @@ export default function AdminCodesPage() {
                 <tr key={code.id} className={!code.is_active ? 'opacity-50' : ''}>
                   <td className="px-6 py-4 whitespace-nowrap">
                     <div className="flex items-center gap-2">
-                      <span className="font-mono text-sm font-medium text-text-primary dark:text-slate-100">
+                      <span className="font-mono text-sm font-medium text-text-primary">
                         {code.code}
                       </span>
                       <button
                         onClick={() => copyCode(code.code)}
-                        className="text-text-secondary dark:text-slate-400 hover:text-primary transition-colors"
+                        className="text-text-secondary hover:text-primary transition-colors"
                         title="Copy code"
                       >
                         {copiedCode === code.code ? (
@@ -423,17 +423,17 @@ export default function AdminCodesPage() {
                       </button>
                     </div>
                   </td>
-                  <td className="px-6 py-4 text-sm text-text-secondary dark:text-slate-400">
+                  <td className="px-6 py-4 text-sm text-text-secondary">
                     {code.description || '—'}
                   </td>
-                  <td className="px-6 py-4 text-sm text-text-primary dark:text-slate-100">
+                  <td className="px-6 py-4 text-sm text-text-primary">
                     {code.grants_all_programs ? 'All programs' : 'Specific'}
                   </td>
-                  <td className="px-6 py-4 text-sm text-text-primary dark:text-slate-100">
+                  <td className="px-6 py-4 text-sm text-text-primary">
                     {code.use_count}
                     {code.max_uses ? ` / ${code.max_uses}` : ''}
                   </td>
-                  <td className="px-6 py-4 text-sm text-text-secondary dark:text-slate-400">
+                  <td className="px-6 py-4 text-sm text-text-secondary">
                     {formatDate(code.expires_at)}
                   </td>
                   <td className="px-6 py-4">
@@ -441,7 +441,7 @@ export default function AdminCodesPage() {
                       className={`inline-flex px-2 py-1 text-xs font-medium rounded-full ${
                         code.is_active
                           ? 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-300'
-                          : 'bg-gray-100 dark:bg-slate-700 text-gray-800 dark:text-slate-300'
+                          : 'bg-surface-2 text-text-primary dark:text-text-secondary'
                       }`}
                     >
                       {code.is_active ? 'Active' : 'Disabled'}
@@ -451,7 +451,7 @@ export default function AdminCodesPage() {
                     <div className="flex items-center justify-end gap-2">
                       <button
                         onClick={() => toggleCodeActive(code)}
-                        className="text-text-secondary dark:text-slate-400 hover:text-primary transition-colors"
+                        className="text-text-secondary hover:text-primary transition-colors"
                         title={code.is_active ? 'Disable' : 'Enable'}
                       >
                         {code.is_active ? (
@@ -462,7 +462,7 @@ export default function AdminCodesPage() {
                       </button>
                       <button
                         onClick={() => deleteCode(code)}
-                        className="text-text-secondary dark:text-slate-400 hover:text-red-600 dark:hover:text-red-400 transition-colors"
+                        className="text-text-secondary hover:text-red-600 dark:hover:text-red-400 transition-colors"
                         title="Delete"
                       >
                         <Trash2 className="w-5 h-5" />

--- a/web/app/admin/downloads/page.tsx
+++ b/web/app/admin/downloads/page.tsx
@@ -83,7 +83,7 @@ function DownloadTypeIcon({ type }: { type: string }) {
     case 'sed_plot':
       return <FileText className="w-4 h-4 text-pink-600 dark:text-pink-400" />;
     default:
-      return <Download className="w-4 h-4 text-gray-600 dark:text-gray-400" />;
+      return <Download className="w-4 h-4 text-text-secondary" />;
   }
 }
 
@@ -175,7 +175,7 @@ export default function AdminDownloadsPage() {
       <div className="p-8">
         <div className="flex items-center justify-center py-16">
           <Loader2 className="w-8 h-8 animate-spin text-primary" />
-          <span className="ml-3 text-text-secondary dark:text-slate-400">Loading download statistics...</span>
+          <span className="ml-3 text-text-secondary">Loading download statistics...</span>
         </div>
       </div>
     );
@@ -195,8 +195,8 @@ export default function AdminDownloadsPage() {
     <div className="p-8">
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-semibold text-text-primary dark:text-slate-100">Download Analytics</h1>
-          <p className="text-sm text-text-secondary dark:text-slate-400 mt-1">
+          <h1 className="text-2xl font-semibold text-text-primary">Download Analytics</h1>
+          <p className="text-sm text-text-secondary mt-1">
             Track spectrum downloads across all users
           </p>
         </div>
@@ -217,10 +217,10 @@ export default function AdminDownloadsPage() {
 
         {hasActiveFilters && (
           <>
-            <div className="h-6 w-px bg-border dark:bg-slate-700 mx-1" />
+            <div className="h-6 w-px bg-border mx-1" />
             <button
               onClick={handleClearAll}
-              className="inline-flex items-center gap-1 px-3 py-1.5 text-sm text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200 transition-colors"
+              className="inline-flex items-center gap-1 px-3 py-1.5 text-sm text-text-secondary hover:text-text-primary transition-colors"
             >
               <X className="w-3.5 h-3.5" />
               Reset
@@ -237,8 +237,8 @@ export default function AdminDownloadsPage() {
               <Download className="w-5 h-5 text-blue-600 dark:text-blue-400" />
             </div>
             <div>
-              <p className="text-sm text-text-secondary dark:text-slate-400">Total Downloads</p>
-              <p className="text-2xl font-semibold text-text-primary dark:text-slate-100">
+              <p className="text-sm text-text-secondary">Total Downloads</p>
+              <p className="text-2xl font-semibold text-text-primary">
                 {stats?.total_downloads?.toLocaleString() || 0}
               </p>
             </div>
@@ -251,8 +251,8 @@ export default function AdminDownloadsPage() {
               <Users className="w-5 h-5 text-green-600 dark:text-green-400" />
             </div>
             <div>
-              <p className="text-sm text-text-secondary dark:text-slate-400">Unique Users</p>
-              <p className="text-2xl font-semibold text-text-primary dark:text-slate-100">
+              <p className="text-sm text-text-secondary">Unique Users</p>
+              <p className="text-2xl font-semibold text-text-primary">
                 {stats?.unique_users?.toLocaleString() || 0}
               </p>
             </div>
@@ -265,8 +265,8 @@ export default function AdminDownloadsPage() {
               <File className="w-5 h-5 text-purple-600 dark:text-purple-400" />
             </div>
             <div>
-              <p className="text-sm text-text-secondary dark:text-slate-400">Files Downloaded</p>
-              <p className="text-2xl font-semibold text-text-primary dark:text-slate-100">
+              <p className="text-sm text-text-secondary">Files Downloaded</p>
+              <p className="text-2xl font-semibold text-text-primary">
                 {stats?.total_files?.toLocaleString() || 0}
               </p>
             </div>
@@ -279,8 +279,8 @@ export default function AdminDownloadsPage() {
               <BarChart3 className="w-5 h-5 text-orange-600 dark:text-orange-400" />
             </div>
             <div>
-              <p className="text-sm text-text-secondary dark:text-slate-400">Targets Downloaded</p>
-              <p className="text-2xl font-semibold text-text-primary dark:text-slate-100">
+              <p className="text-sm text-text-secondary">Targets Downloaded</p>
+              <p className="text-2xl font-semibold text-text-primary">
                 {stats?.total_targets?.toLocaleString() || 0}
               </p>
             </div>
@@ -291,16 +291,16 @@ export default function AdminDownloadsPage() {
       {/* Downloads by Type */}
       {stats?.by_type && Object.keys(stats.by_type).length > 0 && (
         <Card className="p-4 mb-6">
-          <h2 className="text-lg font-medium text-text-primary dark:text-slate-100 mb-4">Downloads by Type</h2>
+          <h2 className="text-lg font-medium text-text-primary mb-4">Downloads by Type</h2>
           <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
             {Object.entries(stats.by_type).map(([type, count]) => (
               <div key={type} className="flex items-center gap-2">
                 <DownloadTypeIcon type={type} />
                 <div>
-                  <p className="text-xs text-text-secondary dark:text-slate-400">
+                  <p className="text-xs text-text-secondary">
                     {DOWNLOAD_TYPE_LABELS[type] || type}
                   </p>
-                  <p className="text-lg font-semibold text-text-primary dark:text-slate-100">
+                  <p className="text-lg font-semibold text-text-primary">
                     {count.toLocaleString()}
                   </p>
                 </div>
@@ -313,25 +313,25 @@ export default function AdminDownloadsPage() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Recent Downloads */}
         <Card className="overflow-hidden">
-          <div className="px-4 py-3 border-b border-border dark:border-slate-700">
-            <h2 className="text-lg font-medium text-text-primary dark:text-slate-100">Recent Downloads</h2>
+          <div className="px-4 py-3 border-b border-border">
+            <h2 className="text-lg font-medium text-text-primary">Recent Downloads</h2>
           </div>
           {!stats?.recent_downloads || stats.recent_downloads.length === 0 ? (
             <div className="p-8 text-center">
-              <p className="text-text-secondary dark:text-slate-400">No downloads recorded yet</p>
+              <p className="text-text-secondary">No downloads recorded yet</p>
             </div>
           ) : (
-            <div className="divide-y divide-border dark:divide-slate-700 max-h-96 overflow-y-auto">
+            <div className="divide-y divide-border max-h-96 overflow-y-auto">
               {stats.recent_downloads.map((download) => (
-                <div key={download.id} className="px-4 py-3 hover:bg-gray-50 dark:hover:bg-slate-700">
+                <div key={download.id} className="px-4 py-3 hover:bg-card dark:hover:bg-card-hover">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-3">
                       <DownloadTypeIcon type={download.download_type} />
                       <div>
-                        <p className="text-sm text-text-primary dark:text-slate-100">
+                        <p className="text-sm text-text-primary">
                           {download.full_name || download.email || 'Unknown User'}
                         </p>
-                        <p className="text-xs text-text-secondary dark:text-slate-400">
+                        <p className="text-xs text-text-secondary">
                           {DOWNLOAD_TYPE_LABELS[download.download_type] || download.download_type}
                           {download.target_count && download.target_count > 1 && (
                             <span className="ml-1">({download.target_count} targets)</span>
@@ -339,7 +339,7 @@ export default function AdminDownloadsPage() {
                         </p>
                       </div>
                     </div>
-                    <span className="text-xs text-text-secondary dark:text-slate-400">
+                    <span className="text-xs text-text-secondary">
                       {formatTimestamp(download.requested_at)}
                     </span>
                   </div>
@@ -351,20 +351,20 @@ export default function AdminDownloadsPage() {
 
         {/* Most Downloaded Objects */}
         <Card className="overflow-hidden">
-          <div className="px-4 py-3 border-b border-border dark:border-slate-700">
-            <h2 className="text-lg font-medium text-text-primary dark:text-slate-100">Most Downloaded Targets</h2>
+          <div className="px-4 py-3 border-b border-border">
+            <h2 className="text-lg font-medium text-text-primary">Most Downloaded Targets</h2>
           </div>
           {!stats?.most_downloaded_targets || stats.most_downloaded_targets.length === 0 ? (
             <div className="p-8 text-center">
-              <p className="text-text-secondary dark:text-slate-400">No target download data yet</p>
+              <p className="text-text-secondary">No target download data yet</p>
             </div>
           ) : (
-            <div className="divide-y divide-border dark:divide-slate-700 max-h-96 overflow-y-auto">
+            <div className="divide-y divide-border max-h-96 overflow-y-auto">
               {stats.most_downloaded_targets.map((item, index) => (
-                <div key={item.target_id} className="px-4 py-3 hover:bg-gray-50 dark:hover:bg-slate-700">
+                <div key={item.target_id} className="px-4 py-3 hover:bg-card dark:hover:bg-card-hover">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-3">
-                      <span className="w-6 h-6 flex items-center justify-center text-xs font-medium text-text-secondary dark:text-slate-400 bg-gray-100 dark:bg-slate-800 rounded">
+                      <span className="w-6 h-6 flex items-center justify-center text-xs font-medium text-text-secondary bg-card rounded">
                         {index + 1}
                       </span>
                       <Link
@@ -374,7 +374,7 @@ export default function AdminDownloadsPage() {
                         {item.target_id}
                       </Link>
                     </div>
-                    <span className="text-sm text-text-secondary dark:text-slate-400">
+                    <span className="text-sm text-text-secondary">
                       {item.download_count} download{item.download_count !== 1 ? 's' : ''}
                     </span>
                   </div>

--- a/web/app/admin/layout.tsx
+++ b/web/app/admin/layout.tsx
@@ -29,7 +29,7 @@ export default function AdminLayout({
     return (
       <div className="container mx-auto px-4 py-16 flex items-center justify-center">
         <Loader2 className="w-8 h-8 animate-spin text-primary" />
-        <span className="ml-3 text-text-secondary dark:text-slate-400">Loading...</span>
+        <span className="ml-3 text-text-secondary">Loading...</span>
       </div>
     );
   }
@@ -42,15 +42,15 @@ export default function AdminLayout({
           <div className="w-16 h-16 bg-red-100 dark:bg-red-950 rounded-full flex items-center justify-center mx-auto mb-4">
             <AlertTriangle className="w-8 h-8 text-red-600 dark:text-red-400" />
           </div>
-          <h1 className="text-2xl font-semibold text-text-primary dark:text-slate-100 mb-2">
+          <h1 className="text-2xl font-semibold text-text-primary mb-2">
             Authentication Required
           </h1>
-          <p className="text-text-secondary dark:text-slate-400 mb-6">
+          <p className="text-text-secondary mb-6">
             Please sign in to access the admin area.
           </p>
           <Link
             href="/login"
-            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-hover transition-colors"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary rounded-lg hover:bg-primary-hover transition-colors"
           >
             Sign In
           </Link>
@@ -67,15 +67,15 @@ export default function AdminLayout({
           <div className="w-16 h-16 bg-red-100 dark:bg-red-950 rounded-full flex items-center justify-center mx-auto mb-4">
             <Shield className="w-8 h-8 text-red-600 dark:text-red-400" />
           </div>
-          <h1 className="text-2xl font-semibold text-text-primary dark:text-slate-100 mb-2">
+          <h1 className="text-2xl font-semibold text-text-primary mb-2">
             Access Denied
           </h1>
-          <p className="text-text-secondary dark:text-slate-400 mb-6">
+          <p className="text-text-secondary mb-6">
             You don&apos;t have permission to access the admin area.
           </p>
           <Link
             href="/"
-            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-hover transition-colors"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary rounded-lg hover:bg-primary-hover transition-colors"
           >
             Return Home
           </Link>
@@ -91,7 +91,7 @@ export default function AdminLayout({
         <aside className="w-56 flex-shrink-0">
           <div className="flex items-center gap-2 mb-6">
             <Shield className="w-6 h-6 text-primary" />
-            <h1 className="text-xl font-semibold text-text-primary dark:text-slate-100">Admin</h1>
+            <h1 className="text-xl font-semibold text-text-primary">Admin</h1>
           </div>
 
           <nav className="space-y-1">
@@ -106,8 +106,8 @@ export default function AdminLayout({
                   className={`
                     flex items-center gap-3 px-4 py-2 rounded-lg transition-colors
                     ${isActive
-                      ? 'bg-primary text-white'
-                      : 'text-text-secondary dark:text-slate-400 hover:bg-card dark:hover:bg-slate-700 hover:text-text-primary dark:hover:text-slate-100'
+                      ? 'bg-primary text-on-primary'
+                      : 'text-text-secondary hover:bg-card dark:hover:bg-card-hover hover:text-text-primary'
                     }
                   `}
                 >

--- a/web/app/admin/nircam/[id]/page.tsx
+++ b/web/app/admin/nircam/[id]/page.tsx
@@ -213,7 +213,7 @@ export default function ExposureDetailPage() {
   if (!exposure) {
     return (
       <div className="py-8">
-        <p className="text-text-secondary dark:text-slate-400">Exposure not found.</p>
+        <p className="text-text-secondary">Exposure not found.</p>
         <Link href="/admin/nircam" className="text-primary hover:underline mt-2 inline-block">
           Back to NIRCam
         </Link>
@@ -240,19 +240,19 @@ export default function ExposureDetailPage() {
     <div>
       {/* Header */}
       <div className="flex items-center gap-3 mb-6">
-        <button onClick={() => router.push('/admin/nircam')} className="text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-100" title="Back to list">
+        <button onClick={() => router.push('/admin/nircam')} className="text-text-secondary hover:text-text-primary" title="Back to list">
           <ArrowLeft className="w-5 h-5" />
         </button>
         <div className="flex-1 min-w-0">
-          <h1 className="text-xl font-semibold font-mono text-text-primary dark:text-slate-100 truncate">
+          <h1 className="text-xl font-semibold font-mono text-text-primary truncate">
             {exposure.filename}
           </h1>
-          <p className="text-sm text-text-secondary dark:text-slate-400">
+          <p className="text-sm text-text-secondary">
             {exposure.field} / {exposure.filter} / {exposure.detector}
           </p>
         </div>
         {nav && (
-          <div className="flex items-center gap-1 text-sm text-text-secondary dark:text-slate-400">
+          <div className="flex items-center gap-1 text-sm text-text-secondary">
             <button
               onClick={handlePrev}
               disabled={nav.prev == null}
@@ -277,28 +277,28 @@ export default function ExposureDetailPage() {
         <button
           onClick={() => setShowHelp(prev => !prev)}
           title="Keyboard shortcuts (?)"
-          className="p-1.5 rounded text-text-secondary dark:text-slate-400 hover:bg-surface-hover dark:hover:bg-slate-800"
+          className="p-1.5 rounded text-text-secondary hover:bg-surface-hover dark:hover:bg-slate-800"
         >
           <Keyboard className="w-5 h-5" />
         </button>
       </div>
 
       {showHelp && (
-        <div className="mb-6 rounded-lg border border-border dark:border-slate-700 bg-card dark:bg-slate-900 p-4">
+        <div className="mb-6 rounded-lg border border-border bg-card dark:bg-slate-900 p-4">
           <div className="flex items-center justify-between mb-2">
-            <h2 className="text-sm font-semibold text-text-primary dark:text-slate-100">Keyboard shortcuts</h2>
-            <button onClick={() => setShowHelp(false)} className="text-xs text-text-secondary dark:text-slate-400 hover:underline">close</button>
+            <h2 className="text-sm font-semibold text-text-primary">Keyboard shortcuts</h2>
+            <button onClick={() => setShowHelp(false)} className="text-xs text-text-secondary hover:underline">close</button>
           </div>
           <dl className="grid grid-cols-2 gap-x-6 gap-y-1 text-sm">
-            <div className="flex justify-between"><dt>Next exposure</dt><dd className="font-mono text-text-secondary dark:text-slate-400">→ or N</dd></div>
-            <div className="flex justify-between"><dt>Previous</dt><dd className="font-mono text-text-secondary dark:text-slate-400">← or P</dd></div>
-            <div className="flex justify-between"><dt>Mark pending</dt><dd className="font-mono text-text-secondary dark:text-slate-400">1</dd></div>
-            <div className="flex justify-between"><dt>Mark approved</dt><dd className="font-mono text-text-secondary dark:text-slate-400">2</dd></div>
-            <div className="flex justify-between"><dt>Mark excluded</dt><dd className="font-mono text-text-secondary dark:text-slate-400">3</dd></div>
-            <div className="flex justify-between"><dt>Save</dt><dd className="font-mono text-text-secondary dark:text-slate-400">S</dd></div>
-            <div className="flex justify-between"><dt>Help</dt><dd className="font-mono text-text-secondary dark:text-slate-400">?</dd></div>
+            <div className="flex justify-between"><dt>Next exposure</dt><dd className="font-mono text-text-secondary">→ or N</dd></div>
+            <div className="flex justify-between"><dt>Previous</dt><dd className="font-mono text-text-secondary">← or P</dd></div>
+            <div className="flex justify-between"><dt>Mark pending</dt><dd className="font-mono text-text-secondary">1</dd></div>
+            <div className="flex justify-between"><dt>Mark approved</dt><dd className="font-mono text-text-secondary">2</dd></div>
+            <div className="flex justify-between"><dt>Mark excluded</dt><dd className="font-mono text-text-secondary">3</dd></div>
+            <div className="flex justify-between"><dt>Save</dt><dd className="font-mono text-text-secondary">S</dd></div>
+            <div className="flex justify-between"><dt>Help</dt><dd className="font-mono text-text-secondary">?</dd></div>
           </dl>
-          <p className="mt-2 text-xs text-text-secondary dark:text-slate-400">
+          <p className="mt-2 text-xs text-text-secondary">
             Navigation auto-saves the triage panel if there are unsaved changes. Mask edits save separately from the editor toolbar.
           </p>
         </div>
@@ -332,7 +332,7 @@ export default function ExposureDetailPage() {
                 className="w-full h-auto"
               />
             ) : (
-              <div className="flex items-center justify-center py-24 text-text-secondary dark:text-slate-400">
+              <div className="flex items-center justify-center py-24 text-text-secondary">
                 No PNG available
               </div>
             )}
@@ -343,32 +343,32 @@ export default function ExposureDetailPage() {
         <div className="w-80 flex-shrink-0 space-y-4">
           {/* Metadata */}
           <Card className="p-4">
-            <h2 className="text-sm font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider mb-3">
+            <h2 className="text-sm font-medium text-text-secondary uppercase tracking-wider mb-3">
               Metadata
             </h2>
             <dl className="space-y-2 text-sm">
               <div className="flex justify-between">
-                <dt className="text-text-secondary dark:text-slate-400">Field</dt>
-                <dd className="text-text-primary dark:text-slate-100">{exposure.field}</dd>
+                <dt className="text-text-secondary">Field</dt>
+                <dd className="text-text-primary">{exposure.field}</dd>
               </div>
               <div className="flex justify-between">
-                <dt className="text-text-secondary dark:text-slate-400">Filter</dt>
-                <dd className="text-text-primary dark:text-slate-100">{exposure.filter}</dd>
+                <dt className="text-text-secondary">Filter</dt>
+                <dd className="text-text-primary">{exposure.filter}</dd>
               </div>
               <div className="flex justify-between">
-                <dt className="text-text-secondary dark:text-slate-400">Detector</dt>
-                <dd className="text-text-primary dark:text-slate-100">{exposure.detector}</dd>
+                <dt className="text-text-secondary">Detector</dt>
+                <dd className="text-text-primary">{exposure.detector}</dd>
               </div>
               <div className="flex justify-between">
-                <dt className="text-text-secondary dark:text-slate-400">Visit</dt>
-                <dd className="text-text-primary dark:text-slate-100 font-mono text-xs">{exposure.visit || '—'}</dd>
+                <dt className="text-text-secondary">Visit</dt>
+                <dd className="text-text-primary font-mono text-xs">{exposure.visit || '—'}</dd>
               </div>
               <div className="flex justify-between">
-                <dt className="text-text-secondary dark:text-slate-400">Date</dt>
-                <dd className="text-text-primary dark:text-slate-100">{exposure.date_obs || '—'}</dd>
+                <dt className="text-text-secondary">Date</dt>
+                <dd className="text-text-primary">{exposure.date_obs || '—'}</dd>
               </div>
               <div className="flex justify-between">
-                <dt className="text-text-secondary dark:text-slate-400">Stage</dt>
+                <dt className="text-text-secondary">Stage</dt>
                 <dd>
                   <span className={`inline-flex px-2 py-0.5 text-xs font-medium rounded-full font-mono ${stageBadgeClasses(exposure.stage)}`}>
                     {exposure.stage}
@@ -377,8 +377,8 @@ export default function ExposureDetailPage() {
               </div>
               {(exposure.ra_center != null && exposure.dec_center != null) && (
                 <div className="flex justify-between">
-                  <dt className="text-text-secondary dark:text-slate-400">RA, Dec</dt>
-                  <dd className="text-text-primary dark:text-slate-100 font-mono text-xs">
+                  <dt className="text-text-secondary">RA, Dec</dt>
+                  <dd className="text-text-primary font-mono text-xs">
                     {exposure.ra_center.toFixed(5)}, {exposure.dec_center.toFixed(5)}
                   </dd>
                 </div>
@@ -388,18 +388,18 @@ export default function ExposureDetailPage() {
 
           {/* Triage controls */}
           <Card className="p-4">
-            <h2 className="text-sm font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider mb-3">
+            <h2 className="text-sm font-medium text-text-secondary uppercase tracking-wider mb-3">
               Triage
             </h2>
             <div className="space-y-3">
               <div>
-                <label className="block text-xs font-medium text-text-secondary dark:text-slate-400 mb-1">
+                <label className="block text-xs font-medium text-text-secondary mb-1">
                   Review Status
                 </label>
                 <select
                   value={reviewStatus}
                   onChange={(e) => setReviewStatus(e.target.value)}
-                  className="w-full text-sm border border-border dark:border-slate-600 rounded-lg px-3 py-2 bg-white dark:bg-slate-800 text-text-primary dark:text-slate-100"
+                  className="w-full text-sm border border-border dark:border-border-strong rounded-lg px-3 py-2 bg-card text-text-primary"
                 >
                   <option value="pending">Pending</option>
                   <option value="approved">Approved</option>
@@ -408,13 +408,13 @@ export default function ExposureDetailPage() {
               </div>
 
               <div>
-                <label className="block text-xs font-medium text-text-secondary dark:text-slate-400 mb-1">
+                <label className="block text-xs font-medium text-text-secondary mb-1">
                   Masking
                 </label>
                 <select
                   value={masking}
                   onChange={(e) => setMasking(e.target.value)}
-                  className="w-full text-sm border border-border dark:border-slate-600 rounded-lg px-3 py-2 bg-white dark:bg-slate-800 text-text-primary dark:text-slate-100"
+                  className="w-full text-sm border border-border dark:border-border-strong rounded-lg px-3 py-2 bg-card text-text-primary"
                 >
                   <option value="none">None</option>
                   <option value="needed">Needed</option>
@@ -423,13 +423,13 @@ export default function ExposureDetailPage() {
               </div>
 
               <div>
-                <label className="block text-xs font-medium text-text-secondary dark:text-slate-400 mb-1">
+                <label className="block text-xs font-medium text-text-secondary mb-1">
                   Correction
                 </label>
                 <select
                   value={correction}
                   onChange={(e) => setCorrection(e.target.value)}
-                  className="w-full text-sm border border-border dark:border-slate-600 rounded-lg px-3 py-2 bg-white dark:bg-slate-800 text-text-primary dark:text-slate-100"
+                  className="w-full text-sm border border-border dark:border-border-strong rounded-lg px-3 py-2 bg-card text-text-primary"
                 >
                   <option value="none">None</option>
                   <option value="needed">Needed</option>
@@ -438,7 +438,7 @@ export default function ExposureDetailPage() {
               </div>
 
               <div>
-                <label className="block text-xs font-medium text-text-secondary dark:text-slate-400 mb-1">
+                <label className="block text-xs font-medium text-text-secondary mb-1">
                   Notes
                 </label>
                 <textarea
@@ -446,7 +446,7 @@ export default function ExposureDetailPage() {
                   onChange={(e) => setNotes(e.target.value)}
                   placeholder="Describe artifacts, masking needs, etc."
                   rows={4}
-                  className="w-full text-sm border border-border dark:border-slate-600 rounded-lg px-3 py-2 bg-white dark:bg-slate-800 text-text-primary dark:text-slate-100 resize-none"
+                  className="w-full text-sm border border-border dark:border-border-strong rounded-lg px-3 py-2 bg-card text-text-primary resize-none"
                 />
               </div>
 

--- a/web/app/admin/nircam/page.tsx
+++ b/web/app/admin/nircam/page.tsx
@@ -35,14 +35,14 @@ function ReviewBadge({ status }: { status: string }) {
     excluded: 'bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-300',
   };
   return (
-    <span className={`inline-flex px-2 py-0.5 text-xs font-medium rounded-full ${colors[status] || 'bg-gray-100 dark:bg-slate-700 text-gray-800 dark:text-slate-300'}`}>
+    <span className={`inline-flex px-2 py-0.5 text-xs font-medium rounded-full ${colors[status] || 'bg-surface-2 dark:bg-slate-700 text-text-primary dark:text-slate-300'}`}>
       {status}
     </span>
   );
 }
 
 function ActionBadge({ status, label }: { status: string; label: string }) {
-  if (status === 'none') return <span className="text-xs text-text-secondary dark:text-slate-500">&mdash;</span>;
+  if (status === 'none') return <span className="text-xs text-text-secondary dark:text-text-tertiary">&mdash;</span>;
   const colors: Record<string, string> = {
     needed: 'bg-orange-100 dark:bg-orange-900 text-orange-800 dark:text-orange-300',
     done: 'bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-300',
@@ -75,11 +75,11 @@ function StageDistributionBar({ progress }: { progress: ReductionProgress }) {
     .filter(s => s.count > 0);
 
   if (segments.length === 0) {
-    return <div className="h-3 bg-gray-100 dark:bg-slate-800 rounded" />;
+    return <div className="h-3 bg-surface-2 dark:bg-slate-800 rounded" />;
   }
 
   return (
-    <div className="flex h-3 rounded overflow-hidden bg-gray-100 dark:bg-slate-800">
+    <div className="flex h-3 rounded overflow-hidden bg-surface-2 dark:bg-slate-800">
       {segments.map(({ stage, count }) => (
         <div
           key={stage}
@@ -99,8 +99,8 @@ function StageDistributionBar({ progress }: { progress: ReductionProgress }) {
 function ProgressTable({ progress }: { progress: ReductionProgress[] }) {
   if (progress.length === 0) {
     return (
-      <p className="text-sm text-text-secondary dark:text-slate-400 py-4">
-        No reduction data available. Deploy exposures with <code className="text-xs bg-card dark:bg-slate-700 px-1 py-0.5 rounded">campfire deploy nircam</code>.
+      <p className="text-sm text-text-secondary py-4">
+        No reduction data available. Deploy exposures with <code className="text-xs bg-card dark:bg-card-hover px-1 py-0.5 rounded">campfire deploy nircam</code>.
       </p>
     );
   }
@@ -108,23 +108,23 @@ function ProgressTable({ progress }: { progress: ReductionProgress[] }) {
   return (
     <div className="overflow-x-auto">
       <table className="w-full text-sm">
-        <thead className="border-b border-border dark:border-slate-700">
+        <thead className="border-b border-border">
           <tr>
-            <th className="px-3 py-2 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase">Field</th>
-            <th className="px-3 py-2 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase">Filter</th>
-            <th className="px-3 py-2 text-right text-xs font-medium text-text-secondary dark:text-slate-400 uppercase">Total</th>
-            <th className="px-3 py-2 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase w-1/3">Stage distribution</th>
-            <th className="px-3 py-2 text-right text-xs font-medium text-text-secondary dark:text-slate-400 uppercase">Pending</th>
-            <th className="px-3 py-2 text-right text-xs font-medium text-text-secondary dark:text-slate-400 uppercase">Masking</th>
-            <th className="px-3 py-2 text-right text-xs font-medium text-text-secondary dark:text-slate-400 uppercase">Correction</th>
+            <th className="px-3 py-2 text-left text-xs font-medium text-text-secondary uppercase">Field</th>
+            <th className="px-3 py-2 text-left text-xs font-medium text-text-secondary uppercase">Filter</th>
+            <th className="px-3 py-2 text-right text-xs font-medium text-text-secondary uppercase">Total</th>
+            <th className="px-3 py-2 text-left text-xs font-medium text-text-secondary uppercase w-1/3">Stage distribution</th>
+            <th className="px-3 py-2 text-right text-xs font-medium text-text-secondary uppercase">Pending</th>
+            <th className="px-3 py-2 text-right text-xs font-medium text-text-secondary uppercase">Masking</th>
+            <th className="px-3 py-2 text-right text-xs font-medium text-text-secondary uppercase">Correction</th>
           </tr>
         </thead>
-        <tbody className="divide-y divide-border dark:divide-slate-700">
+        <tbody className="divide-y divide-border">
           {progress.map((row) => (
             <tr key={`${row.field}-${row.filter}`} className="hover:bg-card/50 dark:hover:bg-slate-700/50">
-              <td className="px-3 py-2 font-medium text-text-primary dark:text-slate-100">{row.field}</td>
-              <td className="px-3 py-2 text-text-primary dark:text-slate-100">{row.filter}</td>
-              <td className="px-3 py-2 text-right text-text-primary dark:text-slate-100">{row.total}</td>
+              <td className="px-3 py-2 font-medium text-text-primary">{row.field}</td>
+              <td className="px-3 py-2 text-text-primary">{row.filter}</td>
+              <td className="px-3 py-2 text-right text-text-primary">{row.total}</td>
               <td className="px-3 py-2">
                 <StageDistributionBar progress={row} />
               </td>
@@ -132,21 +132,21 @@ function ProgressTable({ progress }: { progress: ReductionProgress[] }) {
                 {row.pending_review > 0 ? (
                   <span className="text-yellow-600 dark:text-yellow-400 font-medium">{row.pending_review}</span>
                 ) : (
-                  <span className="text-text-secondary dark:text-slate-500">0</span>
+                  <span className="text-text-secondary dark:text-text-tertiary">0</span>
                 )}
               </td>
               <td className="px-3 py-2 text-right">
                 {row.needs_masking > 0 ? (
                   <span className="text-orange-600 dark:text-orange-400 font-medium">{row.needs_masking}</span>
                 ) : (
-                  <span className="text-text-secondary dark:text-slate-500">0</span>
+                  <span className="text-text-secondary dark:text-text-tertiary">0</span>
                 )}
               </td>
               <td className="px-3 py-2 text-right">
                 {row.needs_correction > 0 ? (
                   <span className="text-orange-600 dark:text-orange-400 font-medium">{row.needs_correction}</span>
                 ) : (
-                  <span className="text-text-secondary dark:text-slate-500">0</span>
+                  <span className="text-text-secondary dark:text-text-tertiary">0</span>
                 )}
               </td>
             </tr>
@@ -185,20 +185,20 @@ function ExcludedPanel({ excluded }: { excluded: ExcludedExposure[] }) {
 
   return (
     <Card className="mb-6 overflow-hidden">
-      <div className="px-4 py-3 border-b border-border dark:border-slate-700 flex items-baseline justify-between">
-        <h2 className="text-sm font-medium text-text-primary dark:text-slate-100 uppercase tracking-wider">
+      <div className="px-4 py-3 border-b border-border flex items-baseline justify-between">
+        <h2 className="text-sm font-medium text-text-primary uppercase tracking-wider">
           Excluded — copy into <code className="font-mono text-xs">fields.toml</code> <code className="font-mono text-xs">skip = […]</code>
         </h2>
-        <span className="text-xs text-text-secondary dark:text-slate-400">{excluded.length} total</span>
+        <span className="text-xs text-text-secondary">{excluded.length} total</span>
       </div>
-      <div className="divide-y divide-border dark:divide-slate-700">
+      <div className="divide-y divide-border">
         {groups.map(([heading, rows]) => {
           const tomlBlock = rows.map(r => `    "${r.filename}",`).join('\n');
           return (
             <div key={heading} className="p-4">
               <div className="flex items-baseline justify-between mb-2">
-                <h3 className="text-xs font-medium text-text-secondary dark:text-slate-400">
-                  {heading} <span className="text-text-secondary dark:text-slate-500">({rows.length})</span>
+                <h3 className="text-xs font-medium text-text-secondary">
+                  {heading} <span className="text-text-secondary dark:text-text-tertiary">({rows.length})</span>
                 </h3>
                 <button
                   onClick={() => copy(heading, tomlBlock)}
@@ -213,7 +213,7 @@ function ExcludedPanel({ excluded }: { excluded: ExcludedExposure[] }) {
               </div>
               <pre className="text-xs font-mono bg-card dark:bg-slate-900 p-2 rounded overflow-x-auto text-text-primary dark:text-slate-300">{tomlBlock}</pre>
               {rows.some(r => r.notes) && (
-                <ul className="mt-2 text-xs text-text-secondary dark:text-slate-400 space-y-0.5">
+                <ul className="mt-2 text-xs text-text-secondary space-y-0.5">
                   {rows.filter(r => r.notes).map(r => (
                     <li key={r.filename}>
                       <span className="font-mono">{r.filename}</span> — {r.notes}
@@ -338,7 +338,7 @@ export default function AdminNircamPage() {
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-semibold text-text-primary dark:text-slate-100">NIRCam Reductions</h1>
+        <h1 className="text-2xl font-semibold text-text-primary">NIRCam Reductions</h1>
         <Button variant="secondary" size="sm" onClick={handleRefresh} disabled={loading || pageLoading}>
           <RefreshCw className={`w-4 h-4 mr-2 ${pageLoading ? 'animate-spin' : ''}`} />
           Refresh
@@ -353,8 +353,8 @@ export default function AdminNircamPage() {
 
       {/* Progress summary */}
       <Card className="mb-6 overflow-hidden">
-        <div className="px-4 py-3 border-b border-border dark:border-slate-700">
-          <h2 className="text-sm font-medium text-text-primary dark:text-slate-100 uppercase tracking-wider">
+        <div className="px-4 py-3 border-b border-border">
+          <h2 className="text-sm font-medium text-text-primary uppercase tracking-wider">
             Reduction Progress
           </h2>
         </div>
@@ -369,7 +369,7 @@ export default function AdminNircamPage() {
         <select
           value={selectedField}
           onChange={(e) => setSelectedField(e.target.value)}
-          className="text-sm border border-border dark:border-slate-600 rounded-lg px-3 py-1.5 bg-white dark:bg-slate-800 text-text-primary dark:text-slate-100"
+          className="text-sm border border-border dark:border-border-strong rounded-lg px-3 py-1.5 bg-card text-text-primary"
         >
           <option value="">All fields</option>
           {filterOptions.fields.map(f => <option key={f} value={f}>{f}</option>)}
@@ -377,7 +377,7 @@ export default function AdminNircamPage() {
         <select
           value={selectedFilter}
           onChange={(e) => setSelectedFilter(e.target.value)}
-          className="text-sm border border-border dark:border-slate-600 rounded-lg px-3 py-1.5 bg-white dark:bg-slate-800 text-text-primary dark:text-slate-100"
+          className="text-sm border border-border dark:border-border-strong rounded-lg px-3 py-1.5 bg-card text-text-primary"
         >
           <option value="">All filters</option>
           {filterOptions.filters.map(f => <option key={f} value={f}>{f}</option>)}
@@ -385,7 +385,7 @@ export default function AdminNircamPage() {
         <select
           value={selectedDetector}
           onChange={(e) => setSelectedDetector(e.target.value)}
-          className="text-sm border border-border dark:border-slate-600 rounded-lg px-3 py-1.5 bg-white dark:bg-slate-800 text-text-primary dark:text-slate-100"
+          className="text-sm border border-border dark:border-border-strong rounded-lg px-3 py-1.5 bg-card text-text-primary"
         >
           <option value="">All detectors</option>
           {filterOptions.detectors.map(d => <option key={d} value={d}>{d}</option>)}
@@ -393,7 +393,7 @@ export default function AdminNircamPage() {
         <select
           value={selectedStage}
           onChange={(e) => setSelectedStage(e.target.value)}
-          className="text-sm border border-border dark:border-slate-600 rounded-lg px-3 py-1.5 bg-white dark:bg-slate-800 text-text-primary dark:text-slate-100"
+          className="text-sm border border-border dark:border-border-strong rounded-lg px-3 py-1.5 bg-card text-text-primary"
         >
           <option value="">All stages</option>
           {NIRCAM_STAGES.map(s => <option key={s} value={s}>{s}</option>)}
@@ -401,7 +401,7 @@ export default function AdminNircamPage() {
         <select
           value={selectedReview}
           onChange={(e) => setSelectedReview(e.target.value)}
-          className="text-sm border border-border dark:border-slate-600 rounded-lg px-3 py-1.5 bg-white dark:bg-slate-800 text-text-primary dark:text-slate-100"
+          className="text-sm border border-border dark:border-border-strong rounded-lg px-3 py-1.5 bg-card text-text-primary"
         >
           <option value="">All review statuses</option>
           <option value="pending">Pending</option>
@@ -421,22 +421,22 @@ export default function AdminNircamPage() {
       {/* Exposure table */}
       <Card className="overflow-hidden">
         <table className="w-full">
-          <thead className="bg-card dark:bg-slate-800 border-b border-border dark:border-slate-700">
+          <thead className="bg-card border-b border-border">
             <tr>
-              <th className="px-4 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase">Filename</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase">Filter</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase">Detector</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase">Stage</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase">Review</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase">Masking</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase">Correction</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase">Filename</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase">Filter</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase">Detector</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase">Stage</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase">Review</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase">Masking</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase">Correction</th>
               <th className="px-4 py-3"></th>
             </tr>
           </thead>
-          <tbody className="bg-white dark:bg-slate-800 divide-y divide-border dark:divide-slate-700">
+          <tbody className="bg-card divide-y divide-border">
             {exposures.length === 0 ? (
               <tr>
-                <td colSpan={8} className="px-4 py-12 text-center text-text-secondary dark:text-slate-400">
+                <td colSpan={8} className="px-4 py-12 text-center text-text-secondary">
                   No exposures found.
                 </td>
               </tr>
@@ -459,15 +459,15 @@ export default function AdminNircamPage() {
                       {exp.filename}
                     </Link>
                   </td>
-                  <td className="px-4 py-3 text-sm text-text-primary dark:text-slate-100">{exp.filter}</td>
-                  <td className="px-4 py-3 text-sm text-text-secondary dark:text-slate-400">{exp.detector}</td>
+                  <td className="px-4 py-3 text-sm text-text-primary">{exp.filter}</td>
+                  <td className="px-4 py-3 text-sm text-text-secondary">{exp.detector}</td>
                   <td className="px-4 py-3"><StageBadge stage={exp.stage} /></td>
                   <td className="px-4 py-3"><ReviewBadge status={exp.review_status} /></td>
                   <td className="px-4 py-3"><ActionBadge status={exp.masking} label="mask" /></td>
                   <td className="px-4 py-3"><ActionBadge status={exp.correction} label="corr" /></td>
                   <td className="px-4 py-3 text-right">
                     <Link href={`/admin/nircam/${exp.id}`} onClick={onRowEnter}>
-                      <ChevronRight className="w-4 h-4 text-text-secondary dark:text-slate-400" />
+                      <ChevronRight className="w-4 h-4 text-text-secondary" />
                     </Link>
                   </td>
                 </tr>
@@ -484,7 +484,7 @@ export default function AdminNircamPage() {
           onPageSizeChange={setPageSize}
           pageSizeOptions={PAGE_SIZE_OPTIONS}
           loading={pageLoading}
-          className="border-t border-border dark:border-slate-700"
+          className="border-t border-border"
         />
       </Card>
     </div>

--- a/web/app/admin/programs/page.tsx
+++ b/web/app/admin/programs/page.tsx
@@ -81,7 +81,7 @@ export default function AdminProgramsPage() {
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-semibold text-text-primary dark:text-slate-100">Programs</h1>
+        <h1 className="text-2xl font-semibold text-text-primary">Programs</h1>
         <Button variant="secondary" size="sm" onClick={fetchPrograms}>
           <RefreshCw className="w-4 h-4 mr-2" />
           Refresh
@@ -103,32 +103,32 @@ export default function AdminProgramsPage() {
 
       <Card className="overflow-hidden">
         <table className="w-full">
-          <thead className="bg-card dark:bg-slate-800 border-b border-border dark:border-slate-700">
+          <thead className="bg-card border-b border-border">
             <tr>
-              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
                 Program
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
                 PI
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
                 Targets
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
                 Users with Access
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
                 Visibility
               </th>
-              <th className="px-6 py-3 text-right text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+              <th className="px-6 py-3 text-right text-xs font-medium text-text-secondary uppercase tracking-wider">
                 Actions
               </th>
             </tr>
           </thead>
-          <tbody className="bg-white dark:bg-slate-800 divide-y divide-border dark:divide-slate-700">
+          <tbody className="bg-card divide-y divide-border">
             {programs.length === 0 ? (
               <tr>
-                <td colSpan={6} className="px-6 py-12 text-center text-text-secondary dark:text-slate-400">
+                <td colSpan={6} className="px-6 py-12 text-center text-text-secondary">
                   No programs found.
                 </td>
               </tr>
@@ -137,26 +137,26 @@ export default function AdminProgramsPage() {
                 <tr key={program.slug}>
                   <td className="px-6 py-4">
                     <div>
-                      <div className="text-sm font-medium text-text-primary dark:text-slate-100">
+                      <div className="text-sm font-medium text-text-primary">
                         {program.program_name || program.slug}
                       </div>
-                      <div className="text-xs text-text-secondary dark:text-slate-400">
+                      <div className="text-xs text-text-secondary">
                         {program.slug}
                       </div>
                     </div>
                   </td>
-                  <td className="px-6 py-4 text-sm text-text-secondary dark:text-slate-400">
+                  <td className="px-6 py-4 text-sm text-text-secondary">
                     {program.pi_name || '—'}
                   </td>
                   <td className="px-6 py-4">
-                    <div className="flex items-center gap-1 text-sm text-text-primary dark:text-slate-100">
-                      <FileText className="w-4 h-4 text-text-secondary dark:text-slate-400" />
+                    <div className="flex items-center gap-1 text-sm text-text-primary">
+                      <FileText className="w-4 h-4 text-text-secondary" />
                       {program.target_count}
                     </div>
                   </td>
                   <td className="px-6 py-4">
-                    <div className="flex items-center gap-1 text-sm text-text-primary dark:text-slate-100">
-                      <Users className="w-4 h-4 text-text-secondary dark:text-slate-400" />
+                    <div className="flex items-center gap-1 text-sm text-text-primary">
+                      <Users className="w-4 h-4 text-text-secondary" />
                       {program.is_public ? 'All' : program.user_access_count}
                     </div>
                   </td>
@@ -165,7 +165,7 @@ export default function AdminProgramsPage() {
                       className={`inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded-full ${
                         program.is_public
                           ? 'bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-300'
-                          : 'bg-gray-100 dark:bg-slate-700 text-gray-800 dark:text-slate-300'
+                          : 'bg-surface-2 text-text-primary dark:text-text-secondary'
                       }`}
                     >
                       {program.is_public ? (

--- a/web/app/admin/requests/page.tsx
+++ b/web/app/admin/requests/page.tsx
@@ -254,7 +254,7 @@ export default function AdminRequestsPage() {
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-semibold text-text-primary dark:text-slate-100">Account Requests</h1>
+        <h1 className="text-2xl font-semibold text-text-primary">Account Requests</h1>
         <Button variant="secondary" size="sm" onClick={fetchRequests} disabled={loading}>
           <RefreshCw className={`w-4 h-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
           Refresh
@@ -279,15 +279,15 @@ export default function AdminRequestsPage() {
               className={`
                 px-4 py-2 rounded-lg text-sm font-medium transition-colors
                 ${isActive
-                  ? 'bg-primary text-white'
-                  : 'bg-gray-100 dark:bg-slate-700 text-text-secondary dark:text-slate-400 hover:bg-gray-200 dark:hover:bg-slate-600'
+                  ? 'bg-primary text-on-primary'
+                  : 'bg-card-hover text-text-secondary hover:bg-surface-2'
                 }
               `}
             >
               {status.charAt(0).toUpperCase() + status.slice(1)}
               {count > 0 && (
                 <span className={`ml-2 px-2 py-0.5 rounded-full text-xs ${
-                  isActive ? 'bg-white/20' : 'bg-gray-200 dark:bg-slate-600'
+                  isActive ? 'bg-white/20' : 'bg-surface-2'
                 }`}>
                   {count}
                 </span>
@@ -300,26 +300,26 @@ export default function AdminRequestsPage() {
       {/* Requests Table */}
       <Card className="overflow-hidden">
         <table className="w-full">
-          <thead className="bg-card dark:bg-slate-800 border-b border-border dark:border-slate-700">
+          <thead className="bg-card border-b border-border">
             <tr>
-              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
                 Requester
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
                 Submitted
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
                 Status
               </th>
-              <th className="px-6 py-3 text-right text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+              <th className="px-6 py-3 text-right text-xs font-medium text-text-secondary uppercase tracking-wider">
                 Actions
               </th>
             </tr>
           </thead>
-          <tbody className="bg-white dark:bg-slate-800 divide-y divide-border dark:divide-slate-700">
+          <tbody className="bg-card divide-y divide-border">
             {requests.length === 0 ? (
               <tr>
-                <td colSpan={4} className="px-6 py-12 text-center text-text-secondary dark:text-slate-400">
+                <td colSpan={4} className="px-6 py-12 text-center text-text-secondary">
                   No {statusFilter === 'all' ? '' : statusFilter} requests found.
                 </td>
               </tr>
@@ -328,23 +328,23 @@ export default function AdminRequestsPage() {
                 <tr key={request.id}>
                   <td className="px-6 py-4">
                     <div>
-                      <div className="text-sm font-medium text-text-primary dark:text-slate-100">
+                      <div className="text-sm font-medium text-text-primary">
                         {request.full_name}
                       </div>
-                      <div className="text-sm text-text-secondary dark:text-slate-400 flex items-center gap-1">
+                      <div className="text-sm text-text-secondary flex items-center gap-1">
                         <Mail className="w-3 h-3" />
                         {request.email}
                       </div>
                     </div>
                   </td>
-                  <td className="px-6 py-4 text-sm text-text-secondary dark:text-slate-400">
+                  <td className="px-6 py-4 text-sm text-text-secondary">
                     {formatDate(request.created_at)}
                   </td>
                   <td className="px-6 py-4">
                     <div>
                       {getStatusBadge(request.status)}
                       {request.reviewed_at && request.reviewed_by_name && (
-                        <div className="text-xs text-text-secondary dark:text-slate-400 mt-1">
+                        <div className="text-xs text-text-secondary mt-1">
                           by {request.reviewed_by_name}
                         </div>
                       )}
@@ -374,7 +374,7 @@ export default function AdminRequestsPage() {
                       )}
                       <button
                         onClick={() => handleDelete(request)}
-                        className="text-text-secondary dark:text-slate-400 hover:text-red-600 dark:hover:text-red-400 transition-colors p-2"
+                        className="text-text-secondary hover:text-red-600 dark:hover:text-red-400 transition-colors p-2"
                         title="Delete request"
                       >
                         <Trash2 className="w-4 h-4" />
@@ -393,33 +393,33 @@ export default function AdminRequestsPage() {
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
           <Card className="w-full max-w-lg p-6">
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold text-text-primary dark:text-slate-100">
+              <h2 className="text-lg font-semibold text-text-primary">
                 Approve Request
               </h2>
               <button
                 onClick={() => setShowApproveModal(false)}
-                className="text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-100"
+                className="text-text-secondary hover:text-text-primary"
               >
                 <X className="w-5 h-5" />
               </button>
             </div>
 
-            <div className="mb-4 p-3 bg-gray-50 dark:bg-slate-700 rounded-lg">
-              <p className="text-sm text-text-primary dark:text-slate-100">
+            <div className="mb-4 p-3 bg-surface-2 rounded-lg">
+              <p className="text-sm text-text-primary">
                 <strong>Name:</strong> {selectedRequest.full_name}
               </p>
-              <p className="text-sm text-text-primary dark:text-slate-100">
+              <p className="text-sm text-text-primary">
                 <strong>Email:</strong> {selectedRequest.email}
               </p>
             </div>
 
             {/* Program Access */}
             <div className="mb-4">
-              <label className="block text-sm font-medium text-text-primary dark:text-slate-100 mb-2">
+              <label className="block text-sm font-medium text-text-primary mb-2">
                 Program Access
               </label>
               {programs.length === 0 ? (
-                <p className="text-sm text-text-secondary dark:text-slate-400">No programs available.</p>
+                <p className="text-sm text-text-secondary">No programs available.</p>
               ) : (
                 <>
                   <div className="grid grid-cols-2 gap-2 max-h-48 overflow-y-auto">
@@ -434,7 +434,7 @@ export default function AdminRequestsPage() {
                             transition-colors
                             ${selected
                               ? 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-300 hover:bg-green-200 dark:hover:bg-green-800'
-                              : 'bg-gray-100 dark:bg-slate-700 text-gray-600 dark:text-slate-400 hover:bg-gray-200 dark:hover:bg-slate-600'
+                              : 'bg-card-hover text-text-secondary hover:bg-gray-200 dark:hover:bg-slate-600'
                             }
                           `}
                         >
@@ -471,18 +471,18 @@ export default function AdminRequestsPage() {
                   type="checkbox"
                   checked={approveCanComment}
                   onChange={(e) => setApproveCanComment(e.target.checked)}
-                  className="w-4 h-4 rounded border-border dark:border-slate-600 text-primary focus:ring-primary dark:bg-slate-700"
+                  className="w-4 h-4 rounded border-border dark:border-border-strong text-primary focus:ring-primary dark:bg-surface-2"
                 />
-                <span className="text-sm text-text-primary dark:text-slate-100">Can comment/inspect</span>
+                <span className="text-sm text-text-primary">Can comment/inspect</span>
               </label>
               <label className="flex items-center gap-2 cursor-pointer">
                 <input
                   type="checkbox"
                   checked={approveIsAdmin}
                   onChange={(e) => setApproveIsAdmin(e.target.checked)}
-                  className="w-4 h-4 rounded border-border dark:border-slate-600 text-primary focus:ring-primary dark:bg-slate-700"
+                  className="w-4 h-4 rounded border-border dark:border-border-strong text-primary focus:ring-primary dark:bg-surface-2"
                 />
-                <span className="text-sm text-text-primary dark:text-slate-100">Admin privileges</span>
+                <span className="text-sm text-text-primary">Admin privileges</span>
               </label>
             </div>
 
@@ -522,38 +522,38 @@ export default function AdminRequestsPage() {
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
           <Card className="w-full max-w-md p-6">
             <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold text-text-primary dark:text-slate-100">
+              <h2 className="text-lg font-semibold text-text-primary">
                 Reject Request
               </h2>
               <button
                 onClick={() => setShowRejectModal(false)}
-                className="text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-100"
+                className="text-text-secondary hover:text-text-primary"
               >
                 <X className="w-5 h-5" />
               </button>
             </div>
 
-            <div className="mb-4 p-3 bg-gray-50 dark:bg-slate-700 rounded-lg">
-              <p className="text-sm text-text-primary dark:text-slate-100">
+            <div className="mb-4 p-3 bg-surface-2 rounded-lg">
+              <p className="text-sm text-text-primary">
                 <strong>Name:</strong> {selectedRequest.full_name}
               </p>
-              <p className="text-sm text-text-primary dark:text-slate-100">
+              <p className="text-sm text-text-primary">
                 <strong>Email:</strong> {selectedRequest.email}
               </p>
             </div>
 
             <div className="mb-6">
-              <label className="block text-sm font-medium text-text-primary dark:text-slate-100 mb-2">
+              <label className="block text-sm font-medium text-text-primary mb-2">
                 Reason (optional)
               </label>
               <textarea
                 value={rejectReason}
                 onChange={(e) => setRejectReason(e.target.value)}
-                className="w-full px-4 py-2 border border-border dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary"
+                className="w-full px-4 py-2 border border-border dark:border-border-strong rounded-lg bg-background dark:bg-surface-2 text-text-primary focus:outline-none focus:ring-2 focus:ring-primary"
                 placeholder="Enter a reason for rejection..."
                 rows={3}
               />
-              <p className="text-xs text-text-secondary dark:text-slate-400 mt-1">
+              <p className="text-xs text-text-secondary mt-1">
                 This is for internal tracking only.
               </p>
             </div>

--- a/web/app/admin/users/page.tsx
+++ b/web/app/admin/users/page.tsx
@@ -315,7 +315,7 @@ export default function AdminUsersPage() {
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-semibold text-text-primary dark:text-slate-100">Users</h1>
+        <h1 className="text-2xl font-semibold text-text-primary">Users</h1>
         <div className="flex gap-2">
           <Button variant="primary" size="sm" onClick={() => setShowInviteForm(true)}>
             <UserPlus className="w-4 h-4 mr-2" />
@@ -338,7 +338,7 @@ export default function AdminUsersPage() {
       {showInviteForm && (
         <Card className="mb-6 p-6">
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-text-primary dark:text-slate-100 flex items-center gap-2">
+            <h2 className="text-lg font-semibold text-text-primary flex items-center gap-2">
               <Mail className="w-5 h-5" />
               Invite New User
             </h2>
@@ -347,7 +347,7 @@ export default function AdminUsersPage() {
                 setShowInviteForm(false);
                 setInviteError(null);
               }}
-              className="text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-100"
+              className="text-text-secondary hover:text-text-primary"
             >
               <X className="w-5 h-5" />
             </button>
@@ -362,7 +362,7 @@ export default function AdminUsersPage() {
           <div className="space-y-4">
             {/* Email */}
             <div>
-              <label className="block text-sm font-medium text-text-primary dark:text-slate-100 mb-1">
+              <label className="block text-sm font-medium text-text-primary mb-1">
                 Email Address
               </label>
               <input
@@ -370,13 +370,13 @@ export default function AdminUsersPage() {
                 value={inviteEmail}
                 onChange={(e) => setInviteEmail(e.target.value)}
                 placeholder="user@example.com"
-                className="w-full px-4 py-2 border border-border dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary"
+                className="w-full px-4 py-2 border border-border dark:border-border-strong rounded-lg bg-background dark:bg-surface-2 text-text-primary focus:outline-none focus:ring-2 focus:ring-primary"
               />
             </div>
 
             {/* Program Access */}
             <div>
-              <label className="block text-sm font-medium text-text-primary dark:text-slate-100 mb-2">
+              <label className="block text-sm font-medium text-text-primary mb-2">
                 Program Access
               </label>
               <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
@@ -391,7 +391,7 @@ export default function AdminUsersPage() {
                         transition-colors
                         ${selected
                           ? 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-300 hover:bg-green-200 dark:hover:bg-green-800'
-                          : 'bg-gray-100 dark:bg-slate-700 text-gray-600 dark:text-slate-400 hover:bg-gray-200 dark:hover:bg-slate-600'
+                          : 'bg-card-hover text-text-secondary hover:bg-gray-200 dark:hover:bg-slate-600'
                         }
                       `}
                     >
@@ -426,18 +426,18 @@ export default function AdminUsersPage() {
                   type="checkbox"
                   checked={inviteCanComment}
                   onChange={(e) => setInviteCanComment(e.target.checked)}
-                  className="w-4 h-4 rounded border-border dark:border-slate-600 text-primary focus:ring-primary dark:bg-slate-700"
+                  className="w-4 h-4 rounded border-border dark:border-border-strong text-primary focus:ring-primary dark:bg-surface-2"
                 />
-                <span className="text-sm text-text-primary dark:text-slate-100">Can comment/inspect</span>
+                <span className="text-sm text-text-primary">Can comment/inspect</span>
               </label>
               <label className="flex items-center gap-2 cursor-pointer">
                 <input
                   type="checkbox"
                   checked={inviteIsAdmin}
                   onChange={(e) => setInviteIsAdmin(e.target.checked)}
-                  className="w-4 h-4 rounded border-border dark:border-slate-600 text-primary focus:ring-primary dark:bg-slate-700"
+                  className="w-4 h-4 rounded border-border dark:border-border-strong text-primary focus:ring-primary dark:bg-surface-2"
                 />
-                <span className="text-sm text-text-primary dark:text-slate-100">Admin privileges</span>
+                <span className="text-sm text-text-primary">Admin privileges</span>
               </label>
             </div>
 
@@ -479,7 +479,7 @@ export default function AdminUsersPage() {
       {/* Pending Invites */}
       {invites.length > 0 && (
         <Card className="mb-6 p-4">
-          <h3 className="text-sm font-medium text-text-primary dark:text-slate-100 mb-3">
+          <h3 className="text-sm font-medium text-text-primary mb-3">
             Pending Invites ({invites.length})
           </h3>
           <div className="space-y-2">
@@ -491,10 +491,10 @@ export default function AdminUsersPage() {
                 <div className="flex items-center gap-3">
                   <Mail className="w-4 h-4 text-yellow-600 dark:text-yellow-400" />
                   <div>
-                    <span className="text-sm font-medium text-text-primary dark:text-slate-100">
+                    <span className="text-sm font-medium text-text-primary">
                       {invite.email}
                     </span>
-                    <div className="text-xs text-text-secondary dark:text-slate-400">
+                    <div className="text-xs text-text-secondary">
                       {invite.program_slugs.length} programs ·
                       Invited {formatDate(invite.created_at)}
                       {invite.invited_by_name && ` by ${invite.invited_by_name}`}
@@ -505,7 +505,7 @@ export default function AdminUsersPage() {
                   <button
                     onClick={() => resendInvite(invite.id, invite.email)}
                     disabled={resendingInvite === invite.id}
-                    className="text-text-secondary dark:text-slate-400 hover:text-primary dark:hover:text-primary transition-colors disabled:opacity-50"
+                    className="text-text-secondary hover:text-primary dark:hover:text-primary transition-colors disabled:opacity-50"
                     title="Resend invite email"
                   >
                     {resendingInvite === invite.id ? (
@@ -516,7 +516,7 @@ export default function AdminUsersPage() {
                   </button>
                   <button
                     onClick={() => cancelInvite(invite.id)}
-                    className="text-text-secondary dark:text-slate-400 hover:text-red-600 dark:hover:text-red-400 transition-colors"
+                    className="text-text-secondary hover:text-red-600 dark:hover:text-red-400 transition-colors"
                     title="Cancel invite"
                   >
                     <X className="w-4 h-4" />
@@ -530,49 +530,49 @@ export default function AdminUsersPage() {
 
       <Card className="overflow-hidden">
         <table className="w-full">
-          <thead className="bg-card dark:bg-slate-800 border-b border-border dark:border-slate-700">
+          <thead className="bg-card border-b border-border">
             <tr>
-              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
                 User
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
                 Joined
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
                 Program Access
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+              <th className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider">
                 Role
               </th>
-              <th className="px-6 py-3 text-right text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+              <th className="px-6 py-3 text-right text-xs font-medium text-text-secondary uppercase tracking-wider">
                 Actions
               </th>
             </tr>
           </thead>
-          <tbody className="bg-white dark:bg-slate-800 divide-y divide-border dark:divide-slate-700">
+          <tbody className="bg-card divide-y divide-border">
             {users.length === 0 ? (
               <tr>
-                <td colSpan={5} className="px-6 py-12 text-center text-text-secondary dark:text-slate-400">
+                <td colSpan={5} className="px-6 py-12 text-center text-text-secondary">
                   No users found.
                 </td>
               </tr>
             ) : (
               users.map((user) => (
                 <React.Fragment key={user.user_id}>
-                  <tr className={expandedUser === user.user_id ? 'bg-gray-50 dark:bg-slate-700' : ''}>
+                  <tr className={expandedUser === user.user_id ? 'bg-surface-2' : ''}>
                     <td className="px-6 py-4">
                       <div className="flex items-center">
                         <div>
-                          <div className="text-sm font-medium text-text-primary dark:text-slate-100">
+                          <div className="text-sm font-medium text-text-primary">
                             {user.full_name}
                           </div>
                           {user.is_group_account && (
-                            <span className="text-xs text-text-secondary dark:text-slate-400">(Group account)</span>
+                            <span className="text-xs text-text-secondary">(Group account)</span>
                           )}
                         </div>
                       </div>
                     </td>
-                    <td className="px-6 py-4 text-sm text-text-secondary dark:text-slate-400">
+                    <td className="px-6 py-4 text-sm text-text-secondary">
                       {formatDate(user.created_at)}
                     </td>
                     <td className="px-6 py-4">
@@ -595,7 +595,7 @@ export default function AdminUsersPage() {
                         className={`inline-flex px-2 py-1 text-xs font-medium rounded-full ${
                           user.is_admin
                             ? 'bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-300'
-                            : 'bg-gray-100 dark:bg-slate-700 text-gray-800 dark:text-slate-300'
+                            : 'bg-surface-2 text-text-primary dark:text-text-secondary'
                         }`}
                       >
                         {user.is_admin ? 'Admin' : 'User'}
@@ -606,7 +606,7 @@ export default function AdminUsersPage() {
                         <button
                           onClick={() => toggleAdmin(user)}
                           disabled={savingUser === user.user_id}
-                          className="text-text-secondary dark:text-slate-400 hover:text-primary transition-colors disabled:opacity-50"
+                          className="text-text-secondary hover:text-primary transition-colors disabled:opacity-50"
                           title={user.is_admin ? 'Remove admin' : 'Make admin'}
                         >
                           {user.is_admin ? (
@@ -617,7 +617,7 @@ export default function AdminUsersPage() {
                         </button>
                         <button
                           onClick={() => deleteUser(user)}
-                          className="text-text-secondary dark:text-slate-400 hover:text-red-600 dark:hover:text-red-400 transition-colors"
+                          className="text-text-secondary hover:text-red-600 dark:hover:text-red-400 transition-colors"
                           title="Delete user"
                         >
                           <Trash2 className="w-5 h-5" />
@@ -629,10 +629,10 @@ export default function AdminUsersPage() {
                   {/* Expanded row for program access */}
                   {expandedUser === user.user_id && (
                     <tr>
-                      <td colSpan={5} className="px-6 py-4 bg-gray-50 dark:bg-slate-700 border-t border-border dark:border-slate-600">
+                      <td colSpan={5} className="px-6 py-4 bg-surface-2 border-t border-border dark:border-border-strong">
                         <div className="space-y-3">
                           <div className="flex items-center justify-between">
-                            <span className="text-sm font-medium text-text-primary dark:text-slate-100">
+                            <span className="text-sm font-medium text-text-primary">
                               Program Access
                             </span>
                             <div className="flex gap-2">
@@ -656,7 +656,7 @@ export default function AdminUsersPage() {
                           </div>
 
                           {proprietaryPrograms.length === 0 ? (
-                            <p className="text-sm text-text-secondary dark:text-slate-400">
+                            <p className="text-sm text-text-secondary">
                               No proprietary programs to manage access for.
                             </p>
                           ) : (
@@ -673,7 +673,7 @@ export default function AdminUsersPage() {
                                       transition-colors disabled:opacity-50
                                       ${hasAccess
                                         ? 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-300 hover:bg-green-200 dark:hover:bg-green-800'
-                                        : 'bg-gray-100 dark:bg-slate-700 text-gray-600 dark:text-slate-400 hover:bg-gray-200 dark:hover:bg-slate-600'
+                                        : 'bg-card-hover text-text-secondary hover:bg-gray-200 dark:hover:bg-slate-600'
                                       }
                                     `}
                                   >
@@ -688,7 +688,7 @@ export default function AdminUsersPage() {
                           )}
 
                           {savingUser === user.user_id && (
-                            <div className="flex items-center gap-2 text-sm text-text-secondary dark:text-slate-400">
+                            <div className="flex items-center gap-2 text-sm text-text-secondary">
                               <Loader2 className="w-4 h-4 animate-spin" />
                               Saving changes...
                             </div>

--- a/web/app/docs/[[...slug]]/page.tsx
+++ b/web/app/docs/[[...slug]]/page.tsx
@@ -68,15 +68,15 @@ export default function DocsPage() {
         <div className="w-16 h-16 bg-red-100 dark:bg-red-950 rounded-full flex items-center justify-center mx-auto mb-4">
           <AlertCircle className="w-8 h-8 text-red-600 dark:text-red-400" />
         </div>
-        <h1 className="text-2xl font-semibold text-text-primary dark:text-slate-100 mb-2">
+        <h1 className="text-2xl font-semibold text-text-primary mb-2">
           Page Not Found
         </h1>
-        <p className="text-text-secondary dark:text-slate-400 mb-6">
+        <p className="text-text-secondary mb-6">
           The documentation page you&apos;re looking for doesn&apos;t exist.
         </p>
         <Link
           href="/docs"
-          className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-hover transition-colors"
+          className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary rounded-lg hover:bg-primary-hover transition-colors"
         >
           Back to Docs
         </Link>
@@ -89,7 +89,7 @@ export default function DocsPage() {
       <article className="flex-1 min-w-0">
         {/* Breadcrumbs */}
         {breadcrumbs.length > 0 && (
-          <nav className="flex items-center gap-1 text-sm text-text-secondary dark:text-slate-400 mb-6">
+          <nav className="flex items-center gap-1 text-sm text-text-secondary mb-6">
             <Link href="/docs" className="hover:text-primary transition-colors">
               Docs
             </Link>
@@ -97,7 +97,7 @@ export default function DocsPage() {
               <React.Fragment key={crumb.slug}>
                 <ChevronRight className="w-4 h-4" />
                 {index === breadcrumbs.length - 1 ? (
-                  <span className="text-text-primary dark:text-slate-200">{crumb.title}</span>
+                  <span className="text-text-primary">{crumb.title}</span>
                 ) : (
                   <Link
                     href={`/docs/${crumb.slug}`}

--- a/web/app/docs/layout.tsx
+++ b/web/app/docs/layout.tsx
@@ -27,7 +27,7 @@ function NavItem({ item, level = 0 }: { item: DocPage; level?: number }) {
             w-full flex items-center justify-between gap-2 px-3 py-2 rounded-lg text-left transition-colors
             ${isActive || isParentOfActive
               ? 'bg-primary/10 text-primary dark:bg-primary/20'
-              : 'text-text-secondary dark:text-slate-400 hover:bg-card dark:hover:bg-slate-800 hover:text-text-primary dark:hover:text-slate-200'
+              : 'text-text-secondary hover:bg-card hover:text-text-primary'
             }
           `}
         >
@@ -42,7 +42,7 @@ function NavItem({ item, level = 0 }: { item: DocPage; level?: number }) {
           )}
         </button>
         {isOpen && (
-          <div className="ml-4 mt-1 space-y-1 border-l border-border dark:border-slate-700 pl-3">
+          <div className="ml-4 mt-1 space-y-1 border-l border-border pl-3">
             {item.children?.map((child) => (
               <NavItem key={child.slug} item={child} level={level + 1} />
             ))}
@@ -58,8 +58,8 @@ function NavItem({ item, level = 0 }: { item: DocPage; level?: number }) {
       className={`
         flex items-center gap-2 px-3 py-2 rounded-lg transition-colors
         ${isActive
-          ? 'bg-primary text-white'
-          : 'text-text-secondary dark:text-slate-400 hover:bg-card dark:hover:bg-slate-800 hover:text-text-primary dark:hover:text-slate-200'
+          ? 'bg-primary text-on-primary'
+          : 'text-text-secondary hover:bg-card hover:text-text-primary'
         }
       `}
     >
@@ -81,7 +81,7 @@ export default function DocsLayout({
       {/* Mobile sidebar toggle */}
       <button
         onClick={() => setSidebarOpen(!sidebarOpen)}
-        className="lg:hidden fixed bottom-4 right-4 z-50 p-3 bg-primary text-white rounded-full shadow-lg hover:bg-primary-hover transition-colors"
+        className="lg:hidden fixed bottom-4 right-4 z-50 p-3 bg-primary text-on-primary rounded-full shadow-lg hover:bg-primary-hover transition-colors"
         aria-label="Toggle navigation"
       >
         {sidebarOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
@@ -95,7 +95,7 @@ export default function DocsLayout({
             lg:sticky lg:top-24 lg:self-start lg:z-0
             lg:max-h-[calc(100vh-8rem)] lg:overflow-y-auto
             w-64 lg:w-56 flex-shrink-0
-            bg-background dark:bg-slate-900 lg:bg-transparent
+            bg-background lg:bg-transparent
             transform transition-transform duration-200 ease-in-out
             ${sidebarOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'}
             overflow-y-auto
@@ -114,7 +114,7 @@ export default function DocsLayout({
 
           <div className="flex items-center gap-2 mb-6">
             <BookOpen className="w-6 h-6 text-primary" />
-            <h1 className="text-xl font-semibold text-text-primary dark:text-slate-100">
+            <h1 className="text-xl font-semibold text-text-primary">
               Documentation
             </h1>
           </div>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -10,6 +10,11 @@
   /* Accent color (applied dynamically by AccentColorContext) */
   --primary: #c026d3;
   --primary-hover: #a21caf;
+  /* Phase 1 vocabulary — accent extras. Values mirror current usage (no visual change);
+     retuned to ember in the restyle phase. See docs/token-migration-plan.md */
+  --primary-text: #c026d3;          /* accent used as inline text/links (today = --primary) */
+  --on-primary: #ffffff;            /* text/icon on a primary fill */
+  --primary-soft: rgba(192, 38, 211, 0.10); /* active-chip / selected background */
 
   /* Theme colors — adapt in dark mode */
   --background: #ffffff;
@@ -18,6 +23,16 @@
   --border: #e2e8f0;
   --text-primary: #0f172a;
   --text-secondary: #64748b;
+  /* Phase 1 vocabulary — extended neutrals/text. Values match the current slate scale. */
+  --surface-2: #f1f5f9;             /* table headers, insets (today ≈ slate-100) */
+  --border-strong: #cbd5e1;         /* emphasized edges, inputs (today ≈ slate-300) */
+  --text-tertiary: #94a3b8;         /* muted, placeholder, icons (today ≈ slate-400) */
+
+  /* Phase 1 vocabulary — UI status (semantic). Approximate current usage; retuned later. */
+  --success: #16a34a;
+  --warning: #d97706;
+  --danger: #dc2626;
+  --info: #2563eb;
 
   /* Plotly chart colors (read via JavaScript) */
   --plot-bg: #ffffff;
@@ -50,6 +65,9 @@
   /* Accent color - muted/pale for dark mode (applied dynamically) */
   --primary: #e879f9;
   --primary-hover: #f0abfc;
+  --primary-text: #e879f9;          /* accent as inline text/links (today = --primary) */
+  --on-primary: #ffffff;            /* text/icon on a primary fill */
+  --primary-soft: rgba(232, 121, 249, 0.14); /* active-chip / selected background */
   --background-start-rgb: 15, 23, 42;
   --background-end-rgb: 15, 23, 42;
 
@@ -60,6 +78,16 @@
   --border: #334155;
   --text-primary: #f1f5f9;
   --text-secondary: #94a3b8;
+  /* Phase 1 vocabulary — extended neutrals/text (dark). Values match the current slate scale. */
+  --surface-2: #334155;             /* table headers, insets (today ≈ slate-700) */
+  --border-strong: #475569;         /* emphasized edges, inputs (today ≈ slate-600) */
+  --text-tertiary: #64748b;         /* muted, placeholder, icons (today ≈ slate-500) */
+
+  /* Phase 1 vocabulary — UI status (semantic, dark). Approximate current usage. */
+  --success: #4ade80;
+  --warning: #fbbf24;
+  --danger: #f87171;
+  --info: #60a5fa;
 
   --plot-bg: #0f172a;
   --plot-paper: #1e293b;

--- a/web/app/inspect/page.tsx
+++ b/web/app/inspect/page.tsx
@@ -60,20 +60,20 @@ function InspectPageInner() {
 
   if (!startId || authLoading || !user) {
     return (
-      <div className="fixed inset-0 z-[200] bg-background dark:bg-slate-900 flex items-center justify-center">
-        <Loader2 className="w-8 h-8 animate-spin text-text-secondary dark:text-slate-400" />
+      <div className="fixed inset-0 z-[200] bg-background flex items-center justify-center">
+        <Loader2 className="w-8 h-8 animate-spin text-text-secondary" />
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="fixed inset-0 z-[200] bg-background dark:bg-slate-900 flex items-center justify-center">
+      <div className="fixed inset-0 z-[200] bg-background flex items-center justify-center">
         <div className="text-center">
           <p className="text-lg text-red-500 mb-4">{error}</p>
           <button
             onClick={() => router.push('/nirspec')}
-            className="px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary-hover transition-colors"
+            className="px-4 py-2 bg-primary text-on-primary rounded-lg hover:bg-primary-hover transition-colors"
           >
             Back to NIRSpec
           </button>
@@ -84,8 +84,8 @@ function InspectPageInner() {
 
   if (loading || !object) {
     return (
-      <div className="fixed inset-0 z-[200] bg-background dark:bg-slate-900 flex items-center justify-center">
-        <div className="text-center text-text-secondary dark:text-slate-400">
+      <div className="fixed inset-0 z-[200] bg-background flex items-center justify-center">
+        <div className="text-center text-text-secondary">
           <Loader2 className="w-8 h-8 animate-spin mx-auto mb-3" />
           <p className="text-sm">Loading inspection mode...</p>
         </div>
@@ -108,8 +108,8 @@ export default function InspectPage() {
   return (
     <Suspense
       fallback={
-        <div className="fixed inset-0 z-[200] bg-background dark:bg-slate-900 flex items-center justify-center">
-          <Loader2 className="w-8 h-8 animate-spin text-text-secondary dark:text-slate-400" />
+        <div className="fixed inset-0 z-[200] bg-background flex items-center justify-center">
+          <Loader2 className="w-8 h-8 animate-spin text-text-secondary" />
         </div>
       }
     >

--- a/web/app/map/page.tsx
+++ b/web/app/map/page.tsx
@@ -30,18 +30,18 @@ export default async function MapPage({ searchParams }: MapPageProps) {
     return (
       <div className="container mx-auto px-4 py-8">
         <div className="flex flex-col items-center justify-center py-16 text-center">
-          <div className="w-16 h-16 bg-card dark:bg-slate-800 rounded-full flex items-center justify-center mb-6">
-            <LogIn className="w-8 h-8 text-text-secondary dark:text-slate-400" />
+          <div className="w-16 h-16 bg-card rounded-full flex items-center justify-center mb-6">
+            <LogIn className="w-8 h-8 text-text-secondary" />
           </div>
-          <h2 className="text-2xl font-semibold text-text-primary dark:text-slate-100 mb-2">
+          <h2 className="text-2xl font-semibold text-text-primary mb-2">
             Sign in to view the map
           </h2>
-          <p className="text-text-secondary dark:text-slate-400 mb-6 max-w-md">
+          <p className="text-text-secondary mb-6 max-w-md">
             Access to the image map viewer requires authentication.
           </p>
           <Link
             href="/login"
-            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-hover transition-colors"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary rounded-lg hover:bg-primary-hover transition-colors"
           >
             <LogIn className="w-5 h-5" />
             Sign In

--- a/web/app/nircam/page.tsx
+++ b/web/app/nircam/page.tsx
@@ -90,19 +90,19 @@ export default function NircamPage() {
         />
 
         <div className="flex flex-col items-center justify-center py-16 text-center">
-          <div className="w-16 h-16 bg-card dark:bg-slate-800 rounded-full flex items-center justify-center mb-6">
-            <LogIn className="w-8 h-8 text-text-secondary dark:text-slate-400" />
+          <div className="w-16 h-16 bg-card rounded-full flex items-center justify-center mb-6">
+            <LogIn className="w-8 h-8 text-text-secondary" />
           </div>
-          <h2 className="text-2xl font-semibold text-text-primary dark:text-slate-100 mb-2">
+          <h2 className="text-2xl font-semibold text-text-primary mb-2">
             Sign in to view NIRCam images
           </h2>
-          <p className="text-text-secondary dark:text-slate-400 mb-6 max-w-md">
+          <p className="text-text-secondary mb-6 max-w-md">
             Access to NIRCam imaging data requires authentication. Please sign in with your
             CAMPFIRE account to browse and download images.
           </p>
           <Link
             href="/login"
-            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-hover transition-colors"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary rounded-lg hover:bg-primary-hover transition-colors"
           >
             <LogIn className="w-5 h-5" />
             Sign In
@@ -127,9 +127,9 @@ export default function NircamPage() {
       <div className="mb-6">
         <div className="flex items-center gap-3 mb-2">
           <ImageIcon className="w-8 h-8 text-primary" />
-          <h1 className="text-2xl font-bold text-text-primary dark:text-slate-100">NIRCam Imaging</h1>
+          <h1 className="text-2xl font-bold text-text-primary">NIRCam Imaging</h1>
         </div>
-        <p className="text-text-secondary dark:text-slate-400">
+        <p className="text-text-secondary">
           Browse and download NIRCam mosaic images from CAMPFIRE fields
         </p>
       </div>
@@ -152,7 +152,7 @@ export default function NircamPage() {
       {loading && (
         <div className="flex items-center justify-center py-16">
           <Loader2 className="w-8 h-8 animate-spin text-primary" />
-          <span className="ml-3 text-text-secondary dark:text-slate-400">Loading images...</span>
+          <span className="ml-3 text-text-secondary">Loading images...</span>
         </div>
       )}
 
@@ -168,7 +168,7 @@ export default function NircamPage() {
         <>
           {/* Results Count */}
           <div className="mb-4 flex items-center justify-between">
-            <span className="text-sm text-text-secondary dark:text-slate-400">
+            <span className="text-sm text-text-secondary">
               {selectedImages.length.toLocaleString()} of {images.length.toLocaleString()} images selected
             </span>
           </div>
@@ -180,12 +180,12 @@ export default function NircamPage() {
 
           {/* Empty State */}
           {images.length === 0 ? (
-            <div className="text-center py-16 bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg">
-              <ImageIcon className="w-12 h-12 text-text-secondary dark:text-slate-400 mx-auto mb-4" />
-              <p className="text-text-secondary dark:text-slate-400">
+            <div className="text-center py-16 bg-card border border-border rounded-lg">
+              <ImageIcon className="w-12 h-12 text-text-secondary mx-auto mb-4" />
+              <p className="text-text-secondary">
                 No NIRCam images available yet.
               </p>
-              <p className="text-text-secondary dark:text-slate-400 text-sm mt-2">
+              <p className="text-text-secondary text-sm mt-2">
                 Check back later or contact the team if you expected to see data here.
               </p>
             </div>

--- a/web/app/nirspec/metadata/page.tsx
+++ b/web/app/nirspec/metadata/page.tsx
@@ -187,19 +187,19 @@ function MetadataPageContent() {
           className="mb-6"
         />
         <div className="flex flex-col items-center justify-center py-16 text-center">
-          <div className="w-16 h-16 bg-card dark:bg-slate-800 rounded-full flex items-center justify-center mb-6">
-            <LogIn className="w-8 h-8 text-text-secondary dark:text-slate-400" />
+          <div className="w-16 h-16 bg-card rounded-full flex items-center justify-center mb-6">
+            <LogIn className="w-8 h-8 text-text-secondary" />
           </div>
-          <h2 className="text-2xl font-semibold text-text-primary dark:text-slate-100 mb-2">
+          <h2 className="text-2xl font-semibold text-text-primary mb-2">
             Sign in to view database metadata
           </h2>
-          <p className="text-text-secondary dark:text-slate-400 mb-6 max-w-md">
+          <p className="text-text-secondary mb-6 max-w-md">
             Access to JWST program information requires authentication. Please sign in
             with your CAMPFIRE account to browse programs and observations.
           </p>
           <Link
             href="/login"
-            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-hover transition-colors"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary rounded-lg hover:bg-primary-hover transition-colors"
           >
             <LogIn className="w-5 h-5" />
             Sign In
@@ -223,11 +223,11 @@ function MetadataPageContent() {
       <div className="mb-6">
         <div className="flex items-center gap-3 mb-2">
           <Database className="w-7 h-7 text-primary" />
-          <h1 className="text-2xl font-bold text-text-primary dark:text-slate-100">
+          <h1 className="text-2xl font-bold text-text-primary">
             NIRSpec Metadata
           </h1>
         </div>
-        <p className="text-text-secondary dark:text-slate-400 max-w-3xl">
+        <p className="text-text-secondary max-w-3xl">
           Programs, observations, and pipeline reductions in the CAMPFIRE database. Program
           metadata is sourced from{' '}
           <a
@@ -337,7 +337,7 @@ const ObservationsBulkActions: React.FC<{ filtered: ObservationOverview[] }> = (
       <button
         onClick={downloadCsv}
         disabled={!hasPointings}
-        className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs rounded-md border border-border dark:border-slate-700 hover:bg-card-hover dark:hover:bg-slate-700/40 disabled:opacity-50 disabled:cursor-not-allowed text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-100 transition-colors"
+        className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs rounded-md border border-border hover:bg-card-hover dark:hover:bg-slate-700/40 disabled:opacity-50 disabled:cursor-not-allowed text-text-secondary hover:text-text-primary transition-colors"
         title="Download CSV of pointings for filtered observations"
       >
         <Download className="w-3.5 h-3.5" />
@@ -346,7 +346,7 @@ const ObservationsBulkActions: React.FC<{ filtered: ObservationOverview[] }> = (
       <button
         onClick={downloadDs9}
         disabled={!hasPointings}
-        className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs rounded-md border border-border dark:border-slate-700 hover:bg-card-hover dark:hover:bg-slate-700/40 disabled:opacity-50 disabled:cursor-not-allowed text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-100 transition-colors"
+        className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs rounded-md border border-border hover:bg-card-hover dark:hover:bg-slate-700/40 disabled:opacity-50 disabled:cursor-not-allowed text-text-secondary hover:text-text-primary transition-colors"
         title="Download DS9 region file for filtered observations"
       >
         <FileText className="w-3.5 h-3.5" />

--- a/web/app/nirspec/metadata/programs/[slug]/page.tsx
+++ b/web/app/nirspec/metadata/programs/[slug]/page.tsx
@@ -93,18 +93,18 @@ export default function ProgramDetailPage() {
       <div className="container mx-auto px-4 py-8">
         {breadcrumbs(programSlug)}
         <div className="flex flex-col items-center justify-center py-16 text-center">
-          <div className="w-16 h-16 bg-card dark:bg-slate-800 rounded-full flex items-center justify-center mb-6">
-            <LogIn className="w-8 h-8 text-text-secondary dark:text-slate-400" />
+          <div className="w-16 h-16 bg-card rounded-full flex items-center justify-center mb-6">
+            <LogIn className="w-8 h-8 text-text-secondary" />
           </div>
-          <h2 className="text-2xl font-semibold text-text-primary dark:text-slate-100 mb-2">
+          <h2 className="text-2xl font-semibold text-text-primary mb-2">
             Sign in to view program details
           </h2>
-          <p className="text-text-secondary dark:text-slate-400 mb-6 max-w-md">
+          <p className="text-text-secondary mb-6 max-w-md">
             Access to program information requires authentication.
           </p>
           <Link
             href="/login"
-            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-hover transition-colors"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary rounded-lg hover:bg-primary-hover transition-colors"
           >
             <LogIn className="w-5 h-5" />
             Sign In
@@ -133,17 +133,17 @@ export default function ProgramDetailPage() {
           <div className="w-16 h-16 bg-red-100 dark:bg-red-950 rounded-full flex items-center justify-center mb-4">
             <AlertCircle className="w-8 h-8 text-red-600 dark:text-red-400" />
           </div>
-          <h2 className="text-2xl font-semibold text-text-primary dark:text-slate-100 mb-2">
+          <h2 className="text-2xl font-semibold text-text-primary mb-2">
             {error === 'Access denied' ? 'Access Denied' : 'Program Not Found'}
           </h2>
-          <p className="text-text-secondary dark:text-slate-400 mb-6">
+          <p className="text-text-secondary mb-6">
             {error === 'Access denied'
               ? 'You do not have access to this program.'
               : 'The program you are looking for does not exist.'}
           </p>
           <Link
             href={METADATA_HREF}
-            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-hover transition-colors"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary rounded-lg hover:bg-primary-hover transition-colors"
           >
             Back to Metadata
           </Link>
@@ -164,10 +164,10 @@ export default function ProgramDetailPage() {
           <div className="flex items-center gap-3">
             <Telescope className="w-8 h-8 text-primary flex-shrink-0" />
             <div>
-              <h1 className="text-2xl font-bold text-text-primary dark:text-slate-100">
+              <h1 className="text-2xl font-bold text-text-primary">
                 {program.program_name || program.slug}
               </h1>
-              <p className="text-sm text-text-secondary dark:text-slate-400">
+              <p className="text-sm text-text-secondary">
                 {program.jwst_pids && program.jwst_pids.length > 0 && (
                   <>PID{program.jwst_pids.length > 1 ? 's' : ''} {program.jwst_pids.join(', ')}</>
                 )}
@@ -184,7 +184,7 @@ export default function ProgramDetailPage() {
                   href={`https://www.stsci.edu/jwst-program-info/program/?program=${pid}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm text-text-secondary dark:text-slate-400 hover:text-primary border border-border dark:border-slate-700 rounded-lg transition-colors"
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm text-text-secondary hover:text-primary border border-border rounded-lg transition-colors"
                 >
                   <ExternalLink className="w-4 h-4" />
                   {program.jwst_pids.length > 1 ? `PID ${pid}` : 'STScI'}
@@ -195,7 +195,7 @@ export default function ProgramDetailPage() {
         </div>
 
         {program.description && (
-          <p className="text-text-secondary dark:text-slate-400 mb-6">
+          <p className="text-text-secondary mb-6">
             {program.description}
           </p>
         )}
@@ -220,14 +220,14 @@ export default function ProgramDetailPage() {
       {observations.length > 0 && (
         <div className="mb-8">
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-text-primary dark:text-slate-100">
+            <h2 className="text-lg font-semibold text-text-primary">
               Observations
             </h2>
             {totalPointings > 0 && (
               <div className="flex gap-2 text-xs">
                 <button
                   onClick={downloadAllCsv}
-                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-text-secondary dark:text-slate-400 hover:text-primary border border-border dark:border-slate-700 rounded transition-colors"
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-text-secondary hover:text-primary border border-border rounded transition-colors"
                   title={`Download all ${totalPointings} pointings as CSV`}
                 >
                   <Download className="w-3.5 h-3.5" />
@@ -235,7 +235,7 @@ export default function ProgramDetailPage() {
                 </button>
                 <button
                   onClick={downloadAllDs9}
-                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-text-secondary dark:text-slate-400 hover:text-primary border border-border dark:border-slate-700 rounded transition-colors"
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-text-secondary hover:text-primary border border-border rounded transition-colors"
                   title={`Download all ${totalPointings} pointings as DS9 region file`}
                 >
                   <Download className="w-3.5 h-3.5" />
@@ -248,16 +248,16 @@ export default function ProgramDetailPage() {
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
-                  <tr className="border-b border-border dark:border-slate-700 bg-gray-50 dark:bg-slate-800/50">
+                  <tr className="border-b border-border bg-gray-50 dark:bg-slate-800/50">
                     <th className="px-2 py-3 w-8"></th>
-                    <th className="text-left px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Observation</th>
-                    <th className="text-left px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Field</th>
-                    <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Pointings</th>
-                    <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Targets</th>
-                    <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Spectra</th>
-                    <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Total Size</th>
-                    <th className="text-left px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Reduction</th>
-                    <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400"></th>
+                    <th className="text-left px-4 py-3 font-medium text-text-secondary">Observation</th>
+                    <th className="text-left px-4 py-3 font-medium text-text-secondary">Field</th>
+                    <th className="text-right px-4 py-3 font-medium text-text-secondary">Pointings</th>
+                    <th className="text-right px-4 py-3 font-medium text-text-secondary">Targets</th>
+                    <th className="text-right px-4 py-3 font-medium text-text-secondary">Spectra</th>
+                    <th className="text-right px-4 py-3 font-medium text-text-secondary">Total Size</th>
+                    <th className="text-left px-4 py-3 font-medium text-text-secondary">Reduction</th>
+                    <th className="text-right px-4 py-3 font-medium text-text-secondary"></th>
                   </tr>
                 </thead>
                 <tbody>
@@ -268,7 +268,7 @@ export default function ProgramDetailPage() {
                       <React.Fragment key={obs.observation}>
                         <tr
                           id={obs.observation}
-                          className="border-b border-border dark:border-slate-700 last:border-b-0 hover:bg-gray-50 dark:hover:bg-slate-800/30 transition-colors"
+                          className="border-b border-border last:border-b-0 hover:bg-gray-50 dark:hover:bg-slate-800/30 transition-colors"
                         >
                           <td className="px-2 py-3 text-center">
                             {hasPointings ? (
@@ -287,22 +287,22 @@ export default function ProgramDetailPage() {
                               <span className="text-text-secondary/40">—</span>
                             )}
                           </td>
-                          <td className="px-4 py-3 text-text-primary dark:text-slate-100 font-medium">
+                          <td className="px-4 py-3 text-text-primary font-medium">
                             {obs.observation}
                           </td>
-                          <td className="px-4 py-3 text-text-secondary dark:text-slate-400">
+                          <td className="px-4 py-3 text-text-secondary">
                             {obs.field}
                           </td>
-                          <td className="px-4 py-3 text-right text-text-primary dark:text-slate-100">
+                          <td className="px-4 py-3 text-right text-text-primary">
                             {hasPointings ? obs.pointings!.length : '—'}
                           </td>
-                          <td className="px-4 py-3 text-right text-text-primary dark:text-slate-100">
+                          <td className="px-4 py-3 text-right text-text-primary">
                             {obs.target_count.toLocaleString()}
                           </td>
-                          <td className="px-4 py-3 text-right text-text-primary dark:text-slate-100">
+                          <td className="px-4 py-3 text-right text-text-primary">
                             {obs.spectrum_count.toLocaleString()}
                           </td>
-                          <td className="px-4 py-3 text-right text-text-secondary dark:text-slate-400">
+                          <td className="px-4 py-3 text-right text-text-secondary">
                             {formatBytes(obs.total_size_bytes)}
                           </td>
                           <td className="px-4 py-3">
@@ -319,7 +319,7 @@ export default function ProgramDetailPage() {
                           </td>
                         </tr>
                         {isExpanded && hasPointings && (
-                          <tr className="border-b border-border dark:border-slate-700 bg-gray-50/50 dark:bg-slate-800/20">
+                          <tr className="border-b border-border bg-gray-50/50 dark:bg-slate-800/20">
                             <td colSpan={9} className="px-4 py-3">
                               <PointingsSubtable
                                 obsName={obs.observation}
@@ -365,13 +365,13 @@ function PointingsSubtable({ pointings, onDownloadCsv, onDownloadDs9 }: Pointing
   return (
     <div>
       <div className="flex items-center justify-between mb-2">
-        <span className="text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wide">
+        <span className="text-xs font-medium text-text-secondary uppercase tracking-wide">
           Pointings ({pointings.length})
         </span>
         <div className="flex gap-2">
           <button
             onClick={onDownloadCsv}
-            className="inline-flex items-center gap-1 px-2 py-1 text-xs text-text-secondary dark:text-slate-400 hover:text-primary border border-border dark:border-slate-700 rounded transition-colors"
+            className="inline-flex items-center gap-1 px-2 py-1 text-xs text-text-secondary hover:text-primary border border-border rounded transition-colors"
             title="Download these pointings as CSV"
           >
             <Download className="w-3 h-3" />
@@ -379,7 +379,7 @@ function PointingsSubtable({ pointings, onDownloadCsv, onDownloadDs9 }: Pointing
           </button>
           <button
             onClick={onDownloadDs9}
-            className="inline-flex items-center gap-1 px-2 py-1 text-xs text-text-secondary dark:text-slate-400 hover:text-primary border border-border dark:border-slate-700 rounded transition-colors"
+            className="inline-flex items-center gap-1 px-2 py-1 text-xs text-text-secondary hover:text-primary border border-border rounded transition-colors"
             title="Download these pointings as DS9 region file"
           >
             <Download className="w-3 h-3" />
@@ -390,7 +390,7 @@ function PointingsSubtable({ pointings, onDownloadCsv, onDownloadDs9 }: Pointing
       <div className="overflow-x-auto">
         <table className="w-full text-xs">
           <thead>
-            <tr className="border-b border-border/60 dark:border-slate-700/60 text-text-secondary dark:text-slate-400">
+            <tr className="border-b border-border/60 dark:border-slate-700/60 text-text-secondary">
               <th className="text-left px-2 py-2 font-medium">MSA Design</th>
               <th className="text-right px-2 py-2 font-medium">RA</th>
               <th className="text-right px-2 py-2 font-medium">Dec</th>
@@ -404,28 +404,28 @@ function PointingsSubtable({ pointings, onDownloadCsv, onDownloadDs9 }: Pointing
           <tbody>
             {pointings.map((p) => (
               <tr key={p.msametid} className="border-b border-border/30 dark:border-slate-700/30 last:border-b-0">
-                <td className="px-2 py-1.5 text-text-primary dark:text-slate-100 font-mono">
+                <td className="px-2 py-1.5 text-text-primary font-mono">
                   {p.msametid}
                 </td>
-                <td className="px-2 py-1.5 text-right text-text-primary dark:text-slate-100 font-mono">
+                <td className="px-2 py-1.5 text-right text-text-primary font-mono">
                   {p.ra_center.toFixed(5)}
                 </td>
-                <td className="px-2 py-1.5 text-right text-text-primary dark:text-slate-100 font-mono">
+                <td className="px-2 py-1.5 text-right text-text-primary font-mono">
                   {p.dec_center.toFixed(5)}
                 </td>
-                <td className="px-2 py-1.5 text-right text-text-primary dark:text-slate-100 font-mono">
+                <td className="px-2 py-1.5 text-right text-text-primary font-mono">
                   {p.pa_aper.toFixed(2)}
                 </td>
-                <td className="px-2 py-1.5 text-text-secondary dark:text-slate-400">
+                <td className="px-2 py-1.5 text-text-secondary">
                   {p.gratings.join(', ')}
                 </td>
-                <td className="px-2 py-1.5 text-right text-text-primary dark:text-slate-100">
+                <td className="px-2 py-1.5 text-right text-text-primary">
                   {p.n_dithers}
                 </td>
-                <td className="px-2 py-1.5 text-right text-text-secondary dark:text-slate-400">
+                <td className="px-2 py-1.5 text-right text-text-secondary">
                   {p.exptime_total.toFixed(0)}s
                 </td>
-                <td className="px-2 py-1.5 text-text-secondary dark:text-slate-400">
+                <td className="px-2 py-1.5 text-text-secondary">
                   {p.date_obs_start}
                 </td>
               </tr>

--- a/web/app/nirspec/objects/[id]/loading.tsx
+++ b/web/app/nirspec/objects/[id]/loading.tsx
@@ -21,40 +21,40 @@ export default function ObjectDetailLoading() {
 
       {/* Header skeleton */}
       <div className="mb-4">
-        <div className="h-9 bg-gray-200 dark:bg-slate-700 rounded w-80 mb-2" />
-        <div className="h-4 bg-gray-200 dark:bg-slate-700 rounded w-48 mb-3" />
-        <div className="h-4 bg-gray-200 dark:bg-slate-700 rounded w-64 mb-4" />
+        <div className="h-9 bg-surface-2 dark:bg-card-hover rounded w-80 mb-2" />
+        <div className="h-4 bg-surface-2 dark:bg-card-hover rounded w-48 mb-3" />
+        <div className="h-4 bg-surface-2 dark:bg-card-hover rounded w-64 mb-4" />
       </div>
 
       {/* Metric Cards skeleton */}
       <div className="mb-4 grid grid-cols-4 gap-4">
         {[1, 2, 3, 4].map((i) => (
           <Card key={i} className="p-4">
-            <div className="h-4 bg-gray-200 dark:bg-slate-700 rounded w-16 mb-2" />
-            <div className="h-6 bg-gray-200 dark:bg-slate-700 rounded w-12" />
+            <div className="h-4 bg-surface-2 dark:bg-card-hover rounded w-16 mb-2" />
+            <div className="h-6 bg-surface-2 dark:bg-card-hover rounded w-12" />
           </Card>
         ))}
       </div>
 
       {/* Action buttons skeleton */}
       <div className="flex gap-4 mb-6">
-        <div className="h-10 bg-gray-200 dark:bg-slate-700 rounded w-32" />
-        <div className="h-10 bg-gray-200 dark:bg-slate-700 rounded w-32" />
+        <div className="h-10 bg-surface-2 dark:bg-card-hover rounded w-32" />
+        <div className="h-10 bg-surface-2 dark:bg-card-hover rounded w-32" />
       </div>
 
       {/* Member targets table skeleton */}
       <Card className="p-6 mb-6">
-        <div className="h-6 bg-gray-200 dark:bg-slate-700 rounded w-48 mb-4" />
+        <div className="h-6 bg-surface-2 dark:bg-card-hover rounded w-48 mb-4" />
         <div className="space-y-3">
           {[1, 2, 3].map((i) => (
-            <div key={i} className="h-10 bg-gray-200 dark:bg-slate-700 rounded" />
+            <div key={i} className="h-10 bg-surface-2 dark:bg-card-hover rounded" />
           ))}
         </div>
       </Card>
 
       {/* Spectrum viewer skeleton */}
       <Card className="p-6">
-        <div className="h-64 bg-gray-200 dark:bg-slate-700 rounded" />
+        <div className="h-64 bg-surface-2 dark:bg-card-hover rounded" />
       </Card>
     </div>
   );

--- a/web/app/nirspec/objects/[id]/page.tsx
+++ b/web/app/nirspec/objects/[id]/page.tsx
@@ -84,18 +84,18 @@ export default async function ObjectDetailPage({ params, searchParams }: ObjectD
         />
 
         <div className="flex flex-col items-center justify-center py-16 text-center">
-          <div className="w-16 h-16 bg-card dark:bg-slate-800 rounded-full flex items-center justify-center mb-6">
-            <LogIn className="w-8 h-8 text-text-secondary dark:text-slate-400" />
+          <div className="w-16 h-16 bg-card rounded-full flex items-center justify-center mb-6">
+            <LogIn className="w-8 h-8 text-text-secondary" />
           </div>
-          <h2 className="text-2xl font-semibold text-text-primary dark:text-slate-100 mb-2">
+          <h2 className="text-2xl font-semibold text-text-primary mb-2">
             Sign in to view this object
           </h2>
-          <p className="text-text-secondary dark:text-slate-400 mb-6 max-w-md">
+          <p className="text-text-secondary mb-6 max-w-md">
             Access to object details requires authentication.
           </p>
           <Link
             href="/login"
-            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-hover transition-colors"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary rounded-lg hover:bg-primary-hover transition-colors"
           >
             <LogIn className="w-5 h-5" />
             Sign In

--- a/web/app/nirspec/page.tsx
+++ b/web/app/nirspec/page.tsx
@@ -165,19 +165,19 @@ function SpectraPageContent() {
         />
 
         <div className="flex flex-col items-center justify-center py-16 text-center">
-          <div className="w-16 h-16 bg-card dark:bg-slate-800 rounded-full flex items-center justify-center mb-6">
-            <LogIn className="w-8 h-8 text-text-secondary dark:text-slate-400" />
+          <div className="w-16 h-16 bg-card rounded-full flex items-center justify-center mb-6">
+            <LogIn className="w-8 h-8 text-text-secondary" />
           </div>
-          <h2 className="text-2xl font-semibold text-text-primary dark:text-slate-100 mb-2">
+          <h2 className="text-2xl font-semibold text-text-primary mb-2">
             Sign in to view spectra
           </h2>
-          <p className="text-text-secondary dark:text-slate-400 mb-6 max-w-md">
+          <p className="text-text-secondary mb-6 max-w-md">
             Access to NIRSpec spectra requires authentication. Please sign in with your
             CAMPFIRE account to browse the catalog.
           </p>
           <Link
             href="/login"
-            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-hover transition-colors"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary rounded-lg hover:bg-primary-hover transition-colors"
           >
             <LogIn className="w-5 h-5" />
             Sign In
@@ -200,8 +200,8 @@ function SpectraPageContent() {
 
       {/* Page Header */}
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-text-primary dark:text-slate-100 mb-2">NIRSpec Spectra</h1>
-        <p className="text-text-secondary dark:text-slate-400">
+        <h1 className="text-2xl font-bold text-text-primary mb-2">NIRSpec Spectra</h1>
+        <p className="text-text-secondary">
           Browse and filter the CAMPFIRE spectroscopic catalog
         </p>
       </div>
@@ -279,7 +279,7 @@ function SpectraPageLoading() {
       />
       <div className="flex items-center justify-center py-16">
         <Loader2 className="w-8 h-8 animate-spin text-primary" />
-        <span className="ml-3 text-text-secondary dark:text-slate-400">Loading...</span>
+        <span className="ml-3 text-text-secondary">Loading...</span>
       </div>
     </div>
   );

--- a/web/app/nirspec/tags/[...slug]/page.tsx
+++ b/web/app/nirspec/tags/[...slug]/page.tsx
@@ -69,15 +69,15 @@ export default function ListDetailPage() {
       <div className="container mx-auto px-4 py-8">
         <Breadcrumbs items={breadcrumbs} className="mb-6" />
         <div className="flex flex-col items-center justify-center py-16 text-center">
-          <div className="w-16 h-16 bg-card dark:bg-slate-800 rounded-full flex items-center justify-center mb-6">
-            <LogIn className="w-8 h-8 text-text-secondary dark:text-slate-400" />
+          <div className="w-16 h-16 bg-card rounded-full flex items-center justify-center mb-6">
+            <LogIn className="w-8 h-8 text-text-secondary" />
           </div>
-          <h2 className="text-2xl font-semibold text-text-primary dark:text-slate-100 mb-2">
+          <h2 className="text-2xl font-semibold text-text-primary mb-2">
             Sign in to view this tag
           </h2>
           <Link
             href="/login"
-            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-hover transition-colors mt-4"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary rounded-lg hover:bg-primary-hover transition-colors mt-4"
           >
             <LogIn className="w-5 h-5" />
             Sign In
@@ -93,7 +93,7 @@ export default function ListDetailPage() {
         <Breadcrumbs items={breadcrumbs} className="mb-6" />
         <div className="flex items-center justify-center py-16">
           <Loader2 className="w-8 h-8 animate-spin text-primary" />
-          <span className="ml-3 text-text-secondary dark:text-slate-400">Loading tag...</span>
+          <span className="ml-3 text-text-secondary">Loading tag...</span>
         </div>
       </div>
     );
@@ -139,11 +139,11 @@ export default function ListDetailPage() {
                     />
                   )}
                   <div>
-                    <h1 className="text-2xl font-bold text-text-primary dark:text-slate-100">
+                    <h1 className="text-2xl font-bold text-text-primary">
                       {list.name}
                     </h1>
                     <div className="mt-1 flex items-center gap-2">
-                      <span className="text-sm font-mono text-text-secondary dark:text-slate-400">#{list.slug}</span>
+                      <span className="text-sm font-mono text-text-secondary">#{list.slug}</span>
                       <ListBadge visibility={list.visibility} isSystem={list.is_system} size="md" />
                     </div>
                   </div>
@@ -173,12 +173,12 @@ export default function ListDetailPage() {
               </div>
 
               {list.description && (
-                <p className="text-text-secondary dark:text-slate-400 mb-4">
+                <p className="text-text-secondary mb-4">
                   {list.description}
                 </p>
               )}
 
-              <div className="flex flex-wrap items-center gap-4 text-sm text-text-secondary dark:text-slate-400">
+              <div className="flex flex-wrap items-center gap-4 text-sm text-text-secondary">
                 <span className="inline-flex items-center gap-1.5">
                   <Hash className="w-4 h-4" />
                   {totalMembers.toLocaleString()} {totalMembers === 1 ? 'object' : 'objects'}
@@ -196,10 +196,10 @@ export default function ListDetailPage() {
               </div>
 
               {/* Action buttons */}
-              <div className="mt-4 pt-4 border-t border-border dark:border-slate-700">
+              <div className="mt-4 pt-4 border-t border-border">
                 <Link
                   href={`/nirspec?view=objects&tags=${list.id}`}
-                  className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium bg-primary text-white rounded-lg hover:bg-primary-hover transition-colors"
+                  className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium bg-primary text-on-primary rounded-lg hover:bg-primary-hover transition-colors"
                 >
                   <ExternalLink className="w-4 h-4" />
                   View in NIRSpec
@@ -211,7 +211,7 @@ export default function ListDetailPage() {
 
         {/* Members Table */}
         <div>
-          <h2 className="text-lg font-semibold text-text-primary dark:text-slate-100 mb-4 flex items-center gap-2">
+          <h2 className="text-lg font-semibold text-text-primary mb-4 flex items-center gap-2">
             <Tag className="w-5 h-5 text-primary" />
             Members
           </h2>

--- a/web/app/nirspec/tags/page.tsx
+++ b/web/app/nirspec/tags/page.tsx
@@ -26,18 +26,18 @@ export default function ListsPage() {
       <div className="container mx-auto px-4 py-8">
         <Breadcrumbs items={breadcrumbs} className="mb-6" />
         <div className="flex flex-col items-center justify-center py-16 text-center">
-          <div className="w-16 h-16 bg-card dark:bg-slate-800 rounded-full flex items-center justify-center mb-6">
-            <LogIn className="w-8 h-8 text-text-secondary dark:text-slate-400" />
+          <div className="w-16 h-16 bg-card rounded-full flex items-center justify-center mb-6">
+            <LogIn className="w-8 h-8 text-text-secondary" />
           </div>
-          <h2 className="text-2xl font-semibold text-text-primary dark:text-slate-100 mb-2">
+          <h2 className="text-2xl font-semibold text-text-primary mb-2">
             Sign in to view tags
           </h2>
-          <p className="text-text-secondary dark:text-slate-400 mb-6 max-w-md">
+          <p className="text-text-secondary mb-6 max-w-md">
             Please sign in with your CAMPFIRE account to browse tags.
           </p>
           <Link
             href="/login"
-            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-hover transition-colors"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary rounded-lg hover:bg-primary-hover transition-colors"
           >
             <LogIn className="w-5 h-5" />
             Sign In
@@ -55,9 +55,9 @@ export default function ListsPage() {
       <div className="mb-8">
         <div className="flex items-center gap-3 mb-2">
           <Tag className="w-8 h-8 text-primary" />
-          <h1 className="text-2xl font-bold text-text-primary dark:text-slate-100">Tags</h1>
+          <h1 className="text-2xl font-bold text-text-primary">Tags</h1>
         </div>
-        <p className="text-text-secondary dark:text-slate-400">
+        <p className="text-text-secondary">
           Tags let you classify unique objects in the NIRSpec database. Several system tags are provided by default,
           and you can create your own — privately or shared with collaborators. All tags are included in database
           downloads, so classifications carry through to your research workflows.
@@ -68,7 +68,7 @@ export default function ListsPage() {
       {isLoading || authLoading ? (
         <div className="flex items-center justify-center py-16">
           <Loader2 className="w-8 h-8 animate-spin text-primary" />
-          <span className="ml-3 text-text-secondary dark:text-slate-400">Loading tags...</span>
+          <span className="ml-3 text-text-secondary">Loading tags...</span>
         </div>
       ) : error ? (
         <div className="bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-900 rounded-lg p-4">
@@ -76,19 +76,19 @@ export default function ListsPage() {
         </div>
       ) : lists.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-16 text-center">
-          <Tag className="w-12 h-12 text-text-secondary dark:text-slate-500 mb-4" />
-          <p className="text-text-secondary dark:text-slate-400">No tags available yet.</p>
+          <Tag className="w-12 h-12 text-text-secondary dark:text-text-tertiary mb-4" />
+          <p className="text-text-secondary">No tags available yet.</p>
         </div>
       ) : (
         <Card className="overflow-hidden">
           <table className="w-full">
             <thead>
-              <tr className="bg-card dark:bg-slate-800/50 border-b border-border dark:border-slate-700">
-                <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wider text-text-secondary dark:text-slate-400">Tag</th>
-                <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wider text-text-secondary dark:text-slate-400 hidden md:table-cell">Description</th>
-                <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wider text-text-secondary dark:text-slate-400">Type</th>
-                <th className="px-4 py-2.5 text-right text-xs font-medium uppercase tracking-wider text-text-secondary dark:text-slate-400">Objects</th>
-                <th className="px-4 py-2.5 text-right text-xs font-medium uppercase tracking-wider text-text-secondary dark:text-slate-400 hidden sm:table-cell">Creator</th>
+              <tr className="bg-card dark:bg-slate-800/50 border-b border-border">
+                <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wider text-text-secondary">Tag</th>
+                <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wider text-text-secondary hidden md:table-cell">Description</th>
+                <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wider text-text-secondary">Type</th>
+                <th className="px-4 py-2.5 text-right text-xs font-medium uppercase tracking-wider text-text-secondary">Objects</th>
+                <th className="px-4 py-2.5 text-right text-xs font-medium uppercase tracking-wider text-text-secondary hidden sm:table-cell">Creator</th>
               </tr>
             </thead>
             <tbody>
@@ -101,22 +101,22 @@ export default function ListsPage() {
                       ) : list.color ? (
                         <span className="w-4 h-4 rounded-full flex-shrink-0" style={{ backgroundColor: list.color }} />
                       ) : (
-                        <Tag className="w-4 h-4 text-text-secondary dark:text-slate-500 flex-shrink-0" />
+                        <Tag className="w-4 h-4 text-text-secondary dark:text-text-tertiary flex-shrink-0" />
                       )}
                       <div className="min-w-0">
-                        <span className="font-medium text-text-primary dark:text-slate-100">{list.name}</span>
-                        <span className="ml-2 text-xs font-mono text-text-secondary dark:text-slate-500">#{list.slug}</span>
+                        <span className="font-medium text-text-primary">{list.name}</span>
+                        <span className="ml-2 text-xs font-mono text-text-secondary dark:text-text-tertiary">#{list.slug}</span>
                       </div>
                     </Link>
                   </td>
                   <td className="px-4 py-3 hidden md:table-cell">
-                    <span className="text-sm text-text-secondary dark:text-slate-400 line-clamp-1">{list.description || '—'}</span>
+                    <span className="text-sm text-text-secondary line-clamp-1">{list.description || '—'}</span>
                   </td>
                   <td className="px-4 py-3">
                     <ListBadge visibility={list.visibility} />
                   </td>
                   <td className="px-4 py-3 text-right">
-                    <span className="inline-flex items-center gap-1 text-sm text-text-secondary dark:text-slate-400">
+                    <span className="inline-flex items-center gap-1 text-sm text-text-secondary">
                       <Hash className="w-3 h-3" />
                       {list.member_count.toLocaleString()}
                     </span>
@@ -128,12 +128,12 @@ export default function ListsPage() {
                         System
                       </span>
                     ) : list.creator_name ? (
-                      <span className="inline-flex items-center gap-1 text-sm text-text-secondary dark:text-slate-400">
+                      <span className="inline-flex items-center gap-1 text-sm text-text-secondary">
                         <User className="w-3 h-3" />
                         {list.creator_name}
                       </span>
                     ) : (
-                      <span className="text-sm text-text-secondary dark:text-slate-500">—</span>
+                      <span className="text-sm text-text-secondary dark:text-text-tertiary">—</span>
                     )}
                   </td>
                 </tr>

--- a/web/app/nirspec/targets/[id]/loading.tsx
+++ b/web/app/nirspec/targets/[id]/loading.tsx
@@ -21,9 +21,9 @@ export default function SpectrumDetailLoading() {
         </div>
         {/* Pagination skeleton */}
         <div className="flex items-center space-x-4">
-          <div className="w-8 h-8 bg-gray-200 dark:bg-slate-700 rounded" />
-          <div className="w-16 h-5 bg-gray-200 dark:bg-slate-700 rounded" />
-          <div className="w-8 h-8 bg-gray-200 dark:bg-slate-700 rounded" />
+          <div className="w-8 h-8 bg-surface-2 dark:bg-card-hover rounded" />
+          <div className="w-16 h-5 bg-surface-2 dark:bg-card-hover rounded" />
+          <div className="w-8 h-8 bg-surface-2 dark:bg-card-hover rounded" />
         </div>
       </div>
 
@@ -33,45 +33,45 @@ export default function SpectrumDetailLoading() {
         <div className="flex-1" style={{ minHeight: '350px' }}>
           {/* Title skeleton */}
           <div className="mb-4">
-            <div className="h-9 bg-gray-200 dark:bg-slate-700 rounded w-80 mb-2" />
-            <div className="h-4 bg-gray-200 dark:bg-slate-700 rounded w-48 mb-3" />
-            <div className="h-4 bg-gray-200 dark:bg-slate-700 rounded w-64" />
+            <div className="h-9 bg-surface-2 dark:bg-card-hover rounded w-80 mb-2" />
+            <div className="h-4 bg-surface-2 dark:bg-card-hover rounded w-48 mb-3" />
+            <div className="h-4 bg-surface-2 dark:bg-card-hover rounded w-64" />
           </div>
 
           {/* Metric Cards skeleton */}
           <div className="mb-4 grid grid-cols-4 gap-4">
             {[1, 2, 3, 4].map((i) => (
               <Card key={i} className="p-4">
-                <div className="h-4 bg-gray-200 dark:bg-slate-700 rounded w-16 mb-2" />
-                <div className="h-6 bg-gray-200 dark:bg-slate-700 rounded w-12" />
+                <div className="h-4 bg-surface-2 dark:bg-card-hover rounded w-16 mb-2" />
+                <div className="h-6 bg-surface-2 dark:bg-card-hover rounded w-12" />
               </Card>
             ))}
           </div>
 
           {/* Action buttons skeleton */}
           <div className="flex gap-4 mb-6">
-            <div className="h-10 bg-gray-200 dark:bg-slate-700 rounded w-32" />
-            <div className="h-10 bg-gray-200 dark:bg-slate-700 rounded w-32" />
+            <div className="h-10 bg-surface-2 dark:bg-card-hover rounded w-32" />
+            <div className="h-10 bg-surface-2 dark:bg-card-hover rounded w-32" />
           </div>
 
           {/* Tab navigation skeleton */}
           <div className="flex gap-2">
             {[1, 2, 3, 4, 5].map((i) => (
-              <div key={i} className="h-10 bg-gray-200 dark:bg-slate-700 rounded w-20" />
+              <div key={i} className="h-10 bg-surface-2 dark:bg-card-hover rounded w-20" />
             ))}
           </div>
         </div>
 
         {/* Right Column: RGB Image skeleton */}
         <div className="flex-shrink-0" style={{ width: '300px' }}>
-          <div className="w-[300px] h-[300px] bg-gray-200 dark:bg-slate-700 rounded-lg" />
+          <div className="w-[300px] h-[300px] bg-surface-2 dark:bg-card-hover rounded-lg" />
         </div>
       </div>
 
       {/* Tab content skeleton */}
       <div className="mt-6">
         <Card className="p-6">
-          <div className="h-64 bg-gray-200 dark:bg-slate-700 rounded" />
+          <div className="h-64 bg-surface-2 dark:bg-card-hover rounded" />
         </Card>
       </div>
     </div>

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -20,13 +20,13 @@ export default function Home() {
           <div className="flex items-center justify-center mb-4">
             <Flame className="w-16 h-16 text-primary" />
           </div>
-          <h1 className="text-5xl font-bold text-text-primary dark:text-slate-100 mb-4">
+          <h1 className="text-5xl font-bold text-text-primary mb-4">
             CAMPFIRE
           </h1>
-          <p className="text-xl text-text-secondary dark:text-slate-400 mb-2">
+          <p className="text-xl text-text-secondary mb-2">
             COSMOS Archive of MultiPle-Field Internal Reductions & Extractions
           </p>
-          <p className="text-lg text-text-secondary dark:text-slate-400">
+          <p className="text-lg text-text-secondary">
             Internal archive for JWST NIRCam imaging and NIRSpec spectroscopy data
           </p>
         </div>
@@ -44,9 +44,9 @@ export default function Home() {
               <Card className="p-8">
                 <div className="flex items-center mb-4">
                   <Camera className="w-8 h-8 text-primary mr-3" />
-                  <h2 className="text-2xl font-bold text-text-primary dark:text-slate-100">NIRCam</h2>
+                  <h2 className="text-2xl font-bold text-text-primary">NIRCam</h2>
                 </div>
-                <p className="text-text-secondary dark:text-slate-400 mb-6">
+                <p className="text-text-secondary mb-6">
                   Browse and download reduced NIRCam imaging mosaics from multiple survey fields.
                 </p>
                 {isLoggedIn ? (
@@ -66,9 +66,9 @@ export default function Home() {
               <Card className="p-8">
                 <div className="flex items-center mb-4">
                   <Sparkles className="w-8 h-8 text-primary mr-3" />
-                  <h2 className="text-2xl font-bold text-text-primary dark:text-slate-100">NIRSpec</h2>
+                  <h2 className="text-2xl font-bold text-text-primary">NIRSpec</h2>
                 </div>
-                <p className="text-text-secondary dark:text-slate-400 mb-6">
+                <p className="text-text-secondary mb-6">
                   Explore reduced spectroscopy data with interactive tools and quality assessments.
                 </p>
                 {isLoggedIn ? (
@@ -94,11 +94,11 @@ export default function Home() {
                     <Card className="p-6">
                       <div className="flex items-center mb-3">
                         <Settings className="w-6 h-6 text-primary mr-2" />
-                        <h3 className="text-lg font-semibold text-text-primary dark:text-slate-100">
+                        <h3 className="text-lg font-semibold text-text-primary">
                           Settings
                         </h3>
                       </div>
-                      <p className="text-text-secondary dark:text-slate-400 text-sm mb-4">
+                      <p className="text-text-secondary text-sm mb-4">
                         Configure your display preferences, spectrum settings, and manage API keys.
                       </p>
                       <Link href="/profile">
@@ -113,11 +113,11 @@ export default function Home() {
                   <Card className="p-6">
                     <div className="flex items-center mb-3">
                       <BookOpen className="w-6 h-6 text-primary mr-2" />
-                      <h3 className="text-lg font-semibold text-text-primary dark:text-slate-100">
+                      <h3 className="text-lg font-semibold text-text-primary">
                         Documentation
                       </h3>
                     </div>
-                    <p className="text-text-secondary dark:text-slate-400 text-sm mb-4">
+                    <p className="text-text-secondary text-sm mb-4">
                       Learn about the data products, inspection workflow, and how to use the archive.
                     </p>
                     <Link href="/docs">
@@ -133,11 +133,11 @@ export default function Home() {
                   <Card className="p-6">
                     <div className="flex items-center mb-3">
                       <LogIn className="w-6 h-6 text-primary mr-2" />
-                      <h3 className="text-lg font-semibold text-text-primary dark:text-slate-100">
+                      <h3 className="text-lg font-semibold text-text-primary">
                         Access Required
                       </h3>
                     </div>
-                    <p className="text-text-secondary dark:text-slate-400 text-sm mb-4">
+                    <p className="text-text-secondary text-sm mb-4">
                       CAMPFIRE contains proprietary JWST data. Log in with your credentials or request access to browse the archive.
                     </p>
                     <div className="flex gap-2">
@@ -158,11 +158,11 @@ export default function Home() {
                   <Card className="p-6">
                     <div className="flex items-center mb-3">
                       <BookOpen className="w-6 h-6 text-primary mr-2" />
-                      <h3 className="text-lg font-semibold text-text-primary dark:text-slate-100">
+                      <h3 className="text-lg font-semibold text-text-primary">
                         Getting Started
                       </h3>
                     </div>
-                    <p className="text-text-secondary dark:text-slate-400 text-sm mb-4">
+                    <p className="text-text-secondary text-sm mb-4">
                       New to CAMPFIRE? Learn about the archive, data products, and how to get started.
                     </p>
                     <Link href="/docs/getting-started">

--- a/web/app/profile/api-keys/page.tsx
+++ b/web/app/profile/api-keys/page.tsx
@@ -196,7 +196,7 @@ export default function ApiKeysPage() {
           </p>
           <Link
             href="/login"
-            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-hover transition-colors"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary rounded-lg hover:bg-primary-hover transition-colors"
           >
             <LogIn className="w-5 h-5" />
             Sign In
@@ -316,14 +316,14 @@ export default function ApiKeysPage() {
           <div className="space-y-4">
             <div>
               <p className="text-sm font-medium text-text-primary mb-1.5">1. Install</p>
-              <div className="bg-gray-50 dark:bg-slate-800 rounded-lg p-3 font-mono text-sm border border-border">
+              <div className="bg-card rounded-lg p-3 font-mono text-sm border border-border">
                 <span className="text-text-primary">pip install &quot;git+https://github.com/hollisakins/campfire.git#subdirectory=python/&quot;</span>
               </div>
             </div>
 
             <div>
               <p className="text-sm font-medium text-text-primary mb-1.5">2. Authenticate <span className="text-xs font-normal text-text-secondary">(recommended)</span></p>
-              <div className="bg-gray-50 dark:bg-slate-800 rounded-lg p-3 font-mono text-sm border border-border">
+              <div className="bg-card rounded-lg p-3 font-mono text-sm border border-border">
                 <span className="text-text-primary">campfire login</span>
               </div>
               <p className="text-xs text-text-secondary mt-1.5">
@@ -333,7 +333,7 @@ export default function ApiKeysPage() {
 
             <div>
               <p className="text-sm font-medium text-text-primary mb-1.5">3. Alternative: API key <span className="text-xs font-normal text-text-secondary">(headless environments)</span></p>
-              <div className="bg-gray-50 dark:bg-slate-800 rounded-lg p-3 font-mono text-sm border border-border">
+              <div className="bg-card rounded-lg p-3 font-mono text-sm border border-border">
                 <span className="text-text-primary">campfire login --api-key</span>
               </div>
               <p className="text-xs text-text-secondary mt-1.5">
@@ -359,7 +359,7 @@ export default function ApiKeysPage() {
             <div>
               <h3 className="text-lg font-semibold text-text-primary">Active Sessions</h3>
               <p className="text-sm text-text-secondary mt-0.5">
-                Devices authenticated via <code className="text-xs bg-gray-100 dark:bg-slate-700 px-1.5 py-0.5 rounded">campfire login</code>
+                Devices authenticated via <code className="text-xs bg-surface-2 px-1.5 py-0.5 rounded">campfire login</code>
               </p>
             </div>
           </div>
@@ -372,7 +372,7 @@ export default function ApiKeysPage() {
             <div className="text-center py-6">
               <Terminal className="w-10 h-10 text-text-secondary mx-auto mb-2 opacity-50" />
               <p className="text-sm text-text-secondary">
-                No active CLI sessions. Run <code className="text-xs bg-gray-100 dark:bg-slate-700 px-1.5 py-0.5 rounded">campfire login</code> to get started.
+                No active CLI sessions. Run <code className="text-xs bg-surface-2 px-1.5 py-0.5 rounded">campfire login</code> to get started.
               </p>
             </div>
           ) : (
@@ -510,13 +510,13 @@ export default function ApiKeysPage() {
                   className={`p-4 border rounded-lg ${
                     key.is_active
                       ? 'border-border bg-background'
-                      : 'border-gray-300 dark:border-slate-600 bg-gray-50 dark:bg-slate-800 opacity-60'
+                      : 'border-border-strong bg-card opacity-60'
                   }`}
                 >
                   <div className="flex items-start justify-between">
                     <div className="flex-1">
                       <div className="flex items-center gap-3 mb-2">
-                        <code className="text-sm font-mono text-text-primary bg-gray-100 dark:bg-slate-700 px-2 py-1 rounded">
+                        <code className="text-sm font-mono text-text-primary bg-surface-2 px-2 py-1 rounded">
                           {key.key_prefix}
                         </code>
                         {!key.is_active && (
@@ -537,7 +537,7 @@ export default function ApiKeysPage() {
                             Last used {new Date(key.last_used_at).toLocaleDateString()}
                           </span>
                         )}
-                        {!key.last_used_at && <span className="text-gray-400 dark:text-slate-500">Never used</span>}
+                        {!key.last_used_at && <span className="text-text-tertiary">Never used</span>}
                       </div>
                     </div>
 

--- a/web/app/profile/change-email/page.tsx
+++ b/web/app/profile/change-email/page.tsx
@@ -6,7 +6,7 @@ import { ChangeEmailForm } from '@/components/auth/ChangeEmailForm';
 
 export default function ChangeEmailPage() {
   return (
-    <div className="min-h-screen bg-background dark:bg-slate-900">
+    <div className="min-h-screen bg-background">
       <div className="container mx-auto px-4 py-8">
         <Breadcrumbs
           items={[

--- a/web/app/profile/email-changed/page.tsx
+++ b/web/app/profile/email-changed/page.tsx
@@ -53,7 +53,7 @@ export default function EmailChangedPage() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-background dark:bg-slate-900">
+    <div className="min-h-screen bg-background">
       <div className="container mx-auto px-4 py-8">
         <Breadcrumbs
           items={[

--- a/web/app/profile/page.tsx
+++ b/web/app/profile/page.tsx
@@ -172,18 +172,18 @@ export default function ProfilePage() {
         />
 
         <div className="flex flex-col items-center justify-center py-16 text-center">
-          <div className="w-16 h-16 bg-card dark:bg-slate-800 rounded-full flex items-center justify-center mb-6">
-            <LogIn className="w-8 h-8 text-text-secondary dark:text-slate-400" />
+          <div className="w-16 h-16 bg-card rounded-full flex items-center justify-center mb-6">
+            <LogIn className="w-8 h-8 text-text-secondary" />
           </div>
-          <h2 className="text-2xl font-semibold text-text-primary dark:text-slate-100 mb-2">
+          <h2 className="text-2xl font-semibold text-text-primary mb-2">
             Sign in to view your profile
           </h2>
-          <p className="text-text-secondary dark:text-slate-400 mb-6 max-w-md">
+          <p className="text-text-secondary mb-6 max-w-md">
             Please sign in to manage your profile and access codes.
           </p>
           <Link
             href="/login"
-            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-hover transition-colors"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary rounded-lg hover:bg-primary-hover transition-colors"
           >
             <LogIn className="w-5 h-5" />
             Sign In
@@ -205,7 +205,7 @@ export default function ProfilePage() {
         />
         <div className="flex items-center justify-center py-16">
           <Loader2 className="w-8 h-8 animate-spin text-primary" />
-          <span className="ml-3 text-text-secondary dark:text-slate-400">Loading profile...</span>
+          <span className="ml-3 text-text-secondary">Loading profile...</span>
         </div>
       </div>
     );
@@ -255,16 +255,16 @@ export default function ProfilePage() {
                       type="text"
                       value={editName}
                       onChange={(e) => setEditName(e.target.value)}
-                      className="text-xl font-semibold text-text-primary dark:text-slate-100 px-2 py-1 border border-border dark:border-slate-600 rounded bg-white dark:bg-slate-700 focus:outline-none focus:ring-2 focus:ring-primary w-full"
+                      className="text-xl font-semibold text-text-primary px-2 py-1 border border-border dark:border-border-strong rounded bg-card focus:outline-none focus:ring-2 focus:ring-primary w-full"
                       autoFocus
                     />
-                    <div className="flex items-center border border-border dark:border-slate-600 rounded bg-white dark:bg-slate-700 focus-within:ring-2 focus-within:ring-primary">
-                      <span className="pl-2 text-text-secondary dark:text-slate-400 select-none">@</span>
+                    <div className="flex items-center border border-border dark:border-border-strong rounded bg-card focus-within:ring-2 focus-within:ring-primary">
+                      <span className="pl-2 text-text-secondary select-none">@</span>
                       <input
                         type="text"
                         value={editUsername}
                         onChange={(e) => setEditUsername(e.target.value)}
-                        className="text-sm text-text-primary dark:text-slate-100 px-2 py-1 bg-transparent focus:outline-none w-full"
+                        className="text-sm text-text-primary px-2 py-1 bg-transparent focus:outline-none w-full"
                       />
                     </div>
                     {saveError && (
@@ -273,7 +273,7 @@ export default function ProfilePage() {
                   </div>
                 ) : (
                   <div className="flex items-center gap-2">
-                    <h1 className="text-xl font-semibold text-text-primary dark:text-slate-100">
+                    <h1 className="text-xl font-semibold text-text-primary">
                       {profileData.profile.full_name}
                     </h1>
                     {profileData.profile.is_group_account && (
@@ -283,7 +283,7 @@ export default function ProfilePage() {
                     )}
                   </div>
                 )}
-                {!isEditing && <p className="text-text-secondary dark:text-slate-400">@{profileData.profile.username} &middot; {profileData.email}</p>}
+                {!isEditing && <p className="text-text-secondary">@{profileData.profile.username} &middot; {profileData.email}</p>}
               </div>
             </div>
 
@@ -327,9 +327,9 @@ export default function ProfilePage() {
             </div>
           </div>
 
-          <div className="pt-4 border-t border-border dark:border-slate-700 space-y-3">
+          <div className="pt-4 border-t border-border space-y-3">
             <div className="flex items-center justify-between">
-              <p className="text-sm text-text-secondary dark:text-slate-400">
+              <p className="text-sm text-text-secondary">
                 Member since {new Date(profileData.profile.created_at).toLocaleDateString()}
               </p>
               <Button variant="secondary" size="sm" onClick={handleSignOut}>
@@ -345,7 +345,7 @@ export default function ProfilePage() {
                 >
                   Change password
                 </Link>
-                <span className="text-border dark:text-slate-600">•</span>
+                <span className="text-border dark:text-border-strong">•</span>
                 <Link
                   href="/profile/change-email"
                   className="text-text-secondary hover:text-primary transition-colors"
@@ -368,20 +368,20 @@ export default function ProfilePage() {
 
         {/* My Lists */}
         <Link href="/profile/tags" className="block">
-          <Card className="p-6 hover:bg-background-hover dark:hover:bg-slate-700 transition-colors cursor-pointer">
+          <Card className="p-6 hover:bg-background-hover dark:hover:bg-card-hover transition-colors cursor-pointer">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">
                 <div className="w-12 h-12 bg-primary/10 rounded-full flex items-center justify-center">
                   <Tag className="w-6 h-6 text-primary" />
                 </div>
                 <div>
-                  <h2 className="text-lg font-semibold text-text-primary dark:text-slate-100">My Tags</h2>
-                  <p className="text-sm text-text-secondary dark:text-slate-400">
+                  <h2 className="text-lg font-semibold text-text-primary">My Tags</h2>
+                  <p className="text-sm text-text-secondary">
                     Create and manage your tags
                   </p>
                 </div>
               </div>
-              <ChevronRight className="w-5 h-5 text-text-secondary dark:text-slate-400" />
+              <ChevronRight className="w-5 h-5 text-text-secondary" />
             </div>
           </Card>
         </Link>
@@ -396,10 +396,10 @@ export default function ProfilePage() {
             <div className="w-10 h-10 bg-primary/10 rounded-full flex items-center justify-center">
               <KeyRound className="w-5 h-5 text-primary" />
             </div>
-            <h2 className="text-lg font-semibold text-text-primary dark:text-slate-100">Access Codes</h2>
+            <h2 className="text-lg font-semibold text-text-primary">Access Codes</h2>
           </div>
 
-          <p className="text-sm text-text-secondary dark:text-slate-400 mb-4">
+          <p className="text-sm text-text-secondary mb-4">
             Enter an access code below to gain access to proprietary programs. Public programs are accessible to all users.
           </p>
 
@@ -423,7 +423,7 @@ export default function ProfilePage() {
               value={accessCode}
               onChange={(e) => setAccessCode(e.target.value.toUpperCase())}
               placeholder="CAMPFIRE-XXXXXX"
-              className="flex-1 px-4 py-2 border border-border dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary font-mono uppercase"
+              className="flex-1 px-4 py-2 border border-border dark:border-border-strong rounded-lg bg-card text-text-primary focus:outline-none focus:ring-2 focus:ring-primary font-mono uppercase"
               disabled={redeemLoading}
             />
             <Button type="submit" variant="primary" disabled={redeemLoading || !accessCode.trim()}>
@@ -440,25 +440,25 @@ export default function ProfilePage() {
 
           {/* Redemption History */}
           {profileData.redemptions.length > 0 && (
-            <div className="mt-6 pt-6 border-t border-border dark:border-slate-700">
-              <h3 className="text-sm font-semibold text-text-primary dark:text-slate-100 mb-3">Redemption History</h3>
+            <div className="mt-6 pt-6 border-t border-border">
+              <h3 className="text-sm font-semibold text-text-primary mb-3">Redemption History</h3>
               <div className="space-y-2">
                 {profileData.redemptions.map((redemption) => (
                   <div
                     key={redemption.id}
-                    className="flex items-center justify-between py-2 border-b border-border dark:border-slate-700 last:border-0"
+                    className="flex items-center justify-between py-2 border-b border-border last:border-0"
                   >
                     <div>
-                      <span className="font-mono text-sm text-text-primary dark:text-slate-100">
+                      <span className="font-mono text-sm text-text-primary">
                         {redemption.access_codes.code}
                       </span>
                       {redemption.access_codes.description && (
-                        <span className="text-sm text-text-secondary dark:text-slate-400 ml-2">
+                        <span className="text-sm text-text-secondary ml-2">
                           ({redemption.access_codes.description})
                         </span>
                       )}
                     </div>
-                    <span className="text-sm text-text-secondary dark:text-slate-400">
+                    <span className="text-sm text-text-secondary">
                       {new Date(redemption.redeemed_at).toLocaleDateString()}
                     </span>
                   </div>
@@ -476,10 +476,10 @@ export default function ProfilePage() {
               <div className="w-10 h-10 bg-primary/10 rounded-full flex items-center justify-center">
                 <Key className="w-5 h-5 text-primary" />
               </div>
-              <h2 className="text-lg font-semibold text-text-primary dark:text-slate-100">Proprietary Program Access</h2>
+              <h2 className="text-lg font-semibold text-text-primary">Proprietary Program Access</h2>
             </div>
 
-            <p className="text-sm text-text-secondary dark:text-slate-400 mb-4">
+            <p className="text-sm text-text-secondary mb-4">
               You have access to the following proprietary programs:
             </p>
 
@@ -490,7 +490,7 @@ export default function ProfilePage() {
                   className="flex items-center gap-2 px-3 py-2 bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-900 rounded-lg"
                 >
                   <Check className="w-4 h-4 text-green-600 dark:text-green-400 flex-shrink-0" />
-                  <span className="text-sm text-text-primary dark:text-slate-100 truncate">
+                  <span className="text-sm text-text-primary truncate">
                     {program.program_name || program.slug}
                   </span>
                 </div>
@@ -502,20 +502,20 @@ export default function ProfilePage() {
         {/* CLI & API Access */}
         {!profileData.profile.is_group_account && (
           <Link href="/profile/api-keys" className="block">
-          <Card className="p-6 hover:bg-background-hover dark:hover:bg-slate-700 transition-colors cursor-pointer">
+          <Card className="p-6 hover:bg-background-hover dark:hover:bg-card-hover transition-colors cursor-pointer">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">
                 <div className="w-12 h-12 bg-primary/10 rounded-full flex items-center justify-center">
                   <Terminal className="w-6 h-6 text-primary" />
                 </div>
                 <div>
-                  <h2 className="text-lg font-semibold text-text-primary dark:text-slate-100">CLI & API Access</h2>
-                  <p className="text-sm text-text-secondary dark:text-slate-400">
+                  <h2 className="text-lg font-semibold text-text-primary">CLI & API Access</h2>
+                  <p className="text-sm text-text-secondary">
                     Manage CLI sessions and API keys for programmatic access
                   </p>
                 </div>
               </div>
-              <ChevronRight className="w-5 h-5 text-text-secondary dark:text-slate-400" />
+              <ChevronRight className="w-5 h-5 text-text-secondary" />
             </div>
           </Card>
         </Link>

--- a/web/app/profile/tags/page.tsx
+++ b/web/app/profile/tags/page.tsx
@@ -62,15 +62,15 @@ export default function MyListsPage() {
       <div className="container mx-auto px-4 py-8">
         <Breadcrumbs items={breadcrumbs} className="mb-6" />
         <div className="flex flex-col items-center justify-center py-16 text-center">
-          <div className="w-16 h-16 bg-card dark:bg-slate-800 rounded-full flex items-center justify-center mb-6">
-            <LogIn className="w-8 h-8 text-text-secondary dark:text-slate-400" />
+          <div className="w-16 h-16 bg-card rounded-full flex items-center justify-center mb-6">
+            <LogIn className="w-8 h-8 text-text-secondary" />
           </div>
-          <h2 className="text-2xl font-semibold text-text-primary dark:text-slate-100 mb-2">
+          <h2 className="text-2xl font-semibold text-text-primary mb-2">
             Sign in to manage your tags
           </h2>
           <Link
             href="/login"
-            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-hover transition-colors mt-4"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary rounded-lg hover:bg-primary-hover transition-colors mt-4"
           >
             <LogIn className="w-5 h-5" />
             Sign In
@@ -86,7 +86,7 @@ export default function MyListsPage() {
         <Breadcrumbs items={breadcrumbs} className="mb-6" />
         <div className="flex items-center justify-center py-16">
           <Loader2 className="w-8 h-8 animate-spin text-primary" />
-          <span className="ml-3 text-text-secondary dark:text-slate-400">Loading tags...</span>
+          <span className="ml-3 text-text-secondary">Loading tags...</span>
         </div>
       </div>
     );
@@ -101,7 +101,7 @@ export default function MyListsPage() {
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <Tag className="w-8 h-8 text-primary" />
-            <h1 className="text-2xl font-bold text-text-primary dark:text-slate-100">My Tags</h1>
+            <h1 className="text-2xl font-bold text-text-primary">My Tags</h1>
           </div>
           {canComment && !showCreateForm && (
             <Button variant="primary" size="sm" onClick={() => setShowCreateForm(true)}>
@@ -138,18 +138,18 @@ export default function MyListsPage() {
         {/* Lists */}
         {lists.length === 0 && !showCreateForm ? (
           <Card className="p-8 text-center">
-            <Tag className="w-12 h-12 text-text-secondary dark:text-slate-500 mx-auto mb-4" />
-            <p className="text-text-secondary dark:text-slate-400 mb-2">
+            <Tag className="w-12 h-12 text-text-secondary dark:text-text-tertiary mx-auto mb-4" />
+            <p className="text-text-secondary mb-2">
               No tags yet.
             </p>
             {canComment && (
-              <p className="text-sm text-text-secondary dark:text-slate-500">
+              <p className="text-sm text-text-secondary dark:text-text-tertiary">
                 Create a tag to organize objects for your research.
               </p>
             )}
           </Card>
         ) : (
-          <Card className="divide-y divide-border dark:divide-slate-700">
+          <Card className="divide-y divide-border">
             {lists.map(list => (
               <div key={list.id} className="p-4">
                 {editingListId === list.id ? (
@@ -168,19 +168,19 @@ export default function MyListsPage() {
                       <div className="flex items-center gap-2 mb-1">
                         <Link
                           href={`/nirspec/tags/${list.slug}`}
-                          className="text-base font-semibold text-text-primary dark:text-slate-100 hover:text-primary transition-colors truncate"
+                          className="text-base font-semibold text-text-primary hover:text-primary transition-colors truncate"
                         >
                           {list.name}
                         </Link>
-                        <span className="text-xs font-mono text-text-secondary dark:text-slate-500">#{list.slug}</span>
+                        <span className="text-xs font-mono text-text-secondary dark:text-text-tertiary">#{list.slug}</span>
                         <ListBadge visibility={list.visibility} />
                       </div>
                       {list.description && (
-                        <p className="text-sm text-text-secondary dark:text-slate-400 line-clamp-1 mb-1">
+                        <p className="text-sm text-text-secondary line-clamp-1 mb-1">
                           {list.description}
                         </p>
                       )}
-                      <div className="flex items-center gap-3 text-xs text-text-secondary dark:text-slate-500">
+                      <div className="flex items-center gap-3 text-xs text-text-secondary dark:text-text-tertiary">
                         <span className="inline-flex items-center gap-1">
                           <Hash className="w-3 h-3" />
                           {list.member_count} {list.member_count === 1 ? 'object' : 'objects'}
@@ -195,7 +195,7 @@ export default function MyListsPage() {
                     <div className="flex items-center gap-1 flex-shrink-0">
                       <Link
                         href={`/nirspec/tags/${list.slug}`}
-                        className="p-2 rounded-lg text-text-secondary dark:text-slate-400 hover:bg-card-hover dark:hover:bg-slate-700 hover:text-text-primary dark:hover:text-slate-200 transition-colors"
+                        className="p-2 rounded-lg text-text-secondary hover:bg-card-hover hover:text-text-primary transition-colors"
                         title="View tag"
                       >
                         <ExternalLink className="w-4 h-4" />
@@ -204,7 +204,7 @@ export default function MyListsPage() {
                         <>
                           <button
                             onClick={() => setEditingListId(list.id)}
-                            className="p-2 rounded-lg text-text-secondary dark:text-slate-400 hover:bg-card-hover dark:hover:bg-slate-700 hover:text-text-primary dark:hover:text-slate-200 transition-colors"
+                            className="p-2 rounded-lg text-text-secondary hover:bg-card-hover hover:text-text-primary transition-colors"
                             title="Edit tag"
                           >
                             <Edit2 className="w-4 h-4" />
@@ -212,7 +212,7 @@ export default function MyListsPage() {
                           <button
                             onClick={() => handleDelete(list)}
                             disabled={deletingId === list.id}
-                            className="p-2 rounded-lg text-text-secondary dark:text-slate-400 hover:bg-red-50 dark:hover:bg-red-950 hover:text-red-600 dark:hover:text-red-400 transition-colors"
+                            className="p-2 rounded-lg text-text-secondary hover:bg-red-50 dark:hover:bg-red-950 hover:text-red-600 dark:hover:text-red-400 transition-colors"
                             title="Delete tag"
                           >
                             {deletingId === list.id ? (
@@ -235,7 +235,7 @@ export default function MyListsPage() {
         <div className="text-center">
           <Link
             href="/nirspec/tags"
-            className="text-sm text-text-secondary dark:text-slate-400 hover:text-primary transition-colors"
+            className="text-sm text-text-secondary hover:text-primary transition-colors"
           >
             Browse all public tags
           </Link>

--- a/web/app/prototype/layout.tsx
+++ b/web/app/prototype/layout.tsx
@@ -33,22 +33,22 @@ export default function PrototypeLayout({
   ];
 
   return (
-    <div className="min-h-screen bg-background dark:bg-slate-900">
+    <div className="min-h-screen bg-background">
       {/* Header */}
-      <header className="border-b border-border dark:border-slate-700 bg-card dark:bg-slate-800">
+      <header className="border-b border-border bg-card">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-14">
             {/* Left: Back to main app */}
             <div className="flex items-center gap-4">
               <Link
                 href="/nirspec"
-                className="flex items-center gap-2 text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200 transition-colors"
+                className="flex items-center gap-2 text-text-secondary hover:text-text-primary transition-colors"
               >
                 <ArrowLeft className="w-4 h-4" />
                 <span className="text-sm">Back to CAMPFIRE</span>
               </Link>
-              <div className="h-6 w-px bg-border dark:bg-slate-700" />
-              <span className="text-lg font-semibold text-text-primary dark:text-slate-100">
+              <div className="h-6 w-px bg-border" />
+              <span className="text-lg font-semibold text-text-primary">
                 Filter UI Prototype
               </span>
             </div>
@@ -56,7 +56,7 @@ export default function PrototypeLayout({
             {/* Right: Theme toggle */}
             <button
               onClick={toggleTheme}
-              className="p-2 rounded-lg text-text-secondary dark:text-slate-400 hover:bg-card-hover dark:hover:bg-slate-700 transition-colors"
+              className="p-2 rounded-lg text-text-secondary hover:bg-card-hover transition-colors"
               title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
             >
               {isDark ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
@@ -66,7 +66,7 @@ export default function PrototypeLayout({
       </header>
 
       {/* Navigation tabs */}
-      <nav className="border-b border-border dark:border-slate-700 bg-card/50 dark:bg-slate-800/50">
+      <nav className="border-b border-border bg-card/50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex gap-1 overflow-x-auto py-2">
             {navItems.map((item) => {
@@ -79,7 +79,7 @@ export default function PrototypeLayout({
                     px-4 py-2 rounded-lg text-sm font-medium whitespace-nowrap transition-colors
                     ${isActive
                       ? 'bg-primary/10 text-primary dark:bg-primary/20'
-                      : 'text-text-secondary dark:text-slate-400 hover:bg-card-hover dark:hover:bg-slate-700 hover:text-text-primary dark:hover:text-slate-200'
+                      : 'text-text-secondary hover:bg-card-hover hover:text-text-primary'
                     }
                   `}
                 >

--- a/web/app/prototype/overflow-panel/page.tsx
+++ b/web/app/prototype/overflow-panel/page.tsx
@@ -153,11 +153,11 @@ function InlineMultiFilter({
   return (
     <div>
       <div className="flex items-center justify-between mb-2">
-        <label className="text-sm font-medium text-text-primary dark:text-slate-200">
+        <label className="text-sm font-medium text-text-primary">
           {label}
         </label>
         {/* Always show mode selector to prevent layout shift */}
-        <div className={`flex gap-0.5 bg-slate-100 dark:bg-slate-800 rounded-md p-0.5 transition-opacity duration-200 ${hasSelection ? 'opacity-100' : 'opacity-40 pointer-events-none'}`}>
+        <div className={`flex gap-0.5 bg-surface-2 dark:bg-card rounded-md p-0.5 transition-opacity duration-200 ${hasSelection ? 'opacity-100' : 'opacity-40 pointer-events-none'}`}>
           {(['any', 'all', 'none'] as FilterMode[]).map((m) => (
             <button
               key={m}
@@ -167,11 +167,11 @@ function InlineMultiFilter({
                 px-2.5 py-1 text-xs font-medium rounded transition-all duration-200
                 ${mode === m
                   ? m === 'any'
-                    ? 'bg-primary text-white shadow-sm'
+                    ? 'bg-primary text-on-primary shadow-sm'
                     : m === 'all'
-                      ? 'bg-green-500 text-white shadow-sm'
-                      : 'bg-red-500 text-white shadow-sm'
-                  : 'text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200'
+                      ? 'bg-green-500 text-on-primary shadow-sm'
+                      : 'bg-red-500 text-on-primary shadow-sm'
+                  : 'text-text-secondary hover:text-text-primary'
                 }
               `}
             >
@@ -191,8 +191,8 @@ function InlineMultiFilter({
                 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm
                 border transition-all duration-200
                 ${isSelected
-                  ? 'border-transparent text-gray-900 dark:text-slate-100 shadow-sm'
-                  : 'border-border dark:border-slate-700 text-text-secondary dark:text-slate-400 hover:bg-card dark:hover:bg-slate-700 hover:border-slate-300 dark:hover:border-slate-600'
+                  ? 'border-transparent text-text-primary shadow-sm'
+                  : 'border-border text-text-secondary hover:bg-card dark:hover:bg-card-hover hover:border-border-strong'
                 }
               `}
               style={
@@ -210,7 +210,7 @@ function InlineMultiFilter({
         })}
       </div>
       {/* Always reserve space for description to prevent layout shift */}
-      <p className={`mt-2 text-xs text-text-secondary dark:text-slate-500 h-4 transition-opacity duration-200 ${hasSelection ? 'opacity-100' : 'opacity-0'}`}>
+      <p className={`mt-2 text-xs text-text-secondary dark:text-text-tertiary h-4 transition-opacity duration-200 ${hasSelection ? 'opacity-100' : 'opacity-0'}`}>
         {mode === 'any' && 'Show objects with any of the selected'}
         {mode === 'all' && 'Show objects with all of the selected'}
         {mode === 'none' && 'Exclude objects with any of the selected'}
@@ -262,20 +262,20 @@ function InlineRange({ label, description, min, max, onChange, minBound, maxBoun
   return (
     <div>
       <div className="flex items-center justify-between mb-2">
-        <label className="text-sm font-medium text-text-primary dark:text-slate-200">
+        <label className="text-sm font-medium text-text-primary">
           {label}
         </label>
         {isActive && (
           <button
             onClick={() => onChange(null, null)}
-            className="text-xs text-text-secondary dark:text-slate-400 hover:text-primary transition-colors"
+            className="text-xs text-text-secondary hover:text-primary transition-colors"
           >
             Clear
           </button>
         )}
       </div>
       {description && (
-        <p className="text-xs text-text-secondary dark:text-slate-500 mb-2">{description}</p>
+        <p className="text-xs text-text-secondary dark:text-text-tertiary mb-2">{description}</p>
       )}
       <div className="flex items-center gap-3">
         <div className="flex-1">
@@ -288,14 +288,14 @@ function InlineRange({ label, description, min, max, onChange, minBound, maxBoun
             placeholder={`Min (${minBound})`}
             step={step}
             className={`
-              w-full px-3 py-2 text-sm border rounded-lg bg-background dark:bg-slate-900
-              text-text-primary dark:text-slate-200 transition-all duration-200
+              w-full px-3 py-2 text-sm border rounded-lg bg-background
+              text-text-primary transition-all duration-200
               focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary
-              ${isActive ? 'border-primary/50' : 'border-border dark:border-slate-700'}
+              ${isActive ? 'border-primary/50' : 'border-border'}
             `}
           />
         </div>
-        <span className="text-sm text-text-secondary dark:text-slate-400">to</span>
+        <span className="text-sm text-text-secondary">to</span>
         <div className="flex-1">
           <input
             type="number"
@@ -306,10 +306,10 @@ function InlineRange({ label, description, min, max, onChange, minBound, maxBoun
             placeholder={`Max (${maxBound})`}
             step={step}
             className={`
-              w-full px-3 py-2 text-sm border rounded-lg bg-background dark:bg-slate-900
-              text-text-primary dark:text-slate-200 transition-all duration-200
+              w-full px-3 py-2 text-sm border rounded-lg bg-background
+              text-text-primary transition-all duration-200
               focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary
-              ${isActive ? 'border-primary/50' : 'border-border dark:border-slate-700'}
+              ${isActive ? 'border-primary/50' : 'border-border'}
             `}
           />
         </div>
@@ -365,13 +365,13 @@ function SimpleFilter({ label, options, selected, onChange }: SimpleFilterProps)
           border transition-all duration-200
           ${isActive
             ? 'bg-primary/10 border-primary text-primary'
-            : 'bg-card dark:bg-slate-800 border-border dark:border-slate-700 text-text-secondary dark:text-slate-400 hover:border-text-secondary dark:hover:border-slate-600 hover:text-text-primary dark:hover:text-slate-200'
+            : 'bg-card border-border text-text-secondary hover:border-text-secondary dark:hover:border-border-strong hover:text-text-primary'
           }
         `}
       >
         <span>{label}</span>
         {isActive && (
-          <span className="px-1.5 py-0.5 text-[10px] font-bold rounded bg-primary text-white">
+          <span className="px-1.5 py-0.5 text-[10px] font-bold rounded bg-primary text-on-primary">
             {selected.length}
           </span>
         )}
@@ -383,7 +383,7 @@ function SimpleFilter({ label, options, selected, onChange }: SimpleFilterProps)
       </button>
 
       {isOpen && (
-        <div className="absolute z-50 mt-1 min-w-[200px] max-w-[280px] max-h-[400px] overflow-y-auto bg-background dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg shadow-lg animate-in fade-in slide-in-from-top-2 duration-200">
+        <div className="absolute z-50 mt-1 min-w-[200px] max-w-[280px] max-h-[400px] overflow-y-auto bg-background dark:bg-card border border-border rounded-lg shadow-lg animate-in fade-in slide-in-from-top-2 duration-200">
           <div className="p-1">
             {options.map((option) => {
               const isSelected = selected.includes(option.value);
@@ -391,16 +391,16 @@ function SimpleFilter({ label, options, selected, onChange }: SimpleFilterProps)
                 <button
                   key={option.value}
                   onClick={() => toggle(option.value)}
-                  className="w-full flex items-center gap-3 px-3 py-2 text-sm text-left hover:bg-card-hover dark:hover:bg-slate-700 rounded-md transition-colors"
+                  className="w-full flex items-center gap-3 px-3 py-2 text-sm text-left hover:bg-card-hover rounded-md transition-colors"
                 >
                   <div className={`
                     w-4 h-4 rounded border flex items-center justify-center flex-shrink-0 transition-all duration-200
-                    ${isSelected ? 'bg-primary border-primary scale-110' : 'border-border dark:border-slate-600'}
+                    ${isSelected ? 'bg-primary border-primary scale-110' : 'border-border dark:border-border-strong'}
                   `}>
-                    {isSelected && <Check className="w-3 h-3 text-white" />}
+                    {isSelected && <Check className="w-3 h-3 text-on-primary" />}
                   </div>
                   {option.icon && <span className="text-sm">{option.icon}</span>}
-                  <span className={isSelected ? 'text-text-primary dark:text-slate-100' : 'text-text-secondary dark:text-slate-400'}>
+                  <span className={isSelected ? 'text-text-primary' : 'text-text-secondary'}>
                     {option.label}
                   </span>
                 </button>
@@ -408,10 +408,10 @@ function SimpleFilter({ label, options, selected, onChange }: SimpleFilterProps)
             })}
           </div>
           {selected.length > 0 && (
-            <div className="border-t border-border dark:border-slate-700 p-2">
+            <div className="border-t border-border p-2">
               <button
                 onClick={() => { onChange([]); setIsOpen(false); }}
-                className="w-full px-3 py-1.5 text-sm text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200 hover:bg-card dark:hover:bg-slate-700 rounded-md text-left transition-colors"
+                className="w-full px-3 py-1.5 text-sm text-text-secondary hover:text-text-primary hover:bg-card dark:hover:bg-card-hover rounded-md text-left transition-colors"
               >
                 Clear all
               </button>
@@ -465,20 +465,20 @@ function ColumnVisibility({ columns, visibility, onChange }: ColumnVisibilityPro
     <div ref={ref} className="relative inline-block flex-shrink-0">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium border transition-all duration-200 bg-card dark:bg-slate-800 border-border dark:border-slate-700 text-text-secondary dark:text-slate-400 hover:border-text-secondary dark:hover:border-slate-600 hover:text-text-primary dark:hover:text-slate-200"
+        className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium border transition-all duration-200 bg-card border-border text-text-secondary hover:border-text-secondary dark:hover:border-border-strong hover:text-text-primary"
       >
         <Columns3 className="w-4 h-4" />
-        <span className="px-1.5 py-0.5 text-xs bg-slate-100 dark:bg-slate-700 rounded">
+        <span className="px-1.5 py-0.5 text-xs bg-surface-2 rounded">
           {visibleCount}
         </span>
       </button>
 
       {isOpen && (
-        <div className="absolute right-0 z-50 mt-1 w-64 max-h-[400px] overflow-y-auto bg-background dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg shadow-lg animate-in fade-in slide-in-from-top-2 duration-200">
-          <div className="sticky top-0 bg-background dark:bg-slate-800 border-b border-border dark:border-slate-700 p-2">
+        <div className="absolute right-0 z-50 mt-1 w-64 max-h-[400px] overflow-y-auto bg-background dark:bg-card border border-border rounded-lg shadow-lg animate-in fade-in slide-in-from-top-2 duration-200">
+          <div className="sticky top-0 bg-background dark:bg-card border-b border-border p-2">
             <button
               onClick={resetToDefaults}
-              className="flex items-center gap-1.5 px-2 py-1 text-xs text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200 hover:bg-card dark:hover:bg-slate-700 rounded transition-colors"
+              className="flex items-center gap-1.5 px-2 py-1 text-xs text-text-secondary hover:text-text-primary hover:bg-card dark:hover:bg-card-hover rounded transition-colors"
             >
               <RotateCcw className="w-3 h-3" />
               Reset to defaults
@@ -496,22 +496,22 @@ function ColumnVisibility({ columns, visibility, onChange }: ColumnVisibilityPro
                   className={`
                     w-full flex items-center gap-3 px-3 py-2 rounded-md text-sm text-left transition-all duration-200
                     ${isLocked
-                      ? 'opacity-60 cursor-not-allowed bg-slate-50 dark:bg-slate-800'
+                      ? 'opacity-60 cursor-not-allowed bg-card'
                       : isVisible
-                        ? 'bg-primary/10 dark:bg-primary/20 text-text-primary dark:text-slate-100'
-                        : 'text-text-secondary dark:text-slate-400 hover:bg-card-hover dark:hover:bg-slate-700'
+                        ? 'bg-primary/10 dark:bg-primary/20 text-text-primary'
+                        : 'text-text-secondary hover:bg-card-hover'
                     }
                   `}
                 >
                   <div className={`
                     w-4 h-4 rounded border flex items-center justify-center flex-shrink-0 transition-all duration-200
-                    ${isVisible ? 'bg-primary border-primary' : 'border-border dark:border-slate-600'}
+                    ${isVisible ? 'bg-primary border-primary' : 'border-border dark:border-border-strong'}
                   `}>
-                    {isVisible && <Check className="w-3 h-3 text-white" />}
+                    {isVisible && <Check className="w-3 h-3 text-on-primary" />}
                   </div>
                   <span className="flex-1">{col.label}</span>
                   {isLocked && (
-                    <span className="text-xs text-text-secondary dark:text-slate-500">required</span>
+                    <span className="text-xs text-text-secondary dark:text-text-tertiary">required</span>
                   )}
                 </button>
               );
@@ -617,10 +617,10 @@ export default function OverflowPanelPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-xl font-bold text-text-primary dark:text-slate-100">
+          <h1 className="text-xl font-bold text-text-primary">
             D: Slide-Out Panel (Enhanced)
           </h1>
-          <p className="text-sm text-text-secondary dark:text-slate-400">
+          <p className="text-sm text-text-secondary">
             Primary filters in bar. Advanced filters + spectra-specific values in panel.
           </p>
         </div>
@@ -632,7 +632,7 @@ export default function OverflowPanelPage() {
       </div>
 
       {/* Main Filter Bar */}
-      <div className="flex items-center gap-2 p-3 bg-card dark:bg-slate-800 rounded-lg border border-border dark:border-slate-700">
+      <div className="flex items-center gap-2 p-3 bg-card rounded-lg border border-border">
         {/* Primary filters */}
         <SimpleFilter
           label="Program"
@@ -670,7 +670,7 @@ export default function OverflowPanelPage() {
         />
 
         {/* Divider */}
-        <div className="h-7 w-px bg-border dark:bg-slate-700 mx-1 flex-shrink-0" />
+        <div className="h-7 w-px bg-border mx-1 flex-shrink-0" />
 
         {/* Advanced Filters button - fixed height to prevent layout shift */}
         <button
@@ -680,14 +680,14 @@ export default function OverflowPanelPage() {
             border transition-all duration-200
             ${panelFilterCount > 0
               ? 'bg-primary/10 border-primary text-primary'
-              : 'bg-card dark:bg-slate-800 border-border dark:border-slate-700 text-text-secondary dark:text-slate-400 hover:border-text-secondary dark:hover:border-slate-600 hover:text-text-primary dark:hover:text-slate-200'
+              : 'bg-card border-border text-text-secondary hover:border-text-secondary dark:hover:border-border-strong hover:text-text-primary'
             }
           `}
         >
           <SlidersHorizontal className="w-4 h-4" />
           <span>Advanced</span>
           {panelFilterCount > 0 && (
-            <span className="px-1.5 py-0.5 text-[10px] font-bold rounded bg-primary text-white">
+            <span className="px-1.5 py-0.5 text-[10px] font-bold rounded bg-primary text-on-primary">
               {panelFilterCount}
             </span>
           )}
@@ -719,7 +719,7 @@ export default function OverflowPanelPage() {
         {hasAnyActiveFilters && (
           <button
             onClick={() => setFilters(DEFAULT_FILTERS)}
-            className="inline-flex items-center gap-1 px-3 py-1.5 text-sm text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200 transition-colors flex-shrink-0"
+            className="inline-flex items-center gap-1 px-3 py-1.5 text-sm text-text-secondary hover:text-text-primary transition-colors flex-shrink-0"
           >
             <X className="w-3.5 h-3.5" />
             Clear all
@@ -728,18 +728,18 @@ export default function OverflowPanelPage() {
       </div>
 
       {/* Results count */}
-      <div className="text-sm text-text-secondary dark:text-slate-400">
-        <strong className="text-text-primary dark:text-slate-100">{filteredData.length}</strong> of {MOCK_SPECTRA.length} objects
+      <div className="text-sm text-text-secondary">
+        <strong className="text-text-primary">{filteredData.length}</strong> of {MOCK_SPECTRA.length} objects
       </div>
 
       {/* Table */}
-      <div className="border border-border dark:border-slate-700 rounded-lg overflow-hidden">
+      <div className="border border-border rounded-lg overflow-hidden">
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
-              <tr className="bg-slate-50 dark:bg-slate-800 border-b border-border dark:border-slate-700">
+              <tr className="bg-card border-b border-border">
                 {visibleColumns.map(col => (
-                  <th key={col.id} className="px-4 py-3 text-left font-medium text-text-secondary dark:text-slate-400 whitespace-nowrap">
+                  <th key={col.id} className="px-4 py-3 text-left font-medium text-text-secondary whitespace-nowrap">
                     {col.label}
                   </th>
                 ))}
@@ -748,7 +748,7 @@ export default function OverflowPanelPage() {
             <tbody>
               {paginatedData.length === 0 ? (
                 <tr>
-                  <td colSpan={visibleColumns.length} className="px-4 py-8 text-center text-text-secondary dark:text-slate-400">
+                  <td colSpan={visibleColumns.length} className="px-4 py-8 text-center text-text-secondary">
                     No objects match filters
                   </td>
                 </tr>
@@ -759,8 +759,8 @@ export default function OverflowPanelPage() {
                     <tr
                       key={row.id}
                       className={`
-                        border-b border-border dark:border-slate-700 last:border-0
-                        ${idx % 2 === 0 ? 'bg-background dark:bg-slate-900' : 'bg-slate-50/50 dark:bg-slate-800/50'}
+                        border-b border-border last:border-0
+                        ${idx % 2 === 0 ? 'bg-background' : 'bg-slate-50/50 dark:bg-slate-800/50'}
                         hover:bg-slate-100/50 dark:hover:bg-slate-700/30 transition-colors
                       `}
                     >
@@ -770,38 +770,38 @@ export default function OverflowPanelPage() {
                             <span className="font-mono text-sm text-primary">{row.target_id}</span>
                           )}
                           {col.id === 'field' && (
-                            <span className="text-text-primary dark:text-slate-200">{row.field}</span>
+                            <span className="text-text-primary">{row.field}</span>
                           )}
                           {col.id === 'observation' && (
-                            <span className="text-text-secondary dark:text-slate-400">{row.observation || '-'}</span>
+                            <span className="text-text-secondary">{row.observation || '-'}</span>
                           )}
                           {col.id === 'gratings' && (
                             <div className="flex gap-1">
                               {row.spectra.map((s: { grating: string }) => (
-                                <span key={s.grating} className="px-1.5 py-0.5 text-xs rounded bg-slate-100 dark:bg-slate-700 text-text-secondary dark:text-slate-300">
+                                <span key={s.grating} className="px-1.5 py-0.5 text-xs rounded bg-surface-2 text-text-secondary">
                                   {s.grating}
                                 </span>
                               ))}
                             </div>
                           )}
                           {col.id === 'redshift' && (
-                            <span className="text-text-primary dark:text-slate-200">
-                              {row.redshift?.toFixed(4) ?? <span className="text-text-secondary dark:text-slate-500">-</span>}
+                            <span className="text-text-primary">
+                              {row.redshift?.toFixed(4) ?? <span className="text-text-secondary dark:text-text-tertiary">-</span>}
                             </span>
                           )}
                           {col.id === 'quality' && (
                             <span className="inline-flex items-center gap-1">
                               <span>{quality.icon}</span>
-                              <span className="text-xs text-text-secondary dark:text-slate-400">{quality.short}</span>
+                              <span className="text-xs text-text-secondary">{quality.short}</span>
                             </span>
                           )}
                           {col.id === 'max_snr' && (
-                            <span className="text-text-primary dark:text-slate-200">
+                            <span className="text-text-primary">
                               {row.max_snr?.toFixed(1) ?? '-'}
                             </span>
                           )}
                           {col.id === 'exptime' && (
-                            <span className="text-text-secondary dark:text-slate-400">
+                            <span className="text-text-secondary">
                               {(row as typeof row & { total_exptime?: number }).total_exptime?.toFixed(0) ?? '-'}
                             </span>
                           )}
@@ -819,21 +819,21 @@ export default function OverflowPanelPage() {
       {/* Pagination */}
       {totalPages > 1 && (
         <div className="flex items-center justify-between text-sm">
-          <span className="text-text-secondary dark:text-slate-400">
+          <span className="text-text-secondary">
             Page {page + 1} of {totalPages}
           </span>
           <div className="flex gap-2">
             <button
               onClick={() => setPage(p => Math.max(0, p - 1))}
               disabled={page === 0}
-              className="px-3 py-1.5 rounded border border-border dark:border-slate-700 text-text-secondary dark:text-slate-400 hover:bg-card dark:hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="px-3 py-1.5 rounded border border-border text-text-secondary hover:bg-card dark:hover:bg-card-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               Previous
             </button>
             <button
               onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))}
               disabled={page === totalPages - 1}
-              className="px-3 py-1.5 rounded border border-border dark:border-slate-700 text-text-secondary dark:text-slate-400 hover:bg-card dark:hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="px-3 py-1.5 rounded border border-border text-text-secondary hover:bg-card dark:hover:bg-card-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               Next
             </button>
@@ -864,25 +864,25 @@ export default function OverflowPanelPage() {
         <div
           className={`
             absolute right-0 top-0 bottom-0 w-[420px] max-w-[90vw]
-            bg-background dark:bg-slate-900 border-l border-border dark:border-slate-700
+            bg-background border-l border-border
             shadow-2xl flex flex-col
             transition-transform duration-300 ease-out
             ${panelOpen ? 'translate-x-0 pointer-events-auto' : 'translate-x-full'}
           `}
         >
           {/* Panel Header */}
-          <div className="flex items-center justify-between p-4 border-b border-border dark:border-slate-700 bg-card dark:bg-slate-800">
+          <div className="flex items-center justify-between p-4 border-b border-border bg-card">
             <div>
-              <h2 className="text-lg font-semibold text-text-primary dark:text-slate-100">
+              <h2 className="text-lg font-semibold text-text-primary">
                 Advanced Filters
               </h2>
-              <p className="text-xs text-text-secondary dark:text-slate-400 mt-0.5">
+              <p className="text-xs text-text-secondary mt-0.5">
                 Multi-value filters and spectra properties
               </p>
             </div>
             <button
               onClick={() => setPanelOpen(false)}
-              className="p-2 rounded-lg text-text-secondary dark:text-slate-400 hover:bg-card-hover dark:hover:bg-slate-700 hover:text-text-primary dark:hover:text-slate-200 transition-colors"
+              className="p-2 rounded-lg text-text-secondary hover:bg-card-hover hover:text-text-primary transition-colors"
             >
               <X className="w-5 h-5" />
             </button>
@@ -891,7 +891,7 @@ export default function OverflowPanelPage() {
           {/* Panel Content */}
           <div className="flex-1 overflow-y-auto">
             {/* Gratings Section */}
-            <div className="p-4 border-b border-border dark:border-slate-700">
+            <div className="p-4 border-b border-border">
               <InlineMultiFilter
                 label="Gratings"
                 options={gratingOptions}
@@ -903,7 +903,7 @@ export default function OverflowPanelPage() {
             </div>
 
             {/* Spectra-Specific Section */}
-            <div className="p-4 border-b border-border dark:border-slate-700">
+            <div className="p-4 border-b border-border">
               <div className="flex items-start gap-2 mb-4 p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800">
                 <Info className="w-4 h-4 text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0" />
                 <div className="text-xs text-amber-700 dark:text-amber-300">
@@ -938,7 +938,7 @@ export default function OverflowPanelPage() {
                     step={100}
                     precision={0}
                   />
-                  <p className="mt-1 text-xs text-text-secondary dark:text-slate-500 italic">
+                  <p className="mt-1 text-xs text-text-secondary dark:text-text-tertiary italic">
                     Coming soon - requires database migration
                   </p>
                 </div>
@@ -947,7 +947,7 @@ export default function OverflowPanelPage() {
 
             {/* Data Quality Section */}
             <div className="p-4">
-              <h3 className="text-xs font-semibold uppercase tracking-wider text-text-secondary dark:text-slate-500 mb-4">
+              <h3 className="text-xs font-semibold uppercase tracking-wider text-text-secondary dark:text-text-tertiary mb-4">
                 Data Quality
               </h3>
               <InlineMultiFilter
@@ -962,7 +962,7 @@ export default function OverflowPanelPage() {
           </div>
 
           {/* Panel Footer */}
-          <div className="p-4 border-t border-border dark:border-slate-700 bg-card dark:bg-slate-800">
+          <div className="p-4 border-t border-border bg-card">
             <div className="flex gap-3">
               <button
                 onClick={() => {
@@ -977,13 +977,13 @@ export default function OverflowPanelPage() {
                   });
                 }}
                 disabled={panelFilterCount === 0}
-                className="flex-1 px-4 py-2.5 text-sm font-medium rounded-lg border border-border dark:border-slate-700 text-text-secondary dark:text-slate-400 hover:bg-card-hover dark:hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200"
+                className="flex-1 px-4 py-2.5 text-sm font-medium rounded-lg border border-border text-text-secondary hover:bg-card-hover disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200"
               >
                 Clear Filters{panelFilterCount > 0 ? ` (${panelFilterCount})` : ''}
               </button>
               <button
                 onClick={() => setPanelOpen(false)}
-                className="flex-1 px-4 py-2.5 text-sm font-medium rounded-lg bg-primary text-white hover:bg-primary-hover shadow-sm hover:shadow transition-all duration-200"
+                className="flex-1 px-4 py-2.5 text-sm font-medium rounded-lg bg-primary text-on-primary hover:bg-primary-hover shadow-sm hover:shadow transition-all duration-200"
               >
                 Done
               </button>

--- a/web/app/prototype/page.tsx
+++ b/web/app/prototype/page.tsx
@@ -12,16 +12,16 @@ export default function PrototypePage() {
     <div className="space-y-8 max-w-4xl">
       {/* Header */}
       <div>
-        <h1 className="text-2xl font-bold text-text-primary dark:text-slate-100">
+        <h1 className="text-2xl font-bold text-text-primary">
           Filter Bar: Slide-Out Panel Design
         </h1>
-        <p className="mt-2 text-text-secondary dark:text-slate-400">
+        <p className="mt-2 text-text-secondary">
           Final prototype for the CAMPFIRE spectra filter bar. Primary filters remain in the main bar
           while advanced filters are accessible via a slide-out panel.
         </p>
         <Link
           href="/prototype/overflow-panel"
-          className="inline-flex items-center gap-2 mt-4 px-4 py-2 rounded-lg bg-primary text-white hover:bg-primary-hover transition-colors"
+          className="inline-flex items-center gap-2 mt-4 px-4 py-2 rounded-lg bg-primary text-on-primary hover:bg-primary-hover transition-colors"
         >
           <PanelRight className="w-4 h-4" />
           View Live Demo
@@ -55,14 +55,14 @@ export default function PrototypePage() {
 
       {/* Architecture */}
       <div className="space-y-4">
-        <h2 className="text-xl font-semibold text-text-primary dark:text-slate-100 flex items-center gap-2">
+        <h2 className="text-xl font-semibold text-text-primary flex items-center gap-2">
           <Layers className="w-5 h-5 text-primary" />
           Filter Architecture
         </h2>
 
         {/* Main Bar */}
-        <div className="p-4 rounded-lg border border-border dark:border-slate-700 bg-card dark:bg-slate-800">
-          <h3 className="font-medium text-text-primary dark:text-slate-100 mb-3">
+        <div className="p-4 rounded-lg border border-border bg-card">
+          <h3 className="font-medium text-text-primary mb-3">
             Main Filter Bar (Always Visible)
           </h3>
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
@@ -74,18 +74,18 @@ export default function PrototypePage() {
               { name: 'Redshift', type: 'Range input', notes: 'Min/max with popover' },
               { name: 'Advanced', type: 'Panel trigger', notes: 'Opens slide-out panel' },
             ].map((filter) => (
-              <div key={filter.name} className="p-3 rounded-lg bg-slate-50 dark:bg-slate-700/50">
-                <div className="font-medium text-sm text-text-primary dark:text-slate-200">{filter.name}</div>
+              <div key={filter.name} className="p-3 rounded-lg bg-card dark:bg-slate-700/50">
+                <div className="font-medium text-sm text-text-primary">{filter.name}</div>
                 <div className="text-xs text-primary mt-0.5">{filter.type}</div>
-                <div className="text-xs text-text-secondary dark:text-slate-400 mt-1">{filter.notes}</div>
+                <div className="text-xs text-text-secondary mt-1">{filter.notes}</div>
               </div>
             ))}
           </div>
         </div>
 
         {/* Panel */}
-        <div className="p-4 rounded-lg border border-border dark:border-slate-700 bg-card dark:bg-slate-800">
-          <h3 className="font-medium text-text-primary dark:text-slate-100 mb-3">
+        <div className="p-4 rounded-lg border border-border bg-card">
+          <h3 className="font-medium text-text-primary mb-3">
             Slide-Out Panel (On Demand)
           </h3>
           <div className="space-y-4">
@@ -115,7 +115,7 @@ export default function PrototypePage() {
               },
             ].map((group) => (
               <div key={group.section}>
-                <h4 className="text-xs font-semibold uppercase tracking-wider text-text-secondary dark:text-slate-500 mb-2">
+                <h4 className="text-xs font-semibold uppercase tracking-wider text-text-secondary dark:text-text-tertiary mb-2">
                   {group.section}
                 </h4>
                 {group.warning && (
@@ -123,10 +123,10 @@ export default function PrototypePage() {
                 )}
                 <div className="grid gap-2 sm:grid-cols-2">
                   {group.filters.map((filter) => (
-                    <div key={filter.name} className="p-2 rounded bg-slate-50 dark:bg-slate-700/50">
-                      <div className="font-medium text-sm text-text-primary dark:text-slate-200">{filter.name}</div>
+                    <div key={filter.name} className="p-2 rounded bg-card dark:bg-slate-700/50">
+                      <div className="font-medium text-sm text-text-primary">{filter.name}</div>
                       <div className="text-xs text-primary">{filter.type}</div>
-                      <div className="text-xs text-text-secondary dark:text-slate-400 mt-0.5">{filter.notes}</div>
+                      <div className="text-xs text-text-secondary mt-0.5">{filter.notes}</div>
                     </div>
                   ))}
                 </div>
@@ -138,44 +138,44 @@ export default function PrototypePage() {
 
       {/* UI Patterns */}
       <div className="space-y-4">
-        <h2 className="text-xl font-semibold text-text-primary dark:text-slate-100 flex items-center gap-2">
+        <h2 className="text-xl font-semibold text-text-primary flex items-center gap-2">
           <SlidersHorizontal className="w-5 h-5 text-primary" />
           UI Patterns
         </h2>
 
         <div className="grid gap-4 md:grid-cols-2">
           {/* Button States */}
-          <div className="p-4 rounded-lg border border-border dark:border-slate-700">
-            <h3 className="font-medium text-text-primary dark:text-slate-100 mb-3">Filter Button States</h3>
+          <div className="p-4 rounded-lg border border-border">
+            <h3 className="font-medium text-text-primary mb-3">Filter Button States</h3>
             <div className="space-y-3">
               <div className="flex items-center gap-3">
-                <div className="inline-flex items-center gap-1.5 px-3 h-8 rounded-full text-sm font-medium border border-border dark:border-slate-600 bg-card dark:bg-slate-700 text-text-secondary dark:text-slate-400">
+                <div className="inline-flex items-center gap-1.5 px-3 h-8 rounded-full text-sm font-medium border border-border dark:border-border-strong bg-card dark:bg-card-hover text-text-secondary">
                   <span>Filter</span>
                   <ChevronDown className="w-3.5 h-3.5" />
                 </div>
-                <span className="text-xs text-text-secondary dark:text-slate-400">Inactive: border + chevron</span>
+                <span className="text-xs text-text-secondary">Inactive: border + chevron</span>
               </div>
               <div className="flex items-center gap-3">
                 <div className="inline-flex items-center gap-1.5 px-3 h-8 rounded-full text-sm font-medium border border-primary bg-primary/10 text-primary">
                   <span>Filter</span>
-                  <span className="px-1.5 py-0.5 text-[10px] font-bold rounded bg-primary text-white">2</span>
+                  <span className="px-1.5 py-0.5 text-[10px] font-bold rounded bg-primary text-on-primary">2</span>
                   <X className="w-3.5 h-3.5" />
                 </div>
-                <span className="text-xs text-text-secondary dark:text-slate-400">Active: badge + X to clear</span>
+                <span className="text-xs text-text-secondary">Active: badge + X to clear</span>
               </div>
             </div>
           </div>
 
           {/* Mode Selector */}
-          <div className="p-4 rounded-lg border border-border dark:border-slate-700">
-            <h3 className="font-medium text-text-primary dark:text-slate-100 mb-3">Multi-Value Mode Selector</h3>
+          <div className="p-4 rounded-lg border border-border">
+            <h3 className="font-medium text-text-primary mb-3">Multi-Value Mode Selector</h3>
             <div className="space-y-2">
-              <div className="flex gap-0.5 bg-slate-100 dark:bg-slate-700 rounded-md p-0.5 w-fit">
-                <span className="px-2.5 py-1 text-xs font-medium rounded bg-primary text-white">Any</span>
-                <span className="px-2.5 py-1 text-xs font-medium text-text-secondary dark:text-slate-400">All</span>
-                <span className="px-2.5 py-1 text-xs font-medium text-text-secondary dark:text-slate-400">None</span>
+              <div className="flex gap-0.5 bg-surface-2 rounded-md p-0.5 w-fit">
+                <span className="px-2.5 py-1 text-xs font-medium rounded bg-primary text-on-primary">Any</span>
+                <span className="px-2.5 py-1 text-xs font-medium text-text-secondary">All</span>
+                <span className="px-2.5 py-1 text-xs font-medium text-text-secondary">None</span>
               </div>
-              <p className="text-xs text-text-secondary dark:text-slate-400">
+              <p className="text-xs text-text-secondary">
                 <strong>Any:</strong> Match objects with any selected value<br />
                 <strong>All:</strong> Match objects with all selected values<br />
                 <strong>None:</strong> Exclude objects with any selected value
@@ -185,12 +185,12 @@ export default function PrototypePage() {
         </div>
 
         {/* Key Implementation Details */}
-        <div className="p-4 rounded-lg border border-border dark:border-slate-700">
-          <h3 className="font-medium text-text-primary dark:text-slate-100 mb-3">Key Implementation Details</h3>
-          <ul className="space-y-2 text-sm text-text-secondary dark:text-slate-400">
+        <div className="p-4 rounded-lg border border-border">
+          <h3 className="font-medium text-text-primary mb-3">Key Implementation Details</h3>
+          <ul className="space-y-2 text-sm text-text-secondary">
             <li className="flex items-start gap-2">
               <Check className="w-4 h-4 text-green-500 mt-0.5 flex-shrink-0" />
-              <span><strong>Fixed button height</strong> (<code className="px-1 py-0.5 bg-slate-100 dark:bg-slate-700 rounded text-xs">h-8</code>) prevents vertical layout shift when badge appears</span>
+              <span><strong>Fixed button height</strong> (<code className="px-1 py-0.5 bg-surface-2 rounded text-xs">h-8</code>) prevents vertical layout shift when badge appears</span>
             </li>
             <li className="flex items-start gap-2">
               <Check className="w-4 h-4 text-green-500 mt-0.5 flex-shrink-0" />
@@ -198,15 +198,15 @@ export default function PrototypePage() {
             </li>
             <li className="flex items-start gap-2">
               <Check className="w-4 h-4 text-green-500 mt-0.5 flex-shrink-0" />
-              <span><strong>Reserved space for descriptions</strong> (<code className="px-1 py-0.5 bg-slate-100 dark:bg-slate-700 rounded text-xs">h-4</code>) prevents shift when mode changes</span>
+              <span><strong>Reserved space for descriptions</strong> (<code className="px-1 py-0.5 bg-surface-2 rounded text-xs">h-4</code>) prevents shift when mode changes</span>
             </li>
             <li className="flex items-start gap-2">
               <Check className="w-4 h-4 text-green-500 mt-0.5 flex-shrink-0" />
-              <span><strong>Panel uses fixed positioning</strong> with <code className="px-1 py-0.5 bg-slate-100 dark:bg-slate-700 rounded text-xs">z-[100]</code> and explicit coordinates for full viewport coverage</span>
+              <span><strong>Panel uses fixed positioning</strong> with <code className="px-1 py-0.5 bg-surface-2 rounded text-xs">z-[100]</code> and explicit coordinates for full viewport coverage</span>
             </li>
             <li className="flex items-start gap-2">
               <Check className="w-4 h-4 text-green-500 mt-0.5 flex-shrink-0" />
-              <span><strong>300ms transitions</strong> with <code className="px-1 py-0.5 bg-slate-100 dark:bg-slate-700 rounded text-xs">ease-out</code> for smooth panel animation</span>
+              <span><strong>300ms transitions</strong> with <code className="px-1 py-0.5 bg-surface-2 rounded text-xs">ease-out</code> for smooth panel animation</span>
             </li>
             <li className="flex items-start gap-2">
               <Check className="w-4 h-4 text-green-500 mt-0.5 flex-shrink-0" />
@@ -218,7 +218,7 @@ export default function PrototypePage() {
 
       {/* Production Checklist */}
       <div className="space-y-4">
-        <h2 className="text-xl font-semibold text-text-primary dark:text-slate-100">
+        <h2 className="text-xl font-semibold text-text-primary">
           Production Implementation Checklist
         </h2>
         <div className="p-4 rounded-lg border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20">
@@ -252,9 +252,9 @@ export default function PrototypePage() {
       </div>
 
       {/* Files Reference */}
-      <div className="p-4 rounded-lg bg-slate-50 dark:bg-slate-800 border border-border dark:border-slate-700">
-        <h3 className="font-medium text-text-primary dark:text-slate-100 mb-2">Prototype Files</h3>
-        <ul className="text-sm text-text-secondary dark:text-slate-400 space-y-1 font-mono">
+      <div className="p-4 rounded-lg bg-card border border-border">
+        <h3 className="font-medium text-text-primary mb-2">Prototype Files</h3>
+        <ul className="text-sm text-text-secondary space-y-1 font-mono">
           <li>web/app/prototype/overflow-panel/page.tsx - Complete working prototype</li>
           <li>web/lib/mocks/spectra-mock-data.ts - Mock data and filter logic</li>
           <li>web/components/ui/RangeFilterChip.tsx - Reusable range filter component</li>

--- a/web/app/request-access/page.tsx
+++ b/web/app/request-access/page.tsx
@@ -70,7 +70,7 @@ export default function RequestAccessPage() {
                 <p className="text-text-secondary text-center mb-6">
                   {result.message}
                 </p>
-                <div className="bg-gray-50 dark:bg-slate-800 rounded-lg p-4 mb-6">
+                <div className="bg-card rounded-lg p-4 mb-6">
                   <p className="text-sm text-text-secondary">
                     <strong>What happens next?</strong>
                   </p>

--- a/web/app/request-access/status/page.tsx
+++ b/web/app/request-access/status/page.tsx
@@ -62,7 +62,7 @@ export default function RequestStatusPage() {
       case 'rejected':
         return <XCircle className="w-8 h-8 text-red-600" />;
       case 'not_found':
-        return <Search className="w-8 h-8 text-gray-400 dark:text-slate-500" />;
+        return <Search className="w-8 h-8 text-text-tertiary" />;
     }
   };
 
@@ -75,7 +75,7 @@ export default function RequestStatusPage() {
       case 'rejected':
         return 'bg-red-100 dark:bg-red-900/30';
       case 'not_found':
-        return 'bg-gray-100 dark:bg-slate-700';
+        return 'bg-surface-2';
     }
   };
 
@@ -168,7 +168,7 @@ export default function RequestStatusPage() {
               </p>
 
               {result.created_at && (
-                <div className="bg-gray-50 dark:bg-slate-800 rounded-lg p-3 text-sm">
+                <div className="bg-card rounded-lg p-3 text-sm">
                   <p className="text-text-secondary">
                     <strong>Submitted:</strong> {formatDate(result.created_at)}
                   </p>

--- a/web/app/welcome/page.tsx
+++ b/web/app/welcome/page.tsx
@@ -231,7 +231,7 @@ export default function WelcomePage() {
               <label className="block text-sm font-medium text-text-primary mb-2">
                 Email
               </label>
-              <div className="flex items-center gap-2 px-4 py-2 bg-gray-50 dark:bg-slate-800 border border-border rounded-lg text-text-secondary">
+              <div className="flex items-center gap-2 px-4 py-2 bg-card border border-border rounded-lg text-text-secondary">
                 <User className="w-4 h-4" />
                 {userEmail}
               </div>

--- a/web/components/docs/CodeBlock.tsx
+++ b/web/components/docs/CodeBlock.tsx
@@ -52,15 +52,15 @@ export function CodeBlock({ children }: CodeBlockProps) {
   };
 
   return (
-    <div className="relative mb-4 rounded-lg border border-border dark:border-slate-700 overflow-hidden">
+    <div className="relative mb-4 rounded-lg border border-border overflow-hidden">
       {/* Header with language label and copy button */}
-      <div className="flex justify-between items-center px-4 py-1.5 bg-slate-100 dark:bg-slate-800/50 border-b border-border dark:border-slate-700">
-        <span className="text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wide">
+      <div className="flex justify-between items-center px-4 py-1.5 bg-surface-2 dark:bg-slate-800/50 border-b border-border">
+        <span className="text-xs font-medium text-text-secondary uppercase tracking-wide">
           {language || 'code'}
         </span>
         <button
           onClick={handleCopy}
-          className="flex items-center gap-1 text-xs text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200 transition-colors"
+          className="flex items-center gap-1 text-xs text-text-secondary hover:text-text-primary transition-colors"
           aria-label="Copy code"
         >
           {copied ? (

--- a/web/components/docs/DocNavigation.tsx
+++ b/web/components/docs/DocNavigation.tsx
@@ -16,16 +16,16 @@ export default function DocNavigation({ prev, next }: DocNavigationProps) {
   }
 
   return (
-    <nav className="flex justify-between items-center mt-12 pt-8 border-t border-border dark:border-slate-700">
+    <nav className="flex justify-between items-center mt-12 pt-8 border-t border-border">
       {prev ? (
         <Link
           href={`/docs/${prev.slug}`}
-          className="group flex items-center gap-2 text-text-secondary dark:text-slate-400 hover:text-primary transition-colors"
+          className="group flex items-center gap-2 text-text-secondary hover:text-primary transition-colors"
         >
           <ChevronLeft className="w-4 h-4 group-hover:-translate-x-1 transition-transform" />
           <div className="text-right">
             <div className="text-xs uppercase tracking-wide mb-0.5">Previous</div>
-            <div className="font-medium text-text-primary dark:text-slate-200 group-hover:text-primary">
+            <div className="font-medium text-text-primary group-hover:text-primary">
               {prev.title}
             </div>
           </div>
@@ -36,11 +36,11 @@ export default function DocNavigation({ prev, next }: DocNavigationProps) {
       {next ? (
         <Link
           href={`/docs/${next.slug}`}
-          className="group flex items-center gap-2 text-text-secondary dark:text-slate-400 hover:text-primary transition-colors text-right"
+          className="group flex items-center gap-2 text-text-secondary hover:text-primary transition-colors text-right"
         >
           <div>
             <div className="text-xs uppercase tracking-wide mb-0.5">Next</div>
-            <div className="font-medium text-text-primary dark:text-slate-200 group-hover:text-primary">
+            <div className="font-medium text-text-primary group-hover:text-primary">
               {next.title}
             </div>
           </div>

--- a/web/components/docs/MarkdownRenderer.tsx
+++ b/web/components/docs/MarkdownRenderer.tsx
@@ -91,7 +91,7 @@ export default function MarkdownRenderer({ content, onTOCChange }: MarkdownRende
   const components: Components = {
     // Headings with anchor links
     h1: ({ children }) => (
-      <h1 className="text-3xl font-bold text-text-primary dark:text-slate-100 mt-8 mb-4 first:mt-0">
+      <h1 className="text-3xl font-bold text-text-primary mt-8 mb-4 first:mt-0">
         {children}
       </h1>
     ),
@@ -99,7 +99,7 @@ export default function MarkdownRenderer({ content, onTOCChange }: MarkdownRende
       const text = extractTextFromChildren(children);
       const id = headingToId(text);
       return (
-        <h2 id={id} className="text-2xl font-semibold text-text-primary dark:text-slate-100 mt-8 mb-4 scroll-mt-4 group">
+        <h2 id={id} className="text-2xl font-semibold text-text-primary mt-8 mb-4 scroll-mt-4 group">
           <a href={`#${id}`} className="no-underline hover:underline">
             {children}
           </a>
@@ -111,7 +111,7 @@ export default function MarkdownRenderer({ content, onTOCChange }: MarkdownRende
       const text = extractTextFromChildren(children);
       const id = headingToId(text);
       return (
-        <h3 id={id} className="text-xl font-semibold text-text-primary dark:text-slate-100 mt-6 mb-3 scroll-mt-4 group">
+        <h3 id={id} className="text-xl font-semibold text-text-primary mt-6 mb-3 scroll-mt-4 group">
           <a href={`#${id}`} className="no-underline hover:underline">
             {children}
           </a>
@@ -123,7 +123,7 @@ export default function MarkdownRenderer({ content, onTOCChange }: MarkdownRende
       const text = extractTextFromChildren(children);
       const id = headingToId(text);
       return (
-        <h4 id={id} className="text-lg font-semibold text-text-primary dark:text-slate-100 mt-4 mb-2 scroll-mt-4 group">
+        <h4 id={id} className="text-lg font-semibold text-text-primary mt-4 mb-2 scroll-mt-4 group">
           <a href={`#${id}`} className="no-underline hover:underline">
             {children}
           </a>
@@ -186,7 +186,7 @@ export default function MarkdownRenderer({ content, onTOCChange }: MarkdownRende
 
     // Blockquotes
     blockquote: ({ children }) => (
-      <blockquote className="border-l-4 border-primary pl-4 italic text-text-secondary dark:text-slate-400 mb-4">
+      <blockquote className="border-l-4 border-primary pl-4 italic text-text-secondary mb-4">
         {children}
       </blockquote>
     ),
@@ -194,22 +194,22 @@ export default function MarkdownRenderer({ content, onTOCChange }: MarkdownRende
     // Tables
     table: ({ children }) => (
       <div className="overflow-x-auto mb-4">
-        <table className="min-w-full border border-border dark:border-slate-700 rounded-lg overflow-hidden">
+        <table className="min-w-full border border-border rounded-lg overflow-hidden">
           {children}
         </table>
       </div>
     ),
     thead: ({ children }) => (
-      <thead className="bg-card dark:bg-slate-800">{children}</thead>
+      <thead className="bg-card">{children}</thead>
     ),
     tbody: ({ children }) => (
-      <tbody className="divide-y divide-border dark:divide-slate-700">{children}</tbody>
+      <tbody className="divide-y divide-border">{children}</tbody>
     ),
     tr: ({ children }) => (
       <tr className="hover:bg-card-hover dark:hover:bg-slate-800/50">{children}</tr>
     ),
     th: ({ children }) => (
-      <th className="px-4 py-2 text-left font-semibold text-text-primary dark:text-slate-200">
+      <th className="px-4 py-2 text-left font-semibold text-text-primary">
         {children}
       </th>
     ),
@@ -219,12 +219,12 @@ export default function MarkdownRenderer({ content, onTOCChange }: MarkdownRende
 
     // Horizontal rule
     hr: () => (
-      <hr className="border-border dark:border-slate-700 my-8" />
+      <hr className="border-border my-8" />
     ),
 
     // Strong and emphasis
     strong: ({ children }) => (
-      <strong className="font-semibold text-text-primary dark:text-slate-100">{children}</strong>
+      <strong className="font-semibold text-text-primary">{children}</strong>
     ),
     em: ({ children }) => (
       <em className="italic">{children}</em>
@@ -236,11 +236,11 @@ export default function MarkdownRenderer({ content, onTOCChange }: MarkdownRende
         <img
           src={typeof src === 'string' ? src : undefined}
           alt={alt || ''}
-          className="rounded-lg border border-border dark:border-slate-700 shadow-sm max-w-full cursor-pointer hover:opacity-90 transition-opacity"
+          className="rounded-lg border border-border shadow-sm max-w-full cursor-pointer hover:opacity-90 transition-opacity"
           onClick={() => typeof src === 'string' && setLightbox({ src, alt: alt || '' })}
         />
         {alt && (
-          <figcaption className="mt-2 text-center text-sm text-text-secondary dark:text-slate-400 italic">
+          <figcaption className="mt-2 text-center text-sm text-text-secondary italic">
             {alt}
           </figcaption>
         )}

--- a/web/components/docs/ProgramDetailContent.tsx
+++ b/web/components/docs/ProgramDetailContent.tsx
@@ -33,18 +33,18 @@ export default function ProgramDetailContent({ programSlug }: { programSlug: str
   if (!authLoading && !user) {
     return (
       <div className="flex flex-col items-center justify-center py-16 text-center">
-        <div className="w-16 h-16 bg-card dark:bg-slate-800 rounded-full flex items-center justify-center mb-6">
-          <LogIn className="w-8 h-8 text-text-secondary dark:text-slate-400" />
+        <div className="w-16 h-16 bg-card rounded-full flex items-center justify-center mb-6">
+          <LogIn className="w-8 h-8 text-text-secondary" />
         </div>
-        <h2 className="text-2xl font-semibold text-text-primary dark:text-slate-100 mb-2">
+        <h2 className="text-2xl font-semibold text-text-primary mb-2">
           Sign in to view program details
         </h2>
-        <p className="text-text-secondary dark:text-slate-400 mb-6 max-w-md">
+        <p className="text-text-secondary mb-6 max-w-md">
           Access to program information requires authentication.
         </p>
         <Link
           href="/login"
-          className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-hover transition-colors"
+          className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary rounded-lg hover:bg-primary-hover transition-colors"
         >
           <LogIn className="w-5 h-5" />
           Sign In
@@ -57,7 +57,7 @@ export default function ProgramDetailContent({ programSlug }: { programSlug: str
     return (
       <div className="flex items-center justify-center py-16">
         <Loader2 className="w-8 h-8 animate-spin text-primary" />
-        <span className="ml-3 text-text-secondary dark:text-slate-400">Loading program...</span>
+        <span className="ml-3 text-text-secondary">Loading program...</span>
       </div>
     );
   }
@@ -68,17 +68,17 @@ export default function ProgramDetailContent({ programSlug }: { programSlug: str
         <div className="w-16 h-16 bg-red-100 dark:bg-red-950 rounded-full flex items-center justify-center mb-4">
           <AlertCircle className="w-8 h-8 text-red-600 dark:text-red-400" />
         </div>
-        <h2 className="text-2xl font-semibold text-text-primary dark:text-slate-100 mb-2">
+        <h2 className="text-2xl font-semibold text-text-primary mb-2">
           {error === 'Access denied' ? 'Access Denied' : 'Program Not Found'}
         </h2>
-        <p className="text-text-secondary dark:text-slate-400 mb-6">
+        <p className="text-text-secondary mb-6">
           {error === 'Access denied'
             ? 'You do not have access to this program.'
             : 'The program you are looking for does not exist.'}
         </p>
         <Link
           href="/docs/data-products/programs"
-          className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-hover transition-colors"
+          className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary rounded-lg hover:bg-primary-hover transition-colors"
         >
           Back to Programs
         </Link>
@@ -94,14 +94,14 @@ export default function ProgramDetailContent({ programSlug }: { programSlug: str
   return (
     <div>
       {/* Breadcrumbs */}
-      <nav className="flex items-center gap-1 text-sm text-text-secondary dark:text-slate-400 mb-6">
+      <nav className="flex items-center gap-1 text-sm text-text-secondary mb-6">
         <Link href="/docs" className="hover:text-primary transition-colors">Docs</Link>
         <ChevronRight className="w-4 h-4" />
         <Link href="/docs/data-products" className="hover:text-primary transition-colors">Data Products</Link>
         <ChevronRight className="w-4 h-4" />
         <Link href="/docs/data-products/programs" className="hover:text-primary transition-colors">NIRSpec Programs</Link>
         <ChevronRight className="w-4 h-4" />
-        <span className="text-text-primary dark:text-slate-200">{programLabel}</span>
+        <span className="text-text-primary">{programLabel}</span>
       </nav>
 
       {/* Header */}
@@ -110,10 +110,10 @@ export default function ProgramDetailContent({ programSlug }: { programSlug: str
           <div className="flex items-center gap-3">
             <Telescope className="w-8 h-8 text-primary flex-shrink-0" />
             <div>
-              <h1 className="text-2xl font-bold text-text-primary dark:text-slate-100">
+              <h1 className="text-2xl font-bold text-text-primary">
                 {program.program_name || program.slug}
               </h1>
-              <p className="text-sm text-text-secondary dark:text-slate-400">
+              <p className="text-sm text-text-secondary">
                 {program.jwst_pids && program.jwst_pids.length > 0 && (
                   <>PID{program.jwst_pids.length > 1 ? 's' : ''} {program.jwst_pids.join(', ')}</>
                 )}
@@ -130,7 +130,7 @@ export default function ProgramDetailContent({ programSlug }: { programSlug: str
                   href={`https://www.stsci.edu/jwst-program-info/program/?program=${pid}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm text-text-secondary dark:text-slate-400 hover:text-primary border border-border dark:border-slate-700 rounded-lg transition-colors"
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm text-text-secondary hover:text-primary border border-border rounded-lg transition-colors"
                 >
                   <ExternalLink className="w-4 h-4" />
                   {program.jwst_pids.length > 1 ? `PID ${pid}` : 'STScI'}
@@ -141,7 +141,7 @@ export default function ProgramDetailContent({ programSlug }: { programSlug: str
         </div>
 
         {program.description && (
-          <p className="text-text-secondary dark:text-slate-400 mb-6">
+          <p className="text-text-secondary mb-6">
             {program.description}
           </p>
         )}
@@ -165,41 +165,41 @@ export default function ProgramDetailContent({ programSlug }: { programSlug: str
       {/* Observations Table */}
       {observations.length > 0 && (
         <div className="mb-8">
-          <h2 className="text-lg font-semibold text-text-primary dark:text-slate-100 mb-4">
+          <h2 className="text-lg font-semibold text-text-primary mb-4">
             Observations
           </h2>
           <Card className="overflow-hidden">
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
-                  <tr className="border-b border-border dark:border-slate-700 bg-gray-50 dark:bg-slate-800/50">
-                    <th className="text-left px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Observation</th>
-                    <th className="text-left px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Field</th>
-                    <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Targets</th>
-                    <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Spectra</th>
-                    <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Total Size</th>
-                    <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400"></th>
+                  <tr className="border-b border-border bg-gray-50 dark:bg-slate-800/50">
+                    <th className="text-left px-4 py-3 font-medium text-text-secondary">Observation</th>
+                    <th className="text-left px-4 py-3 font-medium text-text-secondary">Field</th>
+                    <th className="text-right px-4 py-3 font-medium text-text-secondary">Targets</th>
+                    <th className="text-right px-4 py-3 font-medium text-text-secondary">Spectra</th>
+                    <th className="text-right px-4 py-3 font-medium text-text-secondary">Total Size</th>
+                    <th className="text-right px-4 py-3 font-medium text-text-secondary"></th>
                   </tr>
                 </thead>
                 <tbody>
                   {observations.map((obs) => (
                     <tr
                       key={obs.observation}
-                      className="border-b border-border dark:border-slate-700 last:border-b-0 hover:bg-gray-50 dark:hover:bg-slate-800/30 transition-colors"
+                      className="border-b border-border last:border-b-0 hover:bg-gray-50 dark:hover:bg-slate-800/30 transition-colors"
                     >
-                      <td className="px-4 py-3 text-text-primary dark:text-slate-100 font-medium">
+                      <td className="px-4 py-3 text-text-primary font-medium">
                         {obs.observation}
                       </td>
-                      <td className="px-4 py-3 text-text-secondary dark:text-slate-400">
+                      <td className="px-4 py-3 text-text-secondary">
                         {obs.field}
                       </td>
-                      <td className="px-4 py-3 text-right text-text-primary dark:text-slate-100">
+                      <td className="px-4 py-3 text-right text-text-primary">
                         {obs.target_count.toLocaleString()}
                       </td>
-                      <td className="px-4 py-3 text-right text-text-primary dark:text-slate-100">
+                      <td className="px-4 py-3 text-right text-text-primary">
                         {obs.spectrum_count.toLocaleString()}
                       </td>
-                      <td className="px-4 py-3 text-right text-text-secondary dark:text-slate-400">
+                      <td className="px-4 py-3 text-right text-text-secondary">
                         {formatBytes(obs.total_size_bytes)}
                       </td>
                       <td className="px-4 py-3 text-right">
@@ -224,7 +224,7 @@ export default function ProgramDetailContent({ programSlug }: { programSlug: str
       <div className="text-center">
         <Link
           href={`/nirspec?programs=${program.slug}`}
-          className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-hover transition-colors"
+          className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary rounded-lg hover:bg-primary-hover transition-colors"
         >
           View all spectra from this program
           <ArrowRight className="w-4 h-4" />

--- a/web/components/docs/ProgramsContent.tsx
+++ b/web/components/docs/ProgramsContent.tsx
@@ -21,18 +21,18 @@ function ProgramCard({ program }: { program: ProgramOverview }) {
       <Card hover className="p-5 h-full">
         <div className="flex items-start justify-between mb-3">
           <div>
-            <h3 className="text-lg font-semibold text-text-primary dark:text-slate-100">
+            <h3 className="text-lg font-semibold text-text-primary">
               {program.program_name || program.slug}
             </h3>
             {program.jwst_pids && program.jwst_pids.length > 0 && (
-              <p className="text-sm text-text-secondary dark:text-slate-400">
+              <p className="text-sm text-text-secondary">
                 PID{program.jwst_pids.length > 1 ? 's' : ''} {program.jwst_pids.join(', ')}
               </p>
             )}
           </div>
           {firstPid && (
             <button
-              className="text-text-secondary dark:text-slate-400 hover:text-primary transition-colors flex-shrink-0"
+              className="text-text-secondary hover:text-primary transition-colors flex-shrink-0"
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
@@ -46,14 +46,14 @@ function ProgramCard({ program }: { program: ProgramOverview }) {
         </div>
 
         {program.pi_name && (
-          <div className="flex items-center gap-1.5 text-sm text-text-secondary dark:text-slate-400 mb-2">
+          <div className="flex items-center gap-1.5 text-sm text-text-secondary mb-2">
             <Users className="w-3.5 h-3.5 flex-shrink-0" />
             <span>PI: {program.pi_name}</span>
           </div>
         )}
 
         {program.description && (
-          <p className="text-sm text-text-secondary dark:text-slate-400 mb-4 line-clamp-2">
+          <p className="text-sm text-text-secondary mb-4 line-clamp-2">
             {program.description}
           </p>
         )}
@@ -93,19 +93,19 @@ export default function ProgramsContent() {
   if (!authLoading && !user) {
     return (
       <div className="flex flex-col items-center justify-center py-16 text-center">
-        <div className="w-16 h-16 bg-card dark:bg-slate-800 rounded-full flex items-center justify-center mb-6">
-          <LogIn className="w-8 h-8 text-text-secondary dark:text-slate-400" />
+        <div className="w-16 h-16 bg-card rounded-full flex items-center justify-center mb-6">
+          <LogIn className="w-8 h-8 text-text-secondary" />
         </div>
-        <h2 className="text-2xl font-semibold text-text-primary dark:text-slate-100 mb-2">
+        <h2 className="text-2xl font-semibold text-text-primary mb-2">
           Sign in to view programs
         </h2>
-        <p className="text-text-secondary dark:text-slate-400 mb-6 max-w-md">
+        <p className="text-text-secondary mb-6 max-w-md">
           Access to JWST program information requires authentication. Please sign in with your
           CAMPFIRE account to browse programs.
         </p>
         <Link
           href="/login"
-          className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-hover transition-colors"
+          className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary rounded-lg hover:bg-primary-hover transition-colors"
         >
           <LogIn className="w-5 h-5" />
           Sign In
@@ -120,9 +120,9 @@ export default function ProgramsContent() {
       <div className="mb-8">
         <div className="flex items-center gap-3 mb-2">
           <Telescope className="w-8 h-8 text-primary" />
-          <h1 className="text-2xl font-bold text-text-primary dark:text-slate-100">JWST Programs</h1>
+          <h1 className="text-2xl font-bold text-text-primary">JWST Programs</h1>
         </div>
-        <p className="text-text-secondary dark:text-slate-400">
+        <p className="text-text-secondary">
           Browse JWST programs with data available in CAMPFIRE
         </p>
       </div>
@@ -131,7 +131,7 @@ export default function ProgramsContent() {
       {isLoading && (
         <div className="flex items-center justify-center py-16">
           <Loader2 className="w-8 h-8 animate-spin text-primary" />
-          <span className="ml-3 text-text-secondary dark:text-slate-400">Loading programs...</span>
+          <span className="ml-3 text-text-secondary">Loading programs...</span>
         </div>
       )}
 
@@ -146,9 +146,9 @@ export default function ProgramsContent() {
       {!isLoading && !error && (
         <>
           {programs.length === 0 ? (
-            <div className="text-center py-16 bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg">
-              <Telescope className="w-12 h-12 text-text-secondary dark:text-slate-400 mx-auto mb-4" />
-              <p className="text-text-secondary dark:text-slate-400">
+            <div className="text-center py-16 bg-card border border-border rounded-lg">
+              <Telescope className="w-12 h-12 text-text-secondary mx-auto mb-4" />
+              <p className="text-text-secondary">
                 No programs available yet.
               </p>
             </div>

--- a/web/components/docs/TableOfContents.tsx
+++ b/web/components/docs/TableOfContents.tsx
@@ -103,7 +103,7 @@ export default function TableOfContents({ items }: TableOfContentsProps) {
 
   return (
     <nav className="hidden xl:block sticky top-24 self-start w-56 flex-shrink-0 pl-8 max-h-[calc(100vh-8rem)] overflow-y-auto">
-      <h4 className="text-sm font-semibold text-text-primary dark:text-slate-200 mb-2">
+      <h4 className="text-sm font-semibold text-text-primary mb-2">
         On this page
       </h4>
       <ul className="space-y-0.5 text-sm">
@@ -116,7 +116,7 @@ export default function TableOfContents({ items }: TableOfContentsProps) {
                 block py-0.5 transition-colors
                 ${activeId === group.parent.id
                   ? 'text-primary font-medium'
-                  : 'text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200'
+                  : 'text-text-secondary hover:text-text-primary'
                 }
               `}
             >
@@ -125,7 +125,7 @@ export default function TableOfContents({ items }: TableOfContentsProps) {
 
             {/* Subsections - only visible when this section is active */}
             {activeH2Id === group.parent.id && group.children.length > 0 && (
-              <ul className="ml-3 mt-0.5 space-y-0.5 border-l border-border dark:border-slate-700 pl-2">
+              <ul className="ml-3 mt-0.5 space-y-0.5 border-l border-border pl-2">
                 {group.children.map((child) => (
                   <li key={child.id}>
                     <a
@@ -134,7 +134,7 @@ export default function TableOfContents({ items }: TableOfContentsProps) {
                         block py-0.5 transition-colors text-[13px]
                         ${activeId === child.id
                           ? 'text-primary font-medium'
-                          : 'text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200'
+                          : 'text-text-secondary hover:text-text-primary'
                         }
                       `}
                     >

--- a/web/components/layout/Footer.tsx
+++ b/web/components/layout/Footer.tsx
@@ -4,8 +4,8 @@ const GITHUB_REPO = 'https://github.com/hollisakins/campfire';
 
 export function Footer() {
   return (
-    <footer className="border-t border-border dark:border-slate-700">
-      <div className="container mx-auto px-4 py-4 flex flex-col sm:flex-row items-center justify-between gap-2 text-sm text-text-secondary dark:text-slate-400">
+    <footer className="border-t border-border">
+      <div className="container mx-auto px-4 py-4 flex flex-col sm:flex-row items-center justify-between gap-2 text-sm text-text-secondary">
         <span>&copy; 2025 Hollis Akins &middot; MIT License</span>
         <div className="flex items-center gap-4">
           <a
@@ -17,7 +17,7 @@ export function Footer() {
             <Github className="w-4 h-4" />
             GitHub
           </a>
-          <span className="text-border dark:text-slate-600">|</span>
+          <span className="text-border dark:text-border-strong">|</span>
           <a
             href={`${GITHUB_REPO}/issues/new?template=bug_report.yml`}
             target="_blank"
@@ -27,7 +27,7 @@ export function Footer() {
             <Bug className="w-4 h-4" />
             Report a Bug
           </a>
-          <span className="text-border dark:text-slate-600">|</span>
+          <span className="text-border dark:text-border-strong">|</span>
           <a
             href={`${GITHUB_REPO}/issues/new?template=feature_request.yml`}
             target="_blank"

--- a/web/components/lists/ListBadge.tsx
+++ b/web/components/lists/ListBadge.tsx
@@ -9,7 +9,7 @@ interface ListBadgeProps {
 }
 
 const visibilityConfig = {
-  private: { label: 'Private', icon: Lock, bg: 'bg-slate-100 dark:bg-slate-700', text: 'text-slate-600 dark:text-slate-300' },
+  private: { label: 'Private', icon: Lock, bg: 'bg-surface-2', text: 'text-text-secondary' },
   public_read: { label: 'Public', icon: Globe, bg: 'bg-blue-50 dark:bg-blue-950', text: 'text-blue-700 dark:text-blue-300' },
   public_edit: { label: 'Collaborative', icon: Users, bg: 'bg-emerald-50 dark:bg-emerald-950', text: 'text-emerald-700 dark:text-emerald-300' },
 };

--- a/web/components/lists/ListCard.tsx
+++ b/web/components/lists/ListCard.tsx
@@ -27,17 +27,17 @@ export function ListCard({ list }: ListCardProps) {
               />
             )}
             <div>
-              <h3 className="text-lg font-semibold text-text-primary dark:text-slate-100">
+              <h3 className="text-lg font-semibold text-text-primary">
                 {list.name}
               </h3>
-              <span className="text-xs font-mono text-text-secondary dark:text-slate-500">#{list.slug}</span>
+              <span className="text-xs font-mono text-text-secondary dark:text-text-tertiary">#{list.slug}</span>
             </div>
           </div>
           <ListBadge visibility={list.visibility} isSystem={list.is_system} />
         </div>
 
         {list.description && (
-          <p className="text-sm text-text-secondary dark:text-slate-400 mb-3 line-clamp-2">
+          <p className="text-sm text-text-secondary mb-3 line-clamp-2">
             {list.description}
           </p>
         )}
@@ -48,7 +48,7 @@ export function ListCard({ list }: ListCardProps) {
             {list.member_count.toLocaleString()} {list.member_count === 1 ? 'object' : 'objects'}
           </span>
           {list.creator_name && (
-            <span className="inline-flex items-center gap-1 text-xs text-text-secondary dark:text-slate-500">
+            <span className="inline-flex items-center gap-1 text-xs text-text-secondary dark:text-text-tertiary">
               <User className="w-3 h-3" />
               {list.creator_name}
             </span>

--- a/web/components/lists/ListColorPicker.tsx
+++ b/web/components/lists/ListColorPicker.tsx
@@ -31,11 +31,11 @@ export function ListColorPicker({ value, onChange }: ListColorPickerProps) {
         className={`w-6 h-6 rounded-full border-2 flex items-center justify-center text-[10px] ${
           value === null
             ? 'border-primary ring-2 ring-primary/30'
-            : 'border-border dark:border-slate-600'
+            : 'border-border dark:border-border-strong'
         } bg-background dark:bg-slate-700`}
         title="No color"
       >
-        <span className="text-text-secondary dark:text-slate-400">&times;</span>
+        <span className="text-text-secondary">&times;</span>
       </button>
       {PRESET_COLORS.map((color) => (
         <button

--- a/web/components/lists/ListEmojiPicker.tsx
+++ b/web/components/lists/ListEmojiPicker.tsx
@@ -29,15 +29,15 @@ export function ListEmojiPicker({ value, onChange }: ListEmojiPickerProps) {
         <button
           type="button"
           onClick={() => setOpen(!open)}
-          className="w-10 h-10 rounded-md border border-border dark:border-slate-600 bg-background dark:bg-slate-700 flex items-center justify-center text-lg hover:bg-gray-50 dark:hover:bg-slate-600 transition-colors"
+          className="w-10 h-10 rounded-md border border-border dark:border-border-strong bg-background dark:bg-slate-700 flex items-center justify-center text-lg hover:bg-gray-50 dark:hover:bg-slate-600 transition-colors"
         >
-          {value || <span className="text-text-secondary dark:text-slate-500 text-sm">+</span>}
+          {value || <span className="text-text-secondary dark:text-text-tertiary text-sm">+</span>}
         </button>
         {value && (
           <button
             type="button"
             onClick={() => onChange(null)}
-            className="text-[11px] text-text-secondary dark:text-slate-400 hover:text-red-500 dark:hover:text-red-400"
+            className="text-[11px] text-text-secondary hover:text-red-500 dark:hover:text-red-400"
           >
             Clear
           </button>
@@ -45,7 +45,7 @@ export function ListEmojiPicker({ value, onChange }: ListEmojiPickerProps) {
       </div>
 
       {open && (
-        <div className="absolute z-50 top-12 left-0 w-[320px] h-[360px] rounded-lg border border-border dark:border-slate-600 bg-card dark:bg-slate-800 shadow-lg overflow-hidden">
+        <div className="absolute z-50 top-12 left-0 w-[320px] h-[360px] rounded-lg border border-border dark:border-border-strong bg-card shadow-lg overflow-hidden">
           <EmojiPicker.Root
             onEmojiSelect={(emoji) => {
               onChange(emoji.emoji);
@@ -54,18 +54,18 @@ export function ListEmojiPicker({ value, onChange }: ListEmojiPickerProps) {
             className="flex flex-col h-full"
           >
             <EmojiPicker.Search
-              className="w-full px-3 py-2 text-sm border-b border-border dark:border-slate-600 bg-background dark:bg-slate-700 text-text-primary dark:text-slate-100 outline-none placeholder:text-text-secondary dark:placeholder:text-slate-500"
+              className="w-full px-3 py-2 text-sm border-b border-border dark:border-border-strong bg-background dark:bg-slate-700 text-text-primary outline-none placeholder:text-text-secondary dark:placeholder:text-slate-500"
               placeholder="Search emoji..."
               autoFocus
             />
             <EmojiPicker.Viewport className="flex-1 overflow-y-auto p-1">
               <EmojiPicker.Loading>
-                <div className="flex items-center justify-center h-full text-xs text-text-secondary dark:text-slate-400">
+                <div className="flex items-center justify-center h-full text-xs text-text-secondary">
                   Loading...
                 </div>
               </EmojiPicker.Loading>
               <EmojiPicker.Empty>
-                <div className="flex items-center justify-center h-full text-xs text-text-secondary dark:text-slate-400">
+                <div className="flex items-center justify-center h-full text-xs text-text-secondary">
                   No emoji found
                 </div>
               </EmojiPicker.Empty>
@@ -73,7 +73,7 @@ export function ListEmojiPicker({ value, onChange }: ListEmojiPickerProps) {
                 className="select-none"
                 components={{
                   CategoryHeader: ({ category, ...props }) => (
-                    <div {...props} className="px-1 py-1.5 text-[10px] font-semibold text-text-secondary dark:text-slate-400 uppercase tracking-wider">
+                    <div {...props} className="px-1 py-1.5 text-[10px] font-semibold text-text-secondary uppercase tracking-wider">
                       {category.label}
                     </div>
                   ),

--- a/web/components/lists/ListForm.tsx
+++ b/web/components/lists/ListForm.tsx
@@ -142,15 +142,15 @@ export function ListForm({ mode, list, initialName, onSuccess, onCreated, onCanc
 
   const slugIcon = {
     idle: null,
-    checking: <Loader2 className="w-3.5 h-3.5 animate-spin text-text-secondary dark:text-slate-500" />,
+    checking: <Loader2 className="w-3.5 h-3.5 animate-spin text-text-secondary dark:text-text-tertiary" />,
     available: <Check className="w-3.5 h-3.5 text-green-600 dark:text-green-400" />,
     taken: <XIcon className="w-3.5 h-3.5 text-red-500 dark:text-red-400" />,
     invalid: <XIcon className="w-3.5 h-3.5 text-red-500 dark:text-red-400" />,
   }[slugStatus];
 
   return (
-    <form onSubmit={handleSubmit} className="border border-border dark:border-slate-700 rounded-lg p-4 bg-card dark:bg-slate-800/50">
-      <h3 className="text-sm font-semibold text-text-primary dark:text-slate-100 mb-3">
+    <form onSubmit={handleSubmit} className="border border-border rounded-lg p-4 bg-card dark:bg-slate-800/50">
+      <h3 className="text-sm font-semibold text-text-primary mb-3">
         {mode === 'create' ? 'Create New Tag' : 'Edit Tag'}
       </h3>
 
@@ -162,7 +162,7 @@ export function ListForm({ mode, list, initialName, onSuccess, onCreated, onCanc
 
       <div className="space-y-3">
         <div>
-          <label className="block text-xs font-medium text-text-secondary dark:text-slate-400 mb-1">
+          <label className="block text-xs font-medium text-text-secondary mb-1">
             Name
           </label>
           <input
@@ -172,30 +172,30 @@ export function ListForm({ mode, list, initialName, onSuccess, onCreated, onCanc
             placeholder="e.g., AGN Candidates"
             maxLength={100}
             minLength={2}
-            className="w-full px-3 py-2 text-sm border border-border dark:border-slate-600 rounded-md bg-background dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+            className="w-full px-3 py-2 text-sm border border-border dark:border-border-strong rounded-md bg-background dark:bg-slate-700 text-text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
             autoFocus
             required
           />
         </div>
 
         <div>
-          <label className="block text-xs font-medium text-text-secondary dark:text-slate-400 mb-1">
+          <label className="block text-xs font-medium text-text-secondary mb-1">
             Shortname
           </label>
           <div className="relative">
-            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-text-secondary dark:text-slate-500">#</span>
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-text-secondary dark:text-text-tertiary">#</span>
             <input
               type="text"
               value={slug}
               onChange={(e) => handleSlugChange(e.target.value)}
               placeholder={username ? `${username}/my-tag` : 'my-tag'}
               maxLength={60}
-              className={`w-full pl-7 pr-8 py-2 text-sm font-mono border rounded-md bg-background dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:border-transparent ${
+              className={`w-full pl-7 pr-8 py-2 text-sm font-mono border rounded-md bg-background dark:bg-slate-700 text-text-primary focus:outline-none focus:ring-2 focus:border-transparent ${
                 slugStatus === 'taken' || slugStatus === 'invalid'
                   ? 'border-red-300 dark:border-red-700 focus:ring-red-500'
                   : slugStatus === 'available'
                   ? 'border-green-300 dark:border-green-700 focus:ring-green-500'
-                  : 'border-border dark:border-slate-600 focus:ring-primary'
+                  : 'border-border dark:border-border-strong focus:ring-primary'
               }`}
             />
             {slugIcon && (
@@ -204,7 +204,7 @@ export function ListForm({ mode, list, initialName, onSuccess, onCreated, onCanc
               </span>
             )}
           </div>
-          <p className="mt-1 text-[11px] text-text-secondary dark:text-slate-500">
+          <p className="mt-1 text-[11px] text-text-secondary dark:text-text-tertiary">
             {slugStatus === 'taken'
               ? 'This shortname is already taken'
               : slugStatus === 'invalid'
@@ -214,7 +214,7 @@ export function ListForm({ mode, list, initialName, onSuccess, onCreated, onCanc
         </div>
 
         <div>
-          <label className="block text-xs font-medium text-text-secondary dark:text-slate-400 mb-1">
+          <label className="block text-xs font-medium text-text-secondary mb-1">
             Description
           </label>
           <textarea
@@ -222,32 +222,32 @@ export function ListForm({ mode, list, initialName, onSuccess, onCreated, onCanc
             onChange={(e) => setDescription(e.target.value)}
             placeholder="Optional description"
             rows={2}
-            className="w-full px-3 py-2 text-sm border border-border dark:border-slate-600 rounded-md bg-background dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent resize-none"
+            className="w-full px-3 py-2 text-sm border border-border dark:border-border-strong rounded-md bg-background dark:bg-slate-700 text-text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent resize-none"
           />
         </div>
 
         <div>
-          <label className="block text-xs font-medium text-text-secondary dark:text-slate-400 mb-1">
+          <label className="block text-xs font-medium text-text-secondary mb-1">
             Icon
           </label>
           <ListEmojiPicker value={icon} onChange={setIcon} />
         </div>
 
         <div>
-          <label className="block text-xs font-medium text-text-secondary dark:text-slate-400 mb-1">
+          <label className="block text-xs font-medium text-text-secondary mb-1">
             Color
           </label>
           <ListColorPicker value={color} onChange={setColor} />
         </div>
 
         <div>
-          <label className="block text-xs font-medium text-text-secondary dark:text-slate-400 mb-1">
+          <label className="block text-xs font-medium text-text-secondary mb-1">
             Visibility
           </label>
           <select
             value={visibility}
             onChange={(e) => setVisibility(e.target.value as typeof visibility)}
-            className="w-full px-3 py-2 text-sm border border-border dark:border-slate-600 rounded-md bg-background dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+            className="w-full px-3 py-2 text-sm border border-border dark:border-border-strong rounded-md bg-background dark:bg-slate-700 text-text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
           >
             <option value="private">Private — only you can see</option>
             <option value="public_read">Public — others can view</option>

--- a/web/components/lists/ListMembersTable.tsx
+++ b/web/components/lists/ListMembersTable.tsx
@@ -19,7 +19,7 @@ function formatCoord(val: number, decimals: number = 6): string {
 
 function QualityBadge({ quality }: { quality: number }) {
   const def = REDSHIFT_QUALITY.find(q => q.value === quality);
-  if (!def || quality === 0) return <span className="text-text-secondary dark:text-slate-500">—</span>;
+  if (!def || quality === 0) return <span className="text-text-secondary dark:text-text-tertiary">—</span>;
   return (
     <span
       className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium"
@@ -37,7 +37,7 @@ export function ListMembersTable({ members, totalMembers, page, pageSize, onPage
   if (members.length === 0 && page === 1) {
     return (
       <Card className="p-8 text-center">
-        <p className="text-text-secondary dark:text-slate-400">
+        <p className="text-text-secondary">
           No objects with this tag yet.
         </p>
       </Card>
@@ -50,14 +50,14 @@ export function ListMembersTable({ members, totalMembers, page, pageSize, onPage
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b border-border dark:border-slate-700 bg-card dark:bg-slate-800/50">
-                <th className="text-left px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Object ID</th>
-                <th className="text-left px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Field</th>
-                <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400">RA</th>
-                <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Dec</th>
-                <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Redshift</th>
-                <th className="text-left px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Quality</th>
-                <th className="text-right px-4 py-3 font-medium text-text-secondary dark:text-slate-400">Spectra</th>
+              <tr className="border-b border-border bg-card dark:bg-slate-800/50">
+                <th className="text-left px-4 py-3 font-medium text-text-secondary">Object ID</th>
+                <th className="text-left px-4 py-3 font-medium text-text-secondary">Field</th>
+                <th className="text-right px-4 py-3 font-medium text-text-secondary">RA</th>
+                <th className="text-right px-4 py-3 font-medium text-text-secondary">Dec</th>
+                <th className="text-right px-4 py-3 font-medium text-text-secondary">Redshift</th>
+                <th className="text-left px-4 py-3 font-medium text-text-secondary">Quality</th>
+                <th className="text-right px-4 py-3 font-medium text-text-secondary">Spectra</th>
               </tr>
             </thead>
             <tbody>
@@ -79,7 +79,7 @@ export function ListMembersTable({ members, totalMembers, page, pageSize, onPage
                           {obj.object_id}
                         </Link>
                       ) : (
-                        <span className="text-xs text-text-secondary dark:text-slate-500 italic">
+                        <span className="text-xs text-text-secondary dark:text-text-tertiary italic">
                           Not yet matched
                         </span>
                       )}
@@ -113,24 +113,24 @@ export function ListMembersTable({ members, totalMembers, page, pageSize, onPage
       {/* Pagination */}
       {totalPages > 1 && (
         <div className="flex items-center justify-between mt-4 px-1">
-          <p className="text-sm text-text-secondary dark:text-slate-400">
+          <p className="text-sm text-text-secondary">
             Showing {(page - 1) * pageSize + 1}–{Math.min(page * pageSize, totalMembers)} of {totalMembers}
           </p>
           <div className="flex items-center gap-1">
             <button
               onClick={() => onPageChange(page - 1)}
               disabled={page <= 1}
-              className="px-3 py-1.5 text-sm border border-border dark:border-slate-700 rounded-md hover:bg-card-hover dark:hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="px-3 py-1.5 text-sm border border-border rounded-md hover:bg-card-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               Previous
             </button>
-            <span className="px-3 py-1.5 text-sm text-text-secondary dark:text-slate-400">
+            <span className="px-3 py-1.5 text-sm text-text-secondary">
               {page} / {totalPages}
             </span>
             <button
               onClick={() => onPageChange(page + 1)}
               disabled={page >= totalPages}
-              className="px-3 py-1.5 text-sm border border-border dark:border-slate-700 rounded-md hover:bg-card-hover dark:hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="px-3 py-1.5 text-sm border border-border rounded-md hover:bg-card-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               Next
             </button>

--- a/web/components/map/LayerControl.tsx
+++ b/web/components/map/LayerControl.tsx
@@ -48,11 +48,11 @@ export function LayerControl({
   const [collapsed, setCollapsed] = useState(false);
 
   return (
-    <div className="absolute top-[80px] left-2.5 z-[1000] bg-white dark:bg-slate-800 rounded-lg shadow-lg border border-gray-200 dark:border-slate-700 min-w-[180px]">
+    <div className="absolute top-[80px] left-2.5 z-[1000] bg-card rounded-lg shadow-lg border border-border min-w-[180px]">
       {/* Header — always visible, click to collapse */}
       <button
         onClick={() => setCollapsed(!collapsed)}
-        className="w-full flex items-center justify-between px-3 py-2 text-xs font-medium text-gray-500 dark:text-slate-400 uppercase tracking-wide hover:bg-gray-50 dark:hover:bg-slate-700/50 rounded-t-lg transition-colors"
+        className="w-full flex items-center justify-between px-3 py-2 text-xs font-medium text-text-secondary uppercase tracking-wide hover:bg-card-hover dark:hover:bg-slate-700/50 rounded-t-lg transition-colors"
       >
         <span className="flex items-center gap-1.5">
           <Layers className="w-3.5 h-3.5" />
@@ -70,14 +70,14 @@ export function LayerControl({
           {/* Field selector */}
           {fields.length > 1 && (
             <div className="mb-3">
-              <label className="block text-xs font-medium text-gray-500 dark:text-slate-400 mb-1 uppercase tracking-wide">
+              <label className="block text-xs font-medium text-text-secondary mb-1 uppercase tracking-wide">
                 Field
               </label>
               <div className="relative">
                 <select
                   value={selectedField}
                   onChange={(e) => onFieldChange(e.target.value)}
-                  className="w-full appearance-none bg-gray-50 dark:bg-slate-700 border border-gray-200 dark:border-slate-600 rounded px-3 py-1.5 text-sm text-gray-900 dark:text-slate-100 pr-8 uppercase"
+                  className="w-full appearance-none bg-card-hover border border-border dark:border-border-strong rounded px-3 py-1.5 text-sm text-text-primary pr-8 uppercase"
                 >
                   {fields.map((f) => (
                     <option key={f} value={f}>
@@ -85,14 +85,14 @@ export function LayerControl({
                     </option>
                   ))}
                 </select>
-                <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+                <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-text-tertiary pointer-events-none" />
               </div>
             </div>
           )}
 
           {/* Filter/layer selector — 3-column grid */}
           <div className="mb-3">
-            <label className="block text-xs font-medium text-gray-500 dark:text-slate-400 mb-1.5 uppercase tracking-wide">
+            <label className="block text-xs font-medium text-text-secondary mb-1.5 uppercase tracking-wide">
               Band
             </label>
             <div className="grid grid-cols-3 gap-1">
@@ -105,7 +105,7 @@ export function LayerControl({
                   } ${
                     activeLayer?.id === layer.id
                       ? 'bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-300 font-medium'
-                      : 'hover:bg-gray-100 dark:hover:bg-slate-700 text-gray-700 dark:text-slate-300'
+                      : 'hover:bg-card-hover text-text-primary dark:text-text-secondary'
                   }`}
                 >
                   {layer.filter.toUpperCase()}
@@ -115,23 +115,23 @@ export function LayerControl({
           </div>
 
           {/* Marker toggle */}
-          <div className="pt-2 border-t border-gray-200 dark:border-slate-700">
+          <div className="pt-2 border-t border-border">
             <label className="flex items-center gap-2 cursor-pointer">
               <input
                 type="checkbox"
                 checked={showMarkers}
                 onChange={(e) => onToggleMarkers(e.target.checked)}
-                className="rounded border-gray-300 dark:border-slate-600"
+                className="rounded border-border-strong"
               />
-              <MapPin className="w-3.5 h-3.5 text-gray-500 dark:text-slate-400" />
-              <span className="text-sm text-gray-700 dark:text-slate-300">
+              <MapPin className="w-3.5 h-3.5 text-text-secondary" />
+              <span className="text-sm text-text-primary dark:text-text-secondary">
                 Objects
                 {isLoadingMarkers ? (
-                  <span className="text-xs text-gray-400 ml-1">loading...</span>
+                  <span className="text-xs text-text-tertiary ml-1">loading...</span>
                 ) : filteredMarkerCount !== undefined && markerCount > 0 ? (
-                  <span className="text-xs text-gray-400 ml-1">({filteredMarkerCount} of {markerCount})</span>
+                  <span className="text-xs text-text-tertiary ml-1">({filteredMarkerCount} of {markerCount})</span>
                 ) : markerCount > 0 ? (
-                  <span className="text-xs text-gray-400 ml-1">({markerCount})</span>
+                  <span className="text-xs text-text-tertiary ml-1">({markerCount})</span>
                 ) : null}
               </span>
             </label>
@@ -145,17 +145,17 @@ export function LayerControl({
                 checked={showSlits}
                 onChange={(e) => onToggleSlits(e.target.checked)}
                 disabled={isLoadingSlits || slitCount === 0}
-                className="rounded border-gray-300 dark:border-slate-600 disabled:opacity-50"
+                className="rounded border-border-strong disabled:opacity-50"
               />
-              <Grid3X3 className="w-3.5 h-3.5 text-gray-500 dark:text-slate-400" />
-              <span className="text-sm text-gray-700 dark:text-slate-300">
+              <Grid3X3 className="w-3.5 h-3.5 text-text-secondary" />
+              <span className="text-sm text-text-primary dark:text-text-secondary">
                 Shutters
                 {isLoadingSlits ? (
-                  <span className="text-xs text-gray-400 ml-1">loading...</span>
+                  <span className="text-xs text-text-tertiary ml-1">loading...</span>
                 ) : filteredSlitCount !== undefined && slitCount > 0 ? (
-                  <span className="text-xs text-gray-400 ml-1">({filteredSlitCount} of {slitCount})</span>
+                  <span className="text-xs text-text-tertiary ml-1">({filteredSlitCount} of {slitCount})</span>
                 ) : slitCount > 0 ? (
-                  <span className="text-xs text-gray-400 ml-1">({slitCount})</span>
+                  <span className="text-xs text-text-tertiary ml-1">({slitCount})</span>
                 ) : null}
               </span>
             </label>
@@ -163,14 +163,14 @@ export function LayerControl({
 
           {/* Filter button */}
           {onOpenFilters && (
-            <div className="pt-2 border-t border-gray-200 dark:border-slate-700 mt-2">
+            <div className="pt-2 border-t border-border mt-2">
               <button
                 onClick={onOpenFilters}
                 className={`
                   w-full flex items-center gap-2 px-2.5 py-1.5 rounded text-sm transition-colors
                   ${hasActiveFilters
                     ? 'bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-300 font-medium'
-                    : 'hover:bg-gray-100 dark:hover:bg-slate-700 text-gray-700 dark:text-slate-300'
+                    : 'hover:bg-card-hover text-text-primary dark:text-text-secondary'
                   }
                 `}
               >

--- a/web/components/map/MapViewer.tsx
+++ b/web/components/map/MapViewer.tsx
@@ -339,8 +339,8 @@ export function MapViewer({
   if (!activeLayer || !mapConfig) {
     if (layers.length === 0) {
       return (
-        <div className="flex items-center justify-center h-full bg-surface dark:bg-slate-900">
-          <div className="text-center text-text-secondary dark:text-slate-400">
+        <div className="flex items-center justify-center h-full bg-surface dark:bg-background">
+          <div className="text-center text-text-secondary">
             <p className="text-lg font-medium mb-2">No map layers available</p>
             <p className="text-sm">Map tiles have not been generated yet.</p>
           </div>

--- a/web/components/map/MapViewerWrapper.tsx
+++ b/web/components/map/MapViewerWrapper.tsx
@@ -9,8 +9,8 @@ const MapViewer = dynamic(
   {
     ssr: false,
     loading: () => (
-      <div className="flex items-center justify-center h-full bg-surface dark:bg-slate-900">
-        <div className="text-text-secondary dark:text-slate-400">Loading map...</div>
+      <div className="flex items-center justify-center h-full bg-surface dark:bg-background">
+        <div className="text-text-secondary">Loading map...</div>
       </div>
     ),
   }

--- a/web/components/metadata/MetadataSearchBar.tsx
+++ b/web/components/metadata/MetadataSearchBar.tsx
@@ -152,7 +152,7 @@ export const MetadataSearchBar: React.FC<MetadataSearchBarProps> = ({
 
   return (
     <div ref={containerRef} className="relative w-full max-w-xl">
-      <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-secondary dark:text-slate-500" />
+      <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-secondary dark:text-text-tertiary" />
       <input
         type="text"
         value={value}
@@ -163,7 +163,7 @@ export const MetadataSearchBar: React.FC<MetadataSearchBarProps> = ({
         onFocus={() => setOpen(true)}
         onKeyDown={handleKey}
         placeholder="Search programs, observations, PIs, or JWST PIDs…"
-        className="w-full pl-9 pr-9 py-2 text-sm border border-border dark:border-slate-700 rounded-md bg-background dark:bg-slate-900 text-text-primary dark:text-slate-100 placeholder:text-text-secondary dark:placeholder:text-slate-500 focus:outline-none focus:ring-1 focus:ring-primary"
+        className="w-full pl-9 pr-9 py-2 text-sm border border-border rounded-md bg-background text-text-primary placeholder:text-text-secondary dark:placeholder:text-text-tertiary focus:outline-none focus:ring-1 focus:ring-primary"
       />
       {value && (
         <button
@@ -171,7 +171,7 @@ export const MetadataSearchBar: React.FC<MetadataSearchBarProps> = ({
             onChange('');
             setOpen(false);
           }}
-          className="absolute right-3 top-1/2 -translate-y-1/2 text-text-secondary dark:text-slate-500 hover:text-text-primary dark:hover:text-slate-200"
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-text-secondary dark:text-text-tertiary hover:text-text-primary"
           aria-label="Clear search"
         >
           <X className="w-4 h-4" />
@@ -179,13 +179,13 @@ export const MetadataSearchBar: React.FC<MetadataSearchBarProps> = ({
       )}
 
       {open && value.trim() && (
-        <div className="absolute z-40 mt-1 w-full bg-background dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg shadow-lg overflow-hidden">
+        <div className="absolute z-40 mt-1 w-full bg-background dark:bg-card border border-border rounded-lg shadow-lg overflow-hidden">
           {results.length === 0 ? (
-            <div className="px-3 py-3 text-sm text-text-secondary dark:text-slate-500 text-center">
+            <div className="px-3 py-3 text-sm text-text-secondary dark:text-text-tertiary text-center">
               No matches
             </div>
           ) : (
-            <ul className="max-h-[320px] overflow-y-auto divide-y divide-border dark:divide-slate-700">
+            <ul className="max-h-[320px] overflow-y-auto divide-y divide-border">
               {results.map((r, i) => {
                 const ResultIcon = Icon(r.kind);
                 return (
@@ -197,22 +197,22 @@ export const MetadataSearchBar: React.FC<MetadataSearchBarProps> = ({
                       onMouseEnter={() => setHighlight(i)}
                       className={`w-full flex items-start gap-3 px-3 py-2 text-left transition-colors ${
                         i === highlight
-                          ? 'bg-card-hover dark:bg-slate-700/60'
-                          : 'hover:bg-card-hover dark:hover:bg-slate-700/40'
+                          ? 'bg-card-hover dark:bg-card-hover/60'
+                          : 'hover:bg-card-hover dark:hover:bg-card-hover/40'
                       }`}
                     >
-                      <ResultIcon className="w-4 h-4 mt-0.5 flex-shrink-0 text-text-secondary dark:text-slate-400" />
+                      <ResultIcon className="w-4 h-4 mt-0.5 flex-shrink-0 text-text-secondary" />
                       <div className="min-w-0 flex-1">
-                        <div className="text-sm font-medium text-text-primary dark:text-slate-100 truncate">
+                        <div className="text-sm font-medium text-text-primary truncate">
                           {r.label}
                         </div>
                         {r.sublabel && (
-                          <div className="text-xs text-text-secondary dark:text-slate-400 truncate">
+                          <div className="text-xs text-text-secondary truncate">
                             {r.sublabel}
                           </div>
                         )}
                       </div>
-                      <span className="text-[10px] uppercase tracking-wider text-text-secondary dark:text-slate-500 self-center">
+                      <span className="text-[10px] uppercase tracking-wider text-text-secondary dark:text-text-tertiary self-center">
                         {r.kind}
                       </span>
                     </button>

--- a/web/components/metadata/ObservationsTable.tsx
+++ b/web/components/metadata/ObservationsTable.tsx
@@ -77,7 +77,7 @@ export const ObservationsTable: React.FC<ObservationsTableProps> = ({
         cell: ({ row }) => (
           <Link
             href={`/nirspec/metadata/programs/${row.original.program_slug}#${row.original.observation}`}
-            className="font-mono text-sm text-text-primary dark:text-slate-100 hover:text-primary"
+            className="font-mono text-sm text-text-primary hover:text-primary"
           >
             {row.original.observation}
           </Link>
@@ -91,7 +91,7 @@ export const ObservationsTable: React.FC<ObservationsTableProps> = ({
         cell: ({ row }) => (
           <Link
             href={`/nirspec/metadata/programs/${row.original.program_slug}`}
-            className="text-sm text-text-secondary dark:text-slate-400 hover:text-primary"
+            className="text-sm text-text-secondary hover:text-primary"
           >
             {row.original.program_name || row.original.program_slug}
           </Link>
@@ -103,7 +103,7 @@ export const ObservationsTable: React.FC<ObservationsTableProps> = ({
         header: 'Field',
         enableSorting: true,
         cell: ({ getValue }) => (
-          <span className="text-sm text-text-secondary dark:text-slate-400">
+          <span className="text-sm text-text-secondary">
             {String(getValue() || '—')}
           </span>
         ),
@@ -116,7 +116,7 @@ export const ObservationsTable: React.FC<ObservationsTableProps> = ({
         cell: ({ getValue }) => {
           const c = getValue();
           return (
-            <span className="text-sm text-text-secondary dark:text-slate-400">
+            <span className="text-sm text-text-secondary">
               {c == null ? '—' : `Cycle ${c}`}
             </span>
           );
@@ -128,7 +128,7 @@ export const ObservationsTable: React.FC<ObservationsTableProps> = ({
         header: 'Gratings',
         enableSorting: false,
         cell: ({ row }) => (
-          <span className="text-xs font-mono text-text-secondary dark:text-slate-400">
+          <span className="text-xs font-mono text-text-secondary">
             {row.original.gratings.length === 0 ? '—' : row.original.gratings.join(', ')}
           </span>
         ),
@@ -139,7 +139,7 @@ export const ObservationsTable: React.FC<ObservationsTableProps> = ({
         header: 'Pointings',
         enableSorting: true,
         cell: ({ getValue }) => (
-          <span className="text-sm tabular-nums text-text-primary dark:text-slate-100">
+          <span className="text-sm tabular-nums text-text-primary">
             {formatNumber(Number(getValue()) || 0)}
           </span>
         ),
@@ -150,7 +150,7 @@ export const ObservationsTable: React.FC<ObservationsTableProps> = ({
         header: 'Targets',
         enableSorting: true,
         cell: ({ getValue }) => (
-          <span className="text-sm tabular-nums text-text-primary dark:text-slate-100">
+          <span className="text-sm tabular-nums text-text-primary">
             {formatNumber(Number(getValue()) || 0)}
           </span>
         ),
@@ -161,7 +161,7 @@ export const ObservationsTable: React.FC<ObservationsTableProps> = ({
         header: 'Spectra',
         enableSorting: true,
         cell: ({ getValue }) => (
-          <span className="text-sm tabular-nums text-text-primary dark:text-slate-100">
+          <span className="text-sm tabular-nums text-text-primary">
             {formatNumber(Number(getValue()) || 0)}
           </span>
         ),
@@ -172,7 +172,7 @@ export const ObservationsTable: React.FC<ObservationsTableProps> = ({
         header: 'Size',
         enableSorting: true,
         cell: ({ getValue }) => (
-          <span className="text-sm tabular-nums text-text-secondary dark:text-slate-400">
+          <span className="text-sm tabular-nums text-text-secondary">
             {formatBytes(Number(getValue()) || 0)}
           </span>
         ),
@@ -191,7 +191,7 @@ export const ObservationsTable: React.FC<ObservationsTableProps> = ({
         header: 'JWST',
         enableSorting: true,
         cell: ({ getValue }) => (
-          <span className="text-xs font-mono text-text-secondary dark:text-slate-400">
+          <span className="text-xs font-mono text-text-secondary">
             {String(getValue() || '—')}
           </span>
         ),
@@ -202,7 +202,7 @@ export const ObservationsTable: React.FC<ObservationsTableProps> = ({
         header: 'CRDS',
         enableSorting: true,
         cell: ({ getValue }) => (
-          <span className="text-xs font-mono text-text-secondary dark:text-slate-400">
+          <span className="text-xs font-mono text-text-secondary">
             {String(getValue() || '—')}
           </span>
         ),
@@ -216,11 +216,11 @@ export const ObservationsTable: React.FC<ObservationsTableProps> = ({
           const username = row.original.deployed_by_username;
           const fullName = row.original.deployed_by_full_name;
           if (!username && !fullName) {
-            return <span className="text-xs text-text-secondary dark:text-slate-500">—</span>;
+            return <span className="text-xs text-text-secondary dark:text-text-tertiary">—</span>;
           }
           return (
             <span
-              className="text-xs text-text-secondary dark:text-slate-400"
+              className="text-xs text-text-secondary"
               title={fullName ?? undefined}
             >
               {username ?? fullName}
@@ -261,9 +261,9 @@ export const ObservationsTable: React.FC<ObservationsTableProps> = ({
   }
 
   return (
-    <div className="bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg">
-      <div className="flex items-center justify-between px-3 py-2 border-b border-border dark:border-slate-700">
-        <div className="text-sm text-text-secondary dark:text-slate-400">
+    <div className="bg-card border border-border rounded-lg">
+      <div className="flex items-center justify-between px-3 py-2 border-b border-border">
+        <div className="text-sm text-text-secondary">
           {observations.length.toLocaleString()} observation
           {observations.length === 1 ? '' : 's'}
         </div>
@@ -278,7 +278,7 @@ export const ObservationsTable: React.FC<ObservationsTableProps> = ({
       </div>
       <div className="overflow-x-auto">
         <table className="w-full text-sm">
-          <thead className="bg-card-hover dark:bg-slate-700/40 sticky top-0">
+          <thead className="bg-card-hover dark:bg-card-hover/40 sticky top-0">
             {table.getHeaderGroups().map((hg) => (
               <tr key={hg.id}>
                 {hg.headers.map((h) => {
@@ -287,12 +287,12 @@ export const ObservationsTable: React.FC<ObservationsTableProps> = ({
                   return (
                     <th
                       key={h.id}
-                      className="px-3 py-2 text-left text-[11px] uppercase tracking-wider font-semibold text-text-secondary dark:text-slate-400 border-b border-border dark:border-slate-700 whitespace-nowrap"
+                      className="px-3 py-2 text-left text-[11px] uppercase tracking-wider font-semibold text-text-secondary border-b border-border whitespace-nowrap"
                     >
                       {sortable ? (
                         <button
                           onClick={h.column.getToggleSortingHandler()}
-                          className="inline-flex items-center gap-1 hover:text-text-primary dark:hover:text-slate-200"
+                          className="inline-flex items-center gap-1 hover:text-text-primary"
                         >
                           {flexRender(h.column.columnDef.header, h.getContext())}
                           {sorted === 'asc' ? (
@@ -316,7 +316,7 @@ export const ObservationsTable: React.FC<ObservationsTableProps> = ({
             {table.getRowModel().rows.map((row) => (
               <tr
                 key={row.id}
-                className="border-b border-border dark:border-slate-700 last:border-b-0 hover:bg-card-hover dark:hover:bg-slate-700/40 transition-colors"
+                className="border-b border-border last:border-b-0 hover:bg-card-hover dark:hover:bg-card-hover/40 transition-colors"
               >
                 {row.getVisibleCells().map((cell) => (
                   <td key={cell.id} className="px-3 py-2 align-middle">

--- a/web/components/metadata/ProgramRow.tsx
+++ b/web/components/metadata/ProgramRow.tsx
@@ -54,7 +54,7 @@ export const ProgramRow: React.FC<ProgramRowProps> = ({ program }) => {
 
   return (
     <div
-      className="group grid grid-cols-[auto,1fr,auto,auto] gap-4 px-4 py-3 border-b border-border dark:border-slate-700 hover:bg-card-hover dark:hover:bg-slate-700/40 cursor-pointer transition-colors"
+      className="group grid grid-cols-[auto,1fr,auto,auto] gap-4 px-4 py-3 border-b border-border hover:bg-card-hover dark:hover:bg-card-hover/40 cursor-pointer transition-colors"
       onClick={() => router.push(`/nirspec/metadata/programs/${program.slug}`)}
     >
       {/* Identity column */}
@@ -63,10 +63,10 @@ export const ProgramRow: React.FC<ProgramRowProps> = ({ program }) => {
           <Telescope className="w-4 h-4 text-primary" />
         </div>
         <div className="min-w-0">
-          <div className="font-semibold text-text-primary dark:text-slate-100 truncate">
+          <div className="font-semibold text-text-primary truncate">
             {program.program_name || program.slug}
           </div>
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 mt-0.5 text-xs text-text-secondary dark:text-slate-400">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 mt-0.5 text-xs text-text-secondary">
             <span className="font-mono">{program.slug}</span>
             {program.pi_name && (
               <span className="inline-flex items-center gap-1">
@@ -80,22 +80,22 @@ export const ProgramRow: React.FC<ProgramRowProps> = ({ program }) => {
 
       {/* Stats column */}
       <div className="flex flex-col justify-center min-w-0">
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-text-secondary dark:text-slate-400">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-text-secondary">
           <span className="inline-flex items-center gap-1">
             <Hash className="w-3 h-3" />
-            <span className="text-text-primary dark:text-slate-100 font-medium">
+            <span className="text-text-primary font-medium">
               {formatNumber(program.target_count)}
             </span>{' '}
             targets
           </span>
           <span>
-            <span className="text-text-primary dark:text-slate-100 font-medium">
+            <span className="text-text-primary font-medium">
               {program.n_observations}
             </span>{' '}
             obs
           </span>
           <span>
-            <span className="text-text-primary dark:text-slate-100 font-medium">
+            <span className="text-text-primary font-medium">
               {program.fields.length}
             </span>{' '}
             {program.fields.length === 1 ? 'field' : 'fields'}
@@ -120,13 +120,13 @@ export const ProgramRow: React.FC<ProgramRowProps> = ({ program }) => {
               public
             </span>
           ) : (
-            <span className="inline-flex items-center gap-1 text-text-secondary dark:text-slate-400" title="Restricted">
+            <span className="inline-flex items-center gap-1 text-text-secondary" title="Restricted">
               <Lock className="w-3 h-3" />
               restricted
             </span>
           )}
         </div>
-        <div className="text-text-secondary dark:text-slate-400 mt-0.5">
+        <div className="text-text-secondary mt-0.5">
           reduced {formatRelative(program.last_reduced_at)}
         </div>
       </div>
@@ -139,13 +139,13 @@ export const ProgramRow: React.FC<ProgramRowProps> = ({ program }) => {
             target="_blank"
             rel="noopener noreferrer"
             onClick={(e) => e.stopPropagation()}
-            className="text-text-secondary dark:text-slate-400 hover:text-primary transition-colors"
+            className="text-text-secondary hover:text-primary transition-colors"
             title="View on STScI"
           >
             <ExternalLink className="w-4 h-4" />
           </a>
         )}
-        <ArrowRight className="w-4 h-4 text-text-secondary dark:text-slate-400 group-hover:text-primary transition-colors" />
+        <ArrowRight className="w-4 h-4 text-text-secondary group-hover:text-primary transition-colors" />
       </div>
     </div>
   );

--- a/web/components/metadata/ProgramsList.tsx
+++ b/web/components/metadata/ProgramsList.tsx
@@ -22,8 +22,8 @@ export const ProgramsList: React.FC<ProgramsListProps> = ({ programs }) => {
   }
 
   return (
-    <div className="bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg overflow-hidden">
-      <div className="grid grid-cols-[auto,1fr,auto,auto] gap-4 px-4 py-2 bg-card-hover dark:bg-slate-700/40 text-[11px] uppercase tracking-wider font-semibold text-text-secondary dark:text-slate-400 border-b border-border dark:border-slate-700">
+    <div className="bg-card border border-border rounded-lg overflow-hidden">
+      <div className="grid grid-cols-[auto,1fr,auto,auto] gap-4 px-4 py-2 bg-card-hover dark:bg-card-hover/40 text-[11px] uppercase tracking-wider font-semibold text-text-secondary border-b border-border">
         <div className="w-8" />
         <div>Program · stats</div>
         <div className="text-right">Status</div>

--- a/web/components/metadata/ProvenanceCell.tsx
+++ b/web/components/metadata/ProvenanceCell.tsx
@@ -63,18 +63,18 @@ export const ProvenanceCell: React.FC<ProvenanceCellProps> = ({ provenance, comp
           className="group inline-flex items-center gap-1.5 text-left hover:text-primary transition-colors"
           title="Show reduction details"
         >
-          <span className={compact ? 'text-sm font-medium text-text-primary dark:text-slate-100' : 'font-semibold'}>
+          <span className={compact ? 'text-sm font-medium text-text-primary' : 'font-semibold'}>
             {reduction_version ?? '—'}
           </span>
           {reducedRel && (
-            <span className="text-xs text-text-secondary dark:text-slate-400">
+            <span className="text-xs text-text-secondary">
               {reducedRel}
             </span>
           )}
-          <Info className="w-3 h-3 text-text-secondary dark:text-slate-400 opacity-0 group-hover:opacity-100 transition-opacity" />
+          <Info className="w-3 h-3 text-text-secondary opacity-0 group-hover:opacity-100 transition-opacity" />
         </button>
       ) : (
-        <span className="text-xs text-text-secondary dark:text-slate-400 italic">no full reduction</span>
+        <span className="text-xs text-text-secondary italic">no full reduction</span>
       )}
 
       {n_patches_since_full > 0 && (
@@ -89,41 +89,41 @@ export const ProvenanceCell: React.FC<ProvenanceCellProps> = ({ provenance, comp
 
       {open && hasFull && (
         <div
-          className="absolute z-30 top-full left-0 mt-2 w-80 rounded-md border border-border dark:border-slate-700 bg-card dark:bg-slate-800 shadow-lg p-3 text-xs leading-relaxed"
+          className="absolute z-30 top-full left-0 mt-2 w-80 rounded-md border border-border bg-card shadow-lg p-3 text-xs leading-relaxed"
           onMouseDown={(e) => e.preventDefault()}
         >
-          <div className="font-semibold text-text-primary dark:text-slate-100 mb-2">
+          <div className="font-semibold text-text-primary mb-2">
             Last full reduction
           </div>
-          <dl className="grid grid-cols-[auto,1fr] gap-x-3 gap-y-1 text-text-secondary dark:text-slate-400">
+          <dl className="grid grid-cols-[auto,1fr] gap-x-3 gap-y-1 text-text-secondary">
             <dt>Version</dt>
-            <dd className="font-mono text-text-primary dark:text-slate-100">{reduction_version ?? '—'}</dd>
+            <dd className="font-mono text-text-primary">{reduction_version ?? '—'}</dd>
             <dt>cfpipe</dt>
-            <dd className="font-mono text-text-primary dark:text-slate-100">{cfpipe_version ?? '—'}</dd>
+            <dd className="font-mono text-text-primary">{cfpipe_version ?? '—'}</dd>
             <dt>jwst</dt>
-            <dd className="font-mono text-text-primary dark:text-slate-100">{jwst_version ?? '—'}</dd>
+            <dd className="font-mono text-text-primary">{jwst_version ?? '—'}</dd>
             <dt>CRDS</dt>
-            <dd className="font-mono text-text-primary dark:text-slate-100">{crds_context ?? '—'}</dd>
+            <dd className="font-mono text-text-primary">{crds_context ?? '—'}</dd>
             <dt>Reduced</dt>
-            <dd className="font-mono text-text-primary dark:text-slate-100">{formatTimestamp(reduced_at)}</dd>
+            <dd className="font-mono text-text-primary">{formatTimestamp(reduced_at)}</dd>
             <dt>Deployed</dt>
-            <dd className="font-mono text-text-primary dark:text-slate-100">{formatTimestamp(deployed_at)}</dd>
+            <dd className="font-mono text-text-primary">{formatTimestamp(deployed_at)}</dd>
             <dt>By</dt>
-            <dd className="text-text-primary dark:text-slate-100" title={deployed_by_full_name ?? undefined}>
+            <dd className="text-text-primary" title={deployed_by_full_name ?? undefined}>
               {deployed_by_username ?? deployed_by_full_name ?? '—'}
             </dd>
           </dl>
           {n_patches_since_full > 0 && (
-            <div className="mt-3 pt-2 border-t border-border dark:border-slate-700">
+            <div className="mt-3 pt-2 border-t border-border">
               <div className="font-semibold text-amber-700 dark:text-amber-300 mb-1">
                 {n_patches_since_full} patch{n_patches_since_full === 1 ? '' : 'es'} since
               </div>
-              <p className="text-text-secondary dark:text-slate-400">
+              <p className="text-text-secondary">
                 Per-source re-reductions exist after this full reduction. Affected spectra
                 may have a newer reduction version than shown above.
               </p>
               {last_patch_at && (
-                <div className="mt-1 text-text-secondary dark:text-slate-400">
+                <div className="mt-1 text-text-secondary">
                   Most recent: <span className="font-mono">{formatTimestamp(last_patch_at)}</span>
                 </div>
               )}

--- a/web/components/metadata/ScopeHeader.tsx
+++ b/web/components/metadata/ScopeHeader.tsx
@@ -46,12 +46,12 @@ const Stat: React.FC<{
   label: string;
 }> = ({ icon: Icon, value, label }) => (
   <div className="flex items-center gap-2 px-3 py-2">
-    <Icon className="w-4 h-4 text-text-secondary dark:text-slate-400 flex-shrink-0" />
+    <Icon className="w-4 h-4 text-text-secondary flex-shrink-0" />
     <div className="flex flex-col leading-tight">
-      <span className="text-sm font-semibold text-text-primary dark:text-slate-100 tabular-nums">
+      <span className="text-sm font-semibold text-text-primary tabular-nums">
         {value}
       </span>
-      <span className="text-[10px] uppercase tracking-wider text-text-secondary dark:text-slate-400">
+      <span className="text-[10px] uppercase tracking-wider text-text-secondary">
         {label}
       </span>
     </div>
@@ -61,7 +61,7 @@ const Stat: React.FC<{
 export const ScopeHeader: React.FC<ScopeHeaderProps> = ({ overview, loading }) => {
   if (loading || !overview) {
     return (
-      <div className="bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg px-2 py-1 mb-6 h-14 animate-pulse" />
+      <div className="bg-card border border-border rounded-lg px-2 py-1 mb-6 h-14 animate-pulse" />
     );
   }
 
@@ -70,7 +70,7 @@ export const ScopeHeader: React.FC<ScopeHeaderProps> = ({ overview, loading }) =
     : formatRelative(overview.latest_deployed_at);
 
   return (
-    <div className="bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg px-2 py-1 mb-6 flex flex-wrap items-center divide-x divide-border dark:divide-slate-700">
+    <div className="bg-card border border-border rounded-lg px-2 py-1 mb-6 flex flex-wrap items-center divide-x divide-border">
       <Stat icon={Database} value={formatNumber(overview.n_programs)} label="programs" />
       <Stat icon={Telescope} value={formatNumber(overview.n_observations)} label="observations" />
       <Stat icon={MapPin} value={formatNumber(overview.n_pointings)} label="pointings" />

--- a/web/components/nircam/MaskEditor.tsx
+++ b/web/components/nircam/MaskEditor.tsx
@@ -306,7 +306,7 @@ export default function MaskEditor({
   return (
     <div className="flex flex-col h-full">
       {/* Toolbar */}
-      <div className="flex items-center justify-between p-2 border-b border-border dark:border-slate-700 bg-surface dark:bg-slate-900 flex-shrink-0">
+      <div className="flex items-center justify-between p-2 border-b border-border bg-surface dark:bg-slate-900 flex-shrink-0">
         <div className="flex items-center gap-1">
           <ToolButton active={mode === 'inspect'} onClick={() => { setMode('inspect'); setDraftVertices([]); }}
             label="Inspect (pan/zoom)"><Hand className="w-4 h-4" /></ToolButton>
@@ -324,7 +324,7 @@ export default function MaskEditor({
             </ToolButton>
           )}
         </div>
-        <div className="flex items-center gap-3 text-xs text-text-secondary dark:text-slate-400">
+        <div className="flex items-center gap-3 text-xs text-text-secondary">
           <span>{polygons.length} polygon{polygons.length === 1 ? '' : 's'}</span>
           <span>{(scale * 100).toFixed(0)}%</span>
           {saveError && <span className="text-red-500">{saveError}</span>}
@@ -488,7 +488,7 @@ function ToolButton({
       className={`p-1.5 rounded text-sm ${
         active
           ? 'bg-primary/15 text-primary'
-          : 'text-text-secondary dark:text-slate-400 hover:bg-surface-hover dark:hover:bg-slate-800'
+          : 'text-text-secondary hover:bg-surface-hover dark:hover:bg-slate-800'
       }`}
     >
       {children}

--- a/web/components/nircam/NircamTable.tsx
+++ b/web/components/nircam/NircamTable.tsx
@@ -45,7 +45,7 @@ const SortableHeader: React.FC<{
       ) : sorted === 'desc' ? (
         <ArrowDown className="w-3.5 h-3.5 text-primary" />
       ) : (
-        <ArrowUpDown className="w-3.5 h-3.5 text-text-secondary dark:text-slate-400 opacity-0 group-hover:opacity-100 transition-opacity" />
+        <ArrowUpDown className="w-3.5 h-3.5 text-text-secondary opacity-0 group-hover:opacity-100 transition-opacity" />
       )}
     </button>
   );
@@ -119,7 +119,7 @@ export const NircamTable: React.FC<NircamTableProps> = ({
           <SortableHeader column={column}>Field</SortableHeader>
         ),
         cell: ({ row }) => (
-          <span className="text-sm font-medium text-text-primary dark:text-slate-100 uppercase">
+          <span className="text-sm font-medium text-text-primary uppercase">
             {row.original.field}
           </span>
         ),
@@ -131,7 +131,7 @@ export const NircamTable: React.FC<NircamTableProps> = ({
           <SortableHeader column={column}>Filter</SortableHeader>
         ),
         cell: ({ row }) => (
-          <span className="text-sm font-mono text-text-primary dark:text-slate-100 uppercase">
+          <span className="text-sm font-mono text-text-primary uppercase">
             {row.original.filter}
           </span>
         ),
@@ -143,7 +143,7 @@ export const NircamTable: React.FC<NircamTableProps> = ({
           <SortableHeader column={column}>Tile</SortableHeader>
         ),
         cell: ({ row }) => (
-          <span className="text-sm font-mono text-text-primary dark:text-slate-100">
+          <span className="text-sm font-mono text-text-primary">
             {row.original.tile}
           </span>
         ),
@@ -172,7 +172,7 @@ export const NircamTable: React.FC<NircamTableProps> = ({
           <SortableHeader column={column}>Pixel Scale</SortableHeader>
         ),
         cell: ({ row }) => (
-          <span className="text-sm font-mono text-text-primary dark:text-slate-100">
+          <span className="text-sm font-mono text-text-primary">
             {row.original.pixel_scale}
           </span>
         ),
@@ -184,7 +184,7 @@ export const NircamTable: React.FC<NircamTableProps> = ({
           <SortableHeader column={column}>Version</SortableHeader>
         ),
         cell: ({ row }) => (
-          <span className="text-sm font-mono text-text-primary dark:text-slate-100">
+          <span className="text-sm font-mono text-text-primary">
             {row.original.version}
           </span>
         ),
@@ -196,7 +196,7 @@ export const NircamTable: React.FC<NircamTableProps> = ({
           <SortableHeader column={column}>Extension</SortableHeader>
         ),
         cell: ({ row }) => (
-          <span className="text-sm font-mono text-text-primary dark:text-slate-100 uppercase">
+          <span className="text-sm font-mono text-text-primary uppercase">
             {row.original.extension}
           </span>
         ),
@@ -219,7 +219,7 @@ export const NircamTable: React.FC<NircamTableProps> = ({
           <SortableHeader column={column}>Size</SortableHeader>
         ),
         cell: ({ row }) => (
-          <span className="text-sm text-text-secondary dark:text-slate-400">
+          <span className="text-sm text-text-secondary">
             {formatFileSize(row.original.file_size)}
           </span>
         ),
@@ -262,13 +262,13 @@ export const NircamTable: React.FC<NircamTableProps> = ({
     <Card className="overflow-hidden">
       <div className="overflow-x-auto">
         <table className="w-full">
-          <thead className="bg-card dark:bg-slate-800 border-b border-border dark:border-slate-700">
+          <thead className="bg-card border-b border-border">
             {table.getHeaderGroups().map((headerGroup) => (
               <tr key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <th
                     key={header.id}
-                    className="px-4 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider"
+                    className="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider"
                   >
                     {header.isPlaceholder
                       ? null
@@ -278,11 +278,11 @@ export const NircamTable: React.FC<NircamTableProps> = ({
               </tr>
             ))}
           </thead>
-          <tbody className="bg-white dark:bg-slate-800 divide-y divide-border dark:divide-slate-700">
+          <tbody className="bg-card divide-y divide-border">
             {table.getRowModel().rows.map((row) => (
               <tr
                 key={row.id}
-                className="hover:bg-card-hover dark:hover:bg-slate-700 transition-colors"
+                className="hover:bg-card-hover transition-colors"
               >
                 {row.getVisibleCells().map((cell) => (
                   <td key={cell.id} className="px-4 py-3 whitespace-nowrap">
@@ -296,11 +296,11 @@ export const NircamTable: React.FC<NircamTableProps> = ({
       </div>
 
       {filteredImages.length === 0 ? (
-        <div className="text-center py-12 text-text-secondary dark:text-slate-400">
+        <div className="text-center py-12 text-text-secondary">
           No images found matching the current filters.
         </div>
       ) : (
-        <div className="border-t border-border dark:border-slate-700">
+        <div className="border-t border-border">
           <TablePagination
             pageIndex={table.getState().pagination.pageIndex}
             pageSize={table.getState().pagination.pageSize}

--- a/web/components/settings/SettingsCard.tsx
+++ b/web/components/settings/SettingsCard.tsx
@@ -35,7 +35,7 @@ export const SettingsCard: React.FC = () => {
         <div className="w-10 h-10 bg-primary/10 rounded-full flex items-center justify-center">
           <Settings className="w-5 h-5 text-primary" />
         </div>
-        <h2 className="text-lg font-semibold text-text-primary dark:text-slate-100">Settings</h2>
+        <h2 className="text-lg font-semibold text-text-primary">Settings</h2>
       </div>
 
       {/* Group Account Notice */}
@@ -50,15 +50,15 @@ export const SettingsCard: React.FC = () => {
 
       {/* Appearance Section */}
       <div className="mb-8">
-        <h3 className="text-sm font-semibold text-text-primary dark:text-slate-100 mb-3 flex items-center gap-2">
+        <h3 className="text-sm font-semibold text-text-primary mb-3 flex items-center gap-2">
           <Sun className="w-4 h-4" />
           Appearance
         </h3>
 
         <div className="space-y-6">
           <div>
-            <label className="text-sm text-text-secondary dark:text-slate-400 mb-2 block">Theme</label>
-            <div className="flex rounded-lg border border-border dark:border-slate-600 overflow-hidden w-fit">
+            <label className="text-sm text-text-secondary mb-2 block">Theme</label>
+            <div className="flex rounded-lg border border-border dark:border-border-strong overflow-hidden w-fit">
               {themeOptions.map((option) => {
                 const Icon = option.icon;
                 const isActive = theme === option.value;
@@ -73,8 +73,8 @@ export const SettingsCard: React.FC = () => {
                     className={`
                       flex items-center gap-2 px-4 py-2 text-sm transition-colors
                       ${isActive
-                        ? 'bg-primary text-white'
-                        : 'bg-white dark:bg-slate-800 text-text-secondary dark:text-slate-400 hover:bg-gray-100 dark:hover:bg-slate-700'
+                        ? 'bg-primary text-on-primary'
+                        : 'bg-card text-text-secondary hover:bg-card-hover'
                       }
                       ${isGroupAccount ? 'opacity-50 cursor-not-allowed' : ''}
                     `}
@@ -89,11 +89,11 @@ export const SettingsCard: React.FC = () => {
 
           {/* Accent Color */}
           <div>
-            <label className="text-sm text-text-secondary dark:text-slate-400 mb-2 block flex items-center gap-2">
+            <label className="text-sm text-text-secondary mb-2 block flex items-center gap-2">
               <Palette className="w-4 h-4" />
               Accent Color
             </label>
-            <p className="text-xs text-text-secondary dark:text-slate-500 mb-3">
+            <p className="text-xs text-text-secondary dark:text-text-tertiary mb-3">
               Affects buttons, links, and spectrum plot throughout the site
             </p>
             <div className="flex flex-wrap gap-2">
@@ -125,7 +125,7 @@ export const SettingsCard: React.FC = () => {
 
       {/* Spectrum Viewer Defaults Section */}
       <div>
-        <h3 className="text-sm font-semibold text-text-primary dark:text-slate-100 mb-3 flex items-center gap-2">
+        <h3 className="text-sm font-semibold text-text-primary mb-3 flex items-center gap-2">
           <BarChart3 className="w-4 h-4" />
           Spectrum Viewer Defaults
         </h3>
@@ -133,10 +133,10 @@ export const SettingsCard: React.FC = () => {
         <div className="space-y-6">
           {/* Flux Unit */}
           <div>
-            <label className="text-sm text-text-secondary dark:text-slate-400 mb-2 block">
+            <label className="text-sm text-text-secondary mb-2 block">
               Default Flux Units
             </label>
-            <div className="flex rounded-lg border border-border dark:border-slate-600 overflow-hidden w-fit">
+            <div className="flex rounded-lg border border-border dark:border-border-strong overflow-hidden w-fit">
               {fluxUnitOptions.map((option) => (
                 <button
                   key={option.value}
@@ -145,8 +145,8 @@ export const SettingsCard: React.FC = () => {
                   className={`
                     px-4 py-2 text-sm transition-colors
                     ${spectrumPreferences.fluxUnit === option.value
-                      ? 'bg-primary text-white'
-                      : 'bg-white dark:bg-slate-800 text-text-secondary dark:text-slate-400 hover:bg-gray-100 dark:hover:bg-slate-700'
+                      ? 'bg-primary text-on-primary'
+                      : 'bg-card text-text-secondary hover:bg-card-hover'
                     }
                     ${isGroupAccount ? 'opacity-50 cursor-not-allowed' : ''}
                   `}
@@ -159,14 +159,14 @@ export const SettingsCard: React.FC = () => {
 
           {/* 2D Colorscale */}
           <div>
-            <label className="text-sm text-text-secondary dark:text-slate-400 mb-2 block">
+            <label className="text-sm text-text-secondary mb-2 block">
               2D Spectrum Colormap
             </label>
             <select
               value={spectrumPreferences.colorscale2D}
               onChange={(e) => updateSpectrumPreferences({ colorscale2D: e.target.value as Colorscale2D })}
               disabled={isGroupAccount}
-              className={`px-4 py-2 text-sm border border-border dark:border-slate-600 rounded-lg bg-white dark:bg-slate-800 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary ${isGroupAccount ? 'opacity-50 cursor-not-allowed' : ''}`}
+              className={`px-4 py-2 text-sm border border-border dark:border-border-strong rounded-lg bg-card text-text-primary focus:outline-none focus:ring-2 focus:ring-primary ${isGroupAccount ? 'opacity-50 cursor-not-allowed' : ''}`}
             >
               {COLORSCALE_OPTIONS.map((scale) => (
                 <option key={scale} value={scale}>
@@ -178,7 +178,7 @@ export const SettingsCard: React.FC = () => {
 
           {/* SNR Range */}
           <div>
-            <label className="text-sm text-text-secondary dark:text-slate-400 mb-2 block">
+            <label className="text-sm text-text-secondary mb-2 block">
               Default 2D Scale Range
             </label>
             <div className="flex items-center gap-3">
@@ -187,15 +187,15 @@ export const SettingsCard: React.FC = () => {
                 value={spectrumPreferences.snrMin}
                 onChange={(e) => updateSpectrumPreferences({ snrMin: parseFloat(e.target.value) || 0 })}
                 disabled={isGroupAccount}
-                className={`w-20 px-3 py-2 text-sm border border-border dark:border-slate-600 rounded-lg bg-white dark:bg-slate-800 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary ${isGroupAccount ? 'opacity-50 cursor-not-allowed' : ''}`}
+                className={`w-20 px-3 py-2 text-sm border border-border dark:border-border-strong rounded-lg bg-card text-text-primary focus:outline-none focus:ring-2 focus:ring-primary ${isGroupAccount ? 'opacity-50 cursor-not-allowed' : ''}`}
               />
-              <span className="text-text-secondary dark:text-slate-400">to</span>
+              <span className="text-text-secondary">to</span>
               <input
                 type="number"
                 value={spectrumPreferences.snrMax}
                 onChange={(e) => updateSpectrumPreferences({ snrMax: parseFloat(e.target.value) || 0 })}
                 disabled={isGroupAccount}
-                className={`w-20 px-3 py-2 text-sm border border-border dark:border-slate-600 rounded-lg bg-white dark:bg-slate-800 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary ${isGroupAccount ? 'opacity-50 cursor-not-allowed' : ''}`}
+                className={`w-20 px-3 py-2 text-sm border border-border dark:border-border-strong rounded-lg bg-card text-text-primary focus:outline-none focus:ring-2 focus:ring-primary ${isGroupAccount ? 'opacity-50 cursor-not-allowed' : ''}`}
               />
             </div>
           </div>

--- a/web/components/spectra/AdvancedFiltersPanel.tsx
+++ b/web/components/spectra/AdvancedFiltersPanel.tsx
@@ -272,25 +272,25 @@ export function AdvancedFiltersPanel({
       <div
         className={`
           absolute right-0 top-0 bottom-0 w-[420px] max-w-[90vw]
-          bg-background dark:bg-slate-900 border-l border-border dark:border-slate-700
+          bg-background dark:bg-slate-900 border-l border-border
           shadow-2xl flex flex-col
           transition-transform duration-300 ease-out
           ${isOpen ? 'translate-x-0 pointer-events-auto' : 'translate-x-full'}
         `}
       >
         {/* Panel Header */}
-        <div className="flex items-center justify-between p-4 border-b border-border dark:border-slate-700 bg-card dark:bg-slate-800">
+        <div className="flex items-center justify-between p-4 border-b border-border bg-card">
           <div>
-            <h2 className="text-lg font-semibold text-text-primary dark:text-slate-100">
+            <h2 className="text-lg font-semibold text-text-primary">
               {showBasicFilters ? 'Filters' : 'Advanced Filters'}
             </h2>
-            <p className="text-xs text-text-secondary dark:text-slate-400 mt-0.5">
+            <p className="text-xs text-text-secondary mt-0.5">
               {showBasicFilters ? 'Filter objects shown on the map' : 'Multi-value filters and spectra properties'}
             </p>
           </div>
           <button
             onClick={onClose}
-            className="p-2 rounded-lg text-text-secondary dark:text-slate-400 hover:bg-card-hover dark:hover:bg-slate-700 hover:text-text-primary dark:hover:text-slate-200 transition-colors"
+            className="p-2 rounded-lg text-text-secondary hover:bg-card-hover hover:text-text-primary transition-colors"
           >
             <X className="w-5 h-5" />
           </button>
@@ -302,10 +302,10 @@ export function AdvancedFiltersPanel({
           {showBasicFilters && (
             <>
               {/* Programs — collapsible */}
-              <div className="border-b border-border dark:border-slate-700">
+              <div className="border-b border-border">
                 <button
                   onClick={() => setProgramsExpanded(!programsExpanded)}
-                  className="w-full flex items-center justify-between px-4 py-3 text-xs font-semibold uppercase tracking-wider text-text-secondary dark:text-slate-500 hover:bg-card-hover dark:hover:bg-slate-800/50 transition-colors"
+                  className="w-full flex items-center justify-between px-4 py-3 text-xs font-semibold uppercase tracking-wider text-text-secondary dark:text-text-tertiary hover:bg-card-hover dark:hover:bg-slate-800/50 transition-colors"
                 >
                   <span>
                     Programs
@@ -331,10 +331,10 @@ export function AdvancedFiltersPanel({
               </div>
 
               {/* Observations — collapsible */}
-              <div className="border-b border-border dark:border-slate-700">
+              <div className="border-b border-border">
                 <button
                   onClick={() => setObservationsExpanded(!observationsExpanded)}
-                  className="w-full flex items-center justify-between px-4 py-3 text-xs font-semibold uppercase tracking-wider text-text-secondary dark:text-slate-500 hover:bg-card-hover dark:hover:bg-slate-800/50 transition-colors"
+                  className="w-full flex items-center justify-between px-4 py-3 text-xs font-semibold uppercase tracking-wider text-text-secondary dark:text-text-tertiary hover:bg-card-hover dark:hover:bg-slate-800/50 transition-colors"
                 >
                   <span className="flex flex-col items-start">
                     <span>
@@ -343,7 +343,7 @@ export function AdvancedFiltersPanel({
                         <span className="ml-1.5 text-[10px] font-bold text-primary">({filters.observations.length})</span>
                       )}
                     </span>
-                    <span className="text-[10px] font-normal normal-case tracking-normal text-gray-400 dark:text-slate-500">Filters objects and map shutters</span>
+                    <span className="text-[10px] font-normal normal-case tracking-normal text-text-tertiary">Filters objects and map shutters</span>
                   </span>
                   <ChevronDown className={`w-4 h-4 transition-transform ${observationsExpanded ? 'rotate-180' : ''}`} />
                 </button>
@@ -363,7 +363,7 @@ export function AdvancedFiltersPanel({
               </div>
 
               {/* Redshift Quality */}
-              <div className="p-4 border-b border-border dark:border-slate-700">
+              <div className="p-4 border-b border-border">
                 <InlineMultiFilter
                   label="Redshift Quality"
                   options={qualityOptions}
@@ -376,7 +376,7 @@ export function AdvancedFiltersPanel({
               </div>
 
               {/* Redshift Range */}
-              <div className="p-4 border-b border-border dark:border-slate-700">
+              <div className="p-4 border-b border-border">
                 <InlineRange
                   label="Redshift"
                   description="Filter by redshift range"
@@ -394,9 +394,9 @@ export function AdvancedFiltersPanel({
 
           {/* Position Search Section - Inline Form (hidden on map view) */}
           {!showBasicFilters && (
-            <div className="p-4 border-b border-border dark:border-slate-700">
+            <div className="p-4 border-b border-border">
               <div className="flex items-center justify-between mb-3">
-                <h3 className="text-xs font-semibold uppercase tracking-wider text-text-secondary dark:text-slate-500">
+                <h3 className="text-xs font-semibold uppercase tracking-wider text-text-secondary dark:text-text-tertiary">
                   Position Search
                 </h3>
                 {isCoordSearchActive && (
@@ -410,7 +410,7 @@ export function AdvancedFiltersPanel({
               <div className="space-y-3">
                 {/* Coordinate input */}
                 <div>
-                  <label className="block text-xs text-text-secondary dark:text-slate-400 mb-1">
+                  <label className="block text-xs text-text-secondary mb-1">
                     Coordinates (RA Dec)
                   </label>
                   <input
@@ -419,8 +419,8 @@ export function AdvancedFiltersPanel({
                     onChange={(e) => setCoordInput(e.target.value)}
                     onKeyDown={handleKeyDown}
                     placeholder="150.5 -2.3  or  10h02m30s -02d18m00s"
-                    className={`w-full px-3 py-2 text-sm border rounded-md bg-background dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent font-mono
-                      ${validationError ? 'border-red-500 dark:border-red-600' : 'border-border dark:border-slate-600'}
+                    className={`w-full px-3 py-2 text-sm border rounded-md bg-background dark:bg-slate-700 text-text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent font-mono
+                      ${validationError ? 'border-red-500 dark:border-red-600' : 'border-border dark:border-border-strong'}
                     `}
                   />
                   {validationError && (
@@ -430,7 +430,7 @@ export function AdvancedFiltersPanel({
 
                 {/* Radius input with units */}
                 <div>
-                  <label className="block text-xs text-text-secondary dark:text-slate-400 mb-1">
+                  <label className="block text-xs text-text-secondary mb-1">
                     Search radius (max 1 degree)
                   </label>
                   <div className="flex gap-2">
@@ -442,12 +442,12 @@ export function AdvancedFiltersPanel({
                       placeholder="1"
                       min="0"
                       step="0.1"
-                      className="w-24 px-3 py-2 text-sm border border-border dark:border-slate-600 rounded-md bg-background dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+                      className="w-24 px-3 py-2 text-sm border border-border dark:border-border-strong rounded-md bg-background dark:bg-slate-700 text-text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
                     />
                     <select
                       value={unitInput}
                       onChange={(e) => setUnitInput(e.target.value as 'degrees' | 'arcmin' | 'arcsec')}
-                      className="flex-1 px-3 py-2 text-sm border border-border dark:border-slate-600 rounded-md bg-background dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+                      className="flex-1 px-3 py-2 text-sm border border-border dark:border-border-strong rounded-md bg-background dark:bg-slate-700 text-text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
                     >
                       <option value="arcsec">arcseconds</option>
                       <option value="arcmin">arcminutes</option>
@@ -460,14 +460,14 @@ export function AdvancedFiltersPanel({
                 <div className="flex gap-2 pt-1">
                   <button
                     onClick={handleClearCoordSearch}
-                    className="flex-1 px-3 py-1.5 text-sm text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200 border border-border dark:border-slate-600 rounded-md hover:bg-card-hover dark:hover:bg-slate-700 transition-colors"
+                    className="flex-1 px-3 py-1.5 text-sm text-text-secondary hover:text-text-primary border border-border dark:border-border-strong rounded-md hover:bg-card-hover transition-colors"
                   >
                     Clear
                   </button>
                   <button
                     onClick={handleApplyCoordSearch}
                     disabled={validationError !== null && coordInput.trim() !== ''}
-                    className="flex-1 px-3 py-1.5 text-sm bg-primary text-white rounded-md hover:bg-primary-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="flex-1 px-3 py-1.5 text-sm bg-primary text-on-primary rounded-md hover:bg-primary-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     Apply
                   </button>
@@ -477,7 +477,7 @@ export function AdvancedFiltersPanel({
           )}
 
           {/* Gratings Section */}
-          <div className="p-4 border-b border-border dark:border-slate-700">
+          <div className="p-4 border-b border-border">
             <InlineMultiFilter
               label="Gratings"
               options={gratingOptions}
@@ -488,14 +488,14 @@ export function AdvancedFiltersPanel({
               hideModeSelector={viewMode === 'spectra'}
             />
             {viewMode === 'spectra' && (filters.gratings?.length ?? 0) > 0 && (
-              <p className="mt-2 text-xs text-text-secondary dark:text-slate-500">
+              <p className="mt-2 text-xs text-text-secondary dark:text-text-tertiary">
                 Showing only rows with these gratings
               </p>
             )}
           </div>
 
           {/* S/N and Exposure Time Section */}
-          <div className="p-4 border-b border-border dark:border-slate-700">
+          <div className="p-4 border-b border-border">
             <div className="flex items-start gap-2 mb-4 p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800">
               <Info className="w-4 h-4 text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0" />
               <div className="text-xs text-amber-700 dark:text-amber-300">
@@ -536,7 +536,7 @@ export function AdvancedFiltersPanel({
 
           {/* Tags Section */}
           {listOptions.length > 0 && (
-            <div className="p-4 border-b border-border dark:border-slate-700">
+            <div className="p-4 border-b border-border">
               <InlineMultiFilter
                 label="Tags"
                 options={listOptions}
@@ -551,7 +551,7 @@ export function AdvancedFiltersPanel({
 
           {/* Data Quality Section */}
           <div className="p-4">
-            <h3 className="text-xs font-semibold uppercase tracking-wider text-text-secondary dark:text-slate-500 mb-4">
+            <h3 className="text-xs font-semibold uppercase tracking-wider text-text-secondary dark:text-text-tertiary mb-4">
               Data Quality
             </h3>
             <InlineMultiFilter
@@ -566,18 +566,18 @@ export function AdvancedFiltersPanel({
         </div>
 
         {/* Panel Footer */}
-        <div className="p-4 border-t border-border dark:border-slate-700 bg-card dark:bg-slate-800">
+        <div className="p-4 border-t border-border bg-card">
           <div className="flex gap-3">
             <button
               onClick={clearPanelFilters}
               disabled={panelFilterCount === 0}
-              className="flex-1 px-4 py-2.5 text-sm font-medium rounded-lg border border-border dark:border-slate-700 text-text-secondary dark:text-slate-400 hover:bg-card-hover dark:hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200"
+              className="flex-1 px-4 py-2.5 text-sm font-medium rounded-lg border border-border text-text-secondary hover:bg-card-hover disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200"
             >
               Clear Filters{panelFilterCount > 0 ? ` (${panelFilterCount})` : ''}
             </button>
             <button
               onClick={onClose}
-              className="flex-1 px-4 py-2.5 text-sm font-medium rounded-lg bg-primary text-white hover:bg-primary-hover shadow-sm hover:shadow transition-all duration-200"
+              className="flex-1 px-4 py-2.5 text-sm font-medium rounded-lg bg-primary text-on-primary hover:bg-primary-hover shadow-sm hover:shadow transition-all duration-200"
             >
               Done
             </button>

--- a/web/components/spectra/CoordinateDisplay.tsx
+++ b/web/components/spectra/CoordinateDisplay.tsx
@@ -27,37 +27,37 @@ export const CoordinateDisplay: React.FC<CoordinateDisplayProps> = ({ ra, dec })
 
   return (
     <div className="flex items-center gap-2 text-sm">
-      <span className="text-text-secondary dark:text-slate-400">Coordinates:</span>
+      <span className="text-text-secondary">Coordinates:</span>
 
       {/* Decimal Degrees */}
       <button
         onClick={() => copyToClipboard(coords.decimal.combined, setCopiedDecimal)}
-        className="inline-flex items-center gap-1 hover:bg-gray-100 dark:hover:bg-slate-700 px-2 py-1 rounded transition-colors group"
+        className="inline-flex items-center gap-1 hover:bg-card-hover px-2 py-1 rounded transition-colors group"
         title="Click to copy decimal coordinates"
       >
-        <span className="font-mono text-text-primary dark:text-slate-100">
+        <span className="font-mono text-text-primary">
           {coords.decimal.combined}
         </span>
         {copiedDecimal ? (
           <Check className="w-3 h-3 text-green-600 dark:text-green-400" />
         ) : (
-          <Copy className="w-3 h-3 text-gray-400 dark:text-slate-500 group-hover:text-gray-600 dark:group-hover:text-slate-300" />
+          <Copy className="w-3 h-3 text-text-tertiary group-hover:text-text-secondary" />
         )}
       </button>
 
       {/* Sexagesimal */}
       <button
         onClick={() => copyToClipboard(coords.sexagesimal.combined, setCopiedSexagesimal)}
-        className="inline-flex items-center gap-1 hover:bg-gray-100 dark:hover:bg-slate-700 px-2 py-1 rounded transition-colors group"
+        className="inline-flex items-center gap-1 hover:bg-card-hover px-2 py-1 rounded transition-colors group"
         title="Click to copy sexagesimal coordinates"
       >
-        <span className="font-mono text-text-primary dark:text-slate-100">
+        <span className="font-mono text-text-primary">
           {coords.sexagesimal.combined}
         </span>
         {copiedSexagesimal ? (
           <Check className="w-3 h-3 text-green-600 dark:text-green-400" />
         ) : (
-          <Copy className="w-3 h-3 text-gray-400 dark:text-slate-500 group-hover:text-gray-600 dark:group-hover:text-slate-300" />
+          <Copy className="w-3 h-3 text-text-tertiary group-hover:text-text-secondary" />
         )}
       </button>
     </div>

--- a/web/components/spectra/CopyLinkButton.tsx
+++ b/web/components/spectra/CopyLinkButton.tsx
@@ -27,7 +27,7 @@ export const CopyLinkButton: React.FC<CopyLinkButtonProps> = ({ targetId, url: u
   return (
     <button
       onClick={copyToClipboard}
-      className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-text-primary dark:text-slate-100 bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"
+      className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-text-primary bg-card border border-border rounded-lg hover:bg-card dark:hover:bg-card-hover transition-colors"
       title="Copy link to this object"
     >
       {copied ? (

--- a/web/components/spectra/DownloadTableButtons.tsx
+++ b/web/components/spectra/DownloadTableButtons.tsx
@@ -176,7 +176,7 @@ export const DownloadDropdown: React.FC<DownloadDropdownProps> = ({
       <button
         onClick={() => setIsOpen(!isOpen)}
         disabled={loading}
-        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200 hover:bg-card-hover dark:hover:bg-slate-700 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-text-secondary hover:text-text-primary hover:bg-card-hover rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
       >
         <Download className="w-4 h-4" />
         <span>Download</span>
@@ -185,13 +185,13 @@ export const DownloadDropdown: React.FC<DownloadDropdownProps> = ({
 
       {/* Dropdown Panel */}
       {isOpen && (
-        <div className="absolute right-0 z-50 mt-1 w-[320px] bg-background dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg shadow-lg">
+        <div className="absolute right-0 z-50 mt-1 w-[320px] bg-background dark:bg-card border border-border rounded-lg shadow-lg">
           {/* Header */}
-          <div className="px-4 py-3 border-b border-border dark:border-slate-700">
-            <div className="text-sm font-medium text-text-primary dark:text-slate-100">
+          <div className="px-4 py-3 border-b border-border">
+            <div className="text-sm font-medium text-text-primary">
               Download Results
             </div>
-            <div className="text-xs text-text-secondary dark:text-slate-400 mt-0.5">
+            <div className="text-xs text-text-secondary mt-0.5">
               {loading ? 'Loading...' : `${totalCount.toLocaleString()} ${viewMode === 'spectra' ? 'spectra' : (totalCount === 1 ? 'object' : 'objects')}`}
             </div>
           </div>
@@ -202,7 +202,7 @@ export const DownloadDropdown: React.FC<DownloadDropdownProps> = ({
             <button
               onClick={handleCsvDownload}
               disabled={csvLoading || loading}
-              className="w-full flex items-center gap-3 px-3 py-2.5 text-sm text-left hover:bg-card-hover dark:hover:bg-slate-700 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="w-full flex items-center gap-3 px-3 py-2.5 text-sm text-left hover:bg-card-hover rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               title={
                 loading
                   ? 'Please wait while objects are loading'
@@ -214,13 +214,13 @@ export const DownloadDropdown: React.FC<DownloadDropdownProps> = ({
               {csvLoading ? (
                 <Loader2 className="w-4 h-4 animate-spin text-primary" />
               ) : (
-                <FileText className="w-4 h-4 text-text-secondary dark:text-slate-400" />
+                <FileText className="w-4 h-4 text-text-secondary" />
               )}
               <div className="flex-1">
-                <div className="font-medium text-text-primary dark:text-slate-100">
+                <div className="font-medium text-text-primary">
                   {csvLoading ? 'Generating...' : 'CSV Table'}
                 </div>
-                <div className="text-xs text-text-secondary dark:text-slate-400">
+                <div className="text-xs text-text-secondary">
                   Object metadata and properties
                 </div>
               </div>
@@ -230,7 +230,7 @@ export const DownloadDropdown: React.FC<DownloadDropdownProps> = ({
             <button
               onClick={handleFitsDownload}
               disabled={fitsLoading || fitsDisabled}
-              className="w-full flex items-center gap-3 px-3 py-2.5 text-sm text-left hover:bg-card-hover dark:hover:bg-slate-700 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="w-full flex items-center gap-3 px-3 py-2.5 text-sm text-left hover:bg-card-hover rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               title={
                 loading
                   ? 'Please wait while objects are loading'
@@ -242,15 +242,15 @@ export const DownloadDropdown: React.FC<DownloadDropdownProps> = ({
               {fitsLoading ? (
                 <Loader2 className="w-4 h-4 animate-spin text-primary" />
               ) : (
-                <Package className="w-4 h-4 text-text-secondary dark:text-slate-400" />
+                <Package className="w-4 h-4 text-text-secondary" />
               )}
               <div className="flex-1">
-                <div className="font-medium text-text-primary dark:text-slate-100">
+                <div className="font-medium text-text-primary">
                   {fitsProgress
                     ? `Downloading ${fitsProgress.done}/${fitsProgress.total}...`
                     : fitsLoading ? 'Preparing...' : 'FITS ZIP'}
                 </div>
-                <div className="text-xs text-text-secondary dark:text-slate-400">
+                <div className="text-xs text-text-secondary">
                   Spectroscopic data files
                 </div>
               </div>

--- a/web/components/spectra/FloatingInspectionPanel.tsx
+++ b/web/components/spectra/FloatingInspectionPanel.tsx
@@ -72,7 +72,7 @@ export const FloatingInspectionPanel: React.FC<FloatingInspectionPanelProps> = (
   const qualityOptions = REDSHIFT_QUALITY.filter(q => q.value > 0);
 
   return (
-    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-40 bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded-xl shadow-xl px-5 py-3 max-w-5xl w-auto">
+    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-40 bg-card border border-border rounded-xl shadow-xl px-5 py-3 max-w-5xl w-auto">
       {inspection.versionConflict && inspection.conflictInfo && (
         <div className="mb-2">
           <ConflictBanner
@@ -103,17 +103,17 @@ export const FloatingInspectionPanel: React.FC<FloatingInspectionPanelProps> = (
           <ObjectListsSection ref={listsRef} objectId={objectId} ra={ra} dec={dec} dropdownPlacement="top" />
         </div>
 
-        <div className="h-px bg-border dark:bg-slate-700" />
+        <div className="h-px bg-border" />
 
         <div className="flex items-center gap-3">
           <div className="flex items-center gap-2 text-base">
-            <span className="text-text-secondary dark:text-slate-400">z:</span>
+            <span className="text-text-secondary">z:</span>
             {inspection.redshiftQuality === 1 ? (
-              <span className="font-mono text-text-secondary dark:text-slate-400 line-through">
+              <span className="font-mono text-text-secondary line-through">
                 {inspection.currentRedshift?.toFixed(4) ?? '\u2014'}
               </span>
             ) : (
-              <span className="font-mono font-semibold text-text-primary dark:text-slate-100">
+              <span className="font-mono font-semibold text-text-primary">
                 {inspection.currentRedshift?.toFixed(4) ?? '\u2014'}
               </span>
             )}
@@ -127,9 +127,9 @@ export const FloatingInspectionPanel: React.FC<FloatingInspectionPanelProps> = (
               value={inspection.redshiftInspected}
               onChange={e => inspection.setRedshiftInspected(e.target.value)}
               placeholder="Override"
-              className="w-36 pl-2.5 pr-7 py-1.5 text-sm font-mono border border-border dark:border-slate-600 rounded bg-background dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-primary [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+              className="w-36 pl-2.5 pr-7 py-1.5 text-sm font-mono border border-border dark:border-border-strong rounded bg-background dark:bg-card-hover text-text-primary focus:outline-none focus:ring-1 focus:ring-primary [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
             />
-            <kbd className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 font-mono text-xs text-text-secondary dark:text-slate-400 opacity-60">O</kbd>
+            <kbd className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 font-mono text-xs text-text-secondary opacity-60">O</kbd>
           </div>
 
           <div role="radiogroup" aria-label="Redshift quality" className="flex items-center gap-1.5">
@@ -144,8 +144,8 @@ export const FloatingInspectionPanel: React.FC<FloatingInspectionPanelProps> = (
                   onClick={() => setRedshiftQuality(q.value)}
                   className={`px-2.5 py-1.5 text-sm font-medium rounded transition-all
                     ${isSelected
-                      ? 'ring-2 ring-offset-1 dark:ring-offset-slate-800 ring-text-primary'
-                      : 'border border-border dark:border-slate-600 hover:bg-background dark:hover:bg-slate-700 text-text-primary dark:text-slate-100'
+                      ? 'ring-2 ring-offset-1 dark:ring-offset-card ring-text-primary'
+                      : 'border border-border dark:border-border-strong hover:bg-background dark:hover:bg-card-hover text-text-primary'
                     }`}
                   style={isSelected ? { backgroundColor: q.color, color: getContrastColor(q.color) } : undefined}
                   title={`${q.label} \u2014 ${q.description}`}

--- a/web/components/spectra/GratingDetails.tsx
+++ b/web/components/spectra/GratingDetails.tsx
@@ -36,11 +36,11 @@ export const GratingDetails: React.FC<GratingDetailsProps> = ({ spectrum }) => {
         className="flex items-center w-full text-left"
       >
         {isOpen ? (
-          <ChevronDown className="w-5 h-5 text-text-secondary dark:text-slate-400 mr-2" />
+          <ChevronDown className="w-5 h-5 text-text-secondary mr-2" />
         ) : (
-          <ChevronRight className="w-5 h-5 text-text-secondary dark:text-slate-400 mr-2" />
+          <ChevronRight className="w-5 h-5 text-text-secondary mr-2" />
         )}
-        <h3 className="text-sm font-semibold text-text-primary dark:text-slate-100 uppercase tracking-wide">
+        <h3 className="text-sm font-semibold text-text-primary uppercase tracking-wide">
           Grating Details
         </h3>
       </button>
@@ -49,19 +49,19 @@ export const GratingDetails: React.FC<GratingDetailsProps> = ({ spectrum }) => {
         <div className="mt-4">
           <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
             <div>
-              <div className="text-xs text-text-secondary dark:text-slate-400 uppercase tracking-wide mb-1">
+              <div className="text-xs text-text-secondary uppercase tracking-wide mb-1">
                 Configuration
               </div>
-              <div className="text-sm font-mono text-text-primary dark:text-slate-100">
+              <div className="text-sm font-mono text-text-primary">
                 {spectrum.grating}
               </div>
             </div>
 
             <div>
-              <div className="text-xs text-text-secondary dark:text-slate-400 uppercase tracking-wide mb-1">
+              <div className="text-xs text-text-secondary uppercase tracking-wide mb-1">
                 Exposure Time
               </div>
-              <div className="text-sm font-mono text-text-primary dark:text-slate-100">
+              <div className="text-sm font-mono text-text-primary">
                 {spectrum.exposure_time != null
                   ? spectrum.exposure_time > 3600
                     ? `${spectrum.exposure_time.toFixed(0)} s (${(spectrum.exposure_time / 3600).toFixed(2)} hr)`
@@ -73,28 +73,28 @@ export const GratingDetails: React.FC<GratingDetailsProps> = ({ spectrum }) => {
             </div>
 
             <div>
-              <div className="text-xs text-text-secondary dark:text-slate-400 uppercase tracking-wide mb-1">
+              <div className="text-xs text-text-secondary uppercase tracking-wide mb-1">
                 Max S/N
               </div>
-              <div className="text-sm font-mono text-text-primary dark:text-slate-100">
+              <div className="text-sm font-mono text-text-primary">
                 {spectrum.signal_to_noise ? spectrum.signal_to_noise.toFixed(1) : 'N/A'}
               </div>
             </div>
 
             <div>
-              <div className="text-xs text-text-secondary dark:text-slate-400 uppercase tracking-wide mb-1">
+              <div className="text-xs text-text-secondary uppercase tracking-wide mb-1">
                 Version
               </div>
-              <div className="text-sm font-mono text-text-primary dark:text-slate-100">
+              <div className="text-sm font-mono text-text-primary">
                 {spectrum.reduction_version || 'N/A'}
               </div>
             </div>
 
             <div>
-              <div className="text-xs text-text-secondary dark:text-slate-400 uppercase tracking-wide mb-1">
+              <div className="text-xs text-text-secondary uppercase tracking-wide mb-1">
                 FITS File
               </div>
-              <div className="text-sm font-mono text-text-primary dark:text-slate-100 truncate" title={spectrum.fits_path}>
+              <div className="text-sm font-mono text-text-primary truncate" title={spectrum.fits_path}>
                 {spectrum.fits_path.split('/').pop() || spectrum.fits_path}
               </div>
             </div>

--- a/web/components/spectra/MultiSpectrumViewer.tsx
+++ b/web/components/spectra/MultiSpectrumViewer.tsx
@@ -20,7 +20,7 @@ import { FluxUnitToggle, EmissionLinesControl, RedshiftSliderControl, ControlDiv
 const Plot = dynamic(() => import('react-plotly.js'), {
   ssr: false,
   loading: () => (
-    <div className="flex items-center justify-center h-[500px] bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg">
+    <div className="flex items-center justify-center h-[500px] bg-card border border-border rounded-lg">
       <Loader2 className="w-6 h-6 animate-spin text-primary" />
     </div>
   ),
@@ -371,7 +371,7 @@ export const MultiSpectrumViewer: React.FC<MultiSpectrumViewerProps> = ({
 
   if (visibleCount === 0) {
     return (
-      <div className="flex items-center justify-center h-[200px] bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg text-text-secondary dark:text-slate-400">
+      <div className="flex items-center justify-center h-[200px] bg-card border border-border rounded-lg text-text-secondary">
         No spectra selected. Check targets in the table above to compare.
       </div>
     );
@@ -380,7 +380,7 @@ export const MultiSpectrumViewer: React.FC<MultiSpectrumViewerProps> = ({
   return (
     <div>
       {/* Controls bar */}
-      <div className="flex items-center gap-4 flex-wrap px-4 py-2 border-b border-border dark:border-slate-700 bg-gray-50 dark:bg-slate-900">
+      <div className="flex items-center gap-4 flex-wrap px-4 py-2 border-b border-border bg-card dark:bg-background">
         <FluxUnitToggle fluxUnit={fluxUnit} onChange={setFluxUnit} />
         <ControlDivider />
         <EmissionLinesControl showEmissionLines={showEmissionLines} onChange={setShowEmissionLines} />
@@ -395,11 +395,11 @@ export const MultiSpectrumViewer: React.FC<MultiSpectrumViewerProps> = ({
       {/* Plot */}
       <div className="relative">
         {loading && (
-          <div className="absolute inset-0 flex items-center justify-center bg-card/80 dark:bg-slate-800/80 z-10 rounded-lg">
+          <div className="absolute inset-0 flex items-center justify-center bg-card/80 z-10 rounded-lg">
             <div className="flex items-center gap-2">
               <Loader2 className="w-5 h-5 animate-spin text-primary" />
               {loadingProgress && loadingProgress.total > 1 && (
-                <span className="text-sm text-text-secondary dark:text-slate-400">
+                <span className="text-sm text-text-secondary">
                   Loading spectra ({loadingProgress.loaded}/{loadingProgress.total})
                 </span>
               )}

--- a/web/components/spectra/NearbyObjects.tsx
+++ b/web/components/spectra/NearbyObjects.tsx
@@ -82,7 +82,7 @@ export const NearbyObjects: React.FC<NearbyObjectsProps> = ({
       <Card>
         <div className="p-8 text-center">
           <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
-          <p className="text-text-secondary dark:text-slate-400 mt-4">Finding nearby objects...</p>
+          <p className="text-text-secondary mt-4">Finding nearby objects...</p>
         </div>
       </Card>
     );
@@ -102,7 +102,7 @@ export const NearbyObjects: React.FC<NearbyObjectsProps> = ({
     return (
       <Card>
         <div className="p-8 text-center">
-          <p className="text-text-secondary dark:text-slate-400">
+          <p className="text-text-secondary">
             No other objects found within 1 arcminute
           </p>
         </div>
@@ -113,9 +113,9 @@ export const NearbyObjects: React.FC<NearbyObjectsProps> = ({
   return (
     <Card>
       <div className="p-6">
-        <h3 className="text-lg font-semibold text-text-primary dark:text-slate-100 mb-4">
+        <h3 className="text-lg font-semibold text-text-primary mb-4">
           Nearby Objects
-          <span className="text-sm font-normal text-text-secondary dark:text-slate-400 ml-2">
+          <span className="text-sm font-normal text-text-secondary ml-2">
             ({nearbyObjects.length} found within 1 arcmin)
           </span>
         </h3>
@@ -123,23 +123,23 @@ export const NearbyObjects: React.FC<NearbyObjectsProps> = ({
         <div className="overflow-x-auto">
           <table className="w-full">
             <thead>
-              <tr className="border-b border-border dark:border-slate-700">
-                <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary dark:text-slate-400">
+              <tr className="border-b border-border">
+                <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary">
                   Target ID
                 </th>
-                <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary dark:text-slate-400">
+                <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary">
                   Distance
                 </th>
-                <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary dark:text-slate-400">
+                <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary">
                   RA
                 </th>
-                <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary dark:text-slate-400">
+                <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary">
                   Dec
                 </th>
-                <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary dark:text-slate-400">
+                <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary">
                   Redshift
                 </th>
-                <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary dark:text-slate-400">
+                <th className="text-left py-3 px-4 text-sm font-medium text-text-secondary">
                   Quality
                 </th>
               </tr>
@@ -150,7 +150,7 @@ export const NearbyObjects: React.FC<NearbyObjectsProps> = ({
                 return (
                   <tr
                     key={obj.id}
-                    className="border-b border-border dark:border-slate-700 hover:bg-background-hover dark:hover:bg-slate-700 transition-colors"
+                    className="border-b border-border hover:bg-background-hover dark:hover:bg-card-hover transition-colors"
                   >
                     <td className="py-3 px-4">
                       <Link
@@ -161,31 +161,31 @@ export const NearbyObjects: React.FC<NearbyObjectsProps> = ({
                       </Link>
                     </td>
                     <td className="py-3 px-4">
-                      <span className="text-sm font-mono text-text-primary dark:text-slate-100">
+                      <span className="text-sm font-mono text-text-primary">
                         {obj.distance != null
                           ? formatDistance(obj.distance)
                           : 'N/A'}
                       </span>
                     </td>
                     <td className="py-3 px-4">
-                      <span className="text-sm font-mono text-text-primary dark:text-slate-100">
+                      <span className="text-sm font-mono text-text-primary">
                         {obj.ra.toFixed(6)}
                       </span>
                     </td>
                     <td className="py-3 px-4">
-                      <span className="text-sm font-mono text-text-primary dark:text-slate-100">
+                      <span className="text-sm font-mono text-text-primary">
                         {obj.dec.toFixed(6)}
                       </span>
                     </td>
                     <td className="py-3 px-4">
-                      <span className="text-sm font-mono text-text-primary dark:text-slate-100">
+                      <span className="text-sm font-mono text-text-primary">
                         {obj.redshift !== null ? obj.redshift.toFixed(4) : 'N/A'}
                       </span>
                     </td>
                     <td className="py-3 px-4">
                       <div className="flex items-center gap-2">
                         <span className="text-sm">{quality.icon}</span>
-                        <span className="text-xs text-text-secondary dark:text-slate-400">
+                        <span className="text-xs text-text-secondary">
                           {quality.label}
                         </span>
                       </div>

--- a/web/components/spectra/ObjectComments.tsx
+++ b/web/components/spectra/ObjectComments.tsx
@@ -162,7 +162,7 @@ export const ObjectComments: React.FC<ObjectCommentsProps> = ({ objectDbId, memb
     <Card className="p-6">
       <div className="flex items-center gap-2 mb-4">
         <MessageSquare className="w-5 h-5 text-primary" />
-        <h4 className="font-medium text-text-primary dark:text-slate-100">
+        <h4 className="font-medium text-text-primary">
           Discussion ({comments.length})
         </h4>
       </div>
@@ -179,7 +179,7 @@ export const ObjectComments: React.FC<ObjectCommentsProps> = ({ objectDbId, memb
             value={newComment}
             onChange={e => setNewComment(e.target.value)}
             placeholder="Add a comment..."
-            className="w-full px-4 py-2 border border-border dark:border-slate-600 rounded-lg bg-background dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary resize-none text-sm"
+            className="w-full px-4 py-2 border border-border dark:border-border-strong rounded-lg bg-background dark:bg-card-hover text-text-primary focus:outline-none focus:ring-2 focus:ring-primary resize-none text-sm"
             rows={2}
             disabled={submitting}
           />
@@ -188,7 +188,7 @@ export const ObjectComments: React.FC<ObjectCommentsProps> = ({ objectDbId, memb
               <select
                 value={selectedTargetId}
                 onChange={e => setSelectedTargetId(e.target.value)}
-                className="px-3 py-1.5 border border-border dark:border-slate-600 rounded-lg bg-background dark:bg-slate-700 text-text-primary dark:text-slate-100 text-xs font-mono focus:outline-none focus:ring-2 focus:ring-primary"
+                className="px-3 py-1.5 border border-border dark:border-border-strong rounded-lg bg-background dark:bg-card-hover text-text-primary text-xs font-mono focus:outline-none focus:ring-2 focus:ring-primary"
                 disabled={submitting}
               >
                 <option value="">General</option>
@@ -213,17 +213,17 @@ export const ObjectComments: React.FC<ObjectCommentsProps> = ({ objectDbId, memb
       )}
 
       {!user && (
-        <div className="mb-4 p-4 bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg text-center">
-          <p className="text-sm text-text-secondary dark:text-slate-400">Sign in to add comments</p>
+        <div className="mb-4 p-4 bg-card border border-border rounded-lg text-center">
+          <p className="text-sm text-text-secondary">Sign in to add comments</p>
         </div>
       )}
 
       {loading ? (
-        <div className="text-center py-4 text-text-secondary dark:text-slate-400 text-sm">
+        <div className="text-center py-4 text-text-secondary text-sm">
           Loading comments...
         </div>
       ) : comments.length === 0 ? (
-        <div className="text-center py-4 text-text-secondary dark:text-slate-400 text-sm">
+        <div className="text-center py-4 text-text-secondary text-sm">
           No comments yet
         </div>
       ) : (
@@ -231,24 +231,24 @@ export const ObjectComments: React.FC<ObjectCommentsProps> = ({ objectDbId, memb
           {comments.map(comment => (
             <div
               key={comment.id}
-              className="p-3 bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg"
+              className="p-3 bg-card border border-border rounded-lg"
             >
               <div className="flex items-start justify-between mb-1">
                 <div className="flex items-baseline gap-2">
-                  <span className="font-medium text-text-primary dark:text-slate-100 text-sm">
+                  <span className="font-medium text-text-primary text-sm">
                     {comment.user_profile?.full_name || 'Unknown User'}
                   </span>
                   {comment.source_target_display_id && (
-                    <span className="text-xs font-mono text-text-secondary dark:text-slate-400">
+                    <span className="text-xs font-mono text-text-secondary">
                       ({comment.source_target_display_id})
                     </span>
                   )}
                 </div>
-                <span className="text-xs text-text-secondary dark:text-slate-500">
+                <span className="text-xs text-text-secondary dark:text-text-tertiary">
                   {formatDate(comment.created_at)}
                 </span>
               </div>
-              <p className="text-sm text-text-primary dark:text-slate-100 whitespace-pre-wrap">
+              <p className="text-sm text-text-primary whitespace-pre-wrap">
                 {comment.content}
               </p>
             </div>

--- a/web/components/spectra/ObjectListsSection.tsx
+++ b/web/components/spectra/ObjectListsSection.tsx
@@ -216,7 +216,7 @@ export function ObjectListsSection({ objectId, ra, dec, dropdownPlacement = 'bot
 
   if (loading) {
     return (
-      <div className="flex items-center gap-2 text-sm text-text-secondary dark:text-slate-400">
+      <div className="flex items-center gap-2 text-sm text-text-secondary">
         <Loader2 className="w-3 h-3 animate-spin" />
         Loading tags...
       </div>
@@ -227,7 +227,7 @@ export function ObjectListsSection({ objectId, ra, dec, dropdownPlacement = 'bot
     <div className="relative">
       <div className="flex flex-wrap items-center gap-2">
         {memberLists.length === 0 && canEdit && (
-          <span className="text-xs text-text-secondary dark:text-slate-400">
+          <span className="text-xs text-text-secondary">
             Tag object properties:
           </span>
         )}
@@ -260,7 +260,7 @@ export function ObjectListsSection({ objectId, ra, dec, dropdownPlacement = 'bot
           <div className="relative" ref={dropdownRef}>
             <button
               onClick={() => setShowDropdown(!showDropdown)}
-              className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium border border-dashed border-border dark:border-slate-600 text-text-secondary dark:text-slate-400 hover:border-primary hover:text-primary transition-colors"
+              className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium border border-dashed border-border dark:border-border-strong text-text-secondary hover:border-primary hover:text-primary transition-colors"
             >
               <Plus className="w-3 h-3" />
               Add tag
@@ -268,11 +268,11 @@ export function ObjectListsSection({ objectId, ra, dec, dropdownPlacement = 'bot
             </button>
 
             {showDropdown && (
-              <div className={`absolute ${dropdownPlacement === 'top' ? 'bottom-full mb-1' : 'top-full mt-1'} left-0 z-50 w-72 animate-zoom-in bg-background dark:bg-slate-800 rounded-lg shadow-lg border border-border dark:border-slate-700`}>
+              <div className={`absolute ${dropdownPlacement === 'top' ? 'bottom-full mb-1' : 'top-full mt-1'} left-0 z-50 w-72 animate-zoom-in bg-background dark:bg-card rounded-lg shadow-lg border border-border`}>
                 {/* Search input */}
-                <div className="p-2 border-b border-border dark:border-slate-700">
+                <div className="p-2 border-b border-border">
                   <div className="relative">
-                    <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-secondary dark:text-slate-500" />
+                    <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-secondary dark:text-text-tertiary" />
                     <input
                       ref={searchInputRef}
                       type="text"
@@ -280,7 +280,7 @@ export function ObjectListsSection({ objectId, ra, dec, dropdownPlacement = 'bot
                       onChange={(e) => setSearchTerm(e.target.value)}
                       onKeyDown={handleKeyDown}
                       placeholder="Search or create tag..."
-                      className="w-full pl-8 pr-3 py-1.5 text-sm border border-border dark:border-slate-700 rounded-md bg-background dark:bg-slate-900 text-text-primary dark:text-slate-100 placeholder:text-text-secondary dark:placeholder:text-slate-500 focus:outline-none focus:ring-1 focus:ring-primary focus:border-transparent"
+                      className="w-full pl-8 pr-3 py-1.5 text-sm border border-border rounded-md bg-background text-text-primary placeholder:text-text-secondary dark:placeholder:text-text-tertiary focus:outline-none focus:ring-1 focus:ring-primary focus:border-transparent"
                     />
                   </div>
                 </div>
@@ -308,14 +308,14 @@ export function ObjectListsSection({ objectId, ra, dec, dropdownPlacement = 'bot
                       ))}
                     </div>
                   ) : !showCreateOption ? (
-                    <div className="px-3 py-4 text-sm text-text-secondary dark:text-slate-500 text-center">
+                    <div className="px-3 py-4 text-sm text-text-secondary dark:text-text-tertiary text-center">
                       {normalizedSearch ? 'No matching tags' : 'All tags applied'}
                     </div>
                   ) : null}
 
                   {/* Create new tag option */}
                   {showCreateOption && (
-                    <div className={sortedAvailable.length > 0 ? 'border-t border-border dark:border-slate-700 mt-1.5 pt-1.5' : ''}>
+                    <div className={sortedAvailable.length > 0 ? 'border-t border-border mt-1.5 pt-1.5' : ''}>
                       <button
                         onClick={handleOpenCreateModal}
                         className="w-full text-left px-3 py-2 text-sm hover:bg-primary/10 rounded-md flex items-center gap-2 transition-colors text-primary"
@@ -332,7 +332,7 @@ export function ObjectListsSection({ objectId, ra, dec, dropdownPlacement = 'bot
         )}
 
         {memberLists.length === 0 && !canEdit && (
-          <span className="text-xs text-text-secondary dark:text-slate-400">
+          <span className="text-xs text-text-secondary">
             No tags
           </span>
         )}

--- a/web/components/spectra/ObjectNavigation.tsx
+++ b/web/components/spectra/ObjectNavigation.tsx
@@ -137,18 +137,18 @@ export function ObjectNavigation({
       {prevHref ? (
         <Link
           href={prevHref}
-          className="p-2 rounded-lg hover:bg-card dark:hover:bg-slate-700 transition-colors text-text-primary dark:text-slate-100"
+          className="p-2 rounded-lg hover:bg-card dark:hover:bg-card-hover transition-colors text-text-primary"
           aria-label="Previous object"
         >
           <ChevronLeft className="w-5 h-5" />
         </Link>
       ) : (
-        <div className="p-2 text-text-secondary dark:text-slate-500 opacity-50">
+        <div className="p-2 text-text-secondary dark:text-text-tertiary opacity-50">
           <ChevronLeft className="w-5 h-5" />
         </div>
       )}
 
-      <span className="text-sm font-medium text-text-primary dark:text-slate-100 min-w-[60px] text-center">
+      <span className="text-sm font-medium text-text-primary min-w-[60px] text-center">
         {nav.loading ? (
           <Loader2 className="w-4 h-4 animate-spin inline" />
         ) : nav.index > 0 && nav.total > 0 ? (
@@ -161,13 +161,13 @@ export function ObjectNavigation({
       {nextHref ? (
         <Link
           href={nextHref}
-          className="p-2 rounded-lg hover:bg-card dark:hover:bg-slate-700 transition-colors text-text-primary dark:text-slate-100"
+          className="p-2 rounded-lg hover:bg-card dark:hover:bg-card-hover transition-colors text-text-primary"
           aria-label="Next object"
         >
           <ChevronRight className="w-5 h-5" />
         </Link>
       ) : (
-        <div className="p-2 text-text-secondary dark:text-slate-500 opacity-50">
+        <div className="p-2 text-text-secondary dark:text-text-tertiary opacity-50">
           <ChevronRight className="w-5 h-5" />
         </div>
       )}

--- a/web/components/spectra/ObjectSidebar.tsx
+++ b/web/components/spectra/ObjectSidebar.tsx
@@ -49,7 +49,7 @@ export const ObjectSidebar: React.FC<ObjectSidebarProps> = ({
           return (
             <div key={member.target_id}>
               {/* Target row */}
-              <div className="flex items-start gap-2 px-1 py-1 rounded-md hover:bg-gray-100 dark:hover:bg-slate-800">
+              <div className="flex items-start gap-2 px-1 py-1 rounded-md hover:bg-card-hover dark:hover:bg-card">
                 <input
                   type="checkbox"
                   checked={tState === 'on'}
@@ -58,17 +58,17 @@ export const ObjectSidebar: React.FC<ObjectSidebarProps> = ({
                   }}
                   onChange={() => onTargetVisibility(member.target_id, tState !== 'on')}
                   style={{ accentColor: targetColor }}
-                  className="mt-1 rounded border-gray-300 dark:border-slate-600 focus:ring-accent w-3.5 h-3.5"
+                  className="mt-1 rounded border-border-strong focus:ring-accent w-3.5 h-3.5"
                   title={`Toggle ${member.target_id} + shutters`}
                 />
                 <div className="flex-1 min-w-0">
                   <span
-                    className="text-xs font-mono truncate text-text-primary dark:text-slate-200 block"
+                    className="text-xs font-mono truncate text-text-primary block"
                     title={member.target_id}
                   >
                     {member.target_id}
                   </span>
-                  <span className="text-[11px] text-text-secondary dark:text-slate-500 truncate block">
+                  <span className="text-[11px] text-text-secondary dark:text-text-tertiary truncate block">
                     {member.program_name}
                   </span>
                 </div>
@@ -90,17 +90,17 @@ export const ObjectSidebar: React.FC<ObjectSidebarProps> = ({
                         checked={visible}
                         onChange={(e) => onSpectrumVisibility(spectrum.id, e.target.checked)}
                         style={{ accentColor: childColor }}
-                        className="rounded border-gray-300 dark:border-slate-600 focus:ring-accent w-3.5 h-3.5"
+                        className="rounded border-border-strong focus:ring-accent w-3.5 h-3.5"
                         title={`Toggle ${spectrum.grating} on the comparison plot`}
                       />
                       <button
                         type="button"
                         onClick={() => onJumpToSpectrum(spectrum.id)}
-                        className="flex-1 min-w-0 text-left text-xs px-1 py-0.5 rounded hover:bg-gray-100 dark:hover:bg-slate-800 hover:text-primary dark:hover:text-primary text-text-primary dark:text-slate-200"
+                        className="flex-1 min-w-0 text-left text-xs px-1 py-0.5 rounded hover:bg-card-hover dark:hover:bg-card hover:text-primary dark:hover:text-primary text-text-primary"
                         title={`Jump to ${spectrum.grating} card`}
                       >
                         <span className="font-mono">{spectrum.grating}</span>
-                        <span className="ml-1.5 text-text-secondary dark:text-slate-500">
+                        <span className="ml-1.5 text-text-secondary dark:text-text-tertiary">
                           ({formatExposureTime(spectrum.exposure_time)})
                         </span>
                       </button>

--- a/web/components/spectra/PhotometrySED.tsx
+++ b/web/components/spectra/PhotometrySED.tsx
@@ -11,7 +11,7 @@ import type { ObjectPhotometry } from '@/lib/types';
 const Plot = dynamic(() => import('react-plotly.js'), {
   ssr: false,
   loading: () => (
-    <div className="flex items-center justify-center h-[400px] bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg">
+    <div className="flex items-center justify-center h-[400px] bg-card border border-border rounded-lg">
       <Loader2 className="w-6 h-6 animate-spin text-primary" />
     </div>
   ),
@@ -351,7 +351,7 @@ export const PhotometrySED: React.FC<PhotometrySEDProps> = ({
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <BarChart3 className="w-5 h-5 text-text-secondary" />
-          <h3 className="text-lg font-semibold text-text-primary dark:text-slate-100">
+          <h3 className="text-lg font-semibold text-text-primary">
             Photometry
           </h3>
           <span className="text-sm text-text-secondary">
@@ -365,7 +365,7 @@ export const PhotometrySED: React.FC<PhotometrySEDProps> = ({
 
       {/* Photo-z summary */}
       {photometry.photo_z != null && (
-        <div className="text-sm text-text-secondary dark:text-slate-400 px-1">
+        <div className="text-sm text-text-secondary px-1">
           Photo-z: <span className="font-mono text-text-primary dark:text-slate-200">
             {photometry.photo_z.toFixed(4)}
           </span>
@@ -387,7 +387,7 @@ export const PhotometrySED: React.FC<PhotometrySEDProps> = ({
       {/* SED + P(z) side by side */}
       <div className="flex gap-3">
         {/* SED Plot */}
-        <div className={`bg-white dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg overflow-hidden ${hasPzPanel ? 'flex-[2]' : 'flex-1'} min-w-0`}>
+        <div className={`bg-card border border-border rounded-lg overflow-hidden ${hasPzPanel ? 'flex-[2]' : 'flex-1'} min-w-0`}>
           <Plot
             data={traces}
             layout={layout}
@@ -398,7 +398,7 @@ export const PhotometrySED: React.FC<PhotometrySEDProps> = ({
 
         {/* P(z) Panel */}
         {hasPzPanel && (
-          <div className="flex-1 min-w-0 bg-white dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg overflow-hidden">
+          <div className="flex-1 min-w-0 bg-card border border-border rounded-lg overflow-hidden">
             {pzLoading ? (
               <div className="flex items-center justify-center h-[400px]">
                 <Loader2 className="w-5 h-5 animate-spin text-primary" />

--- a/web/components/spectra/PhotometryTable.tsx
+++ b/web/components/spectra/PhotometryTable.tsx
@@ -65,7 +65,7 @@ export const PhotometryTable: React.FC<PhotometryTableProps> = ({ bands }) => {
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between gap-2">
-        <h4 className="text-sm font-medium text-text-secondary dark:text-slate-400">
+        <h4 className="text-sm font-medium text-text-secondary">
           Photometry data
         </h4>
         <div className="flex items-center gap-2">
@@ -82,56 +82,56 @@ export const PhotometryTable: React.FC<PhotometryTableProps> = ({ bands }) => {
         </div>
       </div>
 
-      <div className="overflow-x-auto bg-white dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg">
+      <div className="overflow-x-auto bg-card border border-border rounded-lg">
         <table className="text-xs font-mono w-full">
           <tbody>
-            <tr className="border-b border-border dark:border-slate-700">
-              <th className="sticky left-0 bg-white dark:bg-slate-800 text-left px-3 py-1.5 font-medium text-text-secondary dark:text-slate-400 whitespace-nowrap border-r border-border dark:border-slate-700">
+            <tr className="border-b border-border">
+              <th className="sticky left-0 bg-card text-left px-3 py-1.5 font-medium text-text-secondary whitespace-nowrap border-r border-border">
                 Band
               </th>
               {rows.map(r => (
                 <td
                   key={r.name}
-                  className="px-3 py-1.5 text-text-primary dark:text-slate-200 whitespace-nowrap text-right"
+                  className="px-3 py-1.5 text-text-primary whitespace-nowrap text-right"
                 >
                   {r.name}
                 </td>
               ))}
             </tr>
-            <tr className="border-b border-border dark:border-slate-700">
-              <th className="sticky left-0 bg-white dark:bg-slate-800 text-left px-3 py-1.5 font-medium text-text-secondary dark:text-slate-400 whitespace-nowrap border-r border-border dark:border-slate-700">
+            <tr className="border-b border-border">
+              <th className="sticky left-0 bg-card text-left px-3 py-1.5 font-medium text-text-secondary whitespace-nowrap border-r border-border">
                 λ (µm)
               </th>
               {rows.map(r => (
                 <td
                   key={r.name}
-                  className="px-3 py-1.5 text-text-primary dark:text-slate-200 whitespace-nowrap text-right"
+                  className="px-3 py-1.5 text-text-primary whitespace-nowrap text-right"
                 >
                   {formatNumber(r.wav)}
                 </td>
               ))}
             </tr>
-            <tr className="border-b border-border dark:border-slate-700">
-              <th className="sticky left-0 bg-white dark:bg-slate-800 text-left px-3 py-1.5 font-medium text-text-secondary dark:text-slate-400 whitespace-nowrap border-r border-border dark:border-slate-700">
+            <tr className="border-b border-border">
+              <th className="sticky left-0 bg-card text-left px-3 py-1.5 font-medium text-text-secondary whitespace-nowrap border-r border-border">
                 Flux (µJy)
               </th>
               {rows.map(r => (
                 <td
                   key={r.name}
-                  className="px-3 py-1.5 text-text-primary dark:text-slate-200 whitespace-nowrap text-right"
+                  className="px-3 py-1.5 text-text-primary whitespace-nowrap text-right"
                 >
                   {formatNumber(r.flux)}
                 </td>
               ))}
             </tr>
             <tr>
-              <th className="sticky left-0 bg-white dark:bg-slate-800 text-left px-3 py-1.5 font-medium text-text-secondary dark:text-slate-400 whitespace-nowrap border-r border-border dark:border-slate-700">
+              <th className="sticky left-0 bg-card text-left px-3 py-1.5 font-medium text-text-secondary whitespace-nowrap border-r border-border">
                 Error (µJy)
               </th>
               {rows.map(r => (
                 <td
                   key={r.name}
-                  className="px-3 py-1.5 text-text-primary dark:text-slate-200 whitespace-nowrap text-right"
+                  className="px-3 py-1.5 text-text-primary whitespace-nowrap text-right"
                 >
                   {formatNumber(r.flux_err)}
                 </td>
@@ -153,7 +153,7 @@ interface CopyButtonProps {
 const CopyButton: React.FC<CopyButtonProps> = ({ label, active, onClick }) => (
   <button
     onClick={onClick}
-    className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium text-text-primary dark:text-slate-100 bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded-md hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"
+    className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium text-text-primary bg-card border border-border rounded-md hover:bg-card-hover transition-colors"
   >
     {active ? (
       <>

--- a/web/components/spectra/PlottingControls.tsx
+++ b/web/components/spectra/PlottingControls.tsx
@@ -14,14 +14,14 @@ interface FluxUnitToggleProps {
 export const FluxUnitToggle: React.FC<FluxUnitToggleProps> = ({ fluxUnit, onChange }) => {
   return (
     <div className="flex items-center gap-2">
-      <span className="text-sm text-text-secondary dark:text-slate-400">Units:</span>
-      <div className="flex rounded-md overflow-hidden border border-border dark:border-slate-600">
+      <span className="text-sm text-text-secondary">Units:</span>
+      <div className="flex rounded-md overflow-hidden border border-border dark:border-border-strong">
         <button
           onClick={() => onChange('fnu')}
           className={`px-3 py-1 text-sm transition-colors ${
             fluxUnit === 'fnu'
-              ? 'bg-primary text-white'
-              : 'bg-white dark:bg-slate-700 text-text-secondary dark:text-slate-400 hover:bg-gray-100 dark:hover:bg-slate-600'
+              ? 'bg-primary text-on-primary'
+              : 'bg-background dark:bg-card-hover text-text-secondary hover:bg-card-hover dark:hover:bg-slate-600'
           }`}
         >
           fν
@@ -30,8 +30,8 @@ export const FluxUnitToggle: React.FC<FluxUnitToggleProps> = ({ fluxUnit, onChan
           onClick={() => onChange('flambda')}
           className={`px-3 py-1 text-sm transition-colors ${
             fluxUnit === 'flambda'
-              ? 'bg-primary text-white'
-              : 'bg-white dark:bg-slate-700 text-text-secondary dark:text-slate-400 hover:bg-gray-100 dark:hover:bg-slate-600'
+              ? 'bg-primary text-on-primary'
+              : 'bg-background dark:bg-card-hover text-text-secondary hover:bg-card-hover dark:hover:bg-slate-600'
           }`}
         >
           fλ
@@ -57,9 +57,9 @@ export const EmissionLinesControl: React.FC<EmissionLinesControlProps> = ({
           type="checkbox"
           checked={showEmissionLines}
           onChange={(e) => onChange(e.target.checked)}
-          className="w-4 h-4 rounded border-border dark:border-slate-600 text-primary focus:ring-primary dark:bg-slate-700"
+          className="w-4 h-4 rounded border-border dark:border-border-strong text-primary focus:ring-primary dark:bg-card-hover"
         />
-        <span className="text-sm text-text-secondary dark:text-slate-400">Emission lines</span>
+        <span className="text-sm text-text-secondary">Emission lines</span>
       </label>
     </div>
   );
@@ -117,18 +117,18 @@ export const RedshiftSliderControl: React.FC<RedshiftSliderControlProps> = ({
   };
 
   const stepBtnClass =
-    'p-0.5 rounded text-text-secondary dark:text-slate-400 hover:bg-gray-100 dark:hover:bg-slate-600 hover:text-text-primary dark:hover:text-slate-200 transition-colors disabled:opacity-30 disabled:pointer-events-none';
+    'p-0.5 rounded text-text-secondary hover:bg-card-hover dark:hover:bg-slate-600 hover:text-text-primary transition-colors disabled:opacity-30 disabled:pointer-events-none';
 
   return (
     <div className="flex items-center gap-2 flex-1 max-w-md">
-      <span className="text-sm text-text-secondary dark:text-slate-400">z =</span>
+      <span className="text-sm text-text-secondary">z =</span>
       <input
         type="text"
         value={inputValue}
         onChange={(e) => setInputValue(e.target.value)}
         onBlur={handleInputBlur}
         onKeyDown={handleInputKeyDown}
-        className="w-20 px-2 py-1 text-sm border border-border dark:border-slate-600 rounded bg-white dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-primary"
+        className="w-20 px-2 py-1 text-sm border border-border dark:border-border-strong rounded bg-background dark:bg-card-hover text-text-primary focus:outline-none focus:ring-1 focus:ring-primary"
       />
       <div className="flex items-center gap-0.5">
         <button
@@ -155,7 +155,7 @@ export const RedshiftSliderControl: React.FC<RedshiftSliderControlProps> = ({
         min={min}
         max={max}
         step={step}
-        className="flex-1 h-2 bg-gray-200 dark:bg-slate-600 rounded-lg appearance-none cursor-pointer accent-primary"
+        className="flex-1 h-2 bg-surface-2 dark:bg-slate-600 rounded-lg appearance-none cursor-pointer accent-primary"
       />
       <div className="flex items-center gap-0.5">
         <button
@@ -180,5 +180,5 @@ export const RedshiftSliderControl: React.FC<RedshiftSliderControlProps> = ({
 };
 
 export const ControlDivider: React.FC = () => {
-  return <div className="h-6 w-px bg-border dark:bg-slate-600" />;
+  return <div className="h-6 w-px bg-border dark:bg-border-strong" />;
 };

--- a/web/components/spectra/RGBImage.tsx
+++ b/web/components/spectra/RGBImage.tsx
@@ -24,10 +24,10 @@ export const RGBImage: React.FC<RGBImageProps> = ({
   if (!rgbImageUrl || imageError) {
     return (
       <div
-        className="bg-gray-200 dark:bg-slate-700 rounded-lg flex items-center justify-center"
+        className="bg-surface-2 rounded-lg flex items-center justify-center"
         style={{ width: size, height: size }}
       >
-        <p className="text-gray-500 dark:text-slate-400 text-sm text-center px-4">
+        <p className="text-text-secondary text-sm text-center px-4">
           No RGB image available
         </p>
       </div>
@@ -36,7 +36,7 @@ export const RGBImage: React.FC<RGBImageProps> = ({
 
   return (
     <div
-      className="relative rounded-lg overflow-hidden border border-gray-300 dark:border-slate-600"
+      className="relative rounded-lg overflow-hidden border border-border-strong"
       style={{ width: size, height: size }}
     >
       <Image

--- a/web/components/spectra/RedshiftFitPlot.tsx
+++ b/web/components/spectra/RedshiftFitPlot.tsx
@@ -343,18 +343,18 @@ export const RedshiftFitPlot: React.FC<RedshiftFitPlotProps> = ({
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-[700px] bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg">
+      <div className="flex items-center justify-center h-[700px] bg-card border border-border rounded-lg">
         <Loader2 className="w-6 h-6 animate-spin text-primary mr-3" />
-        <span className="text-text-secondary dark:text-slate-400">Loading redshift fit...</span>
+        <span className="text-text-secondary">Loading redshift fit...</span>
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="flex flex-col items-center justify-center h-[700px] bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg">
+      <div className="flex flex-col items-center justify-center h-[700px] bg-card border border-border rounded-lg">
         <AlertCircle className="w-8 h-8 text-red-500 dark:text-red-400 mb-3" />
-        <p className="text-text-secondary dark:text-slate-400">{error}</p>
+        <p className="text-text-secondary">{error}</p>
       </div>
     );
   }
@@ -364,9 +364,9 @@ export const RedshiftFitPlot: React.FC<RedshiftFitPlotProps> = ({
   }
 
   return (
-    <div className="bg-white dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg overflow-hidden">
+    <div className="bg-card border border-border rounded-lg overflow-hidden">
       {/* Controls */}
-      <div className="flex flex-wrap items-center gap-4 px-4 py-2 border-b border-border dark:border-slate-700 bg-gray-50 dark:bg-slate-900">
+      <div className="flex flex-wrap items-center gap-4 px-4 py-2 border-b border-border bg-gray-50 dark:bg-slate-900">
         <FluxUnitToggle fluxUnit={fluxUnit} onChange={setFluxUnit} />
 
         <ControlDivider />

--- a/web/components/spectra/RedshiftFitSummary.tsx
+++ b/web/components/spectra/RedshiftFitSummary.tsx
@@ -105,7 +105,7 @@ export const RedshiftFitSummary: React.FC<RedshiftFitSummaryProps> = ({
       <Card className="p-6">
         <div className="flex items-center justify-center py-8">
           <Loader2 className="w-5 h-5 animate-spin text-primary mr-3" />
-          <span className="text-text-secondary dark:text-slate-400">Loading redshift fits...</span>
+          <span className="text-text-secondary">Loading redshift fits...</span>
         </div>
       </Card>
     );
@@ -115,11 +115,11 @@ export const RedshiftFitSummary: React.FC<RedshiftFitSummaryProps> = ({
     return (
       <Card className="p-6">
         <div className="flex flex-col items-center justify-center py-8 text-center">
-          <AlertCircle className="w-6 h-6 text-text-secondary dark:text-slate-400 mb-2" />
-          <p className="text-text-secondary dark:text-slate-400">
+          <AlertCircle className="w-6 h-6 text-text-secondary mb-2" />
+          <p className="text-text-secondary">
             No redshift fitting data available for this object
           </p>
-          <p className="text-xs text-text-secondary dark:text-slate-500 mt-1">
+          <p className="text-xs text-text-secondary dark:text-text-tertiary mt-1">
             Redshift fits have not been computed for any grating
           </p>
         </div>
@@ -130,9 +130,9 @@ export const RedshiftFitSummary: React.FC<RedshiftFitSummaryProps> = ({
   return (
     <Card className="p-6">
       <div className="flex items-center gap-2 mb-4">
-        <h3 className="text-lg font-semibold text-text-primary dark:text-slate-100">Redshift Fit Summary</h3>
+        <h3 className="text-lg font-semibold text-text-primary">Redshift Fit Summary</h3>
         <div className="group relative">
-          <Info className="w-4 h-4 text-text-secondary dark:text-slate-400 cursor-help" />
+          <Info className="w-4 h-4 text-text-secondary cursor-help" />
           <div className="absolute left-0 top-6 w-64 p-2 bg-gray-900 text-white text-xs rounded shadow-lg opacity-0 group-hover:opacity-100 pointer-events-none transition-opacity z-10">
             If multiple gratings are available, the automatic redshift is determined from a decision tree, generally preferring PRISM redshifts but using grating redshifts if they agree.
           </div>
@@ -142,23 +142,23 @@ export const RedshiftFitSummary: React.FC<RedshiftFitSummaryProps> = ({
       <div className="overflow-x-auto">
         <table className="w-full">
           <thead>
-            <tr className="border-b border-border dark:border-slate-700">
-              <th className="text-left py-2 px-3 text-sm font-medium text-text-secondary dark:text-slate-400">
+            <tr className="border-b border-border">
+              <th className="text-left py-2 px-3 text-sm font-medium text-text-secondary">
                 Observation
               </th>
-              <th className="text-left py-2 px-3 text-sm font-medium text-text-secondary dark:text-slate-400">
+              <th className="text-left py-2 px-3 text-sm font-medium text-text-secondary">
                 Grating
               </th>
-              <th className="text-right py-2 px-3 text-sm font-medium text-text-secondary dark:text-slate-400">
+              <th className="text-right py-2 px-3 text-sm font-medium text-text-secondary">
                 Redshift
               </th>
-              <th className="text-right py-2 px-3 text-sm font-medium text-text-secondary dark:text-slate-400">
+              <th className="text-right py-2 px-3 text-sm font-medium text-text-secondary">
                 χ²_min
               </th>
-              <th className="text-right py-2 px-3 text-sm font-medium text-text-secondary dark:text-slate-400">
+              <th className="text-right py-2 px-3 text-sm font-medium text-text-secondary">
                 Confidence
               </th>
-              <th className="text-center py-2 px-3 text-sm font-medium text-text-secondary dark:text-slate-400">
+              <th className="text-center py-2 px-3 text-sm font-medium text-text-secondary">
                 Used
               </th>
             </tr>
@@ -167,37 +167,37 @@ export const RedshiftFitSummary: React.FC<RedshiftFitSummaryProps> = ({
             {gratingFits.map((fit, index) => (
               <tr
                 key={index}
-                className={`border-b border-border dark:border-slate-700 last:border-0 ${
+                className={`border-b border-border last:border-0 ${
                   fit.isUsedForAuto ? 'bg-green-50 dark:bg-green-950' : ''
                 }`}
               >
-                <td className="py-2 px-3 text-sm text-text-primary dark:text-slate-100">
-                  {fit.observation ?? <span className="text-text-secondary dark:text-slate-400">—</span>}
+                <td className="py-2 px-3 text-sm text-text-primary">
+                  {fit.observation ?? <span className="text-text-secondary">—</span>}
                 </td>
-                <td className="py-2 px-3 text-sm font-medium text-text-primary dark:text-slate-100">
+                <td className="py-2 px-3 text-sm font-medium text-text-primary">
                   {fit.grating}
                 </td>
-                <td className="py-2 px-3 text-sm text-right text-text-primary dark:text-slate-100 tabular-nums">
+                <td className="py-2 px-3 text-sm text-right text-text-primary tabular-nums">
                   {fit.error ? (
-                    <span className="text-text-secondary dark:text-slate-400 text-xs">{fit.error}</span>
+                    <span className="text-text-secondary text-xs">{fit.error}</span>
                   ) : fit.redshift !== undefined ? (
                     fit.redshift.toFixed(4)
                   ) : (
-                    <span className="text-text-secondary dark:text-slate-400">—</span>
+                    <span className="text-text-secondary">—</span>
                   )}
                 </td>
-                <td className="py-2 px-3 text-sm text-right text-text-primary dark:text-slate-100 tabular-nums">
+                <td className="py-2 px-3 text-sm text-right text-text-primary tabular-nums">
                   {fit.chi2Min !== undefined ? (
                     fit.chi2Min.toFixed(2)
                   ) : (
-                    <span className="text-text-secondary dark:text-slate-400">—</span>
+                    <span className="text-text-secondary">—</span>
                   )}
                 </td>
-                <td className="py-2 px-3 text-sm text-right text-text-primary dark:text-slate-100 tabular-nums">
+                <td className="py-2 px-3 text-sm text-right text-text-primary tabular-nums">
                   {fit.confidence !== undefined ? (
                     `${fit.confidence.toFixed(1)}%`
                   ) : (
-                    <span className="text-text-secondary dark:text-slate-400">—</span>
+                    <span className="text-text-secondary">—</span>
                   )}
                 </td>
                 <td className="py-2 px-3 text-center">

--- a/web/components/spectra/SpectraDetailSection.tsx
+++ b/web/components/spectra/SpectraDetailSection.tsx
@@ -87,7 +87,7 @@ export const SpectraDetailSection: React.FC<SpectraDetailSectionProps> = ({
 
   if (cards.length === 0) {
     return (
-      <div className="text-center py-8 text-sm text-text-secondary dark:text-slate-400 border border-dashed border-border dark:border-slate-700 rounded-lg">
+      <div className="text-center py-8 text-sm text-text-secondary border border-dashed border-border rounded-lg">
         No member spectra are visible. Toggle visibility in the sidebar.
       </div>
     );
@@ -98,12 +98,12 @@ export const SpectraDetailSection: React.FC<SpectraDetailSectionProps> = ({
   return (
     <div>
       <div className="flex items-center justify-between mb-3">
-        <h2 className="text-lg font-semibold text-text-primary dark:text-slate-100">
+        <h2 className="text-lg font-semibold text-text-primary">
           Spectra
         </h2>
         <button
           onClick={allExpanded ? onCollapseAll : onExpandAll}
-          className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200 border border-border dark:border-slate-700 rounded-md hover:bg-card-hover dark:hover:bg-slate-700 transition-colors"
+          className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium text-text-secondary hover:text-text-primary border border-border rounded-md hover:bg-card-hover transition-colors"
           title="Use J / K to step through cards"
         >
           {allExpanded ? (

--- a/web/components/spectra/SpectraFilterBar.tsx
+++ b/web/components/spectra/SpectraFilterBar.tsx
@@ -203,22 +203,22 @@ export const SpectraFilterBar: React.FC<SpectraFilterBarProps> = ({
         <div className="relative">
           <button
             onClick={() => setScopeDropdownOpen(!scopeDropdownOpen)}
-            className="flex items-center gap-1 px-3 py-2 text-sm border border-r-0 border-border dark:border-slate-700 rounded-l-lg bg-card dark:bg-slate-800 text-text-primary dark:text-slate-100 hover:bg-card-hover dark:hover:bg-slate-700 transition-colors"
+            className="flex items-center gap-1 px-3 py-2 text-sm border border-r-0 border-border rounded-l-lg bg-card text-text-primary hover:bg-card-hover transition-colors"
           >
             <span className="whitespace-nowrap">{currentScope.label}</span>
             <ChevronDown className={`w-3.5 h-3.5 transition-transform ${scopeDropdownOpen ? 'rotate-180' : ''}`} />
           </button>
           {/* Dropdown menu */}
           {scopeDropdownOpen && (
-            <div className="absolute top-full left-0 mt-1 w-40 bg-background dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg shadow-lg z-50 py-1">
+            <div className="absolute top-full left-0 mt-1 w-40 bg-background dark:bg-slate-800 border border-border rounded-lg shadow-lg z-50 py-1">
               {searchScopeOptions.map((option) => (
                 <button
                   key={option.value}
                   onClick={() => handleScopeChange(option.value)}
-                  className={`w-full text-left px-3 py-2 text-sm hover:bg-card-hover dark:hover:bg-slate-700 transition-colors ${
+                  className={`w-full text-left px-3 py-2 text-sm hover:bg-card-hover transition-colors ${
                     filters.search_scope === option.value
                       ? 'text-primary font-medium'
-                      : 'text-text-primary dark:text-slate-100'
+                      : 'text-text-primary'
                   }`}
                 >
                   {option.label}
@@ -229,19 +229,19 @@ export const SpectraFilterBar: React.FC<SpectraFilterBarProps> = ({
         </div>
         {/* Search input */}
         <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-secondary dark:text-slate-400" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-secondary" />
           <input
             type="text"
             value={localSearch}
             onChange={(e) => setLocalSearch(e.target.value)}
             placeholder={currentScope.placeholder}
-            className="w-full pl-10 pr-10 py-2 text-sm border border-border dark:border-slate-700 rounded-r-lg bg-background dark:bg-slate-800 text-text-primary dark:text-slate-100 placeholder:text-text-secondary dark:placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+            className="w-full pl-10 pr-10 py-2 text-sm border border-border rounded-r-lg bg-background dark:bg-slate-800 text-text-primary placeholder:text-text-secondary dark:placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
           />
           {/* Show clear button when there's text */}
           {localSearch && (
             <button
               onClick={() => setLocalSearch('')}
-              className="absolute right-3 top-1/2 -translate-y-1/2 text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200"
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-text-secondary hover:text-text-primary"
             >
               <X className="w-4 h-4" />
             </button>
@@ -281,7 +281,7 @@ export const SpectraFilterBar: React.FC<SpectraFilterBarProps> = ({
         />
 
         {/* Divider */}
-        <div className="h-6 w-px bg-border dark:bg-slate-700 mx-1" />
+        <div className="h-6 w-px bg-border mx-1" />
 
         {/* Redshift range filter */}
         <RangeFilterChip
@@ -312,7 +312,7 @@ export const SpectraFilterBar: React.FC<SpectraFilterBarProps> = ({
         />
 
         {/* Divider */}
-        <div className="h-6 w-px bg-border dark:bg-slate-700 mx-1" />
+        <div className="h-6 w-px bg-border mx-1" />
 
         {/* Advanced Filters button */}
         <button
@@ -322,14 +322,14 @@ export const SpectraFilterBar: React.FC<SpectraFilterBarProps> = ({
             border transition-all duration-200
             ${panelFilterCount > 0
               ? 'bg-primary/10 border-primary text-primary'
-              : 'bg-card dark:bg-slate-800 border-border dark:border-slate-700 text-text-secondary dark:text-slate-400 hover:border-text-secondary dark:hover:border-slate-600 hover:text-text-primary dark:hover:text-slate-200'
+              : 'bg-card border-border text-text-secondary hover:border-text-secondary dark:hover:border-border-strong hover:text-text-primary'
             }
           `}
         >
           <SlidersHorizontal className="w-4 h-4" />
           <span>Advanced</span>
           {panelFilterCount > 0 && (
-            <span className="px-1.5 py-0.5 text-[10px] font-bold rounded bg-primary text-white">
+            <span className="px-1.5 py-0.5 text-[10px] font-bold rounded bg-primary text-on-primary">
               {panelFilterCount}
             </span>
           )}
@@ -354,7 +354,7 @@ export const SpectraFilterBar: React.FC<SpectraFilterBarProps> = ({
             const qs = filterParams.toString();
             router.push(`/map${qs ? `?${qs}` : ''}`);
           }}
-          className="inline-flex items-center gap-1.5 px-3 h-8 rounded-full text-sm font-medium border border-border dark:border-slate-700 bg-card dark:bg-slate-800 text-text-secondary dark:text-slate-400 hover:border-text-secondary dark:hover:border-slate-600 hover:text-text-primary dark:hover:text-slate-200 transition-all duration-200"
+          className="inline-flex items-center gap-1.5 px-3 h-8 rounded-full text-sm font-medium border border-border bg-card text-text-secondary hover:border-text-secondary dark:hover:border-border-strong hover:text-text-primary transition-all duration-200"
           title="Show filtered objects on map"
         >
           <Map className="w-4 h-4" />
@@ -364,10 +364,10 @@ export const SpectraFilterBar: React.FC<SpectraFilterBarProps> = ({
         {/* Clear all button */}
         {hasActiveFilters && (
           <>
-            <div className="h-6 w-px bg-border dark:bg-slate-700 mx-1" />
+            <div className="h-6 w-px bg-border mx-1" />
             <button
               onClick={handleClearAll}
-              className="inline-flex items-center gap-1 px-3 py-1.5 text-sm text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200 transition-colors"
+              className="inline-flex items-center gap-1 px-3 py-1.5 text-sm text-text-secondary hover:text-text-primary transition-colors"
             >
               <X className="w-3.5 h-3.5" />
               Clear all

--- a/web/components/spectra/SpectraTable.tsx
+++ b/web/components/spectra/SpectraTable.tsx
@@ -166,7 +166,7 @@ const SortableHeader: React.FC<{
       ) : sorted === 'desc' ? (
         <ArrowDown className="w-3.5 h-3.5 text-primary" />
       ) : (
-        <ArrowUpDown className="w-3.5 h-3.5 text-text-secondary dark:text-slate-400 opacity-0 group-hover:opacity-100 transition-opacity" />
+        <ArrowUpDown className="w-3.5 h-3.5 text-text-secondary opacity-0 group-hover:opacity-100 transition-opacity" />
       )}
     </button>
   );
@@ -181,7 +181,7 @@ const TableSkeletonRow: React.FC<{ columns: ColumnDef<SpectrumTarget>[] }> = ({ 
         className="px-4 py-3 whitespace-nowrap"
         style={{ width: `${col.minSize || 150}px` }}
       >
-        <div className="h-4 bg-gray-200 dark:bg-slate-700 rounded w-full"></div>
+        <div className="h-4 bg-surface-2 dark:bg-slate-700 rounded w-full"></div>
       </td>
     ))}
   </tr>
@@ -214,15 +214,15 @@ const ViewModeTooltip: React.FC = () => {
     <div ref={ref} className="relative flex items-center">
       <button
         onClick={() => setOpen(!open)}
-        className="text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200 transition-colors"
+        className="text-text-secondary hover:text-text-primary transition-colors"
         aria-label="View mode help"
       >
         <HelpCircle className="w-3.5 h-3.5" />
       </button>
       {open && (
-        <div className="absolute left-0 top-full mt-1.5 z-50 w-64 px-3 py-2 text-xs text-text-secondary dark:text-slate-400 bg-background dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg shadow-lg">
-          <p><span className="font-medium text-text-primary dark:text-slate-200">Objects</span> = unique sources across programs</p>
-          <p><span className="font-medium text-text-primary dark:text-slate-200">Spectra</span> = individual grating exposures</p>
+        <div className="absolute left-0 top-full mt-1.5 z-50 w-64 px-3 py-2 text-xs text-text-secondary bg-background dark:bg-slate-800 border border-border rounded-lg shadow-lg">
+          <p><span className="font-medium text-text-primary">Objects</span> = unique sources across programs</p>
+          <p><span className="font-medium text-text-primary">Spectra</span> = individual grating exposures</p>
         </div>
       )}
     </div>
@@ -354,7 +354,7 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
       <SortableHeader column={column}>Distance</SortableHeader>
     ),
     cell: ({ row }) => (
-      <span className="text-sm font-mono text-text-primary dark:text-slate-100">
+      <span className="text-sm font-mono text-text-primary">
         {row.original.distance != null ? formatDistance(row.original.distance) : 'N/A'}
       </span>
     ),
@@ -463,7 +463,7 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
           <SortableHeader column={column}>Field</SortableHeader>
         ),
         cell: ({ row }) => (
-          <span className="text-sm text-text-primary dark:text-slate-100 uppercase">{row.original.field}</span>
+          <span className="text-sm text-text-primary uppercase">{row.original.field}</span>
         ),
         sortingFn: 'alphanumeric',
       },
@@ -474,7 +474,7 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
           <SortableHeader column={column}>RA</SortableHeader>
         ),
         cell: ({ row }) => (
-          <span className="text-sm font-mono text-text-primary dark:text-slate-100">
+          <span className="text-sm font-mono text-text-primary">
             {row.original.ra.toFixed(6)}
           </span>
         ),
@@ -487,7 +487,7 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
           <SortableHeader column={column}>Dec</SortableHeader>
         ),
         cell: ({ row }) => (
-          <span className="text-sm font-mono text-text-primary dark:text-slate-100">
+          <span className="text-sm font-mono text-text-primary">
             {row.original.dec.toFixed(6)}
           </span>
         ),
@@ -506,7 +506,7 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
           <SortableHeader column={column}>Redshift</SortableHeader>
         ),
         cell: ({ row }: { row: { original: SpectrumTarget } }) => (
-          <span className="text-sm font-mono text-text-primary dark:text-slate-100">
+          <span className="text-sm font-mono text-text-primary">
             {row.original.redshift !== null ? row.original.redshift.toFixed(4) : 'N/A'}
           </span>
         ),
@@ -529,7 +529,7 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
         cell: ({ row }: { row: { original: SpectrumTarget } }) => {
           const name = row.original.program_name;
           return (
-            <span className="text-sm text-text-primary dark:text-slate-100">
+            <span className="text-sm text-text-primary">
               {name || row.original.program_slug}
             </span>
           );
@@ -550,7 +550,7 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
           return (
             <div className="flex items-center gap-1.5">
               <span>{quality.icon}</span>
-              <span className="text-sm text-text-primary dark:text-slate-100">{quality.short}</span>
+              <span className="text-sm text-text-primary">{quality.short}</span>
             </div>
           );
         },
@@ -567,7 +567,7 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
         cell: ({ row }: { row: { original: SpectrumTarget } }) => {
           const z = row.original.spectra[0]?.redshift_auto;
           return (
-            <span className="text-sm font-mono text-text-primary dark:text-slate-100">
+            <span className="text-sm font-mono text-text-primary">
               {z != null ? z.toFixed(4) : '—'}
             </span>
           );
@@ -583,7 +583,7 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
         cell: ({ row }: { row: { original: SpectrumTarget } }) => {
           const mask = row.original.spectra[0]?.dq_flags ?? 0;
           if (mask === 0) {
-            return <span className="text-xs text-text-secondary dark:text-slate-500">—</span>;
+            return <span className="text-xs text-text-secondary dark:text-text-tertiary">—</span>;
           }
           const active = decodeBitmask(mask, DQ_FLAGS);
           const defs = DQ_FLAGS.filter(f => active.includes(f.value));
@@ -613,7 +613,7 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
           <SortableHeader column={column} className="justify-center"># Observations</SortableHeader>
         ),
         cell: ({ row }: { row: { original: SpectrumTarget } }) => (
-          <span className="text-sm text-text-primary dark:text-slate-100 text-center block">
+          <span className="text-sm text-text-primary text-center block">
             {row.original.n_targets ?? 0}
           </span>
         ),
@@ -628,7 +628,7 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
           <SortableHeader column={column} className="justify-center"># Spectra</SortableHeader>
         ),
         cell: ({ row }: { row: { original: SpectrumTarget } }) => (
-          <span className="text-sm text-text-primary dark:text-slate-100 text-center block">
+          <span className="text-sm text-text-primary text-center block">
             {row.original.n_spectra ?? 0}
           </span>
         ),
@@ -643,7 +643,7 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
           <SortableHeader column={column} className="justify-end">Photo-z</SortableHeader>
         ),
         cell: ({ row }: { row: { original: SpectrumTarget } }) => (
-          <span className="text-sm font-mono text-text-primary dark:text-slate-100 text-right block">
+          <span className="text-sm font-mono text-text-primary text-right block">
             {row.original.photo_z != null ? row.original.photo_z.toFixed(4) : '—'}
           </span>
         ),
@@ -694,7 +694,7 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
         header: () => <span className="normal-case">Tags</span>,
         cell: ({ row }: { row: { original: SpectrumTarget } }) => {
           const lists = row.original.lists ?? [];
-          if (lists.length === 0) return <span className="text-xs text-text-secondary dark:text-slate-500">---</span>;
+          if (lists.length === 0) return <span className="text-xs text-text-secondary dark:text-text-tertiary">---</span>;
           return (
             <div className="flex flex-wrap gap-1 max-w-[200px]">
               {lists.map((l) => (
@@ -726,7 +726,7 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
           <SortableHeader column={column}>S/N</SortableHeader>
         ),
         cell: ({ row }: { row: { original: SpectrumTarget } }) => (
-          <span className="text-sm font-mono text-text-primary dark:text-slate-100">
+          <span className="text-sm font-mono text-text-primary">
             {row.original.max_snr ? row.original.max_snr.toFixed(1) : 'N/A'}
           </span>
         ),
@@ -743,7 +743,7 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
         cell: ({ row }: { row: { original: SpectrumTarget } }) => {
           const snr = row.original.spectra[0]?.signal_to_noise;
           return (
-            <span className="text-sm font-mono text-text-primary dark:text-slate-100">
+            <span className="text-sm font-mono text-text-primary">
               {snr != null ? snr.toFixed(1) : 'N/A'}
             </span>
           );
@@ -759,7 +759,7 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
           <SortableHeader column={column}>Exp. Time</SortableHeader>
         ),
         cell: ({ row }: { row: { original: SpectrumTarget } }) => (
-          <span className="text-sm font-mono text-text-primary dark:text-slate-100">
+          <span className="text-sm font-mono text-text-primary">
             {row.original.max_exposure_time ? `${row.original.max_exposure_time.toFixed(0)}s` : 'N/A'}
           </span>
         ),
@@ -776,7 +776,7 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
         cell: ({ row }: { row: { original: SpectrumTarget } }) => {
           const expTime = row.original.spectra[0]?.exposure_time;
           return (
-            <span className="text-sm font-mono text-text-primary dark:text-slate-100">
+            <span className="text-sm font-mono text-text-primary">
               {expTime != null ? `${expTime.toFixed(0)}s` : 'N/A'}
             </span>
           );
@@ -793,7 +793,7 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
           <SortableHeader column={column}>Grating</SortableHeader>
         ),
         cell: ({ row }: { row: { original: SpectrumTarget } }) => (
-          <span className="text-sm font-mono text-text-primary dark:text-slate-100">
+          <span className="text-sm font-mono text-text-primary">
             {row.original.spectra[0]?.grating ?? 'N/A'}
           </span>
         ),
@@ -807,7 +807,7 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
           <SortableHeader column={column}>Observation</SortableHeader>
         ),
         cell: ({ row }: { row: { original: SpectrumTarget } }) => (
-          <span className="text-sm font-mono text-text-primary dark:text-slate-100">
+          <span className="text-sm font-mono text-text-primary">
             {row.original.observation || 'N/A'}
           </span>
         ),
@@ -916,23 +916,23 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
   return (
     <Card className="overflow-hidden">
       {/* Table header with view mode toggle, column visibility, and download dropdowns */}
-      <div className="flex items-center justify-between px-4 py-2 bg-card dark:bg-slate-800 border-b border-border dark:border-slate-700">
+      <div className="flex items-center justify-between px-4 py-2 bg-card border-b border-border">
         <div className="flex items-center gap-3">
-          <span className="text-sm text-text-secondary dark:text-slate-400">
+          <span className="text-sm text-text-secondary">
             {loading ? 'Loading...' : `${total.toLocaleString()} ${isObjectsMode ? 'unique objects' : 'spectra'}`}
           </span>
           {/* View mode toggle */}
           {onViewModeChange && (
             <>
-              <div className="flex items-center bg-gray-100 dark:bg-slate-700 rounded-md p-0.5">
+              <div className="flex items-center bg-card-hover rounded-md p-0.5">
                 {(['objects', 'spectra'] as const).map((mode) => (
                   <button
                     key={mode}
                     onClick={() => onViewModeChange(mode)}
                     className={`px-2.5 py-1 text-xs font-medium rounded transition-colors ${
                       viewMode === mode
-                        ? 'bg-white dark:bg-slate-600 text-text-primary dark:text-slate-100 shadow-sm'
-                        : 'text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200'
+                        ? 'bg-white dark:bg-slate-600 text-text-primary shadow-sm'
+                        : 'text-text-secondary hover:text-text-primary'
                     }`}
                   >
                     {mode.charAt(0).toUpperCase() + mode.slice(1)}
@@ -960,7 +960,7 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
                   total,
                 });
               }}
-              className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium rounded-lg bg-primary hover:bg-primary-hover text-white transition-colors"
+              className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium rounded-lg bg-primary hover:bg-primary-hover text-on-primary transition-colors"
               title="Streamlined fullscreen view for rapid quality inspection. Auto-filters to uninspected objects and supports keyboard shortcuts for efficient review."
             >
               <ScanEye className="w-3.5 h-3.5" />
@@ -987,13 +987,13 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
 
       <div className="overflow-x-auto">
         <table className="w-full">
-          <thead className="bg-card dark:bg-slate-800 border-b border-border dark:border-slate-700">
+          <thead className="bg-card border-b border-border">
             {table.getHeaderGroups().map((headerGroup) => (
               <tr key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <th
                     key={header.id}
-                    className="px-4 py-3 text-left text-xs font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wider"
+                    className="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider"
                     style={{ width: `${header.getSize()}px` }}
                   >
                     {header.isPlaceholder
@@ -1004,7 +1004,7 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
               </tr>
             ))}
           </thead>
-          <tbody className="bg-white dark:bg-slate-800 divide-y divide-border dark:divide-slate-700">
+          <tbody className="bg-card divide-y divide-border">
             {loading ? (
               // Loading state: show skeleton rows matching visible columns
               <TableSkeleton
@@ -1023,7 +1023,7 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
             ) : spectra.length === 0 ? (
               // Empty state: show message
               <tr>
-                <td colSpan={visibleColumnCount} className="px-4 py-12 text-center text-text-secondary dark:text-slate-400">
+                <td colSpan={visibleColumnCount} className="px-4 py-12 text-center text-text-secondary">
                   No results found.
                   <p className="text-sm mt-2">
                     If you&apos;re looking for proprietary data, you may need to enter an access code on your profile page.
@@ -1045,7 +1045,7 @@ export const SpectraTable: React.FC<SpectraTableProps> = ({
       </div>
 
       {/* Always show pagination footer */}
-      <div className="border-t border-border dark:border-slate-700">
+      <div className="border-t border-border">
         <TablePagination
           pageIndex={table.getState().pagination.pageIndex}
           pageSize={table.getState().pagination.pageSize}

--- a/web/components/spectra/SpectraTableRow.tsx
+++ b/web/components/spectra/SpectraTableRow.tsx
@@ -15,7 +15,7 @@ interface SpectraTableRowProps {
  */
 const SpectraTableRowComponent: React.FC<SpectraTableRowProps> = ({ row }) => {
   return (
-    <tr className="hover:bg-card-hover dark:hover:bg-slate-700 transition-colors">
+    <tr className="hover:bg-card-hover transition-colors">
       {row.getVisibleCells().map((cell: Cell<SpectrumTarget, unknown>) => (
         <td
           key={cell.id}

--- a/web/components/spectra/SpectrumDetailCard.tsx
+++ b/web/components/spectra/SpectrumDetailCard.tsx
@@ -103,7 +103,7 @@ export const SpectrumDetailCard: React.FC<SpectrumDetailCardProps> = ({
   return (
     <div
       id={cardId}
-      className="border border-border dark:border-slate-700 rounded-lg overflow-hidden bg-card dark:bg-slate-800"
+      className="border border-border rounded-lg overflow-hidden bg-card"
     >
       {/* Header row — always visible. Compact summary. */}
       <button
@@ -111,11 +111,11 @@ export const SpectrumDetailCard: React.FC<SpectrumDetailCardProps> = ({
         className="w-full flex flex-wrap items-center gap-x-4 gap-y-2 px-4 py-3 text-left hover:bg-card-hover dark:hover:bg-slate-700/50 transition-colors"
         aria-expanded={expanded}
       >
-        <span className="flex items-center gap-2 text-text-primary dark:text-slate-100">
+        <span className="flex items-center gap-2 text-text-primary">
           {expanded ? (
-            <ChevronDown className="w-4 h-4 text-text-secondary dark:text-slate-400" />
+            <ChevronDown className="w-4 h-4 text-text-secondary" />
           ) : (
-            <ChevronRight className="w-4 h-4 text-text-secondary dark:text-slate-400" />
+            <ChevronRight className="w-4 h-4 text-text-secondary" />
           )}
           <span
             className="inline-block w-2.5 h-2.5 rounded-full flex-shrink-0"
@@ -126,26 +126,26 @@ export const SpectrumDetailCard: React.FC<SpectrumDetailCardProps> = ({
           </span>
         </span>
 
-        <span className="text-sm font-mono text-text-primary dark:text-slate-200">
+        <span className="text-sm font-mono text-text-primary">
           {targetId}
         </span>
 
-        <div className="flex items-center gap-3 text-sm text-text-secondary dark:text-slate-400 ml-auto">
+        <div className="flex items-center gap-3 text-sm text-text-secondary ml-auto">
           <span>
             <span className="opacity-70">z=</span>
-            <span className="font-mono text-text-primary dark:text-slate-200">
+            <span className="font-mono text-text-primary">
               {spectrum.redshift_auto != null ? spectrum.redshift_auto.toFixed(4) : '—'}
             </span>
           </span>
           <span>
             <span className="opacity-70">S/N=</span>
-            <span className="font-mono text-text-primary dark:text-slate-200">
+            <span className="font-mono text-text-primary">
               {spectrum.signal_to_noise != null ? spectrum.signal_to_noise.toFixed(1) : '—'}
             </span>
           </span>
           <span>
             <span className="opacity-70">t=</span>
-            <span className="font-mono text-text-primary dark:text-slate-200">
+            <span className="font-mono text-text-primary">
               {formatExposureTime(spectrum.exposure_time)}
             </span>
           </span>
@@ -154,9 +154,9 @@ export const SpectrumDetailCard: React.FC<SpectrumDetailCardProps> = ({
 
       {/* Expandable body — single border-t separator, no nested card. */}
       {expanded && (
-        <div className="border-t border-border dark:border-slate-700">
+        <div className="border-t border-border">
           {/* Metadata + actions row (sits above the controls bar). */}
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-2 px-4 py-2.5 bg-card dark:bg-slate-800 text-xs text-text-secondary dark:text-slate-400">
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-2 px-4 py-2.5 bg-card text-xs text-text-secondary">
             <div className="flex items-center gap-2">
               <FilterChip
                 label="DQ"
@@ -167,13 +167,13 @@ export const SpectrumDetailCard: React.FC<SpectrumDetailCardProps> = ({
                 dropdownPlacement="bottom"
               />
               {dqSaving && (
-                <Loader2 className="w-3.5 h-3.5 animate-spin text-text-secondary dark:text-slate-400" />
+                <Loader2 className="w-3.5 h-3.5 animate-spin text-text-secondary" />
               )}
             </div>
 
             <span className="flex items-center gap-1.5">
               <span className="opacity-70 uppercase tracking-wide">Version:</span>
-              <span className="font-mono text-text-primary dark:text-slate-200">
+              <span className="font-mono text-text-primary">
                 {spectrum.reduction_version || '—'}
               </span>
             </span>
@@ -183,7 +183,7 @@ export const SpectrumDetailCard: React.FC<SpectrumDetailCardProps> = ({
               title={spectrum.fits_path}
             >
               <span className="opacity-70 uppercase tracking-wide">FITS:</span>
-              <span className="font-mono text-text-primary dark:text-slate-200 truncate">
+              <span className="font-mono text-text-primary truncate">
                 {spectrum.spectrum_id}
               </span>
             </span>
@@ -191,7 +191,7 @@ export const SpectrumDetailCard: React.FC<SpectrumDetailCardProps> = ({
             <button
               onClick={handleDownload}
               disabled={downloading}
-              className="ml-auto inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium border border-border dark:border-slate-600 rounded hover:bg-card-hover dark:hover:bg-slate-700 text-text-primary dark:text-slate-200 disabled:opacity-50"
+              className="ml-auto inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium border border-border dark:border-border-strong rounded hover:bg-card-hover text-text-primary disabled:opacity-50"
             >
               {downloading ? (
                 <Loader2 className="w-3.5 h-3.5 animate-spin" />

--- a/web/components/spectra/SpectrumPlot.tsx
+++ b/web/components/spectra/SpectrumPlot.tsx
@@ -15,7 +15,7 @@ import { RedshiftSliderControl } from './PlottingControls';
 const Plot = dynamic(() => import('react-plotly.js'), {
   ssr: false,
   loading: () => (
-    <div className="flex items-center justify-center h-[700px] bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg">
+    <div className="flex items-center justify-center h-[700px] bg-card border border-border rounded-lg">
       <Loader2 className="w-6 h-6 animate-spin text-primary" />
     </div>
   ),
@@ -664,18 +664,18 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-[700px] bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg">
+      <div className="flex items-center justify-center h-[700px] bg-card border border-border rounded-lg">
         <Loader2 className="w-6 h-6 animate-spin text-primary mr-3" />
-        <span className="text-text-secondary dark:text-slate-400">Loading spectrum...</span>
+        <span className="text-text-secondary">Loading spectrum...</span>
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="flex flex-col items-center justify-center h-[700px] bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg">
+      <div className="flex flex-col items-center justify-center h-[700px] bg-card border border-border rounded-lg">
         <AlertCircle className="w-8 h-8 text-red-500 mb-3" />
-        <p className="text-text-secondary dark:text-slate-400">{error}</p>
+        <p className="text-text-secondary">{error}</p>
         <button
           onClick={() => window.location.reload()}
           className="mt-4 px-4 py-2 text-sm text-primary hover:underline"
@@ -691,19 +691,19 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
   }
 
   return (
-    <div className={bare ? '' : 'bg-white dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg overflow-hidden'}>
+    <div className={bare ? '' : 'bg-card border border-border rounded-lg overflow-hidden'}>
       {/* Controls */}
-      <div className="flex flex-wrap items-center gap-4 px-4 py-2 border-b border-border dark:border-slate-700 bg-gray-50 dark:bg-slate-900">
+      <div className="flex flex-wrap items-center gap-4 px-4 py-2 border-b border-border bg-gray-50 dark:bg-slate-900">
         {/* Flux unit toggle */}
         <div className="flex items-center gap-2">
-          <span className="text-sm text-text-secondary dark:text-slate-400">Units:</span>
-          <div className="flex rounded-md overflow-hidden border border-border dark:border-slate-600">
+          <span className="text-sm text-text-secondary">Units:</span>
+          <div className="flex rounded-md overflow-hidden border border-border dark:border-border-strong">
             <button
               onClick={() => setFluxUnit('fnu')}
               className={`px-3 py-1 text-sm transition-colors ${
                 fluxUnit === 'fnu'
-                  ? 'bg-primary text-white'
-                  : 'bg-white dark:bg-slate-800 text-text-secondary dark:text-slate-400 hover:bg-gray-100 dark:hover:bg-slate-700'
+                  ? 'bg-primary text-on-primary'
+                  : 'bg-card text-text-secondary hover:bg-card-hover'
               }`}
             >
               fν
@@ -712,8 +712,8 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
               onClick={() => setFluxUnit('flambda')}
               className={`px-3 py-1 text-sm transition-colors ${
                 fluxUnit === 'flambda'
-                  ? 'bg-primary text-white'
-                  : 'bg-white dark:bg-slate-800 text-text-secondary dark:text-slate-400 hover:bg-gray-100 dark:hover:bg-slate-700'
+                  ? 'bg-primary text-on-primary'
+                  : 'bg-card text-text-secondary hover:bg-card-hover'
               }`}
             >
               fλ
@@ -722,31 +722,31 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
         </div>
 
         {/* Divider */}
-        <div className="h-6 w-px bg-border dark:bg-slate-600" />
+        <div className="h-6 w-px bg-border dark:bg-border-strong" />
 
         {/* 2D color scale controls */}
         <div className="flex items-center gap-2">
-          <span className="text-sm text-text-secondary dark:text-slate-400">2D scale:</span>
+          <span className="text-sm text-text-secondary">2D scale:</span>
           <input
             type="number"
             value={colorMin}
             onChange={(e) => setColorMin(parseFloat(e.target.value) || 0)}
             step={1}
-            className="w-16 px-2 py-1 text-sm border border-border dark:border-slate-600 rounded bg-white dark:bg-slate-800 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-primary"
+            className="w-16 px-2 py-1 text-sm border border-border dark:border-border-strong rounded bg-card text-text-primary focus:outline-none focus:ring-1 focus:ring-primary"
             title="Color minimum (S/N)"
           />
-          <span className="text-sm text-text-secondary dark:text-slate-400">to</span>
+          <span className="text-sm text-text-secondary">to</span>
           <input
             type="number"
             value={colorMax}
             onChange={(e) => setColorMax(parseFloat(e.target.value) || 0)}
             step={1}
-            className="w-16 px-2 py-1 text-sm border border-border dark:border-slate-600 rounded bg-white dark:bg-slate-800 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-primary"
+            className="w-16 px-2 py-1 text-sm border border-border dark:border-border-strong rounded bg-card text-text-primary focus:outline-none focus:ring-1 focus:ring-primary"
             title="Color maximum (S/N)"
           />
           <button
             onClick={() => { setColorMin(spectrumPreferences.snrMin); setColorMax(spectrumPreferences.snrMax); }}
-            className="px-2 py-1 text-xs text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-100 border border-border dark:border-slate-600 rounded hover:bg-gray-100 dark:hover:bg-slate-700"
+            className="px-2 py-1 text-xs text-text-secondary hover:text-text-primary border border-border dark:border-border-strong rounded hover:bg-card-hover"
             title="Reset to default"
           >
             Reset
@@ -754,7 +754,7 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
           <select
             value={colorscale}
             onChange={(e) => setColorscale(e.target.value as Colorscale2D)}
-            className="px-2 py-1 text-sm border border-border dark:border-slate-600 rounded bg-white dark:bg-slate-800 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-primary"
+            className="px-2 py-1 text-sm border border-border dark:border-border-strong rounded bg-card text-text-primary focus:outline-none focus:ring-1 focus:ring-primary"
             title="Colormap"
           >
             {COLORSCALE_OPTIONS.map((scale) => (
@@ -766,7 +766,7 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
         </div>
 
         {/* Divider */}
-        <div className="h-6 w-px bg-border dark:bg-slate-600" />
+        <div className="h-6 w-px bg-border dark:bg-border-strong" />
 
         {/* Emission lines toggle */}
         <div className="flex items-center gap-2">
@@ -775,9 +775,9 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
               type="checkbox"
               checked={showEmissionLines}
               onChange={(e) => setShowEmissionLines(e.target.checked)}
-              className="w-4 h-4 rounded border-border dark:border-slate-600 text-primary focus:ring-primary"
+              className="w-4 h-4 rounded border-border dark:border-border-strong text-primary focus:ring-primary"
             />
-            <span className="text-sm text-text-secondary dark:text-slate-400">Emission lines</span>
+            <span className="text-sm text-text-secondary">Emission lines</span>
           </label>
         </div>
 
@@ -792,9 +792,9 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
               checked={showModel && !!fitData}
               disabled={!fitData}
               onChange={(e) => setShowModel(e.target.checked)}
-              className="w-4 h-4 rounded border-border dark:border-slate-600 text-primary focus:ring-primary"
+              className="w-4 h-4 rounded border-border dark:border-border-strong text-primary focus:ring-primary"
             />
-            <span className="text-sm text-text-secondary dark:text-slate-400">Model</span>
+            <span className="text-sm text-text-secondary">Model</span>
           </label>
         </div>
 
@@ -832,7 +832,7 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
 
       {/* χ²(z) panel — appears below the spectrum when Model is on. */}
       {chi2PlotData && (
-        <div className="border-t border-border dark:border-slate-700">
+        <div className="border-t border-border">
           <Plot
             data={chi2PlotData.traces}
             layout={chi2PlotData.layout}

--- a/web/components/spectra/SpectrumThumbnail.tsx
+++ b/web/components/spectra/SpectrumThumbnail.tsx
@@ -35,7 +35,7 @@ export const SpectrumThumbnail: React.FC<SpectrumThumbnailProps> = ({
         className="flex items-center justify-center"
         style={{ width, height }}
       >
-        <span className="text-gray-400 dark:text-slate-500 text-xs">--</span>
+        <span className="text-text-tertiary text-xs">--</span>
       </div>
     );
   }
@@ -47,7 +47,7 @@ export const SpectrumThumbnail: React.FC<SpectrumThumbnailProps> = ({
     >
       {isLoading && (
         <div
-          className="absolute inset-0 bg-gray-200 dark:bg-slate-700 animate-pulse rounded"
+          className="absolute inset-0 bg-surface-2 animate-pulse rounded"
           style={{ width, height }}
         />
       )}

--- a/web/components/spectra/SpectrumThumbnailInline.tsx
+++ b/web/components/spectra/SpectrumThumbnailInline.tsx
@@ -69,7 +69,7 @@ export const SpectrumThumbnailInline: React.FC<SpectrumThumbnailInlineProps> = (
         className="flex items-center justify-center"
         style={{ width, height }}
       >
-        <span className="text-gray-400 dark:text-slate-500 text-xs">--</span>
+        <span className="text-text-tertiary text-xs">--</span>
       </div>
     );
   }

--- a/web/components/spectra/StalenessBadge.tsx
+++ b/web/components/spectra/StalenessBadge.tsx
@@ -136,8 +136,8 @@ export const StalenessBadge: React.FC<StalenessBadgeProps> = ({
         Needs Review
       </button>
       {open && (
-        <div className="absolute left-0 top-full mt-1.5 z-50 w-72 p-3 bg-background dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg shadow-lg">
-          <p className="text-sm text-text-primary dark:text-slate-200 mb-3">{tooltip}</p>
+        <div className="absolute left-0 top-full mt-1.5 z-50 w-72 p-3 bg-background dark:bg-card border border-border rounded-lg shadow-lg">
+          <p className="text-sm text-text-primary mb-3">{tooltip}</p>
           {error && (
             <p className="text-xs text-red-600 dark:text-red-400 mb-2">{error}</p>
           )}
@@ -146,12 +146,12 @@ export const StalenessBadge: React.FC<StalenessBadgeProps> = ({
               type="button"
               onClick={handleMarkReviewed}
               disabled={submitting}
-              className="w-full px-3 py-1.5 text-sm font-medium rounded-md bg-primary text-white hover:bg-primary-hover disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+              className="w-full px-3 py-1.5 text-sm font-medium rounded-md bg-primary text-on-primary hover:bg-primary-hover disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
             >
               {submitting ? 'Marking…' : 'Mark as reviewed'}
             </button>
           ) : (
-            <p className="text-xs text-text-secondary dark:text-slate-400">
+            <p className="text-xs text-text-secondary">
               You do not have permission to mark objects as reviewed.
             </p>
           )}

--- a/web/components/spectra/TileThumbnail.tsx
+++ b/web/components/spectra/TileThumbnail.tsx
@@ -80,10 +80,10 @@ export const TileThumbnail: React.FC<TileThumbnailProps> = ({
   if (hasError) {
     const placeholder = (
       <div
-        className={`bg-gray-200 dark:bg-slate-700 rounded flex items-center justify-center ${className || ''}`}
+        className={`bg-surface-2 rounded flex items-center justify-center ${className || ''}`}
         style={{ width: cssSize, height: cssSize }}
       >
-        <span className="text-gray-400 dark:text-slate-500 text-xs">N/A</span>
+        <span className="text-text-tertiary text-xs">N/A</span>
       </div>
     );
     return linkToMap ? (
@@ -98,14 +98,14 @@ export const TileThumbnail: React.FC<TileThumbnailProps> = ({
 
   const img = (
     <div
-      className={`relative rounded overflow-hidden border border-gray-200 dark:border-slate-600 ${
+      className={`relative rounded overflow-hidden border border-border dark:border-border-strong ${
         linkToMap ? 'hover:border-primary dark:hover:border-primary transition-colors' : ''
       } ${className || ''}`}
       style={{ width: cssSize, height: cssSize }}
     >
       {isLoading && (
         <div
-          className="absolute inset-0 bg-gray-200 dark:bg-slate-700 animate-pulse"
+          className="absolute inset-0 bg-surface-2 animate-pulse"
           style={{ width: cssSize, height: cssSize }}
         />
       )}

--- a/web/components/spectra/TileThumbnailWithToggle.tsx
+++ b/web/components/spectra/TileThumbnailWithToggle.tsx
@@ -80,7 +80,7 @@ export const TileThumbnailWithToggle: React.FC<TileThumbnailWithToggleProps> = (
       <div className="flex items-center gap-3">
         <button
           onClick={() => setShowShutters((prev) => !prev)}
-          className="flex items-center gap-1.5 text-xs text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200 transition-colors"
+          className="flex items-center gap-1.5 text-xs text-text-secondary hover:text-text-primary transition-colors"
         >
           {showShutters ? (
             <EyeOff className="w-3.5 h-3.5" />
@@ -93,7 +93,7 @@ export const TileThumbnailWithToggle: React.FC<TileThumbnailWithToggleProps> = (
           onClick={handleDownloadRegion}
           disabled={downloading}
           title="Download DS9 region file (.reg)"
-          className="flex items-center gap-1.5 text-xs text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200 transition-colors disabled:opacity-50"
+          className="flex items-center gap-1.5 text-xs text-text-secondary hover:text-text-primary transition-colors disabled:opacity-50"
         >
           <Download className="w-3.5 h-3.5" />
           {downloading ? 'Preparing...' : '.reg'}

--- a/web/components/spectra/UnifiedObjectPage.tsx
+++ b/web/components/spectra/UnifiedObjectPage.tsx
@@ -235,7 +235,7 @@ export const UnifiedObjectPage: React.FC<UnifiedObjectPageProps> = ({ object }) 
       <div className="flex gap-6 pb-24">
         {/* Desktop sidebar: cutout + members control panel */}
         <div className="hidden lg:block">
-          <div className="w-[260px] flex-shrink-0 sticky top-4 max-h-[calc(100vh-6rem)] overflow-y-auto border-r border-border dark:border-slate-700 pr-3">
+          <div className="w-[260px] flex-shrink-0 sticky top-4 max-h-[calc(100vh-6rem)] overflow-y-auto border-r border-border pr-3">
             <div className="mb-3">
               <TileThumbnailWithToggle
                 targetId={object.object_id}
@@ -279,7 +279,7 @@ export const UnifiedObjectPage: React.FC<UnifiedObjectPageProps> = ({ object }) 
           {/* === Header === */}
           <div className="mb-6">
             <div className="flex items-center gap-3 mb-2 flex-wrap">
-              <h1 className="text-3xl font-bold font-mono text-text-primary dark:text-slate-100">
+              <h1 className="text-3xl font-bold font-mono text-text-primary">
                 {object.object_id}
               </h1>
               <StalenessBadge
@@ -292,16 +292,16 @@ export const UnifiedObjectPage: React.FC<UnifiedObjectPageProps> = ({ object }) 
                 onReviewed={({ last_inspected_at }) => setLastInspectedOverride(last_inspected_at)}
               />
               {!object.is_active && (
-                <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-200 dark:bg-slate-700 text-text-secondary dark:text-slate-300">
+                <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-surface-2 text-text-secondary">
                   Inactive
                 </span>
               )}
             </div>
-            <div className="flex items-center gap-2 text-sm text-text-secondary dark:text-slate-400 mb-3">
+            <div className="flex items-center gap-2 text-sm text-text-secondary mb-3">
               <span>Field:</span>
               <Link
                 href={`/nirspec?view=objects&fields=${object.field}`}
-                className="inline-flex items-center hover:bg-gray-100 dark:hover:bg-slate-700 px-2 py-1 rounded transition-colors text-text-primary dark:text-slate-100"
+                className="inline-flex items-center hover:bg-card-hover px-2 py-1 rounded transition-colors text-text-primary"
               >
                 {object.field}
               </Link>
@@ -336,19 +336,19 @@ export const UnifiedObjectPage: React.FC<UnifiedObjectPageProps> = ({ object }) 
           {/* === Section 1: Spectrum Comparison === */}
           <section className="mb-8">
             <div className="flex flex-wrap gap-5 items-center mb-4">
-              <h2 className="text-lg font-semibold text-text-primary dark:text-slate-100">
+              <h2 className="text-lg font-semibold text-text-primary">
                 Spectrum Comparison{selectedGrating ? ` — ${selectedGrating}` : ''}
               </h2>
               {object.programs.length > 1 && (
                 <div className="flex items-center gap-2">
-                  <span className="text-sm text-text-secondary dark:text-slate-400">Program:</span>
-                  <div className="flex items-center bg-gray-100 dark:bg-slate-700 rounded-md p-0.5">
+                  <span className="text-sm text-text-secondary">Program:</span>
+                  <div className="flex items-center bg-surface-2 rounded-md p-0.5">
                     <button
                       onClick={() => setSelectedProgram(null)}
                       className={`px-2.5 py-1 text-xs font-medium rounded transition-colors ${
                         selectedProgram === null
-                          ? 'bg-white dark:bg-slate-600 text-text-primary dark:text-slate-100 shadow-sm'
-                          : 'text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200'
+                          ? 'bg-background dark:bg-slate-600 text-text-primary shadow-sm'
+                          : 'text-text-secondary hover:text-text-primary'
                       }`}
                     >
                       All
@@ -359,8 +359,8 @@ export const UnifiedObjectPage: React.FC<UnifiedObjectPageProps> = ({ object }) 
                         onClick={() => setSelectedProgram(selectedProgram === p ? null : p)}
                         className={`px-2.5 py-1 text-xs font-medium rounded transition-colors ${
                           selectedProgram === p
-                            ? 'bg-white dark:bg-slate-600 text-text-primary dark:text-slate-100 shadow-sm'
-                            : 'text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200'
+                            ? 'bg-background dark:bg-slate-600 text-text-primary shadow-sm'
+                            : 'text-text-secondary hover:text-text-primary'
                         }`}
                       >
                         {programNames[p] || p}
@@ -370,14 +370,14 @@ export const UnifiedObjectPage: React.FC<UnifiedObjectPageProps> = ({ object }) 
                 </div>
               )}
               <div className="flex items-center gap-2">
-                <span className="text-sm text-text-secondary dark:text-slate-400">Grating:</span>
-                <div className="flex items-center bg-gray-100 dark:bg-slate-700 rounded-md p-0.5">
+                <span className="text-sm text-text-secondary">Grating:</span>
+                <div className="flex items-center bg-surface-2 rounded-md p-0.5">
                   <button
                     onClick={() => setSelectedGrating(null)}
                     className={`px-2.5 py-1 text-xs font-medium rounded transition-colors ${
                       selectedGrating === null
-                        ? 'bg-white dark:bg-slate-600 text-text-primary dark:text-slate-100 shadow-sm'
-                        : 'text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200'
+                        ? 'bg-background dark:bg-slate-600 text-text-primary shadow-sm'
+                        : 'text-text-secondary hover:text-text-primary'
                     }`}
                   >
                     All
@@ -388,8 +388,8 @@ export const UnifiedObjectPage: React.FC<UnifiedObjectPageProps> = ({ object }) 
                       onClick={() => setSelectedGrating(selectedGrating === g ? null : g)}
                       className={`px-2.5 py-1 text-xs font-medium font-mono rounded transition-colors ${
                         g === selectedGrating
-                          ? 'bg-white dark:bg-slate-600 text-text-primary dark:text-slate-100 shadow-sm'
-                          : 'text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200'
+                          ? 'bg-background dark:bg-slate-600 text-text-primary shadow-sm'
+                          : 'text-text-secondary hover:text-text-primary'
                       }`}
                     >
                       {g}
@@ -398,7 +398,7 @@ export const UnifiedObjectPage: React.FC<UnifiedObjectPageProps> = ({ object }) 
                 </div>
               </div>
             </div>
-            <div className="border border-border dark:border-slate-700 rounded-lg overflow-hidden">
+            <div className="border border-border rounded-lg overflow-hidden">
               <MultiSpectrumViewer
                 sources={sources}
                 grating={selectedGrating}

--- a/web/components/spectra/inspection/CommentsPreview.tsx
+++ b/web/components/spectra/inspection/CommentsPreview.tsx
@@ -91,12 +91,12 @@ export const CommentsPreview: React.FC<CommentsPreviewProps> = ({ objectDbId, me
 
   if (commentCount === 0) {
     return (
-      <div className="p-4 border-b border-border dark:border-slate-700">
-        <h3 className="text-xs font-semibold text-text-secondary dark:text-slate-400 uppercase flex items-center gap-1">
+      <div className="p-4 border-b border-border">
+        <h3 className="text-xs font-semibold text-text-secondary uppercase flex items-center gap-1">
           <MessageSquare className="w-3 h-3" />
           Comments (0)
         </h3>
-        <p className="text-xs text-text-secondary dark:text-slate-500 mt-2">
+        <p className="text-xs text-text-secondary dark:text-text-tertiary mt-2">
           No comments yet
         </p>
       </div>
@@ -104,20 +104,20 @@ export const CommentsPreview: React.FC<CommentsPreviewProps> = ({ objectDbId, me
   }
 
   return (
-    <div className="p-4 border-b border-border dark:border-slate-700">
-      <h3 className="text-xs font-semibold text-text-secondary dark:text-slate-400 uppercase mb-2 flex items-center gap-1">
+    <div className="p-4 border-b border-border">
+      <h3 className="text-xs font-semibold text-text-secondary uppercase mb-2 flex items-center gap-1">
         <MessageSquare className="w-3 h-3" />
         Comments ({commentCount})
       </h3>
       <div className="space-y-2 max-h-32 overflow-y-auto">
         {comments.slice().reverse().map(comment => (
           <div key={comment.id} className="text-xs">
-            <div className="flex items-center gap-1 text-text-secondary dark:text-slate-400">
+            <div className="flex items-center gap-1 text-text-secondary">
               <span className="font-medium">{comment.user_profile?.full_name || 'Anonymous'}</span>
               <span>·</span>
               <span>{formatDistanceToNow(new Date(comment.created_at))} ago</span>
             </div>
-            <p className="text-text-primary dark:text-slate-100 mt-0.5 line-clamp-2">
+            <p className="text-text-primary mt-0.5 line-clamp-2">
               {comment.content}
             </p>
           </div>

--- a/web/components/spectra/inspection/DashboardPanel.tsx
+++ b/web/components/spectra/inspection/DashboardPanel.tsx
@@ -39,9 +39,9 @@ export const DashboardPanel: React.FC<DashboardPanelProps> = ({
   const memberTargetIds = object.member_targets.map(m => m.id);
 
   return (
-    <div className="flex-shrink-0 w-[320px] border-l border-border dark:border-slate-700
-                    flex flex-col overflow-hidden bg-background dark:bg-slate-900">
-      <div className="p-4 flex justify-center border-b border-border dark:border-slate-700 flex-shrink-0">
+    <div className="flex-shrink-0 w-[320px] border-l border-border
+                    flex flex-col overflow-hidden bg-background">
+      <div className="p-4 flex justify-center border-b border-border flex-shrink-0">
         <TileThumbnail
           targetId={object.object_id}
           size={560}
@@ -80,7 +80,7 @@ export const DashboardPanel: React.FC<DashboardPanelProps> = ({
         />
       </div>
 
-      <div className="p-4 border-t border-border dark:border-slate-700 bg-background dark:bg-slate-900 flex-shrink-0">
+      <div className="p-4 border-t border-border bg-background flex-shrink-0">
         <SaveButtons
           state={inspectionState}
           canEdit={canEdit}

--- a/web/components/spectra/inspection/EnterInspectionModeButton.tsx
+++ b/web/components/spectra/inspection/EnterInspectionModeButton.tsx
@@ -24,7 +24,7 @@ export const EnterInspectionModeButton: React.FC<EnterInspectionModeButtonProps>
     <div className="mb-4">
       <Link
         href={href}
-        className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg bg-primary hover:bg-primary-hover text-white transition-colors"
+        className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg bg-primary hover:bg-primary-hover text-on-primary transition-colors"
         title="Streamlined fullscreen view for rapid quality inspection. Auto-filters to uninspected objects and supports keyboard shortcuts for efficient review."
       >
         <Maximize2 className="w-4 h-4" />

--- a/web/components/spectra/inspection/InspectionComments.tsx
+++ b/web/components/spectra/inspection/InspectionComments.tsx
@@ -94,17 +94,17 @@ export const InspectionComments: React.FC<InspectionCommentsProps> = ({ targetDb
     });
 
   return (
-    <div className="border-t border-border dark:border-slate-700 flex-shrink-0 bg-background dark:bg-slate-900">
+    <div className="border-t border-border flex-shrink-0 bg-background">
       {/* Collapsed bar */}
       <button
         onClick={() => setExpanded(!expanded)}
-        className="w-full flex items-center justify-between px-4 py-2 hover:bg-card dark:hover:bg-slate-800 transition-colors"
+        className="w-full flex items-center justify-between px-4 py-2 hover:bg-card transition-colors"
       >
-        <div className="flex items-center gap-2 text-sm text-text-secondary dark:text-slate-400">
+        <div className="flex items-center gap-2 text-sm text-text-secondary">
           <MessageSquare className="w-4 h-4" />
           <span>{loading ? 'Loading...' : `${comments.length} comment${comments.length !== 1 ? 's' : ''}`}</span>
         </div>
-        {expanded ? <ChevronDown className="w-4 h-4 text-text-secondary dark:text-slate-400" /> : <ChevronUp className="w-4 h-4 text-text-secondary dark:text-slate-400" />}
+        {expanded ? <ChevronDown className="w-4 h-4 text-text-secondary" /> : <ChevronUp className="w-4 h-4 text-text-secondary" />}
       </button>
 
       {/* Expanded content */}
@@ -118,13 +118,13 @@ export const InspectionComments: React.FC<InspectionCommentsProps> = ({ targetDb
                 value={newComment}
                 onChange={(e) => setNewComment(e.target.value)}
                 placeholder="Add a comment..."
-                className="flex-1 px-3 py-1.5 text-sm border border-border dark:border-slate-600 rounded bg-background dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-primary"
+                className="flex-1 px-3 py-1.5 text-sm border border-border dark:border-border-strong rounded bg-background dark:bg-card-hover text-text-primary focus:outline-none focus:ring-1 focus:ring-primary"
                 disabled={submitting}
               />
               <button
                 type="submit"
                 disabled={submitting || !newComment.trim()}
-                className="px-2.5 py-1.5 rounded bg-primary hover:bg-primary-hover text-white text-sm disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                className="px-2.5 py-1.5 rounded bg-primary hover:bg-primary-hover text-on-primary text-sm disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
               >
                 <Send className="w-3.5 h-3.5" />
               </button>
@@ -133,16 +133,16 @@ export const InspectionComments: React.FC<InspectionCommentsProps> = ({ targetDb
 
           {/* Comments list */}
           {comments.length === 0 ? (
-            <p className="text-xs text-text-secondary dark:text-slate-400 text-center py-2">No comments yet</p>
+            <p className="text-xs text-text-secondary text-center py-2">No comments yet</p>
           ) : (
             <div className="space-y-1.5">
               {comments.map((comment) => (
                 <div key={comment.id} className="text-xs">
-                  <span className="font-medium text-text-primary dark:text-slate-100">
+                  <span className="font-medium text-text-primary">
                     {comment.user_profile?.full_name || 'Unknown'}
                   </span>
-                  <span className="text-text-secondary dark:text-slate-500 mx-1">{formatDate(comment.created_at)}</span>
-                  <p className="text-text-primary dark:text-slate-100 whitespace-pre-wrap">{comment.content}</p>
+                  <span className="text-text-secondary dark:text-text-tertiary mx-1">{formatDate(comment.created_at)}</span>
+                  <p className="text-text-primary whitespace-pre-wrap">{comment.content}</p>
                 </div>
               ))}
             </div>

--- a/web/components/spectra/inspection/InspectionHeader.tsx
+++ b/web/components/spectra/inspection/InspectionHeader.tsx
@@ -47,13 +47,13 @@ export const InspectionHeader: React.FC<InspectionHeaderProps> = ({
   onClose,
 }) => {
   return (
-    <div className="h-12 border-b border-border dark:border-slate-700 px-4 flex items-center justify-between bg-background dark:bg-slate-900 flex-shrink-0">
+    <div className="h-12 border-b border-border px-4 flex items-center justify-between bg-background flex-shrink-0">
       {/* Left: Navigation */}
       <div className="flex items-center gap-2">
         <button
           onClick={onPrev}
           disabled={!hasPrev}
-          className="p-1.5 rounded hover:bg-card dark:hover:bg-slate-700 transition-colors disabled:opacity-30 disabled:cursor-not-allowed text-text-primary dark:text-slate-100"
+          className="p-1.5 rounded hover:bg-card dark:hover:bg-card-hover transition-colors disabled:opacity-30 disabled:cursor-not-allowed text-text-primary"
           aria-label="Previous object"
           title="Previous (← or P)"
         >
@@ -62,7 +62,7 @@ export const InspectionHeader: React.FC<InspectionHeaderProps> = ({
         <button
           onClick={onNext}
           disabled={!hasNext}
-          className="p-1.5 rounded hover:bg-card dark:hover:bg-slate-700 transition-colors disabled:opacity-30 disabled:cursor-not-allowed text-text-primary dark:text-slate-100"
+          className="p-1.5 rounded hover:bg-card dark:hover:bg-card-hover transition-colors disabled:opacity-30 disabled:cursor-not-allowed text-text-primary"
           aria-label="Next object"
           title="Next (→ or N)"
         >
@@ -72,19 +72,19 @@ export const InspectionHeader: React.FC<InspectionHeaderProps> = ({
 
       {/* Center: Object info */}
       <div className="flex items-center gap-3">
-        <span className="font-mono font-bold text-text-primary dark:text-slate-100 text-sm">
+        <span className="font-mono font-bold text-text-primary text-sm">
           {targetId}
         </span>
         {commentCount > 0 && (
-          <span className="text-xs text-text-secondary dark:text-slate-400 flex items-center gap-1">
+          <span className="text-xs text-text-secondary flex items-center gap-1">
             <MessageSquare className="w-3 h-3" />
             {commentCount}
           </span>
         )}
-        <span className="text-text-secondary dark:text-slate-400 text-xs uppercase">
+        <span className="text-text-secondary text-xs uppercase">
           {programName && `${programName} / `}{field}
         </span>
-        <span className="text-text-secondary dark:text-slate-400 text-sm">
+        <span className="text-text-secondary text-sm">
           {loading ? (
             <Loader2 className="w-3.5 h-3.5 animate-spin inline" />
           ) : index > 0 && total > 0 ? (
@@ -103,8 +103,8 @@ export const InspectionHeader: React.FC<InspectionHeaderProps> = ({
               title={spec.title}
               className={`px-3 py-1 text-xs font-medium rounded transition-colors
                 ${idx === activeGratingIdx
-                  ? 'bg-primary text-white'
-                  : 'bg-card dark:bg-slate-800 text-text-secondary dark:text-slate-400 hover:bg-gray-100 dark:hover:bg-slate-700 border border-border dark:border-slate-600'
+                  ? 'bg-primary text-on-primary'
+                  : 'bg-card text-text-secondary hover:bg-card-hover border border-border dark:border-border-strong'
                 }`}
             >
               <span className="mr-1">{spec.grating}</span>
@@ -120,14 +120,14 @@ export const InspectionHeader: React.FC<InspectionHeaderProps> = ({
       <div className="flex items-center gap-1">
         <button
           onClick={onToggleHelp}
-          className="p-1.5 rounded hover:bg-card dark:hover:bg-slate-700 transition-colors text-text-secondary dark:text-slate-400"
+          className="p-1.5 rounded hover:bg-card dark:hover:bg-card-hover transition-colors text-text-secondary"
           title="Keyboard shortcuts (?)"
         >
           <HelpCircle className="w-4 h-4" />
         </button>
         <button
           onClick={onClose}
-          className="p-1.5 rounded hover:bg-card dark:hover:bg-slate-700 transition-colors text-text-secondary dark:text-slate-400"
+          className="p-1.5 rounded hover:bg-card dark:hover:bg-card-hover transition-colors text-text-secondary"
           title="Exit inspection mode (Esc)"
         >
           <X className="w-5 h-5" />

--- a/web/components/spectra/inspection/InspectionModeOverlay.tsx
+++ b/web/components/spectra/inspection/InspectionModeOverlay.tsx
@@ -374,25 +374,25 @@ export const InspectionModeOverlay: React.FC<InspectionModeOverlayProps> = ({
 
   return (
     <div
-      className="fixed inset-0 z-[200] bg-background dark:bg-slate-900 flex flex-col overflow-hidden"
+      className="fixed inset-0 z-[200] bg-background flex flex-col overflow-hidden"
       style={{ isolation: 'isolate' }}
       data-inspection-mode
     >
       {!queueReady ? (
-        <div className="h-12 border-b border-border dark:border-slate-700 px-4 flex items-center justify-between bg-background dark:bg-slate-900 flex-shrink-0">
+        <div className="h-12 border-b border-border px-4 flex items-center justify-between bg-background flex-shrink-0">
           <div />
-          <Loader2 className="w-4 h-4 animate-spin text-text-secondary dark:text-slate-400" />
+          <Loader2 className="w-4 h-4 animate-spin text-text-secondary" />
           <div className="flex items-center gap-1">
             <button
               onClick={() => setShowHelp(prev => !prev)}
-              className="p-1.5 rounded hover:bg-card dark:hover:bg-slate-700 transition-colors text-text-secondary dark:text-slate-400"
+              className="p-1.5 rounded hover:bg-card dark:hover:bg-card-hover transition-colors text-text-secondary"
               title="Keyboard shortcuts (?)"
             >
               <HelpCircle className="w-4 h-4" />
             </button>
             <button
               onClick={handleClose}
-              className="p-1.5 rounded hover:bg-card dark:hover:bg-slate-700 transition-colors text-text-secondary dark:text-slate-400"
+              className="p-1.5 rounded hover:bg-card dark:hover:bg-card-hover transition-colors text-text-secondary"
               title="Exit inspection mode (Esc)"
             >
               <X className="w-5 h-5" />
@@ -448,7 +448,7 @@ export const InspectionModeOverlay: React.FC<InspectionModeOverlayProps> = ({
 
       {!queueReady && (
         <div className="flex-1 flex items-center justify-center">
-          <div className="text-center text-text-secondary dark:text-slate-400">
+          <div className="text-center text-text-secondary">
             Loading inspection queue...
           </div>
         </div>
@@ -457,12 +457,12 @@ export const InspectionModeOverlay: React.FC<InspectionModeOverlayProps> = ({
       {queueReady && queue.isEmpty && (
         <div className="flex-1 flex items-center justify-center">
           <div className="text-center">
-            <p className="text-lg text-text-secondary dark:text-slate-400 mb-4">
+            <p className="text-lg text-text-secondary mb-4">
               No uninspected objects match your filters.
             </p>
             <button
               onClick={handleClose}
-              className="px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary-hover transition-colors"
+              className="px-4 py-2 bg-primary text-on-primary rounded-lg hover:bg-primary-hover transition-colors"
             >
               Exit Inspection Mode
             </button>

--- a/web/components/spectra/inspection/KeyboardShortcutSheet.tsx
+++ b/web/components/spectra/inspection/KeyboardShortcutSheet.tsx
@@ -34,21 +34,21 @@ export const KeyboardShortcutSheet: React.FC<KeyboardShortcutSheetProps> = ({ on
     <div className="fixed inset-0 z-[210] flex items-center justify-center bg-black/40">
       <div
         ref={panelRef}
-        className="bg-background dark:bg-slate-800 border border-border dark:border-slate-600 rounded-lg shadow-xl p-5 w-80"
+        className="bg-background dark:bg-card border border-border dark:border-border-strong rounded-lg shadow-xl p-5 w-80"
       >
-        <h3 className="text-sm font-semibold text-text-primary dark:text-slate-100 mb-3">
+        <h3 className="text-sm font-semibold text-text-primary mb-3">
           Keyboard Shortcuts
         </h3>
         <table className="w-full text-sm">
           <tbody>
             {SHORTCUTS.map((s) => (
-              <tr key={s.key} className="border-b border-border/50 dark:border-slate-700/50 last:border-0">
+              <tr key={s.key} className="border-b border-border/50 last:border-0">
                 <td className="py-1.5 pr-3">
-                  <kbd className="font-mono text-xs px-1.5 py-0.5 rounded bg-card dark:bg-slate-700 border border-border dark:border-slate-600 text-text-primary dark:text-slate-100">
+                  <kbd className="font-mono text-xs px-1.5 py-0.5 rounded bg-card dark:bg-card-hover border border-border dark:border-border-strong text-text-primary">
                     {s.key}
                   </kbd>
                 </td>
-                <td className="py-1.5 text-text-secondary dark:text-slate-400">
+                <td className="py-1.5 text-text-secondary">
                   {s.action}
                 </td>
               </tr>

--- a/web/components/spectra/inspection/MemberSpectraTable.tsx
+++ b/web/components/spectra/inspection/MemberSpectraTable.tsx
@@ -32,14 +32,14 @@ export const MemberSpectraTable: React.FC<MemberSpectraTableProps> = ({ object }
   if (rows.length === 0) return null;
 
   return (
-    <div className="px-4 py-3 border-b border-border dark:border-slate-700">
-      <h3 className="text-xs font-semibold text-text-secondary dark:text-slate-400 uppercase mb-2">
+    <div className="px-4 py-3 border-b border-border">
+      <h3 className="text-xs font-semibold text-text-secondary uppercase mb-2">
         Member spectra ({rows.length})
       </h3>
       <div className="overflow-x-auto">
         <table className="w-full text-[11px]">
           <thead>
-            <tr className="text-text-secondary dark:text-slate-500">
+            <tr className="text-text-secondary dark:text-text-tertiary">
               <th className="text-left font-medium pb-1 pr-2">Grating</th>
               <th className="text-left font-medium pb-1 pr-2">Obs</th>
               <th className="text-right font-medium pb-1 pr-2">z_auto</th>
@@ -52,7 +52,7 @@ export const MemberSpectraTable: React.FC<MemberSpectraTableProps> = ({ object }
               const dqDefs = DQ_FLAGS.filter(f => (r.dqMask & f.value) !== 0);
               return (
                 <tr key={r.key} className="border-t border-border/30 dark:border-slate-700/40">
-                  <td className="py-1 pr-2 font-mono text-text-primary dark:text-slate-200">
+                  <td className="py-1 pr-2 font-mono text-text-primary">
                     {r.grating}
                     {r.isSelected && (
                       <span className="ml-1 text-emerald-600 dark:text-emerald-400" title="Drives objects.redshift_auto">
@@ -60,18 +60,18 @@ export const MemberSpectraTable: React.FC<MemberSpectraTableProps> = ({ object }
                       </span>
                     )}
                   </td>
-                  <td className="py-1 pr-2 text-text-secondary dark:text-slate-400 truncate max-w-[80px]" title={`${r.programSlug} · ${r.observation}`}>
+                  <td className="py-1 pr-2 text-text-secondary truncate max-w-[80px]" title={`${r.programSlug} · ${r.observation}`}>
                     {r.observation}
                   </td>
-                  <td className="py-1 pr-2 text-right font-mono text-text-primary dark:text-slate-200">
+                  <td className="py-1 pr-2 text-right font-mono text-text-primary">
                     {r.zAuto != null ? r.zAuto.toFixed(4) : '—'}
                   </td>
-                  <td className="py-1 pr-2 text-right font-mono text-text-primary dark:text-slate-200">
+                  <td className="py-1 pr-2 text-right font-mono text-text-primary">
                     {r.snr != null ? r.snr.toFixed(1) : '—'}
                   </td>
                   <td className="py-1">
                     {dqDefs.length === 0 ? (
-                      <span className="text-text-secondary dark:text-slate-500">—</span>
+                      <span className="text-text-secondary dark:text-text-tertiary">—</span>
                     ) : (
                       <div className="flex flex-wrap gap-0.5">
                         {dqDefs.map(f => (

--- a/web/components/spectra/inspection/MetadataSection.tsx
+++ b/web/components/spectra/inspection/MetadataSection.tsx
@@ -11,10 +11,10 @@ interface MetadataSectionProps {
 
 const MetadataRow: React.FC<{ label: string; value: string; tooltip?: string }> = ({ label, value, tooltip }) => (
   <div className="flex justify-between items-center">
-    <span className="text-text-secondary dark:text-slate-400" title={tooltip}>
+    <span className="text-text-secondary" title={tooltip}>
       {label}:
     </span>
-    <span className="font-mono text-text-primary dark:text-slate-100">
+    <span className="font-mono text-text-primary">
       {value}
     </span>
   </div>
@@ -22,8 +22,8 @@ const MetadataRow: React.FC<{ label: string; value: string; tooltip?: string }> 
 
 export const MetadataSection: React.FC<MetadataSectionProps> = ({ spectrum, activeSpec }) => {
   return (
-    <div className="p-4 border-b border-border dark:border-slate-700">
-      <h3 className="text-xs font-semibold text-text-secondary dark:text-slate-400 uppercase mb-2 flex items-center gap-1">
+    <div className="p-4 border-b border-border">
+      <h3 className="text-xs font-semibold text-text-secondary uppercase mb-2 flex items-center gap-1">
         <Info className="w-3 h-3" />
         Metadata
       </h3>

--- a/web/components/spectra/inspection/NearbyObjectsPreview.tsx
+++ b/web/components/spectra/inspection/NearbyObjectsPreview.tsx
@@ -68,11 +68,11 @@ export const NearbyObjectsPreview: React.FC<NearbyObjectsPreviewProps> = ({
 
   if (loading) {
     return (
-      <div className="px-4 py-3 border-b border-border dark:border-slate-700">
-        <h3 className="text-xs font-semibold text-text-secondary dark:text-slate-400 uppercase tracking-wide">
+      <div className="px-4 py-3 border-b border-border">
+        <h3 className="text-xs font-semibold text-text-secondary uppercase tracking-wide">
           Nearby
         </h3>
-        <p className="text-xs text-text-secondary dark:text-slate-500 mt-1">Searching...</p>
+        <p className="text-xs text-text-secondary dark:text-text-tertiary mt-1">Searching...</p>
       </div>
     );
   }
@@ -82,8 +82,8 @@ export const NearbyObjectsPreview: React.FC<NearbyObjectsPreviewProps> = ({
   const queueIdSet = new Set(queueIds);
 
   return (
-    <div className="px-4 py-3 border-b border-border dark:border-slate-700">
-      <h3 className="text-xs font-semibold text-text-secondary dark:text-slate-400 uppercase tracking-wide mb-2">
+    <div className="px-4 py-3 border-b border-border">
+      <h3 className="text-xs font-semibold text-text-secondary uppercase tracking-wide mb-2">
         Nearby{' '}
         <span className="font-normal normal-case">
           ({nearbyObjects.length} within 0.3&quot;)
@@ -106,30 +106,30 @@ export const NearbyObjectsPreview: React.FC<NearbyObjectsPreviewProps> = ({
                   window.open(`/nirspec/objects/${encodeURIComponent(objId)}`, '_blank');
                 }
               }}
-              className="w-full text-left px-2 py-1.5 rounded hover:bg-card dark:hover:bg-slate-800 transition-colors group"
+              className="w-full text-left px-2 py-1.5 rounded hover:bg-card transition-colors group"
             >
               <div className="flex items-center gap-1.5 text-xs">
                 <span className="flex-shrink-0">{getQualityIcon(obj.redshift_quality)}</span>
-                <span className="font-mono text-text-primary dark:text-slate-200 truncate flex-1">
+                <span className="font-mono text-text-primary truncate flex-1">
                   {objId}
                 </span>
-                <span className="font-mono text-text-secondary dark:text-slate-500 flex-shrink-0">
+                <span className="font-mono text-text-secondary dark:text-text-tertiary flex-shrink-0">
                   {obj.distance != null ? formatDistance(obj.distance) : ''}
                 </span>
                 {!inQueue && (
-                  <ExternalLink className="w-3 h-3 text-text-secondary dark:text-slate-500 flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
+                  <ExternalLink className="w-3 h-3 text-text-secondary dark:text-text-tertiary flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
                 )}
               </div>
               <div className="flex items-center gap-1 mt-0.5 ml-5">
                 {gratings.map(g => (
                   <span
                     key={g}
-                    className="px-1 rounded text-[10px] leading-tight bg-card dark:bg-slate-700 text-text-secondary dark:text-slate-400"
+                    className="px-1 rounded text-[10px] leading-tight bg-card dark:bg-card-hover text-text-secondary"
                   >
                     {g}
                   </span>
                 ))}
-                <span className="font-mono text-text-secondary dark:text-slate-500 text-[11px] ml-auto">
+                <span className="font-mono text-text-secondary dark:text-text-tertiary text-[11px] ml-auto">
                   {obj.redshift !== null ? `z=${obj.redshift.toFixed(4)}` : 'z=?'}
                 </span>
               </div>

--- a/web/components/spectra/inspection/QualitySection.tsx
+++ b/web/components/spectra/inspection/QualitySection.tsx
@@ -11,9 +11,9 @@ interface QualitySectionProps {
 
 export const QualitySection: React.FC<QualitySectionProps> = ({ state, canEdit }) => {
   return (
-    <div className="p-4 border-b border-border dark:border-slate-700">
+    <div className="p-4 border-b border-border">
       <div className="flex items-center gap-1 mb-2">
-        <h3 className="text-xs font-semibold text-text-secondary dark:text-slate-400 uppercase">
+        <h3 className="text-xs font-semibold text-text-secondary uppercase">
           Quality<span className="text-red-500">*</span>
         </h3>
         {state.redshiftQuality === 0 && (
@@ -33,8 +33,8 @@ export const QualitySection: React.FC<QualitySectionProps> = ({ state, canEdit }
               disabled={!canEdit}
               className={`px-3 py-2 text-sm font-medium rounded transition-all
                 ${isSelected
-                  ? 'ring-2 ring-offset-1 dark:ring-offset-slate-900 ring-text-primary'
-                  : 'border border-border dark:border-slate-600 hover:bg-card dark:hover:bg-slate-700'
+                  ? 'ring-2 ring-offset-1 dark:ring-offset-background ring-text-primary'
+                  : 'border border-border dark:border-border-strong hover:bg-card dark:hover:bg-card-hover'
                 }
                 disabled:opacity-50 disabled:cursor-not-allowed`}
               style={isSelected ? { backgroundColor: q.color, color: getContrastColor(q.color) } : undefined}

--- a/web/components/spectra/inspection/RedshiftSection.tsx
+++ b/web/components/spectra/inspection/RedshiftSection.tsx
@@ -103,19 +103,19 @@ export const RedshiftSection = forwardRef<RedshiftSectionHandle, RedshiftSection
     : (redshiftInspected ?? redshiftAuto);
 
   return (
-    <div className="p-4 border-b border-border dark:border-slate-700">
-      <h3 className="text-xs font-semibold text-text-secondary dark:text-slate-400 uppercase mb-2">
+    <div className="p-4 border-b border-border">
+      <h3 className="text-xs font-semibold text-text-secondary uppercase mb-2">
         Redshift
       </h3>
 
       {/* Current redshift - bold and prominent */}
       <div className="mb-3 text-center">
-        <div className="text-xs text-text-secondary dark:text-slate-400 mb-1">Current</div>
-        <div className="text-2xl font-bold font-mono text-text-primary dark:text-slate-100">
+        <div className="text-xs text-text-secondary mb-1">Current</div>
+        <div className="text-2xl font-bold font-mono text-text-primary">
           {currentRedshift?.toFixed(4) || '—'}
         </div>
         {localRedshift && (
-          <div className="text-xs text-text-secondary dark:text-slate-400 mt-0.5">
+          <div className="text-xs text-text-secondary mt-0.5">
             (overridden)
           </div>
         )}
@@ -125,10 +125,10 @@ export const RedshiftSection = forwardRef<RedshiftSectionHandle, RedshiftSection
       <div className="grid grid-cols-2 gap-2 text-sm">
         {/* Auto column */}
         <div>
-          <label className="text-xs text-text-secondary dark:text-slate-400 block mb-1">
+          <label className="text-xs text-text-secondary block mb-1">
             Auto:
           </label>
-          <div className="px-2 py-1.5 font-mono text-sm bg-card dark:bg-slate-800 rounded border border-border dark:border-slate-600 text-text-primary dark:text-slate-100">
+          <div className="px-2 py-1.5 font-mono text-sm bg-card rounded border border-border dark:border-border-strong text-text-primary">
             {redshiftAuto?.toFixed(4) || '—'}
           </div>
         </div>
@@ -136,7 +136,7 @@ export const RedshiftSection = forwardRef<RedshiftSectionHandle, RedshiftSection
         {/* Override column */}
         <div>
           <div className="flex items-center justify-between mb-1">
-            <label className="text-xs text-text-secondary dark:text-slate-400">
+            <label className="text-xs text-text-secondary">
               Override:
             </label>
             {localRedshift && canEdit && (
@@ -158,19 +158,19 @@ export const RedshiftSection = forwardRef<RedshiftSectionHandle, RedshiftSection
             onChange={(e) => handleChange(e.target.value)}
             placeholder="auto"
             disabled={!canEdit}
-            className={`w-full px-2 py-1.5 text-sm font-mono border rounded bg-background dark:bg-slate-700
-                       text-text-primary dark:text-slate-100 focus:outline-none
+            className={`w-full px-2 py-1.5 text-sm font-mono border rounded bg-background dark:bg-card-hover
+                       text-text-primary focus:outline-none
                        focus:ring-1 focus:ring-primary disabled:opacity-60 transition-all duration-300
                        ${isSliderSync
                          ? 'border-amber-400 dark:border-amber-500 ring-1 ring-amber-400/50 dark:ring-amber-500/50'
-                         : 'border-border dark:border-slate-600'
+                         : 'border-border dark:border-border-strong'
                        }`}
             title="Press Z to focus"
           />
         </div>
       </div>
 
-      <p className="text-xs text-text-secondary dark:text-slate-400 mt-2 text-center">
+      <p className="text-xs text-text-secondary mt-2 text-center">
         Press Z to focus override
       </p>
     </div>

--- a/web/components/spectra/inspection/SaveButtons.tsx
+++ b/web/components/spectra/inspection/SaveButtons.tsx
@@ -33,8 +33,8 @@ export const SaveButtons: React.FC<SaveButtonsProps> = ({ state, canEdit, onSave
           onClick={onSave}
           disabled={!state.hasChanges || state.saving || state.redshiftQuality === 0}
           className="inline-flex items-center justify-center gap-1 px-3 py-2
-                     text-sm font-medium rounded-lg border border-border dark:border-slate-600
-                     text-text-primary dark:text-slate-100 hover:bg-card dark:hover:bg-slate-700
+                     text-sm font-medium rounded-lg border border-border dark:border-border-strong
+                     text-text-primary hover:bg-card dark:hover:bg-card-hover
                      transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
           title="Save (S)"
         >
@@ -50,7 +50,7 @@ export const SaveButtons: React.FC<SaveButtonsProps> = ({ state, canEdit, onSave
           onClick={onSaveAndNext}
           className="inline-flex items-center justify-center gap-1 px-3 py-2
                      text-sm font-medium rounded-lg bg-primary hover:bg-primary-hover
-                     text-white transition-colors"
+                     text-on-primary transition-colors"
           title="Save & Next (→)"
         >
           <span>Save & Next</span>
@@ -58,7 +58,7 @@ export const SaveButtons: React.FC<SaveButtonsProps> = ({ state, canEdit, onSave
         </button>
       </div>
 
-      <p className="text-xs text-text-secondary dark:text-slate-400 text-center">
+      <p className="text-xs text-text-secondary text-center">
         S = Save • → = Save & Next
       </p>
     </div>

--- a/web/components/ui/Badge.tsx
+++ b/web/components/ui/Badge.tsx
@@ -11,16 +11,16 @@ export const Badge: React.FC<BadgeProps> = ({ value, label, className = '', comp
   return (
     <div
       className={`
-        bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded-xl
+        bg-card border border-border rounded-xl
         flex flex-col items-center justify-center
         ${compact ? 'px-3 py-2' : 'px-6 py-4'}
         ${className}
       `}
     >
-      <div className={`font-bold text-text-primary dark:text-slate-100 ${compact ? 'text-xl' : 'text-3xl'}`}>
+      <div className={`font-bold text-text-primary ${compact ? 'text-xl' : 'text-3xl'}`}>
         {value}
       </div>
-      <div className={`font-medium text-text-secondary dark:text-slate-400 uppercase tracking-wide ${compact ? 'text-[10px] mt-0.5' : 'text-xs mt-1'}`}>
+      <div className={`font-medium text-text-secondary uppercase tracking-wide ${compact ? 'text-[10px] mt-0.5' : 'text-xs mt-1'}`}>
         {label}
       </div>
     </div>

--- a/web/components/ui/Breadcrumbs.tsx
+++ b/web/components/ui/Breadcrumbs.tsx
@@ -23,17 +23,17 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ items, className = '' 
             {item.href && !isLast ? (
               <Link
                 href={item.href}
-                className="text-text-secondary dark:text-slate-400 hover:text-primary transition-colors"
+                className="text-text-secondary hover:text-primary transition-colors"
               >
                 {item.label}
               </Link>
             ) : (
-              <span className={isLast ? 'text-text-primary dark:text-slate-100 font-medium' : 'text-text-secondary dark:text-slate-400'}>
+              <span className={isLast ? 'text-text-primary font-medium' : 'text-text-secondary'}>
                 {item.label}
               </span>
             )}
             {!isLast && (
-              <ChevronRight className="w-4 h-4 text-text-secondary dark:text-slate-500" />
+              <ChevronRight className="w-4 h-4 text-text-secondary dark:text-text-tertiary" />
             )}
           </React.Fragment>
         );

--- a/web/components/ui/Button.tsx
+++ b/web/components/ui/Button.tsx
@@ -17,7 +17,7 @@ export const Button: React.FC<ButtonProps> = ({
   const baseClasses = 'inline-flex items-center justify-center whitespace-nowrap rounded-lg font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-background';
 
   const variantClasses = {
-    primary: 'bg-primary hover:bg-primary-hover text-white focus:ring-primary',
+    primary: 'bg-primary hover:bg-primary-hover text-on-primary focus:ring-primary',
     secondary: 'border-2 border-border hover:border-text-secondary text-text-primary bg-card',
     ghost: 'text-text-primary hover:bg-card',
   };

--- a/web/components/ui/ChipSelect.tsx
+++ b/web/components/ui/ChipSelect.tsx
@@ -114,8 +114,8 @@ export const ChipSelect: React.FC<ChipSelectProps> = ({
               border transition-all duration-150
               ${disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}
               ${isSelected
-                ? 'border-transparent text-gray-900 dark:text-slate-100'
-                : 'border-border dark:border-slate-700 bg-card/50 dark:bg-slate-800/50 text-text-secondary dark:text-slate-400 hover:bg-card dark:hover:bg-slate-700 hover:text-text-primary dark:hover:text-slate-200'
+                ? 'border-transparent text-text-primary'
+                : 'border-border bg-card/50 text-text-secondary hover:bg-card-hover hover:text-text-primary'
               }
             `}
             style={

--- a/web/components/ui/ColumnVisibilityDropdown.tsx
+++ b/web/components/ui/ColumnVisibilityDropdown.tsx
@@ -73,15 +73,15 @@ export const ColumnVisibilityDropdown: React.FC<ColumnVisibilityDropdownProps> =
         className={`
           inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium
           border transition-all duration-150
-          bg-card dark:bg-slate-800 border-border dark:border-slate-700
-          text-text-secondary dark:text-slate-400
-          hover:border-text-secondary dark:hover:border-slate-600
-          hover:text-text-primary dark:hover:text-slate-200
+          bg-card border-border
+          text-text-secondary
+          hover:border-text-secondary dark:hover:border-border-strong
+          hover:text-text-primary
         `}
       >
         <Columns3 className="w-4 h-4" />
         <span>Columns</span>
-        <span className="text-xs px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-700 text-text-secondary dark:text-slate-400">
+        <span className="text-xs px-1.5 py-0.5 rounded bg-surface-2 text-text-secondary">
           {visibleCount}
         </span>
         <ChevronDown className={`w-3.5 h-3.5 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
@@ -89,19 +89,19 @@ export const ColumnVisibilityDropdown: React.FC<ColumnVisibilityDropdownProps> =
 
       {/* Dropdown */}
       {isOpen && (
-        <div className="absolute right-0 z-50 mt-2 w-64 max-h-[400px] overflow-y-auto bg-background dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg shadow-lg">
+        <div className="absolute right-0 z-50 mt-2 w-64 max-h-[400px] overflow-y-auto bg-card border border-border rounded-lg shadow-lg">
           {/* Header with quick actions */}
-          <div className="sticky top-0 z-10 bg-background dark:bg-slate-800 border-b border-border dark:border-slate-700 p-2 flex gap-2">
+          <div className="sticky top-0 z-10 bg-card border-b border-border p-2 flex gap-2">
             <button
               onClick={showAll}
-              className="flex-1 flex items-center justify-center gap-1 px-2 py-1 text-xs rounded bg-slate-100 dark:bg-slate-700 text-text-secondary dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors"
+              className="flex-1 flex items-center justify-center gap-1 px-2 py-1 text-xs rounded bg-surface-2 text-text-secondary hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors"
             >
               <Eye className="w-3 h-3" />
               Show all
             </button>
             <button
               onClick={resetToDefaults}
-              className="flex-1 flex items-center justify-center gap-1 px-2 py-1 text-xs rounded bg-slate-100 dark:bg-slate-700 text-text-secondary dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors"
+              className="flex-1 flex items-center justify-center gap-1 px-2 py-1 text-xs rounded bg-surface-2 text-text-secondary hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors"
             >
               <RotateCcw className="w-3 h-3" />
               Defaults
@@ -123,10 +123,10 @@ export const ColumnVisibilityDropdown: React.FC<ColumnVisibilityDropdownProps> =
                     w-full flex items-center gap-3 px-3 py-2 rounded-md text-sm text-left
                     transition-colors
                     ${isLocked
-                      ? 'opacity-60 cursor-not-allowed bg-slate-50 dark:bg-slate-800'
+                      ? 'opacity-60 cursor-not-allowed bg-card'
                       : isVisible
-                        ? 'bg-primary/10 dark:bg-primary/20 text-text-primary dark:text-slate-100'
-                        : 'text-text-secondary dark:text-slate-400 hover:bg-card-hover dark:hover:bg-slate-700'
+                        ? 'bg-primary/10 dark:bg-primary/20 text-text-primary'
+                        : 'text-text-secondary hover:bg-card-hover'
                     }
                   `}
                 >
@@ -135,10 +135,10 @@ export const ColumnVisibilityDropdown: React.FC<ColumnVisibilityDropdownProps> =
                     w-4 h-4 rounded border flex items-center justify-center flex-shrink-0
                     ${isVisible
                       ? 'bg-primary border-primary'
-                      : 'border-border dark:border-slate-600'
+                      : 'border-border dark:border-border-strong'
                     }
                   `}>
-                    {isVisible && <Check className="w-3 h-3 text-white" />}
+                    {isVisible && <Check className="w-3 h-3 text-on-primary" />}
                   </div>
 
                   {/* Label */}
@@ -146,7 +146,7 @@ export const ColumnVisibilityDropdown: React.FC<ColumnVisibilityDropdownProps> =
 
                   {/* Lock indicator */}
                   {isLocked && (
-                    <span className="text-xs text-text-secondary dark:text-slate-500">
+                    <span className="text-xs text-text-secondary dark:text-text-tertiary">
                       required
                     </span>
                   )}

--- a/web/components/ui/CoordinateSearchChip.tsx
+++ b/web/components/ui/CoordinateSearchChip.tsx
@@ -139,7 +139,7 @@ export const CoordinateSearchChip: React.FC<CoordinateSearchChipProps> = ({
           border transition-all duration-150
           ${isActive
             ? 'bg-primary/10 border-primary text-primary'
-            : 'bg-card dark:bg-slate-800 border-border dark:border-slate-700 text-text-secondary dark:text-slate-400 hover:border-text-secondary dark:hover:border-slate-600 hover:text-text-primary dark:hover:text-slate-200'
+            : 'bg-card border-border text-text-secondary hover:border-text-secondary dark:hover:border-border-strong hover:text-text-primary'
           }
         `}
       >
@@ -157,11 +157,11 @@ export const CoordinateSearchChip: React.FC<CoordinateSearchChipProps> = ({
 
       {/* Dropdown */}
       {isOpen && (
-        <div className="absolute z-50 mt-1 w-[320px] bg-background dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg shadow-lg p-4">
+        <div className="absolute z-50 mt-1 w-[320px] bg-card border border-border rounded-lg shadow-lg p-4">
           <div className="space-y-4">
             {/* Coordinate input */}
             <div>
-              <label className="block text-xs text-text-secondary dark:text-slate-400 mb-1">
+              <label className="block text-xs text-text-secondary mb-1">
                 Coordinates (RA Dec)
               </label>
               <input
@@ -170,21 +170,21 @@ export const CoordinateSearchChip: React.FC<CoordinateSearchChipProps> = ({
                 onChange={(e) => setCoordInput(e.target.value)}
                 onKeyDown={handleKeyDown}
                 placeholder="150.5 -2.3  or  10h02m30s -02d18m00s"
-                className={`w-full px-3 py-2 text-sm border rounded-md bg-background dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent font-mono
-                  ${validationError ? 'border-red-500 dark:border-red-600' : 'border-border dark:border-slate-600'}
+                className={`w-full px-3 py-2 text-sm border rounded-md bg-background dark:bg-surface-2 text-text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent font-mono
+                  ${validationError ? 'border-red-500 dark:border-red-600' : 'border-border dark:border-border-strong'}
                 `}
               />
               {validationError && (
                 <p className="text-xs text-red-500 dark:text-red-400 mt-1">{validationError}</p>
               )}
-              <p className="text-xs text-text-secondary dark:text-slate-400 mt-1">
+              <p className="text-xs text-text-secondary mt-1">
                 Decimal or hmsdms
               </p>
             </div>
 
             {/* Radius input with units */}
             <div>
-              <label className="block text-xs text-text-secondary dark:text-slate-400 mb-1">
+              <label className="block text-xs text-text-secondary mb-1">
                 Search radius (max 1 degree)
               </label>
               <div className="flex gap-2">
@@ -196,12 +196,12 @@ export const CoordinateSearchChip: React.FC<CoordinateSearchChipProps> = ({
                   placeholder="1"
                   min="0"
                   step="0.1"
-                  className="w-24 px-3 py-2 text-sm border border-border dark:border-slate-600 rounded-md bg-background dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+                  className="w-24 px-3 py-2 text-sm border border-border dark:border-border-strong rounded-md bg-background dark:bg-surface-2 text-text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
                 />
                 <select
                   value={unitInput}
                   onChange={(e) => setUnitInput(e.target.value as 'degrees' | 'arcmin' | 'arcsec')}
-                  className="flex-1 px-3 py-2 text-sm border border-border dark:border-slate-600 rounded-md bg-background dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+                  className="flex-1 px-3 py-2 text-sm border border-border dark:border-border-strong rounded-md bg-background dark:bg-surface-2 text-text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
                 >
                   <option value="arcsec">arcseconds</option>
                   <option value="arcmin">arcminutes</option>
@@ -211,7 +211,7 @@ export const CoordinateSearchChip: React.FC<CoordinateSearchChipProps> = ({
             </div>
 
             {/* Action buttons */}
-            <div className="flex gap-2 pt-2 border-t border-border dark:border-slate-700">
+            <div className="flex gap-2 pt-2 border-t border-border">
               <button
                 onClick={() => {
                   setCoordInput('');
@@ -219,14 +219,14 @@ export const CoordinateSearchChip: React.FC<CoordinateSearchChipProps> = ({
                   setUnitInput('arcmin');
                   setValidationError(null);
                 }}
-                className="flex-1 px-3 py-1.5 text-sm text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200 transition-colors"
+                className="flex-1 px-3 py-1.5 text-sm text-text-secondary hover:text-text-primary transition-colors"
               >
                 Clear
               </button>
               <button
                 onClick={handleApply}
                 disabled={validationError !== null && coordInput.trim() !== ''}
-                className="flex-1 px-3 py-1.5 text-sm bg-primary text-white rounded-md hover:bg-primary-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex-1 px-3 py-1.5 text-sm bg-primary text-on-primary rounded-md hover:bg-primary-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Apply
               </button>

--- a/web/components/ui/EmptyState.tsx
+++ b/web/components/ui/EmptyState.tsx
@@ -17,14 +17,14 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
   className = '',
 }) => (
   <div
-    className={`text-center py-16 bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg ${className}`}
+    className={`text-center py-16 bg-card border border-border rounded-lg ${className}`}
   >
     {Icon && (
-      <Icon className="w-12 h-12 text-text-secondary dark:text-slate-400 mx-auto mb-4" />
+      <Icon className="w-12 h-12 text-text-secondary mx-auto mb-4" />
     )}
-    <p className="text-text-primary dark:text-slate-100 font-medium">{title}</p>
+    <p className="text-text-primary font-medium">{title}</p>
     {description && (
-      <p className="text-text-secondary dark:text-slate-400 mt-2 text-sm max-w-md mx-auto">
+      <p className="text-text-secondary mt-2 text-sm max-w-md mx-auto">
         {description}
       </p>
     )}

--- a/web/components/ui/FilterChip.tsx
+++ b/web/components/ui/FilterChip.tsx
@@ -205,7 +205,7 @@ export const FilterChip: React.FC<FilterChipProps> = ({
           ${disabled ? 'opacity-60 cursor-not-allowed' : ''}
           ${isActive
             ? 'bg-primary/10 border-primary text-primary'
-            : 'bg-card dark:bg-slate-800 border-border dark:border-slate-700 text-text-secondary dark:text-slate-400 hover:border-text-secondary dark:hover:border-slate-600 hover:text-text-primary dark:hover:text-slate-200'
+            : 'bg-card border-border text-text-secondary hover:border-text-secondary dark:hover:border-border-strong hover:text-text-primary'
           }
         `}
       >
@@ -223,20 +223,20 @@ export const FilterChip: React.FC<FilterChipProps> = ({
       {/* Dropdown */}
       {isOpen && !disabled && (
         <div
-          className={`absolute z-50 ${dropdownPlacement === 'top' ? 'bottom-full mb-1' : 'mt-1'} ${searchable ? 'min-w-[280px] max-w-[360px]' : 'min-w-[200px] max-w-[280px]'} bg-background dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg shadow-lg`}
+          className={`absolute z-50 ${dropdownPlacement === 'top' ? 'bottom-full mb-1' : 'mt-1'} ${searchable ? 'min-w-[280px] max-w-[360px]' : 'min-w-[200px] max-w-[280px]'} bg-card border border-border rounded-lg shadow-lg`}
         >
           {/* Search input */}
           {searchable && (
-            <div className="p-2 border-b border-border dark:border-slate-700">
+            <div className="p-2 border-b border-border">
               <div className="relative">
-                <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-secondary dark:text-slate-500" />
+                <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-secondary dark:text-text-tertiary" />
                 <input
                   ref={searchInputRef}
                   type="text"
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
                   placeholder="Search..."
-                  className="w-full pl-8 pr-3 py-1.5 text-sm border border-border dark:border-slate-700 rounded-md bg-background dark:bg-slate-900 text-text-primary dark:text-slate-100 placeholder:text-text-secondary dark:placeholder:text-slate-500 focus:outline-none focus:ring-1 focus:ring-primary focus:border-transparent"
+                  className="w-full pl-8 pr-3 py-1.5 text-sm border border-border rounded-md bg-background text-text-primary placeholder:text-text-secondary dark:placeholder:text-text-tertiary focus:outline-none focus:ring-1 focus:ring-primary focus:border-transparent"
                 />
               </div>
             </div>
@@ -251,13 +251,13 @@ export const FilterChip: React.FC<FilterChipProps> = ({
                   <button
                     key={option.value}
                     onClick={() => handleToggle(option.value)}
-                    className="w-full flex items-center gap-3 px-3 py-2 text-sm text-left hover:bg-card-hover dark:hover:bg-slate-700 rounded-md transition-colors"
+                    className="w-full flex items-center gap-3 px-3 py-2 text-sm text-left hover:bg-card-hover rounded-md transition-colors"
                   >
                     {/* Checkbox */}
                     <div
                       className={`
                         w-4 h-4 rounded border flex items-center justify-center flex-shrink-0 transition-all duration-200
-                        ${isSelected ? 'bg-primary border-primary scale-110' : 'border-border dark:border-slate-600'}
+                        ${isSelected ? 'bg-primary border-primary scale-110' : 'border-border dark:border-border-strong'}
                       `}
                       style={
                         isSelected && option.color
@@ -265,14 +265,14 @@ export const FilterChip: React.FC<FilterChipProps> = ({
                           : undefined
                       }
                     >
-                      {isSelected && <Check className="w-3 h-3 text-white" />}
+                      {isSelected && <Check className="w-3 h-3 text-on-primary" />}
                     </div>
 
                     {/* Icon */}
                     {option.icon && <span className="text-sm">{option.icon}</span>}
 
                     {/* Label */}
-                    <span className={isSelected ? 'text-text-primary dark:text-slate-100' : 'text-text-secondary dark:text-slate-400'}>
+                    <span className={isSelected ? 'text-text-primary' : 'text-text-secondary'}>
                       {option.label}
                     </span>
                   </button>
@@ -281,7 +281,7 @@ export const FilterChip: React.FC<FilterChipProps> = ({
 
               {/* Empty state */}
               {filteredOptions.length === 0 && searchTerm && (
-                <div className="px-3 py-4 text-sm text-text-secondary dark:text-slate-500 text-center">
+                <div className="px-3 py-4 text-sm text-text-secondary dark:text-text-tertiary text-center">
                   No matches
                 </div>
               )}
@@ -290,20 +290,20 @@ export const FilterChip: React.FC<FilterChipProps> = ({
 
           {/* Extra checkbox (e.g., "Needs review only" for the Quality filter) */}
           {extraCheckbox && (
-            <div className="border-t border-border dark:border-slate-700 p-1">
+            <div className="border-t border-border p-1">
               <button
                 onClick={() => extraCheckbox.onChange(!extraCheckbox.checked)}
-                className="w-full flex items-center gap-3 px-3 py-2 text-sm text-left hover:bg-card-hover dark:hover:bg-slate-700 rounded-md transition-colors"
+                className="w-full flex items-center gap-3 px-3 py-2 text-sm text-left hover:bg-card-hover rounded-md transition-colors"
               >
                 <div
                   className={`
                     w-4 h-4 rounded border flex items-center justify-center flex-shrink-0 transition-all duration-200
-                    ${extraCheckbox.checked ? 'bg-primary border-primary scale-110' : 'border-border dark:border-slate-600'}
+                    ${extraCheckbox.checked ? 'bg-primary border-primary scale-110' : 'border-border dark:border-border-strong'}
                   `}
                 >
-                  {extraCheckbox.checked && <Check className="w-3 h-3 text-white" />}
+                  {extraCheckbox.checked && <Check className="w-3 h-3 text-on-primary" />}
                 </div>
-                <span className={extraCheckbox.checked ? 'text-text-primary dark:text-slate-100' : 'text-text-secondary dark:text-slate-400'}>
+                <span className={extraCheckbox.checked ? 'text-text-primary' : 'text-text-secondary'}>
                   {extraCheckbox.label}
                 </span>
               </button>
@@ -312,7 +312,7 @@ export const FilterChip: React.FC<FilterChipProps> = ({
 
           {/* Shortcut button */}
           {shortcut && (
-            <div className="border-t border-border dark:border-slate-700 p-2">
+            <div className="border-t border-border p-2">
               <button
                 onClick={() => {
                   onChange(shortcut.values);
@@ -326,14 +326,14 @@ export const FilterChip: React.FC<FilterChipProps> = ({
 
           {/* Clear all button */}
           {multiSelect && (selected.length > 0 || extraCheckbox?.checked) && (
-            <div className={`${shortcut ? 'px-2 pb-2' : 'border-t border-border dark:border-slate-700 p-2'}`}>
+            <div className={`${shortcut ? 'px-2 pb-2' : 'border-t border-border p-2'}`}>
               <button
                 onClick={() => {
                   onChange([]);
                   if (extraCheckbox?.checked) extraCheckbox.onChange(false);
                   setIsOpen(false);
                 }}
-                className="w-full px-3 py-1.5 text-sm text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200 hover:bg-card dark:hover:bg-slate-700 rounded-md text-left transition-colors"
+                className="w-full px-3 py-1.5 text-sm text-text-secondary hover:text-text-primary hover:bg-card-hover rounded-md text-left transition-colors"
               >
                 Clear all
               </button>
@@ -342,10 +342,10 @@ export const FilterChip: React.FC<FilterChipProps> = ({
 
           {/* Footer link */}
           {footerLink && (
-            <div className="border-t border-border dark:border-slate-700 px-3 py-2">
+            <div className="border-t border-border px-3 py-2">
               <Link
                 href={footerLink.href}
-                className="flex items-center gap-1.5 text-xs text-text-secondary dark:text-slate-500 hover:text-primary transition-colors"
+                className="flex items-center gap-1.5 text-xs text-text-secondary dark:text-text-tertiary hover:text-primary transition-colors"
               >
                 <HelpCircle className="w-3 h-3" />
                 <span>{footerLink.label}</span>

--- a/web/components/ui/FilterChipWithMode.tsx
+++ b/web/components/ui/FilterChipWithMode.tsx
@@ -167,7 +167,7 @@ export const FilterChipWithMode: React.FC<FilterChipWithModeProps> = ({
           ${disabled ? 'opacity-60 cursor-not-allowed' : ''}
           ${isActive
             ? getModeColor()
-            : 'bg-card dark:bg-slate-800 border-border dark:border-slate-700 text-text-secondary dark:text-slate-400 hover:border-text-secondary dark:hover:border-slate-600 hover:text-text-primary dark:hover:text-slate-200'
+            : 'bg-card border-border text-text-secondary hover:border-text-secondary dark:hover:border-border-strong hover:text-text-primary'
           }
         `}
       >
@@ -184,7 +184,7 @@ export const FilterChipWithMode: React.FC<FilterChipWithModeProps> = ({
 
       {/* Dropdown */}
       {isOpen && !disabled && (
-        <div className="absolute z-50 mt-1 min-w-[280px] max-w-[360px] max-h-[450px] overflow-y-auto bg-background dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg shadow-lg">
+        <div className="absolute z-50 mt-1 min-w-[280px] max-w-[360px] max-h-[450px] overflow-y-auto bg-card border border-border rounded-lg shadow-lg">
           {/* Options */}
           <div className="p-3 flex flex-wrap gap-2">
             {options.map((option) => {
@@ -197,8 +197,8 @@ export const FilterChipWithMode: React.FC<FilterChipWithModeProps> = ({
                     inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm
                     border transition-all duration-150
                     ${isSelected
-                      ? 'border-transparent text-gray-900 dark:text-slate-100'
-                      : 'border-border dark:border-slate-700 bg-card/50 dark:bg-slate-800/50 text-text-secondary dark:text-slate-400 hover:bg-card dark:hover:bg-slate-700 hover:text-text-primary dark:hover:text-slate-200'
+                      ? 'border-transparent text-text-primary'
+                      : 'border-border bg-card/50 text-text-secondary hover:bg-card-hover hover:text-text-primary'
                     }
                   `}
                   style={
@@ -224,8 +224,8 @@ export const FilterChipWithMode: React.FC<FilterChipWithModeProps> = ({
 
           {/* Mode selector - only show when there are selections and mode toggle is enabled */}
           {showModeToggle && selected.length > 0 && (
-            <div className="border-t border-border dark:border-slate-700 p-3">
-              <div className="text-xs font-medium text-text-secondary dark:text-slate-400 mb-2">
+            <div className="border-t border-border p-3">
+              <div className="text-xs font-medium text-text-secondary mb-2">
                 Filter mode
               </div>
               <div className="flex gap-1">
@@ -237,11 +237,11 @@ export const FilterChipWithMode: React.FC<FilterChipWithModeProps> = ({
                       flex-1 px-3 py-1.5 text-xs font-medium rounded-md transition-colors
                       ${mode === m
                         ? m === 'any'
-                          ? 'bg-primary text-white'
+                          ? 'bg-primary text-on-primary'
                           : m === 'all'
-                            ? 'bg-green-500 text-white'
-                            : 'bg-red-500 text-white'
-                        : 'bg-slate-100 dark:bg-slate-700 text-text-secondary dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-600'
+                            ? 'bg-green-500 text-on-primary'
+                            : 'bg-red-500 text-on-primary'
+                        : 'bg-surface-2 text-text-secondary hover:bg-slate-200 dark:hover:bg-slate-600'
                       }
                     `}
                   >
@@ -249,7 +249,7 @@ export const FilterChipWithMode: React.FC<FilterChipWithModeProps> = ({
                   </button>
                 ))}
               </div>
-              <p className="mt-2 text-xs text-text-secondary dark:text-slate-500">
+              <p className="mt-2 text-xs text-text-secondary dark:text-text-tertiary">
                 {mode === 'any' && 'Show objects matching ANY selected option'}
                 {mode === 'all' && 'Show objects matching ALL selected options'}
                 {mode === 'none' && 'Exclude objects matching ANY selected option'}
@@ -259,13 +259,13 @@ export const FilterChipWithMode: React.FC<FilterChipWithModeProps> = ({
 
           {/* Clear button */}
           {selected.length > 0 && (
-            <div className="border-t border-border dark:border-slate-700 p-2">
+            <div className="border-t border-border p-2">
               <button
                 onClick={() => {
                   onChange([]);
                   setIsOpen(false);
                 }}
-                className="w-full px-3 py-1.5 text-sm text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200 hover:bg-card dark:hover:bg-slate-700 rounded-md text-left"
+                className="w-full px-3 py-1.5 text-sm text-text-secondary hover:text-text-primary hover:bg-card-hover rounded-md text-left"
               >
                 Clear all
               </button>

--- a/web/components/ui/InlineMultiFilter.tsx
+++ b/web/components/ui/InlineMultiFilter.tsx
@@ -95,12 +95,12 @@ export function InlineMultiFilter({
   return (
     <div>
       <div className="flex items-center justify-between mb-2">
-        <label className="text-sm font-medium text-text-primary dark:text-slate-200">
+        <label className="text-sm font-medium text-text-primary">
           {label}
         </label>
         {/* Mode selector (hidden for filters where mode doesn't apply) */}
         {!hideModeSelector && (
-          <div className={`flex gap-0.5 bg-slate-100 dark:bg-slate-800 rounded-md p-0.5 transition-opacity duration-200 ${hasSelection ? 'opacity-100' : 'opacity-40 pointer-events-none'}`}>
+          <div className={`flex gap-0.5 bg-surface-2 dark:bg-slate-800 rounded-md p-0.5 transition-opacity duration-200 ${hasSelection ? 'opacity-100' : 'opacity-40 pointer-events-none'}`}>
             {(['any', 'all', 'none'] as FilterMode[]).map((m) => (
               <button
                 key={m}
@@ -110,11 +110,11 @@ export function InlineMultiFilter({
                   px-2.5 py-1 text-xs font-medium rounded transition-all duration-200
                   ${mode === m
                     ? m === 'any'
-                      ? 'bg-primary text-white shadow-sm'
+                      ? 'bg-primary text-on-primary shadow-sm'
                       : m === 'all'
                         ? 'bg-green-500 text-white shadow-sm'
                         : 'bg-red-500 text-white shadow-sm'
-                    : 'text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200'
+                    : 'text-text-secondary hover:text-text-primary'
                   }
                 `}
               >
@@ -135,8 +135,8 @@ export function InlineMultiFilter({
                 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm
                 border transition-all duration-200
                 ${isSelected
-                  ? 'border-transparent text-gray-900 dark:text-slate-100 shadow-sm'
-                  : 'border-border dark:border-slate-700 text-text-secondary dark:text-slate-400 hover:bg-card dark:hover:bg-slate-700 hover:border-slate-300 dark:hover:border-slate-600'
+                  ? 'border-transparent text-text-primary shadow-sm'
+                  : 'border-border text-text-secondary hover:bg-card dark:hover:bg-slate-700 hover:border-border-strong'
                 }
               `}
               style={
@@ -155,7 +155,7 @@ export function InlineMultiFilter({
       </div>
       {/* Mode description (hidden when mode selector is hidden) */}
       {!hideModeSelector && (
-        <p className={`mt-2 text-xs text-text-secondary dark:text-slate-500 h-4 transition-opacity duration-200 ${hasSelection ? 'opacity-100' : 'opacity-0'}`}>
+        <p className={`mt-2 text-xs text-text-tertiary h-4 transition-opacity duration-200 ${hasSelection ? 'opacity-100' : 'opacity-0'}`}>
           {mode === 'any' && 'Show targets with any of the selected'}
           {mode === 'all' && 'Show targets with all of the selected'}
           {mode === 'none' && 'Exclude targets with any of the selected'}

--- a/web/components/ui/InlineRange.tsx
+++ b/web/components/ui/InlineRange.tsx
@@ -49,20 +49,20 @@ export function InlineRange({
   return (
     <div>
       <div className="flex items-center justify-between mb-2">
-        <label className="text-sm font-medium text-text-primary dark:text-slate-200">
+        <label className="text-sm font-medium text-text-primary">
           {label}
         </label>
         {isActive && (
           <button
             onClick={() => onChange(null, null)}
-            className="text-xs text-text-secondary dark:text-slate-400 hover:text-primary transition-colors"
+            className="text-xs text-text-secondary hover:text-primary transition-colors"
           >
             Clear
           </button>
         )}
       </div>
       {description && (
-        <p className="text-xs text-text-secondary dark:text-slate-500 mb-2">{description}</p>
+        <p className="text-xs text-text-tertiary mb-2">{description}</p>
       )}
       <div className="flex items-center gap-3">
         <div className="flex-1">
@@ -75,14 +75,14 @@ export function InlineRange({
             placeholder={`Min (${minBound})`}
             step={step}
             className={`
-              w-full px-3 py-2 text-sm border rounded-lg bg-background dark:bg-slate-900
-              text-text-primary dark:text-slate-200 transition-all duration-200
+              w-full px-3 py-2 text-sm border rounded-lg bg-background
+              text-text-primary transition-all duration-200
               focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary
-              ${isActive ? 'border-primary/50' : 'border-border dark:border-slate-700'}
+              ${isActive ? 'border-primary/50' : 'border-border'}
             `}
           />
         </div>
-        <span className="text-sm text-text-secondary dark:text-slate-400">to</span>
+        <span className="text-sm text-text-secondary">to</span>
         <div className="flex-1">
           <input
             type="number"
@@ -93,10 +93,10 @@ export function InlineRange({
             placeholder={`Max (${maxBound})`}
             step={step}
             className={`
-              w-full px-3 py-2 text-sm border rounded-lg bg-background dark:bg-slate-900
-              text-text-primary dark:text-slate-200 transition-all duration-200
+              w-full px-3 py-2 text-sm border rounded-lg bg-background
+              text-text-primary transition-all duration-200
               focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary
-              ${isActive ? 'border-primary/50' : 'border-border dark:border-slate-700'}
+              ${isActive ? 'border-primary/50' : 'border-border'}
             `}
           />
         </div>

--- a/web/components/ui/LoadingState.tsx
+++ b/web/components/ui/LoadingState.tsx
@@ -12,6 +12,6 @@ export const LoadingState: React.FC<LoadingStateProps> = ({
 }) => (
   <div className={`flex items-center justify-center py-16 ${className}`}>
     <Loader2 className="w-8 h-8 animate-spin text-primary" />
-    <span className="ml-3 text-text-secondary dark:text-slate-400">{label}</span>
+    <span className="ml-3 text-text-secondary">{label}</span>
   </div>
 );

--- a/web/components/ui/QueryBuilder.tsx
+++ b/web/components/ui/QueryBuilder.tsx
@@ -213,24 +213,24 @@ const GroupComponent: React.FC<GroupComponentProps> = ({
     <div className={`
       rounded-lg border
       ${isRoot
-        ? 'border-border dark:border-slate-700 bg-card dark:bg-slate-800'
-        : 'border-dashed border-slate-300 dark:border-slate-600 bg-slate-50 dark:bg-slate-800/50'
+        ? 'border-border bg-card'
+        : 'border-dashed border-border-strong bg-card dark:bg-slate-800/50'
       }
     `}>
       {/* Group header */}
-      <div className="flex items-center gap-2 p-3 border-b border-border dark:border-slate-700">
+      <div className="flex items-center gap-2 p-3 border-b border-border">
         {!isRoot && (
-          <GripVertical className="w-4 h-4 text-text-secondary dark:text-slate-500 cursor-grab" />
+          <GripVertical className="w-4 h-4 text-text-tertiary cursor-grab" />
         )}
 
         {/* Logic toggle */}
-        <div className="flex rounded-md overflow-hidden border border-border dark:border-slate-600">
+        <div className="flex rounded-md overflow-hidden border border-border dark:border-border-strong">
           <button
             onClick={() => onUpdateGroupLogic(group.id, 'AND')}
             className={`px-3 py-1 text-xs font-medium transition-colors ${
               group.logic === 'AND'
-                ? 'bg-primary text-white'
-                : 'bg-card dark:bg-slate-700 text-text-secondary dark:text-slate-400 hover:bg-card-hover dark:hover:bg-slate-600'
+                ? 'bg-primary text-on-primary'
+                : 'bg-card dark:bg-slate-700 text-text-secondary hover:bg-card-hover dark:hover:bg-slate-600'
             }`}
           >
             AND
@@ -240,14 +240,14 @@ const GroupComponent: React.FC<GroupComponentProps> = ({
             className={`px-3 py-1 text-xs font-medium transition-colors ${
               group.logic === 'OR'
                 ? 'bg-orange-500 text-white'
-                : 'bg-card dark:bg-slate-700 text-text-secondary dark:text-slate-400 hover:bg-card-hover dark:hover:bg-slate-600'
+                : 'bg-card dark:bg-slate-700 text-text-secondary hover:bg-card-hover dark:hover:bg-slate-600'
             }`}
           >
             OR
           </button>
         </div>
 
-        <span className="text-xs text-text-secondary dark:text-slate-500 ml-2">
+        <span className="text-xs text-text-tertiary ml-2">
           {group.logic === 'AND' ? 'All conditions must match' : 'Any condition can match'}
         </span>
 
@@ -257,7 +257,7 @@ const GroupComponent: React.FC<GroupComponentProps> = ({
         {!isRoot && (
           <button
             onClick={() => onRemoveItem(group.id)}
-            className="p-1 text-text-secondary dark:text-slate-400 hover:text-red-500 transition-colors"
+            className="p-1 text-text-secondary hover:text-red-500 transition-colors"
           >
             <X className="w-4 h-4" />
           </button>
@@ -267,7 +267,7 @@ const GroupComponent: React.FC<GroupComponentProps> = ({
       {/* Conditions */}
       <div className="p-3 space-y-2">
         {group.conditions.length === 0 ? (
-          <div className="text-sm text-text-secondary dark:text-slate-500 text-center py-4">
+          <div className="text-sm text-text-tertiary text-center py-4">
             No conditions yet. Add a condition or group below.
           </div>
         ) : (
@@ -276,7 +276,7 @@ const GroupComponent: React.FC<GroupComponentProps> = ({
               {/* Logic separator */}
               {index > 0 && (
                 <div className="flex items-center gap-2 py-1">
-                  <div className="flex-1 h-px bg-border dark:bg-slate-700" />
+                  <div className="flex-1 h-px bg-border" />
                   <span className={`text-xs font-medium px-2 ${
                     group.logic === 'AND'
                       ? 'text-primary'
@@ -284,7 +284,7 @@ const GroupComponent: React.FC<GroupComponentProps> = ({
                   }`}>
                     {group.logic}
                   </span>
-                  <div className="flex-1 h-px bg-border dark:bg-slate-700" />
+                  <div className="flex-1 h-px bg-border" />
                 </div>
               )}
 
@@ -312,17 +312,17 @@ const GroupComponent: React.FC<GroupComponentProps> = ({
       </div>
 
       {/* Add buttons */}
-      <div className="flex gap-2 p-3 border-t border-border dark:border-slate-700">
+      <div className="flex gap-2 p-3 border-t border-border">
         <button
           onClick={() => onAddCondition(group.id)}
-          className="flex items-center gap-1 px-3 py-1.5 text-sm text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200 hover:bg-card-hover dark:hover:bg-slate-700 rounded-md transition-colors"
+          className="flex items-center gap-1 px-3 py-1.5 text-sm text-text-secondary hover:text-text-primary hover:bg-card-hover rounded-md transition-colors"
         >
           <Plus className="w-4 h-4" />
           Add condition
         </button>
         <button
           onClick={() => onAddGroup(group.id)}
-          className="flex items-center gap-1 px-3 py-1.5 text-sm text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200 hover:bg-card-hover dark:hover:bg-slate-700 rounded-md transition-colors"
+          className="flex items-center gap-1 px-3 py-1.5 text-sm text-text-secondary hover:text-text-primary hover:bg-card-hover rounded-md transition-colors"
         >
           <Plus className="w-4 h-4" />
           Add group
@@ -360,14 +360,14 @@ const ConditionComponent: React.FC<ConditionComponentProps> = ({
   };
 
   return (
-    <div className="flex items-center gap-2 p-2 bg-background dark:bg-slate-900 rounded-md border border-border dark:border-slate-700">
-      <GripVertical className="w-4 h-4 text-text-secondary dark:text-slate-500 cursor-grab flex-shrink-0" />
+    <div className="flex items-center gap-2 p-2 bg-background rounded-md border border-border">
+      <GripVertical className="w-4 h-4 text-text-tertiary cursor-grab flex-shrink-0" />
 
       {/* Field selector */}
       <select
         value={condition.field}
         onChange={(e) => handleFieldChange(e.target.value)}
-        className="px-2 py-1 text-sm bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded text-text-primary dark:text-slate-200"
+        className="px-2 py-1 text-sm bg-card border border-border rounded text-text-primary"
       >
         {fields.map(f => (
           <option key={f.id} value={f.id}>{f.label}</option>
@@ -378,7 +378,7 @@ const ConditionComponent: React.FC<ConditionComponentProps> = ({
       <select
         value={condition.operator}
         onChange={(e) => onUpdate({ operator: e.target.value as Operator })}
-        className="px-2 py-1 text-sm bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded text-text-primary dark:text-slate-200"
+        className="px-2 py-1 text-sm bg-card border border-border rounded text-text-primary"
       >
         {operators.map(op => (
           <option key={op.value} value={op.value}>{op.label}</option>
@@ -397,7 +397,7 @@ const ConditionComponent: React.FC<ConditionComponentProps> = ({
             });
             onUpdate({ value: selected });
           }}
-          className="flex-1 min-w-[150px] px-2 py-1 text-sm bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded text-text-primary dark:text-slate-200"
+          className="flex-1 min-w-[150px] px-2 py-1 text-sm bg-card border border-border rounded text-text-primary"
           size={Math.min(field.options.length, 4)}
         >
           {field.options.map(opt => (
@@ -411,7 +411,7 @@ const ConditionComponent: React.FC<ConditionComponentProps> = ({
             const numVal = Number(e.target.value);
             onUpdate({ value: isNaN(numVal) ? e.target.value : numVal });
           }}
-          className="flex-1 px-2 py-1 text-sm bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded text-text-primary dark:text-slate-200"
+          className="flex-1 px-2 py-1 text-sm bg-card border border-border rounded text-text-primary"
         >
           <option value="">Select...</option>
           {field.options.map(opt => (
@@ -423,7 +423,7 @@ const ConditionComponent: React.FC<ConditionComponentProps> = ({
           type="number"
           value={condition.value as number}
           onChange={(e) => onUpdate({ value: parseFloat(e.target.value) || 0 })}
-          className="flex-1 px-2 py-1 text-sm bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded text-text-primary dark:text-slate-200"
+          className="flex-1 px-2 py-1 text-sm bg-card border border-border rounded text-text-primary"
           step="any"
         />
       ) : (
@@ -431,7 +431,7 @@ const ConditionComponent: React.FC<ConditionComponentProps> = ({
           type="text"
           value={condition.value as string}
           onChange={(e) => onUpdate({ value: e.target.value })}
-          className="flex-1 px-2 py-1 text-sm bg-card dark:bg-slate-800 border border-border dark:border-slate-700 rounded text-text-primary dark:text-slate-200"
+          className="flex-1 px-2 py-1 text-sm bg-card border border-border rounded text-text-primary"
           placeholder="Enter value..."
         />
       )}
@@ -439,7 +439,7 @@ const ConditionComponent: React.FC<ConditionComponentProps> = ({
       {/* Remove button */}
       <button
         onClick={onRemove}
-        className="p-1 text-text-secondary dark:text-slate-400 hover:text-red-500 transition-colors flex-shrink-0"
+        className="p-1 text-text-secondary hover:text-red-500 transition-colors flex-shrink-0"
       >
         <X className="w-4 h-4" />
       </button>

--- a/web/components/ui/RangeFilterChip.tsx
+++ b/web/components/ui/RangeFilterChip.tsx
@@ -103,7 +103,7 @@ export const RangeFilterChip: React.FC<RangeFilterChipProps> = ({
           border transition-all duration-150
           ${isActive
             ? 'bg-primary/10 border-primary text-primary'
-            : 'bg-card dark:bg-slate-800 border-border dark:border-slate-700 text-text-secondary dark:text-slate-400 hover:border-text-secondary dark:hover:border-slate-600 hover:text-text-primary dark:hover:text-slate-200'
+            : 'bg-card border-border text-text-secondary hover:border-text-secondary dark:hover:border-border-strong hover:text-text-primary'
           }
         `}
       >
@@ -120,12 +120,12 @@ export const RangeFilterChip: React.FC<RangeFilterChipProps> = ({
 
       {/* Dropdown */}
       {isOpen && (
-        <div className="absolute z-50 mt-1 w-[280px] bg-background dark:bg-slate-800 border border-border dark:border-slate-700 rounded-lg shadow-lg p-4">
+        <div className="absolute z-50 mt-1 w-[280px] bg-card border border-border rounded-lg shadow-lg p-4">
           <div className="space-y-4">
             {/* Range inputs */}
             <div className="flex items-center gap-2">
               <div className="flex-1">
-                <label className="block text-xs text-text-secondary dark:text-slate-400 mb-1">Min</label>
+                <label className="block text-xs text-text-secondary mb-1">Min</label>
                 <input
                   type="number"
                   value={localMin}
@@ -135,12 +135,12 @@ export const RangeFilterChip: React.FC<RangeFilterChipProps> = ({
                   min={minBound}
                   max={maxBound}
                   step={step}
-                  className="w-full px-3 py-2 text-sm border border-border dark:border-slate-600 rounded-md bg-background dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+                  className="w-full px-3 py-2 text-sm border border-border dark:border-border-strong rounded-md bg-background dark:bg-surface-2 text-text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
                 />
               </div>
-              <span className="text-text-secondary dark:text-slate-400 mt-5">—</span>
+              <span className="text-text-secondary mt-5">—</span>
               <div className="flex-1">
-                <label className="block text-xs text-text-secondary dark:text-slate-400 mb-1">Max</label>
+                <label className="block text-xs text-text-secondary mb-1">Max</label>
                 <input
                   type="number"
                   value={localMax}
@@ -150,14 +150,14 @@ export const RangeFilterChip: React.FC<RangeFilterChipProps> = ({
                   min={minBound}
                   max={maxBound}
                   step={step}
-                  className="w-full px-3 py-2 text-sm border border-border dark:border-slate-600 rounded-md bg-background dark:bg-slate-700 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+                  className="w-full px-3 py-2 text-sm border border-border dark:border-border-strong rounded-md bg-background dark:bg-surface-2 text-text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
                 />
               </div>
             </div>
 
             {/* Quick presets */}
             <div>
-              <label className="block text-xs text-text-secondary dark:text-slate-400 mb-2">Quick ranges</label>
+              <label className="block text-xs text-text-secondary mb-2">Quick ranges</label>
               <div className="flex flex-wrap gap-1.5">
                 {(quickRanges ?? [
                   { label: '0-1', min: 0, max: 1 },
@@ -172,7 +172,7 @@ export const RangeFilterChip: React.FC<RangeFilterChipProps> = ({
                       setLocalMin(preset.min?.toString() ?? '');
                       setLocalMax(preset.max?.toString() ?? '');
                     }}
-                    className="px-2 py-1 text-xs rounded border border-border dark:border-slate-600 dark:bg-slate-700 dark:text-slate-300 hover:border-primary hover:text-primary transition-colors"
+                    className="px-2 py-1 text-xs rounded border border-border dark:border-border-strong dark:bg-surface-2 dark:text-slate-300 hover:border-primary hover:text-primary transition-colors"
                   >
                     {preset.label}
                   </button>
@@ -181,19 +181,19 @@ export const RangeFilterChip: React.FC<RangeFilterChipProps> = ({
             </div>
 
             {/* Action buttons */}
-            <div className="flex gap-2 pt-2 border-t border-border dark:border-slate-700">
+            <div className="flex gap-2 pt-2 border-t border-border">
               <button
                 onClick={() => {
                   setLocalMin('');
                   setLocalMax('');
                 }}
-                className="flex-1 px-3 py-1.5 text-sm text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200 transition-colors"
+                className="flex-1 px-3 py-1.5 text-sm text-text-secondary hover:text-text-primary transition-colors"
               >
                 Clear
               </button>
               <button
                 onClick={handleApply}
-                className="flex-1 px-3 py-1.5 text-sm bg-primary text-white rounded-md hover:bg-primary-hover transition-colors"
+                className="flex-1 px-3 py-1.5 text-sm bg-primary text-on-primary rounded-md hover:bg-primary-hover transition-colors"
               >
                 Apply
               </button>

--- a/web/components/ui/TablePagination.tsx
+++ b/web/components/ui/TablePagination.tsx
@@ -41,12 +41,12 @@ export const TablePagination: React.FC<TablePaginationProps> = ({
   return (
     <div className={`flex items-center justify-between gap-4 py-3 px-4 ${className}`}>
       {/* Left side: Page size selector */}
-      <div className="flex items-center gap-2 text-sm text-text-secondary dark:text-slate-400">
+      <div className="flex items-center gap-2 text-sm text-text-secondary">
         <span>Show</span>
         <select
           value={pageSize}
           onChange={handlePageSizeChange}
-          className="px-2 py-1 border border-border dark:border-slate-600 rounded-md bg-background dark:bg-slate-800 text-text-primary dark:text-slate-100 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          className="px-2 py-1 border border-border dark:border-border-strong rounded-md bg-card text-text-primary text-sm focus:outline-none focus:ring-2 focus:ring-primary"
         >
           {pageSizeOptions.map((size) => (
             <option key={size} value={size}>
@@ -58,7 +58,7 @@ export const TablePagination: React.FC<TablePaginationProps> = ({
       </div>
 
       {/* Center: Row count info */}
-      <div className="flex items-center gap-2 text-sm text-text-secondary dark:text-slate-400">
+      <div className="flex items-center gap-2 text-sm text-text-secondary">
         {loading && (
           <Loader2 className="w-3.5 h-3.5 animate-spin text-primary" />
         )}
@@ -66,11 +66,11 @@ export const TablePagination: React.FC<TablePaginationProps> = ({
           <span>No results</span>
         ) : (
           <span>
-            Showing <span className="font-medium text-text-primary dark:text-slate-100">{startRow.toLocaleString()}</span>
+            Showing <span className="font-medium text-text-primary">{startRow.toLocaleString()}</span>
             {' - '}
-            <span className="font-medium text-text-primary dark:text-slate-100">{endRow.toLocaleString()}</span>
+            <span className="font-medium text-text-primary">{endRow.toLocaleString()}</span>
             {' of '}
-            <span className="font-medium text-text-primary dark:text-slate-100">{totalRows.toLocaleString()}</span>
+            <span className="font-medium text-text-primary">{totalRows.toLocaleString()}</span>
           </span>
         )}
       </div>
@@ -84,8 +84,8 @@ export const TablePagination: React.FC<TablePaginationProps> = ({
           className={`
             p-1.5 rounded-md transition-colors
             ${canPreviousPage
-              ? 'hover:bg-card dark:hover:bg-slate-700 text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-100'
-              : 'text-border dark:text-slate-600 cursor-not-allowed'
+              ? 'hover:bg-card-hover text-text-secondary hover:text-text-primary'
+              : 'text-border dark:text-border-strong cursor-not-allowed'
             }
           `}
           title="First page"
@@ -100,8 +100,8 @@ export const TablePagination: React.FC<TablePaginationProps> = ({
           className={`
             p-1.5 rounded-md transition-colors
             ${canPreviousPage
-              ? 'hover:bg-card dark:hover:bg-slate-700 text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-100'
-              : 'text-border dark:text-slate-600 cursor-not-allowed'
+              ? 'hover:bg-card-hover text-text-secondary hover:text-text-primary'
+              : 'text-border dark:text-border-strong cursor-not-allowed'
             }
           `}
           title="Previous page"
@@ -111,7 +111,7 @@ export const TablePagination: React.FC<TablePaginationProps> = ({
 
         {/* Page indicator */}
         <div className="flex items-center gap-1 px-2">
-          <span className="text-sm text-text-secondary dark:text-slate-400">Page</span>
+          <span className="text-sm text-text-secondary">Page</span>
           <input
             type="number"
             value={pageIndex + 1}
@@ -122,9 +122,9 @@ export const TablePagination: React.FC<TablePaginationProps> = ({
             }}
             min={1}
             max={pageCount || 1}
-            className="w-12 px-2 py-1 text-sm text-center border border-border dark:border-slate-600 rounded-md bg-background dark:bg-slate-800 text-text-primary dark:text-slate-100 focus:outline-none focus:ring-2 focus:ring-primary"
+            className="w-12 px-2 py-1 text-sm text-center border border-border dark:border-border-strong rounded-md bg-card text-text-primary focus:outline-none focus:ring-2 focus:ring-primary"
           />
-          <span className="text-sm text-text-secondary dark:text-slate-400">of {pageCount || 1}</span>
+          <span className="text-sm text-text-secondary">of {pageCount || 1}</span>
         </div>
 
         {/* Next page */}
@@ -134,8 +134,8 @@ export const TablePagination: React.FC<TablePaginationProps> = ({
           className={`
             p-1.5 rounded-md transition-colors
             ${canNextPage
-              ? 'hover:bg-card dark:hover:bg-slate-700 text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-100'
-              : 'text-border dark:text-slate-600 cursor-not-allowed'
+              ? 'hover:bg-card-hover text-text-secondary hover:text-text-primary'
+              : 'text-border dark:text-border-strong cursor-not-allowed'
             }
           `}
           title="Next page"
@@ -150,8 +150,8 @@ export const TablePagination: React.FC<TablePaginationProps> = ({
           className={`
             p-1.5 rounded-md transition-colors
             ${canNextPage
-              ? 'hover:bg-card dark:hover:bg-slate-700 text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-100'
-              : 'text-border dark:text-slate-600 cursor-not-allowed'
+              ? 'hover:bg-card-hover text-text-secondary hover:text-text-primary'
+              : 'text-border dark:text-border-strong cursor-not-allowed'
             }
           `}
           title="Last page"

--- a/web/components/ui/Tabs.tsx
+++ b/web/components/ui/Tabs.tsx
@@ -48,7 +48,7 @@ interface TabsListProps {
 
 export const TabsList: React.FC<TabsListProps> = ({ children, className = '' }) => {
   return (
-    <div className={`flex border-b border-border dark:border-slate-700 ${className}`}>
+    <div className={`flex border-b border-border ${className}`}>
       {children}
     </div>
   );
@@ -74,7 +74,7 @@ export const TabsTrigger: React.FC<TabsTriggerProps> = ({ value, children, class
         px-6 py-3 font-medium text-sm transition-colors relative
         ${isActive
           ? 'text-primary'
-          : 'text-text-secondary dark:text-slate-400 hover:text-text-primary dark:hover:text-slate-200'
+          : 'text-text-secondary hover:text-text-primary'
         }
         ${className}
       `}

--- a/web/components/ui/ThemeToggle.tsx
+++ b/web/components/ui/ThemeToggle.tsx
@@ -19,7 +19,7 @@ export const ThemeToggle: React.FC<ThemeToggleProps> = ({ className = '' }) => {
   ];
 
   return (
-    <div className={`flex rounded-lg border border-border dark:border-slate-600 overflow-hidden ${className}`}>
+    <div className={`flex rounded-lg border border-border dark:border-border-strong overflow-hidden ${className}`}>
       {options.map((option) => {
         const Icon = option.icon;
         const isActive = theme === option.value;
@@ -30,8 +30,8 @@ export const ThemeToggle: React.FC<ThemeToggleProps> = ({ className = '' }) => {
             className={`
               flex items-center gap-2 px-3 py-2 text-sm transition-colors
               ${isActive
-                ? 'bg-primary text-white'
-                : 'bg-white dark:bg-slate-800 text-text-secondary dark:text-slate-400 hover:bg-gray-100 dark:hover:bg-slate-700'
+                ? 'bg-primary text-on-primary'
+                : 'bg-card text-text-secondary hover:bg-card-hover'
               }
             `}
             title={option.label}

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -12,14 +12,24 @@ const config: Config = {
       colors: {
         primary: 'var(--primary)',
         'primary-hover': 'var(--primary-hover)',
+        'primary-text': 'var(--primary-text)',
+        'on-primary': 'var(--on-primary)',
+        'primary-soft': 'var(--primary-soft)',
         header: '#475569',       // Dark slate header
         background: 'var(--background)',
         card: 'var(--card)',
         'card-hover': 'var(--card-hover)',
+        'surface-2': 'var(--surface-2)',
         border: 'var(--border)',
+        'border-strong': 'var(--border-strong)',
+        success: 'var(--success)',
+        warning: 'var(--warning)',
+        danger: 'var(--danger)',
+        info: 'var(--info)',
         text: {
           primary: 'var(--text-primary)',
           secondary: 'var(--text-secondary)',
+          tertiary: 'var(--text-tertiary)',
         }
       },
       fontFamily: {


### PR DESCRIPTION
## Summary

Establishes a committed design system for CAMPFIRE (**Direction 2 — "Ember & Dusk"**) and migrates the web app onto a clean **semantic design-token** architecture, so future visual iteration is a values change rather than a hunt-and-replace.

**This PR is a deliberate visual no-op.** It is the *refactor* half of a refactor-then-restyle plan: components move off raw `slate-*`/`gray-*`/`white` chrome onto semantic tokens whose values still match today's palette. A follow-up PR (**Phase 3**) will flip the token values to warm-paper/dusk + swap fonts (Inter / JetBrains Mono) + ember accent — that's the commit where the look actually changes.

Opening as **draft** to test on the Vercel preview (real Supabase env) before merge.

## What's here

- **Docs** (`docs/`): the committed design system (`design-system.md`), the migration plan (`token-migration-plan.md`), the Claude Design brief, and three direction mockups.
- **Phase 1** — semantic token vocabulary added to `globals.css` (light + dark) and exposed via `tailwind.config.ts`: `--surface-2`, `--border-strong`, `--text-tertiary`, `--primary-text`, `--on-primary`, `--primary-soft`, `--success/--warning/--danger/--info`. Values mirror the current slate scale → no visual change.
- **Phase 2** — migrated `components/**` and `app/**` off raw chrome onto tokens, one commit per directory. Most changes delete *redundant* `dark:` overrides (e.g. `bg-card dark:bg-slate-800` → `bg-card`, where slate-800 already equals `--card`'s dark value — pixel-exact); off-scale shades snap sub-perceptually (every snap documented in commits).

## By the numbers

- **119 files, 1,459 insertions / 1,459 deletions** — perfectly balanced, the signature of a faithful no-op.
- Raw chrome **~2,330 → ~208 (~91%)**.
- **Zero hex changed** — all scientific/plot colors (emission lines, model overlays, SED, fit plots, quality flags) left byte-identical.
- `tsc` clean; `next build` compiles + lints clean (prerender only fails on missing Supabase env locally, unrelated).

## Intentionally deferred (~208 remaining)

These need a *new token decision*, so they belong in the restyle, not a no-op:
- **`Navigation`** — fixed-dark top bar; needs inverted/header tokens.
- **Fixed-dark code blocks / scrims / map overlays** — want an "always-dark surface" token (or lint allowlist).
- Opacity-modified darks, off-scale raised pills, input fills, markdown body-copy, status `text-white` — resolve via a body-text token, a status-token pass, and minor tuning.

## Notes
- Found two **pre-existing** latent bugs (not introduced here): `hover:bg-background-hover` references an undefined token in `NearbyObjects.tsx` and `profile/page.tsx` (harmless no-ops). Left as-is.
- Next: **Phase 3** (value/font flip → Direction 2 goes live) and **Phase 4** (ESLint guardrail banning raw `slate-*`/hex in chrome).

## Test plan
- [ ] Vercel preview: confirm chrome is visually unchanged from `main` in **both** light and dark themes, across Targets list, an object/spectrum page, filters/dropdowns, settings, and an admin table.

Generated with Claude Code
