### PR TITLE
fix(nircam): handle partial-overlap exposures in campfire drizzle

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -47,6 +47,25 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- NIRCam campfire-native drizzle (`resample.implementation = "campfire"`): a
+  tile no longer aborts with `ValueError: No or too few valid pixels in the
+  pixel map` when a selected exposure only partially overlaps it. The pixmap
+  was built with `output_wcs.invert(ra, dec)` at its default
+  `with_bounding_box=True`, which returns NaN for every input pixel mapping
+  outside the output WCS bounding box. cdriz (`drizzle` 2.x) raises on *any*
+  NaN in the pixmap, so an exposure that merely grazes a (rotated) tile — e.g.
+  a COSMOS exposure overlapping tile `B2` by ~2 pixels at a corner — crashed
+  the entire drizzle. The inverse is now called with `with_bounding_box=False`,
+  producing a finite, geometrically-continuous pixmap; cdriz drops off-frame
+  pixels through its normal output-bounds clipping while keeping correct kernel
+  geometry at the tile edge, and overlap detection (`_output_bbox_in_tile`) now
+  keys off pixels mapping *inside* the frame rather than finite ones. Replacing
+  the NaNs with an out-of-frame sentinel was rejected: cdriz derives each
+  pixel's drizzle footprint from neighbouring pixmap entries, so a sentinel
+  poisons the geometry and silently zeroes the whole exposure's contribution.
+  Output for tiles that already built is unchanged (any exposure that
+  previously succeeded had an all-finite pixmap, computed identically here).
+  The default `jwst` implementation was never affected.
 - NIRCam campfire-native drizzle (`resample.implementation = "campfire"`): the
   output mosaic i2d now carries the same header metadata as a jwst
   `Image3Pipeline` product. Previously `_write_i2d_fits` built a blank

--- a/pipeline/campfire_pipeline/nircam/drizzle.py
+++ b/pipeline/campfire_pipeline/nircam/drizzle.py
@@ -138,8 +138,21 @@ def _input_to_output_pixmap(input_gwcs, output_wcs, in_shape):
     """
     in_ny, in_nx = in_shape
     iy, ix = np.indices((in_ny, in_nx), dtype=np.float64)
+    # ``with_bounding_box=False`` on the inverse is essential: with the default
+    # (True), ``invert`` returns NaN for every input pixel whose footprint maps
+    # outside the output WCS bounding box (e.g. an exposure that only partially
+    # overlaps the tile). cdriz (``drizzle`` 2.x) then raises "No or too few
+    # valid pixels in the pixel map" when the *finite* remainder is degenerate,
+    # aborting the whole tile. A finite, geometrically-continuous pixmap instead
+    # lets cdriz drop off-frame pixels via its normal output-bounds clipping
+    # while keeping correct kernel geometry at the tile edge. This is how
+    # jwst/stcal treat the pixmap — a pure coordinate map, with all masking
+    # (DQ, low weight) carried by the weight array, not by NaNs in the pixmap.
+    # Replacing the NaNs with a sentinel does *not* work: cdriz derives each
+    # pixel's drizzle footprint from neighbouring pixmap entries, so a sentinel
+    # poisons the geometry and zeroes the whole exposure's contribution.
     ra, dec = input_gwcs(ix, iy)
-    out_x, out_y = output_wcs.invert(ra, dec)
+    out_x, out_y = output_wcs.invert(ra, dec, with_bounding_box=False)
     pixmap = np.empty((in_ny, in_nx, 2), dtype=np.float64)
     pixmap[..., 0] = out_x
     pixmap[..., 1] = out_y
@@ -149,16 +162,25 @@ def _input_to_output_pixmap(input_gwcs, output_wcs, in_shape):
 def _output_bbox_in_tile(pixmap, out_shape, pad=4):
     """Return ``(sly, slx)`` bbox of input footprint in output frame, or None.
 
-    Pads by ``pad`` pixels on each side to cover the kernel halo, then clips
-    to the tile bounds. Returns ``None`` if the input does not overlap the
-    output tile.
+    Considers only input pixels that map *inside* the output frame (the pixmap
+    is now finite and continuous everywhere — see ``_input_to_output_pixmap`` —
+    so an in-frame test, not an ``isfinite`` test, is what identifies the
+    overlapping footprint). Pads by ``pad`` pixels on each side to cover the
+    kernel halo, then clips to the tile bounds. Returns ``None`` if the input
+    does not overlap the output tile.
     """
     out_ny, out_nx = out_shape
-    valid = np.isfinite(pixmap).all(axis=-1)
-    if not valid.any():
+    out_x = pixmap[..., 0]
+    out_y = pixmap[..., 1]
+    inside = (
+        np.isfinite(out_x) & np.isfinite(out_y)
+        & (out_x >= 0) & (out_x <= out_nx - 1)
+        & (out_y >= 0) & (out_y <= out_ny - 1)
+    )
+    if not inside.any():
         return None
-    out_x = pixmap[..., 0][valid]
-    out_y = pixmap[..., 1][valid]
+    out_x = out_x[inside]
+    out_y = out_y[inside]
 
     x_min = int(np.floor(out_x.min())) - pad
     x_max = int(np.ceil(out_x.max())) + pad + 1

--- a/pipeline/tests/test_nircam_drizzle.py
+++ b/pipeline/tests/test_nircam_drizzle.py
@@ -24,7 +24,7 @@ import numpy as np
 import pytest
 
 from campfire_pipeline.nircam.drizzle import (
-    _apply_output_metadata, _sanitize_variance,
+    _apply_output_metadata, _sanitize_variance, _output_bbox_in_tile,
 )
 
 Drizzle = pytest.importorskip("drizzle.resample").Drizzle
@@ -72,6 +72,97 @@ def test_sanitize_variance_drops_pixel_with_no_valid_component():
     assert var_weight[0, 1] == 0.0      # fully dead -> dropped
     assert np.isfinite(var_total).all()
     assert weight[0, 1] == 9.0          # input weight not mutated
+
+
+# ---------------------------------------------------------------------------
+# pixmap overlap detection + the cdriz "too few valid pixels" crash guard
+# ---------------------------------------------------------------------------
+
+def test_output_bbox_in_tile_uses_in_frame_pixels():
+    """``_output_bbox_in_tile`` must key off pixels that map *inside* the
+    output frame, not merely finite ones — the pixmap is finite everywhere now.
+    """
+    out_shape = (50, 50)
+    pm = np.empty((10, 10, 2), np.float64)
+    iy, ix = np.indices((10, 10), dtype=np.float64)
+    # map the whole input far off-frame except a 3x3 patch landing at (5..7, 5..7)
+    pm[..., 0] = ix - 1000.0
+    pm[..., 1] = iy - 1000.0
+    pm[:3, :3, 0] = ix[:3, :3] + 5.0
+    pm[:3, :3, 1] = iy[:3, :3] + 5.0
+
+    sly, slx = _output_bbox_in_tile(pm, out_shape, pad=1)
+    # the in-frame patch spans output [5,7]x[5,7]; pad=1 grows + clips to tile
+    assert slx.start <= 5 and slx.stop >= 8
+    assert sly.start <= 5 and sly.stop >= 8
+    assert slx.stop <= 50 and sly.stop <= 50
+
+    # a footprint entirely off-frame -> no overlap
+    pm_off = np.empty((10, 10, 2), np.float64)
+    pm_off[..., 0] = ix - 1000.0
+    pm_off[..., 1] = iy - 1000.0
+    assert _output_bbox_in_tile(pm_off, out_shape) is None
+
+
+def test_drizzle_does_not_crash_on_grazing_finite_pixmap():
+    """A finite, geometrically-continuous pixmap whose footprint barely grazes
+    the output frame must drizzle (the in-frame pixels) without raising.
+
+    This is the corner-graze case (exposure 19): with the default
+    ``with_bounding_box=True`` invert, off-frame pixels became NaN and cdriz
+    raised "No or too few valid pixels in the pixel map" on the degenerate
+    finite remainder. With the finite-everywhere pixmap, cdriz clips the
+    off-frame pixels itself and keeps correct edge geometry — no crash, and the
+    in-frame contribution (here ~0) is handled gracefully.
+    """
+    ny = nx = 64
+    out_shape = (16, 16)
+    iy, ix = np.indices((ny, nx), dtype=np.float64)
+    # continuous identity-shifted map; only a corner pokes into the 16x16 frame
+    pm = np.empty((ny, nx, 2), np.float64)
+    pm[..., 0] = ix - 62.0
+    pm[..., 1] = iy - 62.0
+
+    out = np.zeros(out_shape, np.float32)
+    wht = np.zeros(out_shape, np.float32)
+    d = Drizzle(out_img=out, out_wht=wht, kernel="square",
+                fillval="INDEF", disable_ctx=True)
+    # must not raise ValueError("No or too few valid pixels ...")
+    d.add_image(data=np.ones((ny, nx), np.float32),
+                weight_map=np.ones((ny, nx), np.float32),
+                exptime=1.0, pixmap=pm, pixfrac=1.0, in_units="cps")
+    assert np.isfinite(wht).all()
+
+
+def test_drizzle_partial_overlap_keeps_full_interior_weight():
+    """A finite, continuous pixmap that half-overlaps the output frame must
+    deposit full weight across the in-frame bulk (not just the boundary).
+
+    Guards against the rejected sentinel approach, which poisoned cdriz's
+    per-pixel geometry (it derives each footprint from neighbouring pixmap
+    entries) and zeroed the entire exposure's contribution. A continuous map —
+    what ``invert(with_bounding_box=False)`` actually produces — has no such
+    discontinuity at the frame edge.
+    """
+    ny = nx = 64
+    iy, ix = np.indices((ny, nx), dtype=np.float64)
+    pm = np.empty((ny, nx, 2), np.float64)
+    # continuous shift: input cols 0..19 map off-frame (output x < 0),
+    # cols 20..63 map in-frame to output x 0..43.
+    pm[..., 0] = ix - 20.0
+    pm[..., 1] = iy
+
+    out = np.zeros((ny, nx), np.float32)
+    wht = np.zeros((ny, nx), np.float32)
+    d = Drizzle(out_img=out, out_wht=wht, kernel="square",
+                fillval="INDEF", disable_ctx=True)
+    d.add_image(data=np.ones((ny, nx), np.float32),
+                weight_map=np.ones((ny, nx), np.float32),
+                exptime=1.0, pixmap=pm, pixfrac=1.0, in_units="cps")
+    # interior of the in-frame region gets full unit weight
+    assert wht[:, 5:40].min() > 0.99
+    # output columns no input maps to stay empty (no smear from the edge)
+    assert wht[:, 45:].max() == 0.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The campfire-native resample (`resample.implementation = "campfire"`) aborts an entire tile with a cryptic error whenever a selected exposure only **partially overlaps** it:

```
ValueError: No or too few valid pixels in the pixel map.
```

Hit in practice on COSMOS f410m, tile B2, 30mas — the build crashed on input 19/46 (`jw01837004008_06201_00001_nrcalong`).

## Root cause

`_input_to_output_pixmap` built the pixmap with `output_wcs.invert(ra, dec)` at its default `with_bounding_box=True`, which returns **NaN** for every input pixel that maps outside the output WCS bounding box. cdriz (`drizzle` 2.x) raises on **any** NaN in the pixmap (verified empirically — a single NaN aborts the call regardless of how many valid pixels surround it).

Tile B2 is rotated 20°, and exposure 19 sits mostly south/left of it, grazing the tile by ~2 pixels at a corner. Its footprint mapped almost entirely off-frame → **4,194,296 of 4,194,304 pixmap entries were NaN** → cdriz aborted the whole 46-exposure tile. Exposures that map fully inside the bounding box (zero NaN) were unaffected, which is why 1–18 succeeded.

This was a latent landmine: *any* exposure extending past the output bounding box would crash the tile, not just corner-grazes.

## Fix

Invert with `with_bounding_box=False`, producing a **finite, geometrically-continuous** pixmap. cdriz then drops off-frame pixels through its normal output-bounds clipping while keeping correct kernel geometry at the tile edge — this is how jwst/stcal treat the pixmap (a pure coordinate map; masking is carried by the weight array). `_output_bbox_in_tile` now detects overlap from pixels mapping *inside* the frame rather than from `isfinite`.

A sentinel-replacement alternative (NaN → out-of-frame constant) was **rejected**: cdriz derives each pixel's drizzle footprint from neighbouring pixmap entries, so a sentinel poisons the geometry and silently zeroes the whole exposure's contribution (e.g. exposure #1 dropped from its correct 3.26M weighted pixels to 1.25M). That would be worse than the crash — silent data loss.

## Verification

- Exposure 19 now drizzles cleanly through the real code path (contributes ~0, as its overlap is negligible) — no crash.
- Exposures 1–18 produce **bit-identical** pixmaps to before (the bounding box only ever NaN'd out-of-frame points; in-frame values are computed identically) → **no regression** on tiles that already built.
- Added 3 regression tests; full pipeline suite green (**111 passed**).
- The default `jwst` implementation was never affected.

## Changelog

Added an **Infrastructure** (PATCH) entry to `pipeline/CHANGELOG.md` — fixes crashes with no change to existing scientific output.

Generated with Claude Code