### PR TITLE
Validate program slug in observations.toml early

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -47,6 +47,12 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- `Observation.load` now validates the observations.toml `program` field
+  against `programs.toml` (when present): if the value is not a known program
+  *slug* it raises immediately, with a hint when the value matches a program
+  *name* instead. Previously a slug/name mix-up was silently baked into the
+  ECSV `program_slug` metadata and only surfaced much later at deploy time as
+  a cryptic Supabase row-level-security error.
 - NIRCam campfire-native drizzle (`resample.implementation = "campfire"`): the
   output mosaic i2d now carries the same header metadata as a jwst
   `Image3Pipeline` product. Previously `_write_i2d_fits` built a blank

--- a/pipeline/campfire_pipeline/config.py
+++ b/pipeline/campfire_pipeline/config.py
@@ -268,6 +268,46 @@ def resolve_fields_file(explicit_path=None):
     )
 
 
+def resolve_programs_file(explicit_path=None):
+    """Find the programs.toml file mapping program slugs to metadata.
+
+    Search order:
+    1. explicit_path (if provided and exists)
+    2. $CAMPFIRE_ROOT/config/programs.toml
+    3. ./programs.toml (backwards compat)
+
+    Returns
+    -------
+    str
+
+    Raises
+    ------
+    FileNotFoundError
+        If no programs file is found. Callers that treat the cross-check as
+        best-effort should catch this.
+    """
+    tried = []
+
+    if explicit_path and os.path.isfile(explicit_path):
+        return explicit_path
+    if explicit_path:
+        tried.append(explicit_path)
+
+    campfire_root = _get_campfire_root()
+    candidate = os.path.join(campfire_root, 'config', 'programs.toml')
+    if os.path.isfile(candidate):
+        return candidate
+    tried.append(candidate)
+
+    if os.path.isfile('programs.toml'):
+        return 'programs.toml'
+    tried.append('programs.toml')
+
+    raise FileNotFoundError(
+        f"programs.toml not found. Searched: {tried}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Stage config getters
 # ---------------------------------------------------------------------------

--- a/pipeline/campfire_pipeline/nirspec/observation.py
+++ b/pipeline/campfire_pipeline/nirspec/observation.py
@@ -16,6 +16,43 @@ from astropy.table import Table
 from campfire_pipeline.common.io import log
 
 
+def _validate_program_slug(obs_name, program_slug):
+    """Best-effort check that observations.toml ``program`` is a real slug.
+
+    A program *name*/slug mix-up is otherwise baked into the ECSV metadata
+    here and only surfaces much later at deploy time as a cryptic Supabase
+    RLS error. Validation requires programs.toml; its absence is not an error
+    (the pipeline is usable without it).
+    """
+    from campfire_pipeline.config import resolve_programs_file
+
+    try:
+        programs_file = resolve_programs_file()
+    except FileNotFoundError:
+        return
+
+    with open(programs_file, 'r') as f:
+        programs = toml.load(f)
+
+    if program_slug in programs:
+        return
+
+    matches = [
+        slug for slug, info in programs.items()
+        if str(info.get('program_name', '')).lower() == str(program_slug).lower()
+    ]
+    hint = (
+        f" '{program_slug}' is the program_name of slug '{matches[0]}' — use "
+        f"the slug, not the name." if matches else ''
+    )
+    known = ', '.join(sorted(programs)) or '(none)'
+    raise ValueError(
+        f"Observation '{obs_name}': program '{program_slug}' is not a slug in "
+        f"{programs_file}.{hint} Program slugs are the [section] keys in "
+        f"programs.toml; known slugs: {known}."
+    )
+
+
 @dataclass
 class Observation:
     name: str
@@ -46,6 +83,7 @@ class Observation:
 
         field_name = obs['field']
         program_slug = obs['program']
+        _validate_program_slug(name, program_slug)
         data_subdir = obs['data_subdir']
         gratings = obs.get('gratings', [])
 

--- a/python/campfire/deploy/config.py
+++ b/python/campfire/deploy/config.py
@@ -280,6 +280,44 @@ def resolve_program_slug(obs_name: str) -> str:
     return ''
 
 
+def validate_program_slug(program_slug: str, programs_config: dict, obs_name: str) -> None:
+    """Ensure *program_slug* is a real slug defined in programs.toml.
+
+    Guards against the common mistake of putting a program *name* (or any
+    other non-slug string) in the observations.toml ``program`` field. That
+    value is baked into the ECSV metadata by the pipeline and, left
+    unguarded, silently creates a junk private program at deploy time; the
+    observation insert then fails its representation read-back with a cryptic
+    Supabase error (``new row violates row-level security policy``). Fail
+    early here with an actionable message instead.
+    """
+    if program_slug in programs_config:
+        return
+
+    # Did they use the program *name* instead of the slug?
+    matches = [
+        slug for slug, info in programs_config.items()
+        if str(info.get('program_name', '')).lower() == str(program_slug).lower()
+    ]
+    known = ', '.join(sorted(programs_config)) or '(none)'
+    print(
+        f"Error: observation '{obs_name}' resolves to program_slug "
+        f"'{program_slug}', which is not a program defined in programs.toml."
+    )
+    if matches:
+        print(
+            f"  '{program_slug}' is the program_name of slug '{matches[0]}' "
+            f"— use the slug, not the name."
+        )
+    print("  Program slugs are the [section] keys in programs.toml.")
+    print(f"  Known slugs: {known}")
+    print(
+        f"  Fix the 'program' field in observations.toml, then regenerate the "
+        f"ECSV metadata (e.g. 'cfpipe nirspec summary --obs {obs_name}')."
+    )
+    sys.exit(1)
+
+
 def resolve_field(obs_name: str) -> str:
     """Get field name for an observation from observations.toml."""
     obs = load_observations()

--- a/python/campfire/deploy/deploy.py
+++ b/python/campfire/deploy/deploy.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 from tqdm import tqdm
 
-from campfire.deploy.config import load_observations, load_programs, resolve_field, resolve_imaging_config, resolve_obs_dir
+from campfire.deploy.config import load_observations, load_programs, resolve_field, resolve_imaging_config, resolve_obs_dir, validate_program_slug
 from campfire.deploy.discover import (
     discover_pointings_ecsv,
     discover_rgb_images,
@@ -159,6 +159,14 @@ def deploy_observation(
 
     field = get_field(summary)
     program_slug = get_program_slug(summary)
+
+    # Validate the program slug resolves to a known program before doing any
+    # work (including dry runs). A slug/name mix-up in observations.toml is
+    # otherwise baked into the ECSV and only surfaces downstream as a cryptic
+    # Supabase RLS error.
+    programs_config = load_programs()
+    validate_program_slug(program_slug, programs_config, obs_name)
+
     objects = get_unique_objects(summary)
     spectra = get_spectra_records(summary, obs_name)
     spec_paths = get_spec_paths(summary, obs_dir)
@@ -279,7 +287,6 @@ def deploy_observation(
         return {'field': field, 'needs_reconcile': False}
 
     # --- Live deployment ---
-    programs_config = load_programs()
     sb = get_supabase_client(config)
 
     # Check for existing targets and confirm

--- a/python/campfire/deploy/supabase.py
+++ b/python/campfire/deploy/supabase.py
@@ -194,7 +194,20 @@ def upsert_programs(
 ) -> None:
     """Upsert program records."""
     for slug in program_slugs:
-        info = programs_config.get(slug, {})
+        if slug not in programs_config:
+            # Refuse to invent a program from defaults: that silently creates
+            # a junk private program (is_public=False, empty metadata) and is
+            # what turns a slug/name mix-up into a cryptic RLS failure on the
+            # observation insert. Callers should validate first; this is the
+            # defense-in-depth backstop.
+            known = ', '.join(sorted(programs_config)) or '(none)'
+            raise ValueError(
+                f"Program slug '{slug}' is not defined in programs.toml; "
+                f"refusing to create a program from defaults. This usually "
+                f"means a program name was used where a slug was expected. "
+                f"Known slugs: {known}."
+            )
+        info = programs_config[slug]
         data = {
             'slug': slug,
             'program_name': info.get('program_name', slug),


### PR DESCRIPTION
## Summary

Add early validation of the `program` field in `observations.toml` to catch slug/name mix-ups before they are baked into ECSV metadata. A program name used where a slug is expected silently creates a junk private program at deploy time, surfacing only as a cryptic Supabase row-level-security error. This change fails fast with an actionable error message instead.

## Changes

**Pipeline (`pipeline/campfire_pipeline/`)**
- Add `resolve_programs_file()` to locate `programs.toml` (search: explicit path → `$CAMPFIRE_ROOT/config/programs.toml` → `./programs.toml`)
- Add `_validate_program_slug()` in `nirspec/observation.py` to validate the program field against `programs.toml` when present; includes a helpful hint if the value matches a program *name* instead of a slug
- Call validation in `Observation.load()` immediately after reading the program field from `observations.toml`
- Update `CHANGELOG.md` under Infrastructure

**Deploy (`python/campfire/deploy/`)**
- Add `validate_program_slug()` in `config.py` to check that a program slug is defined in `programs_config`; prints actionable error messages and exits if validation fails
- Add defense-in-depth check in `supabase.py` `upsert_programs()` to refuse creating a program from defaults if the slug is not in `programs_config`
- Call `validate_program_slug()` early in `deploy.py` `deploy_observation()` before any work (including dry runs), with clear error messaging

## Implementation Details

- Pipeline-side validation is best-effort: if `programs.toml` is missing, validation is skipped (the pipeline is usable without it)
- Deploy-side validation is strict: the program slug must be defined in `programs_config` before proceeding
- Both implementations detect when a program *name* was used instead of a slug and provide a specific hint
- Error messages include the list of known slugs to guide users toward the correct value

https://claude.ai/code/session_01UEuKWhYi4cGj97GVNaADtL