### PR TITLE
fix(nircam): make jhat alignment robust to refcat-footprint-edge exposures

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -47,6 +47,30 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- NIRCam `jhat` WCS-alignment step no longer aborts the entire `process` run
+  on exposures near/over the edge of the reference-catalog footprint. Two
+  distinct jhat crash modes were taking down the whole run (one bad exposure
+  killed the other 1600+):
+  - *Zero refcat overlap.* When no refcat sources land on the detector, jhat
+    skips its matching steps leaving `refcat_xcol` unset, then indexes
+    `phot.t[None]` and raises a bare `KeyError(None)`. `jhat_step` now catches
+    that specific signature, leaves the input WCS untouched, and stamps
+    `CFP_JHAT=NO_REFCAT_OVERLAP` so the exposure reads as
+    intentionally-not-aligned and isn't retried every run.
+  - *Degenerate diagnostic plot.* jhat's dx/dy plotters compute a NaN axis
+    limit from a degenerate best-match panel (few matches, common at the
+    footprint edge) and raise `ValueError: Axis limits cannot be NaN or Inf` —
+    sometimes *after* a perfectly good WCS solution has already been written,
+    so the crash discarded a valid alignment. The plots are diagnostic-only,
+    but jhat gates them on several independent flags not all reachable through
+    `align_wcs`, so the `saveplots` config flag alone can't suppress them.
+    Diagnostic plotting now defaults to off and is enforced by no-op'ing jhat's
+    plot functions at the source; the affected exposures align normally. Plots
+    re-enable per-field with `[<field>.jhat].saveplots = true` (restoring the
+    crash risk on edge exposures).
+  Net effect: the `process` run completes, edge exposures with real refcat
+  coverage are aligned and included, and only the truly-uncoverable ones are
+  skipped (and recorded as such). Genuine alignment errors still propagate.
 - `Observation.load` now validates the observations.toml `program` field
   against `programs.toml` (when present): if the value is not a known program
   *slug* it raises immediately, with a hint when the value matches a program

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -271,7 +271,12 @@
     objmag_lim = [19, 28]
     delta_mag_lim = [-3, 4]
     histocut_order = "dxdy"
-    saveplots = true
+    # Off by default: jhat's diagnostic dxdy_plot crashes with "Axis limits
+    # cannot be NaN or Inf" on exposures with a degenerate best-match sub-panel
+    # (common near the refcat-footprint edge), aborting the run *after* a valid
+    # WCS solution is already computed. Plots are diagnostic-only. Set true to
+    # restore them on fields known to be free of edge exposures.
+    saveplots = false
     savephottable = true
 
 # --- combine phase (ensemble) ---

--- a/pipeline/campfire_pipeline/nircam/steps/jhat.py
+++ b/pipeline/campfire_pipeline/nircam/steps/jhat.py
@@ -25,6 +25,62 @@ from campfire_pipeline.common.io import log, atomic_save
 from campfire_pipeline.common import cfp
 
 
+# Sentinel stamped into CFP_JHAT when an exposure cannot be aligned because it
+# lies at/beyond the edge of the reference catalog footprint (zero refcat
+# sources land on the detector). The input WCS is left untouched. Recorded so
+# the exposure reads as intentionally-not-aligned and isn't retried every run.
+NO_REFCAT_SENTINEL = 'NO_REFCAT_OVERLAP'
+
+
+def _disable_jhat_plots():
+    """No-op jhat's diagnostic plot functions so they can't abort a run.
+
+    jhat's dx/dy diagnostic plotters compute a NaN axis limit and raise
+    ``ValueError: Axis limits cannot be NaN or Inf`` on exposures whose
+    best-match panel is degenerate (common near the edge of the reference
+    catalog's footprint, where few sources match). That crash happens *inside*
+    ``run_all`` and takes down the whole batch -- in some code paths *after* a
+    perfectly good WCS solution has already been written. The plots are purely
+    diagnostic, but jhat gates them on several independent flags (``saveplots``,
+    ``showplots``, ``show_initial_plot``), not all reachable through
+    ``align_wcs``, so the config flag alone can't suppress them. We disable them
+    at the source by replacing the plot functions with no-ops.
+
+    Reaching the right namespace is subtle: jhat's package ``__init__`` rebinds
+    the ``st_wcs_align`` attribute on the ``jhat`` package from the *submodule*
+    to a same-named *class*, so ``import jhat.st_wcs_align`` yields the class,
+    not the module. The plot functions are module-level globals referenced by
+    ``run_all`` at call time, so we patch the dict ``run_all`` actually resolves
+    against: ``run_all.__globals__``.
+    """
+    from jhat.st_wcs_align import st_wcs_align as _WcsAlign
+    plot_globals = _WcsAlign.run_all.__globals__
+
+    def _noop(*args, **kwargs):
+        return None
+
+    for fn_name in ('dxdy_plot', 'initial_dxdy_plot', 'infoplots',
+                    'plot_rotated'):
+        if fn_name in plot_globals:
+            plot_globals[fn_name] = _noop
+
+
+def _stamp_jhat(exposure_file, value):
+    """Atomically set CFP_JHAT=*value* on *exposure_file* (header only).
+
+    Used for the no-refcat-overlap skip path, where jhat produces no output
+    to promote -- we stamp the canonical file in place. Writes to a sibling
+    .tmp on the same filesystem then renames, mirroring the atomicity the rest
+    of this module relies on for networked-FS clusters.
+    """
+    base, ext = os.path.splitext(exposure_file)
+    tmp_path = f'{base}.tmp{ext}'
+    with fits.open(exposure_file) as hdul:
+        hdul[0].header['CFP_JHAT'] = (value, cfp.CFP_COMMENTS['CFP_JHAT'])
+        hdul.writeto(tmp_path, overwrite=True)
+    os.replace(tmp_path, exposure_file)
+
+
 def _copy_diagnostics(scratch_subdir, diag_dir, rootname):
     """Move jhat's diagnostic PDFs and ECSV photometry tables to ``diag_dir``."""
     if not os.path.isdir(scratch_subdir):
@@ -65,6 +121,12 @@ def jhat_step(exposure_file, field, step_config, overwrite=False, status=None):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         from jhat import align_wcs_batch
+
+    # Unless diagnostics are explicitly requested, neutralize jhat's plotting:
+    # it crashes the run on degenerate-match (footprint-edge) exposures and the
+    # config ``saveplots`` flag can't fully suppress it. See _disable_jhat_plots.
+    if not step_config.get('saveplots', False):
+        _disable_jhat_plots()
 
     rootname = os.path.basename(exposure_file).removesuffix('.fits')
     filtname = exposure_file.split('/')[-2]
@@ -163,9 +225,29 @@ def jhat_step(exposure_file, field, step_config, overwrite=False, status=None):
                 iterate_with_xyshifts=step_config.get('iterate_with_xyshifts',
                                                      True),
                 showplots=0,
-                saveplots=step_config.get('saveplots', True),
+                # Off by default; jhat's plotters are also no-op'd above unless
+                # this is set (see _disable_jhat_plots). Re-enable diagnostics
+                # per-field via [<field>.jhat].saveplots = true.
+                saveplots=step_config.get('saveplots', False),
                 savephottable=step_config.get('savephottable', True),
             )
+        except KeyError as e:
+            # jhat raises a bare ``KeyError(None)`` when it finds zero
+            # reference sources within the image bounds: it prints
+            # "0 sources from reference catalog within the image bounderies"
+            # and skips the matching steps, leaving ``refcat_xcol`` unset, then
+            # indexes ``phot.t[None]``. This means the exposure lies at/over
+            # the edge of the refcat footprint -- a data-coverage condition,
+            # not a campfire failure -- so it must not abort the whole run.
+            # Record the skip and move on; the input WCS is preserved.
+            if e.args == (None,):
+                log(f"jhat: no refcat overlap for {rootname}; skipping "
+                    f"alignment (input WCS preserved, CFP_JHAT="
+                    f"{NO_REFCAT_SENTINEL})")
+                _stamp_jhat(exposure_file, NO_REFCAT_SENTINEL)
+                return
+            log(f"jhat failed on {exposure_file}")
+            raise
         except Exception:
             log(f"jhat failed on {exposure_file}")
             raise


### PR DESCRIPTION
## Problem

`cfpipe nircam process --field cosmos --filters f444w` crashed with `KeyError: None` deep inside jhat's WCS alignment. A single un-alignable edge exposure aborted the **entire** run — 1 of 1605 f444w exposures failing killed everything.

Investigation found **two distinct** jhat crash modes, both tied to exposures near/over the edge of the reference-catalog footprint:

1. **Zero refcat overlap** — when no refcat sources land on the detector, jhat prints `0 sources from reference catalog within the image bounderies`, skips its matching steps leaving `refcat_xcol` unset, then indexes `phot.t[None]` → bare `KeyError(None)`.
2. **Degenerate diagnostic plot** — jhat's dx/dy plotters compute a NaN axis limit from a degenerate best-match panel (few matches, common at the footprint edge) → `ValueError: Axis limits cannot be NaN or Inf`. Critically this sometimes fires *after* a perfectly good WCS solution has already been written, discarding a valid alignment.

## Fix

- **Zero overlap:** `jhat_step` catches the specific `KeyError(None)` signature, leaves the input WCS untouched, and stamps `CFP_JHAT=NO_REFCAT_OVERLAP` so the exposure reads as intentionally-not-aligned and isn't retried every run.
- **Degenerate plot:** Diagnostic plotting defaults to off and is enforced by no-op'ing jhat's plot functions at the source (`run_all.__globals__`). The config `saveplots` flag alone can't suppress them — jhat gates plots on several independent flags not all reachable through `align_wcs`. Plots re-enable per-field via `[<field>.jhat].saveplots = true` (restoring the crash risk on edge exposures).

Genuine alignment errors still propagate (`debug=True` preserved; only the exact `KeyError(None)` zero-overlap signature is swallowed).

## Verification

End-to-end `cfpipe` run, exit 0:
- footprint-edge `nrcalong` (zero overlap) → `CFP_JHAT='NO_REFCAT_OVERLAP'`, input WCS preserved
- two `nrcblong` edge exposures with real coverage (2330/4910 matched sources) → aligned normally, `CFP_JHAT='cosmos2025_v1_refcat.ecsv'`
- idempotent re-run: 1605/1605 already stamped, 0 dispatched, no crash

## Changelog

Categorized **Infrastructure** (PATCH) — no change to scientific output for alignable exposures; previously-crashing edge exposures now either align correctly or are explicitly skipped.

Generated with Claude Code