### PR TITLE
Handle missing NOD_TYPE keyword in NIRSpec Cycle 1 files

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -161,6 +161,13 @@ Release procedure: edit the `## Unreleased` section below, then run
   Per-request backoff sleeps also gained ±1s of jitter so the parallel
   workers don't retry in lockstep against an overloaded endpoint. No change
   to which products are returned on success.
+- NIRSpec file ingest no longer crashes with `KeyError: 'NOD_TYPE'` on
+  programs whose exposures omit the `NOD_TYPE` primary-header keyword (seen in
+  some Cycle 1 programs). `Observation` table building (`observation.py`) and
+  the stage-3 exposures table (`stage3.py`) now read it through a shared
+  `read_nod_type` helper that falls back to `3-SHUTTER-SLITLET` (the canonical
+  `N-SHUTTER-SLITLET` form for a 3-shutter slitlet) and logs a warning naming
+  the offending file. Files that already carry `NOD_TYPE` are unaffected.
 
 ## v0.5.1 — 2026-05-27
 

--- a/pipeline/campfire_pipeline/nirspec/observation.py
+++ b/pipeline/campfire_pipeline/nirspec/observation.py
@@ -15,6 +15,37 @@ from astropy.table import Table
 
 from campfire_pipeline.common.io import log
 
+# Default slitlet assumed when a file is missing the NOD_TYPE keyword.
+# Some Cycle 1 programs do not write NOD_TYPE; the canonical format is
+# "N-SHUTTER-SLITLET", so a 3-shutter slitlet is "3-SHUTTER-SLITLET".
+DEFAULT_NOD_TYPE = '3-SHUTTER-SLITLET'
+
+
+def read_nod_type(hdr, filename):
+    """Read NOD_TYPE from a primary header, defaulting if missing.
+
+    Some Cycle 1 programs do not write the NOD_TYPE keyword. When it is
+    absent we assume a 3-shutter slitlet (`DEFAULT_NOD_TYPE`) and emit a
+    warning so the assumption is visible.
+
+    Parameters
+    ----------
+    hdr : astropy.io.fits.Header
+        Primary header to read from.
+    filename : str
+        File path or name, used only for the warning message.
+
+    Returns
+    -------
+    str
+        The NOD_TYPE value, or `DEFAULT_NOD_TYPE` if the keyword is absent.
+    """
+    if 'NOD_TYPE' in hdr:
+        return hdr['NOD_TYPE']
+    log(f"WARNING: NOD_TYPE keyword missing from {os.path.basename(filename)}; "
+        f"assuming {DEFAULT_NOD_TYPE}")
+    return DEFAULT_NOD_TYPE
+
 
 def _validate_program_slug(obs_name, program_slug):
     """Best-effort check that observations.toml ``program`` is a real slug.
@@ -407,7 +438,7 @@ class Observation:
             PRIDTPTS.append(hdr['PRIDTPTS'])
             PATT_NUM.append(hdr['PATT_NUM'])
             NUMDTHPT.append(hdr['NUMDTHPT'])
-            NOD_TYPE.append(hdr['NOD_TYPE'])
+            NOD_TYPE.append(read_nod_type(hdr, f))
             SUBPXPTS.append(hdr['SUBPXPTS'])
             hdr1 = fits.getheader(f, ext=1)
             SHUTTRID.append(hdr1['SHUTTRID'])

--- a/pipeline/campfire_pipeline/nirspec/stage3.py
+++ b/pipeline/campfire_pipeline/nirspec/stage3.py
@@ -14,6 +14,7 @@ from astropy.io.fits import table_to_hdu
 from jwst import associations
 
 from campfire_pipeline.common.io import log
+from campfire_pipeline.nirspec.observation import read_nod_type
 from campfire_pipeline.nirspec.extraction import (
     boxcar_profile,
     optext_profile,
@@ -248,7 +249,7 @@ def run_stage3_single_source(
         exposures = Table()
         exposures['filename'] = cal_files
         exposures['dither_type'] = [hdr['PATTTYPE'] for hdr in hdrs0]
-        exposures['nod_type'] = [hdr['NOD_TYPE'] for hdr in hdrs0]
+        exposures['nod_type'] = [read_nod_type(hdr, fn) for hdr, fn in zip(hdrs0, cal_files)]
         exposures['nod_number'] = [hdr['PRIDTPTS'] for hdr in hdrs0]
         exposures['dither_number'] = [hdr['PATT_NUM'] for hdr in hdrs0]
         exposures['exptime'] = [hdr['EFFEXPTM'] for hdr in hdrs0]


### PR DESCRIPTION
## Summary

Fixes crashes when processing NIRSpec exposures from some Cycle 1 programs that omit the `NOD_TYPE` primary-header keyword. The pipeline now gracefully defaults to `3-SHUTTER-SLITLET` (the canonical form for a 3-shutter slitlet) and logs a warning identifying the affected file.

## Changes

- **`observation.py`**: Added `read_nod_type()` helper function that reads `NOD_TYPE` from a FITS header, falling back to `DEFAULT_NOD_TYPE` (`'3-SHUTTER-SLITLET'`) if the keyword is absent. Emits a warning with the filename when defaulting.
- **`observation.py`**: Updated `discover_files()` to use `read_nod_type()` instead of direct header access, preventing `KeyError` on missing `NOD_TYPE`.
- **`stage3.py`**: Updated exposures table construction to use the shared `read_nod_type()` helper, ensuring consistent handling across the pipeline.
- **`CHANGELOG.md`**: Documented the fix under Unreleased.

## Implementation Details

The `read_nod_type()` function is shared between `observation.py` and `stage3.py` to ensure consistent behavior across file ingest and stage-3 processing. Files that already carry the `NOD_TYPE` keyword are unaffected; only missing keywords trigger the default and warning.

https://claude.ai/code/session_01LLBFLXr2PkvfxrvEU6oioc