### PR TITLE
fix(nircam): re-split resample extensions after an interrupted run

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -62,6 +62,16 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- NIRCam `resample` now recovers split-extension files after an interrupted
+  run. Previously the `_sci/_err/_wht/_srcmask` split was gated solely on
+  `needs_rebuild`, which only checks for the `_i2d.fits` mosaic. If a prior run
+  produced the i2d but crashed before splitting, a re-run found the i2d present
+  and inputs unchanged, took the up-to-date branch, and skipped splitting — so
+  the extension files (and their `_latest_` symlinks) were never created
+  without a manual `--overwrite`. The step now detects missing extension files
+  for an otherwise up-to-date tile and re-splits from the existing i2d (no
+  re-drizzle, no bkgsub redo). SRCMASK is only re-split when the i2d actually
+  carries that extension.
 - NIRCam `jhat` WCS-alignment step no longer aborts the entire `process` run
   on exposures near/over the edge of the reference-catalog footprint. Two
   distinct jhat crash modes were taking down the whole run (one bad exposure

--- a/pipeline/campfire_pipeline/nircam/steps/resample.py
+++ b/pipeline/campfire_pipeline/nircam/steps/resample.py
@@ -350,7 +350,35 @@ def resample_step(filtname, exposure_files, field, step_config,
                         f"({n_no_cov / sci.size * 100:.1f}%)"
                     )
 
-        do_split = needs_rebuild and step_config.get('split_extensions', True)
+        split_enabled = step_config.get('split_extensions', True)
+
+        # Recover from a prior run that produced the i2d but failed (or was
+        # interrupted) before writing the separated extension files. Since
+        # splitting only reads from the existing i2d, we can re-split without
+        # re-drizzling. needs_rebuild stays False, so bkgsub and the NaN-fill
+        # (both already baked into the on-disk i2d) are not redone.
+        missing_extensions = False
+        if split_enabled and not needs_rebuild and os.path.exists(mosaic_file):
+            base = os.path.basename(mosaic_file)
+            required = ('_sci.fits', '_err.fits', '_wht.fits')
+            missing_extensions = any(
+                not os.path.exists(os.path.join(
+                    mosaic_outdir, base.replace('_i2d.fits', suffix)))
+                for suffix in required
+            )
+            if not missing_extensions:
+                # SRCMASK is only expected when the i2d carries that extension.
+                srcmask_path = os.path.join(
+                    mosaic_outdir, base.replace('_i2d.fits', '_srcmask.fits'),
+                )
+                if not os.path.exists(srcmask_path):
+                    with fits.open(mosaic_file) as hdul:
+                        missing_extensions = 'SRCMASK' in hdul
+            if missing_extensions:
+                log(f"  {mosaic_name} i2d present but split extensions "
+                    f"missing; re-splitting")
+
+        do_split = (needs_rebuild or missing_extensions) and split_enabled
         do_plot = needs_rebuild and step_config.get('plot', True)
 
         if do_split or do_plot:


### PR DESCRIPTION
## Problem

If the NIRCam `resample` (drizzle-combine) step produces the `_i2d.fits` mosaic but crashes/is interrupted before writing the separated extension files, a re-run does **not** regenerate them.

The split was gated solely on `needs_rebuild`:

```python
do_split = needs_rebuild and step_config.get('split_extensions', True)
```

…and `needs_rebuild` only becomes `True` when `--overwrite` is set, the **`_i2d.fits` is absent**, or the manifest reports inputs/config changed. It never checks whether `_sci/_err/_wht/_srcmask` exist. So with the i2d present and inputs unchanged, the step takes the up-to-date branch and silently leaves you with an i2d but no extension files. The `_latest_` symlink loop only links extensions that exist, so those symlinks were skipped too. Recovery required a manual `--overwrite` (full re-drizzle).

## Fix

For an otherwise up-to-date tile, detect missing extension files and re-split from the existing i2d. Splitting only reads from the i2d, so:

- no re-drizzle,
- `needs_rebuild` stays `False`, so bkgsub and the WHT=0 NaN-fill (both already baked into the on-disk i2d) are not redone.

SRCMASK is only treated as missing when the i2d actually carries a `SRCMASK` extension, matching the existing conditional-split behavior.

## Changelog

Added under **Infrastructure** (no change to scientific output → PATCH).

Generated with Claude Code