### PR TITLE
perf(nircam): lazy step-module imports to cut cfpipe startup latency

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -62,6 +62,19 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- NIRCam CLI startup is now proportional to the work being run, not to the
+  whole step catalog. `orchestrate.py` previously imported all 14 step modules
+  at module top, so every `cfpipe nircam` invocation — including `--help` and a
+  `combine` run that touches none of the process-phase steps — eagerly imported
+  `photutils.segmentation` (via `wisp`/`striping`) and `matplotlib` (via
+  `outlier`). On cluster NFS that was ~140s for photutils + ~40s for matplotlib
+  of pure startup latency before the first log line. Step workers are now
+  imported lazily inside their runner functions (only when a phase actually
+  dispatches the step), and the headless matplotlib backend is selected via
+  `MPLBACKEND=Agg` in `_thread_caps` instead of an eager
+  `import matplotlib; matplotlib.use('Agg')` in each CLI module. No change to
+  outputs or step behavior; `import campfire_pipeline.nircam.cli` now loads zero
+  step modules and zero heavy scientific deps.
 - NIRCam `jhat` WCS-alignment step no longer aborts the entire `process` run
   on exposures near/over the edge of the reference-catalog footprint. Two
   distinct jhat crash modes were taking down the whole run (one bad exposure

--- a/pipeline/campfire_pipeline/_thread_caps.py
+++ b/pipeline/campfire_pipeline/_thread_caps.py
@@ -1,5 +1,5 @@
 """
-Pin BLAS / OpenMP thread counts to 1 by default.
+Pin BLAS / OpenMP thread counts to 1 and force the matplotlib Agg backend.
 
 Imported as the *first* thing by every ``cfpipe`` entry point, before
 matplotlib/numpy/astropy. The pipeline parallelizes via fork-pool
@@ -15,6 +15,13 @@ already exported wins. ``setup_environment`` also applies the same
 defaults for the programmatic-import path; this module is the
 defense-in-depth that runs before any module that might trigger a BLAS
 call at import time.
+
+``MPLBACKEND=Agg`` is set here for the same reason: it selects the
+headless backend at matplotlib *import* time without us having to
+``import matplotlib; matplotlib.use('Agg')`` eagerly in every CLI module.
+That eager import cost ~40s on cluster NFS for every command — including
+ones that never plot — so the CLIs now rely on this env var and import
+matplotlib lazily only where they actually draw.
 """
 
 import os
@@ -30,3 +37,7 @@ _BLAS_THREAD_VARS = (
 
 for _v in _BLAS_THREAD_VARS:
     os.environ.setdefault(_v, '1')
+
+# Headless backend, chosen at matplotlib import time. setdefault so an
+# explicit user MPLBACKEND still wins.
+os.environ.setdefault('MPLBACKEND', 'Agg')

--- a/pipeline/campfire_pipeline/cli.py
+++ b/pipeline/campfire_pipeline/cli.py
@@ -15,9 +15,6 @@ import os
 import sys
 from pathlib import Path
 
-import matplotlib
-matplotlib.use('Agg')
-
 import click
 
 from campfire_pipeline.config import load_config, setup_environment, resolve_paths

--- a/pipeline/campfire_pipeline/nircam/cli.py
+++ b/pipeline/campfire_pipeline/nircam/cli.py
@@ -20,9 +20,6 @@ from campfire_pipeline import _thread_caps  # noqa: F401  (must precede numpy/ma
 
 import os
 
-import matplotlib
-matplotlib.use('Agg')
-
 import click
 
 from campfire_pipeline.config import load_config, setup_environment

--- a/pipeline/campfire_pipeline/nircam/expmap.py
+++ b/pipeline/campfire_pipeline/nircam/expmap.py
@@ -42,9 +42,6 @@ import os
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
-import matplotlib
-matplotlib.use('Agg')
-
 import numpy as np
 import tqdm
 from astropy.coordinates import SkyCoord

--- a/pipeline/campfire_pipeline/nircam/orchestrate.py
+++ b/pipeline/campfire_pipeline/nircam/orchestrate.py
@@ -13,8 +13,10 @@ The legacy ``stage1.py`` / ``stage2.py`` / ``stage3.py`` orchestrators
 remain in place for now but are not invoked from the new CLI.
 """
 
+import functools
 import os
 import warnings
+from importlib import import_module
 
 from astropy.io import fits
 
@@ -23,25 +25,17 @@ from campfire_pipeline.common.parallel import dispatch
 from campfire_pipeline.config import get_nircam_step_config
 
 from campfire_pipeline.nircam.status import StepStatus
-from campfire_pipeline.nircam.steps.detector1 import detector1_step
-from campfire_pipeline.nircam.steps.persistence import persistence_step
-from campfire_pipeline.nircam.steps.wisp import wisp_step
-from campfire_pipeline.nircam.steps.striping import striping_step
-from campfire_pipeline.nircam.steps.image2 import image2_step
-from campfire_pipeline.nircam.steps.diag_striping import diag_striping_step
-from campfire_pipeline.nircam.steps.edge import edge_step
-from campfire_pipeline.nircam.steps.sky import sky_step
-from campfire_pipeline.nircam.steps.variance import variance_step
-from campfire_pipeline.nircam.steps.wcs_shift import wcs_shift_step, _match_rule
-from campfire_pipeline.nircam.steps.preview import preview_step
-from campfire_pipeline.nircam.steps.jhat import jhat_step
-from campfire_pipeline.nircam.steps.apply_masks import apply_masks_step
-from campfire_pipeline.nircam.steps.bad_pixel import (
-    build_bad_pixel_masks, bad_pixel_step,
-)
-from campfire_pipeline.nircam.steps.outlier import outlier_step
-from campfire_pipeline.nircam.steps.resample import resample_step
-from campfire_pipeline.nircam.prefetch import prefetch_process_references
+
+# Step worker functions are imported lazily (see ``_load_step`` and the
+# per-runner local imports below), NOT at module top. Each step module pulls
+# in heavy scientific deps — photutils.segmentation via wisp/striping
+# (~140s to import on cluster NFS), matplotlib via outlier, the jwst/crds
+# stack via detector1/image2/jhat. Importing ``orchestrate`` is what every
+# ``cfpipe`` invocation does (the NIRCam CLI imports it at module top), so an
+# eager step import made *every* command — including ``--help`` and a
+# ``combine`` run that never touches the process-phase steps — pay for all of
+# them. Deferring the import to the moment a phase actually dispatches a step
+# keeps startup proportional to the work being done.
 
 
 # Step ordering — also used by the CLI to validate ``cfpipe nircam <step>``
@@ -75,6 +69,33 @@ STEP_NAMES = [name for name, _ in ALL_STEPS]
 # Steps that hit CRDS — used by run_step() to decide when to pre-fetch
 # reference files before parallel dispatch.
 _CRDS_STEPS = {'detector1', 'wisp', 'striping', 'image2'}
+
+# Per-exposure steps dispatched through the generic ``_run_per_exposure``
+# helper: step_name -> (step module basename, worker callable, CFP key). The
+# module is imported lazily inside the runner so ``orchestrate`` import never
+# drags in a step the current phase won't run.
+_PER_EXPOSURE_STEPS = {
+    'wisp':       ('wisp',        'wisp_step',        'CFP_WISP'),
+    'striping':   ('striping',    'striping_step',    'CFP_1F'),
+    'image2':     ('image2',      'image2_step',      'CFP_IMG2'),
+    'edge':       ('edge',        'edge_step',        'CFP_EDGE'),
+    'sky':        ('sky',         'sky_step',         'CFP_SKY'),
+    'variance':   ('variance',    'variance_step',    'CFP_VAR'),
+    'preview':    ('preview',     'preview_step',     'CFP_PREV'),
+    'jhat':       ('jhat',        'jhat_step',        'CFP_JHAT'),
+    'apply_mask': ('apply_masks', 'apply_masks_step', 'CFP_MASK'),
+}
+
+
+def _load_step(module_basename, func_name):
+    """Import and return a step's worker callable on demand.
+
+    Kept tiny and explicit so the lazy-import intent is obvious at each call
+    site — see the module docstring for why step modules are not imported at
+    the top of ``orchestrate``.
+    """
+    module = import_module(f'campfire_pipeline.nircam.steps.{module_basename}')
+    return getattr(module, func_name)
 
 
 # ---------------------------------------------------------------------------
@@ -181,6 +202,7 @@ def _run_detector1(field, config, filtname, n_processes, overwrite, status):
     if not pending:
         return
 
+    from campfire_pipeline.nircam.steps.detector1 import detector1_step
     cfg = get_nircam_step_config('detector1', config, field)
     log(f"detector1: dispatching {len(pending)} files for {filtname}")
     dispatch(detector1_step, pending, n_processes=n_processes,
@@ -209,18 +231,22 @@ def _run_persistence(field, config, filtname, n_processes, overwrite, status):
         log(f"persistence: CFP_PERS already set on all {len(exposures)} "
             f"exposures for {filtname}; skipping")
         return
+    from campfire_pipeline.nircam.steps.persistence import persistence_step
     cfg = get_nircam_step_config('persistence', config, field)
     persistence_step(exposures, field, cfg, overwrite=overwrite, status=status)
     status.mark_all(exposures, 'CFP_PERS')
 
 
-def _run_per_exposure(step_name, fn, cfp_key, field, config, filtname,
+def _run_per_exposure(step_name, field, config, filtname,
                       n_processes, overwrite, status):
     """Generic per-exposure parallel dispatch.
 
     Filters out already-stamped exposures *before* spinning up the worker
-    pool — a no-op pass on a finished field skips the Pool entirely.
+    pool — a no-op pass on a finished field skips the Pool entirely. The
+    step's worker callable is imported lazily here (after the early-out
+    checks), so a no-op pass doesn't import the step's heavy deps at all.
     """
+    module_basename, func_name, cfp_key = _PER_EXPOSURE_STEPS[step_name]
     exposures = field.get_exposure_files(filtname)
     if not exposures:
         log(f"{step_name}: no exposures for {filtname}")
@@ -229,6 +255,7 @@ def _run_per_exposure(step_name, fn, cfp_key, field, config, filtname,
                                  overwrite)
     if not pending:
         return
+    fn = _load_step(module_basename, func_name)
     cfg = get_nircam_step_config(step_name, config, field)
     log(f"{step_name}: dispatching {len(pending)} exposures for {filtname}")
     dispatch(fn, pending, n_processes=n_processes,
@@ -252,6 +279,7 @@ def _run_diag_striping(field, config, filtname, n_processes, overwrite, status):
                                  status, overwrite)
     if not pending:
         return
+    from campfire_pipeline.nircam.steps.diag_striping import diag_striping_step
     log(f"diag_striping: dispatching {len(pending)} exposures for {filtname}")
     dispatch(diag_striping_step, pending, n_processes=n_processes,
              field=field, step_config=cfg, overwrite=overwrite,
@@ -271,6 +299,9 @@ def _run_wcs_shift(field, config, filtname, n_processes, overwrite, status):
         log(f"wcs_shift: no exposures for {filtname}")
         return
 
+    from campfire_pipeline.nircam.steps.wcs_shift import (
+        wcs_shift_step, _match_rule,
+    )
     # Pre-filter to exposures actually matched by some rule. Saves I/O on
     # the (typical) majority of files that no rule touches — they're never
     # stamped, so _filter_pending wouldn't catch them.
@@ -308,6 +339,9 @@ def _run_bad_pixel(field, config, filtname, n_processes, overwrite, status):
     if not cfg.get('enabled', False):
         log(f"bad_pixel: disabled by config; skipping {filtname}")
         return
+    from campfire_pipeline.nircam.steps.bad_pixel import (
+        build_bad_pixel_masks, bad_pixel_step,
+    )
     # Ensemble: build per-detector masks once (no CFP key — it's a reference
     # product, not a per-exposure mutation). Cheap to call when up-to-date,
     # but we still skip when --overwrite is off and all reference products
@@ -446,6 +480,7 @@ def _run_resample(field, config, filtname, n_processes, overwrite, status,
     if not exposures:
         log(f"resample: no CFP_OUT-stamped exposures for {filtname}")
         return
+    from campfire_pipeline.nircam.steps.resample import resample_step
     cfg = get_nircam_step_config('resample', config, field)
     resample_step(filtname, exposures, field, cfg, reduction_version,
                   overwrite=overwrite)
@@ -453,40 +488,24 @@ def _run_resample(field, config, filtname, n_processes, overwrite, status,
 
 # Dispatch table: step name → callable that takes (field, config, filtname,
 # n_processes, overwrite, status). Resample needs reduction_version, so it's
-# handled specially in run_combine / run_step. The lambda-wrapped entries
-# adapt the (step_name, fn, cfp_key) triple onto _run_per_exposure's signature.
+# handled specially in run_combine / run_step. Per-exposure steps bind their
+# name onto ``_run_per_exposure`` via ``functools.partial``; that runner looks
+# up the (module, worker, cfp_key) triple in ``_PER_EXPOSURE_STEPS`` and
+# imports the worker lazily when it actually dispatches.
 _RUNNERS = {
     'detector1':   _run_detector1,
     'persistence': _run_persistence,
-    'wisp':        lambda f, c, fl, n, ow, st: _run_per_exposure(
-                       'wisp', wisp_step, 'CFP_WISP',
-                       f, c, fl, n, ow, st),
-    'striping':    lambda f, c, fl, n, ow, st: _run_per_exposure(
-                       'striping', striping_step, 'CFP_1F',
-                       f, c, fl, n, ow, st),
-    'image2':      lambda f, c, fl, n, ow, st: _run_per_exposure(
-                       'image2', image2_step, 'CFP_IMG2',
-                       f, c, fl, n, ow, st),
+    'wisp':        functools.partial(_run_per_exposure, 'wisp'),
+    'striping':    functools.partial(_run_per_exposure, 'striping'),
+    'image2':      functools.partial(_run_per_exposure, 'image2'),
     'diag_striping': _run_diag_striping,
-    'edge':        lambda f, c, fl, n, ow, st: _run_per_exposure(
-                       'edge', edge_step, 'CFP_EDGE',
-                       f, c, fl, n, ow, st),
-    'sky':         lambda f, c, fl, n, ow, st: _run_per_exposure(
-                       'sky', sky_step, 'CFP_SKY',
-                       f, c, fl, n, ow, st),
-    'variance':    lambda f, c, fl, n, ow, st: _run_per_exposure(
-                       'variance', variance_step, 'CFP_VAR',
-                       f, c, fl, n, ow, st),
+    'edge':        functools.partial(_run_per_exposure, 'edge'),
+    'sky':         functools.partial(_run_per_exposure, 'sky'),
+    'variance':    functools.partial(_run_per_exposure, 'variance'),
     'wcs_shift':   _run_wcs_shift,
-    'preview':     lambda f, c, fl, n, ow, st: _run_per_exposure(
-                       'preview', preview_step, 'CFP_PREV',
-                       f, c, fl, n, ow, st),
-    'jhat':        lambda f, c, fl, n, ow, st: _run_per_exposure(
-                       'jhat', jhat_step, 'CFP_JHAT',
-                       f, c, fl, n, ow, st),
-    'apply_mask':  lambda f, c, fl, n, ow, st: _run_per_exposure(
-                       'apply_mask', apply_masks_step, 'CFP_MASK',
-                       f, c, fl, n, ow, st),
+    'preview':     functools.partial(_run_per_exposure, 'preview'),
+    'jhat':        functools.partial(_run_per_exposure, 'jhat'),
+    'apply_mask':  functools.partial(_run_per_exposure, 'apply_mask'),
     'bad_pixel':   _run_bad_pixel,
     'outlier':     _run_outlier,
     # 'resample' handled in run_combine/run_step (needs reduction_version)
@@ -547,6 +566,7 @@ def run_process(field, config, filters=None, n_processes=1, overwrite=False):
     persistence step runs serially since it operates over the whole filter
     set at once.
     """
+    from campfire_pipeline.nircam.prefetch import prefetch_process_references
     filters = _resolve_filters(filters, field)
     status = _scan_status(field, filters, overwrite=overwrite)
     log(f"=== Process phase: field={field.name}, filters={filters} ===")
@@ -591,6 +611,7 @@ def run_step(step_name, field, config, filters=None, n_processes=1,
     status = _scan_status(field, filters, overwrite=overwrite)
     log(f"=== Step '{step_name}': field={field.name}, filters={filters} ===")
     if step_name in _CRDS_STEPS:
+        from campfire_pipeline.nircam.prefetch import prefetch_process_references
         prefetch_process_references(field, filters, n_processes)
 
     for filt in filters:

--- a/pipeline/campfire_pipeline/nirspec/cli.py
+++ b/pipeline/campfire_pipeline/nirspec/cli.py
@@ -21,9 +21,6 @@ Also available directly as: campfire-nirspec <command>
 
 from campfire_pipeline import _thread_caps  # noqa: F401  (must precede numpy/matplotlib)
 
-import matplotlib
-matplotlib.use('Agg')
-
 import click
 
 from campfire_pipeline.config import load_config, setup_environment, resolve_paths, get_stage_config, resolve_template_grid_paths


### PR DESCRIPTION
## Problem

`cfpipe nircam combine` on the CANDIDE cluster took **~5 minutes** from command to the first log line (`Workspace ready`). Profiling with `python -X importtime` on the node showed the delay is entirely **import-bound**, dominated by two eager imports that the command never actually needs:

| Module | Cumulative import | Pulled in by |
|---|---|---|
| `photutils.segmentation` | **142 s (61% of startup)** | `steps.wisp`, `steps.striping` — **process-phase** steps |
| `matplotlib` | **41 s** | eager `import matplotlib` in every CLI module + `steps.outlier` |
| `import nircam.cli` (total) | **231 s** | |
| `python -c "pass"` | **7.2 s** | env is on slow NFS (local disk ≈ 0.02s) |

`orchestrate.py` imported all 14 step modules at module top, so importing the NIRCam CLI — which `orchestrate` does for *every* `cfpipe nircam` command, including `--help` — paid the photutils + matplotlib + scipy cost even for a `combine` run that touches none of the process-phase steps.

(The bigger systemic lever is getting the conda env off NFS — that 7s empty-interpreter start — but that's environmental. This PR removes the dead-weight imports from the code path.)

## Changes

**1. Lazy step-module imports in `orchestrate.py`.** Step workers are imported inside their runner functions (only when a phase actually dispatches the step), not at module top:
- Per-exposure steps resolve through a new `_PER_EXPOSURE_STEPS` table + `_load_step` helper; `_RUNNERS` binds names via `functools.partial`.
- Named runners (`detector1`, `persistence`, `diag_striping`, `wcs_shift`, `bad_pixel`, `resample`) do local imports. `outlier` already imported lazily.
- `prefetch_process_references` deferred into `run_process` / `run_step` (combine doesn't use it).
- For per-exposure and the opt-in steps, the import sits *after* the early-out checks, so a no-op pass (already-stamped / disabled) imports nothing.

**2. `MPLBACKEND=Agg` via `_thread_caps`.** Replaces the eager `import matplotlib; matplotlib.use('Agg')` in `cli.py`, `nircam/cli.py`, `nirspec/cli.py`, `expmap.py`. The env var selects the headless backend at matplotlib *import* time, so the CLIs no longer import matplotlib just to set the backend.

## Result

`import campfire_pipeline.nircam.cli` now loads **zero step modules and zero heavy scientific deps** (verified: `photutils`, `matplotlib`, `scipy.ndimage`, `jwst`, `crds` all absent from `sys.modules` after import). matplotlib still loads when `outlier` runs during combine — but *after* "Workspace ready", overlapped with work, not blocking startup.

## Verification

- `python -m pytest tests/` → **111 passed**
- Every `_PER_EXPOSURE_STEPS` entry resolves to a callable (no module/func typos)
- `cfpipe`, `cfpipe nircam`, `cfpipe nirspec`, and per-command `--help` all render; all step commands registered
- Agg backend confirmed selected via env var
- No external code imports the step functions / `_RUNNERS` from `orchestrate` (only public names: `STEP_NAMES`, `ALL_STEPS`, `PROCESS_STEPS`, `COMBINE_STEPS`, `run_*`)

## Changelog

Added under `## Unreleased` → **Infrastructure** (no scientific-output change → PATCH).

Generated with Claude Code