### PR TITLE
perf(nircam): NFS cache tier — reference caching, CRDS cache lock, memmap sweep

### DIFF
--- a/docs/design-nircam-exposure-major.md
+++ b/docs/design-nircam-exposure-major.md
@@ -251,64 +251,87 @@ server-contact attempts. The audit's "10k+ round trips" figure was a guess
 that likely overstates steady state; the fix hierarchy below doesn't depend
 on which estimate is right.
 
-What the env vars do:
+What the env vars do — **and why we rejected them** (see §4.1a, §4.2):
 
 - **`CRDS_READONLY_CACHE=1`** — the client treats the cache as immutable: no
   downloads, no config-refresh writes, no lock handling. Removes (3) and the
-  write half of (2). Failure mode: a genuinely missing reference becomes a
-  hard error instead of a download — which is *correct* for us, because the
-  serial prefetch is supposed to have warmed everything; a miss means the
-  prefetch is broken and we want to hear about it loudly, not have 16 workers
-  race to download over NFS.
+  write half of (2). The original proposal leaned on "a miss is then a hard
+  error, which is correct because the prefetch warmed everything." That makes
+  the prefetch a *correctness* dependency, and — decisively — readonly and
+  CRDS's own cache locking are mutually exclusive: `create_lock` returns a
+  no-op `FakeLock` under a readonly cache. So this env would *disable* the very
+  mechanism (§4.1a) that makes a cold miss safe. Not taken.
 - **`CRDS_MODE=local`** — never contact the server; resolve purely from the
-  local cache. Removes the network half of (2). Requires pinned context +
-  warm cache, both of which we guarantee.
+  local cache. Removes the network half of (2). Only meaningful paired with
+  readonly; dropped with it.
 
-### 4.2 Recommended approach, in order of preference
+### 4.1a CRDS cache locking (the mechanism we actually rely on)
 
-**Level 1 — workers don't call CRDS at all (the real fix).**
-`prefetch_process_references` already dedups exposures by
-`(DETECTOR, READPATT, SUBARRAY)` / `(DETECTOR, FILTER, PUPIL)` and warms the
-reference bytes. Extend it to also **record the resolved paths** —
-`{(det, filt, pupil): flat_path, ...}` — and pass that dict through
-`step_config` into the chain. `resolve_flat` (_flat.py:39-46, called per
-exposure from wisp and striping) becomes a dict lookup; `getreferences`
-disappears from worker code entirely. Combined with the `lru_cache` on the
-reference *arrays* (audit H4), a worker touches each reference file at most
-once, by plain path.
+CRDS ships a global cache lock and uses it by default: `CRDS_USE_LOCKING`
+defaults **True**, `CRDS_LOCKING_MODE` defaults `multiprocessing`. stpipe
+wraps its entire `crds.getreferences()` in
+`with crds_cache_locking.get_cache_lock():` (`stpipe/crds_client.py`), and the
+cache-existence check (`if not os.path.exists(localpath): download`) runs
+*inside* that guarded region (`crds/client/api.py:get_local_files`). That is
+textbook double-checked locking: worker A acquires the lock, sees the file
+missing, downloads, releases; worker B — blocked on the same lock the whole
+time — then acquires, finds the file present, and skips the download. No two
+workers ever write the same cache file.
 
-Residual: the jwst-internal pipelines (detector1, image2) resolve their own
-references via the datamodel layer. Overriding every reftype through step
-params is invasive; instead we accept their internal lookups — with Level 2
-hardening they cost one mapping-chain load per worker process plus stats of
-already-warm files.
+The lock object is created at crds import (`init_locks()`); forkserver workers
+share **one** lock because `crds` is in the `common/parallel.py` preload list,
+so the helper's lock is inherited by every forked worker — real cross-worker
+coordination on CANDIDE. (macOS spawn re-imports crds per worker → private
+locks → no-op coordination; dev-only, where the `_RetryOnIOError` wrappers
+still self-heal.) The one gap: the lock only guards callers who take it.
+stpipe-internal lookups (detector1, image2) are covered automatically; our two
+**direct** `crds.getreferences` calls — `resolve_flat` and the prefetch
+warm-up — have to take the lock explicitly or they bypass it. Those unguarded
+direct calls are the likely origin of the historical "empty or corrupt FITS"
+races the retry wrappers were written for.
 
-**Level 2 — env hardening for whatever CRDS calls remain.**
-After (and only after) the serial prefetch has run with write access:
+### 4.2 Landed approach (PR 1) and the deeper fix
 
-```python
-# in the worker entry / dispatch initializer, not blanket in setup_environment:
-os.environ.setdefault('CRDS_READONLY_CACHE', '1')
-os.environ.setdefault('CRDS_MODE', 'local')
-```
+**PR 1 — lock the direct calls, slim the prefetch (shipped).** The minimal,
+robust fix: wrap the two direct `crds.getreferences` calls (`resolve_flat`,
+prefetch `_fetch`) in `crds_cache_locking.get_cache_lock()`. Every reference
+fetch in the pipeline is now lock-guarded, so a cold-cache miss in any worker
+is a safe serialized download instead of a race. That demotes the prefetch
+from load-bearing to a pure warm-up, which lets it shrink:
 
-Scoping matters: the prefetch itself must keep write access (it downloads on
-cache miss), and forkserver inherits the environment from when the forkserver
-process starts — so the clean mechanism is a `dispatch` worker-initializer
-(or a `setdefault` at the top of the chain worker), not a global in
-`setup_environment`. Gate behind `[environment]` config flags so a laptop run
-with a cold cache behaves as today. Also fix: `prefetch_process_references`
-currently early-returns when `n_processes <= 1` — it must run unconditionally
-once readonly mode exists, since it's now load-bearing for correctness.
+- one shared header pass — each uncal `getheader` once, both the
+  `(DETECTOR, READPATT, SUBARRAY)` and `(DETECTOR, FILTER, PUPIL)` dedup keys
+  derived from it (was two passes, two header reads per uncal);
+- skip-when-pending — an uncal whose canonical already carries `CFP_DET1` +
+  `CFP_IMG2` is skipped without reading its header, so re-running a finished
+  field touches zero headers (directly addresses the multi-minute NFS header
+  scan that motivated this section).
 
-**Level 3 — measure before going further.** Before considering node-local
-CRDS cache seeding (sync `$CRDS_PATH` to `$TMPDIR` per node), instrument one
-worker (strace `-e trace=%file` or a crds logging hook) on CANDIDE and count
-actual NFS ops attributable to CRDS for one chain task, before and after
-Levels 1–2. My expectation is that Levels 1–2 reduce CRDS to noise and
-Level 3 is unnecessary complexity; the measurement either confirms that or
-tells us otherwise. (Flagged explicitly because the audit's CRDS cost
-estimate was the least-grounded of the High findings.)
+No `CRDS_READONLY_CACHE`, no `CRDS_MODE=local`, no `dispatch(worker_env=...)`
+plumbing (it had no other consumer and was removed). Reference selection is
+unchanged — same `getreferences` args, just lock-wrapped — so the PR-1
+parity/equivalence results hold by construction.
+
+**Deeper fix (PR 2/3) — workers don't call CRDS at all.** Extend the prefetch
+to also **record the resolved paths** — `{(det, filt, pupil): flat_path, ...}`
+— and thread that dict through `step_config` into the chain. `resolve_flat`
+(_flat.py, called per exposure from wisp and striping) becomes a dict lookup
+and `getreferences` disappears from worker code entirely, removing even the
+lock-contended call. Combined with the reference-array `lru_cache` (§5), a
+worker touches each reference at most once, by plain path. Residual: the
+jwst-internal pipelines (detector1, image2) still resolve their own references
+via the datamodel layer; those go through stpipe's lock automatically, costing
+one mapping-chain load per worker process plus stats of already-warm files.
+(This is what the original "Level 1" proposed; with the lock in place it's now
+an optimization, not a correctness requirement.)
+
+**Measure before going further.** Before considering node-local CRDS cache
+seeding (sync `$CRDS_PATH` to `$TMPDIR` per node), instrument one worker
+(`strace -e trace=%file` or a crds logging hook) on CANDIDE and count actual
+NFS ops attributable to CRDS for one chain task. Expectation: the lock +
+slimmed prefetch reduce CRDS to noise and node-local seeding is unnecessary
+complexity; the measurement confirms or refutes. (Flagged because the audit's
+CRDS cost estimate was the least-grounded of the High findings.)
 
 ## 5. Reference-data caching in workers
 
@@ -368,20 +391,21 @@ composed and where they land**.
 | M2 memmap'd full reads ×12 | Subsumed — one `memmap=False` read |
 | H6 diagnostic small-file flood | Addressed — scratch compose + `diagnostics/` export (§6) |
 | H4 reference re-reads | §5 (cache-tier PR, prerequisite) |
-| H5 CRDS | §4 (Levels 1–2 in cache-tier PR; Level 3 measured) |
+| H5 CRDS | §4 (cache-lock + slimmed prefetch in cache-tier PR; worker-side `getreferences` removal in PR 2/3; node-local seeding only if measured to matter) |
 | H7 footprint-per-tile, H8 drizzle/outlier double-opens, M4 hash fast-path | **Not subsumed** — combine phase, separate local-fix PRs |
 | M5 combine-phase + `check`/`status` globs, M9 lazy `--version` | **Not subsumed** — separate small PRs |
 
 ## 8. Migration plan
 
 1. **PR 1 — cache tier** (no architecture change): reference-array
-   `lru_cache` (§5), prefetch records resolved paths + `resolve_flat` lookup
-   (§4.2 L1), CRDS env hardening with worker-scoped setdefault + prefetch
-   unconditional (§4.2 L2), `memmap=False` sweep, lazy `--version`.
+   `lru_cache` (§5), CRDS cache-lock around the two direct `getreferences`
+   calls + slimmed prefetch (single header pass, skip-when-pending) (§4.2),
+   detector-major dispatch ordering, `memmap=False` sweep, lazy `--version`.
    Independently shippable and measurable.
 2. **PR 2 — combine-phase local fixes**: footprint hoisting (H7),
    single-pass drizzle/outlier opens (H8), `_visit_up_to_date` stat
-   fast-path (M4), prefetch single-pass headers.
+   fast-path (M4). (The prefetch single-pass headers originally slated here
+   landed early in PR 1 alongside the CRDS rework.)
 3. **PR 3 — the chain**: `ChainContext`, `*_transform` extraction with kept
    `*_step` wrappers, `process_exposure_chain` driver, scratch workspace +
    diagnostics routing. Gated by a config flag

--- a/docs/design-nircam-exposure-major.md
+++ b/docs/design-nircam-exposure-major.md
@@ -1,0 +1,436 @@
+# Design: Exposure-major NIRCam processing (NFS I/O consolidation)
+
+**Status:** draft for review
+**Date:** 2026-06-11
+**Context:** [NFS audit](nfs_audit.md) — findings H4–H8, M1–M2, M5–M7
+**Driver:** On CANDIDE (code + data on NFS), the process phase's step-major
+dispatch turns each exposure into ~12 read → mutate → atomic-write cycles,
+with the NFS file as the inter-step communication channel and `CFP_*` header
+keywords as the resume protocol. The audit measured this as the single
+largest concentration of NFS metadata traffic (~8,600 write cycles + as many
+full reads + per-step side-opens for a 720-exposure run).
+
+## 1. Goals / non-goals
+
+**Goals**
+
+- One NFS read and one NFS write per exposure per process phase, instead of
+  ~12 of each.
+- High-churn I/O (jhat scratch, matplotlib output, transient files) on
+  node-local disk; NFS receives only finished products.
+- Eliminate per-exposure CRDS resolution inside workers.
+- Keep diagnostic plots available (not sacrificed for performance).
+- Bit-identical science output. Same step functions, same order, same
+  arithmetic — this is an Infrastructure change (PATCH bump), and the
+  migration plan verifies that.
+
+**Non-goals**
+
+- The combine phase keeps its current shape (outlier is per-visit, resample
+  per-tile, bkgsub/RGB per-mosaic — none of it chains per-exposure). Its
+  audit fixes (H7, H8, M4) are separate local PRs.
+- No change to the canonical-file model (one FITS per exposure on NFS) or to
+  the `CFP_*` provenance vocabulary. Downstream consumers see the same files
+  with the same stamps.
+- No change to `cfpipe nircam <step>` single-step CLI semantics (see §3.6).
+
+## 2. Current architecture (what we're changing and why it is how it is)
+
+`run_process` (orchestrate.py:562) iterates `PROCESS_STEPS` in order, and
+each step independently dispatches over all pending exposures:
+
+```
+for filt in filters:
+    for step in PROCESS_STEPS:           # step-major
+        dispatch(step_fn, pending_exposures, ...)
+```
+
+Every (step, exposure) pair is an independent Pool task. Consequences:
+
+- **The NFS file is the inter-step channel.** A step must read the canonical
+  FITS its predecessor wrote, and `atomic_save` it back (.tmp write +
+  reopen-for-update to stamp `CFP_*`/append SRCMASK/CFMASK + rename) for the
+  next step to see it.
+- **Side-opens multiply.** Steps re-extract non-datamodel extensions
+  (SRCMASK, CFMASK, WCS_BAK) with extra `fits.open`s before/after the
+  datamodel load, because the jwst datamodel drops unknown extensions
+  (audit M7 / nircam-steps#2).
+- **Per-step skip checks and directory listings** (`get_exposure_files`
+  re-globbed ~12–16× per filter per phase; audit M5).
+- **Resume granularity is per-step**, which is the one genuine benefit of
+  step-major — and the one we've agreed to trade away: a crash re-running a
+  single exposure's full chain is cheap and rare.
+
+A structural constraint discovered while designing this: **persistence is an
+ensemble barrier.** `persistence_step` (steps/persistence.py:87) takes the
+whole filter's exposure list — snowblind groups by detector and needs every
+exposure's `_jump.fits` (persistence is flagged from temporally adjacent
+exposures). It cannot live inside a per-exposure chain. This cleanly splits
+the process phase into three stages:
+
+| Stage | Unit | Steps |
+|---|---|---|
+| A — produce | per exposure | detector1 (uncal → canonical + `_jump.fits`) |
+| B — barrier | per filter (serial, grouped by detector) | persistence (consumes all jump files, deletes them) |
+| C — **the chain** | per exposure | wisp → striping → image2 → edge → sky → [diag_striping] → variance → [wcs_shift] → preview → jhat |
+
+Stage C is 8–10 of the 12 steps and carries nearly all of the I/O churn.
+Stages A and B are already minimal (detector1 is one read + one write;
+persistence is one ensemble pass) and stay as they are.
+
+## 3. Proposed architecture
+
+### 3.1 Stage C becomes one dispatch: `process_exposure_chain`
+
+```
+for filt in filters:
+    _run_detector1(...)            # unchanged (per-exposure dispatch)
+    _run_persistence(...)          # unchanged (serial ensemble barrier)
+    dispatch(process_exposure_chain, pending_exposures,
+             field=field, chain=chain_spec, step_configs=cfgs,
+             overwrite=overwrite, status=status)
+```
+
+One Pool task = one exposure pulled through every remaining chain step.
+The worker:
+
+1. **Reads the canonical FITS once** (`memmap=False`; full model + all
+   sidecar extensions into a `ChainContext`).
+2. Runs each pending step as an in-memory transform (§3.2).
+3. **Writes once** via `atomic_save`, with *all* newly-earned `CFP_*` keys
+   applied to the header *before* the staging write (killing the
+   reopen-for-update on this path — audit M1) and the sidecar extensions
+   attached from memory.
+
+Per-exposure I/O for stage C drops from ~10 reads + ~10 (write + reopen +
+rename) + side-opens to **1 read + 1 write + 1 rename**.
+
+### 3.2 Step contract
+
+All chainable steps already share the signature
+`step(exposure_file, field, step_config, overwrite=False, status=None)` and
+internally do open → compute → `atomic_save`. The refactor splits each into:
+
+```python
+def <name>_transform(ctx, field, step_config):
+    """Pure in-memory transform. Mutates/replaces ctx.model and ctx.extras.
+    No file I/O on the canonical path. May read reference data (cached, §5)
+    and write diagnostics to ctx.scratch_dir (§6)."""
+```
+
+with a `ChainContext` carrying what today round-trips through the file:
+
+```python
+@dataclass
+class ChainContext:
+    model: ImageModel          # the datamodel, held open across steps
+    extras: dict[str, fits.ImageHDU]   # SRCMASK / CFMASK / WCS_BAK, in memory
+    header_updates: dict       # accumulated CFP_* stamps (+ STKSH-style cards)
+    scratch_dir: str           # node-local per-exposure workspace
+    rootname: str
+    filtname: str
+```
+
+The existing `<name>_step(exposure_file, ...)` entry points are **kept** as
+thin wrappers — read file → build ctx → call transform → `atomic_save` —
+preserving the single-step CLI path (§3.6) with zero behavior change. The
+transform is the new unit; the wrapper is the old contract.
+
+Step-specific notes:
+
+- **image2** — `Image2Pipeline.call` accepts an in-memory datamodel instead
+  of a path (jwst `Step.call` dispatches on input type). The wrapper's
+  current 3-opens-per-exposure pattern (SRCMASK extract + EXP_TYPE getval +
+  pipeline open; image2.py:25,58,109) collapses to zero extra opens: EXP_TYPE
+  comes from `ctx.model.meta`, SRCMASK from `ctx.extras`. **Verified
+  2026-06-11 on the pinned stack (jwst 1.20.2 / stdatamodels 4.1.0 /
+  crds 13.1.12, context jwst_1481.pmap)** — see §9 Q1: `.call(model)` is
+  fully equivalent to `.call(path)`.
+- **wcs_shift / diag_striping** — conditional steps: the driver builds the
+  effective chain per exposure (rule-matched / config-enabled) exactly as the
+  per-step runners filter today; absent steps simply contribute no stamp.
+- **preview** — writes its 2 PNGs from `ctx.model` data; the PNGs compose on
+  scratch and copy back (§6). Whether previews are a downstream contract
+  (web/quick-look) and should stay in the canonical dir or move to
+  `diagnostics/` is an open question (§8).
+- **jhat (chain terminus)** — jhat is an external, file-based tool and
+  already operates in `$TMPDIR` scratch (jhat.py:156). It slots in naturally
+  as the *last* step: the chain writes `ctx.model` to a scratch FITS (this
+  write was going to happen anyway — it replaces the final in-memory hop),
+  runs jhat there, and the jhat-aligned output becomes the model for the
+  single NFS `atomic_save`. The current scratch→NFS `copy2 + .tmp + replace`
+  promotion logic (jhat.py:269-282) is the model for the final export.
+
+### 3.3 Skip / resume semantics
+
+The driver consults the existing `StepStatus` pre-scan (unchanged — one
+header open per exposure per phase, audit-endorsed):
+
+```python
+effective = [s for s in CHAIN_STEPS if s.enabled(exposure, field, config)]
+pending   = [s for s in effective if not status.has(f, s.cfp_key)]
+if not pending: return                      # fully processed, zero I/O
+# read once, run pending in order, write once stamping their keys
+```
+
+- **Crash mid-chain:** the canonical file is untouched (single atomic write
+  at the end), so a re-run sees the same `pending` list and redoes the whole
+  remaining chain for that exposure. Accepted trade-off (cheap, rare).
+  This is *cleaner* than today: a file is either in its prior state or fully
+  chained — never a half-stepped intermediate.
+- **Legacy / mixed state:** an exposure stamped through, say, `CFP_SKY` by an
+  old step-major run resumes mid-chain correctly — the on-disk file reflects
+  the steps applied so far, exactly as the stamps say. The chain reads it and
+  applies only the remainder. No migration of existing fields needed.
+- **`reset --from` caveat (unchanged from today):** steps mutate the file in
+  place, so re-running a mid-chain step on an already-processed file was
+  never valid without re-running upstream (except steps with explicit
+  backups, e.g. WCS_BAK). Chaining neither fixes nor worsens this; the doc
+  notes it so nobody assumes otherwise.
+
+### 3.4 Failure isolation
+
+Today a step bug fails one (step, exposure) task; under chaining it fails
+that exposure's whole remaining chain. `process_exposure_chain` wraps each
+transform so the error report names the step, and `dispatch(retry=True)`
+semantics still apply (re-running the chain task is idempotent given the
+stamps). Net behavior for the operator is the same: the exposure is left
+unstamped at the failing step and shows up in `cfpipe nircam status`.
+
+### 3.5 Memory budget
+
+A worker holds one open ImageModel (~6 detector-sized arrays ≈ 100–150 MB)
+plus extras and step working memory; jwst Image2Pipeline peaks higher
+(~2–4× transiently). Budget ~1 GB/worker to be safe — at 8–16 workers this
+is well within a CANDIDE node. Same order as today's peak (steps already
+materialize full arrays); the difference is holding *one* model across steps
+rather than re-materializing it 10 times.
+
+### 3.6 CLI compatibility
+
+- `cfpipe nircam run` / `process` → exposure-major (stage A, barrier B,
+  chain C).
+- `cfpipe nircam <step>` (`run_step`) → unchanged: the kept `<name>_step`
+  wrappers run the old read-transform-write per step. Ad-hoc re-runs,
+  debugging, and `reset --from` workflows are untouched.
+- `status` / `check` → unchanged (`CFP_*` vocabulary identical).
+
+## 4. CRDS strategy
+
+### 4.1 How CRDS resolution actually works (and what the env vars change)
+
+This section exists because "set `CRDS_READONLY_CACHE=1`" was proposed
+without explanation. Mechanics of a `crds.getreferences()` call:
+
+1. **Context → mapping chain.** The pinned context (`jwst_1481.pmap`) names
+   an instrument map (`.imap`), which names one rules file (`.rmap`) per
+   reference type. These are small text files under
+   `$CRDS_PATH/mappings/jwst/` — on NFS in our layout. **Loaded mappings are
+   cached in memory per process** (`crds.rmap` keeps a module-level cache),
+   so the NFS mapping reads are paid on the *first* resolution in each
+   process, not per call.
+2. **Client mode bookkeeping.** In the default `CRDS_MODE=auto`, each call
+   decides local-vs-remote operation: it consults
+   `$CRDS_PATH/config/jwst/server_config` and may attempt to contact
+   `CRDS_SERVER_URL` (to refresh config / check for newer contexts / fetch
+   the bad-files list). On a cluster this is at best extra NFS reads and at
+   worst a hung or slow outbound HTTP attempt per worker.
+3. **Cache write-readiness.** In the default read-write mode, the client
+   checks whether it may need to download (cache-writability probes, lock
+   handling around the download path) even when the file is already cached.
+4. **Resolution + existence check.** Match parameters against the rmap,
+   stat the resolved reference file in `$CRDS_PATH/references/jwst/`,
+   download if missing.
+
+So the per-call NFS cost in a *steady-state warm worker* is modest (in-memory
+mappings + one stat); the real costs are (a) the first-call mapping-chain
+load **per worker process** — and forkserver workers do *not* inherit the
+parent's in-memory mapping cache, since the forkserver preloads modules, not
+post-fork parent state — (b) mode/config bookkeeping per call, and (c) any
+server-contact attempts. The audit's "10k+ round trips" figure was a guess
+that likely overstates steady state; the fix hierarchy below doesn't depend
+on which estimate is right.
+
+What the env vars do:
+
+- **`CRDS_READONLY_CACHE=1`** — the client treats the cache as immutable: no
+  downloads, no config-refresh writes, no lock handling. Removes (3) and the
+  write half of (2). Failure mode: a genuinely missing reference becomes a
+  hard error instead of a download — which is *correct* for us, because the
+  serial prefetch is supposed to have warmed everything; a miss means the
+  prefetch is broken and we want to hear about it loudly, not have 16 workers
+  race to download over NFS.
+- **`CRDS_MODE=local`** — never contact the server; resolve purely from the
+  local cache. Removes the network half of (2). Requires pinned context +
+  warm cache, both of which we guarantee.
+
+### 4.2 Recommended approach, in order of preference
+
+**Level 1 — workers don't call CRDS at all (the real fix).**
+`prefetch_process_references` already dedups exposures by
+`(DETECTOR, READPATT, SUBARRAY)` / `(DETECTOR, FILTER, PUPIL)` and warms the
+reference bytes. Extend it to also **record the resolved paths** —
+`{(det, filt, pupil): flat_path, ...}` — and pass that dict through
+`step_config` into the chain. `resolve_flat` (_flat.py:39-46, called per
+exposure from wisp and striping) becomes a dict lookup; `getreferences`
+disappears from worker code entirely. Combined with the `lru_cache` on the
+reference *arrays* (audit H4), a worker touches each reference file at most
+once, by plain path.
+
+Residual: the jwst-internal pipelines (detector1, image2) resolve their own
+references via the datamodel layer. Overriding every reftype through step
+params is invasive; instead we accept their internal lookups — with Level 2
+hardening they cost one mapping-chain load per worker process plus stats of
+already-warm files.
+
+**Level 2 — env hardening for whatever CRDS calls remain.**
+After (and only after) the serial prefetch has run with write access:
+
+```python
+# in the worker entry / dispatch initializer, not blanket in setup_environment:
+os.environ.setdefault('CRDS_READONLY_CACHE', '1')
+os.environ.setdefault('CRDS_MODE', 'local')
+```
+
+Scoping matters: the prefetch itself must keep write access (it downloads on
+cache miss), and forkserver inherits the environment from when the forkserver
+process starts — so the clean mechanism is a `dispatch` worker-initializer
+(or a `setdefault` at the top of the chain worker), not a global in
+`setup_environment`. Gate behind `[environment]` config flags so a laptop run
+with a cold cache behaves as today. Also fix: `prefetch_process_references`
+currently early-returns when `n_processes <= 1` — it must run unconditionally
+once readonly mode exists, since it's now load-bearing for correctness.
+
+**Level 3 — measure before going further.** Before considering node-local
+CRDS cache seeding (sync `$CRDS_PATH` to `$TMPDIR` per node), instrument one
+worker (strace `-e trace=%file` or a crds logging hook) on CANDIDE and count
+actual NFS ops attributable to CRDS for one chain task, before and after
+Levels 1–2. My expectation is that Levels 1–2 reduce CRDS to noise and
+Level 3 is unnecessary complexity; the measurement either confirms that or
+tells us otherwise. (Flagged explicitly because the audit's CRDS cost
+estimate was the least-grounded of the High findings.)
+
+## 5. Reference-data caching in workers
+
+Independent of CRDS resolution, the reference *arrays* must stop being
+re-read per exposure (audit H4 — wisp templates read 5×/exposure today):
+
+```python
+@functools.lru_cache(maxsize=8)
+def _load_template(path):
+    a = fits.getdata(path, memmap=False)
+    a[np.isnan(a)] = 0
+    return a
+# per exposure: w = _load_template(p).copy(); w[sci_before == 0] = 0
+```
+
+Same pattern for flat arrays (keyed on resolved path from §4.2) and
+bad-pixel masks. Pool workers persist across tasks, so each worker pays one
+read per reference file for its lifetime. Under exposure-major this matters
+*more* — a worker processes many exposures back-to-back — so this lands in
+the cache-tier PR *before* the chain refactor.
+
+## 6. Diagnostics: keep the plots, move the churn
+
+Decision: diagnostics stay on by default; what changes is **where they're
+composed and where they land**.
+
+- **Compose on scratch.** Each chain task owns
+  `ctx.scratch_dir = $TMPDIR/<job>/<rootname>/` (the same workspace jhat
+  uses). Steps write figures there — matplotlib's create/write/close churn
+  happens on node-local disk.
+- **Export in one batch per exposure.** At chain end (after the canonical
+  `atomic_save`), copy the exposure's diagnostic files to
+  `products/nircam/<field>/<filter>/diagnostics/` — a **new subdirectory**,
+  so the ~5–7 files/exposure stop inflating the directory that
+  `get_exposure_files`, resample, and `status` repeatedly glob (audit H6).
+  Net NFS cost: same file count as today, but batched, sequential, and out
+  of the canonical namespace. jhat's PDF/ECSV copies and the per-visit
+  outlier PDFs route to the same place.
+- **Optional `diagnostics_format = "tar"`** config: instead of copying
+  individual files, append to one `<filter>_diagnostics_<jobid>.tar` per
+  chain run (workers write per-exposure tars on scratch; parent concatenates,
+  or each worker copies one tarball per exposure). This is the maximally
+  NFS-friendly form (~1 file per exposure → 1 file per filter) at the cost of
+  `tar -x` to view a single plot. Default stays loose files in
+  `diagnostics/`; the tar mode exists for the largest fields.
+- `field.diag_dir(filtname)` helper creates the subdir; `cfpipe nircam
+  status`/`check` and `get_exposure_files` need no changes since they glob
+  the canonical dir only.
+
+## 7. What this design subsumes / what remains
+
+| Audit item | Disposition |
+|---|---|
+| M1 atomic_save reopen ×12/exposure | Subsumed — one save, headers pre-applied; reopen survives only for the `extra_hdus` path in the legacy per-step wrappers |
+| M7 per-step side-opens (SRCMASK/EXP_TYPE/WCS_BAK) | Subsumed — carried in `ChainContext` |
+| M5 per-step `get_exposure_files` re-globs (process phase) | Subsumed — one dispatch per filter |
+| M2 memmap'd full reads ×12 | Subsumed — one `memmap=False` read |
+| H6 diagnostic small-file flood | Addressed — scratch compose + `diagnostics/` export (§6) |
+| H4 reference re-reads | §5 (cache-tier PR, prerequisite) |
+| H5 CRDS | §4 (Levels 1–2 in cache-tier PR; Level 3 measured) |
+| H7 footprint-per-tile, H8 drizzle/outlier double-opens, M4 hash fast-path | **Not subsumed** — combine phase, separate local-fix PRs |
+| M5 combine-phase + `check`/`status` globs, M9 lazy `--version` | **Not subsumed** — separate small PRs |
+
+## 8. Migration plan
+
+1. **PR 1 — cache tier** (no architecture change): reference-array
+   `lru_cache` (§5), prefetch records resolved paths + `resolve_flat` lookup
+   (§4.2 L1), CRDS env hardening with worker-scoped setdefault + prefetch
+   unconditional (§4.2 L2), `memmap=False` sweep, lazy `--version`.
+   Independently shippable and measurable.
+2. **PR 2 — combine-phase local fixes**: footprint hoisting (H7),
+   single-pass drizzle/outlier opens (H8), `_visit_up_to_date` stat
+   fast-path (M4), prefetch single-pass headers.
+3. **PR 3 — the chain**: `ChainContext`, `*_transform` extraction with kept
+   `*_step` wrappers, `process_exposure_chain` driver, scratch workspace +
+   diagnostics routing. Gated by a config flag
+   (`[nircam].exposure_major = true`) for the first release so step-major
+   remains one config line away.
+4. **Validation for PR 3**: run a small real field both ways
+   (`exposure_major` on/off) and diff: (a) canonical FITS bit-identical
+   modulo header card order/HISTORY, (b) identical `CFP_*` stamp sets,
+   (c) mosaics bit-identical through combine. Same functions, same order,
+   same inputs → any pixel difference is a bug. Changelog: Infrastructure
+   (PATCH) per the bump policy, *contingent on (a) holding*.
+5. Measure on CANDIDE: wall-clock + NFS op counts (strace sample) for a
+   representative filter, before/after each PR — so we know which tier
+   bought what.
+
+## 9. Open questions
+
+1. **`Image2Pipeline.call(model)` parity** — **RESOLVED 2026-06-11: PASS.**
+   Tested on jwst 1.20.2 / stdatamodels 4.1.0 / crds 13.1.12 (context
+   jwst_1481.pmap) with a real canonical exposure
+   (`rj0911/f090w/jw06882025001_02101_00001_nrca1.fits`), invoking
+   `Image2Pipeline` with the exact production kwargs from `image2_step`
+   once with the file path and once with a pre-loaded `ImageModel`:
+   - **CRDS selection identical** — every `meta.ref_file` entry matches,
+     including the image2-relevant ones (distortion 0265, filteroffset 0005,
+     flat 0697, photom 0155).
+   - **All 7 output arrays bitwise identical** (data, err, dq, var_poisson,
+     var_rnoise, var_flat, area; NaN-aware).
+   - **Photometry keywords and BUNIT identical**; **WCS evaluation identical
+     to machine precision** at 4 sample pixels including SIP corners.
+   - **`meta.filename` identical** in both modes (no special-casing needed).
+   - **The caller's model is neither mutated nor returned** (`result is not
+     model_in`; input data/dq unchanged) — the chain must treat the call as
+     consuming its model and adopt the returned one, which the
+     `ChainContext` design already does.
+   Caveat: the test input was a fully-calibrated (cal-stage) file, so flat
+   and photom were re-applied to already-calibrated pixels — meaningless
+   scientifically but valid for parity since both modes received the same
+   input, and CRDS selection parameters (detector/filter/pupil/date) are
+   calibration-state-independent. Test script:
+   `pipeline/scripts/test_image2_call_parity.py` (re-run against a
+   rate-stage input during PR 3 validation for belt-and-braces).
+2. **Preview PNGs** — diagnostics (→ `diagnostics/`) or a downstream
+   contract (stay in canonical dir)? Affects only the export path.
+3. **`$TMPDIR` on CANDIDE** — confirm it's node-local and sized for
+   ~workers × (1 exposure FITS + diagnostics) on the relevant queues
+   (assumed true; jhat already relies on it).
+4. **diag_striping in-chain** — it's opt-in and heavy; confirm its transform
+   doesn't need anything beyond `ChainContext` (it currently re-opens the
+   file a third time for SRCMASK at save — subsumed if not).
+5. **Tar mode for diagnostics** — wanted in v1, or defer until a field
+   actually hurts with loose files in `diagnostics/`?

--- a/docs/nfs_audit.md
+++ b/docs/nfs_audit.md
@@ -1,0 +1,304 @@
+# NFS Performance Audit — `campfire_pipeline`
+
+**Date:** 2026-06-11
+**Scope:** `pipeline/campfire_pipeline/` (~23k lines), audited against the CANDIDE deployment model: code *and* data on NFS, where every metadata operation (stat, open, readdir, unlink) is a ~1ms+ network round trip and only large sequential I/O is cheap.
+**Method:** 11 parallel Opus auditors (2 data-flow tracers, 7 module auditors, 2 cross-cutting specialists for concurrency and runtime I/O), each followed by an independent skeptical verifier that re-checked every cited `file:line` and loop-multiplier claim against the source. 74 raw findings → 73 survived verification (one claim — "NIRCam workers re-glob shared input dirs via the pickled `field` object" — was **refuted**: the orchestrator resolves file lists in the parent and passes per-task paths). I then re-validated the top findings against the code directly and consolidated overlapping findings across modules. Line numbers below were verified against the working tree at the time of audit. Frequency estimates are labeled **(guess)** when not derived from counted call sites.
+
+**No code was modified in this pass.**
+
+---
+
+## 1. Data-flow summary
+
+### NIRSpec arm
+
+`cfpipe nirspec run --obs X --all -p N` iterates observations serially. Per observation, all products land in **one flat workspace directory** `$CAMPFIRE_ROOT/products/<obs>/` — file *naming*, not directory nesting, separates products. Multiprocessing (via `common/parallel.py::dispatch`, forkserver on Linux) fans out per stage:
+
+- **stage1**: per-exposure (`_uncal.fits` → `_rate.fits`, in-place background subtraction + `_bkg.pdf`).
+- **stage2a**: per-rate-file workers, each containing the **per-source inner loop** (~100–300 sources): write per-source MSA metafile + asn JSON, rewrite the shared rate-file header, run `Spec2Pipeline` → `<prod>_cal.fits`, delete the temp files. Then per-cal dispatches for `fix_units`, resample (`_s2d.fits`), and per-source `_nods.pdf` plots.
+- **stage2b**: per-bkg-group nodded subtraction → `_cal_bkgsub.fits` / `_s2d_bkgsub.fits`.
+- **stage3**: per-(source × grating) `Spec3Pipeline` → `_s2d`/`_x1d` → optimal extraction → packaged `_spec.fits` + `_prof.pdf` + `_spec.pdf`.
+- **zfit**: *serial* loop over spec files (numba-threaded internally, no Pool) → `_zfit.fits` (+ `_zfit.pdf`).
+- **summary**: globs + re-opens every spec/zfit/cal product → 3 ECSVs. Under `--all`, `_run_summary` runs **twice** (`nirspec/cli.py:519,533`), doubling all of its I/O.
+
+**Volume per mid-size obs** (~200 sources, 2 gratings, ~24 exposures): ~5,500 residual files in one flat directory, ~4–5k *transient* create+unlink pairs (per-source msa/json, spec3 asn, crf cleanup), and an estimated **20–30k+ FITS header-open round trips** from the repeated `discover_files`/summary sweeps. Cal files are written as **per-source copies**, so the `*_cal.fits` population is sources × nods × detectors (1,000–5,000 files), which every later glob and header sweep pays for.
+
+### NIRCam arm
+
+`cfpipe nircam run --field X --all -p N` iterates filters; within a filter, ~12 in-place per-exposure steps (detector1, persistence, wisp, striping, image2, edge, sky, variance, preview, jhat, diag_striping, apply_masks) each dispatch over exposures, mutating **one canonical FITS per exposure** in `products/nircam/<field>/<filter>/` (also flat) via `atomic_save` (.tmp write → optional reopen-for-update → rename). Combine phase: per-visit outlier detection, per-tile drizzle/resample, background, RGB tiles.
+
+**Volume per typical field run** (6 filters × 120 exposures, 8 visits, 4 tiles — **guess** on counts): ~8,600 canonical atomic-write path-touches (720 exposures × 12 steps × tmp+rename), ~1,440 `_jump.fits` create+delete ops, **~3,000–5,000 diagnostic PDFs/PNGs** (≈7 per exposure with default `plot=true`), ~340 mosaic/manifest files, plus several thousand header-only opens (status scans, prefetch, geometry).
+
+### Where round trips concentrate
+
+1. **Header re-opens of the same files** — `discover_files` × 3 stages, summary/shutters/pointings, geometry per-tile WCS scans, prefetch double-reads. The same FITS primary header is routinely opened 2–5× by different code paths within one run.
+2. **The per-source inner loop in stage2a** — TOML re-parse, shared-header rewrite, and temp-file create/delete, all × sources × rate-files.
+3. **Flat directories with thousands of entries** — every `glob` is a full readdir of a directory bloated by per-source copies and diagnostic files, and globs are re-run per step / per stage / per tile rather than cached.
+4. **CRDS context resolution inside parallel workers** against an NFS cache of hundreds of small mapping files.
+
+Bulk pixel I/O (rate/cal/mosaic reads and writes) is sequential and large — that part of the architecture is NFS-fine. The problem is almost entirely metadata amplification around it.
+
+---
+
+## 2. Findings — High impact
+
+### H1. Uncached TOML `@property` re-parsed inside the stage2a per-source loop — **[local fix]**
+
+**Location:** `pipeline/campfire_pipeline/nirspec/observation.py:276-372` (properties), `pipeline/campfire_pipeline/nirspec/stage2.py:580-582` (hot access)
+
+`Observation.stuck_closed_shutters` and `Observation.bkg_overrides` are plain `@property` methods with **no caching**: each access does `os.path.exists` → `toml.load` (open+read+close) → rebuild an astropy Table / nested dict from scratch. `stuck_closed_shutters_mtime` / `bkg_override_mtime` additionally call `os.path.getmtime` each time. `run_stage2a_single_rate` accesses `obs.stuck_closed_shutters` **at line 580, inside the `for source_id` loop** (and the mtime at 582); `run_stage2b` reads `obs.bkg_overrides` per bkg-group.
+
+**Why it's costly:** every access ≈ 3+ NFS round trips (stat + open/read/close + getmtime) for a file whose contents never change during a run. At ~100–300 sources × 10–100 rate files this is **up to ~30,000 redundant re-reads of the same small TOML per observation**, re-done independently in every worker. This is likely the single largest avoidable metadata multiplier in the NIRSpec arm.
+
+**Fix:** hoist `stuck_tab = obs.stuck_closed_shutters` and `stuck_mtime = obs.stuck_closed_shutters_mtime` above the per-source loop in `run_stage2a_single_rate` (one-line change, removes the ×sources factor immediately), and convert the properties to lazily-cached attributes:
+
+```python
+@property
+def stuck_closed_shutters(self):
+    if self._stuck_cache is None:
+        ...  # existing exists/toml.load/Table build
+        self._stuck_cache = tab
+    return self._stuck_cache
+```
+
+The file is only legitimately re-read between stage2a passes (the stuck-shutter re-run path merges new entries), so an explicit `invalidate()` after the merge keeps that working.
+
+### H2. Summary phase opens every spec FITS ~4× and SHA-256-streams every byte — twice per `--all` run — **[local fix]**, hash consolidation **[architectural]**
+
+**Location:** `pipeline/campfire_pipeline/metadata/summary.py:339-377`, `reader.py:179-185,257`, `shutters.py:49,68-90,152`, `slits.py:17,30`, `pointings.py:46-72`; doubled by `nirspec/cli.py:519,533`
+
+Per spec file, the summary stack performs: `read_fits_metadata` (`fits.open`, reader.py:195) **plus an unconditional `_compute_file_hash`** that streams the entire file through SHA-256 (reader.py:257); each zfit file is opened **twice** (`read_zfit_data` reader.py:117, `read_zfit_chi2` reader.py:161); `generate_shutters_table` then **re-globs the same `*_spec.fits`** (shutters.py:49) and re-opens each file 2× more (`_get_grating` for the primary header, `compute_slit_centers`→`get_exposure_table` for HDU 7), plus `get_source_pos` once per source. `generate_pointings_table` globs **every per-source cal copy** (thousands of entries) and then opens each unique exposure twice via two separate `fits.getheader(ext=0/1)` calls. All of it runs **twice** under `cfpipe nirspec run --all`.
+
+**Why it's costly:** ~150–900 spec files × ~4 opens + 2× zfit opens + the cal-copy glob ≈ **8,000–16,000 fits opens per observation**, plus a full-file re-read of every spectrum (multi-GB of NFS traffic — sequential, so bandwidth-OK, but pure overhead) just to recompute a provenance hash that never changes.
+
+**Fix (local):**
+- Open each spec file **once** per generator: pull GRATING from `hdul[0].header`, HDU 7 as a Table, and the source position from one `with fits.open(spec_file, memmap=False)` block; add a `exp_table=`/`pre_read` kwarg to `compute_slit_centers`.
+- Merge `read_zfit_data`/`read_zfit_chi2` into a single open.
+- List the obs dir **once** per `_run_summary` with `os.scandir` and partition by suffix in memory, instead of 4 independent globs (`*_spec.fits` ×2, `*_zfit.fits`, `*_cal.fits`).
+- Read both pointings headers from one open: `with fits.open(cal, memmap=False) as h: h0, h1 = h[0].header, h[1].header`.
+- Drop the redundant `zfit_path.exists()` guards (reader.py:113,157) — the paths come from a glob; the existing try/except already handles absence.
+
+**Fix (architectural):** compute the SHA-256 **once, when stage3 writes the spec file**, and stash it in the header (e.g. `CMPFRHSH`); `read_fits_metadata` then does `primary.get('CMPFRHSH') or _compute_file_hash(...)`. Alternatively adopt the size+mtime_ns fast path that `nircam/manifest.py:59-73` already implements. Needs your call because the hash is part of the deploy provenance contract.
+
+Also worth a look: whether the second `_run_summary` call under `--all` can pass/reuse the first call's partial results instead of redoing everything.
+
+### H3. `discover_files` opens every cal product twice — and is re-run per stage — **[local fix]**
+
+**Location:** `pipeline/campfire_pipeline/nirspec/observation.py:433-445`; callers `stage2.py:295`, `stage2.py:392/459`, `stage3.py:64`, plus detect-stuck and summary paths
+
+The discovery loop calls `fits.getheader(f, ext=0)` **and** `fits.getheader(f, ext=1)` for every matching product — two full open/read/close cycles per file (`getheader` does not hold the handle between calls). The cal-file set is per-source copies: 1,000–5,000 files. `discover_files` runs fresh in stage2a (post-Spec2), twice in stage2b, and again in stage3, all serially in the parent.
+
+**Why it's costly:** 2 opens × N_products × ~4–5 invocations ≈ **10,000–50,000 serial header opens per observation**, none of it parallelized, all of it re-deriving metadata that doesn't change once a product exists.
+
+**Fix:** (1) one open per file: `with fits.open(f, memmap=False) as h: hdr0, hdr1 = h[0].header, h[1].header` — halves the count for a few lines' change. (2) Add `SRCFLUX` to the columns extracted here, killing the separate double-`getheader` sweeps at `stage2.py:400-404` and `stage3.py:75-79` (each currently opens every file twice more because the `'SRCFLUX' in fits.getheader(...)` membership test and the value read are two separate calls). (3) Bigger win, still self-contained: persist the discovered table to a single workspace-level sidecar (e.g. `_<obs>_products.ecsv`, invalidated by directory mtime or explicitly by the stages that add files) so later stages read one file instead of re-sweeping thousands.
+
+### H4. NIRCam reference data re-read from NFS for every exposure (wisp templates 5×/exposure, flats via CRDS per exposure) — **[local fix]**
+
+**Location:** `pipeline/campfire_pipeline/nircam/steps/wisp.py:157,197`, `_flat.py:39-46,59`, `bad_pixel.py:176`
+
+`wisp_step` re-reads each of the 4 candidate template FITS (~16MB each) via `fits.getdata` inside the fit loop **for every exposure**, then re-reads the chosen template a **fifth** time for the subtraction. `resolve_flat` + `apply_flat_with_retry` open a fresh `FlatModel` per exposure from both `striping` and `wisp`. `bad_pixel` reads its mask per exposure. Nothing is memoized per worker or preloaded before the fork.
+
+**Why it's costly:** a fixed reference working set is multiplied by exposures × workers: ~400 template reads + up to ~2×N_exposures flat opens per run **(guess on exposure counts)** — each a full NFS open plus memmap'd data pull of a 16MB array that was identical last time.
+
+**Fix:** module-level `lru_cache` keyed on path, copying before exposure-specific mutation:
+
+```python
+@functools.lru_cache(maxsize=8)
+def _load_template(path):
+    a = fits.getdata(path)
+    a[np.isnan(a)] = 0
+    return a
+# per exposure:
+w = _load_template(p).copy(); w[sci_before == 0] = 0
+```
+
+Same pattern for `FlatModel` data keyed on resolved flat path. One read per (worker, file) instead of per (exposure, file). See also H5 for eliminating the per-exposure CRDS *resolution*.
+
+### H5. CRDS cache on NFS with read-write mode: every worker re-resolves context against hundreds of small mapping files — **[local fix]**
+
+**Location:** `pipeline/campfire_pipeline/config.py:158-164` (CRDS_PATH default), `nircam/steps/_flat.py:45` (per-exposure `crds.getreferences` from wisp.py:122 and striping.py:270)
+
+`CRDS_PATH` defaults to `$CAMPFIRE_ROOT/cache/crds` — on NFS — and `CRDS_READONLY_CACHE` is never set anywhere in the package (verified by grep). The serial prefetch (`prefetch.py`, `_prefetch_crds_references`) correctly warms the reference *bytes*, but each `crds.getreferences()` call made **inside a worker** still walks/stats the `mappings/jwst/` tree (hundreds of `.pmap/.imap/.rmap` files) and may refresh `server_config` / touch cache-write state. `resolve_flat` does this once per exposure in two different steps.
+
+**Why it's costly:** several hundred `getreferences` calls per run × tens-to-hundreds of small mapping-file stats each ≈ **order 10k+ NFS metadata round trips (guess)**, bunched at dispatch start when all workers cold-resolve simultaneously.
+
+**Fix (both cheap):**
+1. In `setup_environment`, when the context is pinned (it always is — `config_default.toml:12`): `os.environ.setdefault('CRDS_READONLY_CACHE', '1')`, optionally behind a `[environment]` config flag. With a pinned context and prefetch-warmed cache this is safe and removes server-refresh/lock/write-attempt traffic from every call.
+2. Memoize flat resolution by `(detector, filter, pupil)` — either `lru_cache` in `_flat.py` or, better, resolve once per unique config in the parent during prefetch and pass the resolved path into workers via `step_config`, so workers never call `getreferences` at all.
+
+Pointing `CRDS_PATH` at node-local scratch seeded per node is a further deployment-level option, but readonly mode + memoization captures most of the win without changing the layout.
+
+### H6. ~7 diagnostic files per exposure (NIRCam) and ~5 PDFs per source (NIRSpec) written into the same flat directories everything else globs — **[architectural]** (with a one-line config mitigation)
+
+**Location (NIRCam):** `steps/striping.py:358-366`, `sky.py:91-101`, `wisp.py:184-194,219-227`, `diag_striping.py:849-869`, `preview.py:41-94` (2 PNGs via .tmp+rename), `outlier.py:319-335` — all defaulting `plot=True`, all into `field.filter_dir(filt)`.
+**Location (NIRSpec):** `nirspec/plots.py:190-192,418,459,652-653,770-771,1038-1040` — `_zfit.pdf`, `_nods.pdf`, `_prof.pdf`, `_spec.pdf`, stuck-shutter diagnostics, into the workspace dir.
+
+**Why it's costly:** a 200-exposure × 4-filter NIRCam run emits **~5,600 small diagnostic files** (each ≥2 metadata ops; preview pays create+rename ×2); a NIRSpec obs adds 500–1,500 per-source PDFs. Beyond the create/close round trips themselves, these inflate the very directories that `Field.get_exposure_files`, `Observation.glob`, `discover_files`, RGB's `_find_mosaic`, and the summary generators repeatedly list — so every later glob pays O(entries) for files the pipeline never reads back. This is the *compounding* finding: it makes every glob-shaped finding worse.
+
+**Fix:**
+- **Today, zero code:** `plot = false` in cluster config for production runs.
+- **Architectural (recommended):** a `diagnostics/` subdirectory per filter / per obs (`field.diag_dir(filt)`, and a workspace `plots/` dir for NIRSpec), so diagnostics stop polluting the canonical-glob namespace even when enabled. Self-contained path change in each step, but it changes where you look for QA products, so it's your call. Consolidating per-step diagnostics into one multi-page PDF per (filter, step) via `PdfPages` is a further option where you'd accept serializing plot output.
+- Same routing applies to jhat's diagnostic copies (`jhat.py:84-97` listdir + `copy2` per exposure into the canonical dir) and the `savephottable` per-exposure ECSV.
+
+The parallel-write pattern is *not* an obstacle here: workers can write per-exposure diagnostics into a subdirectory just as safely as into the parent.
+
+### H7. `select_overlapping_files` re-opens every candidate exposure's WCS per tile (N_exposures × N_tiles) — **[local fix]**
+
+**Location:** `pipeline/campfire_pipeline/nircam/geometry.py:37-46`; per-tile callers `manifest.py:334-351` (`get_stale_tiles`) and `steps/resample.py:223`
+
+The function `fits.open`s every exposure to read `hdul[1].header` WCS and build a footprint polygon — and both callers invoke it **inside their tile loop** over the same candidate list. An exposure's footprint never changes between tiles.
+
+**Why it's costly:** ~100–300 exposures × ~4–30 tiles = **1,000–9,000 redundant fits opens per resample run or `cfpipe nircam check`** (guess on tile counts). `get_stale_tiles` additionally resolves `with_step='CFP_OUT'` without a `StepStatus`, adding one more `fits.open` per candidate (`manifest.py:327-331` → `field.py:456-461` fallback), so each file is opened twice per check before any work happens.
+
+**Fix:** compute footprints once per filter — `polys = {f: footprint(f) for f in candidate_files}` (or reuse the S_REGION strings `orchestrate._read_sregions` already collects) — and make the per-tile loop pure shapely intersection. Thread a `StepStatus.scan` into `get_stale_tiles` like `_run_resample` already does (`orchestrate.py:478`).
+
+### H8. Drizzle and outlier open every input 2–3× per tile/visit — **[local fix]**
+
+**Location:** `pipeline/campfire_pipeline/nircam/drizzle.py:110-128` (header pass) + `:387` (`ImageModel` pass, via 530-557); `outlier_detect.py:44-70` (visit-WCS pass) + drizzle_tile_singles (`drizzle.py:387`) + `:191-218` (flag-loop third open)
+
+`drizzle_tile` does a header-only scan of all N CRF inputs to size the output WCS (`ImageModel` for input[0], `getheader` for the rest), then re-opens **every** input via `ImageModel` (which also parses the embedded ASDF/gwcs — many small reads) in the drizzle loop. `outlier_detect_for_visit` does the same dance **plus a third open** of each visit file to mutate DQ.
+
+**Why it's costly:** at COSMOS-Web scale (~200 inputs/tile, 2–30 tiles, 8–15 filters — **guess**) the redundant first-pass scan alone is 10³–10⁴ extra opens per field run, each an open+stat+header+ASDF-parse over NFS. The flag-loop open is a necessary write, but the WCS pre-pass duplicates data the main pass already holds.
+
+**Fix:** make the pre-pass uniformly cheap (plain `fits.getheader` for *all* inputs including input[0] — drop the `ImageModel` open there) so the expensive ASDF-parsing open happens exactly once per input, in the drizzle loop. Pass `memmap=False` on the `ImageModel`/`fits.open` calls since all six arrays (data/err/dq/var_*) are fully materialized anyway (see M2).
+
+---
+
+## 3. Findings — Medium impact
+
+### M1. `atomic_save` reopens the just-written file in update mode on essentially every step write — **[local fix]**
+
+**Location:** `pipeline/campfire_pipeline/common/io.py:45-65`; called with `header_updates=cfp.format(...)` by ~12 NIRCam steps per exposure
+
+After staging the write to `.tmp`, any `header_updates`/`extra_hdus` triggers a second `fits.open(tmp, mode='update')` — re-open, re-parse, header mutate (and with `extra_hdus`, HDU replace/append, which forces astropy to rewrite from the change point), flush, close — then `os.replace`. Since every step stamps a `CFP_*` key, the branch is always taken: **~8,640 reopen cycles per typical NIRCam field run** (720 exposures × 12 steps). Nuance: the `.tmp` was written microseconds earlier so its pages are warm in the client cache — the cost is the open/close/commit round trips and the rewrite-on-append, not a cold re-read; this is why it's Medium, not High.
+
+**Fix:** apply `header_updates` *before* the staging write when only headers change — set keys on `hdul[0].header` / the datamodel's fits-pointer header, then save once. Keep the reopen **only** for the `extra_hdus` path (jwst datamodels can't carry non-schema extensions through `.save`). The atomicity contract (`.tmp` + `os.replace`) is correct and must be preserved.
+
+### M2. astropy/stdatamodels default `memmap=True` over NFS — full-array and header-only reads both pay for it — **[local fix]**
+
+memmap turns one sequential read (NFS's strong suit) into demand-paged small reads (its weak suit). Two distinct cases, both worth `memmap=False`:
+
+- **Full-array reads** that immediately materialize everything: `drizzle.py:387` (6 full arrays per input), `nirspec/stage3.py:314-315` (opt-ext s2d/x1d, all extensions copied into `_spec.fits`), `manifest.py:42` `compute_file_hash` (**explicitly passes `memmap=True`**, then `.tobytes()` the whole SCI+DQ — the worst combination; ~33MB per file as page faults), per-exposure step opens (`striping.py:260`, `sky.py:46`, `edge.py:36`, `variance.py:68`, `bad_pixel.py:102,176`).
+- **Header-only opens** where memmap setup is pure waste: `common/cfp.py:103,128,147`, `nircam/status.py` scan/add_paths, `metadata/reader.py:117,161,195`, `shutters.py:152`, `slits.py:17,30`.
+
+**Fix:** add `memmap=False` at these call sites (or `fits.getheader` for pure header probes). For jwst `ImageModel`, stdatamodels forwards open kwargs in current versions — `ImageModel(path, memmap=False)`; verify on the installed version. Mechanical, low-risk, and the hash case alone converts thousands of page-fault RPCs into one streamed read per file.
+
+### M3. stage2a per-source side effects: shared rate-header rewrite, temp-file churn, and NFS cwd — **[architectural]**
+
+**Location:** `pipeline/campfire_pipeline/nirspec/stage2.py:605-617,685-688` (per-source msa FITS + asn JSON create→delete), `:608-610` (shared rate file `mode='update'`+flush per source), `:497,766,893` + `stage3.py:219`, `stage1.py:812` (`os.chdir(workspace_dir)` before jwst pipeline calls)
+
+Three compounding behaviors in the hottest loop: (a) the shared rate file's primary header is rewritten (open-update + flush + close) once per source just to repoint `MSAMETFL`, ~N_sources × N_rate_files times per run; (b) two tiny files are created and deleted per source on NFS (~4 directory-metadata ops each); (c) workers chdir into the NFS workspace, so jwst's internal scratch and intermediates land on NFS.
+
+**Why architectural:** the per-source metafile/asn is forced by the jwst `Spec2Pipeline` API, and the header toggle is how the pipeline currently communicates the metafile. The clean fix changes where transient I/O happens, not what's computed: route the per-source metafile + asn into **node-local scratch** (`$TMPDIR`), point the association at it, chdir workers into scratch, and move only the final `_cal/_s2d/_x1d` to the workspace. If `Spec2Pipeline` can take the metafile via the asn/step override without mutating the rate header (worth testing — the header is restored from `OGMETFL` anyway), the per-source rewrite disappears entirely. This eliminates ~N_sources × (1 header rewrite + 4 metadata ops) per rate file but changes the I/O contract for intermediates, so it needs your sign-off and a careful test of jwst's relative-path behavior.
+
+### M4. Outlier/resample staleness machinery hashes full SCI+DQ when the stat fast path is available but unused — **[local fix]**
+
+**Location:** `pipeline/campfire_pipeline/nircam/orchestrate.py:439-444` (`_visit_up_to_date` calls `compute_file_hash` directly), `manifest.py:23-50,59-73,76-87`
+
+`manifest.file_unchanged` has the right design — size+mtime_ns stat fast path, hash only on mismatch — but `orchestrate._visit_up_to_date` bypasses it and hashes every visit file's full SCI+DQ (~32MB each, memmap'd) **on every combine run, including no-ops**: ~800 full hash-reads for a 200-exposure × 4-filter field where nothing changed (guess on counts). `input_entry` also unconditionally hashes on every manifest write.
+
+**Fix:** make `_visit_up_to_date` consult `file_unchanged` with the manifest's stored size/mtime_ns (the data is already recorded), so unchanged files cost one stat. Add `memmap=False` to `compute_file_hash` (see M2) for the cases that genuinely must hash.
+
+### M5. Repeated directory listings: per-step, per-stage, per-tile globs of large flat dirs — **[local fix]**
+
+The same listing is re-derived many times against directories whose contents are static within a phase:
+
+| Call site | Pattern | Multiplier |
+|---|---|---|
+| `nircam/field.py:397-463` `get_exposure_files` | glob per pattern + per skip-pattern | ~12–16 calls per filter per phase (every runner + `_scan_status`) |
+| `nirspec/observation.py:374-402` `Observation.glob` | glob per include + per exclude pattern, no memoization; `check_exp_type=True` adds `fits.getheader` per matched uncal | every `_setup`, `discover_raw_files`, `discover_files` |
+| `nirspec/stage3.py:291` | two `glob.glob` of the whole workspace **per source task** to find that source's crf/cal intermediates | hundreds–thousands of tasks × workers |
+| `nircam/rgb.py:51-73,179-186` `_find_mosaic` | glob of the filter dir per (tile, filter) | n_filters × n_tiles, inside pool workers |
+| `metadata/*` | 4 independent globs per `_run_summary` (×2 under `--all`) | see H2 |
+| `nirspec/redshift_fitting.py:481,670,688` | glob per grating + `os.path.exists` per spec file for skip checks | ~600 stats + 4 globs per zfit run |
+
+**Fix pattern, applied per site:** list once, reuse. Memoize `get_exposure_files` per (filter, skip) with an explicit invalidate after detector1 adds files; cache `Observation.glob` per (directory, ext) on the instance; in stage3 cleanup, the intermediate names are deterministic from `product_name` — construct them and `try: os.remove(...) except FileNotFoundError: pass` with **zero** globs; resolve RGB mosaic paths once per filter in the parent and pass them to workers; replace per-file `os.path.exists` skip loops with one `os.scandir` into a basename set.
+
+### M6. Plotting re-reads data the process just had in memory — **[local fix]**
+
+**Location:** `nirspec/plots.py:329-387` (`plot_stage2a_results` re-opens each s2d 3–4× via `fits.getdata`: norm pass, shape pass, imshow pass — ~5,600 opens for a 200-source obs vs ~1,600 if read once); `plots.py:113-133` + `redshift_fitting.py:306-308` (`plot_zfit_results` re-opens the zfit FITS written milliseconds earlier *and* re-reads the spec FITS the fitter already loaded — up to ~1,800 redundant opens per zfit run); same pattern in `plot_stuck_shutter_diagnostics`.
+
+**Fix:** read-once dicts keyed by path inside the plot function; pass in-memory arrays (`spec_data=`, `zfit_data=` kwargs) from the fitter to the plotter, falling back to file reads only when called standalone.
+
+### M7. Redundant double/triple header reads in NIRCam orchestration — **[local fix]**
+
+- `prefetch.py:84-92,102-110`: `prefetch_detector1_references` and `prefetch_image2_references` each `fits.getheader` every uncal, back-to-back (`:128-129`), and `_filter_imaging_uncals` (`orchestrate.py:161`) reads EXP_TYPE in a third pass → up to 3 header opens per uncal per detector1 run. **Fix:** one `{file: header}` pass feeding all three consumers.
+- `orchestrate.py:114-122,459`: `_read_sregions` opens **all** filter exposures before outlier dispatch even when only one visit is pending. **Fix:** read sregions only for pending visits + overlap candidates, or fold S_REGION capture into the `StepStatus.scan` that already opens every header.
+- `orchestrate.py:187-200`: detector1 skip-check does `os.path.exists` per uncal on top of the status cache that already encodes absence. **Fix:** trust `status.has`.
+
+### M8. Look-before-you-leap `exists()`-then-open throughout — **[local fix]**, aggregate
+
+Individually Low, collectively thousands of redundant GETATTR round trips per run. Verified sites: `nirspec/stage1.py:55` (exists per uncal), `observation.py:241-249` (2–3 exists per uncal in symlink), `stage3.py:112-200` (~3–5 exists per source), `redshift_fitting.py:688`, `stuck_shutters.py:89-91`, `metadata/reader.py:70,84,113,157`, `nircam/steps/` (detector1.py:52, preview.py:46-49, image2.py:102, apply_masks.py:57, persistence.py:130, wisp.py:105), `manifest.py:201-204` (`load_manifest`), `refcat/extract.py:57,107-116`, `config.py:76-85,211-308` (config resolution chains), `common/query.py:388-401,752-781` (download path — once-per-download, lowest priority).
+
+**Fix pattern:** where the next operation opens the same path, try/except `FileNotFoundError` around the open (halves round trips and removes the TOCTOU window); where the check gates a *skip*, batch one `os.scandir` listing into a set and test membership.
+
+### M9. `cfpipe` startup runs 4 git subprocesses — including a full `git status` subtree walk — on every invocation — **[local fix]**
+
+**Location:** `pipeline/campfire_pipeline/cli.py:29`
+
+`@click.version_option(version=get_reduction_version(), ...)` evaluates eagerly at module import, for **every** command. `_git_version` runs `git describe`, `git rev-list`, `git rev-parse`, and `git status --porcelain -- pipeline` — the last stats every tracked file under `pipeline/` against the NFS-resident `.git` and working tree. Pure startup latency for every command (and every shell-out in a SLURM array); the codebase already treats NFS startup latency as a known pain (`_thread_caps.py` docstring).
+
+**Fix:** replace with a lazy eager-option callback so the git work runs only for `cfpipe --version`. Reduction runs that stamp `CMPFRVER` already call `get_reduction_version(config)` later — they keep working.
+
+---
+
+## 4. Findings — Low impact
+
+- **L1. Per-(source, grating) `_zfit.fits` files** (`redshift_fitting.py:277-304`) — ~200–900 small FITS per run. Acceptable if they're the science contract (they are: summary + inspection consume them). Consolidation into one per-obs container is possible but changes the deploy read path. **[architectural]** — flagged for awareness, not action.
+- **L2. Per-visit/per-tile manifest JSONs** (`manifest.py:169-204`) — tens of small JSONs per filter; the look-before-leap in `load_manifest` is the fixable part. Consolidating to one per-filter manifest would serialize the parallel per-visit writes — probably not worth it. **[local fix]** for the open pattern only.
+- **L3. `bkgsub.call()` re-opens the input mosaic** it already read, just for the WCS header / HDU template (`bkgsub.py:130,444`) — 1 redundant open per (filter, tile). Stash the header at first open. **[local fix]**
+- **L4. `bad_pixel` writes a diagnostic `stack_dq_*.fits` alongside every mask** (`bad_pixel.py:116-142`) — 8 extra 16MB FITS per SW filter when enabled (off by default). Gate behind `save_stack_dq=False`. **[local fix]**
+- **L5. jhat copies diagnostics into the canonical dir per exposure** (`jhat.py:84-97,269-282`) — listdir + 1–3 small copies per exposure; the scratch-on-`$TMPDIR` design itself is correct. Route to the diagnostics dir (H6); consider `savephottable=False` for production. **[local fix]**
+- **L6. `load_r_curve` leaks its HDUList and memmaps a tiny table** (`common/spectral.py:53-54`) — ~1–4 calls/run; latent fd leak under forkserver. Context-manager + `memmap=False`. **[local fix]**
+- **L7. Extended-wavelength `_gated_configs` reads every rate header twice** (build + verify both iterate it; `extended_wavelength.py:63,215,276`) — only when `extend_g140m_g235m` is on. Share one pass. The extended-ref cache on `$CAMPFIRE_ROOT/cache` is fine (write-once, guarded). **[local fix]**
+- **L8. `masks.py` sentinel probes open the same rate file 5–8× per apply cycle** (`masks.py:134,255,364` and the per-file apply chain) — only for observations with manual masks. Read the 3 sentinel keywords in one open and pass them down. **[local fix]**
+- **L9. `stuck_shutters` analysis opens each s2d twice** (`stuck_shutters.py:302,305` — SCI then VAR_RNOISE as separate `fits.getdata`) — one `fits.open` reading both. The dispatch pattern itself (paths in, data read in-worker, no shared writes) is the correct template. **[local fix]**
+- **L10. Logging is `print()`-to-stdout with heavy per-source chatter** (`common/io.py:9-11`; 32 call sites in stage2.py alone). No log *files* are created by the pipeline — the NFS exposure depends entirely on whether the SLURM script redirects stdout to NFS. **(guess — job-config concern, not code.)** Recommend `#SBATCH --output` to node-local scratch with copy-back, or accept sequential append as cheap. **[architectural]** (deployment docs)
+- **L11. Download path (`common/query.py:388-401,752-781`)** — exists+stat per file and a header open per uncal at download time; dominated by MAST transfer bandwidth, runs once. Collapse exists+stat to one try/except `os.stat` if touched anyway. **[local fix]**
+
+---
+
+## 5. What's already NFS-friendly (don't re-fix)
+
+Worth calling out so the good patterns get reused, not accidentally regressed:
+
+- **`StepStatus.scan`** (`nircam/status.py:31-48`): one header open per exposure per phase, consulted in-memory thereafter — the model consolidation pattern. CFP provenance lives *in* the FITS headers, not sidecar files.
+- **Serial CRDS prefetch before every parallel dispatch**, deduplicated by detector/filter config (`nircam/prefetch.py`, `nirspec/stage1.py:297,359`, `stage2.py:146`) — workers never race on cold downloads. (The residual gap is context *resolution*, H5.)
+- **`dispatch` + forkserver preload** (`common/parallel.py:45-60`): heavy modules imported once and inherited copy-on-write; kwargs pickled, not re-read; **no SQLite anywhere, no file locking, no concurrent writes to any shared file** — each worker writes only its own canonical output via `atomic_save`. The refuted finding confirms the orchestrator resolves file lists in the parent.
+- **Scratch on `$TMPDIR`**: jhat (`jhat.py:156`), outlier's chdir-into-scratch so stcal's MedianComputer `.bin` churn stays off NFS (explicitly documented in `outlier_detect.py`), `refcat/hsc.py:281`, `stage1.py:166`.
+- **`expmap.py`**: on-disk header cache keyed by (path, mtime_ns, size), `memmap=False`, thread-pooled misses — the model pattern for metadata scans, worth replicating in `discover_files` (H3).
+- **`manifest.file_unchanged`** size+mtime_ns fast path (the gap is the caller that bypasses it, M4).
+- **`atomic_save`'s** `.tmp` + `os.replace` atomicity contract.
+- **Consolidated ECSV outputs** (one summary/shutters/pointings file per obs); **zfit reference data** (template pickle, R-curve, IGM grid) loaded once per grating before the serial fit loop.
+
+---
+
+## 6. Triage: quick wins vs larger refactors
+
+### Quick wins (local, low-risk, biggest first)
+
+1. **H1** — hoist the two TOML properties out of the per-source loop + cache on the instance. Two small edits, removes up to ~30k NFS ops per NIRSpec obs.
+2. **H5** — `CRDS_READONLY_CACHE=1` in `setup_environment` + memoize `resolve_flat`. ~10 lines.
+3. **H3** — single-open `discover_files` + fold in SRCFLUX. Halves a 10–50k-open sweep.
+4. **H4** — `lru_cache` wisp templates and flat data. ~15 lines.
+5. **H7** — hoist footprint computation out of the tile loops; pass `status` into `get_stale_tiles`.
+6. **M4** — route `_visit_up_to_date` through `file_unchanged`.
+7. **M2** — `memmap=False` sweep (mechanical; prioritize `compute_file_hash`, drizzle inputs, opt-ext, header-only probes).
+8. **H2 (local half)** — one open per spec file in summary/shutters, merged zfit reads, single scandir per `_run_summary`.
+9. **M9** — lazy `--version`.
+10. **H6 (config half)** — `plot=false` in the CANDIDE production config, today.
+11. **M6/M7/M8** — plot read-once caches, prefetch single-pass headers, try/except-open conversions; good batched cleanup PRs.
+
+### Larger refactors (need your decision — they change layout or I/O contracts)
+
+1. **H6** — `diagnostics/` subdirectories (and/or consolidated multi-page PDFs). Changes where QA products live; biggest structural payoff because it shrinks every directory the pipeline repeatedly lists.
+2. **H2 (hash half)** — compute spec-file hashes at write time (header keyword) or adopt stat-based provenance. Touches the deploy contract.
+3. **M3** — stage2a transients on node-local scratch + non-mutating metafile handoff to `Spec2Pipeline`; jwst cwd to `$TMPDIR` with explicit copy-back of finals. Highest-risk/highest-reward NIRSpec change; needs validation that jwst resolves relative inputs correctly from scratch.
+4. **H3 (sidecar half)** — persisted products-metadata table per workspace replacing repeated `discover_files` sweeps (mirror `expmap.py`'s cache design).
+5. **Per-source cal copies** (flagged in H2/pointings): the layout multiplies the cal population by source count. Any consolidation (e.g. recording unique-exposure headers once at stage2) ripples into stage2b/stage3 grouping — design discussion, not a patch.
+
+### Explicit non-findings
+
+- No SQLite on NFS, no file locking, no shared-file concurrent writes anywhere in the package.
+- The bulk pixel I/O architecture (large sequential FITS reads/writes, drizzle accumulation, SHA-256 streams) is bandwidth-bound and NFS-appropriate as-is.
+- `redshift_fitting` is serial-with-numba-threads, not a Pool — it does not multiply NFS load by `n_processes` (the unused `Pool` import at `redshift_fitting.py:515` is dead code worth deleting to avoid future confusion).

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -69,6 +69,38 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- NFS cache tier for the NIRCam pipeline (PR 1 of
+  `docs/design-nircam-exposure-major.md`; findings H4/H5/M2/M9 of
+  `docs/nfs_audit.md`). No change to pixel values or reference selection —
+  verified by the parity/equivalence checks noted below.
+  - Per-worker reference-data caches: wisp templates are read once per worker
+    instead of 5x per exposure (`wisp._load_template`, lru, NaN-cleaning in
+    the cache, exposure-specific masking on a copy); flat references are
+    cached as pristine `FlatModel`s with a deep copy handed to each
+    `do_correction` call (jwst mutates the flat it is given, so the cache
+    never exposes a mutated model); per-detector bad-pixel masks are read
+    once per worker (`bad_pixel._load_fl_mask`). Caches die with each step's
+    worker pool, so rebuilt references are always re-read on the next step.
+  - Detector-major dispatch ordering for per-exposure steps
+    (`orchestrate._detector_sorted`): `Pool.map` chunks become
+    detector-contiguous so the per-detector caches hit instead of thrash.
+    Tasks are independent; only log ordering changes.
+  - CRDS worker hardening (`[nircam].crds_readonly_workers`, default on):
+    parallel workers of detector1/wisp/striping/image2 run with
+    `CRDS_READONLY_CACHE=1` + `CRDS_MODE=local`, dropping per-call
+    server-contact and cache-write bookkeeping against the NFS-resident
+    cache. The serial prefetch now runs unconditionally (previously skipped
+    for `n_processes <= 1`) and additionally warms `pars-*` step-parameter
+    references, which stpipe fetches separately and a read-only worker
+    cannot download on a miss.
+  - `memmap=False` on FITS opens that read whole arrays or only headers
+    (steps, drizzle/outlier inputs, manifest hashing, CFP/status header
+    probes, geometry/S_REGION scans): NFS serves one sequential read far
+    better than memmap's page-faulted small reads. Hash values are unchanged
+    (`do_not_scale_image_data` still reads raw stored bytes).
+  - `cfpipe --version` is resolved lazily: the four git subprocesses
+    (including a `git status` walk of the pipeline subtree on NFS) no longer
+    run at module import on every cfpipe invocation.
 - NIRCam CLI startup is now proportional to the work being run, not to the
   whole step catalog. `orchestrate.py` previously imported all 14 step modules
   at module top, so every `cfpipe nircam` invocation — including `--help` and a

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -85,14 +85,18 @@ Release procedure: edit the `## Unreleased` section below, then run
     (`orchestrate._detector_sorted`): `Pool.map` chunks become
     detector-contiguous so the per-detector caches hit instead of thrash.
     Tasks are independent; only log ordering changes.
-  - CRDS worker hardening (`[nircam].crds_readonly_workers`, default on):
-    parallel workers of detector1/wisp/striping/image2 run with
-    `CRDS_READONLY_CACHE=1` + `CRDS_MODE=local`, dropping per-call
-    server-contact and cache-write bookkeeping against the NFS-resident
-    cache. The serial prefetch now runs unconditionally (previously skipped
-    for `n_processes <= 1`) and additionally warms `pars-*` step-parameter
-    references, which stpipe fetches separately and a read-only worker
-    cannot download on a miss.
+  - CRDS cold-fetch races are closed at the source rather than avoided. The
+    two direct `crds.getreferences` calls outside stpipe — the in-memory flat
+    lookup in `steps/_flat.resolve_flat` and the prefetch warm-up — now take
+    the global `crds.cache` lock, the same lock stpipe holds for its own
+    lookups. A worker that hits a cold reference downloads it once while the
+    others block and then find it already cached (CRDS double-checks existence
+    inside the lock). The serial prefetch is therefore a pure warm-up, not a
+    correctness requirement: it reads each uncal header once (both the
+    detector1 and image2 dedup keys come from one `getheader`) and skips
+    exposures whose detector1/image2 output already exists, so re-running a
+    finished field no longer pays the multi-minute NFS header scan. Reference
+    selection is unchanged.
   - `memmap=False` on FITS opens that read whole arrays or only headers
     (steps, drizzle/outlier inputs, manifest hashing, CFP/status header
     probes, geometry/S_REGION scans): NFS serves one sequential read far

--- a/pipeline/campfire_pipeline/cli.py
+++ b/pipeline/campfire_pipeline/cli.py
@@ -25,8 +25,25 @@ from campfire_pipeline.common.version import get_reduction_version
 # Top-level group
 # ---------------------------------------------------------------------------
 
+def _print_version(ctx, param, value):
+    """Eager ``--version`` callback so the git interrogation is lazy.
+
+    ``click.version_option(version=get_reduction_version())`` evaluated the
+    version at module import — i.e. on *every* cfpipe invocation — and
+    ``get_reduction_version()`` runs four git subprocesses including a
+    ``git status`` walk of the pipeline subtree, which on a cluster NFS
+    checkout is pure startup latency for commands that never print it.
+    Reduction runs still resolve the version when they stamp CMPFRVER.
+    """
+    if not value or ctx.resilient_parsing:
+        return
+    click.echo(f'cfpipe, version {get_reduction_version()}')
+    ctx.exit()
+
+
 @click.group()
-@click.version_option(version=get_reduction_version(), prog_name='cfpipe')
+@click.option('--version', is_flag=True, expose_value=False, is_eager=True,
+              callback=_print_version, help='Show the version and exit.')
 def main():
     """CAMPFIRE data reduction pipeline."""
     pass

--- a/pipeline/campfire_pipeline/common/cfp.py
+++ b/pipeline/campfire_pipeline/common/cfp.py
@@ -100,7 +100,7 @@ def has_step(path_or_header, key):
         raise ValueError(f"Unknown CFP key: {key}")
     if isinstance(path_or_header, fits.Header):
         return key in path_or_header
-    with fits.open(path_or_header) as hdul:
+    with fits.open(path_or_header, memmap=False) as hdul:
         return key in hdul[0].header
 
 
@@ -125,7 +125,7 @@ def get_steps(path):
 
     Used by ``cfpipe nircam status`` to render a per-exposure completion table.
     """
-    with fits.open(path) as hdul:
+    with fits.open(path, memmap=False) as hdul:
         hdr = hdul[0].header
         return {k: hdr[k] for k in CFP_KEYS if k in hdr}
 
@@ -144,7 +144,7 @@ def clear_from(path, key):
 
     base, ext = os.path.splitext(path)
     tmp = f'{base}.tmp{ext}' if ext else f'{path}.tmp'
-    with fits.open(path) as hdul:
+    with fits.open(path, memmap=False) as hdul:
         for k in to_clear:
             if k in hdul[0].header:
                 del hdul[0].header[k]

--- a/pipeline/campfire_pipeline/common/parallel.py
+++ b/pipeline/campfire_pipeline/common/parallel.py
@@ -31,6 +31,7 @@ helper risks the same half-built-pool deadlock there. (``spawn`` ignores the
 preload list entirely — each worker re-imports from scratch.)
 """
 
+import os
 import sys
 from functools import partial
 from multiprocessing import get_context
@@ -96,8 +97,19 @@ class _RetryOnIOError:
                     raise
 
 
+def _apply_worker_env(env):
+    """Pool initializer: apply per-worker environment overrides.
+
+    Runs once in each worker process after fork/spawn, so the overrides
+    never leak into the parent (which e.g. must keep CRDS cache write
+    access for the serial prefetch).
+    """
+    if env:
+        os.environ.update(env)
+
+
 def dispatch(func, tasks, n_processes=1, use_starmap=False, retry=False,
-             **kwargs):
+             worker_env=None, **kwargs):
     """Run *func* over *tasks* serially or in parallel.
 
     Parameters
@@ -114,6 +126,11 @@ def dispatch(func, tasks, n_processes=1, use_starmap=False, retry=False,
         If True, each task is unpacked as positional args.
     retry : bool
         If True, wrap worker with retry logic for CRDS file errors.
+    worker_env : dict, optional
+        Environment variable overrides applied in each *worker* process
+        (parallel path only). Deliberately NOT applied on the serial path:
+        the parent process keeps its own environment so e.g. CRDS retains
+        cache write access when no worker pool exists.
     **kwargs
         Extra keyword arguments bound to *func* via functools.partial.
 
@@ -132,7 +149,9 @@ def dispatch(func, tasks, n_processes=1, use_starmap=False, retry=False,
 
     if n_processes > 1:
         log(f"Dispatching {len(tasks)} tasks across {n_processes} workers")
-        with _MP_CTX.Pool(processes=n_processes) as pool:
+        with _MP_CTX.Pool(processes=n_processes,
+                          initializer=_apply_worker_env if worker_env else None,
+                          initargs=(worker_env,) if worker_env else ()) as pool:
             if use_starmap:
                 return pool.starmap(worker, tasks)
             else:

--- a/pipeline/campfire_pipeline/common/parallel.py
+++ b/pipeline/campfire_pipeline/common/parallel.py
@@ -31,7 +31,6 @@ helper risks the same half-built-pool deadlock there. (``spawn`` ignores the
 preload list entirely — each worker re-imports from scratch.)
 """
 
-import os
 import sys
 from functools import partial
 from multiprocessing import get_context
@@ -97,19 +96,8 @@ class _RetryOnIOError:
                     raise
 
 
-def _apply_worker_env(env):
-    """Pool initializer: apply per-worker environment overrides.
-
-    Runs once in each worker process after fork/spawn, so the overrides
-    never leak into the parent (which e.g. must keep CRDS cache write
-    access for the serial prefetch).
-    """
-    if env:
-        os.environ.update(env)
-
-
 def dispatch(func, tasks, n_processes=1, use_starmap=False, retry=False,
-             worker_env=None, **kwargs):
+             **kwargs):
     """Run *func* over *tasks* serially or in parallel.
 
     Parameters
@@ -126,11 +114,6 @@ def dispatch(func, tasks, n_processes=1, use_starmap=False, retry=False,
         If True, each task is unpacked as positional args.
     retry : bool
         If True, wrap worker with retry logic for CRDS file errors.
-    worker_env : dict, optional
-        Environment variable overrides applied in each *worker* process
-        (parallel path only). Deliberately NOT applied on the serial path:
-        the parent process keeps its own environment so e.g. CRDS retains
-        cache write access when no worker pool exists.
     **kwargs
         Extra keyword arguments bound to *func* via functools.partial.
 
@@ -149,9 +132,7 @@ def dispatch(func, tasks, n_processes=1, use_starmap=False, retry=False,
 
     if n_processes > 1:
         log(f"Dispatching {len(tasks)} tasks across {n_processes} workers")
-        with _MP_CTX.Pool(processes=n_processes,
-                          initializer=_apply_worker_env if worker_env else None,
-                          initargs=(worker_env,) if worker_env else ()) as pool:
+        with _MP_CTX.Pool(processes=n_processes) as pool:
             if use_starmap:
                 return pool.starmap(worker, tasks)
             else:

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -142,6 +142,17 @@
 # `cfpipe nircam process` (per-exposure) and `cfpipe nircam combine`
 # (ensemble through resample).
 
+[nircam]
+    # Harden the CRDS environment in parallel workers of CRDS-using steps
+    # (detector1/wisp/striping/image2): CRDS_READONLY_CACHE=1 + CRDS_MODE=local.
+    # The serial prefetch warms the cache (science + pars references) before
+    # dispatch, so workers never legitimately download; readonly/local mode
+    # drops per-call server-contact and cache-write bookkeeping against the
+    # (NFS-resident) cache. Reference selection is unchanged. Set false if a
+    # run must cold-download references from inside workers (e.g. ad-hoc
+    # laptop runs against an empty cache with prefetch failing).
+    crds_readonly_workers = true
+
 # --- process phase (per-exposure) ---
 
 [nircam.detector1]

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -143,15 +143,6 @@
 # (ensemble through resample).
 
 [nircam]
-    # Harden the CRDS environment in parallel workers of CRDS-using steps
-    # (detector1/wisp/striping/image2): CRDS_READONLY_CACHE=1 + CRDS_MODE=local.
-    # The serial prefetch warms the cache (science + pars references) before
-    # dispatch, so workers never legitimately download; readonly/local mode
-    # drops per-call server-contact and cache-write bookkeeping against the
-    # (NFS-resident) cache. Reference selection is unchanged. Set false if a
-    # run must cold-download references from inside workers (e.g. ad-hoc
-    # laptop runs against an empty cache with prefetch failing).
-    crds_readonly_workers = true
 
 # --- process phase (per-exposure) ---
 

--- a/pipeline/campfire_pipeline/nircam/drizzle.py
+++ b/pipeline/campfire_pipeline/nircam/drizzle.py
@@ -108,7 +108,7 @@ def _build_output_wcs(crf_files, crpix, crval, shape, rotation, pixel_scale):
     from stdatamodels.jwst.datamodels import ImageModel
 
     sregions = []
-    with ImageModel(crf_files[0]) as ref:
+    with ImageModel(crf_files[0], memmap=False) as ref:
         ref_wcs = deepcopy(ref.meta.wcs)
         ref_wcsinfo = ref.meta.wcsinfo.instance
         sregions.append(ref.meta.wcsinfo.s_region)
@@ -384,7 +384,7 @@ def _prepare_drizzle_input(crf_file, output_wcs, out_shape, *,
     from stcal.resample.utils import build_driz_weight, resample_range
     from stdatamodels.jwst.datamodels import ImageModel
 
-    with ImageModel(crf_file) as model:
+    with ImageModel(crf_file, memmap=False) as model:
         data = np.asarray(model.data, dtype=np.float32)
         err = np.asarray(model.err, dtype=np.float32)
         in_shape = data.shape

--- a/pipeline/campfire_pipeline/nircam/geometry.py
+++ b/pipeline/campfire_pipeline/nircam/geometry.py
@@ -35,7 +35,7 @@ def select_overlapping_files(exposure_files, tile_polygon, *, in_shape=(2048, 20
 
     selected = []
     for f in exposure_files:
-        with fits.open(f, ignore_missing_simple=True) as hdul:
+        with fits.open(f, ignore_missing_simple=True, memmap=False) as hdul:
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore')
                 wcs = WCS(hdul[1].header, naxis=2)

--- a/pipeline/campfire_pipeline/nircam/manifest.py
+++ b/pipeline/campfire_pipeline/nircam/manifest.py
@@ -37,9 +37,10 @@ def compute_file_hash(filepath):
         Hex digest prefixed with ``sha256:``.
     """
     h = hashlib.sha256()
-    # do_not_scale_image_data lets memmap work even when extensions carry
-    # BZERO/BSCALE/BLANK; the raw stored bytes are a fine fingerprint.
-    with fits.open(filepath, memmap=True, do_not_scale_image_data=True) as hdul:
+    # do_not_scale_image_data: hash the raw stored bytes regardless of
+    # BZERO/BSCALE/BLANK. memmap=False: the arrays are read in full anyway,
+    # and one sequential read beats memmap's page-faulted small reads on NFS.
+    with fits.open(filepath, memmap=False, do_not_scale_image_data=True) as hdul:
         for extname in ('SCI', 'DQ'):
             try:
                 data = hdul[extname].data
@@ -129,7 +130,7 @@ def create_manifest(mosaic_name, field, filtname, tile, pixel_scale,
             'detector': parts[3] if len(parts) > 3 else '',
         }
         try:
-            with fits.open(f, memmap=True) as hdul:
+            with fits.open(f, memmap=False) as hdul:
                 date_obs = hdul[0].header.get('DATE-OBS')
                 if date_obs:
                     extra['date_obs'] = date_obs

--- a/pipeline/campfire_pipeline/nircam/orchestrate.py
+++ b/pipeline/campfire_pipeline/nircam/orchestrate.py
@@ -67,8 +67,57 @@ ALL_STEPS = PROCESS_STEPS + COMBINE_STEPS
 STEP_NAMES = [name for name, _ in ALL_STEPS]
 
 # Steps that hit CRDS — used by run_step() to decide when to pre-fetch
-# reference files before parallel dispatch.
+# reference files before parallel dispatch, and to harden the worker CRDS
+# environment (see _crds_worker_env).
 _CRDS_STEPS = {'detector1', 'wisp', 'striping', 'image2'}
+
+
+def _crds_worker_env(config):
+    """Worker env overrides for CRDS-using steps, or None when disabled.
+
+    With the context pinned and the cache warmed by the serial prefetch,
+    workers never legitimately need to download or write to the CRDS cache.
+    ``CRDS_READONLY_CACHE=1`` drops the per-call cache-writability probes
+    and lock handling; ``CRDS_MODE=local`` skips the server-contact /
+    config-refresh bookkeeping of the default ``auto`` mode. Both are pure
+    metadata savings on an NFS-resident cache — reference selection is
+    unchanged (same pinned context, same mappings). A genuinely missing
+    reference becomes a loud CrdsError instead of 16 workers racing to
+    download over NFS; that means the prefetch is broken and we want to
+    hear about it. Escape hatch for cold-cache laptop runs:
+    ``[nircam].crds_readonly_workers = false``.
+
+    Applied only to worker processes (Pool initializer) — the parent keeps
+    write access for the prefetch itself, as does the serial (n_processes
+    <= 1) path, which runs in the parent.
+    """
+    if not config.get('nircam', {}).get('crds_readonly_workers', True):
+        return None
+    if not os.environ.get('CRDS_CONTEXT'):
+        # Without a pinned context, local/readonly mode could resolve a
+        # different (cache-default) context than the parent would.
+        return None
+    return {'CRDS_READONLY_CACHE': '1', 'CRDS_MODE': 'local'}
+
+
+def _detector_sorted(paths):
+    """Order exposure paths detector-major (stable within detector).
+
+    Tasks are independent, so dispatch order is free to choose — but
+    ``Pool.map`` hands each worker a contiguous chunk, so detector-major
+    order makes a worker's chunk mostly single-detector. Per-worker
+    reference caches (wisp templates, flats, bad-pixel masks — all keyed
+    per detector) then hit instead of thrash.
+    """
+    def key(p):
+        base = os.path.basename(p)
+        parts = base.removesuffix('.fits').split('_')
+        # Detector is the 4th underscore field in both canonical and uncal
+        # names (jw..._<visitgrp>_<expnum>_<detector>[_uncal].fits) — same
+        # token the step modules themselves parse.
+        det = parts[3] if len(parts) > 3 else ''
+        return (det, base)
+    return sorted(paths, key=key)
 
 # Per-exposure steps dispatched through the generic ``_run_per_exposure``
 # helper: step_name -> (step module basename, worker callable, CFP key). The
@@ -115,7 +164,7 @@ def _read_sregions(exposure_files):
     """Return S_REGION header strings parallel to ``exposure_files``."""
     sregions = []
     for f in exposure_files:
-        with fits.open(f) as hdul:
+        with fits.open(f, memmap=False) as hdul:
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore')
                 sregions.append(hdul[1].header['S_REGION'])
@@ -204,10 +253,11 @@ def _run_detector1(field, config, filtname, n_processes, overwrite, status):
 
     from campfire_pipeline.nircam.steps.detector1 import detector1_step
     cfg = get_nircam_step_config('detector1', config, field)
+    pending = _detector_sorted(pending)
     log(f"detector1: dispatching {len(pending)} files for {filtname}")
     dispatch(detector1_step, pending, n_processes=n_processes,
              field=field, step_config=cfg, overwrite=overwrite,
-             status=status)
+             status=status, worker_env=_crds_worker_env(config))
     new_canonical = [
         field.get_exposure_path(
             os.path.basename(u).removesuffix('_uncal.fits'), filtname,
@@ -257,10 +307,13 @@ def _run_per_exposure(step_name, field, config, filtname,
         return
     fn = _load_step(module_basename, func_name)
     cfg = get_nircam_step_config(step_name, config, field)
+    pending = _detector_sorted(pending)
     log(f"{step_name}: dispatching {len(pending)} exposures for {filtname}")
     dispatch(fn, pending, n_processes=n_processes,
              field=field, step_config=cfg, overwrite=overwrite,
-             status=status)
+             status=status,
+             worker_env=(_crds_worker_env(config)
+                         if step_name in _CRDS_STEPS else None))
     status.mark_all(pending, cfp_key)
 
 
@@ -352,6 +405,7 @@ def _run_bad_pixel(field, config, filtname, n_processes, overwrite, status):
                                  overwrite)
     if not pending:
         return
+    pending = _detector_sorted(pending)
     log(f"bad_pixel: dispatching {len(pending)} exposures for {filtname}")
     dispatch(bad_pixel_step, pending, n_processes=n_processes,
              field=field, step_config=cfg, overwrite=overwrite,

--- a/pipeline/campfire_pipeline/nircam/orchestrate.py
+++ b/pipeline/campfire_pipeline/nircam/orchestrate.py
@@ -67,37 +67,8 @@ ALL_STEPS = PROCESS_STEPS + COMBINE_STEPS
 STEP_NAMES = [name for name, _ in ALL_STEPS]
 
 # Steps that hit CRDS — used by run_step() to decide when to pre-fetch
-# reference files before parallel dispatch, and to harden the worker CRDS
-# environment (see _crds_worker_env).
+# reference files before parallel dispatch.
 _CRDS_STEPS = {'detector1', 'wisp', 'striping', 'image2'}
-
-
-def _crds_worker_env(config):
-    """Worker env overrides for CRDS-using steps, or None when disabled.
-
-    With the context pinned and the cache warmed by the serial prefetch,
-    workers never legitimately need to download or write to the CRDS cache.
-    ``CRDS_READONLY_CACHE=1`` drops the per-call cache-writability probes
-    and lock handling; ``CRDS_MODE=local`` skips the server-contact /
-    config-refresh bookkeeping of the default ``auto`` mode. Both are pure
-    metadata savings on an NFS-resident cache — reference selection is
-    unchanged (same pinned context, same mappings). A genuinely missing
-    reference becomes a loud CrdsError instead of 16 workers racing to
-    download over NFS; that means the prefetch is broken and we want to
-    hear about it. Escape hatch for cold-cache laptop runs:
-    ``[nircam].crds_readonly_workers = false``.
-
-    Applied only to worker processes (Pool initializer) — the parent keeps
-    write access for the prefetch itself, as does the serial (n_processes
-    <= 1) path, which runs in the parent.
-    """
-    if not config.get('nircam', {}).get('crds_readonly_workers', True):
-        return None
-    if not os.environ.get('CRDS_CONTEXT'):
-        # Without a pinned context, local/readonly mode could resolve a
-        # different (cache-default) context than the parent would.
-        return None
-    return {'CRDS_READONLY_CACHE': '1', 'CRDS_MODE': 'local'}
 
 
 def _detector_sorted(paths):
@@ -257,7 +228,7 @@ def _run_detector1(field, config, filtname, n_processes, overwrite, status):
     log(f"detector1: dispatching {len(pending)} files for {filtname}")
     dispatch(detector1_step, pending, n_processes=n_processes,
              field=field, step_config=cfg, overwrite=overwrite,
-             status=status, worker_env=_crds_worker_env(config))
+             status=status)
     new_canonical = [
         field.get_exposure_path(
             os.path.basename(u).removesuffix('_uncal.fits'), filtname,
@@ -311,9 +282,7 @@ def _run_per_exposure(step_name, field, config, filtname,
     log(f"{step_name}: dispatching {len(pending)} exposures for {filtname}")
     dispatch(fn, pending, n_processes=n_processes,
              field=field, step_config=cfg, overwrite=overwrite,
-             status=status,
-             worker_env=(_crds_worker_env(config)
-                         if step_name in _CRDS_STEPS else None))
+             status=status)
     status.mark_all(pending, cfp_key)
 
 
@@ -624,7 +593,8 @@ def run_process(field, config, filters=None, n_processes=1, overwrite=False):
     filters = _resolve_filters(filters, field)
     status = _scan_status(field, filters, overwrite=overwrite)
     log(f"=== Process phase: field={field.name}, filters={filters} ===")
-    prefetch_process_references(field, filters, n_processes)
+    prefetch_process_references(field, filters, status=status,
+                               overwrite=overwrite)
     for filt in filters:
         log(f"--- Process: {filt} ---")
         for step_name, _ in PROCESS_STEPS:
@@ -666,7 +636,8 @@ def run_step(step_name, field, config, filters=None, n_processes=1,
     log(f"=== Step '{step_name}': field={field.name}, filters={filters} ===")
     if step_name in _CRDS_STEPS:
         from campfire_pipeline.nircam.prefetch import prefetch_process_references
-        prefetch_process_references(field, filters, n_processes)
+        prefetch_process_references(field, filters, status=status,
+                                    overwrite=overwrite)
 
     for filt in filters:
         if step_name == 'resample':

--- a/pipeline/campfire_pipeline/nircam/outlier_detect.py
+++ b/pipeline/campfire_pipeline/nircam/outlier_detect.py
@@ -59,7 +59,7 @@ def _build_visit_wcs(crf_files):
     from stdatamodels.jwst.datamodels import ImageModel
 
     sregions = []
-    with ImageModel(crf_files[0]) as ref:
+    with ImageModel(crf_files[0], memmap=False) as ref:
         ref_wcs = deepcopy(ref.meta.wcs)
         ref_wcsinfo = ref.meta.wcsinfo.instance
         sregions.append(ref.meta.wcsinfo.s_region)
@@ -191,7 +191,7 @@ def outlier_detect_for_visit(
     for crf in contributing_paths:
         if crf not in visit_set:
             continue  # only flag and save the visit's own files
-        with ImageModel(crf) as model:
+        with ImageModel(crf, memmap=False) as model:
             dq_before = (model.dq & OUTLIER_BIT) != 0
             sci_for_plot = model.data.copy() if plot else None
             # Match jwst.outlier_detection.imaging.detect_outliers: pass

--- a/pipeline/campfire_pipeline/nircam/prefetch.py
+++ b/pipeline/campfire_pipeline/nircam/prefetch.py
@@ -1,22 +1,32 @@
 """CRDS reference file pre-fetching for the NIRCam pipeline.
 
-Multiple workers downloading the same CRDS file simultaneously can leave one
-reading a partially-written file. Running CRDS lookups serially — one query
-per unique detector / filter / pupil combination — before ``dispatch()``
-ensures the cache is fully populated by the time parallel workers start.
+Warming the CRDS cache before ``dispatch()`` lets parallel workers start
+against a populated cache instead of a cold one. It is a *performance* pass,
+not a correctness one: the CRDS cache lock (see ``_fetch`` here and
+``steps/_flat.resolve_flat``) makes any residual cache miss in a worker a
+safe, serialized lazy download — the first worker fetches while the rest
+block, then find the file already cached. So the dedup granularity below only
+affects how much is warmed up front, never which references a step selects.
+CRDS still resolves each file by the exposure's own parameters + USEAFTER
+epoch at run time, exactly as ``Step.get_reference_file()`` does.
 
 Mirrors the NIRSpec pattern in ``nirspec/stage1.py`` and ``nirspec/stage2.py``.
 
-Two correctness anchors keep this in lockstep with the pipeline so we don't
-download references the run will never use:
+Two anchors keep the warmed set aligned with what the run will actually use:
 
 1. The reftype lists come from ``Detector1Pipeline.reference_file_types`` and
    ``Image2Pipeline.reference_file_types`` — the same aggregation jwst itself
-   uses, so we cover everything (incl. ``persat``/``trapdensity``/``trappars``)
-   and nothing extra.
+   uses, so we cover everything (incl. ``persat``/``trapdensity``/``trappars``
+   and the flat that wisp/striping resolve directly) and nothing extra.
 2. The CRDS lookup parameters come from ``model.get_crds_parameters()`` on the
    uncal datamodel — the same call ``Step.get_reference_file()`` makes — so
    the rmap match resolves to byte-identical files.
+
+The scan reads each uncal header at most once (both the detector1 and image2
+dedup keys come from one ``getheader``) and skips exposures whose
+detector1/image2 output already exists, so re-running a finished field reads
+no headers at all — the multi-minute NFS header scan only happens for work
+that remains.
 """
 
 import os
@@ -47,32 +57,6 @@ def _reftypes(pipeline_name):
     return out
 
 
-def _pars_reftypes(pipeline_name):
-    """Return the ``pars-*`` step-parameter reftypes for a pipeline.
-
-    These matter for correctness under the hardened worker CRDS environment
-    (``CRDS_READONLY_CACHE=1``, see ``orchestrate._crds_worker_env``): stpipe
-    fetches ``pars-<step>`` references separately from science references on
-    every ``Step.call``, and a read-only worker cannot download one on a
-    cache miss — so the serial prefetch must warm them too. Fetched in a
-    separate ``_fetch`` call from the science reftypes so a pars lookup
-    failure (e.g. a reftype absent from the pinned context) cannot poison
-    the science-reference warming.
-    """
-    key = f'pars:{pipeline_name}'
-    if key in _REFTYPES_CACHE:
-        return _REFTYPES_CACHE[key]
-    from jwst import pipeline as jwst_pipeline
-    cls = getattr(jwst_pipeline, pipeline_name)
-    out = [cls.get_config_reftype()]
-    for step_cls in cls.step_defs.values():
-        rt = step_cls.get_config_reftype()
-        if rt not in out:
-            out.append(rt)
-    _REFTYPES_CACHE[key] = out
-    return out
-
-
 def _crds_params(uncal_file):
     """Build the canonical CRDS lookup parameters dict from an uncal.
 
@@ -88,10 +72,20 @@ def _crds_params(uncal_file):
 
 
 def _fetch(params, reftypes, key_label):
-    """Run one ``crds.getreferences()`` call; non-fatal on failure."""
+    """Run one ``crds.getreferences()`` under the CRDS cache lock; non-fatal.
+
+    The lock is the same global ``crds.cache`` lock stpipe takes for its own
+    lookups, so this serial warm-up shares a download queue with any lazy
+    worker fetch rather than racing it. A lookup failure is logged and
+    swallowed — warming is best-effort, and a genuine miss self-heals as a
+    safe lazy download in the worker.
+    """
     import crds
+    from crds.core import crds_cache_locking
     try:
-        refs = crds.getreferences(params, reftypes=reftypes, observatory='jwst')
+        with crds_cache_locking.get_cache_lock():
+            refs = crds.getreferences(params, reftypes=reftypes,
+                                      observatory='jwst')
         cached = [
             k for k, v in refs.items()
             if v and 'N/A' not in v.upper() and 'NOT FOUND' not in v.upper()
@@ -102,64 +96,81 @@ def _fetch(params, reftypes, key_label):
         log(f"  CRDS prefetch warning for {key_label}: {e}")
 
 
-def prefetch_detector1_references(uncal_files):
-    """Pre-cache Detector1Pipeline CRDS references; dedup on
-    ``(DETECTOR, READPATT, SUBARRAY)`` (read cheaply from the FITS header)."""
-    reftypes = _reftypes('Detector1Pipeline')
-    seen = set()
-    for f in uncal_files:
-        hdr = fits.getheader(f)
-        key = (hdr.get('DETECTOR'), hdr.get('READPATT'), hdr.get('SUBARRAY'))
-        if key in seen:
-            continue
-        seen.add(key)
-        log(f"Pre-fetching Detector1Pipeline CRDS references for "
-            f"{key[0]} ({key[1]}/{key[2]}) using {os.path.basename(f)}")
-        params = _crds_params(f)
-        _fetch(params, reftypes, key_label='/'.join(map(str, key)))
-        _fetch(params, _pars_reftypes('Detector1Pipeline'),
-               key_label='/'.join(map(str, key)) + ' (pars)')
-    log("NIRCam Detector1Pipeline CRDS reference pre-fetch complete")
+def prefetch_process_references(field, filters, status=None, overwrite=False):
+    """Warm Detector1 + Image2 CRDS references for the pending NIRCam work.
 
+    One serial pass over the uncals in ``filters``. Each uncal header is read
+    at most once: the detector1 dedup key ``(DETECTOR, READPATT, SUBARRAY)``
+    and the image2 dedup key ``(DETECTOR, FILTER, PUPIL)`` are both derived
+    from it, and a CRDS lookup runs only for the first uncal of each unique
+    key. Exposures whose detector1 *and* image2 output already exists (per
+    ``status``) are skipped without reading their header, so re-running a
+    finished field is free.
 
-def prefetch_image2_references(uncal_files):
-    """Pre-cache Image2Pipeline (+ wisp/striping flat) CRDS references; dedup
-    on ``(DETECTOR, FILTER, PUPIL)`` (read cheaply from the FITS header)."""
-    reftypes = _reftypes('Image2Pipeline')
-    seen = set()
-    for f in uncal_files:
-        hdr = fits.getheader(f)
-        key = (hdr.get('DETECTOR'), hdr.get('FILTER'), hdr.get('PUPIL'))
-        if key in seen:
-            continue
-        seen.add(key)
-        log(f"Pre-fetching Image2Pipeline CRDS references for "
-            f"{key[0]}/{key[1]}/{key[2]} using {os.path.basename(f)}")
-        params = _crds_params(f)
-        _fetch(params, reftypes, key_label='/'.join(map(str, key)))
-        _fetch(params, _pars_reftypes('Image2Pipeline'),
-               key_label='/'.join(map(str, key)) + ' (pars)')
-    log("NIRCam Image2Pipeline CRDS reference pre-fetch complete")
-
-
-def prefetch_process_references(field, filters, n_processes):
-    """Gather uncals across ``filters`` and pre-fetch detector1 + image2
-    CRDS references.
-
-    Runs unconditionally (``n_processes`` is kept for signature stability):
-    parallel workers now operate with a read-only CRDS cache (see
-    ``orchestrate._crds_worker_env``), which makes this serial, write-capable
-    pass the only sanctioned download path — skipping it for serial runs
-    saved nothing (the lookups happen either way) and skipping it for
-    parallel runs would turn any cache miss into a worker error.
+    ``status`` is the phase's pre-scanned ``StepStatus`` (``None`` warms
+    everything — used by callers that don't track status). With
+    ``overwrite=True`` the skip check is bypassed and every config is warmed.
+    See the module docstring: this only *warms* the cache; the cache lock
+    makes any miss a safe lazy worker download, so the dedup here never
+    affects reference selection.
     """
-    uncals = []
+    det1_reftypes = _reftypes('Detector1Pipeline')
+    img2_reftypes = _reftypes('Image2Pipeline')
+    det1_seen = set()
+    img2_seen = set()
+    det1_n = 0
+    img2_n = 0
+
     for filt in filters:
         try:
-            uncals.extend(field.get_uncal_files(filt))
+            uncals = field.get_uncal_files(filt)
         except RuntimeError:
+            # Workspace not set up for this filter — nothing to warm.
             continue
-    if not uncals:
-        return
-    prefetch_detector1_references(uncals)
-    prefetch_image2_references(uncals)
+        for f in uncals:
+            rootname = os.path.basename(f).removesuffix('_uncal.fits')
+            canonical = field.get_exposure_path(rootname, filt)
+            # Only consult status for a canonical that exists; short-circuit
+            # keeps status.has() off nonexistent paths (first-run canonicals).
+            done = (not overwrite and status is not None
+                    and os.path.exists(canonical))
+            need_det1 = not (done and status.has(canonical, 'CFP_DET1'))
+            need_img2 = not (done and status.has(canonical, 'CFP_IMG2'))
+            if not (need_det1 or need_img2):
+                continue
+
+            hdr = fits.getheader(f)
+            params = None  # built lazily, at most once per uncal
+
+            if need_det1:
+                key = (hdr.get('DETECTOR'), hdr.get('READPATT'),
+                       hdr.get('SUBARRAY'))
+                if key not in det1_seen:
+                    det1_seen.add(key)
+                    params = _crds_params(f)
+                    log(f"Pre-fetching Detector1 CRDS references for "
+                        f"{key[0]} ({key[1]}/{key[2]}) using "
+                        f"{os.path.basename(f)}")
+                    _fetch(params, det1_reftypes,
+                           key_label='/'.join(map(str, key)))
+                    det1_n += 1
+
+            if need_img2:
+                key = (hdr.get('DETECTOR'), hdr.get('FILTER'),
+                       hdr.get('PUPIL'))
+                if key not in img2_seen:
+                    img2_seen.add(key)
+                    if params is None:
+                        params = _crds_params(f)
+                    log(f"Pre-fetching Image2 CRDS references for "
+                        f"{key[0]}/{key[1]}/{key[2]} using "
+                        f"{os.path.basename(f)}")
+                    _fetch(params, img2_reftypes,
+                           key_label='/'.join(map(str, key)))
+                    img2_n += 1
+
+    if det1_n or img2_n:
+        log(f"NIRCam CRDS reference pre-fetch complete "
+            f"({det1_n} detector1, {img2_n} image2 lookups)")
+    else:
+        log("NIRCam CRDS reference pre-fetch: nothing pending")

--- a/pipeline/campfire_pipeline/nircam/prefetch.py
+++ b/pipeline/campfire_pipeline/nircam/prefetch.py
@@ -47,6 +47,32 @@ def _reftypes(pipeline_name):
     return out
 
 
+def _pars_reftypes(pipeline_name):
+    """Return the ``pars-*`` step-parameter reftypes for a pipeline.
+
+    These matter for correctness under the hardened worker CRDS environment
+    (``CRDS_READONLY_CACHE=1``, see ``orchestrate._crds_worker_env``): stpipe
+    fetches ``pars-<step>`` references separately from science references on
+    every ``Step.call``, and a read-only worker cannot download one on a
+    cache miss — so the serial prefetch must warm them too. Fetched in a
+    separate ``_fetch`` call from the science reftypes so a pars lookup
+    failure (e.g. a reftype absent from the pinned context) cannot poison
+    the science-reference warming.
+    """
+    key = f'pars:{pipeline_name}'
+    if key in _REFTYPES_CACHE:
+        return _REFTYPES_CACHE[key]
+    from jwst import pipeline as jwst_pipeline
+    cls = getattr(jwst_pipeline, pipeline_name)
+    out = [cls.get_config_reftype()]
+    for step_cls in cls.step_defs.values():
+        rt = step_cls.get_config_reftype()
+        if rt not in out:
+            out.append(rt)
+    _REFTYPES_CACHE[key] = out
+    return out
+
+
 def _crds_params(uncal_file):
     """Build the canonical CRDS lookup parameters dict from an uncal.
 
@@ -89,8 +115,10 @@ def prefetch_detector1_references(uncal_files):
         seen.add(key)
         log(f"Pre-fetching Detector1Pipeline CRDS references for "
             f"{key[0]} ({key[1]}/{key[2]}) using {os.path.basename(f)}")
-        _fetch(_crds_params(f), reftypes,
-               key_label='/'.join(map(str, key)))
+        params = _crds_params(f)
+        _fetch(params, reftypes, key_label='/'.join(map(str, key)))
+        _fetch(params, _pars_reftypes('Detector1Pipeline'),
+               key_label='/'.join(map(str, key)) + ' (pars)')
     log("NIRCam Detector1Pipeline CRDS reference pre-fetch complete")
 
 
@@ -107,16 +135,24 @@ def prefetch_image2_references(uncal_files):
         seen.add(key)
         log(f"Pre-fetching Image2Pipeline CRDS references for "
             f"{key[0]}/{key[1]}/{key[2]} using {os.path.basename(f)}")
-        _fetch(_crds_params(f), reftypes,
-               key_label='/'.join(map(str, key)))
+        params = _crds_params(f)
+        _fetch(params, reftypes, key_label='/'.join(map(str, key)))
+        _fetch(params, _pars_reftypes('Image2Pipeline'),
+               key_label='/'.join(map(str, key)) + ' (pars)')
     log("NIRCam Image2Pipeline CRDS reference pre-fetch complete")
 
 
 def prefetch_process_references(field, filters, n_processes):
     """Gather uncals across ``filters`` and pre-fetch detector1 + image2
-    CRDS references. No-op when ``n_processes <= 1``."""
-    if n_processes <= 1:
-        return
+    CRDS references.
+
+    Runs unconditionally (``n_processes`` is kept for signature stability):
+    parallel workers now operate with a read-only CRDS cache (see
+    ``orchestrate._crds_worker_env``), which makes this serial, write-capable
+    pass the only sanctioned download path — skipping it for serial runs
+    saved nothing (the lookups happen either way) and skipping it for
+    parallel runs would turn any cache miss into a worker error.
+    """
     uncals = []
     for filt in filters:
         try:

--- a/pipeline/campfire_pipeline/nircam/status.py
+++ b/pipeline/campfire_pipeline/nircam/status.py
@@ -37,7 +37,7 @@ class StepStatus:
                 present[p] = set()
                 continue
             try:
-                with fits.open(p) as hdul:
+                with fits.open(p, memmap=False) as hdul:
                     hdr = hdul[0].header
                     present[p] = {k for k in cfp.CFP_KEYS if k in hdr}
             except (OSError, IOError):
@@ -77,7 +77,7 @@ class StepStatus:
                 self._present[p] = set()
                 continue
             try:
-                with fits.open(p) as hdul:
+                with fits.open(p, memmap=False) as hdul:
                     hdr = hdul[0].header
                     self._present[p] = {k for k in cfp.CFP_KEYS if k in hdr}
             except (OSError, IOError):

--- a/pipeline/campfire_pipeline/nircam/steps/_flat.py
+++ b/pipeline/campfire_pipeline/nircam/steps/_flat.py
@@ -3,9 +3,12 @@ Shared flat-field helpers used by ``wisp_step`` and ``striping_step``.
 
 Both steps need to apply a NIRCam flat in-memory (without writing a
 flat-fielded copy to disk). The CRDS lookup falls back to a custom-flat
-override when present, and the apply call is wrapped with a short retry
-loop because parallel workers occasionally collide on CRDS cache files
-during a cold-fetch.
+override when present. The ``crds.getreferences`` call is taken under the
+global CRDS cache lock (the same lock stpipe holds for its own lookups),
+so a cold-fetch is serialized across workers — the first downloads, the
+rest block and then find the file already cached — rather than several
+workers racing to write the same cache file. The apply call keeps a short
+retry loop as defense in depth.
 
 Flat reference data is cached per worker process: the same ~50MB flat
 applies to every exposure sharing a (detector, filter, pupil), and on the
@@ -76,7 +79,18 @@ def resolve_flat(model, field, use_custom):
         import crds
         crds_context = crds.get_default_context()
     import crds
-    refs = crds.getreferences(crds_dict, reftypes=['flat'], context=crds_context)
+    from crds.core import crds_cache_locking
+    # Hold the global "crds.cache" lock around the lookup. This is a direct
+    # getreferences (not via stpipe), so without the lock two workers could
+    # cold-fetch the same flat at once and one read a half-written file. CRDS
+    # double-checks cache existence inside the lock, so a blocked worker finds
+    # the file already downloaded and skips. Forkserver workers share one lock
+    # object (crds is in the preload list), so the coordination is real on the
+    # cluster; on macOS spawn each worker gets a private lock (dev-only no-op).
+    with crds_cache_locking.get_cache_lock():
+        refs = crds.getreferences(
+            crds_dict, reftypes=['flat'], context=crds_context,
+        )
     return refs.get('flat')
 
 

--- a/pipeline/campfire_pipeline/nircam/steps/_flat.py
+++ b/pipeline/campfire_pipeline/nircam/steps/_flat.py
@@ -6,12 +6,46 @@ flat-fielded copy to disk). The CRDS lookup falls back to a custom-flat
 override when present, and the apply call is wrapped with a short retry
 loop because parallel workers occasionally collide on CRDS cache files
 during a cold-fetch.
+
+Flat reference data is cached per worker process: the same ~50MB flat
+applies to every exposure sharing a (detector, filter, pupil), and on the
+cluster the products live on NFS, so re-reading it per exposure is pure
+network round trips. The cache holds *pristine* FlatModels and hands
+``do_correction`` a deep copy each call — jwst's ``apply_flat_field``
+mutates the flat it is given in place (NaN/zero -> 1.0, DQ bit updates),
+so reusing a model directly would depend on that mutation staying
+idempotent across jwst versions. ``dispatch()`` builds a fresh Pool per
+step, so the cache lives for exactly one step's dispatch and never goes
+stale. The orchestrator sorts each step's task list by detector, so a
+two-slot cache covers a worker's (detector-contiguous) chunk.
 """
 
 import os
 from time import sleep
 
 from campfire_pipeline.common.io import log
+
+
+# path -> pristine FlatModel, per worker process. Insertion-ordered dict
+# used as a tiny LRU; evicted models are closed explicitly.
+_FLAT_CACHE = {}
+_FLAT_CACHE_MAX = 2
+
+
+def _get_flat(flatfile):
+    """Return the pristine cached FlatModel for ``flatfile`` (read on miss)."""
+    from jwst.datamodels import FlatModel
+
+    flat = _FLAT_CACHE.pop(flatfile, None)
+    if flat is None:
+        # memmap=False: the arrays are consumed in full, and one sequential
+        # read beats memmap's page-faulted small reads on NFS.
+        flat = FlatModel(flatfile, memmap=False)
+    _FLAT_CACHE[flatfile] = flat  # (re-)insert as most recently used
+    while len(_FLAT_CACHE) > _FLAT_CACHE_MAX:
+        oldest = next(iter(_FLAT_CACHE))
+        _FLAT_CACHE.pop(oldest).close()
+    return flat
 
 
 def resolve_flat(model, field, use_custom):
@@ -48,7 +82,6 @@ def resolve_flat(model, field, use_custom):
 
 def apply_flat_with_retry(model, flatfile, delays=(0, 3, 10)):
     """Apply flat in-memory, retrying on transient CRDS races."""
-    from jwst.datamodels import FlatModel
     from jwst.flatfield.flat_field import do_correction
 
     last_exc = None
@@ -56,8 +89,14 @@ def apply_flat_with_retry(model, flatfile, delays=(0, 3, 10)):
         if delay:
             sleep(delay)
         try:
-            with FlatModel(flatfile) as flat:
+            # Deep-copy the cached pristine flat: do_correction mutates the
+            # flat it receives (see module docstring). An in-memory copy is
+            # microseconds vs an ~50MB NFS re-read per exposure.
+            flat = _get_flat(flatfile).copy()
+            try:
                 model, _ = do_correction(model, flat)
+            finally:
+                flat.close()
             return model
         except Exception as e:
             last_exc = e

--- a/pipeline/campfire_pipeline/nircam/steps/bad_pixel.py
+++ b/pipeline/campfire_pipeline/nircam/steps/bad_pixel.py
@@ -28,6 +28,7 @@ JUMP_DET, SATURATED, and PERSISTENCE are transient and should not
 promote a pixel to "permanently bad" through repeated occurrence.
 """
 
+import functools
 import os
 from datetime import datetime
 
@@ -46,6 +47,22 @@ LW_DETECTORS = ['nrcalong', 'nrcblong']
 ALL_DETECTORS = LW_DETECTORS + SW_DETECTORS  # LW first so the loop below
                                               # matches 'nrcalong' before
                                               # 'nrca1' on substring fallback
+
+
+@functools.lru_cache(maxsize=16)
+def _load_fl_mask(fl_path):
+    """Read a per-detector bad-pixel mask once per worker, read-only.
+
+    The same ``fl_pixels_<filter>_<detector>.fits`` applies to every
+    exposure of that detector; without caching each worker re-reads it
+    from NFS per exposure. The mask is only ever used as a boolean index,
+    so a single read-only array is safe to share. The cache dies with the
+    step's worker pool (``dispatch`` builds a fresh Pool per step), so a
+    rebuilt reference product is always re-read on the next run.
+    """
+    mask = fits.getdata(fl_path, memmap=False).astype(bool)
+    mask.flags.writeable = False
+    return mask
 
 
 def _detectors_for_filter(filtname):
@@ -99,7 +116,7 @@ def build_bad_pixel_masks(filtname, exposure_files, field, step_config,
     with tqdm.tqdm(total=len(exposure_files)) as pbar:
         for ef in exposure_files:
             try:
-                dq = fits.getdata(ef, extname='DQ')
+                dq = fits.getdata(ef, extname='DQ', memmap=False)
             except KeyError:
                 log(f"  skipped {os.path.basename(ef)} (no DQ)")
                 pbar.update(1)
@@ -173,9 +190,9 @@ def bad_pixel_step(exposure_file, field, step_config, overwrite=False,
     from jwst.datamodels import ImageModel
     from stdatamodels import util as stutil
 
-    fl = fits.getdata(fl_path).astype(bool)
+    fl = _load_fl_mask(fl_path)
 
-    with ImageModel(exposure_file) as model:
+    with ImageModel(exposure_file, memmap=False) as model:
         model.dq[fl] |= 1  # DO_NOT_USE
 
         now = datetime.now().strftime('%Y-%m-%d %H:%M:%S')

--- a/pipeline/campfire_pipeline/nircam/steps/diag_striping.py
+++ b/pipeline/campfire_pipeline/nircam/steps/diag_striping.py
@@ -471,7 +471,7 @@ def _coarse_fine_search(data, mask, bin_width,
 
 def _read_srcmask(exposure_file):
     """Return SRCMASK as a bool array, or None if the extension is absent."""
-    with fits.open(exposure_file) as hdul:
+    with fits.open(exposure_file, memmap=False) as hdul:
         if 'SRCMASK' not in hdul:
             return None
         return hdul['SRCMASK'].data.astype(bool)
@@ -679,7 +679,7 @@ def diag_striping_step(exposure_file, field, step_config, overwrite=False,
 
     from jwst.datamodels import ImageModel, dqflags
 
-    model = ImageModel(exposure_file)
+    model = ImageModel(exposure_file, memmap=False)
     sci_before = model.data.copy()
     dq_before = model.dq.copy()
     err_before = model.err.copy()
@@ -818,7 +818,7 @@ def diag_striping_step(exposure_file, field, step_config, overwrite=False,
 
     # Preserve SRCMASK (image2 round-trip pattern: re-attach extension).
     srcmask_hdu = None
-    with fits.open(exposure_file) as hdul:
+    with fits.open(exposure_file, memmap=False) as hdul:
         if 'SRCMASK' in hdul:
             hdu = hdul['SRCMASK']
             srcmask_hdu = fits.ImageHDU(

--- a/pipeline/campfire_pipeline/nircam/steps/edge.py
+++ b/pipeline/campfire_pipeline/nircam/steps/edge.py
@@ -33,7 +33,7 @@ def edge_step(exposure_file, field, step_config, overwrite=False, status=None):
     from jwst.datamodels import ImageModel
     from stdatamodels import util as stutil
 
-    with ImageModel(exposure_file) as model:
+    with ImageModel(exposure_file, memmap=False) as model:
         size = model.data.shape[0]
 
         mean_cols = np.array([np.mean(model.data[:, ii]) for ii in range(size)])

--- a/pipeline/campfire_pipeline/nircam/steps/image2.py
+++ b/pipeline/campfire_pipeline/nircam/steps/image2.py
@@ -22,7 +22,7 @@ from campfire_pipeline.nircam.constants import SW_FILTERS, LW_FILTERS
 
 def _extract_srcmask(exposure_file):
     """Return a copy of the SRCMASK HDU from ``exposure_file``, or None."""
-    with fits.open(exposure_file) as hdul:
+    with fits.open(exposure_file, memmap=False) as hdul:
         if 'SRCMASK' not in hdul:
             return None
         hdu = hdul['SRCMASK']

--- a/pipeline/campfire_pipeline/nircam/steps/outlier.py
+++ b/pipeline/campfire_pipeline/nircam/steps/outlier.py
@@ -58,7 +58,7 @@ EXTRA_EXT_NAMES = ('SRCMASK', 'CFMASK')
 
 def _capture_extras(canonical):
     extras = []
-    with fits.open(canonical) as hdul:
+    with fits.open(canonical, memmap=False) as hdul:
         for name in EXTRA_EXT_NAMES:
             if name not in hdul:
                 continue
@@ -304,7 +304,7 @@ def outlier_step(visit, visit_files, filter_files, sregions,
             scratch_out = os.path.join(scratch, matches[0])
 
             if do_plot:
-                with fits.open(canonical) as hdul:
+                with fits.open(canonical, memmap=False) as hdul:
                     sci_before = hdul['SCI'].data.copy()
                     dq_before = hdul['DQ'].data.copy()
 
@@ -318,7 +318,7 @@ def outlier_step(visit, visit_files, filter_files, sregions,
 
             if do_plot:
                 from campfire_pipeline.nircam.steps._plots import plot_outlier
-                with fits.open(canonical) as hdul:
+                with fits.open(canonical, memmap=False) as hdul:
                     dq_after = hdul['DQ'].data.copy()
                 new_outlier = (
                     ((dq_after & OUTLIER_BIT) != 0)

--- a/pipeline/campfire_pipeline/nircam/steps/sky.py
+++ b/pipeline/campfire_pipeline/nircam/steps/sky.py
@@ -31,7 +31,7 @@ def sky_step(exposure_file, field, step_config, overwrite=False, status=None):
 
     # Read SRCMASK from the canonical file's extension (was a sidecar in the
     # legacy layout).
-    with fits.open(exposure_file) as hdul:
+    with fits.open(exposure_file, memmap=False) as hdul:
         if 'SRCMASK' not in hdul:
             log(f"No SRCMASK on {rootname}; cannot run sky step "
                 f"(striping must run first)")
@@ -43,7 +43,7 @@ def sky_step(exposure_file, field, step_config, overwrite=False, status=None):
     from jwst.datamodels import ImageModel, dqflags
     from stdatamodels import util as stutil
 
-    with ImageModel(exposure_file) as model:
+    with ImageModel(exposure_file, memmap=False) as model:
         sci = model.data
         dq = model.dq
         # Only DO_NOT_USE pixels are unusable for the sky sample —

--- a/pipeline/campfire_pipeline/nircam/steps/striping.py
+++ b/pipeline/campfire_pipeline/nircam/steps/striping.py
@@ -257,7 +257,7 @@ def striping_step(exposure_file, field, step_config, overwrite=False,
 
     from jwst.datamodels import ImageModel, dqflags
 
-    model = ImageModel(exposure_file)
+    model = ImageModel(exposure_file, memmap=False)
     sci_before = model.data.copy()
 
     if mask_sources:

--- a/pipeline/campfire_pipeline/nircam/steps/variance.py
+++ b/pipeline/campfire_pipeline/nircam/steps/variance.py
@@ -65,7 +65,7 @@ def variance_step(exposure_file, field, step_config, overwrite=False,
 
     block_size = step_config.get('block_size', 7)
 
-    with ImageModel(exposure_file) as model:
+    with ImageModel(exposure_file, memmap=False) as model:
         sci = model.data
         var_rnoise = model.var_rnoise
 

--- a/pipeline/campfire_pipeline/nircam/steps/wcs_shift.py
+++ b/pipeline/campfire_pipeline/nircam/steps/wcs_shift.py
@@ -144,7 +144,7 @@ def wcs_shift_step(exposure_file, field, step_config, overwrite=False,
     # (so it survives the datamodel save round-trip).
     existing_wcs_bak = None
     srcmask_hdu = None
-    with fits.open(exposure_file) as hdul:
+    with fits.open(exposure_file, memmap=False) as hdul:
         if WCS_BAK_EXTNAME in hdul:
             wb = hdul[WCS_BAK_EXTNAME]
             existing_wcs_bak = fits.ImageHDU(
@@ -157,7 +157,7 @@ def wcs_shift_step(exposure_file, field, step_config, overwrite=False,
                 data=sm.data.copy(), header=sm.header.copy(), name='SRCMASK',
             )
 
-    model = ImageModel(exposure_file)
+    model = ImageModel(exposure_file, memmap=False)
 
     if already_applied:
         if existing_wcs_bak is None:

--- a/pipeline/campfire_pipeline/nircam/steps/wisp.py
+++ b/pipeline/campfire_pipeline/nircam/steps/wisp.py
@@ -19,6 +19,7 @@ copy idiom from the legacy implementation work without re-reading from disk.
 """
 
 import copy
+import functools
 import os
 from datetime import datetime
 
@@ -54,6 +55,24 @@ def _calc_variance(data, template, coeff):
     return mad ** 2
 
 
+@functools.lru_cache(maxsize=8)
+def _load_template(path):
+    """Read a wisp template once per worker, NaN-cleaned, read-only.
+
+    The same ~16MB template applies to every exposure of a given
+    (detector, filter), and each exposure's fit loop touches all four
+    candidates plus a fifth read of the winner — over NFS that's pure
+    re-read churn. The NaN replacement is template-intrinsic so it lives
+    in the cache; the exposure-specific ``sci == 0`` masking happens on a
+    copy at the call sites. The array is marked read-only as a guard
+    against accidental in-place mutation of the shared cache entry.
+    """
+    data = fits.getdata(path, memmap=False)
+    data[np.isnan(data)] = 0
+    data.flags.writeable = False
+    return data
+
+
 def wisp_step(exposure_file, field, step_config, overwrite=False, status=None):
     """Subtract a fitted wisp template from a single canonical exposure.
 
@@ -85,7 +104,7 @@ def wisp_step(exposure_file, field, step_config, overwrite=False, status=None):
     if detector not in WISP_DETECTORS:
         log(f"Skipping wisp on {rootname}: detector {detector} has no wisps")
         from jwst.datamodels import ImageModel
-        with ImageModel(exposure_file) as m:
+        with ImageModel(exposure_file, memmap=False) as m:
             atomic_save(
                 m, exposure_file,
                 header_updates=cfp.format(
@@ -111,7 +130,7 @@ def wisp_step(exposure_file, field, step_config, overwrite=False, status=None):
 
     from jwst.datamodels import ImageModel
 
-    model = ImageModel(exposure_file)
+    model = ImageModel(exposure_file, memmap=False)
     sci_before = model.data.copy()
 
     # Deep-copy and flat-field for fitting only; the actual subtraction goes
@@ -154,8 +173,7 @@ def wisp_step(exposure_file, field, step_config, overwrite=False, status=None):
     min_x = np.zeros(len(template_files))
     min_y = np.zeros(len(template_files))
     for i, (tname, sname) in enumerate(zip(template_files, short_names)):
-        wisp = fits.getdata(os.path.join(field.wisp_dir, tname))
-        wisp[np.isnan(wisp)] = 0
+        wisp = _load_template(os.path.join(field.wisp_dir, tname)).copy()
         wisp[sci_before == 0] = 0
         seg_w = wisp[y1:y2, x1:x2]
 
@@ -193,9 +211,10 @@ def wisp_step(exposure_file, field, step_config, overwrite=False, status=None):
         plt.close(fig_fit)
         log(f"Saved {os.path.basename(fit_pdf)}")
 
-    # Subtract from the original (un-flat-fielded) data
-    wisp_final = fits.getdata(os.path.join(field.wisp_dir, template_name))
-    wisp_final[np.isnan(wisp_final)] = 0
+    # Subtract from the original (un-flat-fielded) data. Cache hit: the fit
+    # loop above already loaded this template.
+    wisp_final = _load_template(
+        os.path.join(field.wisp_dir, template_name)).copy()
     wisp_final[sci_before == 0] = 0
     model.data = sci_before - minval * wisp_final
     sci_after = model.data.copy()

--- a/pipeline/scripts/test_image2_call_parity.py
+++ b/pipeline/scripts/test_image2_call_parity.py
@@ -1,0 +1,166 @@
+"""Parity test: Image2Pipeline.call(path) vs Image2Pipeline.call(model).
+
+Open question #1 of docs/design-nircam-exposure-major.md: the exposure-major
+chain wants to hand Image2Pipeline an in-memory ImageModel instead of a path.
+This verifies, on the pinned jwst version, that the two invocation modes:
+  1. select the same CRDS reference files (meta.ref_file.*),
+  2. produce bitwise-identical output arrays,
+  3. produce the same photometry keywords and WCS,
+  4. (model mode) do not mutate the caller's input model in place.
+"""
+import os
+import tempfile
+import shutil
+import sys
+import numpy as np
+
+SRC = ('/Users/hba423/simmons/campfire-data/products/nircam/rj0911/f090w/'
+       'jw06882025001_02101_00001_nrca1.fits')
+WORKDIR = os.path.join(tempfile.gettempdir(), 'image2_parity')
+
+os.makedirs(WORKDIR, exist_ok=True)
+local = os.path.join(WORKDIR, os.path.basename(SRC))
+if not os.path.exists(local):
+    shutil.copy2(SRC, local)
+
+# Production environment: same config resolution as cfpipe (CRDS_PATH,
+# CRDS_CONTEXT, thread caps).
+from campfire_pipeline.config import load_config, setup_environment
+config = load_config()
+setup_environment(config)
+print(f"CRDS_CONTEXT={os.environ.get('CRDS_CONTEXT')} "
+      f"CRDS_PATH={os.environ.get('CRDS_PATH')}")
+
+import jwst
+print(f"jwst {jwst.__version__}")
+from jwst.pipeline import calwebb_image2
+from stdatamodels.jwst.datamodels import ImageModel
+
+# Exactly the kwargs image2_step builds (no custom flat).
+KW = {
+    'output_dir': WORKDIR,
+    'save_results': False,
+    'steps': {
+        'bkg_subtract': {'skip': True},
+        'assign_wcs': {
+            'skip': False, 'save_results': False,
+            'sip_approx': True, 'sip_degree': None, 'sip_inv_degree': None,
+            'sip_max_inv_pix_error': 0.25, 'sip_max_pix_error': 0.25,
+            'sip_npoints': 32, 'slit_y_high': 0.55, 'slit_y_low': -0.55,
+        },
+        'flat_field': {'skip': False},
+        'photom': {'skip': False},
+        'resample': {'skip': True},
+    },
+}
+
+
+def unwrap(result):
+    if isinstance(result, list):
+        assert len(result) == 1, f"expected 1 result, got {len(result)}"
+        return result[0]
+    return result
+
+
+print("\n=== Run A: Image2Pipeline.call(path) ===", flush=True)
+res_a = unwrap(calwebb_image2.Image2Pipeline.call(local, **KW))
+
+print("\n=== Run B: Image2Pipeline.call(model) ===", flush=True)
+model_in = ImageModel(local)
+# Snapshot input arrays to detect in-place mutation by the pipeline.
+snap_data = model_in.data.copy()
+snap_dq = model_in.dq.copy()
+res_b = unwrap(calwebb_image2.Image2Pipeline.call(model_in, **KW))
+
+print("\n" + "=" * 70)
+print("PARITY REPORT")
+print("=" * 70)
+failures = []
+
+# --- 1. CRDS reference selection ---
+ref_a = res_a.meta.ref_file.instance
+ref_b = res_b.meta.ref_file.instance
+keys = sorted(set(ref_a) | set(ref_b))
+print("\n[1] CRDS reference files selected:")
+for k in keys:
+    va, vb = ref_a.get(k), ref_b.get(k)
+    same = va == vb
+    if not same:
+        failures.append(f"ref_file.{k}: {va} != {vb}")
+    name = (va or {}).get('name', va) if isinstance(va, dict) else va
+    print(f"  {'OK ' if same else 'DIFF'} {k}: {name}")
+
+# --- 2. Output arrays, bitwise ---
+print("\n[2] Output arrays (bitwise, NaN-aware):")
+for attr in ('data', 'err', 'dq', 'var_poisson', 'var_rnoise', 'var_flat',
+             'area'):
+    a = getattr(res_a, attr, None)
+    b = getattr(res_b, attr, None)
+    if a is None and b is None:
+        continue
+    eq = (a is not None and b is not None and a.shape == b.shape
+          and np.array_equal(a, b, equal_nan=np.issubdtype(a.dtype,
+                                                           np.floating)))
+    if not eq:
+        n_diff = (np.sum(~np.isclose(a, b, equal_nan=True))
+                  if a is not None and b is not None and a.shape == b.shape
+                  else 'shape/None mismatch')
+        failures.append(f"array {attr}: {n_diff} differing px")
+    print(f"  {'OK ' if eq else 'DIFF'} {attr}")
+
+# --- 3. Photometry keywords + units ---
+print("\n[3] Photometry / units:")
+for key in ('photometry.conversion_megajanskys',
+            'photometry.conversion_microjanskys',
+            'photometry.pixelarea_steradians', 'bunit_data', 'bunit_err'):
+    parts = key.split('.')
+    ga = res_a.meta
+    gb = res_b.meta
+    for p in parts:
+        ga = getattr(ga, p, None) if ga is not None else None
+        gb = getattr(gb, p, None) if gb is not None else None
+    same = ga == gb
+    if not same:
+        failures.append(f"meta.{key}: {ga} != {gb}")
+    print(f"  {'OK ' if same else 'DIFF'} meta.{key} = {ga}")
+
+# --- 4. WCS evaluation at sample pixels ---
+print("\n[4] WCS evaluation:")
+pts = [(0, 0), (1023.5, 1023.5), (2047, 2047), (100.25, 1900.75)]
+wcs_ok = True
+for (x, y) in pts:
+    ra_a, dec_a = res_a.meta.wcs(x, y)
+    ra_b, dec_b = res_b.meta.wcs(x, y)
+    same = (ra_a == ra_b) and (dec_a == dec_b)
+    wcs_ok &= same
+    print(f"  {'OK ' if same else 'DIFF'} ({x},{y}) -> "
+          f"({ra_a:.10f},{dec_a:.10f}) vs ({ra_b:.10f},{dec_b:.10f})")
+if not wcs_ok:
+    failures.append("WCS evaluation differs")
+
+# --- 5. Filename metadata (cosmetic but affects saved FILENAME card) ---
+print("\n[5] meta.filename:")
+print(f"  A (path input):  {res_a.meta.filename}")
+print(f"  B (model input): {res_b.meta.filename}")
+if res_a.meta.filename != res_b.meta.filename:
+    print("  NOTE: differs (cosmetic; chain must set meta.filename "
+          "explicitly like persistence_step already does)")
+
+# --- 6. Input-model mutation check ---
+print("\n[6] Caller's model mutated in place by run B?")
+mut_data = not np.array_equal(model_in.data, snap_data, equal_nan=True)
+mut_dq = not np.array_equal(model_in.dq, snap_dq)
+print(f"  data mutated: {mut_data}; dq mutated: {mut_dq}; "
+      f"result is same object: {res_b is model_in}")
+if mut_data or mut_dq or res_b is model_in:
+    print("  NOTE: pipeline operates on/returns the caller's model — chain "
+          "must not reuse the input model after the call (it doesn't).")
+
+print("\n" + "=" * 70)
+if failures:
+    print(f"PARITY: FAIL — {len(failures)} difference(s):")
+    for f in failures:
+        print(f"  - {f}")
+    sys.exit(1)
+print("PARITY: PASS — model input is equivalent to path input "
+      "(refs, arrays, photometry, WCS)")


### PR DESCRIPTION
## Summary

PR 1 of [`docs/design-nircam-exposure-major.md`](../blob/perf/nircam-cache-tier/docs/design-nircam-exposure-major.md) (included here along with the full NFS audit, `docs/nfs_audit.md`). Targets audit findings **H4** (reference data re-read per exposure), **H5** (CRDS metadata traffic from workers), **M2** (memmap over NFS), and **M9** (eager git interrogation at CLI import). **No change to pixel values or reference selection** — Infrastructure / PATCH.

### Changes

- **Per-worker reference caches.** Wisp templates: read once per worker instead of 5×/exposure (`wisp._load_template`, NaN-cleaning cached, exposure-specific masking on a copy, cache entries read-only). Flats: cached as *pristine* `FlatModel`s with a deep copy handed to each `do_correction` call — jwst's `apply_flat_field` mutates the flat it's given (NaN/zero→1.0 + DQ bits), so the cache never exposes a mutated model. Bad-pixel masks: read once per worker. All caches die with each step's Pool (fresh Pool per `dispatch`), so rebuilt references are always re-read.
- **Detector-major dispatch ordering** (`orchestrate._detector_sorted`): `Pool.map` chunks become detector-contiguous so the per-detector caches hit instead of thrash. Tasks are independent; only log ordering changes.
- **CRDS cache lock for cold-fetch races.** The two direct `crds.getreferences` calls that bypass stpipe — `resolve_flat` (per-exposure flat lookup in wisp/striping) and the prefetch warm-up — now take the global `crds.cache` lock (`crds_cache_locking.get_cache_lock()`), the same lock stpipe holds for its own lookups. CRDS double-checks cache existence *inside* the lock, so a cold-fetch is downloaded once while other workers block then find it cached — closing the worker-vs-worker download race at the source (the likely origin of the "empty or corrupt FITS" errors the retry wrappers guard against). On the cluster, forkserver workers share one lock object because `crds` is in the `parallel.py` preload list; on macOS spawn each worker gets a private lock (dev-only no-op, where the retry wrappers still self-heal).
- **Slimmed prefetch.** Because misses are now safe, the serial prefetch is a pure warm-up, not a correctness requirement, so it shrinks: (a) **one shared header pass** — each uncal header is read once, deriving both the detector1 `(DETECTOR/READPATT/SUBARRAY)` and image2 `(DETECTOR/FILTER/PUPIL)` dedup keys (was two passes, two reads per uncal); (b) **skip-when-pending** — an uncal whose canonical already carries `CFP_DET1` + `CFP_IMG2` is skipped without reading its header, so re-running a finished field touches zero headers (was the multi-minute NFS header scan).
- **`memmap=False` sweep** on FITS opens that read whole arrays or only headers: per-exposure steps, drizzle/outlier inputs, manifest SCI+DQ hashing, CFP/StepStatus header probes, S_REGION scans. NFS serves one sequential read far better than memmap's page-faulted small reads. Hash values unchanged (`do_not_scale_image_data` still hashes raw stored bytes).
- **Lazy `cfpipe --version`**: the four git subprocesses (including a `git status` walk of `pipeline/` over NFS) no longer run at module import on every invocation.

### CRDS approach, and why not `CRDS_READONLY_CACHE`

An earlier revision of this PR hardened the workers with `CRDS_READONLY_CACHE=1` + `CRDS_MODE=local` (via a `dispatch(worker_env=...)` initializer) on the theory that a warmed cache plus read-only workers means a miss should be a loud error. That was reworked into the lock-based approach above because:

- **readonly and locking are mutually exclusive** — CRDS returns a no-op `FakeLock` under a read-only cache. The readonly env would have *disabled* the very mechanism that makes a cold miss safe, while making the prefetch a hard correctness dependency (a USEAFTER-boundary gap or a stale skip becomes a `CrdsError`, not a self-healing lazy download).
- The lock is **already on by default** (`CRDS_USE_LOCKING=True`, `multiprocessing` mode) and is the tool CRDS itself uses; we just had to extend it to our two non-stpipe call sites.

Removed with the readonly approach: `[nircam].crds_readonly_workers`, `_crds_worker_env`, the `dispatch(worker_env=...)` / `_apply_worker_env` plumbing (no remaining consumer), and the `pars-*` prefetch warming (only needed when a read-only worker couldn't download them).

The design doc's deeper "Level 1" plan (parent resolves flat paths, workers never call `getreferences`) remains future work (PR 2/3); with the lock in place it's now an optimization rather than a correctness requirement, and avoids the USEAFTER-dedup hazard that blocked it as a same-PR change.

### Verification

- **111/111 pipeline tests pass** (re-run after the CRDS rework).
- Live `crds_cache_locking.get_cache_lock()` round-trips (`CrdsMultiprocessingLock`, locking enabled).
- Prefetch logic (mocked CRDS): single shared header pass (N uncals → N header reads, not 2N), correct det1/image2 dedup, finished field → zero header reads + `nothing pending`, `overwrite` bypasses the skip, mixed done/pending states warm only what's pending.
- Cached-flat `do_correction` output bitwise-identical to fresh-read across first **and second** use (data / var_flat / dq); cached model verified still pristine afterwards.
- Wisp template cache bitwise-identical to the old read path (synthetic template with NaNs/zeros); call-site masking does not leak into the cache.
- `cfpipe --version` still prints the setuptools-scm version.

Reference selection is unchanged (same `getreferences` args, just lock-wrapped), so the parity/equivalence results above hold by construction.

### Changelog

Entry added under `## Unreleased` → Infrastructure (PATCH).

Generated with Claude Code
