### PR TITLE
fix(deploy): map non-finite floats to NULL before spectra/targets upsert

### DIFF
--- a/python/campfire/deploy/summary.py
+++ b/python/campfire/deploy/summary.py
@@ -6,10 +6,30 @@ ECSV per observation; this module reads it and builds the records needed
 for Supabase upserts and R2 upload planning.
 """
 
+import math
 import sys
 from pathlib import Path
 
 from astropy.table import Table
+
+
+def _finite_or_none(value) -> float | None:
+    """Coerce a scalar to a JSON-safe float, mapping non-finite to None.
+
+    PostgREST/httpx serialize request bodies with ``allow_nan=False``, so any
+    ``inf``, ``-inf``, or ``nan`` float raises
+    ``ValueError: Out of range float values are not JSON compliant`` and aborts
+    the whole upsert. Non-finite science values (e.g. signal_to_noise = inf
+    from a zero-noise division, or NaN from a failed fit) carry no meaningful
+    measurement, so they map to SQL NULL.
+
+    Returns None for None input or any non-finite float; otherwise the value
+    as a float.
+    """
+    if value is None:
+        return None
+    val = float(value)
+    return val if math.isfinite(val) else None
 
 
 def load_summary(obs_dir: Path, obs_name: str) -> Table:
@@ -76,7 +96,7 @@ def get_unique_objects(summary: Table) -> list[dict]:
             'observation': observation,
             'ra': float(row['ra']),
             'dec': float(row['dec']),
-            'redshift_best': float(row['redshift_best']) if row['redshift_best'] is not None else None,
+            'redshift_best': _finite_or_none(row['redshift_best']),
         })
 
     return objects
@@ -119,8 +139,8 @@ def get_spectra_records(summary: Table, obs_name: str) -> list[dict]:
             'grating': row['grating'],
             'fits_path': r2_key,
             'reduction_version': row['reduction_version'],
-            'signal_to_noise': float(row['signal_to_noise']) if row['signal_to_noise'] is not None else None,
-            'exposure_time': float(row['exposure_time']) if row['exposure_time'] is not None else None,
+            'signal_to_noise': _finite_or_none(row['signal_to_noise']),
+            'exposure_time': _finite_or_none(row['exposure_time']),
             'file_hash': row['file_hash'],
             'file_size': int(row['file_size']) if row['file_size'] is not None else None,
         }
@@ -143,12 +163,8 @@ def get_spectra_records(summary: Table, obs_name: str) -> list[dict]:
         # the previous value rather than silently keeping it.
         if has_redshift_auto:
             raw = row['redshift_auto']
-            if raw is None:
-                rec['redshift_auto'] = None
-            else:
-                val = float(raw)
-                # zfit may emit NaN for failed fits; store as NULL.
-                rec['redshift_auto'] = None if val != val else val
+            # zfit may emit NaN for failed fits (or inf); store either as NULL.
+            rec['redshift_auto'] = _finite_or_none(raw)
 
         records.append(rec)
     return records

--- a/python/tests/test_deploy_summary.py
+++ b/python/tests/test_deploy_summary.py
@@ -1,0 +1,68 @@
+"""Unit tests for deploy.summary record building — focused on JSON-safety of
+non-finite floats. PostgREST/httpx serialize with allow_nan=False, so inf/nan
+leaking into a record aborts the entire spectra/targets upsert."""
+
+from __future__ import annotations
+
+import math
+
+from astropy.table import Table
+
+from campfire.deploy.summary import (
+    _finite_or_none,
+    get_spectra_records,
+    get_unique_objects,
+)
+
+
+def test_finite_or_none():
+    assert _finite_or_none(None) is None
+    assert _finite_or_none(math.inf) is None
+    assert _finite_or_none(-math.inf) is None
+    assert _finite_or_none(math.nan) is None
+    assert _finite_or_none(0.0) == 0.0
+    assert _finite_or_none(3.5) == 3.5
+
+
+def _spectra_table() -> Table:
+    t = Table()
+    t['object_id'] = ['t1', 't2']
+    t['grating'] = ['prism', 'prism']
+    t['fits_filename'] = ['a_spec.fits', 'b_spec.fits']
+    t['reduction_version'] = ['v1', 'v1']
+    # t1 has a zero-noise division -> inf SNR; t2 is finite
+    t['signal_to_noise'] = [math.inf, 12.0]
+    t['exposure_time'] = [1000.0, math.nan]
+    t['file_hash'] = ['h1', 'h2']
+    t['file_size'] = [100, 200]
+    t['redshift_auto'] = [math.nan, 3.1]
+    t.meta['cfpipe_version'] = '0.5.0'
+    return t
+
+
+def test_get_spectra_records_sanitizes_non_finite():
+    records = get_spectra_records(_spectra_table(), 'obs1')
+
+    r1, r2 = records
+    # inf SNR and nan exposure_time / redshift become NULL, not a crash
+    assert r1['signal_to_noise'] is None
+    assert r1['redshift_auto'] is None
+    assert r2['exposure_time'] is None
+    # finite values pass through untouched
+    assert r2['signal_to_noise'] == 12.0
+    assert r2['redshift_auto'] == 3.1
+    assert r1['exposure_time'] == 1000.0
+
+
+def test_get_unique_objects_sanitizes_redshift():
+    t = Table()
+    t['object_id'] = ['t1']
+    t['source_id'] = [1]
+    t['ra'] = [150.0]
+    t['dec'] = [2.0]
+    t['redshift_best'] = [math.inf]
+    t.meta['program_slug'] = 'prog'
+    t.meta['obs_name'] = 'obs1'
+
+    objects = get_unique_objects(t)
+    assert objects[0]['redshift_best'] is None


### PR DESCRIPTION
PostgREST/httpx serialize request bodies with allow_nan=False, so any inf,
-inf, or nan float (e.g. signal_to_noise = inf from a zero-noise division)
raised "Out of range float values are not JSON compliant" and aborted the
entire upsert mid-deploy.

Add a _finite_or_none helper in deploy.summary and route the science-value
fields (signal_to_noise, exposure_time, redshift_best, redshift_auto) through
it so non-finite measurements become SQL NULL. This also fixes already-produced
ECSV/FITS data without a pipeline re-run. ra/dec are intentionally left strict —
non-finite coordinates are a different, NOT-NULL-violating error that should
surface rather than be silently nulled.