### PR TITLE
perf(nircam): combine-phase NFS fixes — footprint hoist, single CRDS-input open, manifest stat fast-path

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -69,6 +69,21 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- NIRCam combine-phase NFS fixes (PR 2 of
+  `docs/design-nircam-exposure-major.md`; findings H7/M4 of `docs/nfs_audit.md`).
+  No change to pixel values, tile selection, or staleness decisions.
+  - Footprint computation hoisted out of the per-tile loop
+    (`geometry.compute_footprints` + pure-geometry `geometry.select_overlapping`).
+    `resample` and `manifest.get_stale_tiles` previously re-opened every candidate
+    exposure's WCS once per tile to test overlap (N_exposures × N_tiles
+    `fits.open`s); footprints are tile-invariant, so they are now computed once
+    per filter and reused across tiles. Selection is bit-identical — same
+    `wcs_pix2world` four-corner polygons, same order.
+  - `outlier`/`resample` staleness takes the manifest stat fast path
+    (`orchestrate._visit_up_to_date` → `manifest.file_unchanged`): an unchanged
+    combine run compares size + `mtime_ns` instead of re-hashing each visit
+    file's full SCI+DQ (~32 MB), falling back to the content hash only on a stat
+    mismatch. Identical staleness decisions.
 - NFS cache tier for the NIRCam pipeline (PR 1 of
   `docs/design-nircam-exposure-major.md`; findings H4/H5/M2/M9 of
   `docs/nfs_audit.md`). No change to pixel values or reference selection —

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -70,15 +70,29 @@ Release procedure: edit the `## Unreleased` section below, then run
 
 ### Infrastructure
 - NIRCam combine-phase NFS fixes (PR 2 of
-  `docs/design-nircam-exposure-major.md`; findings H7/M4 of `docs/nfs_audit.md`).
-  No change to pixel values, tile selection, or staleness decisions.
+  `docs/design-nircam-exposure-major.md`; findings H7/H8/M4 of
+  `docs/nfs_audit.md`). No change to pixel values, tile selection, staleness
+  decisions, or drizzle/outlier output.
   - Footprint computation hoisted out of the per-tile loop
-    (`geometry.compute_footprints` + pure-geometry `geometry.select_overlapping`).
-    `resample` and `manifest.get_stale_tiles` previously re-opened every candidate
-    exposure's WCS once per tile to test overlap (N_exposures × N_tiles
-    `fits.open`s); footprints are tile-invariant, so they are now computed once
-    per filter and reused across tiles. Selection is bit-identical — same
-    `wcs_pix2world` four-corner polygons, same order.
+    (`geometry.compute_input_geometry` + pure-geometry
+    `geometry.select_overlapping`). `resample` and `manifest.get_stale_tiles`
+    previously re-opened every candidate exposure's WCS once per tile to test
+    overlap (N_exposures × N_tiles `fits.open`s); footprints are tile-invariant,
+    so they are now computed once per filter and reused across tiles. Selection
+    is bit-identical — same `wcs_pix2world` four-corner polygons, same order.
+  - One CRDS-input open per file in the combine reducers (drizzle + outlier).
+    `drizzle_tile` and `outlier_detect_for_visit` previously walked their input
+    set twice — a WCS-sizing pass that opened the reference input and
+    `getheader`-scanned every other input's `S_REGION`, then an array pass that
+    re-opened every input. The output WCS is now bootstrapped from the
+    reference input's array-pass open (no separate sizing open), and the other
+    inputs' `S_REGION` strings are passed in from a read that already happens —
+    the orchestrator's `_read_sregions` (outlier) and the resample geometry
+    pass (`compute_input_geometry` now also returns `S_REGION`) — so the
+    per-tile / per-visit `getheader` scan is gone. Verified bit-identical
+    (drizzle SCI/ERR/WHT/CON and flagged outlier DQ, byte-for-byte) on a real
+    visit via an A/B run. The outlier flag-write pass (a second open of visit
+    files only) is unchanged — it necessarily follows the median.
   - `outlier`/`resample` staleness takes the manifest stat fast path
     (`orchestrate._visit_up_to_date` → `manifest.file_unchanged`): an unchanged
     combine run compares size + `mtime_ns` instead of re-hashing each visit

--- a/pipeline/campfire_pipeline/nircam/drizzle.py
+++ b/pipeline/campfire_pipeline/nircam/drizzle.py
@@ -78,53 +78,66 @@ from astropy.io import fits
 from campfire_pipeline.common.io import log
 
 
-def _build_output_wcs(crf_files, crpix, crval, shape, rotation, pixel_scale):
-    """Build the output gwcs using stcal's TAN convention.
+def _sregion_for(crf_file, sregions):
+    """S_REGION for ``crf_file``: from the supplied map, else read the header.
 
-    ``crpix`` / ``crval`` / ``shape`` / ``rotation`` / ``pixel_scale`` are
-    the campfire tile parameters from ``Field.get_tile_wcs``. The first
-    CRF supplies a reference gwcs and ``wcsinfo`` so stcal can construct
-    the output frame.
+    ``sregions`` is an optional ``{path: s_region}`` mapping passed in by
+    callers that already read every input's header once (the outlier
+    orchestrator's ``_read_sregions``; resample's geometry pass), so the
+    per-visit / per-tile WCS build does not re-open files just to read this
+    one keyword. Falls back to a direct ``getheader`` when absent.
+    """
+    if sregions is not None:
+        s = sregions.get(crf_file)
+        if s is not None:
+            return s
+    return fits.getheader(crf_file, extname='SCI')['S_REGION']
 
-    All inputs' ``S_REGION`` polygons are passed so the gwcs's
-    ``bounding_box`` covers the full union footprint — important for the
-    inverse transform (``world → output_pix``) to return finite values
-    for inputs whose footprint extends beyond the first CRF's bbox. The
-    output ``shape``, ``crpix``, and ``crval`` are explicit overrides so
-    the geometry is fully determined by the campfire tile parameters and
-    does not depend on input ordering.
 
-    Parameters
-    ----------
-    crf_files : list of str
-    crpix, crval, shape, rotation, pixel_scale : tile WCS overrides
-        (see ``Field.get_tile_wcs``).
+def build_output_wcs_from_ref(ref_model, crf_files, sregions=None, *,
+                              crpix=None, crval=None, shape=None,
+                              rotation=None, pixel_scale=None):
+    """Build the drizzle output gwcs from an already-open reference model.
 
-    Returns
-    -------
-    `gwcs.wcs.WCS`
+    ``crf_files[0]`` must be the model passed as ``ref_model``: its embedded
+    gwcs + ``wcsinfo`` anchor the output frame, and reusing this single open
+    is what lets the reduce pass avoid a separate WCS-sizing traversal that
+    re-opened it. The remaining inputs contribute only their ``S_REGION``
+    footprint strings (so the gwcs ``bounding_box`` covers the union
+    footprint — important for the inverse transform to return finite values
+    for inputs extending beyond the reference's bbox), taken from
+    ``sregions`` when supplied (no opens) or read from the header otherwise.
+
+    With all grid overrides ``None`` (outlier per-visit WCS) the grid is
+    auto-derived from the reference, matching ``wcs_from_sregions`` defaults.
+    With them supplied (resample tile WCS from ``Field.get_tile_wcs``) they
+    pin ``pscale``/``rotation``/``shape``/``crpix``/``crval`` so the geometry
+    is fully determined by the tile parameters and does not depend on input
+    ordering — exactly as before.
     """
     from stcal.alignment.util import wcs_from_sregions
-    from stdatamodels.jwst.datamodels import ImageModel
 
-    sregions = []
-    with ImageModel(crf_files[0], memmap=False) as ref:
-        ref_wcs = deepcopy(ref.meta.wcs)
-        ref_wcsinfo = ref.meta.wcsinfo.instance
-        sregions.append(ref.meta.wcsinfo.s_region)
+    ref_wcs = deepcopy(ref_model.meta.wcs)
+    ref_wcsinfo = ref_model.meta.wcsinfo.instance
+    s_regions = [ref_model.meta.wcsinfo.s_region]
     for crf in crf_files[1:]:
-        sregions.append(fits.getheader(crf, extname='SCI')['S_REGION'])
+        s_regions.append(_sregion_for(crf, sregions))
 
-    nx, ny = shape
+    kwargs = {}
+    if pixel_scale is not None:
+        kwargs['pscale'] = pixel_scale / 3600.0
+    if rotation is not None:
+        kwargs['rotation'] = rotation
+    if shape is not None:
+        nx, ny = shape
+        kwargs['shape'] = (ny, nx)
+    if crpix is not None:
+        kwargs['crpix'] = tuple(crpix)
+    if crval is not None:
+        kwargs['crval'] = tuple(crval)
+
     return wcs_from_sregions(
-        sregions,
-        ref_wcs=ref_wcs,
-        ref_wcsinfo=ref_wcsinfo,
-        pscale=pixel_scale / 3600.0,
-        rotation=rotation,
-        shape=(ny, nx),
-        crpix=tuple(crpix),
-        crval=tuple(crval),
+        s_regions, ref_wcs=ref_wcs, ref_wcsinfo=ref_wcsinfo, **kwargs,
     )
 
 
@@ -363,64 +376,60 @@ def _sanitize_variance(var_rnoise, var_poisson, var_flat, weight):
     return var_total, var_weight
 
 
-def _prepare_drizzle_input(crf_file, output_wcs, out_shape, *,
-                           weight_type, good_bits, blender=None):
-    """Open one CRF and prepare the per-input arrays drizzle needs.
+def _prep_from_model(model, output_wcs, out_shape, *,
+                     weight_type, good_bits, blender=None):
+    """Prepare the per-input arrays drizzle needs from an already-open model.
 
     Returns a dict with ``data``, ``err``, ``var_total``, ``weight``,
     ``pixmap``, ``exptime``, ``xmin``/``xmax``/``ymin``/``ymax``,
-    ``in_shape``, ``input_gwcs`` — or ``None`` if the input footprint
-    does not overlap the tile.
+    ``in_shape``, ``input_gwcs`` — or ``None`` if the input footprint does
+    not overlap the tile.
 
-    If ``blender`` is given (the resample path), the input model is fed to it
-    for header blending — only once we know the input overlaps the tile, so
-    skipped inputs don't contribute metadata. This reuses the single open the
-    array prep already does. ``drizzle_tile_singles`` (outlier) passes ``None``.
-
-    Shared by ``drizzle_tile`` (accumulate mode for resample) and
-    ``drizzle_tile_singles`` (per-input rasters for outlier).
+    Split from ``_prepare_drizzle_input`` so a caller that has *already*
+    opened the model — notably the reference input, whose open also builds
+    the output WCS — can prep it without a second open. ``blender`` (resample
+    path) accumulates the model's header metadata, but only once we know the
+    input overlaps the tile, so skipped inputs don't contribute metadata.
     """
     from jwst.datamodels.dqflags import pixel as pixel_flags
     from stcal.resample.utils import build_driz_weight, resample_range
-    from stdatamodels.jwst.datamodels import ImageModel
 
-    with ImageModel(crf_file, memmap=False) as model:
-        data = np.asarray(model.data, dtype=np.float32)
-        err = np.asarray(model.err, dtype=np.float32)
-        in_shape = data.shape
-        input_gwcs = deepcopy(model.meta.wcs)
-        exptime = float(model.meta.exposure.exposure_time)
-        input_pixelarea_a2 = model.meta.photometry.pixelarea_arcsecsq
+    data = np.asarray(model.data, dtype=np.float32)
+    err = np.asarray(model.err, dtype=np.float32)
+    in_shape = data.shape
+    input_gwcs = deepcopy(model.meta.wcs)
+    exptime = float(model.meta.exposure.exposure_time)
+    input_pixelarea_a2 = model.meta.photometry.pixelarea_arcsecsq
 
-        pixmap = _input_to_output_pixmap(input_gwcs, output_wcs, in_shape)
-        bbox = _output_bbox_in_tile(pixmap, out_shape)
-        if bbox is None:
-            return None
-        sly, slx = bbox
+    pixmap = _input_to_output_pixmap(input_gwcs, output_wcs, in_shape)
+    bbox = _output_bbox_in_tile(pixmap, out_shape)
+    if bbox is None:
+        return None
+    sly, slx = bbox
 
-        if blender is not None:
-            blender.accumulate(model)
+    if blender is not None:
+        blender.accumulate(model)
 
-        weight = build_driz_weight(
-            {'data': model.data, 'dq': model.dq,
-             'var_rnoise': model.var_rnoise},
-            weight_type=weight_type,
-            good_bits=good_bits,
-            flag_name_map=pixel_flags,
-        ).astype(np.float32)
+    weight = build_driz_weight(
+        {'data': model.data, 'dq': model.dq,
+         'var_rnoise': model.var_rnoise},
+        weight_type=weight_type,
+        good_bits=good_bits,
+        flag_name_map=pixel_flags,
+    ).astype(np.float32)
 
-        # Sum the variance components, masking each independently (see
-        # _sanitize_variance) so one bad component can't poison the ERR map.
-        var_total, var_weight = _sanitize_variance(
-            np.asarray(model.var_rnoise, dtype=np.float32),
-            np.asarray(model.var_poisson, dtype=np.float32),
-            np.asarray(model.var_flat, dtype=np.float32),
-            weight,
-        )
+    # Sum the variance components, masking each independently (see
+    # _sanitize_variance) so one bad component can't poison the ERR map.
+    var_total, var_weight = _sanitize_variance(
+        np.asarray(model.var_rnoise, dtype=np.float32),
+        np.asarray(model.var_poisson, dtype=np.float32),
+        np.asarray(model.var_flat, dtype=np.float32),
+        weight,
+    )
 
-        xmin, xmax, ymin, ymax = resample_range(
-            in_shape, input_gwcs.bounding_box,
-        )
+    xmin, xmax, ymin, ymax = resample_range(
+        in_shape, input_gwcs.bounding_box,
+    )
 
     return {
         'data': data, 'err': err,
@@ -434,6 +443,25 @@ def _prepare_drizzle_input(crf_file, output_wcs, out_shape, *,
     }
 
 
+def _prepare_drizzle_input(crf_file, output_wcs, out_shape, *,
+                           weight_type, good_bits, blender=None):
+    """Open one CRF and prepare the per-input arrays drizzle needs.
+
+    Thin wrapper over ``_prep_from_model`` that owns the file open. Returns
+    the prep dict or ``None`` if the input footprint does not overlap the
+    tile. Shared by ``drizzle_tile`` (resample) and ``drizzle_tile_singles``
+    (outlier) for the non-reference inputs; the reference input is opened by
+    the caller and prepped via ``_prep_from_model`` directly.
+    """
+    from stdatamodels.jwst.datamodels import ImageModel
+
+    with ImageModel(crf_file, memmap=False) as model:
+        return _prep_from_model(
+            model, output_wcs, out_shape,
+            weight_type=weight_type, good_bits=good_bits, blender=blender,
+        )
+
+
 def _add_image_kwargs(prep, pixfrac):
     """Common kwargs for `Drizzle.add_image` from a `_prepare_drizzle_input` dict."""
     return dict(
@@ -445,6 +473,32 @@ def _add_image_kwargs(prep, pixfrac):
         xmin=prep['xmin'], xmax=prep['xmax'],
         ymin=prep['ymin'], ymax=prep['ymax'],
     )
+
+
+def _bbox_drizzle_single(prep, *, kernel, pixfrac):
+    """Drizzle one prepped input into its bbox-sized buffer; return (sci, wht).
+
+    Extracted from ``drizzle_tile_singles`` so the reference input — prepped
+    from the same open that built the output WCS — drizzles through the exact
+    same path as the streamed inputs (the pixmap is shifted by the bbox
+    origin so cdriz writes into bbox-local coordinates).
+    """
+    from drizzle.resample import Drizzle
+
+    sly, slx = prep['sly'], prep['slx']
+    pixmap_local = prep['pixmap'].copy()
+    pixmap_local[..., 0] -= slx.start
+    pixmap_local[..., 1] -= sly.start
+
+    common = _add_image_kwargs(prep, pixfrac)
+    common['pixmap'] = pixmap_local
+
+    sci_driz = Drizzle(
+        out_shape=prep['bbox_shape'], kernel=kernel, fillval='NaN',
+        disable_ctx=True,
+    )
+    sci_driz.add_image(data=prep['data'], **common)
+    return sci_driz.out_img, sci_driz.out_wht
 
 
 def drizzle_tile(
@@ -462,6 +516,7 @@ def drizzle_tile(
     good_bits='~DO_NOT_USE',
     blendheaders=True,
     reduction_version='unknown',
+    sregions=None,
 ):
     """Drizzle ``crf_files`` into a single i2d at ``output_path``.
 
@@ -490,10 +545,6 @@ def drizzle_tile(
     out_shape = (ny, nx)
 
     log(f"  campfire drizzle: {n_inputs} inputs into {nx}x{ny} tile")
-
-    output_wcs = _build_output_wcs(
-        crf_files, crpix, crval, shape, rotation, pixel_scale,
-    )
 
     blender = None
     if blendheaders:
@@ -525,14 +576,34 @@ def drizzle_tile(
         disable_ctx=True,
     )
 
+    # Open the reference input (crf_files[0]) once: its gwcs + wcsinfo anchor
+    # the output WCS (built from that open plus the other inputs' S_REGION
+    # strings, supplied via `sregions` or read cheaply), and its arrays are
+    # prepped from the same open. Previously the WCS-sizing pass opened it a
+    # first time and the drizzle loop opened it a second time.
+    from stdatamodels.jwst.datamodels import ImageModel
+    with ImageModel(crf_files[0], memmap=False) as _ref:
+        output_wcs = build_output_wcs_from_ref(
+            _ref, crf_files, sregions,
+            crpix=crpix, crval=crval, shape=shape, rotation=rotation,
+            pixel_scale=pixel_scale,
+        )
+        ref_prep = _prep_from_model(
+            _ref, output_wcs, out_shape,
+            weight_type=weight_type, good_bits=good_bits, blender=blender,
+        )
+
     skipped = 0
     input_pixelarea_a2 = None
     for i, crf_file in enumerate(crf_files, start=1):
         basename = os.path.basename(crf_file)
-        prep = _prepare_drizzle_input(
-            crf_file, output_wcs, out_shape,
-            weight_type=weight_type, good_bits=good_bits, blender=blender,
-        )
+        if i == 1:
+            prep = ref_prep
+        else:
+            prep = _prepare_drizzle_input(
+                crf_file, output_wcs, out_shape,
+                weight_type=weight_type, good_bits=good_bits, blender=blender,
+            )
         if prep is None:
             skipped += 1
             log(f"  [{i}/{n_inputs}] {basename}: no tile overlap, skipping")
@@ -648,8 +719,6 @@ def drizzle_tile_singles(
 
     Inputs that don't overlap the tile are skipped (no yield).
     """
-    from drizzle.resample import Drizzle
-
     skipped = 0
     for crf_file in crf_files:
         prep = _prepare_drizzle_input(
@@ -660,21 +729,8 @@ def drizzle_tile_singles(
             skipped += 1
             continue
 
-        sly, slx = prep['sly'], prep['slx']
-        pixmap_local = prep['pixmap'].copy()
-        pixmap_local[..., 0] -= slx.start
-        pixmap_local[..., 1] -= sly.start
-
-        common = _add_image_kwargs(prep, pixfrac)
-        common['pixmap'] = pixmap_local
-
-        sci_driz = Drizzle(
-            out_shape=prep['bbox_shape'], kernel=kernel, fillval='NaN',
-            disable_ctx=True,
-        )
-        sci_driz.add_image(data=prep['data'], **common)
-
-        yield sci_driz.out_img, sci_driz.out_wht, prep
+        sci, wht = _bbox_drizzle_single(prep, kernel=kernel, pixfrac=pixfrac)
+        yield sci, wht, prep
 
     if skipped:
         log(f"  {skipped} inputs did not overlap tile")

--- a/pipeline/campfire_pipeline/nircam/drizzle.py
+++ b/pipeline/campfire_pipeline/nircam/drizzle.py
@@ -82,8 +82,7 @@ def _sregion_for(crf_file, sregions):
     """S_REGION for ``crf_file``: from the supplied map, else read the header.
 
     ``sregions`` is an optional ``{path: s_region}`` mapping passed in by
-    callers that already read every input's header once (the outlier
-    orchestrator's ``_read_sregions``; resample's geometry pass), so the
+    callers that already read every input's header once, so the
     per-visit / per-tile WCS build does not re-open files just to read this
     one keyword. Falls back to a direct ``getheader`` when absent.
     """
@@ -385,11 +384,11 @@ def _prep_from_model(model, output_wcs, out_shape, *,
     ``in_shape``, ``input_gwcs`` — or ``None`` if the input footprint does
     not overlap the tile.
 
-    Split from ``_prepare_drizzle_input`` so a caller that has *already*
-    opened the model — notably the reference input, whose open also builds
-    the output WCS — can prep it without a second open. ``blender`` (resample
-    path) accumulates the model's header metadata, but only once we know the
-    input overlaps the tile, so skipped inputs don't contribute metadata.
+    A caller that has *already* opened the model — notably the reference
+    input, whose open also builds the output WCS — can prep it without a
+    second open. ``blender`` (resample path) accumulates the model's header
+    metadata, but only once we know the input overlaps the tile, so skipped
+    inputs don't contribute metadata.
     """
     from jwst.datamodels.dqflags import pixel as pixel_flags
     from stcal.resample.utils import build_driz_weight, resample_range
@@ -449,9 +448,7 @@ def _prepare_drizzle_input(crf_file, output_wcs, out_shape, *,
 
     Thin wrapper over ``_prep_from_model`` that owns the file open. Returns
     the prep dict or ``None`` if the input footprint does not overlap the
-    tile. Shared by ``drizzle_tile`` (resample) and ``drizzle_tile_singles``
-    (outlier) for the non-reference inputs; the reference input is opened by
-    the caller and prepped via ``_prep_from_model`` directly.
+    tile.
     """
     from stdatamodels.jwst.datamodels import ImageModel
 
@@ -478,10 +475,10 @@ def _add_image_kwargs(prep, pixfrac):
 def _bbox_drizzle_single(prep, *, kernel, pixfrac):
     """Drizzle one prepped input into its bbox-sized buffer; return (sci, wht).
 
-    Extracted from ``drizzle_tile_singles`` so the reference input — prepped
-    from the same open that built the output WCS — drizzles through the exact
-    same path as the streamed inputs (the pixmap is shifted by the bbox
-    origin so cdriz writes into bbox-local coordinates).
+    The reference input — prepped from the same open that built the output
+    WCS — drizzles through the exact same path as the streamed inputs (the
+    pixmap is shifted by the bbox origin so cdriz writes into bbox-local
+    coordinates).
     """
     from drizzle.resample import Drizzle
 
@@ -579,8 +576,7 @@ def drizzle_tile(
     # Open the reference input (crf_files[0]) once: its gwcs + wcsinfo anchor
     # the output WCS (built from that open plus the other inputs' S_REGION
     # strings, supplied via `sregions` or read cheaply), and its arrays are
-    # prepped from the same open. Previously the WCS-sizing pass opened it a
-    # first time and the drizzle loop opened it a second time.
+    # prepped from the same open.
     from stdatamodels.jwst.datamodels import ImageModel
     with ImageModel(crf_files[0], memmap=False) as _ref:
         output_wcs = build_output_wcs_from_ref(

--- a/pipeline/campfire_pipeline/nircam/geometry.py
+++ b/pipeline/campfire_pipeline/nircam/geometry.py
@@ -9,6 +9,7 @@ input set for a given tile.
 """
 
 import warnings
+from collections import namedtuple
 
 import numpy as np
 from astropy.io import fits
@@ -16,19 +17,25 @@ from astropy.wcs import WCS
 from shapely.geometry import Polygon
 
 
-def compute_footprints(exposure_files, *, in_shape=(2048, 2048)):
-    """Return ``{file: shapely Polygon}`` of each exposure's sky footprint.
+# Per-exposure geometry read once from the SCI header: the detector-corner
+# footprint polygon (for tile-overlap selection) and the S_REGION string (for
+# the drizzle output-WCS build). Both come from the same single open.
+InputGeometry = namedtuple('InputGeometry', ['footprint', 's_region'])
 
-    Each footprint is computed from the SCI extension WCS via
-    ``wcs_pix2world`` on the four corners of an ``in_shape`` rectangle
-    (default 2048×2048 = NIRCam detector). NIRCam detectors are all
-    2048², so the default is correct for the pipeline; the parameter
-    exists so this helper can be reused for other instruments.
 
-    Footprints are tile-invariant, so callers selecting against many tiles
-    should call this **once** per filter and pass the result to
-    ``select_overlapping`` per tile — instead of re-opening every exposure
-    inside the tile loop (the old per-tile ``select_overlapping_files``).
+def compute_input_geometry(exposure_files, *, in_shape=(2048, 2048)):
+    """Return ``{file: InputGeometry(footprint, s_region)}`` — one open each.
+
+    The footprint is computed from the SCI extension WCS via ``wcs_pix2world``
+    on the four corners of an ``in_shape`` rectangle (default 2048×2048 =
+    NIRCam detector; all NIRCam detectors are 2048², the parameter exists so
+    this can be reused for other instruments). The ``s_region`` is that same
+    extension's ``S_REGION`` keyword, read from the same open.
+
+    Both are tile-invariant, so callers selecting against many tiles call this
+    **once** per filter and reuse it: ``select_overlapping`` consumes the
+    footprints per tile, and the resample drizzle consumes the S_REGION
+    strings for its output-WCS build — neither re-opens the inputs per tile.
     """
     nx, ny = in_shape
     pixcoords = np.array(
@@ -36,35 +43,40 @@ def compute_footprints(exposure_files, *, in_shape=(2048, 2048)):
          [float(nx), float(ny)], [0.0, float(ny)]]
     )
 
-    footprints = {}
+    geometry = {}
     for f in exposure_files:
         with fits.open(f, ignore_missing_simple=True, memmap=False) as hdul:
+            hdr = hdul[1].header
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore')
-                wcs = WCS(hdul[1].header, naxis=2)
+                wcs = WCS(hdr, naxis=2)
             worldcoords = wcs.wcs_pix2world(pixcoords, 0)
-        footprints[f] = Polygon(worldcoords)
-    return footprints
+            s_region = hdr.get('S_REGION')
+        geometry[f] = InputGeometry(Polygon(worldcoords), s_region)
+    return geometry
 
 
-def select_overlapping(footprints, tile_polygon):
+def select_overlapping(geometry, tile_polygon):
     """Return files whose footprint intersects ``tile_polygon`` — no I/O.
 
-    ``footprints`` is a ``{file: Polygon}`` mapping from
-    ``compute_footprints``; ``tile_polygon`` is a ``shapely`` Polygon in sky
-    coordinates. Iteration follows the mapping's insertion order (the
+    ``geometry`` is a ``{file: InputGeometry}`` mapping from
+    ``compute_input_geometry``; ``tile_polygon`` is a ``shapely`` Polygon in
+    sky coordinates. Iteration follows the mapping's insertion order (the
     original file order), so the selected list matches the legacy
     ``select_overlapping_files`` ordering exactly.
     """
-    return [f for f, poly in footprints.items() if tile_polygon.intersects(poly)]
+    return [
+        f for f, geom in geometry.items()
+        if tile_polygon.intersects(geom.footprint)
+    ]
 
 
 def select_overlapping_files(exposure_files, tile_polygon, *, in_shape=(2048, 2048)):
     """Footprint ``exposure_files`` then return those intersecting ``tile_polygon``.
 
-    Thin wrapper over ``compute_footprints`` + ``select_overlapping`` for
-    single-tile callers. When selecting against multiple tiles, call those
-    two directly so the per-file opens happen once, not once per tile.
+    Thin wrapper over ``compute_input_geometry`` + ``select_overlapping`` for
+    single-tile callers. When selecting against multiple tiles, call those two
+    directly so the per-file opens happen once, not once per tile.
     """
-    footprints = compute_footprints(exposure_files, in_shape=in_shape)
-    return select_overlapping(footprints, tile_polygon)
+    geometry = compute_input_geometry(exposure_files, in_shape=in_shape)
+    return select_overlapping(geometry, tile_polygon)

--- a/pipeline/campfire_pipeline/nircam/geometry.py
+++ b/pipeline/campfire_pipeline/nircam/geometry.py
@@ -16,16 +16,19 @@ from astropy.wcs import WCS
 from shapely.geometry import Polygon
 
 
-def select_overlapping_files(exposure_files, tile_polygon, *, in_shape=(2048, 2048)):
-    """Return the subset of ``exposure_files`` whose detector footprints
-    intersect ``tile_polygon`` (a ``shapely.geometry.Polygon`` in sky
-    coordinates).
+def compute_footprints(exposure_files, *, in_shape=(2048, 2048)):
+    """Return ``{file: shapely Polygon}`` of each exposure's sky footprint.
 
-    Each file's footprint is computed from the SCI extension WCS via
+    Each footprint is computed from the SCI extension WCS via
     ``wcs_pix2world`` on the four corners of an ``in_shape`` rectangle
     (default 2048×2048 = NIRCam detector). NIRCam detectors are all
     2048², so the default is correct for the pipeline; the parameter
     exists so this helper can be reused for other instruments.
+
+    Footprints are tile-invariant, so callers selecting against many tiles
+    should call this **once** per filter and pass the result to
+    ``select_overlapping`` per tile — instead of re-opening every exposure
+    inside the tile loop (the old per-tile ``select_overlapping_files``).
     """
     nx, ny = in_shape
     pixcoords = np.array(
@@ -33,14 +36,35 @@ def select_overlapping_files(exposure_files, tile_polygon, *, in_shape=(2048, 20
          [float(nx), float(ny)], [0.0, float(ny)]]
     )
 
-    selected = []
+    footprints = {}
     for f in exposure_files:
         with fits.open(f, ignore_missing_simple=True, memmap=False) as hdul:
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore')
                 wcs = WCS(hdul[1].header, naxis=2)
             worldcoords = wcs.wcs_pix2world(pixcoords, 0)
-        file_polygon = Polygon(worldcoords)
-        if tile_polygon.intersects(file_polygon):
-            selected.append(f)
-    return selected
+        footprints[f] = Polygon(worldcoords)
+    return footprints
+
+
+def select_overlapping(footprints, tile_polygon):
+    """Return files whose footprint intersects ``tile_polygon`` — no I/O.
+
+    ``footprints`` is a ``{file: Polygon}`` mapping from
+    ``compute_footprints``; ``tile_polygon`` is a ``shapely`` Polygon in sky
+    coordinates. Iteration follows the mapping's insertion order (the
+    original file order), so the selected list matches the legacy
+    ``select_overlapping_files`` ordering exactly.
+    """
+    return [f for f, poly in footprints.items() if tile_polygon.intersects(poly)]
+
+
+def select_overlapping_files(exposure_files, tile_polygon, *, in_shape=(2048, 2048)):
+    """Footprint ``exposure_files`` then return those intersecting ``tile_polygon``.
+
+    Thin wrapper over ``compute_footprints`` + ``select_overlapping`` for
+    single-tile callers. When selecting against multiple tiles, call those
+    two directly so the per-file opens happen once, not once per tile.
+    """
+    footprints = compute_footprints(exposure_files, in_shape=in_shape)
+    return select_overlapping(footprints, tile_polygon)

--- a/pipeline/campfire_pipeline/nircam/manifest.py
+++ b/pipeline/campfire_pipeline/nircam/manifest.py
@@ -305,7 +305,9 @@ def get_stale_tiles(field, filtname, stage_config):
     """
     from shapely.geometry import Polygon
 
-    from campfire_pipeline.nircam.geometry import select_overlapping_files
+    from campfire_pipeline.nircam.geometry import (
+        compute_footprints, select_overlapping,
+    )
 
     resample_cfg = stage_config.get('resample', {})
     version = resample_cfg.get('version', 'v0_1')
@@ -330,6 +332,9 @@ def get_stale_tiles(field, filtname, stage_config):
         skip=files_to_skip if files_to_skip else None,
         with_step='CFP_OUT',
     )
+    # Footprints are tile-invariant: open each candidate's WCS once here,
+    # not once per tile inside the loop below.
+    footprints = compute_footprints(candidate_files)
 
     results = []
     for tile in tiles:
@@ -349,7 +354,7 @@ def get_stale_tiles(field, filtname, stage_config):
 
         # Find which canonical exposures overlap this tile
         tile_polygon = Polygon(field.get_tile_corners(tile))
-        selected = select_overlapping_files(candidate_files, tile_polygon)
+        selected = select_overlapping(footprints, tile_polygon)
 
         changed, reasons = check_inputs_changed(manifest_path, selected)
 

--- a/pipeline/campfire_pipeline/nircam/manifest.py
+++ b/pipeline/campfire_pipeline/nircam/manifest.py
@@ -306,7 +306,7 @@ def get_stale_tiles(field, filtname, stage_config):
     from shapely.geometry import Polygon
 
     from campfire_pipeline.nircam.geometry import (
-        compute_footprints, select_overlapping,
+        compute_input_geometry, select_overlapping,
     )
 
     resample_cfg = stage_config.get('resample', {})
@@ -332,9 +332,9 @@ def get_stale_tiles(field, filtname, stage_config):
         skip=files_to_skip if files_to_skip else None,
         with_step='CFP_OUT',
     )
-    # Footprints are tile-invariant: open each candidate's WCS once here,
-    # not once per tile inside the loop below.
-    footprints = compute_footprints(candidate_files)
+    # Geometry is tile-invariant: open each candidate's WCS once here, not
+    # once per tile inside the loop below.
+    geometry = compute_input_geometry(candidate_files)
 
     results = []
     for tile in tiles:
@@ -354,7 +354,7 @@ def get_stale_tiles(field, filtname, stage_config):
 
         # Find which canonical exposures overlap this tile
         tile_polygon = Polygon(field.get_tile_corners(tile))
-        selected = select_overlapping(footprints, tile_polygon)
+        selected = select_overlapping(geometry, tile_polygon)
 
         changed, reasons = check_inputs_changed(manifest_path, selected)
 

--- a/pipeline/campfire_pipeline/nircam/orchestrate.py
+++ b/pipeline/campfire_pipeline/nircam/orchestrate.py
@@ -439,7 +439,7 @@ def _run_outlier_per_visit(field, cfg, filtname, n_processes, overwrite, status,
     # The CFP_OUT-only short-circuit avoids the polygon-overlap setup work
     # done at the top of outlier_step on no-op runs.
     from campfire_pipeline.nircam.manifest import (
-        compute_file_hash, load_manifest,
+        file_unchanged, load_manifest,
     )
 
     def _visit_up_to_date(visit, visit_files):
@@ -451,19 +451,21 @@ def _run_outlier_per_visit(field, cfg, filtname, n_processes, overwrite, status,
         manifest = load_manifest(manifest_path)
         if manifest is None:
             return False
-        # Check that visit_files (a subset of all_inputs) hashes still match.
-        # Cross-visit overlaps are validated inside outlier_step on the slow
-        # path; here we only confirm the visit's own files are unchanged so
-        # we can cheaply skip the obvious no-op case.
-        old_hashes = {
-            inp['filename']: inp['file_hash']
+        # Confirm the visit's own files are unchanged so we can cheaply skip
+        # the obvious no-op case. (Cross-visit overlaps are validated inside
+        # outlier_step on the slow path.) ``file_unchanged`` takes the manifest
+        # size+mtime_ns fast path — a stat per file — and only falls back to a
+        # full SCI+DQ hash on a stat mismatch, so an unchanged combine run no
+        # longer re-hashes ~32MB per visit file.
+        old_entries = {
+            inp['filename']: inp
             for inp in manifest['inputs']
         }
         for f in visit_files:
             bn = os.path.basename(f)
-            if bn not in old_hashes:
+            if bn not in old_entries:
                 return False
-            if compute_file_hash(f) != old_hashes[bn]:
+            if not file_unchanged(f, old_entries[bn]):
                 return False
         return True
 

--- a/pipeline/campfire_pipeline/nircam/orchestrate.py
+++ b/pipeline/campfire_pipeline/nircam/orchestrate.py
@@ -455,8 +455,7 @@ def _run_outlier_per_visit(field, cfg, filtname, n_processes, overwrite, status,
         # the obvious no-op case. (Cross-visit overlaps are validated inside
         # outlier_step on the slow path.) ``file_unchanged`` takes the manifest
         # size+mtime_ns fast path — a stat per file — and only falls back to a
-        # full SCI+DQ hash on a stat mismatch, so an unchanged combine run no
-        # longer re-hashes ~32MB per visit file.
+        # full SCI+DQ hash on a stat mismatch.
         old_entries = {
             inp['filename']: inp
             for inp in manifest['inputs']

--- a/pipeline/campfire_pipeline/nircam/outlier_detect.py
+++ b/pipeline/campfire_pipeline/nircam/outlier_detect.py
@@ -111,9 +111,8 @@ def outlier_detect_for_visit(
 
     # Open the reference input (all_inputs[0]) once: build the per-visit WCS
     # from its gwcs + the other inputs' S_REGION strings (supplied via
-    # `sregions` — read once by the orchestrator's _read_sregions — or read
-    # from the header on a miss), and prep its arrays from the same open. The
-    # remaining inputs are streamed one open each by drizzle_tile_singles.
+    # `sregions`, or read from the header on a miss), and prep its arrays from
+    # the same open. The remaining inputs are streamed one open each.
     with ImageModel(all_inputs[0], memmap=False) as _ref:
         output_wcs = build_output_wcs_from_ref(_ref, all_inputs, sregions)
         nx, ny = output_wcs.pixel_shape
@@ -157,7 +156,6 @@ def outlier_detect_for_visit(
             ref_prep, kernel=kernel, pixfrac=pixfrac)
         _accumulate(idx, all_inputs[0], ref_prep, ref_sci)
         idx += 1
-    # Remaining inputs streamed one open each.
     for (sci_bbox, _wht_bbox, prep), crf in zip(
         drizzle_tile_singles(
             all_inputs[1:], output_wcs, out_shape,

--- a/pipeline/campfire_pipeline/nircam/outlier_detect.py
+++ b/pipeline/campfire_pipeline/nircam/outlier_detect.py
@@ -32,42 +32,11 @@ accumulator updates).
 
 import os
 import tempfile
-from copy import deepcopy
 
 import numpy as np
-from astropy.io import fits
 
 from campfire_pipeline.common import cfp
 from campfire_pipeline.common.io import atomic_save, log
-
-
-def _build_visit_wcs(crf_files):
-    """Build per-visit intermediate WCS via ``wcs_from_sregions`` auto-derivation.
-
-    With ``pscale=None``, ``rotation=None``, ``shape=None`` (all defaults),
-    ``wcs_from_sregions`` derives:
-    - pixel scale from the reference CRF's gwcs at the field reference point
-      (``compute_scale``);
-    - rotation from ``ref_wcsinfo['roll_ref']`` / ``v3yangle`` / ``vparity``
-      (instrument frame, not ICRS-aligned);
-    - shape sized to enclose the union footprint of all input s_regions.
-
-    The resulting gwcs has ``.pixel_shape = (Nx, Ny)`` baked in. Returning
-    array-shape ``(Ny, Nx)`` for downstream use is the caller's job.
-    """
-    from stcal.alignment.util import wcs_from_sregions
-    from stdatamodels.jwst.datamodels import ImageModel
-
-    sregions = []
-    with ImageModel(crf_files[0], memmap=False) as ref:
-        ref_wcs = deepcopy(ref.meta.wcs)
-        ref_wcsinfo = ref.meta.wcsinfo.instance
-        sregions.append(ref.meta.wcsinfo.s_region)
-    for crf in crf_files[1:]:
-        sregions.append(fits.getheader(crf, extname='SCI')['S_REGION'])
-    return wcs_from_sregions(
-        sregions, ref_wcs=ref_wcs, ref_wcsinfo=ref_wcsinfo,
-    )
 
 
 def outlier_detect_for_visit(
@@ -81,6 +50,7 @@ def outlier_detect_for_visit(
     kernel='square',
     weight_type='ivm',
     good_bits='~DO_NOT_USE',
+    sregions=None,
     in_memory=False,
     tempdir=None,
     extras_per_visit=None,
@@ -129,16 +99,29 @@ def outlier_detect_for_visit(
     from stcal.outlier_detection.median import MedianComputer
     from stdatamodels.jwst.datamodels import ImageModel
 
-    from campfire_pipeline.nircam.drizzle import drizzle_tile_singles
+    from campfire_pipeline.nircam.drizzle import (
+        build_output_wcs_from_ref, drizzle_tile_singles,
+        _bbox_drizzle_single, _prep_from_model,
+    )
 
     n_inputs = len(all_inputs)
     if n_inputs == 0:
         log("  outlier (per-visit): no inputs")
         return
 
-    output_wcs = _build_visit_wcs(all_inputs)
-    nx, ny = output_wcs.pixel_shape
-    out_shape = (ny, nx)
+    # Open the reference input (all_inputs[0]) once: build the per-visit WCS
+    # from its gwcs + the other inputs' S_REGION strings (supplied via
+    # `sregions` — read once by the orchestrator's _read_sregions — or read
+    # from the header on a miss), and prep its arrays from the same open. The
+    # remaining inputs are streamed one open each by drizzle_tile_singles.
+    with ImageModel(all_inputs[0], memmap=False) as _ref:
+        output_wcs = build_output_wcs_from_ref(_ref, all_inputs, sregions)
+        nx, ny = output_wcs.pixel_shape
+        out_shape = (ny, nx)
+        ref_prep = _prep_from_model(
+            _ref, output_wcs, out_shape,
+            weight_type=weight_type, good_bits=good_bits,
+        )
 
     log(f"  campfire outlier (per-visit): {n_inputs} inputs into "
         f"{nx}x{ny} visit WCS")
@@ -158,21 +141,33 @@ def outlier_detect_for_visit(
     scratch_sci = np.full(out_shape, np.nan, dtype=np.float32)
 
     contributing_paths = []
-    for idx, ((sci_bbox, _wht_bbox, prep), crf) in enumerate(zip(
-        drizzle_tile_singles(
-            all_inputs, output_wcs, out_shape,
-            pixfrac=pixfrac, kernel=kernel,
-            weight_type=weight_type, good_bits=good_bits,
-        ),
-        all_inputs,
-    )):
-        sly, slx = prep['sly'], prep['slx']
 
+    def _accumulate(idx, crf, prep, sci_bbox):
+        sly, slx = prep['sly'], prep['slx']
         scratch_sci[sly, slx] = sci_bbox
         sci_mc.append(scratch_sci, idx=idx)
         scratch_sci[sly, slx] = np.nan
-
         contributing_paths.append(crf)
+
+    idx = 0
+    # Reference first — its arrays came from the WCS-building open above; it
+    # drizzles through the same bbox path as the streamed inputs.
+    if ref_prep is not None:
+        ref_sci, _ = _bbox_drizzle_single(
+            ref_prep, kernel=kernel, pixfrac=pixfrac)
+        _accumulate(idx, all_inputs[0], ref_prep, ref_sci)
+        idx += 1
+    # Remaining inputs streamed one open each.
+    for (sci_bbox, _wht_bbox, prep), crf in zip(
+        drizzle_tile_singles(
+            all_inputs[1:], output_wcs, out_shape,
+            pixfrac=pixfrac, kernel=kernel,
+            weight_type=weight_type, good_bits=good_bits,
+        ),
+        all_inputs[1:],
+    ):
+        _accumulate(idx, crf, prep, sci_bbox)
+        idx += 1
 
     log("  computing median...")
     median_sci = sci_mc.evaluate()

--- a/pipeline/campfire_pipeline/nircam/steps/outlier.py
+++ b/pipeline/campfire_pipeline/nircam/steps/outlier.py
@@ -387,6 +387,11 @@ def outlier_step_campfire(visit, visit_files, filter_files, sregions,
     snr = tuple(float(x) for x in snr_str.split())
     scale = tuple(float(x) for x in scale_str.split())
 
+    # The orchestrator already read every input's S_REGION once
+    # (_read_sregions) and passed them as `sregions`; reuse that map so the
+    # per-visit WCS build doesn't re-open each input just for one keyword.
+    sregion_map = dict(zip(filter_files, sregions))
+
     outlier_detect_for_visit(
         all_inputs, visit_files,
         snr=snr, scale=scale,
@@ -395,6 +400,7 @@ def outlier_step_campfire(visit, visit_files, filter_files, sregions,
         kernel=step_config.get('kernel', 'square'),
         weight_type=step_config.get('weight_type', 'ivm'),
         good_bits=step_config.get('good_bits', '~DO_NOT_USE'),
+        sregions=sregion_map,
         in_memory=bool(step_config.get('in_memory', False)),
         extras_per_visit=saved_extras,
         plot=do_plot,

--- a/pipeline/campfire_pipeline/nircam/steps/outlier.py
+++ b/pipeline/campfire_pipeline/nircam/steps/outlier.py
@@ -387,9 +387,9 @@ def outlier_step_campfire(visit, visit_files, filter_files, sregions,
     snr = tuple(float(x) for x in snr_str.split())
     scale = tuple(float(x) for x in scale_str.split())
 
-    # The orchestrator already read every input's S_REGION once
-    # (_read_sregions) and passed them as `sregions`; reuse that map so the
-    # per-visit WCS build doesn't re-open each input just for one keyword.
+    # `sregions` is pre-populated by the caller (one S_REGION read per input);
+    # reuse that map so the per-visit WCS build doesn't re-open each input just
+    # for one keyword.
     sregion_map = dict(zip(filter_files, sregions))
 
     outlier_detect_for_visit(

--- a/pipeline/campfire_pipeline/nircam/steps/resample.py
+++ b/pipeline/campfire_pipeline/nircam/steps/resample.py
@@ -28,7 +28,7 @@ from shapely.geometry import Polygon
 
 from campfire_pipeline.common.io import log
 from campfire_pipeline.nircam.geometry import (
-    compute_footprints, select_overlapping,
+    compute_input_geometry, select_overlapping,
 )
 
 
@@ -53,6 +53,7 @@ def _drizzle_tile_via_campfire(
     pixel_scale,
     resample_cfg,
     reduction_version,
+    sregions=None,
 ):
     """Drizzle ``selected_files`` to ``output_path`` via the campfire-native
     drizzle (issue #138).
@@ -77,6 +78,7 @@ def _drizzle_tile_via_campfire(
         good_bits=resample_cfg.get('good_bits', '~DO_NOT_USE'),
         blendheaders=resample_cfg.get('blendheaders', True),
         reduction_version=reduction_version,
+        sregions=sregions,
     )
 
 
@@ -91,6 +93,7 @@ def _drizzle_tile_via_jwst(
     pixel_scale,
     resample_cfg,
     reduction_version,
+    sregions=None,  # accepted for dispatch parity; jwst resamples its own WCS
 ):
     """Drizzle ``selected_files`` to ``output_path`` via JWST ``Image3Pipeline``.
 
@@ -200,9 +203,9 @@ def resample_step(filtname, exposure_files, field, step_config,
     if isinstance(tiles, str):
         tiles = [tiles]
 
-    # Footprints are tile-invariant: open each exposure's WCS once here, not
-    # once per tile inside the loop below.
-    footprints = compute_footprints(exposure_files)
+    # Geometry (footprint + S_REGION) is tile-invariant: open each exposure's
+    # SCI header once here, not once per tile inside the loop below.
+    geometry = compute_input_geometry(exposure_files)
 
     for tile in tiles:
         log(f"resample: tile {tile}, {filtname}, {pixel_scale_str}")
@@ -226,7 +229,7 @@ def resample_step(filtname, exposure_files, field, step_config,
         log(f"  mosaic → {mosaic_file}")
 
         tile_polygon = Polygon(field.get_tile_corners(tile))
-        selected = select_overlapping(footprints, tile_polygon)
+        selected = select_overlapping(geometry, tile_polygon)
         if not selected:
             log(f"  no exposures overlap {tile}; skipping")
             continue
@@ -281,6 +284,10 @@ def resample_step(filtname, exposure_files, field, step_config,
                 pixel_scale=pixel_scale,
                 resample_cfg=step_config,
                 reduction_version=reduction_version,
+                # S_REGIONs read once in the geometry pass above; the campfire
+                # drizzle reuses them for its output-WCS build instead of
+                # re-opening each selected input per tile (jwst path ignores).
+                sregions={f: geometry[f].s_region for f in selected},
             )
 
             manifest = create_manifest(

--- a/pipeline/campfire_pipeline/nircam/steps/resample.py
+++ b/pipeline/campfire_pipeline/nircam/steps/resample.py
@@ -27,7 +27,9 @@ from astropy.io import fits
 from shapely.geometry import Polygon
 
 from campfire_pipeline.common.io import log
-from campfire_pipeline.nircam.geometry import select_overlapping_files
+from campfire_pipeline.nircam.geometry import (
+    compute_footprints, select_overlapping,
+)
 
 
 def _resolve_pixel_scale(value):
@@ -198,6 +200,10 @@ def resample_step(filtname, exposure_files, field, step_config,
     if isinstance(tiles, str):
         tiles = [tiles]
 
+    # Footprints are tile-invariant: open each exposure's WCS once here, not
+    # once per tile inside the loop below.
+    footprints = compute_footprints(exposure_files)
+
     for tile in tiles:
         log(f"resample: tile {tile}, {filtname}, {pixel_scale_str}")
 
@@ -220,7 +226,7 @@ def resample_step(filtname, exposure_files, field, step_config,
         log(f"  mosaic → {mosaic_file}")
 
         tile_polygon = Polygon(field.get_tile_corners(tile))
-        selected = select_overlapping_files(exposure_files, tile_polygon)
+        selected = select_overlapping(footprints, tile_polygon)
         if not selected:
             log(f"  no exposures overlap {tile}; skipping")
             continue


### PR DESCRIPTION
**Stacked on #176** (base: `perf/nircam-cache-tier`). Review/merge #176 first.

PR 2 of `docs/design-nircam-exposure-major.md` — the **combine-phase** NFS fixes (audit findings **H7 / H8 / M4** of `docs/nfs_audit.md`). All three are I/O-shape changes only: **no change to pixel values, tile selection, staleness decisions, or drizzle/outlier output.** Verified bit-identical on a real visit via A/B.

## H7 — footprint hoist
`select_overlapping_files` re-opened every candidate exposure's WCS once per tile to test overlap (N_exposures × N_tiles `fits.open`s). Footprints are tile-invariant, so geometry is split into `compute_input_geometry` (one open per exposure) + a pure-geometry `select_overlapping` (no I/O). Both callers (`resample`, `manifest.get_stale_tiles`) now compute footprints once per filter, above the tile loop. Selection is bit-identical — same `wcs_pix2world` four-corner polygons, same order.

## H8 — one CRDS-input open per file in the combine reducers
`drizzle_tile` and `outlier_detect_for_visit` walked their input set **twice**: a WCS-sizing pass that opened the reference input and `getheader`-scanned every other input's `S_REGION`, then an array pass that re-opened every input.

The sizing pass is now collapsed into the reduce pass:
- The reference input (`inputs[0]`) is opened **once** — output WCS bootstrapped from its gwcs + wcsinfo, arrays prepped from the same open.
- The other inputs' `S_REGION` strings are supplied from a read that already happens — outlier from the orchestrator's `_read_sregions`, resample from the H7 geometry pass (`compute_input_geometry` now also returns `S_REGION`). The per-tile / per-visit `getheader` scan is gone.

The audit's suggested "drop the ImageModel open of input[0], getheader all" was unsafe — the reference gwcs lives in the ASDF extension, not the header — so the reference keeps one ImageModel open (now its only one). The outlier flag-write pass (a second open of visit files only) is unchanged; it necessarily follows the median.

## M4 — manifest stat fast-path
`orchestrate._visit_up_to_date` now goes through `manifest.file_unchanged` (size + `mtime_ns` stat, content hash only on mismatch) instead of re-hashing each visit file's full SCI+DQ (~32 MB) on every unchanged combine run. Identical staleness decisions; old manifests without stat fields degrade to hashing.

## Verification
Bit-identical A/B on a real visit (4 nrcalong dithers): drizzle SCI/ERR/WHT/CON and flagged outlier DQ byte-for-byte equal old vs new, with the new sregions-passed path exercised. 111/111 pipeline tests pass.

**Changelog:** Infrastructure (no scientific impact) → PATCH.

Generated with Claude Code
