### PR TITLE
feat(nircam): cal-frame 1/f striping rework + GP per-amp-row estimator

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -26,6 +26,29 @@ Release procedure: edit the `## Unreleased` section below, then run
 ## Unreleased
 
 ### Calibration
+- NIRCam `striping` now runs **after** `image2`, on flat-fielded, flux-
+  calibrated cal-stage data, and fits *and applies* the 1/f correction in that
+  same frame. Process order is now detector1 → persistence → wisp → image2 →
+  striping → edge → sky → … Previously striping fit on a flat-fielded *copy*
+  but subtracted the correction from the *un-flat* rate SCI, which image2 then
+  re-divided by the per-amp-structured flat — leaving a coherent per-amp DC
+  step at the amplifier boundaries (`≈ N/g·(1−1/g)`, a ~10–30σ residual
+  amp-to-amp offset in the column background, verified to reproduce at
+  r=0.9997). Fitting and subtracting in the cal frame removes that leak.
+  Consequences: striping measures its pedestal with the scale-free `fit_sky_tot`
+  Gaussian sky-peak fit rather than the rate-tuned `fit_pedestal`;
+  `[nircam.striping]` no longer takes `apply_flat` / `use_custom_flat` and no
+  longer resolves a flat (dropped from CRDS prefetch). `subtract_background` is
+  now a **fit-only** 2D detrend (default **on**, `box=32` / `filter=3`): it
+  removes the field's large-scale structure (e.g. cluster ICL / scattered
+  light) from the working copy so the per-amp-row/per-column medians estimate
+  the 1/f rather than the background, but the model is **never** subtracted from
+  the output SCI — so it cannot leave negative wings around sources (unlike the
+  fine-box mosaic bkgsub) and the ICL is retained for mosaic-level removal.
+  Without it, a smooth gradient that per-amp-row constants cannot represent gets
+  imprinted as amp-boundary steps. `wisp` is unchanged (still rate-frame); its
+  analogous flat round-trip is a separate, SW-only follow-up.
+
 - Opt-in extended-wavelength reduction for G140M/F100LP and G235M/F170LP
   (`[nirspec.stage2].extend_g140m_g235m`, default off). The F100LP/F170LP
   long-pass filters pass light redward of the nominal grating cutoffs; when
@@ -48,6 +71,33 @@ Release procedure: edit the `## Unreleased` section below, then run
   feature failed for fixed-slit sources.
 
 ### Algorithm
+- NIRCam `striping`: new opt-in per-amp-row 1/f offset estimator selectable via
+  `[nircam.striping].estimator` (default **`"median"`** — the production
+  2σ-clipped median with full-row fallback, byte-for-byte unchanged). The new
+  `"gp"` estimator fits a 1-D Gaussian Process (celerite2 `SHOTerm`,
+  `Q = 1/sqrt(2)`, CPU O(n)) along the slow (row) axis *per amplifier*, with
+  each amp-row weighted by its sampling error `sigma_r ≈ 1.25·MAD/sqrt(N_r)`
+  and carrying its own DC mean term. It interpolates the offset across
+  source-masked rows using clean rows of the *same* amplifier instead of
+  substituting the cross-amp full-row median, removing the amp-boundary +
+  slow-axis "box" of striping artifacts around bright/extended sources. The
+  per-column (vertical) step is untouched. Hyperparameters are frozen
+  (`[nircam.striping.gp]`, split by SW/LW channel; calibrate with
+  `scripts/calibrate_gp_striping.py`), never fit per exposure. An aggressive
+  masking variant (`mask_aggressive`) dilates the source mask and folds in
+  JUMP/SATURATED/PERSISTENCE DQ — over-masking only inflates `sigma_r` (the GP
+  interpolates across), whereas under-masking biases the median and the GP
+  would oversubtract. A third value, `estimator = "none"`, builds/writes the
+  `SRCMASK` and runs the rest of the pipeline but applies no campfire 1/f
+  (for comparison runs against JWST's own ramp-stage `clean_flicker_noise`).
+  Default config reproduces the current pipeline exactly; no change unless
+  `estimator` is set away from `"median"`. A/B testbed in
+  `experiments/oneoverf_gp/`, which also evaluates `clean_flicker_noise`: on a
+  cluster field the GP beats the median by ~16% on the amp-row 1/f residual
+  (clean *and* source rows, photometry conserved, slightly faster), while
+  `clean_flicker_noise` is not adopted — its `fit_method="fft"` is NIRSpec-only
+  (skipped for `NRC_IMAGE`) and its `"median"` mode underperforms our amp-row
+  estimators and introduces per-amp DC steps.
 - NIRCam campfire-native drizzle (`resample.implementation = "campfire"`): the
   ERR map no longer fills with `inf`/`nan`. The variance pass summed the three
   variance components before drizzling, so a single input pixel with a
@@ -69,6 +119,18 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- NIRCam `skyfit.fit_sky` now takes `box_size` / `filter_size` (the striping
+  2D-background detrend exposes them via `subtract_background_box` /
+  `subtract_background_filter`), and a byte-order guard prevents a corruption
+  bug: the bottleneck-accelerated path used to `byteswap(inplace=True)` then
+  re-`view` the input, which corrupted native-byte-order arrays in place (the
+  cal-frame `fitdata` is native) and produced garbage background → ±100s in the
+  output SCI. It now casts a copy to native order only when needed. Regression
+  test in `tests/test_nircam_skyfit.py`.
+- NIRCam `detector1` exposes `clean_flicker_noise_opts` — a passthrough merged
+  over the JWST `clean_flicker_noise` step defaults (e.g. `fit_method`,
+  `background_method`), used only when `clean_flicker_noise = true`. Enables the
+  cfn comparison arms; no effect on the default config (cfn off).
 - NFS cache tier for the NIRCam pipeline (PR 1 of
   `docs/design-nircam-exposure-major.md`; findings H4/H5/M2/M9 of
   `docs/nfs_audit.md`). No change to pixel values or reference selection —

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -81,9 +81,19 @@ Release procedure: edit the `## Unreleased` section below, then run
   source-masked rows using clean rows of the *same* amplifier instead of
   substituting the cross-amp full-row median, removing the amp-boundary +
   slow-axis "box" of striping artifacts around bright/extended sources. The
-  per-column (vertical) step is untouched. Hyperparameters are frozen
-  (`[nircam.striping.gp]`, split by SW/LW channel; calibrate with
-  `scripts/calibrate_gp_striping.py`), never fit per exposure. An aggressive
+  per-column (vertical) step is untouched. Only the length scale `rho` (in
+  rows) is a frozen hyperparameter — a detector readout property, independent
+  of filter and flux units (calibrate with `scripts/calibrate_gp_striping.py`).
+  A single channel-agnostic `rho = 5.0` is used: it was measured stable across
+  five filters spanning both channels on rj0911 (LW f277w/f356w/f444w =
+  4.51/4.44/5.03, SW f200w/f150w = 4.10/4.11 rows — one cluster inside its
+  broad flat optimum), so no SW/LW split is needed. The kernel **amplitude
+  self-adapts per
+  exposure** (the marginal `mad_std` of the clean per-amp-row medians,
+  measured on the pre-2D-bg frame — a deterministic robust statistic, not a
+  per-exposure fit), so it tracks the cal-stage flux units that vary ~3× by
+  filter instead of carrying a frozen absolute number. Nothing is optimized
+  per exposure. An aggressive
   masking variant (`mask_aggressive`) dilates the source mask and folds in
   JUMP/SATURATED/PERSISTENCE DQ — over-masking only inflates `sigma_r` (the GP
   interpolates across), whereas under-masking biases the median and the GP
@@ -93,7 +103,7 @@ Release procedure: edit the `## Unreleased` section below, then run
   Default config reproduces the current pipeline exactly; no change unless
   `estimator` is set away from `"median"`. A/B testbed in
   `experiments/oneoverf_gp/`, which also evaluates `clean_flicker_noise`: on a
-  cluster field the GP beats the median by ~16% on the amp-row 1/f residual
+  cluster field the GP beats the median by ~14% on the amp-row 1/f residual
   (clean *and* source rows, photometry conserved, slightly faster), while
   `clean_flicker_noise` is not adopted — its `fit_method="fft"` is NIRSpec-only
   (skipped for `NRC_IMAGE`) and its `"median"` mode underperforms our amp-row

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -199,29 +199,26 @@
     mask_extra_dilation = 4
 
     [nircam.striping.gp]
-        # Frozen SHOTerm hyperparameters (calibrate offline with
-        # scripts/calibrate_gp_striping.py; split by detector channel
-        # because the 1/f amplitude and correlation length differ).
-        # kernel_sigma = amplitude (data units); rho = length scale in rows.
-        # Q is fixed smooth/non-oscillatory; sigma_clip/weak_frac as in
-        # gp_striping.gp_amprow_offsets.
-        # Calibrated 2026-06-16 on rj0911 f444w (LW, 32 amp sequences) in the
-        # CAL frame (MJy/sr) — striping now runs after image2, so kernel_sigma
-        # is in cal-stage flux units (re-calibrate if that ordering changes).
-        # rho (~5 rows) is the detrended-MLE 1/f correlation length;
-        # kernel_sigma is the *raw marginal* amplitude (NOT the detrended
-        # amplitude) — it must stay >> the per-row sampling error so the GP
-        # trusts each clean row's median and only smooths/interpolates at the
-        # rho scale. A pipeline-faithful (kernel_sigma, rho) scan
-        # (experiments/oneoverf_gp/scan_fitframe.py) confirms this regime
-        # beats the median estimator on both clean and source-covered rows,
-        # whereas a too-small kernel_sigma over-regularizes and loses to it.
-        # SW not yet calibrated — seeded with the LW values; re-run the
-        # calibration on an SW field before estimator="gp" on SW data.
-        kernel_sigma_lw = 8.309341e-03
-        rho_lw = 5.0294
-        kernel_sigma_sw = 8.309341e-03
-        rho_sw = 5.0294
+        # rho is the ONLY frozen SHOTerm hyperparameter — the 1/f correlation
+        # length in *rows*. It is a detector readout/clocking property (the
+        # filter sits upstream in the optical path and does not enter the
+        # readout), so it is independent of filter and of flux units. Measured
+        # stable across 5 filters spanning both channels on rj0911 (detrended
+        # MLE; scripts/calibrate_gp_striping.py): LW f277w/f356w/f444w =
+        # 4.51/4.44/5.03, SW f200w/f150w = 4.10/4.11 — one tight cluster, all
+        # inside rho's broad flat optimum. So a single channel-agnostic rho is
+        # used (no SW/LW split). Set rho_lw / rho_sw to override per channel if
+        # a future detector/readout ever needs it.
+        rho = 5.0
+        # The kernel amplitude is NOT frozen: it self-adapts per exposure to
+        # the marginal mad_std of the clean per-amp-row medians (~ the true
+        # 1/f amplitude) — a deterministic robust statistic, not a fit — so it
+        # tracks each exposure's cal-stage flux units (filter / detector /
+        # photometric calibration) instead of a frozen absolute number.
+        # kernel_sigma_factor is a frozen O(1) multiplier on that; set an
+        # explicit kernel_sigma_lw/_sw only as an escape hatch (overrides the
+        # self-adaptation). See gp_striping.gp_amprow_offsets.
+        kernel_sigma_factor = 1.0
         q = 0.70710678
         sigma_clip = 2.0
         weak_frac = 0.5

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -158,12 +158,73 @@
     plot = true
 
 [nircam.striping]
-    apply_flat = true
-    use_custom_flat = false
+    # Runs after image2 on cal-stage data (no flat applied here): the 1/f
+    # correction is fit and subtracted in the same flat-fielded frame, so it
+    # no longer leaks a per-amp DC offset through the flat re-division (the
+    # old "fit on a flat copy, subtract from the un-flat rate SCI" round-trip).
     mask_sources = true
+    # 2D-background pre-subtraction (fit-only — it detrends the working copy so
+    # the per-amp-row/per-column medians estimate the 1/f, NOT the field's
+    # large-scale structure; the bkgd is never subtracted from the output SCI).
+    # Required on fields with real large-scale background (e.g. cluster ICL /
+    # scattered light): without it, a smooth gradient can't be represented by
+    # per-amp-row constants, so the striping imprints amp-boundary steps. The
+    # box/filter sizes below set the smoothing scale; being fit-only +
+    # median-based it cannot put negative wings in the output (unlike the
+    # fine-box mosaic bkgsub, which is applied to the output and relies on its
+    # aggressive mask).
     subtract_background = true
+    # 2D-background box / filter sizes (fit-only). Effective smoothing scale
+    # ~box*filter px; smaller removes the field's large-scale structure
+    # (cluster ICL) from the 1/f fit more completely, but too small absorbs
+    # the 1/f. 32/3 chosen on rj0911 f444w (cluster) as the ICL-removal vs
+    # 1/f-fidelity sweet spot; filter_size must be odd.
+    subtract_background_box = 32
+    subtract_background_filter = 3
     maxiters = 3
     plot = true
+    # Per-amp-row 1/f offset estimator. "median" (default) is the
+    # production 2σ-clipped median with full-row fallback. "gp" fits a 1-D
+    # Gaussian Process along the slow axis per amplifier, interpolating the
+    # offset across masked source rows within the same amp instead of
+    # substituting the full-row median (which mixes the four amps' distinct
+    # offsets and produces the "box" of amp-row artifacts around bright
+    # sources). The per-column (vertical) step is unchanged either way.
+    estimator = "median"
+    # Aggressive masking for the GP path: grow the source mask and fold in
+    # JUMP/SATURATED/PERSISTENCE DQ. Over-masking only inflates the GP's
+    # per-row sigma_r (interpolated across); under-masking biases the median
+    # and the GP oversubtracts a trough around the source.
+    mask_aggressive = false
+    mask_extra_dilation = 4
+
+    [nircam.striping.gp]
+        # Frozen SHOTerm hyperparameters (calibrate offline with
+        # scripts/calibrate_gp_striping.py; split by detector channel
+        # because the 1/f amplitude and correlation length differ).
+        # kernel_sigma = amplitude (data units); rho = length scale in rows.
+        # Q is fixed smooth/non-oscillatory; sigma_clip/weak_frac as in
+        # gp_striping.gp_amprow_offsets.
+        # Calibrated 2026-06-16 on rj0911 f444w (LW, 32 amp sequences) in the
+        # CAL frame (MJy/sr) — striping now runs after image2, so kernel_sigma
+        # is in cal-stage flux units (re-calibrate if that ordering changes).
+        # rho (~5 rows) is the detrended-MLE 1/f correlation length;
+        # kernel_sigma is the *raw marginal* amplitude (NOT the detrended
+        # amplitude) — it must stay >> the per-row sampling error so the GP
+        # trusts each clean row's median and only smooths/interpolates at the
+        # rho scale. A pipeline-faithful (kernel_sigma, rho) scan
+        # (experiments/oneoverf_gp/scan_fitframe.py) confirms this regime
+        # beats the median estimator on both clean and source-covered rows,
+        # whereas a too-small kernel_sigma over-regularizes and loses to it.
+        # SW not yet calibrated — seeded with the LW values; re-run the
+        # calibration on an SW field before estimator="gp" on SW data.
+        kernel_sigma_lw = 8.309341e-03
+        rho_lw = 5.0294
+        kernel_sigma_sw = 8.309341e-03
+        rho_sw = 5.0294
+        q = 0.70710678
+        sigma_clip = 2.0
+        weak_frac = 0.5
 
 [nircam.image2]
     use_custom_flat = false

--- a/pipeline/campfire_pipeline/nircam/gp_striping.py
+++ b/pipeline/campfire_pipeline/nircam/gp_striping.py
@@ -137,7 +137,9 @@ def _gp_predict_amp(rows, y_r, yerr, dc_level, kernel_sigma, rho, q,
     return mu, var
 
 
-def gp_amprow_offsets(data, mask, kernel_sigma, rho, q=1.0 / np.sqrt(2.0),
+def gp_amprow_offsets(data, mask, rho, kernel_sigma=None,
+                      kernel_sigma_factor=1.0, amplitude_data=None,
+                      q=1.0 / np.sqrt(2.0),
                       sigma_clip_sigma=2.0, maxiters=3,
                       ref_border=_REF_BORDER, weak_frac=0.5):
     """Per-amp, per-row 1/f offset via 1-D GP smoothing along the slow axis.
@@ -155,16 +157,48 @@ def gp_amprow_offsets(data, mask, kernel_sigma, rho, q=1.0 / np.sqrt(2.0),
     the output array is full-frame; those weakly-constrained edge rows are
     flagged in the diagnostics.
 
+    Hyperparameters
+    ---------------
+    Only ``rho`` (length scale, in rows) is a frozen hyperparameter — it is a
+    detector readout/clocking property, independent of filter and of flux
+    units. The kernel amplitude ``kernel_sigma`` is **self-adapting** by
+    default: it is set per-exposure to the marginal ``mad_std`` of the
+    per-amp-centered clean row medians times a frozen O(1)
+    ``kernel_sigma_factor``. That is a deterministic robust statistic computed
+    once per exposure — *not* an optimization, so it adds no per-exposure
+    fitting — and it removes the cal-stage flux-unit (filter / detector /
+    photometric-calibration) dependence that an absolute frozen amplitude
+    would carry. Pass an explicit ``kernel_sigma`` to override (escape hatch
+    / calibration reproduction). The amplitude is floored to the typical
+    per-row sampling error so the solve stays conditioned.
+
+    When the caller pre-subtracts a 2D background from ``data`` (the striping
+    step does, to keep large-scale structure out of the per-amp-row fit), pass
+    the **pre-subtraction** frame as ``amplitude_data`` so the amplitude is
+    measured there. The prior amplitude must reflect how far the offset can
+    vary *across a wide source gap* — i.e. the full pre-detrend 1/f marginal,
+    not the post-detrend residual. Measuring it on the post-detrend ``data``
+    underestimates the amplitude, over-regularizes the gap interpolation, and
+    loses to the plain per-row median (verified on rj0911 f444w). ``None`` →
+    measure on ``data`` itself (correct when no 2D-bg detrend was applied).
+
     Parameters
     ----------
     data : (H, W) ndarray
         Frame to measure (flat-fielded, pedestal/background pre-subtracted).
     mask : (H, W) bool ndarray
         True where masked (DQ flagged or source).
-    kernel_sigma : float
-        SHOTerm amplitude (frozen hyperparameter; data units).
     rho : float
         SHOTerm length scale in *rows* (frozen hyperparameter).
+    kernel_sigma : float, optional
+        SHOTerm amplitude (data units). ``None`` (default) → self-adapt from
+        the exposure (see above).
+    kernel_sigma_factor : float
+        Frozen O(1) multiplier on the self-adapted amplitude. Ignored when
+        ``kernel_sigma`` is given.
+    amplitude_data : (H, W) ndarray, optional
+        Frame to measure the self-adapted amplitude on (the pre-2D-bg-detrend
+        data). ``None`` → use ``data``. Ignored when ``kernel_sigma`` is given.
     q : float
         SHOTerm quality factor. ``1/sqrt(2)`` → smooth, non-oscillatory.
     sigma_clip_sigma, maxiters : float, int
@@ -183,6 +217,8 @@ def gp_amprow_offsets(data, mask, kernel_sigma, rho, q=1.0 / np.sqrt(2.0),
         Per-amp per-row offset broadcast across each amp's columns.
     diagnostics : list[str]
         One ``'A:anchors/weak/maxσ'`` string per amplifier for logging.
+    kernel_sigma_eff : float
+        The amplitude actually used (self-adapted or the override value).
     """
     n_rows = data.shape[0]
     rows_all = np.arange(n_rows)
@@ -192,15 +228,51 @@ def gp_amprow_offsets(data, mask, kernel_sigma, rho, q=1.0 / np.sqrt(2.0),
     horizontal = np.zeros(data.shape, dtype=np.float64)
     diagnostics = []
 
+    # ---- Pass 1: per-amp robust row statistics --------------------------
+    # Everything needed to (a) self-calibrate the kernel amplitude from this
+    # exposure and (b) fit each amp's GP in pass 2.
+    # Self-adapt the amplitude on the pre-detrend frame when supplied.
+    self_adapt = kernel_sigma is None
+    amp_ref = amplitude_data if (self_adapt and amplitude_data is not None) \
+        else data
+
+    amp_stats = []
+    centered = []   # per-amp-centered clean row medians, pooled over amps
+    yerr_pool = []  # per-row sampling errors, pooled (amplitude floor)
     for amp in ('A', 'B', 'C', 'D'):
         _, _, colstart, colstop = NIR_AMPS[amp]['data']
-        ampdata = data[sci, colstart:colstop]
-        ampmask = mask[sci, colstart:colstop]
-
         y_r, s_hat, n_r = _amprow_statistics(
-            ampdata, ampmask, sigma_clip_sigma, maxiters)
-
+            data[sci, colstart:colstop], mask[sci, colstart:colstop],
+            sigma_clip_sigma, maxiters)
         good = (n_r > 0) & np.isfinite(y_r) & np.isfinite(s_hat)
+        amp_stats.append((amp, colstart, colstop, y_r, s_hat, n_r, good))
+        if good.any():
+            sp = np.where(s_hat[good] > 0, s_hat[good], np.nan)
+            yerr_pool.append(_MEDIAN_SE_FACTOR * sp / np.sqrt(n_r[good]))
+        if self_adapt:
+            if amp_ref is data:
+                if good.any():
+                    centered.append(y_r[good] - np.median(y_r[good]))
+            else:
+                ar, _, an = _amprow_statistics(
+                    amp_ref[sci, colstart:colstop],
+                    mask[sci, colstart:colstop], sigma_clip_sigma, maxiters)
+                ag = (an > 0) & np.isfinite(ar)
+                if ag.any():
+                    centered.append(ar[ag] - np.median(ar[ag]))
+
+    # ---- Self-adapting kernel amplitude ---------------------------------
+    if kernel_sigma is None:
+        marg = (float(mad_std(np.concatenate(centered))) if centered else 0.0)
+        marg *= float(kernel_sigma_factor)
+        floor = (float(np.nanmedian(np.concatenate(yerr_pool)))
+                 if yerr_pool else 1.0)
+        kernel_sigma_eff = float(max(marg, floor))
+    else:
+        kernel_sigma_eff = float(kernel_sigma)
+
+    # ---- Pass 2: per-amp GP fit -----------------------------------------
+    for amp, colstart, colstop, y_r, s_hat, n_r, good in amp_stats:
         n_anchor = int(good.sum())
 
         if n_anchor < 2:
@@ -224,13 +296,13 @@ def gp_amprow_offsets(data, mask, kernel_sigma, rho, q=1.0 / np.sqrt(2.0),
 
         mu, var = _gp_predict_amp(
             rows_sci[good], y_r[good], yerr, dc,
-            kernel_sigma, rho, q, rows_all,
+            kernel_sigma_eff, rho, q, rows_all,
         )
         horizontal[:, colstart:colstop] = mu[:, None]
 
         post_sigma = np.sqrt(np.clip(var, 0.0, None))
-        n_weak = int(np.sum(post_sigma[sci] > weak_frac * kernel_sigma))
+        n_weak = int(np.sum(post_sigma[sci] > weak_frac * kernel_sigma_eff))
         diagnostics.append(
             f'{amp}:{n_anchor}/{n_weak}/{post_sigma.max():.2e}')
 
-    return horizontal, diagnostics
+    return horizontal, diagnostics, kernel_sigma_eff

--- a/pipeline/campfire_pipeline/nircam/gp_striping.py
+++ b/pipeline/campfire_pipeline/nircam/gp_striping.py
@@ -1,0 +1,236 @@
+"""
+GP-based per-amp-row 1/f ("striping") offset estimator for NIRCam.
+
+Alternative to the median + full-row-fallback estimator in
+``steps/striping.fit_residual_striping``. Selected via
+``[nircam.striping].estimator = "gp"``.
+
+Motivation
+----------
+The production estimator fits one additive offset per *amp-row* (the
+512-pixel segment of a row belonging to one of the four readout
+amplifiers) as a 2σ-clipped median of its unmasked background pixels.
+When a bright/extended source fills most of an amp-row, the per-amp
+median is biased, an asymmetry guard trips, and the code falls back to
+the **full-row** median — the median across all four amps in that row.
+But the four amps carry physically distinct offsets (~3–5 % in SW), so
+that fallback substitutes the wrong quantity exactly where a good local
+estimate is hardest. The result is a step at the amplifier boundary and,
+because the fallback only fires on the rows the source covers, a step in
+the slow direction at the top/bottom of the source — the "box" of
+amp-row artifacts around bright sources.
+
+Idea
+----
+1/f noise is low-frequency and rows are clocked out sequentially, so for
+a fixed amplifier the offset ``n[a, r]`` is a *smooth function of the
+slow-axis row index r*. Model it per amplifier as a 1-D GP::
+
+    y_r = f(r) + eps_r,    eps_r ~ N(0, sigma_r^2)
+
+where ``y_r`` is the (sigma-clipped) amp-row median and ``sigma_r`` is
+its *sampling* uncertainty (``1.25 * s_hat / sqrt(N_r)``, ``s_hat`` from
+the MAD). The diagonal ``sigma_r^2`` carries each row's uncorrelated
+estimation error; the kernel carries the correlated structure to keep. A
+heavily-masked row gets a large ``sigma_r`` and is automatically
+down-weighted — no hard threshold, no fallback. The GP posterior mean
+interpolates over masked gaps using neighbouring rows *of the same
+amplifier*; the kernel length scale sets how far that reaches. Each
+amplifier carries its own DC mean term, so amp-to-amp steps are never
+reintroduced.
+
+Implementation uses **celerite2** on its default CPU backend
+(semiseparable kernels → exact O(n) solve in 1-D; no GPU, no per-call
+JIT warmup). Hyperparameters are *frozen* (calibrated offline; see
+``scripts/calibrate_gp_striping.py``) — fitting them per exposure would
+turn a deterministic linear solve into an optimization loop and invite
+overfitting.
+"""
+
+import warnings
+
+import numpy as np
+from astropy.stats import mad_std, sigma_clip
+
+from campfire_pipeline.nircam.constants import NIR_AMPS
+
+# 1.25 ≈ sqrt(pi/2): asymptotic ratio of the standard error of the median
+# to that of the mean for a Gaussian sample, so sigma_r ≈ 1.25 s_hat/sqrt(N).
+_MEDIAN_SE_FACTOR = 1.2533
+
+# Reference-pixel border (4 px on every side); science rows are the rest.
+_REF_BORDER = 4
+
+
+def _amprow_statistics(ampdata, ampmask, sigma, maxiters):
+    """Per-row robust statistics of an amplifier's background pixels.
+
+    Parameters
+    ----------
+    ampdata : (R, C) ndarray
+        One amplifier's science columns (reference columns already
+        excluded by the caller via ``NIR_AMPS``), all rows.
+    ampmask : (R, C) bool ndarray
+        True where a pixel is masked (DQ or source).
+    sigma, maxiters : float, int
+        Per-row sigma-clip parameters.
+
+    Returns
+    -------
+    y_r : (R,) ndarray
+        Sigma-clipped median of the surviving pixels in each amp-row
+        (NaN where no pixel survives).
+    s_hat : (R,) ndarray
+        Robust per-pixel scatter (``mad_std``) of the surviving sample.
+    n_r : (R,) int ndarray
+        Number of surviving pixels per amp-row.
+    """
+    w = ampdata.astype(np.float64, copy=True)
+    w[ampmask | ~np.isfinite(w)] = np.nan
+
+    with warnings.catch_warnings():
+        # Empty / all-NaN amp-rows (fully masked) flow through as NaN; the
+        # caller drops them via ``n_r == 0``, so the inner RuntimeWarnings
+        # are noise.
+        warnings.filterwarnings('ignore', category=RuntimeWarning,
+                                message='All-NaN slice encountered')
+        warnings.filterwarnings('ignore', category=RuntimeWarning,
+                                message='Mean of empty slice')
+        warnings.filterwarnings('ignore', category=RuntimeWarning,
+                                message='Degrees of freedom <= 0')
+        warnings.filterwarnings('ignore', category=RuntimeWarning,
+                                message='invalid value encountered')
+        # sigma_clip emits an AstropyUserWarning when the input has NaNs
+        # (our masked / fully-masked amp-rows); expected, suppress it.
+        warnings.filterwarnings(
+            'ignore', message='Input data contains invalid values')
+        clipped = sigma_clip(
+            w, sigma=sigma, maxiters=maxiters, axis=1,
+            cenfunc='median', stdfunc='mad_std', masked=True,
+        )
+        wc = np.ma.filled(clipped, np.nan)
+        y_r = np.nanmedian(wc, axis=1)
+        s_hat = mad_std(wc, axis=1, ignore_nan=True)
+        n_r = np.sum(np.isfinite(wc), axis=1)
+    return y_r, s_hat, n_r.astype(np.int64)
+
+
+def _gp_predict_amp(rows, y_r, yerr, dc_level, kernel_sigma, rho, q,
+                    rows_predict):
+    """Fit a 1-D SHOTerm GP on anchor rows; predict at ``rows_predict``.
+
+    Returns ``(mu, var)`` over ``rows_predict``. ``celerite2`` imported
+    lazily so the median estimator path carries no GP dependency.
+    """
+    import celerite2
+    from celerite2 import terms
+
+    kernel = terms.SHOTerm(sigma=float(kernel_sigma), rho=float(rho),
+                           Q=float(q))
+    gp = celerite2.GaussianProcess(kernel, mean=float(dc_level))
+    gp.compute(rows.astype(np.float64), yerr=yerr.astype(np.float64))
+    mu, var = gp.predict(
+        y_r.astype(np.float64),
+        t=rows_predict.astype(np.float64),
+        return_var=True,
+    )
+    return mu, var
+
+
+def gp_amprow_offsets(data, mask, kernel_sigma, rho, q=1.0 / np.sqrt(2.0),
+                      sigma_clip_sigma=2.0, maxiters=3,
+                      ref_border=_REF_BORDER, weak_frac=0.5):
+    """Per-amp, per-row 1/f offset via 1-D GP smoothing along the slow axis.
+
+    Drop-in replacement for the per-amp-row median + full-row fallback in
+    ``fit_residual_striping``. Returns the **horizontal** correction only;
+    the caller still measures the per-column (vertical) pattern on
+    ``data - horizontal`` exactly as before.
+
+    Geometry matches the existing code: amplifiers are the column strips of
+    ``NIR_AMPS`` (reference columns already excluded), and the offset is one
+    value per row (axis 0 = the slow read axis) broadcast across the amp's
+    columns. Reference-border rows (the first/last ``ref_border``) are
+    excluded from the fit but still receive a (GP-extrapolated) offset so
+    the output array is full-frame; those weakly-constrained edge rows are
+    flagged in the diagnostics.
+
+    Parameters
+    ----------
+    data : (H, W) ndarray
+        Frame to measure (flat-fielded, pedestal/background pre-subtracted).
+    mask : (H, W) bool ndarray
+        True where masked (DQ flagged or source).
+    kernel_sigma : float
+        SHOTerm amplitude (frozen hyperparameter; data units).
+    rho : float
+        SHOTerm length scale in *rows* (frozen hyperparameter).
+    q : float
+        SHOTerm quality factor. ``1/sqrt(2)`` → smooth, non-oscillatory.
+    sigma_clip_sigma, maxiters : float, int
+        Per-amp-row sigma-clip used to build ``y_r`` / ``s_hat`` / ``N_r``.
+    ref_border : int
+        Reference-pixel border width to exclude from the science fit.
+    weak_frac : float
+        A predicted row is counted "weakly constrained" when its posterior
+        std exceeds ``weak_frac * kernel_sigma`` — i.e. the GP has reverted
+        toward the per-amp DC because no anchor row lies within ~rho. This
+        is reported, not hidden: it flags wide source-filled gaps.
+
+    Returns
+    -------
+    horizontal : (H, W) ndarray
+        Per-amp per-row offset broadcast across each amp's columns.
+    diagnostics : list[str]
+        One ``'A:anchors/weak/maxσ'`` string per amplifier for logging.
+    """
+    n_rows = data.shape[0]
+    rows_all = np.arange(n_rows)
+    sci = slice(ref_border, n_rows - ref_border)
+    rows_sci = rows_all[sci]
+
+    horizontal = np.zeros(data.shape, dtype=np.float64)
+    diagnostics = []
+
+    for amp in ('A', 'B', 'C', 'D'):
+        _, _, colstart, colstop = NIR_AMPS[amp]['data']
+        ampdata = data[sci, colstart:colstop]
+        ampmask = mask[sci, colstart:colstop]
+
+        y_r, s_hat, n_r = _amprow_statistics(
+            ampdata, ampmask, sigma_clip_sigma, maxiters)
+
+        good = (n_r > 0) & np.isfinite(y_r) & np.isfinite(s_hat)
+        n_anchor = int(good.sum())
+
+        if n_anchor < 2:
+            # Not enough anchors to fit a GP: hold the amp at its DC level
+            # (robust median of whatever measured), or 0 if nothing did.
+            dc = float(np.nanmedian(y_r[good])) if n_anchor else 0.0
+            horizontal[:, colstart:colstop] = dc
+            diagnostics.append(f'{amp}:{n_anchor}/--/-- (DC-only)')
+            continue
+
+        # Per-pixel scatter can be exactly 0 on rows whose surviving pixels
+        # are all identical (rare; e.g. heavy clipping). Floor it to the
+        # amp's typical scatter so the GP weight stays finite.
+        s_pos = s_hat[good]
+        s_floor = np.median(s_pos[s_pos > 0]) if np.any(s_pos > 0) else 1.0
+        s_use = np.where(s_pos > 0, s_pos, s_floor)
+        yerr = _MEDIAN_SE_FACTOR * s_use / np.sqrt(n_r[good])
+
+        # Per-amp DC mean term: robust median of the well-measured rows.
+        dc = float(np.median(y_r[good]))
+
+        mu, var = _gp_predict_amp(
+            rows_sci[good], y_r[good], yerr, dc,
+            kernel_sigma, rho, q, rows_all,
+        )
+        horizontal[:, colstart:colstop] = mu[:, None]
+
+        post_sigma = np.sqrt(np.clip(var, 0.0, None))
+        n_weak = int(np.sum(post_sigma[sci] > weak_frac * kernel_sigma))
+        diagnostics.append(
+            f'{amp}:{n_anchor}/{n_weak}/{post_sigma.max():.2e}')
+
+    return horizontal, diagnostics

--- a/pipeline/campfire_pipeline/nircam/orchestrate.py
+++ b/pipeline/campfire_pipeline/nircam/orchestrate.py
@@ -45,8 +45,8 @@ PROCESS_STEPS = [
     ('detector1',   'CFP_DET1'),
     ('persistence', 'CFP_PERS'),
     ('wisp',        'CFP_WISP'),
-    ('striping',    'CFP_1F'),
     ('image2',      'CFP_IMG2'),
+    ('striping',    'CFP_1F'),
     ('edge',        'CFP_EDGE'),
     ('sky',         'CFP_SKY'),
     ('diag_striping', 'CFP_DIAG'),
@@ -67,8 +67,10 @@ ALL_STEPS = PROCESS_STEPS + COMBINE_STEPS
 STEP_NAMES = [name for name, _ in ALL_STEPS]
 
 # Steps that hit CRDS — used by run_step() to decide when to pre-fetch
-# reference files before parallel dispatch.
-_CRDS_STEPS = {'detector1', 'wisp', 'striping', 'image2'}
+# reference files before parallel dispatch. striping now runs *after* image2
+# (on flat-fielded, flux-calibrated cal-stage data) so it no longer resolves a
+# flat itself; wisp still runs in the rate frame and resolves its own flat.
+_CRDS_STEPS = {'detector1', 'wisp', 'image2'}
 
 
 def _detector_sorted(paths):

--- a/pipeline/campfire_pipeline/nircam/skyfit.py
+++ b/pipeline/campfire_pipeline/nircam/skyfit.py
@@ -72,13 +72,20 @@ def fit_sky_tot(data, return_diagnostics=False):
     return popt[1]
 
 
-def fit_sky(data, use_bottleneck=True):
+def fit_sky(data, use_bottleneck=True, box_size=128, filter_size=5):
     """Measure a 2D background on unmasked pixels via ``photutils.Background2D``.
 
     Used by the 1/f striping step for chips with a large, low-surface-
     brightness residual after wisp subtraction. The caller passes data
     with masked pixels already set to zero; the function masks zero
     pixels before fitting.
+
+    ``box_size`` controls the background smoothing scale. In the striping
+    step this is a *fit-only* detrend (the model is never subtracted from the
+    output), so a smaller box removes the large-scale field structure (e.g.
+    cluster ICL) more completely from the 1/f fit — but it must stay well
+    above the per-amp-row 1/f variation scale, or the background model starts
+    absorbing the 1/f itself.
 
     Falls back through ``exclude_percentile`` 90 → 95 → 97.5 if
     ``Background2D`` raises (it raises when too many pixels are masked
@@ -87,17 +94,21 @@ def fit_sky(data, use_bottleneck=True):
     skystd = np.nanstd(data)
     data[data > (2 * skystd)] = 0
     mask = data == 0
-    if use_bottleneck:
-        # bottleneck wants native byte order
-        data.byteswap(inplace=True)
-        data = data.view(data.dtype.newbyteorder('='))
+    if use_bottleneck and data.dtype.byteorder not in ('=', '|'):
+        # bottleneck wants native byte order. Convert *value-preserving* via
+        # astype — the old ``byteswap(inplace=True) + view`` idiom only
+        # produced correct values from non-native (big-endian) input and
+        # silently corrupted an already-native array into garbage (and
+        # mutated the caller's array in place). Guarding on byteorder makes
+        # native input a no-op.
+        data = data.astype(data.dtype.newbyteorder('='))
 
     for exclude_percentile in (90, 95, 97.5):
         try:
             bkg = Background2D(
-                data, box_size=128,
+                data, box_size=box_size,
                 sigma_clip=SigmaClip(sigma=3),
-                filter_size=5,
+                filter_size=filter_size,
                 bkg_estimator=BiweightLocationBackground(),
                 exclude_percentile=exclude_percentile,
                 mask=mask,
@@ -108,9 +119,9 @@ def fit_sky(data, use_bottleneck=True):
             continue
     # Final attempt: let the exception propagate
     bkg = Background2D(
-        data, box_size=128,
+        data, box_size=box_size,
         sigma_clip=SigmaClip(sigma=3),
-        filter_size=5,
+        filter_size=filter_size,
         bkg_estimator=BiweightLocationBackground(),
         exclude_percentile=97.5,
         mask=mask,

--- a/pipeline/campfire_pipeline/nircam/steps/detector1.py
+++ b/pipeline/campfire_pipeline/nircam/steps/detector1.py
@@ -41,6 +41,10 @@ def detector1_step(uncal_file, field, step_config, overwrite=False,
     from jwst.pipeline import calwebb_detector1
 
     clean_flicker_noise = step_config.get('clean_flicker_noise', False)
+    # Optional passthrough to the JWST clean_flicker_noise step (e.g.
+    # fit_method = "fft" | "median", background_method, n_sigma). Only used
+    # when clean_flicker_noise is enabled; merged over the defaults below.
+    cfn_opts = step_config.get('clean_flicker_noise_opts', {})
 
     filtname = uncal_file.split('/')[-2]
     assert (filtname.lower() in SW_FILTERS) or (filtname.lower() in LW_FILTERS)
@@ -149,6 +153,7 @@ def detector1_step(uncal_file, field, step_config, overwrite=False,
             'clean_flicker_noise': {
                 'skip': not clean_flicker_noise,
                 'fit_by_channel': True,
+                **cfn_opts,
             },
             'ramp_fit': {
                 'skip': False,

--- a/pipeline/campfire_pipeline/nircam/steps/diag_striping.py
+++ b/pipeline/campfire_pipeline/nircam/steps/diag_striping.py
@@ -789,7 +789,7 @@ def diag_striping_step(exposure_file, field, step_config, overwrite=False,
         diag_model += diag_iter
         working = sci_before - diag_model - hv_model
 
-        h_iter, v_iter, ampcounts = fit_residual_striping(
+        h_iter, v_iter, ampcounts, _ = fit_residual_striping(
             working, mask, maxiters,
         )
         hv_model += h_iter + v_iter

--- a/pipeline/campfire_pipeline/nircam/steps/image2.py
+++ b/pipeline/campfire_pipeline/nircam/steps/image2.py
@@ -1,14 +1,16 @@
 """
 image2: JWST ``Image2Pipeline`` against the canonical exposure file.
 
-Reads the canonical ``<rootname>.fits`` (rate-stage data after striping),
-runs ``Image2Pipeline`` in memory (``save_results=False``), and atomically
-writes the calibrated cal-stage ImageModel back to the same path.
+Reads the canonical ``<rootname>.fits`` (rate-stage data after detector1 /
+persistence / wisp), runs ``Image2Pipeline`` in memory (``save_results=False``),
+and atomically writes the calibrated cal-stage ImageModel back to the same path.
+``striping`` now runs *after* this step, on the cal-stage output, so the 1/f
+correction is fit and applied in the flat-fielded frame (no flat round-trip).
 
-``Image2Pipeline`` returns a fresh model, so the ``SRCMASK`` extension that
-striping wrote to the canonical file is dropped on the round-trip. We pull
-``SRCMASK`` out before the pipeline runs and re-attach it via
-``atomic_save(..., extra_hdus=...)`` after.
+``Image2Pipeline`` returns a fresh model that drops any non-schema extension,
+so the ``SRCMASK`` round-trip protection below is retained as a safety net —
+but in the current ordering SRCMASK is written by ``striping`` *after* image2,
+so ``_extract_srcmask`` typically returns None here (a no-op).
 """
 
 import os

--- a/pipeline/campfire_pipeline/nircam/steps/striping.py
+++ b/pipeline/campfire_pipeline/nircam/steps/striping.py
@@ -202,6 +202,7 @@ def fit_residual_striping(
     nmask_prefilter=0.20,
     estimator='median',
     gp_params=None,
+    amplitude_data=None,
 ):
     """Fit per-amp per-row horizontal + per-column vertical 1/f striping.
 
@@ -236,10 +237,16 @@ def fit_residual_striping(
         offset across masked source rows *within the same amplifier* rather
         than substituting the full-row median.
     gp_params : dict, optional
-        Required when ``estimator='gp'``. Keys: ``kernel_sigma`` and
-        ``rho`` (frozen SHOTerm hyperparameters; required), plus optional
-        ``q`` (default ``1/sqrt(2)``), ``sigma_clip`` (default 2.0), and
-        ``weak_frac`` (default 0.5).
+        Required when ``estimator='gp'``. Only ``rho`` (frozen SHOTerm
+        length scale, in rows) is required; ``kernel_sigma`` is optional and
+        **self-adapts per exposure** when absent (see ``gp_amprow_offsets``),
+        with an optional frozen O(1) ``kernel_sigma_factor`` (default 1.0).
+        Plus optional ``q`` (default ``1/sqrt(2)``), ``sigma_clip``
+        (default 2.0), and ``weak_frac`` (default 0.5).
+    amplitude_data : (H, W) ndarray, optional
+        ``estimator='gp'`` only. The pre-2D-bg-detrend frame on which to
+        measure the self-adapting kernel amplitude (see ``gp_amprow_offsets``).
+        ``None`` → measure on ``data``.
 
     Returns
     -------
@@ -251,23 +258,28 @@ def fit_residual_striping(
         Per-amp diagnostic strings. For ``'median'``: ``'A-N'`` ... where
         ``N`` is the number of rows that fell back to the full-image
         median. For ``'gp'``: ``'A:anchors/weak/maxσ'`` per amp.
+    diag : dict
+        Extra diagnostics. For ``'gp'``: ``{'kernel_sigma_eff': float}`` (the
+        self-adapted or overridden amplitude actually used). Empty otherwise.
     """
+    diag = {}
     if estimator == 'gp':
         from campfire_pipeline.nircam.gp_striping import gp_amprow_offsets
         params = gp_params or {}
-        if 'kernel_sigma' not in params or 'rho' not in params:
-            raise ValueError(
-                "estimator='gp' requires gp_params with 'kernel_sigma' "
-                "and 'rho'")
-        horizontal, ampcounts = gp_amprow_offsets(
+        if 'rho' not in params:
+            raise ValueError("estimator='gp' requires gp_params with 'rho'")
+        horizontal, ampcounts, kernel_sigma_eff = gp_amprow_offsets(
             data, mask,
-            kernel_sigma=params['kernel_sigma'],
             rho=params['rho'],
+            kernel_sigma=params.get('kernel_sigma'),  # None → self-adapt
+            kernel_sigma_factor=params.get('kernel_sigma_factor', 1.0),
+            amplitude_data=amplitude_data,  # pre-2D-bg frame for the amplitude
             q=params.get('q', 1.0 / np.sqrt(2.0)),
             sigma_clip_sigma=params.get('sigma_clip', 2.0),
             maxiters=maxiters,
             weak_frac=params.get('weak_frac', 0.5),
         )
+        diag['kernel_sigma_eff'] = kernel_sigma_eff
     elif estimator == 'median':
         horizontal, ampcounts = _median_amprow_offsets(
             data, mask, maxiters, asymmetry_threshold, nmask_prefilter)
@@ -280,36 +292,46 @@ def fit_residual_striping(
     )
     vertical = np.broadcast_to(vertical_1d, data.shape).copy()
 
-    return horizontal, vertical, ampcounts
+    return horizontal, vertical, ampcounts, diag
 
 
 def _resolve_gp_params(gp_cfg, model):
-    """Resolve frozen GP hyperparameters for this exposure's channel.
+    """Resolve GP hyperparameters for this exposure's channel.
 
-    Hyperparameters are calibrated offline (see
-    ``scripts/calibrate_gp_striping.py``) and split by detector channel
-    (SW vs LW) because the 1/f amplitude and correlation length differ.
-    Config keys: ``kernel_sigma_sw`` / ``rho_sw`` / ``kernel_sigma_lw`` /
-    ``rho_lw`` (per-channel), or channel-agnostic ``kernel_sigma`` / ``rho``
-    (used as a fallback for whichever channel-specific key is absent).
-    Shared optional keys: ``q`` (default ``1/sqrt(2)``), ``sigma_clip``
+    Only ``rho`` (SHOTerm length scale, in rows) is a frozen hyperparameter —
+    a readout/clocking property, independent of filter and flux units, and
+    (verified across both channels) effectively channel-independent, so a
+    single channel-agnostic ``rho`` is used by default. Calibrate offline with
+    ``scripts/calibrate_gp_striping.py``. The kernel amplitude self-adapts
+    per exposure (see ``gp_amprow_offsets``), so ``kernel_sigma`` is *not*
+    required; an explicit value (``kernel_sigma_sw``/``_lw`` or
+    channel-agnostic ``kernel_sigma``) overrides the self-adaptation as an
+    escape hatch.
+
+    Config keys: ``rho`` (channel-agnostic) — required; ``rho_sw`` / ``rho_lw``
+    override it per channel if ever needed. Optional: ``kernel_sigma_sw`` /
+    ``kernel_sigma_lw`` / ``kernel_sigma`` (override), ``kernel_sigma_factor``
+    (frozen O(1), default 1.0), ``q`` (default ``1/sqrt(2)``), ``sigma_clip``
     (default 2.0), ``weak_frac`` (default 0.5).
     """
     channel = (getattr(model.meta.instrument, 'channel', None) or '').upper()
     suffix = 'sw' if channel == 'SHORT' else 'lw'
 
-    def pick(name):
-        val = gp_cfg.get(f'{name}_{suffix}', gp_cfg.get(name))
-        if val is None:
-            raise ValueError(
-                f"estimator='gp' needs [nircam.striping.gp].{name}_{suffix} "
-                f"(or {name}); run scripts/calibrate_gp_striping.py and set "
-                f"the frozen value in config")
-        return float(val)
+    rho = gp_cfg.get(f'rho_{suffix}', gp_cfg.get('rho'))
+    if rho is None:
+        raise ValueError(
+            f"estimator='gp' needs [nircam.striping.gp].rho_{suffix} (or "
+            f"rho); run scripts/calibrate_gp_striping.py and set the frozen "
+            f"value in config")
+
+    # Optional explicit amplitude override (None → self-adapt per exposure).
+    kernel_sigma = gp_cfg.get(f'kernel_sigma_{suffix}',
+                              gp_cfg.get('kernel_sigma'))
 
     return {
-        'kernel_sigma': pick('kernel_sigma'),
-        'rho': pick('rho'),
+        'rho': float(rho),
+        'kernel_sigma': None if kernel_sigma is None else float(kernel_sigma),
+        'kernel_sigma_factor': float(gp_cfg.get('kernel_sigma_factor', 1.0)),
         'q': float(gp_cfg.get('q', 1.0 / np.sqrt(2.0))),
         'sigma_clip': float(gp_cfg.get('sigma_clip', 2.0)),
         'weak_frac': float(gp_cfg.get('weak_frac', 0.5)),
@@ -343,6 +365,12 @@ def striping_step(exposure_file, field, step_config, overwrite=False,
     use_bottleneck = step_config.get('use_bottleneck', True)
     do_plot = step_config.get('plot', True)
     estimator = step_config.get('estimator', 'median')
+    _VALID_ESTIMATORS = ('median', 'gp', 'none')
+    if estimator not in _VALID_ESTIMATORS:
+        raise ValueError(
+            f"[nircam.striping].estimator = {estimator!r} is not valid "
+            f"(expected one of {_VALID_ESTIMATORS}). Note: the legacy "
+            f"'baseline' value was removed — use 'median'.")
     # Aggressive masking pairs with the GP estimator: grow the source mask
     # and fold in additional DQ classes so leaked source/CR flux cannot bias
     # the per-amp-row median that the GP then interpolates. Over-masking is
@@ -421,6 +449,12 @@ def striping_step(exposure_file, field, step_config, overwrite=False,
         log(f"Pedestal: {pedestal:.5e}")
         fitdata -= pedestal
 
+        # Pre-2D-bg snapshot: the GP measures its self-adapting amplitude here
+        # (the full 1/f marginal that bounds the cross-source-gap variation),
+        # then fits the post-bg ``fitdata``. Equal to ``fitdata`` when bg-sub
+        # is off, so it is always safe to pass.
+        amplitude_data = fitdata.copy()
+
         if subtract_background:
             try:
                 log("Subtracting 2D background for fit")
@@ -437,20 +471,24 @@ def striping_step(exposure_file, field, step_config, overwrite=False,
         NMASK_PREFILTER = 0.20
         if estimator == 'gp':
             gp_params = _resolve_gp_params(gp_cfg, model)
-            horizontal, vertical, ampcounts = fit_residual_striping(
+            horizontal, vertical, ampcounts, gp_diag = fit_residual_striping(
                 fitdata, mask, maxiters,
                 estimator='gp', gp_params=gp_params,
+                amplitude_data=amplitude_data,
             )
-            log(f"{rootname}: GP striping (sigma={gp_params['kernel_sigma']:.3e}, "
+            ks_eff = gp_diag['kernel_sigma_eff']
+            ks_src = ('override' if gp_params['kernel_sigma'] is not None
+                      else 'self-adapt')
+            log(f"{rootname}: GP striping (sigma={ks_eff:.3e} [{ks_src}], "
                 f"rho={gp_params['rho']:.1f}) "
                 f"[amp:anchors/weak/maxσ] {', '.join(ampcounts)}")
             cfp_value = (
-                f'estimator=gp, kernel_sigma={gp_params["kernel_sigma"]:.4e}, '
+                f'estimator=gp, kernel_sigma={ks_eff:.4e} ({ks_src}), '
                 f'rho={gp_params["rho"]:.2f}, q={gp_params["q"]:.4f}, '
                 f'aggr_mask={int(mask_aggressive)}, maxiters={maxiters} (cal-frame)'
             )
         else:
-            horizontal, vertical, ampcounts = fit_residual_striping(
+            horizontal, vertical, ampcounts, _ = fit_residual_striping(
                 fitdata, mask, maxiters,
                 asymmetry_threshold=ASYMMETRY_THRESHOLD,
                 nmask_prefilter=NMASK_PREFILTER,

--- a/pipeline/campfire_pipeline/nircam/steps/striping.py
+++ b/pipeline/campfire_pipeline/nircam/steps/striping.py
@@ -1,23 +1,30 @@
 """
 striping: 1/f striping subtraction with ``SRCMASK`` extension write.
 
-Per-exposure step. Builds a tiered source mask, fits pedestal + (optional)
-2D background + horizontal + vertical striping patterns on a flat-fielded
-copy of the data, then subtracts the additive striping patterns from the
-original un-flat-fielded SCI. Writes the source mask as a ``SRCMASK``
-extension on the canonical file (replacing the legacy
-``_rate_1fmask.fits`` sidecar) so the sky_subtraction step can read it
-through a single canonical file.
+Per-exposure step. Runs **after** ``image2``, on flat-fielded, flux-
+calibrated cal-stage data. Builds a tiered source mask, fits pedestal +
+(optional) 2D background + horizontal + vertical striping patterns on a
+pedestal-subtracted working copy of the cal-stage SCI, then subtracts the
+additive striping patterns from the SCI **in that same cal frame**.
 
-Imports the numerical helpers (``fit_pedestal``, ``fit_sky``,
-``collapse_image``, ``measure_fullimage_striping``) from the legacy
-``stage1`` module to avoid duplicating ~200 lines of tested code; those
+Fitting and applying in the cal frame (rather than the legacy "fit on a
+flat-fielded copy, subtract from the un-flat rate SCI" round-trip) is exact:
+the old path removed the per-amp-row offset in flat units but subtracted it
+from un-flat data that image2 then re-divided by the per-amp-structured
+flat, leaving a coherent per-amp DC step (``N/g·(1−1/g)``) at the amplifier
+boundaries. Subtracting in the cal frame eliminates that leak.
+
+Writes the source mask as a ``SRCMASK`` extension on the canonical file
+(replacing the legacy ``_rate_1fmask.fits`` sidecar) so the sky_subtraction
+step can read it through a single canonical file.
+
+Imports the numerical helpers (``fit_sky_tot``, ``fit_sky``,
+``collapse_image``, ``measure_fullimage_striping``) from ``skyfit``; those
 helpers are pure functions without side effects. The mask-builder is
 re-implemented locally (the legacy ``masksources`` writes a sidecar file
 as a side effect, which we explicitly want to avoid).
 """
 
-import copy
 import os
 import warnings
 from datetime import datetime
@@ -36,25 +43,28 @@ from scipy.ndimage import binary_dilation, median_filter
 from campfire_pipeline.common.io import log, atomic_save
 from campfire_pipeline.common import cfp
 from campfire_pipeline.nircam.constants import NIR_AMPS
-from campfire_pipeline.nircam.steps._flat import (
-    apply_flat_with_retry,
-    resolve_flat,
-)
 from campfire_pipeline.nircam.skyfit import (
     collapse_image,
-    fit_pedestal,
     fit_sky,
+    fit_sky_tot,
     measure_fullimage_striping,
 )
 
 
-def _build_srcmask(model):
+def _build_srcmask(model, extra_dilation=0):
     """Tiered source mask from a JWST ImageModel; returns ``uint8`` array.
 
     Equivalent to ``stage1.masksources`` but in-memory only — the legacy
     function additionally writes ``_1fmask.fits`` as a side effect, which
     the canonical-exposure layout replaces with a SRCMASK extension on the
     canonical file.
+
+    ``extra_dilation`` grows the final mask by that many 1-px binary
+    dilations (3×3 connectivity). Used by the aggressive-masking variant
+    of the GP estimator, whose error budget is asymmetric: over-masking
+    only inflates the per-amp-row ``sigma_r`` (the GP interpolates across),
+    whereas under-masking leaks source wings into the median and the GP
+    faithfully fits — then oversubtracts — the biased offset.
     """
     from jwst.datamodels import dqflags
 
@@ -103,56 +113,22 @@ def _build_srcmask(model):
     mask4 = SegmentationImage.make_source_mask(seg4)
     finalmask = mask4 | mask3
 
+    if extra_dilation > 0:
+        finalmask = binary_dilation(finalmask, iterations=int(extra_dilation))
+
     out = np.zeros(finalmask.shape, dtype=np.uint8)
     out[finalmask] = 1
     return out
 
 
-def fit_residual_striping(
-    data,
-    mask,
-    maxiters,
-    asymmetry_threshold=0.1,
-    nmask_prefilter=0.20,
-):
-    """Fit per-amp per-row horizontal + per-column vertical 1/f striping.
+def _median_amprow_offsets(data, mask, maxiters, asymmetry_threshold,
+                           nmask_prefilter):
+    """Per-amp per-row offset via 2σ-clipped median + full-row fallback.
 
-    Pure function. Operates on a flat-fielded (and ideally pedestal-/
-    background-subtracted) frame. Returns 2D additive correction arrays
-    that should be subtracted from the un-flat-fielded SCI.
-
-    Parameters
-    ----------
-    data : (H, W) ndarray
-        Input frame (flat-fielded, pedestal/background pre-subtracted).
-    mask : (H, W) bool ndarray
-        True where pixels are masked (DQ flagged or source).
-    maxiters : int
-        Sigma-clipping iterations.
-    asymmetry_threshold : float
-        Distribution asymmetry threshold (|mean − median| / std on the
-        post-clip per-row sample) above which a row falls back to the
-        full-image row median. Detects rows where 2σ clipping failed to
-        reject one-sided source-wing contamination. Clean / successfully
-        clipped rows give ratio ≈ 0; heavy bright-source contamination
-        gives ratio ≳ 0.3.
-    nmask_prefilter : float
-        Apply the asymmetry test only to rows where the source mask
-        covers ≥ this fraction of the amp-row width. Below this, take
-        the per-amp median directly. In low-mask (clean) rows the
-        asymmetry statistic has its own sample-noise floor (~0.07 for
-        N ≈ 508 pixels), so a tight threshold like 0.1 would produce
-        many false positives without this prefilter.
-
-    Returns
-    -------
-    horizontal : (H, W) ndarray
-        Per-amp, per-row striping pattern.
-    vertical : (H, W) ndarray
-        Per-column striping pattern (1D x-collapse broadcast to 2D).
-    ampcounts : list[str]
-        Per-amp diagnostic strings ``'A-N'`` ... ``'D-N'`` where ``N`` is
-        the number of rows that fell back to the full-image median.
+    The production estimator. Returns ``(horizontal, ampcounts)`` where
+    ``ampcounts`` reports the number of rows per amp that fell back to the
+    full-image row median. See ``fit_residual_striping`` for the parameter
+    semantics.
     """
     full_horizontal, _ = measure_fullimage_striping(data, mask, maxiters)
 
@@ -215,6 +191,89 @@ def fit_residual_striping(
             else:
                 horizontal[i, colstart:colstop] = h_amp[i]
         ampcounts.append(f'{amp}-{ampcount}')
+    return horizontal, ampcounts
+
+
+def fit_residual_striping(
+    data,
+    mask,
+    maxiters,
+    asymmetry_threshold=0.1,
+    nmask_prefilter=0.20,
+    estimator='median',
+    gp_params=None,
+):
+    """Fit per-amp per-row horizontal + per-column vertical 1/f striping.
+
+    Pure function. Operates on a flat-fielded (and ideally pedestal-/
+    background-subtracted) frame. Returns 2D additive correction arrays
+    that should be subtracted from the un-flat-fielded SCI.
+
+    The per-amp-row **horizontal** estimate is dispatched on ``estimator``;
+    the per-column **vertical** estimate (measured on ``data - horizontal``)
+    is identical for both and is intentionally left untouched.
+
+    Parameters
+    ----------
+    data : (H, W) ndarray
+        Input frame (flat-fielded, pedestal/background pre-subtracted).
+    mask : (H, W) bool ndarray
+        True where pixels are masked (DQ flagged or source).
+    maxiters : int
+        Sigma-clipping iterations.
+    asymmetry_threshold, nmask_prefilter : float
+        ``estimator="median"`` only. Asymmetry test threshold and the
+        mask-fraction below which it is skipped (see
+        ``_median_amprow_offsets``). Clean / successfully clipped rows give
+        asymmetry ≈ 0; heavy bright-source contamination gives ≳ 0.3. The
+        prefilter avoids false positives from the asymmetry statistic's own
+        sample-noise floor (~0.07 for N ≈ 508) in clean rows.
+    estimator : {'median', 'gp'}
+        ``'median'`` (default): the production 2σ-clipped median with
+        full-row fallback. ``'gp'``: a 1-D Gaussian-Process smoother fit
+        along the slow axis per amplifier (see
+        ``campfire_pipeline.nircam.gp_striping``), which interpolates the
+        offset across masked source rows *within the same amplifier* rather
+        than substituting the full-row median.
+    gp_params : dict, optional
+        Required when ``estimator='gp'``. Keys: ``kernel_sigma`` and
+        ``rho`` (frozen SHOTerm hyperparameters; required), plus optional
+        ``q`` (default ``1/sqrt(2)``), ``sigma_clip`` (default 2.0), and
+        ``weak_frac`` (default 0.5).
+
+    Returns
+    -------
+    horizontal : (H, W) ndarray
+        Per-amp, per-row striping pattern.
+    vertical : (H, W) ndarray
+        Per-column striping pattern (1D x-collapse broadcast to 2D).
+    ampcounts : list[str]
+        Per-amp diagnostic strings. For ``'median'``: ``'A-N'`` ... where
+        ``N`` is the number of rows that fell back to the full-image
+        median. For ``'gp'``: ``'A:anchors/weak/maxσ'`` per amp.
+    """
+    if estimator == 'gp':
+        from campfire_pipeline.nircam.gp_striping import gp_amprow_offsets
+        params = gp_params or {}
+        if 'kernel_sigma' not in params or 'rho' not in params:
+            raise ValueError(
+                "estimator='gp' requires gp_params with 'kernel_sigma' "
+                "and 'rho'")
+        horizontal, ampcounts = gp_amprow_offsets(
+            data, mask,
+            kernel_sigma=params['kernel_sigma'],
+            rho=params['rho'],
+            q=params.get('q', 1.0 / np.sqrt(2.0)),
+            sigma_clip_sigma=params.get('sigma_clip', 2.0),
+            maxiters=maxiters,
+            weak_frac=params.get('weak_frac', 0.5),
+        )
+    elif estimator == 'median':
+        horizontal, ampcounts = _median_amprow_offsets(
+            data, mask, maxiters, asymmetry_threshold, nmask_prefilter)
+    else:
+        raise ValueError(
+            f"unknown estimator {estimator!r} (expected 'median' or 'gp')")
 
     vertical_1d = collapse_image(
         data - horizontal, mask, maxiters, dimension='x',
@@ -222,6 +281,39 @@ def fit_residual_striping(
     vertical = np.broadcast_to(vertical_1d, data.shape).copy()
 
     return horizontal, vertical, ampcounts
+
+
+def _resolve_gp_params(gp_cfg, model):
+    """Resolve frozen GP hyperparameters for this exposure's channel.
+
+    Hyperparameters are calibrated offline (see
+    ``scripts/calibrate_gp_striping.py``) and split by detector channel
+    (SW vs LW) because the 1/f amplitude and correlation length differ.
+    Config keys: ``kernel_sigma_sw`` / ``rho_sw`` / ``kernel_sigma_lw`` /
+    ``rho_lw`` (per-channel), or channel-agnostic ``kernel_sigma`` / ``rho``
+    (used as a fallback for whichever channel-specific key is absent).
+    Shared optional keys: ``q`` (default ``1/sqrt(2)``), ``sigma_clip``
+    (default 2.0), ``weak_frac`` (default 0.5).
+    """
+    channel = (getattr(model.meta.instrument, 'channel', None) or '').upper()
+    suffix = 'sw' if channel == 'SHORT' else 'lw'
+
+    def pick(name):
+        val = gp_cfg.get(f'{name}_{suffix}', gp_cfg.get(name))
+        if val is None:
+            raise ValueError(
+                f"estimator='gp' needs [nircam.striping.gp].{name}_{suffix} "
+                f"(or {name}); run scripts/calibrate_gp_striping.py and set "
+                f"the frozen value in config")
+        return float(val)
+
+    return {
+        'kernel_sigma': pick('kernel_sigma'),
+        'rho': pick('rho'),
+        'q': float(gp_cfg.get('q', 1.0 / np.sqrt(2.0))),
+        'sigma_clip': float(gp_cfg.get('sigma_clip', 2.0)),
+        'weak_frac': float(gp_cfg.get('weak_frac', 0.5)),
+    }
 
 
 def striping_step(exposure_file, field, step_config, overwrite=False,
@@ -239,13 +331,26 @@ def striping_step(exposure_file, field, step_config, overwrite=False,
     status : StepStatus, optional
         Pre-scanned CFP_* status cache.
     """
-    apply_flat = step_config.get('apply_flat', True)
-    use_custom_flat = step_config.get('use_custom_flat', False)
     mask_sources = step_config.get('mask_sources', True)
-    subtract_background = step_config.get('subtract_background', True)
+    subtract_background = step_config.get('subtract_background', False)
+    # 2D-background (fit-only detrend) box / filter sizes. The effective
+    # smoothing scale is ~box*filter; smaller pulls the field's large-scale
+    # structure (cluster ICL) out of the 1/f fit more completely, but too
+    # small starts absorbing the 1/f itself. 32/3 calibrated on rj0911 f444w.
+    subtract_background_box = step_config.get('subtract_background_box', 32)
+    subtract_background_filter = step_config.get('subtract_background_filter', 3)
     maxiters = step_config.get('maxiters', 3)
     use_bottleneck = step_config.get('use_bottleneck', True)
     do_plot = step_config.get('plot', True)
+    estimator = step_config.get('estimator', 'median')
+    # Aggressive masking pairs with the GP estimator: grow the source mask
+    # and fold in additional DQ classes so leaked source/CR flux cannot bias
+    # the per-amp-row median that the GP then interpolates. Over-masking is
+    # cheap for the GP (large sigma_r, interpolated across); under-masking
+    # is not (oversubtracted troughs around sources).
+    mask_aggressive = step_config.get('mask_aggressive', False)
+    mask_extra_dilation = step_config.get('mask_extra_dilation', 4)
+    gp_cfg = step_config.get('gp', {})
 
     rootname = os.path.basename(exposure_file).removesuffix('.fits')
 
@@ -261,64 +366,104 @@ def striping_step(exposure_file, field, step_config, overwrite=False,
     sci_before = model.data.copy()
 
     if mask_sources:
-        seg = _build_srcmask(model)
+        seg = _build_srcmask(
+            model, extra_dilation=mask_extra_dilation if mask_aggressive else 0)
     else:
         seg = np.zeros(model.data.shape, dtype=np.uint8)
 
-    fit_model = copy.deepcopy(model)
-    if apply_flat:
-        flatfile = resolve_flat(fit_model, field, use_custom_flat)
-        if flatfile is None:
-            log(f"Flat lookup failed for {rootname}; aborting striping")
-            fit_model.close()
-            model.close()
-            return
-        log(f"Applying flat {os.path.basename(flatfile)} for striping fit")
-        fit_model = apply_flat_with_retry(fit_model, flatfile)
-
+    # Runs after image2, so model.data is already flat-fielded and flux-
+    # calibrated. Fit and apply the 1/f correction directly in the cal frame
+    # (no flat-fielded copy, no apply-to-rate round-trip): the fit operates on
+    # a pedestal-/background-subtracted working copy ``fitdata``; the
+    # corrections are subtracted from the SCI itself further down.
+    #
     # Only DO_NOT_USE pixels are unusable for fitting — JUMP_DET and other
     # informational bits flag pixels that have already been corrected and
     # are still fine for sky/striping estimation. (Some exposures, e.g.
     # bright-target MSATA pointings on MEDIUM8/NGROUPS=9, get JUMP_DET set
     # on >97% of pixels; treating dq>0 as bad masks the entire frame.)
-    mask = np.bitwise_and(fit_model.dq, dqflags.pixel['DO_NOT_USE']) != 0
+    dq_bits = dqflags.pixel['DO_NOT_USE']
+    if mask_aggressive:
+        # Fold CR/jump/saturation/persistence-flagged pixels into the fit
+        # mask too. These carry residual signal (snowball halos, bleeds,
+        # persistence trails) that would otherwise bias the per-amp-row
+        # median; the GP tolerates the extra masking via inflated sigma_r.
+        for bit in ('JUMP_DET', 'SATURATED', 'PERSISTENCE'):
+            dq_bits |= dqflags.pixel[bit]
+    mask = np.bitwise_and(model.dq, dq_bits) != 0
     if mask_sources:
         mask[seg > 0] = True
 
-    log("Measuring pedestal")
-    pedestal_data = fit_model.data[~mask].flatten()
-    median_image = float(np.median(pedestal_data))
-    try:
-        pedestal = float(fit_pedestal(pedestal_data))
-    except RuntimeError:
-        log("Pedestal fit failed, using median")
-        pedestal = median_image
-    log(f"Pedestal: {pedestal:.5e}")
-    fit_model.data -= pedestal
+    if estimator == 'none':
+        # cfn-only reference arm: JWST's clean_flicker_noise already removed
+        # the 1/f at the ramp stage, so campfire applies no further striping.
+        # We still build + write SRCMASK and run the rest of the pipeline so
+        # the frame is directly comparable to the median/gp arms (same
+        # downstream steps, same blank-pixel mask for QA).
+        horizontal = np.zeros(model.data.shape)
+        vertical = np.zeros(model.data.shape)
+        ampcounts = []
+        log(f"{rootname}: estimator=none (no campfire 1/f; SRCMASK only)")
+        cfp_value = 'estimator=none (no campfire 1/f, cfn-only reference)'
+    else:
+        fitdata = model.data.astype(np.float64, copy=True)
 
-    if subtract_background:
+        log("Measuring pedestal")
+        pedestal_data = fitdata[~mask & np.isfinite(fitdata)].flatten()
+        median_image = float(np.median(pedestal_data)) if pedestal_data.size else 0.0
         try:
-            log("Subtracting 2D background for fit")
-            bg_input = fit_model.data.copy()
-            bg_input[mask > 0] = 0
-            bkgd = fit_sky(bg_input, use_bottleneck=use_bottleneck)
-            fit_model.data -= bkgd
-        except Exception as e:
-            log(f"2D background failed for {rootname}: {e}; pedestal-only")
+            # Scale-free Gaussian sky-peak fit (cal-frame units); the rate-tuned
+            # fit_pedestal with its hard-coded -1..1.5 histogram cannot be used here.
+            pedestal = float(fit_sky_tot(pedestal_data))
+        except (RuntimeError, ValueError, TypeError):
+            log("Pedestal fit failed, using median")
+            pedestal = median_image
+        log(f"Pedestal: {pedestal:.5e}")
+        fitdata -= pedestal
 
-    ASYMMETRY_THRESHOLD = 0.1
-    NMASK_PREFILTER = 0.20
-    horizontal, vertical, ampcounts = fit_residual_striping(
-        fit_model.data, mask, maxiters,
-        asymmetry_threshold=ASYMMETRY_THRESHOLD,
-        nmask_prefilter=NMASK_PREFILTER,
-    )
-    log(f"{rootname}: full-row medians used: "
-        f"{', '.join(ampcounts)}/{fit_model.data.shape[0]}")
+        if subtract_background:
+            try:
+                log("Subtracting 2D background for fit")
+                bg_input = fitdata.copy()
+                bg_input[mask > 0] = 0
+                bkgd = fit_sky(bg_input, use_bottleneck=use_bottleneck,
+                               box_size=subtract_background_box,
+                               filter_size=subtract_background_filter)
+                fitdata -= bkgd
+            except Exception as e:
+                log(f"2D background failed for {rootname}: {e}; pedestal-only")
 
-    fit_model.close()
+        ASYMMETRY_THRESHOLD = 0.1
+        NMASK_PREFILTER = 0.20
+        if estimator == 'gp':
+            gp_params = _resolve_gp_params(gp_cfg, model)
+            horizontal, vertical, ampcounts = fit_residual_striping(
+                fitdata, mask, maxiters,
+                estimator='gp', gp_params=gp_params,
+            )
+            log(f"{rootname}: GP striping (sigma={gp_params['kernel_sigma']:.3e}, "
+                f"rho={gp_params['rho']:.1f}) "
+                f"[amp:anchors/weak/maxσ] {', '.join(ampcounts)}")
+            cfp_value = (
+                f'estimator=gp, kernel_sigma={gp_params["kernel_sigma"]:.4e}, '
+                f'rho={gp_params["rho"]:.2f}, q={gp_params["q"]:.4f}, '
+                f'aggr_mask={int(mask_aggressive)}, maxiters={maxiters} (cal-frame)'
+            )
+        else:
+            horizontal, vertical, ampcounts = fit_residual_striping(
+                fitdata, mask, maxiters,
+                asymmetry_threshold=ASYMMETRY_THRESHOLD,
+                nmask_prefilter=NMASK_PREFILTER,
+            )
+            log(f"{rootname}: full-row medians used: "
+                f"{', '.join(ampcounts)}/{fitdata.shape[0]}")
+            cfp_value = (
+                f'estimator=median, asymmetry={ASYMMETRY_THRESHOLD}, '
+                f'nmask_prefilter={NMASK_PREFILTER}, maxiters={maxiters} (cal-frame)'
+            )
 
-    # Apply additive corrections to the original (un-flat-fielded) SCI
+    # Apply additive corrections to the (cal-stage) SCI — same frame the
+    # patterns were fit in, so no flat re-division leak.
     outsci = sci_before - horizontal - vertical
     outsci[sci_before == 0] = 0
     wnan = np.isnan(outsci)
@@ -343,12 +488,7 @@ def striping_step(exposure_file, field, step_config, overwrite=False,
     srcmask_hdu = fits.ImageHDU(seg, name='SRCMASK')
     atomic_save(
         model, exposure_file,
-        header_updates=cfp.format(
-            CFP_1F=(
-                f'asymmetry={ASYMMETRY_THRESHOLD}, '
-                f'nmask_prefilter={NMASK_PREFILTER}, maxiters={maxiters}'
-            ),
-        ),
+        header_updates=cfp.format(CFP_1F=cfp_value),
         extra_hdus=[srcmask_hdu],
     )
     sci_after = model.data.copy()

--- a/pipeline/experiments/oneoverf_gp/.gitignore
+++ b/pipeline/experiments/oneoverf_gp/.gitignore
@@ -1,0 +1,11 @@
+# Heavy / regenerable artifacts — only the analysis code + README are tracked.
+prestriping/
+figs/
+figs_cfn/
+logs/
+diag_scripts/
+__pycache__/
+*.fits
+*.pkl
+*.pdf
+.DS_Store

--- a/pipeline/experiments/oneoverf_gp/README.md
+++ b/pipeline/experiments/oneoverf_gp/README.md
@@ -36,18 +36,31 @@ per-amp DC only where no nearby anchor exists. See
 
 ## Results (high-passed, ICL-insensitive 1/f residual)
 
-**GP vs median** — GP wins across the board, slightly faster:
+**GP vs median** — GP wins across the board, slightly faster (self-adapting
+amplitude; the frozen-8.3e-3 result was statistically identical at −16%):
 
 | metric | median | gp | Δ |
 |---|---|---|---|
-| stripe_std (amp-row 1/f) | 7.39e-4 | 6.24e-4 | **−16%** |
-| stripe_hf | 1.06e-3 | 8.74e-4 | **−18%** |
-| stripe_std, clean rows | 6.08e-4 | 5.14e-4 | −15% |
-| stripe_std, source rows | 8.73e-4 | 7.31e-4 | −16% |
+| stripe_std (amp-row 1/f) | 7.39e-4 | 6.38e-4 | **−14%** |
+| stripe_hf | 1.06e-3 | 8.97e-4 | **−16%** |
+| stripe_std, clean rows | 6.08e-4 | 5.26e-4 | −13% |
+| stripe_std, source rows | 8.73e-4 | 7.48e-4 | −14% |
 | runtime (uncal→mosaic) | 312 s | 283 s | faster |
 
 Background uniformity unchanged, photometry conserved (<0.05%), no negative
 wings. The GP gain holds on clean *and* source rows.
+
+**Hyperparameters: only `rho` is frozen.** The kernel amplitude self-adapts per
+exposure (marginal `mad_std` of the clean per-amp-row medians, measured on the
+pre-2D-bg frame — deterministic, not a fit), because the cal-stage 1/f
+amplitude varies ~3× by filter (PHOTMJSR): f277w/f356w/f444w give 2.99/4.00/
+8.31e-3. `rho` is a detector readout property and is stable across **five
+filters spanning both channels** — LW f277w/f356w/f444w = 4.51/4.44/5.03, SW
+f200w/f150w = 4.10/4.11 rows (one cluster, well inside its flat optimum) — so
+a **single channel-agnostic `rho = 5.0`** is frozen; no SW/LW split, no
+per-filter calibration. Measure amplitude on the *pre*-bg frame: the post-bg
+residual underestimates the cross-source-gap variation, over-regularizes, and
+loses to the median.
 
 **clean_flicker_noise** — `fit_method="fft"` is **NIRSpec-only** (jwst skips it
 for `NRC_IMAGE`; logged 8× per run), so only `"median"` is testable on NIRCam:

--- a/pipeline/experiments/oneoverf_gp/README.md
+++ b/pipeline/experiments/oneoverf_gp/README.md
@@ -1,0 +1,104 @@
+# NIRCam 1/f ("striping") — GP estimator A/B + clean_flicker_noise study
+
+Testbed behind the cal-frame 1/f rework. Two studies, both on **rj0911 f444w**
+(8 LW exposures over a cluster — bright/extended sources + ICL, the failure
+case for the median full-row fallback, plus blank regions for regression):
+
+1. **GP vs median** per-amp-row estimator (`[nircam.striping].estimator`).
+2. **clean_flicker_noise (cfn)** — JWST's ramp-stage 1/f removal, standalone
+   and as a pre-pass under our GP (nirspec-style residual cleanup).
+
+All arms are exact WCS clones of `rj0911` (`$CAMPFIRE_ROOT/config/fields.toml`)
+with `astrom_cats` symlinked so astrometry is held constant; each writes its own
+products/reference tree and differs only in the 1/f treatment.
+
+## Context: the cal-frame move
+
+Striping now runs **after `image2`**, fitting and subtracting the 1/f in the
+flat-fielded cal frame (order: detector1 → persistence → wisp → image2 →
+striping → …). The legacy path fit on a flat-fielded *copy* but subtracted from
+the *un-flat* rate SCI, which image2 then re-divided by the per-amp-structured
+flat — leaving a coherent per-amp DC step at the amp boundaries. See
+`pipeline/CHANGELOG.md` (Calibration).
+
+## What the GP fixes
+
+The production estimator measures one offset per *amp-row* as a 2σ-clipped
+median of its background pixels, and **falls back to the full-row median**
+(across all four amps) when a bright source masks most of an amp-row. Because
+the four amps carry physically distinct offsets, that fallback is the wrong
+quantity exactly under the source — a step at the amp boundary + slow-axis steps
+at the source's top/bottom (the "box" of amp-row artifacts). The GP interpolates
+the offset along the slow axis *within the same amplifier*, weighting each row by
+its sampling error `σ_r ≈ 1.25·MAD/√N_r` and reverting smoothly toward the
+per-amp DC only where no nearby anchor exists. See
+`pipeline/campfire_pipeline/nircam/gp_striping.py`.
+
+## Results (high-passed, ICL-insensitive 1/f residual)
+
+**GP vs median** — GP wins across the board, slightly faster:
+
+| metric | median | gp | Δ |
+|---|---|---|---|
+| stripe_std (amp-row 1/f) | 7.39e-4 | 6.24e-4 | **−16%** |
+| stripe_hf | 1.06e-3 | 8.74e-4 | **−18%** |
+| stripe_std, clean rows | 6.08e-4 | 5.14e-4 | −15% |
+| stripe_std, source rows | 8.73e-4 | 7.31e-4 | −16% |
+| runtime (uncal→mosaic) | 312 s | 283 s | faster |
+
+Background uniformity unchanged, photometry conserved (<0.05%), no negative
+wings. The GP gain holds on clean *and* source rows.
+
+**clean_flicker_noise** — `fit_method="fft"` is **NIRSpec-only** (jwst skips it
+for `NRC_IMAGE`; logged 8× per run), so only `"median"` is testable on NIRCam:
+
+| arm | stripe_std (amp-row) | col_std | vs gp |
+|---|---|---|---|
+| uncorrected | 1.97e-3 | 9.57e-4 | +216% |
+| cfn-med alone | 1.71e-3 | 8.94e-4 | +175% |
+| gp (ours) | 6.24e-4 | 6.47e-4 | — |
+| cfn-med + gp | 6.45e-4 | 5.13e-4 | +3.5% |
+
+cfn-median alone removes only ~13% of the amp-row 1/f (vs GP's ~68%) and
+introduces per-amp DC steps via `fit_by_channel`. As a pre-pass it gives **no**
+amp-row gain over GP-alone and only a detector-specific column gain (−45% on
+NRCB-long, +10% on NRCA-long) at the cost of full ramp-stage reprocessing.
+**Conclusion: GP-alone is the best single approach; cfn is not adopted.**
+
+## Arms
+
+| arm | field | detector1 | striping |
+|---|---|---|---|
+| control | `rj0911_med` | — | median |
+| GP | `rj0911_gp` | — | gp |
+| GP+aggr | `rj0911_gpa` | — | gp, dilated mask + JUMP/SAT/PERS DQ |
+| cfn alone | `rj0911_cfn` | cfn median | none |
+| cfn+GP | `rj0911_cfngp` | cfn median | gp |
+| cfn-fft alone | `rj0911_cfnfft` | cfn fft (→skipped) | none |
+| cfn-fft+GP | `rj0911_cfnfftgp` | cfn fft (→skipped) | gp |
+
+`estimator = "none"` builds/writes `SRCMASK` and runs the rest of the pipeline
+but applies no campfire 1/f — used for the cfn-standalone arms.
+
+## Reproduce
+
+```bash
+# GP A/B (seeds gp/gpa trees from the post-image2 snapshot, runs to mosaic)
+python ../../scripts/calibrate_gp_striping.py --field rj0911_med --filter f444w
+#   -> paste kernel_sigma_lw / rho_lw into config_default.toml [nircam.striping.gp]
+bash run_arms_medgp.sh && python analyze_ab.py        # -> figs/
+
+# cfn matrix (full from uncal — cfn changes detector1)
+bash run_arms_cfn.sh && python analyze_cfn.py         # -> figs_cfn/
+```
+
+## Files (the rest — FITS snapshots, figs, logs, scratch — are gitignored)
+
+- `ab_metrics.py` — residual-stripe, background-uniformity, radial-profile,
+  aperture-photometry metrics (high-pass isolates 1/f from retained ICL).
+- `analyze_ab.py` — GP-vs-median table (`figs/summary.md`) + figures.
+- `analyze_cfn.py` — 6-arm cfn table (`figs_cfn/summary_cfn.md`) + figures,
+  adds a per-column residual metric (`col_std`).
+- `calibrate_gp_striping.py` — in `../../scripts/`; freezes SW/LW hyperparams.
+- `run_arms_medgp.sh`, `run_arms_cfn.sh` — drivers.
+- `rho_scan.py`, `scan_fitframe.py`, `diag_bgsub_boxsize.py` — diagnostics.

--- a/pipeline/experiments/oneoverf_gp/ab_metrics.py
+++ b/pipeline/experiments/oneoverf_gp/ab_metrics.py
@@ -1,0 +1,249 @@
+"""
+Metrics for the GP-vs-median 1/f ("striping") A/B on NIRCam exposures.
+
+All metrics operate on a post-striping canonical exposure: the SCI array
+plus its ``SRCMASK`` extension and ``DQ``. "Blank" pixels are finite,
+non-source, non-DO_NOT_USE, and outside the 4-px reference border.
+
+The 1/f offset is per amp-row (the 512-col amp strip × one row), so the
+residual-stripe metrics collapse each amplifier's blank pixels to a
+per-row median and measure how much structure is left along the slow
+(row) axis. Background-uniformity is the robust width of the blank-pixel
+histogram. Both are "lower is better"; we report them per amp and pooled.
+"""
+
+import numpy as np
+from astropy.io import fits
+from astropy.stats import mad_std
+
+from campfire_pipeline.nircam.constants import NIR_AMPS
+
+_REF = 4
+_DO_NOT_USE = 1  # jwst dqflags.pixel['DO_NOT_USE']
+
+
+def load_exposure(path):
+    """Return ``(sci, blank_mask)`` for a post-striping canonical file.
+
+    ``blank_mask`` is True on pixels usable as background: finite, not
+    flagged DO_NOT_USE, not in SRCMASK, and outside the reference border.
+    """
+    with fits.open(path, memmap=False) as hdul:
+        sci = hdul['SCI'].data.astype(np.float64)
+        dq = hdul['DQ'].data if 'DQ' in hdul else np.zeros(sci.shape, int)
+        seg = (hdul['SRCMASK'].data.astype(bool) if 'SRCMASK' in hdul
+               else np.zeros(sci.shape, bool))
+    blank = np.isfinite(sci) & (sci != 0)
+    blank &= (np.bitwise_and(dq, _DO_NOT_USE) == 0)
+    blank &= ~seg
+    border = np.zeros(sci.shape, bool)
+    border[:_REF] = border[-_REF:] = True
+    border[:, :_REF] = border[:, -_REF:] = True
+    blank &= ~border
+    return sci, blank, seg
+
+
+def amprow_residual_medians(sci, blank):
+    """Per-amp per-row median of blank pixels. Returns dict amp -> (R,) array.
+
+    Rows with no blank pixels in that amp are NaN.
+    """
+    out = {}
+    for amp in ('A', 'B', 'C', 'D'):
+        _, _, c0, c1 = NIR_AMPS[amp]['data']
+        sub = sci[:, c0:c1].copy()
+        m = blank[:, c0:c1]
+        sub[~m] = np.nan
+        with np.errstate(invalid='ignore'):
+            rowmed = np.nanmedian(sub, axis=1)
+        out[amp] = rowmed
+    return out
+
+
+def _highpass(seq, size=51):
+    """High-pass a per-row sequence: subtract a running median to remove
+    large-scale structure (e.g. cluster ICL retained through striping),
+    leaving the 1/f residual. NaN gaps are interpolated for the filter then
+    restored, so masked rows stay NaN.
+    """
+    from scipy.ndimage import median_filter
+    out = np.full(seq.shape, np.nan, dtype=float)
+    good = np.isfinite(seq)
+    if good.sum() < max(size, 16):
+        if good.any():
+            out[good] = seq[good] - np.nanmedian(seq)
+        return out
+    idx = np.arange(seq.size)
+    filled = np.interp(idx, idx[good], seq[good])
+    trend = median_filter(filled, size=size, mode='nearest')
+    out[good] = seq[good] - trend[good]
+    return out
+
+
+def stripe_metrics(sci, blank):
+    """Residual-stripe + background-uniformity metrics for one exposure.
+
+    Returns a dict with, pooled over amps (mean of per-amp values):
+      stripe_std  : mad_std of the *high-passed* per-amp-row residual medians
+                    (leftover 1/f striping amplitude; high-pass removes any
+                    retained large-scale background / ICL that would otherwise
+                    dominate this metric and mask the estimator difference).
+      stripe_hf   : mad_std of the row-to-row first difference of those
+                    medians (high-frequency banding / steps).
+      bkg_width   : mad_std of all blank pixels (histogram width).
+      psd_lowfreq : fraction of row-median power below 1/64 cycles/row.
+    Plus per-amp ``stripe_std_<amp>``.
+    """
+    rowmeds = amprow_residual_medians(sci, blank)
+    stds, hfs = [], []
+    per_amp = {}
+    for amp, rm in rowmeds.items():
+        good = np.isfinite(rm)
+        if good.sum() < 32:
+            continue
+        hp = _highpass(rm)
+        s = float(mad_std(hp[np.isfinite(hp)]))
+        diff = np.diff(rm[good])
+        hf = float(mad_std(diff[np.isfinite(diff)]))
+        stds.append(s)
+        hfs.append(hf)
+        per_amp[f'stripe_std_{amp}'] = s
+    bkg = float(mad_std(sci[blank])) if blank.any() else np.nan
+
+    # Low-frequency power fraction of the pooled, gap-filled row-median
+    # sequence (interp over NaN rows so the FFT is well-defined).
+    pooled = []
+    for amp, rm in rowmeds.items():
+        good = np.isfinite(rm)
+        if good.sum() < 64:
+            continue
+        idx = np.arange(rm.size)
+        filled = np.interp(idx, idx[good], rm[good] - np.median(rm[good]))
+        pooled.append(filled)
+    if pooled:
+        ps = np.abs(np.fft.rfft(np.mean(pooled, axis=0))) ** 2
+        freq = np.fft.rfftfreq(pooled[0].size)
+        lowfrac = float(ps[freq < 1 / 64.0].sum() / ps[1:].sum())
+    else:
+        lowfrac = np.nan
+
+    return {
+        'stripe_std': float(np.mean(stds)) if stds else np.nan,
+        'stripe_hf': float(np.mean(hfs)) if hfs else np.nan,
+        'bkg_width': bkg,
+        'psd_lowfreq': lowfrac,
+        **per_amp,
+    }
+
+
+def stripe_metrics_split(sci, blank, seg, clean_frac=0.20, source_frac=0.40):
+    """Residual amp-row-median scatter split by amp-row source coverage.
+
+    For each amp, the per-row residual median is computed on blank pixels.
+    Rows are classified by the SRCMASK coverage of that amp-row:
+      clean rows  : source fraction < clean_frac
+      source rows : source fraction > source_frac   (where the median
+                    estimator tends to hit its full-row fallback)
+    Returns mad_std of the residual medians in each class, pooled over amps.
+    This isolates the GP's target regime (source rows) from the clean-row
+    regime where the per-row median is already near-optimal.
+    """
+    clean_vals, source_vals = [], []
+    for amp in ('A', 'B', 'C', 'D'):
+        _, _, c0, c1 = NIR_AMPS[amp]['data']
+        sub = sci[:, c0:c1].copy()
+        m = blank[:, c0:c1]
+        sub[~m] = np.nan
+        with np.errstate(invalid='ignore'):
+            rowmed = np.nanmedian(sub, axis=1)
+        srcfrac = seg[:, c0:c1].mean(axis=1)
+        # High-pass to strip any retained large-scale background (ICL) so the
+        # metric isolates the 1/f residual, not the cluster light.
+        rowmed = _highpass(rowmed)
+        clean = np.isfinite(rowmed) & (srcfrac < clean_frac)
+        source = np.isfinite(rowmed) & (srcfrac > source_frac)
+        clean_vals.append(rowmed[clean])
+        source_vals.append(rowmed[source])
+    cv = np.concatenate(clean_vals) if clean_vals else np.array([])
+    sv = np.concatenate(source_vals) if source_vals else np.array([])
+    return {
+        'stripe_std_clean': float(mad_std(cv)) if cv.size > 16 else np.nan,
+        'stripe_std_source': float(mad_std(sv)) if sv.size > 16 else np.nan,
+        'n_clean_rows': int(cv.size),
+        'n_source_rows': int(sv.size),
+    }
+
+
+def detect_bright_sources(sci, blank, nmax=8, min_sep=80, edge=60):
+    """Bright source centroids via sep, ordered by flux.
+
+    Returns a list of ``(y, x, flux)``; sources within ``min_sep`` of a
+    brighter one or within ``edge`` of the frame edge are dropped.
+    """
+    import sep
+    data = sci.byteswap().view(sci.dtype.newbyteorder('=')) \
+        if sci.dtype.byteorder not in ('=', '|') else sci.copy()
+    bkg = sep.Background(data, mask=~blank)
+    sub = data - bkg.back()
+    try:
+        obj = sep.extract(sub, thresh=8.0, err=bkg.globalrms, minarea=9)
+    except Exception:
+        return []
+    h, w = sci.shape
+    order = np.argsort(obj['flux'])[::-1]
+    picked = []
+    for i in order:
+        y, x = float(obj['y'][i]), float(obj['x'][i])
+        if x < edge or x > w - edge or y < edge or y > h - edge:
+            continue
+        if any((y - py) ** 2 + (x - px) ** 2 < min_sep ** 2
+               for py, px, _ in picked):
+            continue
+        picked.append((y, x, float(obj['flux'][i])))
+        if len(picked) >= nmax:
+            break
+    return picked
+
+
+def radial_profile(sci, blank, yc, xc, rmax=150, nbin=30):
+    """Median radial profile of *blank* pixels around (yc, xc).
+
+    Returns ``(r_centers, profile)``. Source pixels are excluded (blank),
+    so the profile measures the background floor around the source — a
+    negative trough flags oversubtraction (leaked flux biased the median).
+    """
+    y0, y1 = int(max(yc - rmax, 0)), int(min(yc + rmax, sci.shape[0]))
+    x0, x1 = int(max(xc - rmax, 0)), int(min(xc + rmax, sci.shape[1]))
+    yy, xx = np.mgrid[y0:y1, x0:x1]
+    r = np.sqrt((yy - yc) ** 2 + (xx - xc) ** 2)
+    stamp = sci[y0:y1, x0:x1]
+    m = blank[y0:y1, x0:x1] & (r <= rmax)
+    edges = np.linspace(0, rmax, nbin + 1)
+    centers = 0.5 * (edges[1:] + edges[:-1])
+    prof = np.full(nbin, np.nan)
+    rr, vv = r[m], stamp[m]
+    for k in range(nbin):
+        sel = (rr >= edges[k]) & (rr < edges[k + 1])
+        if sel.sum() >= 5:
+            prof[k] = np.median(vv[sel])
+    return centers, prof
+
+
+def aperture_photometry(sci, sources, r=10.0, r_in=15.0, r_out=25.0):
+    """Local-background-subtracted aperture sums at ``sources`` positions.
+
+    Returns an array of fluxes aligned with ``sources``. Used to check
+    photometric conservation across arms (same positions, same apertures).
+    """
+    import sep
+    data = sci.byteswap().view(sci.dtype.newbyteorder('=')) \
+        if sci.dtype.byteorder not in ('=', '|') else sci.copy()
+    # Non-finite pixels (bad/edge) must be masked, not summed, or sep
+    # propagates NaN through the aperture/annulus.
+    badmask = ~np.isfinite(data)
+    data = np.where(badmask, 0.0, data)
+    ys = np.array([s[0] for s in sources])
+    xs = np.array([s[1] for s in sources])
+    flux, _, _ = sep.sum_circle(data, xs, ys, r, mask=badmask,
+                                bkgann=(r_in, r_out), subpix=5)
+    return flux

--- a/pipeline/experiments/oneoverf_gp/analyze_ab.py
+++ b/pipeline/experiments/oneoverf_gp/analyze_ab.py
@@ -1,0 +1,337 @@
+"""
+Analyze the GP-vs-median 1/f striping A/B and emit metrics + figures.
+
+Arms (post-striping canonical exposures, one tree each):
+    before  pre-striping snapshot (experiments/oneoverf_gp/prestriping/)
+    median  products/nircam/rj0911_med/f444w     (control)
+    gp      products/nircam/rj0911_gp/f444w
+    gp_aggr products/nircam/rj0911_gpa/f444w
+
+Outputs (to experiments/oneoverf_gp/figs/):
+    summary.md                       per-exposure + pooled metric table
+    stripe_rowmedians_<root>.png     residual amp-row medians vs row, all arms
+    compare_<root>.png               matched-zscale full frame, all arms
+    zoom_<root>.png                  matched-zscale zoom on brightest source
+    radial_<root>.png                background radial profiles around sources
+    photometry.png                   aperture-flux stability vs control
+
+Run after the three arms finish:
+    conda run -n campfire python experiments/oneoverf_gp/analyze_ab.py
+"""
+
+import glob
+import os
+
+import numpy as np
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from astropy.visualization import ZScaleInterval
+
+from ab_metrics import (
+    aperture_photometry,
+    amprow_residual_medians,
+    detect_bright_sources,
+    load_exposure,
+    radial_profile,
+    stripe_metrics,
+    stripe_metrics_split,
+)
+from campfire_pipeline.nircam.constants import NIR_AMPS
+
+ROOT = os.environ.get('CAMPFIRE_ROOT', '.')
+HERE = os.path.dirname(os.path.abspath(__file__))
+FIGS = os.path.join(HERE, 'figs')
+os.makedirs(FIGS, exist_ok=True)
+
+ARMS = {
+    'before': os.path.join(HERE, 'prestriping'),
+    'median': os.path.join(ROOT, 'products/nircam/rj0911_med/f444w'),
+    'gp':     os.path.join(ROOT, 'products/nircam/rj0911_gp/f444w'),
+    'gp_aggr': os.path.join(ROOT, 'products/nircam/rj0911_gpa/f444w'),
+}
+COLORS = {'before': '0.6', 'median': 'tab:blue', 'gp': 'tab:orange',
+          'gp_aggr': 'tab:red'}
+# Arms that actually carry a corrected SCI (skip 'before' in metric tables).
+CORR_ARMS = ['median', 'gp', 'gp_aggr']
+
+
+def roots():
+    """Exposure rootnames present in the median arm."""
+    files = sorted(glob.glob(os.path.join(ARMS['median'], '*long.fits')))
+    return [os.path.basename(f).removesuffix('.fits') for f in files]
+
+
+def arm_path(arm, root):
+    return os.path.join(ARMS[arm], f'{root}.fits')
+
+
+def build_summary():
+    rows = []
+    for root in roots():
+        for arm in CORR_ARMS:
+            p = arm_path(arm, root)
+            if not os.path.exists(p):
+                continue
+            sci, blank, seg = load_exposure(p)
+            m = stripe_metrics(sci, blank)
+            m.update(stripe_metrics_split(sci, blank, seg))
+            m.update(root=root, arm=arm)
+            rows.append(m)
+    return rows
+
+
+def write_summary_md(rows):
+    keys = ['stripe_std', 'stripe_hf', 'stripe_std_clean', 'stripe_std_source',
+            'bkg_width']
+    lines = ['# GP vs median 1/f striping — A/B metrics (rj0911 f444w)\n',
+             'Lower `stripe_std` / `stripe_hf` / `bkg_width` = cleaner; '
+             '`psd_lowfreq` = fraction of residual row-median power at low '
+             'frequency.\n',
+             '## Pooled over exposures (mean ± std)\n',
+             '| arm | ' + ' | '.join(keys) + ' |',
+             '|' + '---|' * (len(keys) + 1)]
+    for arm in CORR_ARMS:
+        sub = [r for r in rows if r['arm'] == arm]
+        if not sub:
+            continue
+        cells = []
+        for k in keys:
+            v = np.array([r[k] for r in sub if np.isfinite(r.get(k, np.nan))])
+            cells.append(f'{v.mean():.4e} ± {v.std():.1e}' if v.size else 'n/a')
+        lines.append(f'| {arm} | ' + ' | '.join(cells) + ' |')
+    lines.append('\n## Per exposure\n')
+    lines.append('| root | arm | ' + ' | '.join(keys) + ' |')
+    lines.append('|' + '---|' * (len(keys) + 2))
+    for r in rows:
+        cells = [f'{r.get(k, np.nan):.3e}' for k in keys]
+        lines.append(f'| {r["root"]} | {r["arm"]} | ' + ' | '.join(cells) + ' |')
+    path = os.path.join(FIGS, 'summary.md')
+    with open(path, 'w') as f:
+        f.write('\n'.join(lines) + '\n')
+    print('wrote', path)
+    # Also echo the pooled table to stdout.
+    print('\n'.join(lines[:6 + len(CORR_ARMS)]))
+
+
+def plot_rowmedians(root):
+    """Residual per-amp-row medians vs row for each corrected arm (per amp).
+
+    Corrected arms are all cal-stage (matched units); 'before' is rate-stage
+    (different units) so it is excluded here.
+    """
+    fig, axes = plt.subplots(4, 1, figsize=(11, 9), sharex=True)
+    span = 0.0
+    for arm in CORR_ARMS:
+        p = arm_path(arm, root)
+        if not os.path.exists(p):
+            continue
+        sci, blank, _ = load_exposure(p)
+        rms = amprow_residual_medians(sci, blank)
+        for ax, amp in zip(axes, ('A', 'B', 'C', 'D')):
+            rm = rms[amp] - np.nanmedian(rms[amp])
+            ax.plot(rm, color=COLORS[arm], lw=0.6, label=arm, alpha=0.85)
+            good = np.isfinite(rm)
+            if good.any():
+                span = max(span, float(np.nanpercentile(np.abs(rm[good]), 99)))
+    for ax, amp in zip(axes, ('A', 'B', 'C', 'D')):
+        ax.set_ylabel(f'amp {amp}\nrow median')
+        ax.axhline(0, color='k', lw=0.4, ls=':')
+        if span > 0:
+            ax.set_ylim(-1.5 * span, 1.5 * span)
+    axes[0].legend(ncol=3, fontsize=8, loc='upper right')
+    axes[-1].set_xlabel('row (slow axis)')
+    fig.suptitle(f'Residual amp-row medians (cal stage) — {root}')
+    fig.tight_layout()
+    out = os.path.join(FIGS, f'stripe_rowmedians_{root}.png')
+    fig.savefig(out, dpi=110)
+    plt.close(fig)
+    print('wrote', out)
+
+
+def _zscale(sci, contrast=0.15):
+    return ZScaleInterval(contrast=contrast).get_limits(
+        sci[np.isfinite(sci) & (sci != 0)])
+
+
+def plot_compare(root, zoom=None, tag='compare'):
+    """Comparison panels: corrected arms share one zscale (matched units).
+
+    'before' (rate-stage, different units) is shown first on its OWN zscale,
+    labelled, purely as raw-stripe context — it is not part of the matched
+    comparison among median/gp/gp_aggr.
+    """
+    arms = ([a for a in ['before'] if os.path.exists(arm_path(a, root))]
+            + [a for a in CORR_ARMS if os.path.exists(arm_path(a, root))])
+    # Matched stretch for the corrected (cal-stage) arms, from the control.
+    smed, _, _ = load_exposure(arm_path('median', root))
+    if zoom is not None:
+        y0, y1, x0, x1 = zoom
+        smed = smed[y0:y1, x0:x1]
+    vmin, vmax = _zscale(smed)
+    fig, axes = plt.subplots(1, len(arms), figsize=(4.2 * len(arms), 4.4))
+    if len(arms) == 1:
+        axes = [axes]
+    for ax, arm in zip(axes, arms):
+        sci, _, _ = load_exposure(arm_path(arm, root))
+        if zoom is not None:
+            sci = sci[y0:y1, x0:x1]
+        if arm == 'before':
+            lo, hi = _zscale(sci)
+            ax.set_title('before (rate, own scale)', fontsize=9)
+        else:
+            lo, hi = vmin, vmax
+            ax.set_title(arm)
+        ax.imshow(sci, origin='lower', cmap='Greys_r', vmin=lo, vmax=hi)
+        ax.set_xticks([]); ax.set_yticks([])
+    fig.suptitle(f'{tag} — {root}  '
+                 f'(corrected arms matched zscale [{vmin:.4g}, {vmax:.4g}])')
+    fig.tight_layout()
+    out = os.path.join(FIGS, f'{tag}_{root}.png')
+    fig.savefig(out, dpi=120)
+    plt.close(fig)
+    print('wrote', out)
+
+
+def plot_difference(root, zoom=None, tag='difference'):
+    """Per-exposure (gp − median) and (gp_aggr − median) difference maps.
+
+    The cal-stage frames share the detector pixel grid (same uncal input),
+    so the difference is the difference in the *applied 1/f correction*.
+    Where the median fell back to the full-row value, its correction is the
+    wrong (cross-amp) quantity over the source's amp-rows; that shows up as
+    a structured amp-boundary + slow-axis "box" in the difference, while
+    clean rows differ only by the GP's smoothing. Diverging cmap, symmetric
+    robust limits.
+    """
+    med, _, _ = load_exposure(arm_path('median', root))
+    panels = [('median (control)', med, 'grey')]
+    for arm in ('gp', 'gp_aggr'):
+        p = arm_path(arm, root)
+        if os.path.exists(p):
+            sci, _, _ = load_exposure(p)
+            panels.append((f'{arm} − median', sci - med, 'div'))
+    if zoom is not None:
+        y0, y1, x0, x1 = zoom
+        panels = [(t, a[y0:y1, x0:x1], k) for t, a, k in panels]
+    gvmin, gvmax = _zscale(panels[0][1])
+    # Symmetric limit for the difference panels from their robust scatter.
+    diffs = np.concatenate([a[np.isfinite(a)].ravel() for _, a, k in panels
+                            if k == 'div'])
+    dlim = 3.0 * float(np.nanstd(diffs)) if diffs.size else 1.0
+    fig, axes = plt.subplots(1, len(panels), figsize=(4.3 * len(panels), 4.5))
+    for ax, (title, arr, kind) in zip(axes, panels):
+        if kind == 'div':
+            im = ax.imshow(arr, origin='lower', cmap='RdBu_r',
+                           vmin=-dlim, vmax=dlim)
+            fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+        else:
+            ax.imshow(arr, origin='lower', cmap='Greys_r',
+                      vmin=gvmin, vmax=gvmax)
+        ax.set_title(title, fontsize=9)
+        ax.set_xticks([]); ax.set_yticks([])
+    fig.suptitle(f'{tag} — {root}  (diff limit ±{dlim:.3g})')
+    fig.tight_layout()
+    out = os.path.join(FIGS, f'{tag}_{root}.png')
+    fig.savefig(out, dpi=120)
+    plt.close(fig)
+    print('wrote', out)
+
+
+def plot_radial(root, sources):
+    """Background radial profiles around bright sources, all arms overlaid."""
+    n = min(len(sources), 6)
+    if n == 0:
+        return
+    ncol = 3
+    nrow = int(np.ceil(n / ncol))
+    fig, axes = plt.subplots(nrow, ncol, figsize=(4 * ncol, 3 * nrow),
+                             squeeze=False)
+    loaded = {arm: load_exposure(arm_path(arm, root))
+              for arm in CORR_ARMS if os.path.exists(arm_path(arm, root))}
+    for i in range(n):
+        ax = axes[i // ncol][i % ncol]
+        yc, xc, flux = sources[i]
+        for arm, (sci, blank, _) in loaded.items():
+            r, prof = radial_profile(sci, blank, yc, xc)
+            ax.plot(r, prof, color=COLORS[arm], label=arm, lw=1.2)
+        ax.axhline(0, color='k', lw=0.4, ls=':')
+        ax.set_title(f'src ({int(xc)},{int(yc)}) f={flux:.0f}', fontsize=8)
+        ax.set_xlabel('r [px]'); ax.set_ylabel('bkg median')
+    axes[0][0].legend(fontsize=8)
+    fig.suptitle(f'Background radial profiles around bright sources — {root}\n'
+                 '(negative trough = oversubtraction)')
+    fig.tight_layout()
+    out = os.path.join(FIGS, f'radial_{root}.png')
+    fig.savefig(out, dpi=120)
+    plt.close(fig)
+    print('wrote', out)
+
+
+def plot_photometry(root, sources):
+    """Aperture flux of each arm vs the control, to check conservation."""
+    if not sources:
+        return
+    fluxes = {}
+    for arm in CORR_ARMS:
+        p = arm_path(arm, root)
+        if os.path.exists(p):
+            sci, _, _ = load_exposure(p)
+            fluxes[arm] = aperture_photometry(sci, sources)
+    if 'median' not in fluxes:
+        return
+    base = fluxes['median']
+    fig, ax = plt.subplots(figsize=(6, 5))
+    for arm in ('gp', 'gp_aggr'):
+        if arm not in fluxes:
+            continue
+        frac = (fluxes[arm] - base) / np.where(base != 0, base, np.nan)
+        ax.plot(base, frac * 100, 'o', color=COLORS[arm], label=arm, alpha=0.8)
+    ax.axhline(0, color='k', lw=0.5)
+    ax.set_xscale('symlog')
+    ax.set_xlabel('control aperture flux')
+    ax.set_ylabel('Δflux vs control [%]')
+    ax.set_title(f'Photometric conservation — {root}')
+    ax.legend()
+    fig.tight_layout()
+    out = os.path.join(FIGS, f'photometry_{root}.png')
+    fig.savefig(out, dpi=120)
+    plt.close(fig)
+    print('wrote', out)
+
+
+def main():
+    rs = roots()
+    print('exposures:', rs)
+    rows = build_summary()
+    write_summary_md(rows)
+
+    # Pick the exposure with the brightest detected source for the visuals.
+    rep = rs[0]
+    best_sources = []
+    best_root = rep
+    for root in rs:
+        sci, blank, _ = load_exposure(arm_path('median', root))
+        srcs = detect_bright_sources(sci, blank)
+        if srcs and (not best_sources or srcs[0][2] > best_sources[0][2]):
+            best_sources, best_root = srcs, root
+    print(f'representative exposure: {best_root} '
+          f'({len(best_sources)} bright sources)')
+
+    plot_rowmedians(best_root)
+    plot_compare(best_root, tag='compare')
+    plot_difference(best_root, tag='difference')
+    if best_sources:
+        yc, xc, _ = best_sources[0]
+        half = 220
+        h, w = load_exposure(arm_path('median', best_root))[0].shape
+        zoom = (max(int(yc) - half, 0), min(int(yc) + half, h),
+                max(int(xc) - half, 0), min(int(xc) + half, w))
+        plot_compare(best_root, zoom=zoom, tag='zoom')
+        plot_difference(best_root, zoom=zoom, tag='difference_zoom')
+        plot_radial(best_root, best_sources)
+        plot_photometry(best_root, best_sources)
+
+
+if __name__ == '__main__':
+    main()

--- a/pipeline/experiments/oneoverf_gp/analyze_cfn.py
+++ b/pipeline/experiments/oneoverf_gp/analyze_cfn.py
@@ -1,0 +1,375 @@
+"""
+clean_flicker_noise (cfn) matrix analysis vs our median/GP striping.
+
+Six arms (post-striping canonical exposures, one products tree each):
+    median     rj0911_med        our production 2σ-clipped median (control)
+    gp         rj0911_gp         our GP striping (the new method)
+    cfn        rj0911_cfn        JWST cfn (median) standalone, no campfire 1/f
+    cfngp      rj0911_cfngp      JWST cfn (median) + GP residual cleanup
+    cfnfft     rj0911_cfnfft     JWST cfn (fft) standalone, no campfire 1/f
+    cfnfftgp   rj0911_cfnfftgp   JWST cfn (fft) + GP residual cleanup
+
+Three questions this answers:
+  1. cfn standalone vs our GP  — does JWST's ramp-stage 1/f removal match or
+     beat our amp-row GP on its own?
+  2. cfn + GP (residual cleanup, nirspec-style) — does layering GP on top of
+     cfn beat either alone?
+  3. cfn median vs fft method.
+
+All arms share the same uncal input + WCS + astrom_cats, so frames are on the
+same detector grid and directly differenceable. Metrics are the ICL-insensitive
+(high-passed) 1/f residuals from ab_metrics.
+
+Outputs (experiments/oneoverf_gp/figs_cfn/):
+    summary_cfn.md                 pooled + per-exposure metric table
+    cfn_rowmedians_<root>.png      residual amp-row medians, all arms
+    cfn_compare_<root>.png         matched-zscale frames, 2x3 grid
+    cfn_radial_<root>.png          background radial profiles around sources
+    cfn_photometry_<root>.png      aperture-flux vs median control
+
+    conda run -n campfire python experiments/oneoverf_gp/analyze_cfn.py
+"""
+
+import glob
+import os
+
+import numpy as np
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from astropy.visualization import ZScaleInterval
+
+from astropy.stats import mad_std
+
+from ab_metrics import (
+    _highpass,
+    aperture_photometry,
+    amprow_residual_medians,
+    detect_bright_sources,
+    load_exposure,
+    radial_profile,
+    stripe_metrics,
+    stripe_metrics_split,
+)
+
+ROOT = os.environ.get('CAMPFIRE_ROOT', '.')
+HERE = os.path.dirname(os.path.abspath(__file__))
+FIGS = os.path.join(HERE, 'figs_cfn')
+os.makedirs(FIGS, exist_ok=True)
+
+# Ordered so the table reads: our methods first, then cfn standalone, then
+# cfn+GP combos. Tree names map to products/nircam/<tree>/f444w.
+ARMS = [
+    ('median',   'rj0911_med'),
+    ('gp',       'rj0911_gp'),
+    ('cfn',      'rj0911_cfn'),
+    ('cfngp',    'rj0911_cfngp'),
+    ('cfnfft',   'rj0911_cfnfft'),
+    ('cfnfftgp', 'rj0911_cfnfftgp'),
+]
+ARM_DIR = {name: os.path.join(ROOT, 'products/nircam', tree, 'f444w')
+           for name, tree in ARMS}
+ARM_NAMES = [name for name, _ in ARMS]
+COLORS = {
+    'median':   'tab:blue',
+    'gp':       'tab:orange',
+    'cfn':      'tab:green',
+    'cfngp':    'tab:red',
+    'cfnfft':   '0.5',
+    'cfnfftgp': 'tab:brown',
+}
+# fit_method="fft" is NIRSpec-only: jwst skips clean_flicker_noise for
+# NRC_IMAGE, so cfnfft == a fully-uncorrected baseline and cfnfftgp == gp.
+# Relabel accordingly and drop the redundant cfnfftgp from the plots.
+DISPLAY = {
+    'median':   'median (ours)',
+    'gp':       'gp (ours)',
+    'cfn':      'cfn-med alone',
+    'cfngp':    'cfn-med + gp',
+    'cfnfft':   'uncorrected',   # cfn-fft skipped on NIRCam -> no correction
+    'cfnfftgp': '(= gp; fft skipped)',
+}
+# Plot order: worst (uncorrected) -> our methods -> cfn combos. Excludes the
+# redundant cfnfftgp.
+PLOT_ARMS = ['cfnfft', 'cfn', 'median', 'gp', 'cfngp']
+# Baseline against which photometry / difference is measured.
+BASE = 'median'
+
+
+def lab(arm):
+    return DISPLAY.get(arm, arm)
+
+
+def present_arms():
+    """Arms whose products tree actually has exposures on disk."""
+    return [a for a in ARM_NAMES
+            if glob.glob(os.path.join(ARM_DIR[a], '*long.fits'))]
+
+
+def roots():
+    """Exposure rootnames common to all present arms."""
+    arms = present_arms()
+    if not arms:
+        return []
+    sets = []
+    for a in arms:
+        fs = glob.glob(os.path.join(ARM_DIR[a], '*long.fits'))
+        sets.append({os.path.basename(f).removesuffix('.fits') for f in fs})
+    common = set.intersection(*sets)
+    return sorted(common)
+
+
+def arm_path(arm, root):
+    return os.path.join(ARM_DIR[arm], f'{root}.fits')
+
+
+def column_residual_std(sci, blank):
+    """Residual *vertical* (per-column) striping scatter, high-passed.
+
+    The cfn-standalone arms (estimator='none') get no campfire per-column
+    step, so a fair comparison needs a vertical metric too: collapse blank
+    pixels to a per-column median (over rows), high-pass along the column
+    index to drop large-scale background, then take the mad_std. Lower =
+    less residual column striping.
+    """
+    sub = sci.copy()
+    sub[~blank] = np.nan
+    with np.errstate(invalid='ignore'):
+        colmed = np.nanmedian(sub, axis=0)
+    hp = _highpass(colmed)
+    finite = np.isfinite(hp)
+    return float(mad_std(hp[finite])) if finite.sum() > 32 else np.nan
+
+
+def build_summary(arms, rs):
+    rows = []
+    for root in rs:
+        for arm in arms:
+            p = arm_path(arm, root)
+            if not os.path.exists(p):
+                continue
+            sci, blank, seg = load_exposure(p)
+            m = stripe_metrics(sci, blank)
+            m.update(stripe_metrics_split(sci, blank, seg))
+            m['col_std'] = column_residual_std(sci, blank)
+            m.update(root=root, arm=arm)
+            rows.append(m)
+    return rows
+
+
+def write_summary_md(rows, arms):
+    keys = ['stripe_std', 'stripe_hf', 'col_std', 'stripe_std_clean',
+            'stripe_std_source', 'bkg_width']
+    # Pooled means for the headline comparison vs gp (our method).
+    pooled = {}
+    for arm in arms:
+        sub = [r for r in rows if r['arm'] == arm]
+        pooled[arm] = {k: np.nanmean([r.get(k, np.nan) for r in sub])
+                       for k in keys} if sub else {}
+    ref = pooled.get('gp', {})
+
+    lines = [
+        '# clean_flicker_noise matrix vs median/GP striping (rj0911 f444w)\n',
+        'Lower = cleaner. Metrics are high-passed (ICL-insensitive) 1/f '
+        'residuals. Δ% columns are relative to **gp** (our method).\n',
+        '> **Note:** `fit_method="fft"` is NIRSpec-only — jwst skips '
+        'clean_flicker_noise for `NRC_IMAGE` (confirmed in run logs). So '
+        '`cfnfft` is a fully-uncorrected baseline and `cfnfftgp` is '
+        'byte-identical to `gp`. Only `fit_method="median"` is a real cfn '
+        'test on NIRCam.\n',
+        '## Pooled over exposures (mean), Δ% vs gp\n',
+        '| arm | ' + ' | '.join(keys) + ' | Δ stripe_std vs gp |',
+        '|' + '---|' * (len(keys) + 2),
+    ]
+    for arm in arms:
+        p = pooled.get(arm, {})
+        if not p:
+            continue
+        cells = [f'{p[k]:.4e}' if np.isfinite(p.get(k, np.nan)) else 'n/a'
+                 for k in keys]
+        if ref.get('stripe_std') and np.isfinite(ref['stripe_std']) and arm != 'gp':
+            d = 100 * (p['stripe_std'] - ref['stripe_std']) / ref['stripe_std']
+            dcell = f'{d:+.1f}%'
+        else:
+            dcell = '—'
+        lines.append(f'| {arm} | ' + ' | '.join(cells) + f' | {dcell} |')
+
+    lines.append('\n## Per exposure\n')
+    lines.append('| root | arm | ' + ' | '.join(keys) + ' |')
+    lines.append('|' + '---|' * (len(keys) + 2))
+    for r in rows:
+        cells = [f'{r.get(k, np.nan):.3e}' for k in keys]
+        lines.append(f'| {r["root"]} | {r["arm"]} | ' + ' | '.join(cells) + ' |')
+
+    path = os.path.join(FIGS, 'summary_cfn.md')
+    with open(path, 'w') as f:
+        f.write('\n'.join(lines) + '\n')
+    print('wrote', path)
+    print('\n'.join(lines[:5 + len(arms)]))
+
+
+def _zscale(sci, contrast=0.15):
+    return ZScaleInterval(contrast=contrast).get_limits(
+        sci[np.isfinite(sci) & (sci != 0)])
+
+
+def plot_rowmedians(root, arms):
+    fig, axes = plt.subplots(4, 1, figsize=(11, 9), sharex=True)
+    span = 0.0
+    for arm in arms:
+        p = arm_path(arm, root)
+        if not os.path.exists(p):
+            continue
+        sci, blank, _ = load_exposure(p)
+        rms = amprow_residual_medians(sci, blank)
+        for ax, amp in zip(axes, ('A', 'B', 'C', 'D')):
+            rm = rms[amp] - np.nanmedian(rms[amp])
+            ax.plot(rm, color=COLORS[arm], lw=0.6, label=lab(arm), alpha=0.8)
+            good = np.isfinite(rm)
+            if good.any():
+                span = max(span, float(np.nanpercentile(np.abs(rm[good]), 99)))
+    for ax, amp in zip(axes, ('A', 'B', 'C', 'D')):
+        ax.set_ylabel(f'amp {amp}\nrow median')
+        ax.axhline(0, color='k', lw=0.4, ls=':')
+        if span > 0:
+            ax.set_ylim(-1.5 * span, 1.5 * span)
+    axes[0].legend(ncol=len(arms), fontsize=7, loc='upper right')
+    axes[-1].set_xlabel('row (slow axis)')
+    fig.suptitle(f'Residual amp-row medians (cal stage) — {root}')
+    fig.tight_layout()
+    out = os.path.join(FIGS, f'cfn_rowmedians_{root}.png')
+    fig.savefig(out, dpi=110)
+    plt.close(fig)
+    print('wrote', out)
+
+
+def plot_compare(root, arms, zoom=None, tag='cfn_compare'):
+    """Matched-zscale frames (stretch from the median control)."""
+    smed, _, _ = load_exposure(arm_path(BASE, root))
+    if zoom is not None:
+        y0, y1, x0, x1 = zoom
+        smed = smed[y0:y1, x0:x1]
+    vmin, vmax = _zscale(smed)
+    n = len(arms)
+    ncol = 3
+    nrow = int(np.ceil(n / ncol))
+    fig, axes = plt.subplots(nrow, ncol, figsize=(4.4 * ncol, 4.6 * nrow),
+                             squeeze=False)
+    for i in range(nrow * ncol):
+        ax = axes[i // ncol][i % ncol]
+        if i >= n:
+            ax.axis('off')
+            continue
+        arm = arms[i]
+        sci, _, _ = load_exposure(arm_path(arm, root))
+        if zoom is not None:
+            sci = sci[y0:y1, x0:x1]
+        ax.imshow(sci, origin='lower', cmap='Greys_r', vmin=vmin, vmax=vmax)
+        ax.set_title(lab(arm))
+        ax.set_xticks([]); ax.set_yticks([])
+    fig.suptitle(f'{tag} — {root}  (matched zscale [{vmin:.4g}, {vmax:.4g}])')
+    fig.tight_layout()
+    out = os.path.join(FIGS, f'{tag}_{root}.png')
+    fig.savefig(out, dpi=130)
+    plt.close(fig)
+    print('wrote', out)
+
+
+def plot_radial(root, arms, sources):
+    n = min(len(sources), 6)
+    if n == 0:
+        return
+    ncol = 3
+    nrow = int(np.ceil(n / ncol))
+    fig, axes = plt.subplots(nrow, ncol, figsize=(4 * ncol, 3 * nrow),
+                             squeeze=False)
+    loaded = {arm: load_exposure(arm_path(arm, root))
+              for arm in arms if os.path.exists(arm_path(arm, root))}
+    for i in range(n):
+        ax = axes[i // ncol][i % ncol]
+        yc, xc, flux = sources[i]
+        for arm, (sci, blank, _) in loaded.items():
+            r, prof = radial_profile(sci, blank, yc, xc)
+            ax.plot(r, prof, color=COLORS[arm], label=lab(arm), lw=1.1)
+        ax.axhline(0, color='k', lw=0.4, ls=':')
+        ax.set_title(f'src ({int(xc)},{int(yc)}) f={flux:.0f}', fontsize=8)
+        ax.set_xlabel('r [px]'); ax.set_ylabel('bkg median')
+    axes[0][0].legend(fontsize=7)
+    fig.suptitle(f'Background radial profiles around bright sources — {root}\n'
+                 '(negative trough = oversubtraction)')
+    fig.tight_layout()
+    out = os.path.join(FIGS, f'cfn_radial_{root}.png')
+    fig.savefig(out, dpi=120)
+    plt.close(fig)
+    print('wrote', out)
+
+
+def plot_photometry(root, arms, sources):
+    if not sources:
+        return
+    fluxes = {}
+    for arm in arms:
+        p = arm_path(arm, root)
+        if os.path.exists(p):
+            sci, _, _ = load_exposure(p)
+            fluxes[arm] = aperture_photometry(sci, sources)
+    if BASE not in fluxes:
+        return
+    base = fluxes[BASE]
+    fig, ax = plt.subplots(figsize=(7, 5))
+    for arm in arms:
+        if arm == BASE or arm not in fluxes:
+            continue
+        frac = (fluxes[arm] - base) / np.where(base != 0, base, np.nan)
+        ax.plot(base, frac * 100, 'o', color=COLORS[arm], label=lab(arm), alpha=0.8)
+    ax.axhline(0, color='k', lw=0.5)
+    ax.set_xscale('symlog')
+    ax.set_xlabel(f'{BASE} aperture flux')
+    ax.set_ylabel(f'Δflux vs {BASE} [%]')
+    ax.set_title(f'Photometric conservation — {root}')
+    ax.legend(fontsize=8)
+    fig.tight_layout()
+    out = os.path.join(FIGS, f'cfn_photometry_{root}.png')
+    fig.savefig(out, dpi=120)
+    plt.close(fig)
+    print('wrote', out)
+
+
+def main():
+    arms = present_arms()
+    rs = roots()
+    print('present arms:', arms)
+    print('common exposures:', rs)
+    if not rs:
+        print('no common exposures yet; arms still running?')
+        return
+    rows = build_summary(arms, rs)
+    write_summary_md(rows, arms)
+
+    # Curated arm set for the figures (drops the redundant cfnfftgp == gp;
+    # cfnfft shown as the uncorrected baseline).
+    plot_arms = [a for a in PLOT_ARMS if a in arms]
+
+    rep, best_sources = rs[0], []
+    for root in rs:
+        sci, blank, _ = load_exposure(arm_path(BASE, root))
+        srcs = detect_bright_sources(sci, blank)
+        if srcs and (not best_sources or srcs[0][2] > best_sources[0][2]):
+            best_sources, rep = srcs, root
+    print(f'representative exposure: {rep} ({len(best_sources)} bright sources)')
+
+    plot_rowmedians(rep, plot_arms)
+    plot_compare(rep, plot_arms, tag='cfn_compare')
+    if best_sources:
+        yc, xc, _ = best_sources[0]
+        half = 220
+        h, w = load_exposure(arm_path(BASE, rep))[0].shape
+        zoom = (max(int(yc) - half, 0), min(int(yc) + half, h),
+                max(int(xc) - half, 0), min(int(xc) + half, w))
+        plot_compare(rep, plot_arms, zoom=zoom, tag='cfn_zoom')
+        plot_radial(rep, plot_arms, best_sources)
+        plot_photometry(rep, plot_arms, best_sources)
+
+
+if __name__ == '__main__':
+    main()

--- a/pipeline/experiments/oneoverf_gp/diag_bgsub_boxsize.py
+++ b/pipeline/experiments/oneoverf_gp/diag_bgsub_boxsize.py
@@ -1,0 +1,104 @@
+"""
+Diagnostic: subtract_background route in the striping step (GP estimator).
+
+For a cluster exposure (real ICL present), sweep the fit_sky background box
+size and show, per box:
+  (a) before        — pedestal-subtracted cal-stage input (ICL + 1/f + sources)
+  (b) source mask   — SRCMASK overlaid (is the diffuse ICL masked?)
+  (c) bg model      — the 2D background fit_sky removes from the *fit* copy
+  (d) after         — GP-corrected output (data - horizontal - vertical)
+
+The bg-sub is fit-only: the model (c) is subtracted from the working copy that
+feeds the per-amp-row/per-column 1/f medians, NOT from the output (d). So (c)
+shows how much large-scale structure each box pulls out of the 1/f fit; (d)
+shows the resulting correction quality (amp steps appear if too much ICL is
+left in the fit). The annotation reports the residual amp-boundary step in (d).
+"""
+import os
+import numpy as np
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from astropy.io import fits
+
+from campfire_pipeline.config import load_config, get_nircam_step_config
+from campfire_pipeline.nircam.field import Field
+from campfire_pipeline.nircam.constants import NIR_AMPS
+from campfire_pipeline.nircam.skyfit import fit_sky, fit_sky_tot
+from campfire_pipeline.nircam.steps.striping import (
+    _build_srcmask, _resolve_gp_params, fit_residual_striping,
+)
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+# (box_size, filter_size) configs to sweep. filter_size must be odd.
+CONFIGS = [(16, 1), (16, 3), (16, 5), (16, 7)]
+ROOT = 'jw06882025001_04101_00002_nrcalong'
+
+
+def amp_boundary_step(img, mask):
+    bl = mask
+    cp = np.array([np.nanmedian(np.where(bl[:, c], img[:, c], np.nan))
+                   if bl[:, c].sum() > 30 else np.nan for c in range(img.shape[1])])
+    return max(abs(np.nanmedian(cp[b - 40:b]) - np.nanmedian(cp[b:b + 40]))
+               for b in (512, 1024, 1536))
+
+
+def main():
+    from jwst.datamodels import ImageModel, dqflags
+    cfg = load_config()
+    field = Field.load('rj0911_gp')
+    gp_params = _resolve_gp_params(
+        get_nircam_step_config('striping', cfg, field).get('gp', {}),
+        ImageModel(os.path.join(HERE, 'prestriping', ROOT + '.fits')))
+
+    m = ImageModel(os.path.join(HERE, 'prestriping', ROOT + '.fits'))
+    seg = _build_srcmask(m).astype(bool)
+    dq = m.dq
+    data = m.data.astype(np.float64, copy=True)
+    m.close()
+    mask = (np.bitwise_and(dq, dqflags.pixel['DO_NOT_USE']) != 0) | seg
+    blank = ~mask & np.isfinite(data)
+    ped = float(fit_sky_tot(data[blank].flatten()))
+    base = data - ped  # pedestal-subtracted input
+
+    # blank for amp-step metric (exclude ref border)
+    bl = blank.copy(); bl[:4] = bl[-4:] = False; bl[:, :4] = bl[:, -4:] = False
+
+    vmin, vmax = -0.02, 0.04   # stretch that reveals the diffuse ICL
+    # High-res for inspection: ~7in/panel * 200 dpi ~ 1400 px/panel.
+    fig, axes = plt.subplots(len(CONFIGS), 4, figsize=(28, 7 * len(CONFIGS)))
+    col_titles = ['(a) before (ped-sub)', '(b) SRCMASK overlay',
+                  '(c) 2D bg model (removed from fit)', '(d) after (GP)']
+    for r, (box, filt) in enumerate(CONFIGS):
+        bg_in = base.copy(); bg_in[mask] = 0
+        bg = fit_sky(bg_in, box_size=box, filter_size=filt)
+        fitdata = base - bg
+        h, v, _ = fit_residual_striping(fitdata, mask, 3,
+                                        estimator='gp', gp_params=gp_params)
+        after = base - h - v
+        step = amp_boundary_step(after, bl)
+        icl_in_bg = np.nanstd(bg[bl])  # how much large-scale the box pulled out
+
+        panels = [base, base, bg, after]
+        for c, (ax, img, title) in enumerate(zip(axes[r], panels, col_titles)):
+            ax.imshow(img, origin='lower', cmap='Greys_r', vmin=vmin, vmax=vmax,
+                      interpolation='nearest')
+            if c == 1:  # overlay SRCMASK in red
+                ov = np.zeros((*seg.shape, 4)); ov[seg] = [1, 0, 0, 0.35]
+                ax.imshow(ov, origin='lower', interpolation='nearest')
+            ax.set_xticks([]); ax.set_yticks([])
+            if r == 0:
+                ax.set_title(title, fontsize=14)
+        axes[r, 0].set_ylabel(
+            f'box={box} filt={filt}\n(eff~{box*filt}px)\n'
+            f'ampstep={step:.2e}\nbgσ={icl_in_bg:.2e}', fontsize=13)
+    fig.suptitle(f'striping bg-sub filter_size sweep at box=16 (GP) — {ROOT}',
+                 fontsize=15)
+    fig.tight_layout()
+    out = os.path.join(HERE, 'figs', f'bgsub_filtsweep_{ROOT}.png')
+    fig.savefig(out, dpi=200)
+    print('saved', out)
+
+
+if __name__ == '__main__':
+    main()

--- a/pipeline/experiments/oneoverf_gp/rho_scan.py
+++ b/pipeline/experiments/oneoverf_gp/rho_scan.py
@@ -1,0 +1,83 @@
+"""
+Diagnostic: rho-sensitivity of the GP estimator + amp-to-amp offset scale.
+
+Runs the GP per-amp-row estimator directly on a pre-striping snapshot frame
+(rate stage; flat ~ 1, so a faithful stand-in for the estimator input) for a
+range of length scales rho, and reports the residual amp-row-median scatter
+split into clean vs source-covered rows. Also reports the amp-to-amp DC
+offset spread — the quantity the median's full-row fallback gets wrong, and
+the GP's whole reason to exist. If that spread is small (LW), the fallback
+is nearly right and the GP has little to gain.
+"""
+import glob
+import os
+import sys
+
+import numpy as np
+from astropy.stats import mad_std
+
+from campfire_pipeline.nircam.constants import NIR_AMPS
+from campfire_pipeline.nircam.gp_striping import gp_amprow_offsets
+from campfire_pipeline.nircam.steps.striping import (
+    _build_srcmask, _median_amprow_offsets,
+)
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _residual_split(data, horizontal, blank, seg, clean_frac=0.2, src_frac=0.4):
+    clean, source = [], []
+    for amp in ('A', 'B', 'C', 'D'):
+        _, _, c0, c1 = NIR_AMPS[amp]['data']
+        res = (data - horizontal)[:, c0:c1].copy()
+        res[~blank[:, c0:c1]] = np.nan
+        with np.errstate(invalid='ignore'):
+            rm = np.nanmedian(res, axis=1)
+        rm = rm - np.nanmedian(rm)
+        sf = seg[:, c0:c1].mean(axis=1)
+        clean.append(rm[np.isfinite(rm) & (sf < clean_frac)])
+        source.append(rm[np.isfinite(rm) & (sf > src_frac)])
+    cv, sv = np.concatenate(clean), np.concatenate(source)
+    return float(mad_std(cv)), float(mad_std(sv)), cv.size, sv.size
+
+
+def main():
+    path = (sys.argv[1] if len(sys.argv) > 1 else
+            sorted(glob.glob(os.path.join(HERE, 'prestriping', '*00004_nrcalong.fits')))[0])
+    from jwst.datamodels import ImageModel, dqflags
+    m = ImageModel(path, memmap=False)
+    data = m.data.astype(np.float64)
+    seg = _build_srcmask(m).astype(bool)
+    mask = (np.bitwise_and(m.dq, dqflags.pixel['DO_NOT_USE']) != 0) | seg
+    m.close()
+    data = data - np.median(data[np.isfinite(data) & ~mask])  # pedestal
+
+    blank = np.isfinite(data) & ~mask
+    print(f'frame: {os.path.basename(path)}')
+
+    # Amp-to-amp DC offset spread (clean rows only).
+    dcs = []
+    for amp in ('A', 'B', 'C', 'D'):
+        _, _, c0, c1 = NIR_AMPS[amp]['data']
+        sub = data[:, c0:c1][blank[:, c0:c1]]
+        dcs.append(np.median(sub))
+    dcs = np.array(dcs)
+    sky = mad_std(data[blank])
+    ptp = float(np.ptp(dcs))
+    print(f'amp DC offsets (A,B,C,D) = {np.round(dcs, 5)}  '
+          f'peak-to-peak = {ptp:.5e}  (per-pixel sky scatter = {sky:.5e})')
+    print(f'amp-to-amp offset / sky-noise = {ptp / sky:.2f}')
+
+    # Median estimator reference.
+    h_med, _ = _median_amprow_offsets(data, mask, 3, 0.1, 0.20)
+    cm, sm, nc, ns = _residual_split(data, h_med, blank, seg)
+    print(f'\n{"estimator":>16} {"clean":>11} {"source":>11}')
+    print(f'{"median":>16} {cm:11.4e} {sm:11.4e}   (n_clean={nc}, n_source={ns})')
+    for rho in (5.0, 10.0, 20.0, 40.0, 62.3, 120.0):
+        h_gp, _ = gp_amprow_offsets(data, mask, kernel_sigma=0.0636, rho=rho)
+        cg, sg, _, _ = _residual_split(data, h_gp, blank, seg)
+        print(f'{"gp rho=%.0f" % rho:>16} {cg:11.4e} {sg:11.4e}')
+
+
+if __name__ == '__main__':
+    main()

--- a/pipeline/experiments/oneoverf_gp/run_arms_cfn.sh
+++ b/pipeline/experiments/oneoverf_gp/run_arms_cfn.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# clean_flicker_noise (cfn) matrix, full pipeline from uncal (cfn changes
+# detector1, so the post-image2 prestriping snapshot cannot be reused).
+#   rj0911_cfn       cfn median  + striping estimator=none  (cfn standalone)
+#   rj0911_cfngp     cfn median  + striping estimator=gp    (cfn + GP cleanup)
+#   rj0911_cfnfft    cfn fft     + striping estimator=none  (cfn standalone)
+#   rj0911_cfnfftgp  cfn fft     + striping estimator=gp    (cfn + GP cleanup)
+# Each writes to its own products/reference tree; astrom_cats symlinked to
+# rj0911's so astrometry is held constant across all arms.
+set -euo pipefail
+FILT=f444w
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LOG="$HERE/logs"; mkdir -p "$LOG"
+
+for arm in rj0911_cfn rj0911_cfngp rj0911_cfnfft rj0911_cfnfftgp; do
+    echo "=== running $arm ($(date +%H:%M:%S)) ==="
+    /usr/bin/time -p cfpipe nircam run --field "$arm" --filters "$FILT" \
+        -p 8 --all > "$LOG/${arm}.log" 2>&1
+    echo "    done $arm ($(date +%H:%M:%S))"
+done
+echo "=== CFN MATRIX DONE $(date +%H:%M:%S) ==="

--- a/pipeline/experiments/oneoverf_gp/run_arms_medgp.sh
+++ b/pipeline/experiments/oneoverf_gp/run_arms_medgp.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Re-run the median + gp arms from the cal-stage pre-striping snapshot
+# (cal-frame ordering, bg-sub on, box=32/filter=3). gp_aggr skipped.
+set -euo pipefail
+ROOT="${CAMPFIRE_ROOT:?}"
+FILT=f444w
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SNAP="$HERE/prestriping"
+LOG="$HERE/logs"; mkdir -p "$LOG"
+
+for arm in rj0911_med rj0911_gp; do
+    dest="$ROOT/products/nircam/$arm/$FILT"; mkdir -p "$dest"
+    cp "$SNAP"/*long.fits "$dest"/
+    echo "=== running $arm ($(date +%H:%M:%S)) ==="
+    /usr/bin/time -p cfpipe nircam run --field "$arm" --filters "$FILT" \
+        -p 8 --all > "$LOG/${arm}.log" 2>&1
+    echo "    done $arm"
+done
+echo "=== MED+GP ARMS DONE $(date +%H:%M:%S) ==="

--- a/pipeline/experiments/oneoverf_gp/run_arms_v3.sh
+++ b/pipeline/experiments/oneoverf_gp/run_arms_v3.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Re-run all three arms from the cal-stage pre-striping snapshot (cal-frame
+# ordering, subtract_background=true). Seeds every arm tree from the snapshot
+# so striping re-runs identically-fed, then runs each to mosaic.
+set -euo pipefail
+ROOT="${CAMPFIRE_ROOT:?}"
+FILT=f444w
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SNAP="$HERE/prestriping"
+LOG="$HERE/logs"; mkdir -p "$LOG"
+
+for arm in rj0911_med rj0911_gp rj0911_gpa; do
+    dest="$ROOT/products/nircam/$arm/$FILT"; mkdir -p "$dest"
+    cp "$SNAP"/*long.fits "$dest"/
+    echo "=== running $arm ($(date +%H:%M:%S)) ==="
+    /usr/bin/time -p cfpipe nircam run --field "$arm" --filters "$FILT" \
+        -p 8 --all > "$LOG/${arm}.log" 2>&1
+    echo "    done $arm"
+done
+echo "=== ALL ARMS DONE $(date +%H:%M:%S) ==="

--- a/pipeline/experiments/oneoverf_gp/run_rho_frontend.sh
+++ b/pipeline/experiments/oneoverf_gp/run_rho_frontend.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Generate PRE-striping snapshots (detector1 -> persistence -> wisp -> image2,
+# STOP before striping) for the rho cross-filter consistency check. Args =
+# filters to process on the rj0911_rho clone field.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LOG="$HERE/logs"; mkdir -p "$LOG"
+FIELD=rj0911_rho
+
+for filt in "$@"; do
+    echo "=== $filt front-end ($(date +%H:%M:%S)) ==="
+    for step in detector1 persistence wisp image2; do
+        cfpipe nircam "$step" --field "$FIELD" --filters "$filt" -p 8 \
+            >> "$LOG/rho_${filt}.log" 2>&1
+        echo "    $step done"
+    done
+done
+echo "=== RHO FRONT-END DONE $(date +%H:%M:%S) ==="

--- a/pipeline/experiments/oneoverf_gp/scan_fitframe.py
+++ b/pipeline/experiments/oneoverf_gp/scan_fitframe.py
@@ -1,0 +1,97 @@
+"""
+Pipeline-faithful (kernel_sigma, rho) scan for the GP striping estimator.
+
+Reproduces striping_step's fit input exactly on one pre-striping exposure
+(flat-field copy -> pedestal -> 2D background), then sweeps the GP
+hyperparameters in memory, measuring the residual amp-row-median scatter
+(clean vs source-covered rows) the same way analyze_ab does. Avoids 10-min
+full-pipeline re-runs per hyperparameter. The residual is measured on the
+fit frame; the downstream flat re-division / sky pedestal are common-mode
+across estimators, so the *ranking* matches the final cal-frame A/B.
+"""
+import glob
+import os
+import sys
+
+import numpy as np
+from astropy.stats import mad_std
+
+from campfire_pipeline.config import load_config
+from campfire_pipeline.nircam.constants import NIR_AMPS
+from campfire_pipeline.nircam.field import Field
+from campfire_pipeline.nircam.gp_striping import gp_amprow_offsets
+from campfire_pipeline.nircam.skyfit import collapse_image, fit_pedestal, fit_sky
+from campfire_pipeline.nircam.steps.striping import (
+    _build_srcmask, _median_amprow_offsets,
+)
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def build_fit_frame(path, field):
+    """Replicate striping_step's fit input: flat, pedestal, 2D background."""
+    from jwst.datamodels import ImageModel, dqflags
+    from campfire_pipeline.nircam.steps._flat import (
+        apply_flat_with_retry, resolve_flat,
+    )
+    model = ImageModel(path)
+    seg = _build_srcmask(model)
+    fit = model.copy()
+    flatfile = resolve_flat(fit, field, False)
+    fit = apply_flat_with_retry(fit, flatfile)
+    mask = (np.bitwise_and(fit.dq, dqflags.pixel['DO_NOT_USE']) != 0) | (seg > 0)
+    ped = float(fit_pedestal(fit.data[~mask].flatten()))
+    fit.data -= ped
+    bg_in = fit.data.copy(); bg_in[mask] = 0
+    fit.data -= fit_sky(bg_in)
+    data = fit.data.astype(np.float64).copy()
+    model.close(); fit.close()
+    return data, mask, seg.astype(bool)
+
+
+def residual_split(data, horizontal, mask, seg, clean_f=0.2, src_f=0.4):
+    blank = ~mask
+    cv, sv = [], []
+    for amp in ('A', 'B', 'C', 'D'):
+        _, _, c0, c1 = NIR_AMPS[amp]['data']
+        res = (data - horizontal)[:, c0:c1].copy()
+        res[~blank[:, c0:c1]] = np.nan
+        with np.errstate(invalid='ignore'):
+            rm = np.nanmedian(res, axis=1)
+        rm = rm - np.nanmedian(rm)
+        sf = seg[:, c0:c1].mean(axis=1)
+        cv.append(rm[np.isfinite(rm) & (sf < clean_f)])
+        sv.append(rm[np.isfinite(rm) & (sf > src_f)])
+    cv, sv = np.concatenate(cv), np.concatenate(sv)
+    return float(mad_std(cv)), float(mad_std(sv))
+
+
+def with_vertical(data, horizontal, mask):
+    """Apply the (unchanged) vertical step so the residual matches pipeline."""
+    v1d = collapse_image(data - horizontal, mask, 3, dimension='x')
+    return horizontal + np.broadcast_to(v1d, data.shape)
+
+
+def main():
+    path = (sys.argv[1] if len(sys.argv) > 1 else
+            sorted(glob.glob(os.path.join(HERE, 'prestriping', '*00004_nrcalong.fits')))[0])
+    load_config()
+    field = Field.load('rj0911_med')
+    print(f'building fit frame from {os.path.basename(path)} ...')
+    data, mask, seg = build_fit_frame(path, field)
+
+    h_med, _ = _median_amprow_offsets(data, mask, 3, 0.1, 0.20)
+    cm, sm = residual_split(data, with_vertical(data, h_med, mask), mask, seg)
+    print(f'\n{"config":>26} {"clean":>11} {"source":>11}')
+    print(f'{"median (control)":>26} {cm:11.4e} {sm:11.4e}')
+    for ksig in (0.0057, 0.02, 0.0636, 0.2):
+        for rho in (4.0, 6.0, 10.0, 20.0):
+            h, _ = gp_amprow_offsets(data, mask, kernel_sigma=ksig, rho=rho)
+            cg, sg = residual_split(data, with_vertical(data, h, mask), mask, seg)
+            flag = '  <-- beats median both' if (cg < cm and sg < sm) else ''
+            print(f'{"gp ks=%.4g rho=%g" % (ksig, rho):>26} '
+                  f'{cg:11.4e} {sg:11.4e}{flag}')
+
+
+if __name__ == '__main__':
+    main()

--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "snowblind",
     "shapely",
     "photutils>=1.13",
+    "celerite2>=0.2",  # CPU O(n) 1-D GP for the NIRCam striping estimator="gp" path
     "regions>=0.6",
     "tomlkit>=0.13",
     "JWST_FOV_plotter>=0.4",

--- a/pipeline/scripts/calibrate_gp_striping.py
+++ b/pipeline/scripts/calibrate_gp_striping.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python
+"""
+Calibrate frozen SHOTerm hyperparameters for the GP 1/f striping estimator.
+
+The GP estimator (``[nircam.striping].estimator = "gp"``) must NOT optimize
+its hyperparameters per exposure — that turns a deterministic linear solve
+into an optimization loop and invites overfitting. Instead we calibrate
+``kernel_sigma`` (amplitude) and ``rho`` (length scale, in rows) ONCE on a
+representative set of clean exposures and freeze the result in
+``config_default.toml`` (split by detector channel, SW vs LW, because the
+1/f amplitude and correlation length differ).
+
+Method
+------
+For each exposure and each amplifier we form the per-amp-row sequence
+``y_r`` (sigma-clipped background median) with sampling error ``sigma_r``
+on the *clean* rows only (source-masked rows are excluded — we want the
+true 1/f, not source flux). After removing the per-amp DC level, every
+(exposure, amp) sequence is an independent realization of the same GP. We
+maximize the **pooled** Gaussian-process marginal likelihood (sum of the
+per-sequence celerite2 log-likelihoods with a shared kernel) over
+``(log kernel_sigma, log rho)`` with ``Q = 1/sqrt(2)`` fixed.
+
+Usage
+-----
+    conda run -n campfire python scripts/calibrate_gp_striping.py \
+        --field rj0911 --filter f444w
+
+    # or point at explicit canonical exposure files
+    conda run -n campfire python scripts/calibrate_gp_striping.py FILE [FILE ...]
+
+Prints the calibrated ``kernel_sigma`` / ``rho`` for the channel(s) found and
+the config block to paste into ``[nircam.striping.gp]``.
+"""
+
+import argparse
+import glob
+import os
+import sys
+
+import numpy as np
+from astropy.stats import mad_std
+from scipy.optimize import minimize
+
+from campfire_pipeline.nircam.constants import NIR_AMPS
+from campfire_pipeline.nircam.gp_striping import (
+    _MEDIAN_SE_FACTOR,
+    _REF_BORDER,
+    _amprow_statistics,
+)
+
+Q_FIXED = 1.0 / np.sqrt(2.0)
+
+
+def _exposure_sequences(exposure_file, sigma_clip_sigma=2.0, maxiters=3,
+                        max_mask_frac=0.30, detrend_scale=151):
+    """Per-amp (rows, y_centered, yerr) sequences from one canonical exposure.
+
+    Builds the source mask the same way the striping step does, subtracts a
+    global pedestal, then for each amp keeps only *clean* rows (mask fraction
+    below ``max_mask_frac``) and **high-pass detrends** the per-amp-row
+    medians (subtract a ``detrend_scale``-row running median) before
+    returning them. Detrending is essential: without it, a single SHOTerm
+    fit absorbs large-scale sky/background structure into a long ``rho`` and
+    the resulting GP over-smooths the genuine high-frequency row-to-row 1/f
+    (verified — raw fit gives rho~60, detrended ~10, and the rho-scan on
+    real data minimizes residual striping near the detrended value). The
+    estimator removes large scales via its 2D-background step, so the kernel
+    should describe only the residual 1/f. Returns ``(channel, seqs)`` where
+    ``seqs`` is a list of ``(rows, y, yerr)`` arrays.
+    """
+    from scipy.ndimage import median_filter
+    from jwst.datamodels import ImageModel, dqflags
+    from campfire_pipeline.nircam.steps.striping import _build_srcmask
+
+    model = ImageModel(exposure_file, memmap=False)
+    channel = (getattr(model.meta.instrument, 'channel', None) or '').upper()
+    channel = 'sw' if channel == 'SHORT' else 'lw'
+
+    data = model.data.astype(np.float64)
+    seg = _build_srcmask(model)
+    mask = (np.bitwise_and(model.dq, dqflags.pixel['DO_NOT_USE']) != 0)
+    mask[seg > 0] = True
+    model.close()
+
+    # Remove a global pedestal so the per-amp DC subtraction below is small.
+    finite = np.isfinite(data) & ~mask
+    data = data - np.median(data[finite])
+
+    n_rows = data.shape[0]
+    sci = slice(_REF_BORDER, n_rows - _REF_BORDER)
+    rows_sci = np.arange(n_rows)[sci]
+
+    seqs = []
+    for amp in ('A', 'B', 'C', 'D'):
+        _, _, c0, c1 = NIR_AMPS[amp]['data']
+        y_r, s_hat, n_r = _amprow_statistics(
+            data[sci, c0:c1], mask[sci, c0:c1], sigma_clip_sigma, maxiters)
+        width = c1 - c0
+        # Keep only rows whose source-mask fraction is below max_mask_frac,
+        # i.e. enough surviving pixels to measure the true 1/f cleanly.
+        clean = (n_r >= (1.0 - max_mask_frac) * width) \
+            & np.isfinite(y_r) & np.isfinite(s_hat) & (s_hat > 0)
+        if clean.sum() < 50:
+            continue
+        # High-pass detrend: interpolate y_r over masked gaps, subtract a
+        # wide running median (large-scale sky/background), keep clean rows.
+        # The detrended sequence is used to fit RHO (the genuine 1/f
+        # correlation length). The raw (un-detrended) centered sequence
+        # gives KERNEL_SIGMA (the marginal amplitude) — see main() for why
+        # the two come from different quantities.
+        idx = np.arange(y_r.size)
+        y_full = np.interp(idx, idx[clean], y_r[clean])
+        trend = median_filter(y_full, size=detrend_scale, mode='nearest')
+        y_hp = (y_full - trend)[clean]
+        y_raw = y_r[clean] - np.median(y_r[clean])
+        yerr = _MEDIAN_SE_FACTOR * s_hat[clean] / np.sqrt(n_r[clean])
+        seqs.append((rows_sci[clean].astype(np.float64), y_hp, yerr, y_raw))
+    return channel, seqs
+
+
+def _neg_log_like(theta, seqs):
+    """Pooled negative GP log marginal likelihood at ``theta=(logσ, logρ)``."""
+    import celerite2
+    from celerite2 import terms
+
+    kernel_sigma, rho = np.exp(theta)
+    kernel = terms.SHOTerm(sigma=kernel_sigma, rho=rho, Q=Q_FIXED)
+    total = 0.0
+    for rows, y, yerr, _ in seqs:
+        gp = celerite2.GaussianProcess(kernel, mean=0.0)
+        try:
+            gp.compute(rows, yerr=yerr)
+            total += gp.log_likelihood(y)
+        except Exception:
+            return 1e30
+    return -total
+
+
+def calibrate(seqs, sigma0, rho0):
+    """Maximize the pooled marginal likelihood; return (kernel_sigma, rho)."""
+    theta0 = np.log([sigma0, rho0])
+    res = minimize(_neg_log_like, theta0, args=(seqs,), method='Nelder-Mead',
+                   options={'xatol': 1e-3, 'fatol': 1e-2, 'maxiter': 400})
+    sigma, rho = np.exp(res.x)
+    return float(sigma), float(rho), res
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('files', nargs='*', help='canonical exposure FITS files')
+    ap.add_argument('--field', help='field name (with --filter)')
+    ap.add_argument('--filter', dest='filt', help='filter name (with --field)')
+    ap.add_argument('--root', default=os.environ.get('CAMPFIRE_ROOT', '.'),
+                    help='CAMPFIRE_ROOT (default $CAMPFIRE_ROOT)')
+    args = ap.parse_args(argv)
+
+    files = list(args.files)
+    if args.field and args.filt:
+        pat = os.path.join(args.root, 'products', 'nircam', args.field,
+                           args.filt, '*long.fits')
+        pat_sw = os.path.join(args.root, 'products', 'nircam', args.field,
+                              args.filt, '*nrc[ab][1-4].fits')
+        files += sorted(glob.glob(pat)) + sorted(glob.glob(pat_sw))
+    if not files:
+        ap.error('no exposures: pass files or --field/--filter')
+
+    by_channel = {'sw': [], 'lw': []}
+    for f in files:
+        channel, seqs = _exposure_sequences(f)
+        by_channel[channel].extend(seqs)
+        print(f'  {os.path.basename(f)}: channel={channel}, '
+              f'{len(seqs)} clean amp sequences')
+
+    print()
+    block = ['    [nircam.striping.gp]']
+    for channel in ('lw', 'sw'):
+        seqs = by_channel[channel]
+        if not seqs:
+            continue
+        # rho: detrended-MLE correlation length of the high-frequency 1/f.
+        sigma0 = float(np.sqrt(np.mean(np.concatenate([y for _, y, _, _ in seqs]) ** 2)))
+        _, rho, res = calibrate(seqs, max(sigma0, 1e-4), 8.0)
+        # kernel_sigma: the *raw* marginal amplitude (mad_std of the
+        # un-detrended, per-amp-centered row medians). It must be >> the
+        # per-row sampling error so the GP trusts each clean row's data
+        # (posterior ~ per-row median there) and only smooths/interpolates
+        # at the rho scale. The detrended-MLE amplitude is the high-pass
+        # residual only — far too small, and using it makes the GP
+        # over-regularize and lose to the plain per-row median (verified
+        # with experiments/oneoverf_gp/scan_fitframe.py).
+        raw = np.concatenate([yr for _, _, _, yr in seqs])
+        kernel_sigma = float(mad_std(raw))
+        print(f'channel {channel.upper()}: {len(seqs)} sequences  ->  '
+              f'kernel_sigma={kernel_sigma:.5e} (raw marginal)  '
+              f'rho={rho:.3f} (detrended MLE, converged={res.success})')
+        block.append(f'        kernel_sigma_{channel} = {kernel_sigma:.6e}')
+        block.append(f'        rho_{channel} = {rho:.4f}')
+
+    print('\nPaste into config_default.toml:')
+    print('\n'.join(block))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/pipeline/scripts/calibrate_gp_striping.py
+++ b/pipeline/scripts/calibrate_gp_striping.py
@@ -1,25 +1,34 @@
 #!/usr/bin/env python
 """
-Calibrate frozen SHOTerm hyperparameters for the GP 1/f striping estimator.
+Calibrate the frozen ``rho`` hyperparameter for the GP 1/f striping estimator.
 
-The GP estimator (``[nircam.striping].estimator = "gp"``) must NOT optimize
-its hyperparameters per exposure — that turns a deterministic linear solve
-into an optimization loop and invites overfitting. Instead we calibrate
-``kernel_sigma`` (amplitude) and ``rho`` (length scale, in rows) ONCE on a
-representative set of clean exposures and freeze the result in
-``config_default.toml`` (split by detector channel, SW vs LW, because the
-1/f amplitude and correlation length differ).
+``rho`` (the SHOTerm length scale, in rows) is the ONLY frozen GP
+hyperparameter: it is a detector readout/clocking property — independent of
+filter and of flux units — so it is calibrated once per detector channel
+(SW vs LW) and frozen in ``config_default.toml``. The kernel amplitude is
+NOT frozen; it self-adapts per exposure inside ``gp_amprow_offsets`` (the
+marginal ``mad_std`` of the clean per-amp-row medians, a deterministic robust
+statistic — not a per-exposure fit). This script reports ``rho`` as the value
+to paste, and the marginal amplitude only as a sanity check (it should sit
+comfortably above the per-row sampling error).
+
+Neither value is optimized per exposure in the pipeline — that would turn a
+deterministic linear solve into an optimization loop and invite overfitting.
 
 Method
 ------
 For each exposure and each amplifier we form the per-amp-row sequence
 ``y_r`` (sigma-clipped background median) with sampling error ``sigma_r``
 on the *clean* rows only (source-masked rows are excluded — we want the
-true 1/f, not source flux). After removing the per-amp DC level, every
+true 1/f, not source flux). After removing the per-amp DC level and a wide
+running median (high-pass, to strip large-scale sky/ICL), every
 (exposure, amp) sequence is an independent realization of the same GP. We
 maximize the **pooled** Gaussian-process marginal likelihood (sum of the
 per-sequence celerite2 log-likelihoods with a shared kernel) over
-``(log kernel_sigma, log rho)`` with ``Q = 1/sqrt(2)`` fixed.
+``(log kernel_sigma, log rho)`` with ``Q = 1/sqrt(2)`` fixed, and read
+``rho`` off the result. (The MLE amplitude is the high-pass residual only and
+is NOT used by the pipeline; the self-adapting amplitude is the raw marginal
+``mad_std``, printed here for reference.)
 
 Usage
 -----
@@ -29,8 +38,8 @@ Usage
     # or point at explicit canonical exposure files
     conda run -n campfire python scripts/calibrate_gp_striping.py FILE [FILE ...]
 
-Prints the calibrated ``kernel_sigma`` / ``rho`` for the channel(s) found and
-the config block to paste into ``[nircam.striping.gp]``.
+Prints the calibrated ``rho`` per channel and the config block to paste into
+``[nircam.striping.gp]``, plus the self-adapting amplitude scale for sanity.
 """
 
 import argparse
@@ -181,23 +190,26 @@ def main(argv=None):
         # rho: detrended-MLE correlation length of the high-frequency 1/f.
         sigma0 = float(np.sqrt(np.mean(np.concatenate([y for _, y, _, _ in seqs]) ** 2)))
         _, rho, res = calibrate(seqs, max(sigma0, 1e-4), 8.0)
-        # kernel_sigma: the *raw* marginal amplitude (mad_std of the
-        # un-detrended, per-amp-centered row medians). It must be >> the
-        # per-row sampling error so the GP trusts each clean row's data
-        # (posterior ~ per-row median there) and only smooths/interpolates
-        # at the rho scale. The detrended-MLE amplitude is the high-pass
-        # residual only — far too small, and using it makes the GP
-        # over-regularize and lose to the plain per-row median (verified
-        # with experiments/oneoverf_gp/scan_fitframe.py).
+        # Sanity-check amplitudes (NOT frozen — the pipeline self-adapts the
+        # amplitude per exposure to this raw marginal mad_std). Report it
+        # alongside the median per-row sampling error so the operator can
+        # confirm the self-adapting amplitude will sit comfortably above the
+        # noise (the regime where the GP trusts clean rows and only
+        # interpolates at the rho scale).
         raw = np.concatenate([yr for _, _, _, yr in seqs])
         kernel_sigma = float(mad_std(raw))
+        yerr_med = float(np.nanmedian(np.concatenate(
+            [ye for _, _, ye, _ in seqs])))
         print(f'channel {channel.upper()}: {len(seqs)} sequences  ->  '
-              f'kernel_sigma={kernel_sigma:.5e} (raw marginal)  '
-              f'rho={rho:.3f} (detrended MLE, converged={res.success})')
-        block.append(f'        kernel_sigma_{channel} = {kernel_sigma:.6e}')
+              f'rho={rho:.3f} (detrended MLE, converged={res.success});  '
+              f'self-adapt amplitude ~{kernel_sigma:.3e} '
+              f'(>> median sigma_r {yerr_med:.3e}: '
+              f'{kernel_sigma / yerr_med:.0f}x)')
         block.append(f'        rho_{channel} = {rho:.4f}')
 
-    print('\nPaste into config_default.toml:')
+    block.append('        kernel_sigma_factor = 1.0')
+    print('\nPaste into config_default.toml (rho is the only frozen value; '
+          'the amplitude self-adapts per exposure):')
     print('\n'.join(block))
     return 0
 

--- a/pipeline/tests/test_nircam_diag_striping.py
+++ b/pipeline/tests/test_nircam_diag_striping.py
@@ -148,7 +148,7 @@ def test_residual_helper_composes_with_diagonal():
     )
     after_diag = data - diag_model
 
-    h, v, _ = fit_residual_striping(after_diag, mask, maxiters=3)
+    h, v, _, _ = fit_residual_striping(after_diag, mask, maxiters=3)
     cleaned = after_diag - h - v
 
     noise_sigma = 0.02

--- a/pipeline/tests/test_nircam_gp_striping.py
+++ b/pipeline/tests/test_nircam_gp_striping.py
@@ -83,7 +83,8 @@ def test_gp_recovers_clean_offset_and_preserves_dc():
     rng = np.random.default_rng(1)
     data, truth = _planted_frame(rng)
     mask = np.zeros(SHAPE, bool)
-    horizontal, diag = gp_amprow_offsets(data, mask, kernel_sigma=0.02, rho=80.0)
+    horizontal, diag, ks_eff = gp_amprow_offsets(
+        data, mask, rho=80.0, kernel_sigma=0.02)
     clean = np.arange(200, 400)
     for amp, dc in AMP_DC.items():
         # Smoothing beats the per-row noise floor (0.02) substantially.
@@ -92,6 +93,31 @@ def test_gp_recovers_clean_offset_and_preserves_dc():
         _, _, c0, _ = NIR_AMPS[amp]['data']
         assert abs(np.median(horizontal[clean, c0]) - np.median(truth[clean, c0])) < 0.01
     assert len(diag) == 4
+    assert ks_eff == 0.02  # explicit override echoed back
+
+
+def test_gp_self_adapting_amplitude():
+    """With kernel_sigma=None the amplitude self-adapts to the exposure.
+
+    It should land near the marginal scatter of the per-amp-row offset
+    (~0.008 for the planted frame), sit well above the per-row sampling
+    error, and still recover the smooth offset on clean rows.
+    """
+    rng = np.random.default_rng(11)
+    data, truth = _planted_frame(rng)
+    mask = np.zeros(SHAPE, bool)
+    horizontal, _, ks_eff = gp_amprow_offsets(data, mask, rho=80.0)
+    # Self-adapted to the true 1/f marginal amplitude (not the 0.02 noise,
+    # not a frozen absolute) — within a factor of ~2 of the planted ~0.008.
+    assert 0.004 < ks_eff < 0.02
+    # Still recovers the offset on clean rows.
+    clean = np.arange(200, 400)
+    for amp in AMP_DC:
+        assert _amp_rms(horizontal, truth, amp, clean) < 0.012
+    # Frozen O(1) factor scales it linearly.
+    _, _, ks_2x = gp_amprow_offsets(data, mask, rho=80.0,
+                                    kernel_sigma_factor=2.0)
+    assert abs(ks_2x - 2.0 * ks_eff) < 1e-6 * max(ks_2x, 1.0)
 
 
 def test_gp_interpolates_across_source_gap_better_than_median():
@@ -104,7 +130,7 @@ def test_gp_interpolates_across_source_gap_better_than_median():
     data[900:1000, c0 + 80:c0 + 380] += 5.0
     mask[880:1020, c0 + 60:c0 + 400] = True
 
-    h_gp, _ = gp_amprow_offsets(data, mask, kernel_sigma=0.02, rho=80.0)
+    h_gp, _, _ = gp_amprow_offsets(data, mask, rho=80.0, kernel_sigma=0.02)
     h_med, _ = _median_amprow_offsets(data, mask, 3, 0.1, 0.20)
 
     gap = np.arange(900, 1000)
@@ -128,8 +154,8 @@ def test_gp_flags_wide_anchorless_gap():
     # no anchor within a length scale: the GP must revert toward DC with
     # inflated posterior variance and flag those rows weak.
     mask[400:1600, c0:c1] = True
-    _, diag = gp_amprow_offsets(data, mask, kernel_sigma=0.02, rho=60.0,
-                                weak_frac=0.5)
+    _, diag, _ = gp_amprow_offsets(data, mask, rho=60.0, kernel_sigma=0.02,
+                                   weak_frac=0.5)
     # diag format: 'C:anchors/weak/maxσ'
     c_entry = [d for d in diag if d.startswith('C:')][0]
     n_weak = int(c_entry.split(':')[1].split('/')[1])
@@ -140,7 +166,7 @@ def test_gp_full_frame_output_including_reference_rows():
     rng = np.random.default_rng(4)
     data, _ = _planted_frame(rng)
     mask = np.zeros(SHAPE, bool)
-    horizontal, _ = gp_amprow_offsets(data, mask, kernel_sigma=0.02, rho=80.0)
+    horizontal, _, _ = gp_amprow_offsets(data, mask, rho=80.0, kernel_sigma=0.02)
     assert horizontal.shape == SHAPE
     # Reference-border rows (0-3, 2044-2047) get an extrapolated, finite
     # offset even though they're excluded from the fit.
@@ -153,10 +179,11 @@ def test_median_estimator_path_unchanged():
     rng = np.random.default_rng(5)
     data, _ = _planted_frame(rng)
     mask = np.zeros(SHAPE, bool)
-    h1, v1, amp1 = fit_residual_striping(data, mask, 3)
+    h1, v1, amp1, diag1 = fit_residual_striping(data, mask, 3)
     h2, amp2 = _median_amprow_offsets(data, mask, 3, 0.1, 0.20)
     np.testing.assert_array_equal(h1, h2)
     assert amp1 == amp2
+    assert diag1 == {}  # median path carries no extra diagnostics
     # Default estimator is 'median', ampcounts in legacy 'A-N' format.
     assert all('-' in a for a in amp1)
 
@@ -165,15 +192,17 @@ def test_gp_params_contract():
     rng = np.random.default_rng(6)
     data, _ = _planted_frame(rng)
     mask = np.zeros(SHAPE, bool)
-    with pytest.raises(ValueError, match='gp_params'):
+    # rho is the only required gp_param now (kernel_sigma self-adapts).
+    with pytest.raises(ValueError, match='rho'):
         fit_residual_striping(data, mask, 3, estimator='gp')
-    with pytest.raises(ValueError, match='gp_params'):
+    with pytest.raises(ValueError, match='rho'):
         fit_residual_striping(data, mask, 3, estimator='gp',
                               gp_params={'kernel_sigma': 0.02})
     with pytest.raises(ValueError, match='unknown estimator'):
         fit_residual_striping(data, mask, 3, estimator='nope')
-    # Valid params produce a full triple.
-    h, v, diag = fit_residual_striping(
-        data, mask, 3, estimator='gp',
-        gp_params={'kernel_sigma': 0.02, 'rho': 80.0})
-    assert h.shape == SHAPE and v.shape == SHAPE and len(diag) == 4
+    # rho alone is sufficient — amplitude self-adapts; returns a 4-tuple with
+    # the effective amplitude in the diag dict.
+    h, v, amp, diag = fit_residual_striping(
+        data, mask, 3, estimator='gp', gp_params={'rho': 80.0})
+    assert h.shape == SHAPE and v.shape == SHAPE and len(amp) == 4
+    assert diag['kernel_sigma_eff'] > 0

--- a/pipeline/tests/test_nircam_gp_striping.py
+++ b/pipeline/tests/test_nircam_gp_striping.py
@@ -1,0 +1,179 @@
+"""Tests for the GP-based per-amp-row 1/f striping estimator.
+
+Synthesizes NIRCam-shaped frames with a known, smooth per-amp-row 1/f
+offset (constant per column added on top) and verifies that the GP
+estimator:
+
+1. Recovers the smooth per-amp-row offset on a clean frame.
+2. Preserves the *distinct* per-amp DC level (no amp-to-amp step).
+3. Interpolates the offset across a masked bright-source band using
+   anchor rows of the same amp — beating the median + full-row fallback,
+   which substitutes the (wrong) cross-amp median there.
+4. Flags wide, anchorless gaps via inflated posterior variance rather
+   than silently filling them.
+5. Leaves the ``estimator="median"`` path byte-identical and validates
+   the ``gp_params`` contract.
+
+The pure ``gp_amprow_offsets`` / ``fit_residual_striping`` primitives are
+where the algorithmic correctness lives; the full step is exercised by
+the A/B pipeline runs.
+"""
+
+import numpy as np
+import pytest
+
+from campfire_pipeline.nircam.constants import NIR_AMPS
+from campfire_pipeline.nircam.gp_striping import (
+    _amprow_statistics,
+    gp_amprow_offsets,
+)
+from campfire_pipeline.nircam.steps.striping import (
+    _median_amprow_offsets,
+    fit_residual_striping,
+)
+
+celerite2 = pytest.importorskip('celerite2')
+
+SHAPE = (2048, 2048)
+AMP_DC = {'A': 0.05, 'B': 0.02, 'C': -0.03, 'D': 0.01}
+
+
+def _planted_frame(rng, noise=0.02, amp_dc=AMP_DC):
+    """Frame = per-amp DC + smooth per-row 1/f + per-column + white noise.
+
+    Returns ``(data, truth_horizontal)`` where ``truth_horizontal`` is the
+    per-amp per-row offset broadcast across each amp's columns (what the
+    horizontal estimate should recover).
+    """
+    rows = np.arange(SHAPE[0])
+    truth = np.zeros(SHAPE)
+    for amp, dc in amp_dc.items():
+        _, _, c0, c1 = NIR_AMPS[amp]['data']
+        f = dc + 0.01 * np.sin(rows / 130.0) + 0.004 * np.cos(rows / 41.0)
+        truth[:, c0:c1] = f[:, None]
+    col = 0.003 * rng.standard_normal(SHAPE[1])[None, :]
+    data = truth + col + noise * rng.standard_normal(SHAPE)
+    return data, truth
+
+
+def _amp_rms(estimate, truth, amp, rows):
+    _, _, c0, _ = NIR_AMPS[amp]['data']
+    return float(np.sqrt(np.mean((estimate[rows, c0] - truth[rows, c0]) ** 2)))
+
+
+def test_amprow_statistics_basic():
+    rng = np.random.default_rng(0)
+    data, _ = _planted_frame(rng)
+    _, _, c0, c1 = NIR_AMPS['A']['data']
+    mask = np.zeros((SHAPE[0], c1 - c0), bool)
+    y_r, s_hat, n_r = _amprow_statistics(data[:, c0:c1], mask, 2.0, 3)
+    assert y_r.shape == (SHAPE[0],)
+    # All rows have pixels; scatter ~ injected noise; counts ~ amp width.
+    assert np.all(n_r > 0)
+    assert np.isfinite(y_r).all()
+    assert 0.01 < np.median(s_hat) < 0.04
+    # Fully masking a row drives its count to zero and its median to NaN.
+    mask[100, :] = True
+    y_r2, _, n_r2 = _amprow_statistics(data[:, c0:c1], mask, 2.0, 3)
+    assert n_r2[100] == 0
+    assert np.isnan(y_r2[100])
+
+
+def test_gp_recovers_clean_offset_and_preserves_dc():
+    rng = np.random.default_rng(1)
+    data, truth = _planted_frame(rng)
+    mask = np.zeros(SHAPE, bool)
+    horizontal, diag = gp_amprow_offsets(data, mask, kernel_sigma=0.02, rho=80.0)
+    clean = np.arange(200, 400)
+    for amp, dc in AMP_DC.items():
+        # Smoothing beats the per-row noise floor (0.02) substantially.
+        assert _amp_rms(horizontal, truth, amp, clean) < 0.01
+        # Distinct per-amp DC preserved → no amp-to-amp step reintroduced.
+        _, _, c0, _ = NIR_AMPS[amp]['data']
+        assert abs(np.median(horizontal[clean, c0]) - np.median(truth[clean, c0])) < 0.01
+    assert len(diag) == 4
+
+
+def test_gp_interpolates_across_source_gap_better_than_median():
+    rng = np.random.default_rng(2)
+    data, truth = _planted_frame(rng)
+    mask = np.zeros(SHAPE, bool)
+    # Bright extended source filling amp B over a ~100-row band, masked
+    # with a margin (as the real source mask would be).
+    _, _, c0, c1 = NIR_AMPS['B']['data']
+    data[900:1000, c0 + 80:c0 + 380] += 5.0
+    mask[880:1020, c0 + 60:c0 + 400] = True
+
+    h_gp, _ = gp_amprow_offsets(data, mask, kernel_sigma=0.02, rho=80.0)
+    h_med, _ = _median_amprow_offsets(data, mask, 3, 0.1, 0.20)
+
+    gap = np.arange(900, 1000)
+    rms_gp = _amp_rms(h_gp, truth, 'B', gap)
+    rms_med = _amp_rms(h_med, truth, 'B', gap)
+    # GP interpolates from the same amp's clean rows above/below; the median
+    # path falls back to the cross-amp full-row median (wrong quantity).
+    assert rms_gp < rms_med
+    assert rms_gp < 0.01
+    # Neighbouring clean amps unaffected.
+    clean = np.arange(200, 400)
+    assert _amp_rms(h_gp, truth, 'A', clean) < 0.01
+
+
+def test_gp_flags_wide_anchorless_gap():
+    rng = np.random.default_rng(3)
+    data, truth = _planted_frame(rng)
+    mask = np.zeros(SHAPE, bool)
+    _, _, c0, c1 = NIR_AMPS['C']['data']
+    # Mask a very wide band — far wider than rho — so the interior rows have
+    # no anchor within a length scale: the GP must revert toward DC with
+    # inflated posterior variance and flag those rows weak.
+    mask[400:1600, c0:c1] = True
+    _, diag = gp_amprow_offsets(data, mask, kernel_sigma=0.02, rho=60.0,
+                                weak_frac=0.5)
+    # diag format: 'C:anchors/weak/maxσ'
+    c_entry = [d for d in diag if d.startswith('C:')][0]
+    n_weak = int(c_entry.split(':')[1].split('/')[1])
+    assert n_weak > 0
+
+
+def test_gp_full_frame_output_including_reference_rows():
+    rng = np.random.default_rng(4)
+    data, _ = _planted_frame(rng)
+    mask = np.zeros(SHAPE, bool)
+    horizontal, _ = gp_amprow_offsets(data, mask, kernel_sigma=0.02, rho=80.0)
+    assert horizontal.shape == SHAPE
+    # Reference-border rows (0-3, 2044-2047) get an extrapolated, finite
+    # offset even though they're excluded from the fit.
+    _, _, c0, _ = NIR_AMPS['A']['data']
+    assert np.isfinite(horizontal[0, c0])
+    assert np.isfinite(horizontal[-1, c0])
+
+
+def test_median_estimator_path_unchanged():
+    rng = np.random.default_rng(5)
+    data, _ = _planted_frame(rng)
+    mask = np.zeros(SHAPE, bool)
+    h1, v1, amp1 = fit_residual_striping(data, mask, 3)
+    h2, amp2 = _median_amprow_offsets(data, mask, 3, 0.1, 0.20)
+    np.testing.assert_array_equal(h1, h2)
+    assert amp1 == amp2
+    # Default estimator is 'median', ampcounts in legacy 'A-N' format.
+    assert all('-' in a for a in amp1)
+
+
+def test_gp_params_contract():
+    rng = np.random.default_rng(6)
+    data, _ = _planted_frame(rng)
+    mask = np.zeros(SHAPE, bool)
+    with pytest.raises(ValueError, match='gp_params'):
+        fit_residual_striping(data, mask, 3, estimator='gp')
+    with pytest.raises(ValueError, match='gp_params'):
+        fit_residual_striping(data, mask, 3, estimator='gp',
+                              gp_params={'kernel_sigma': 0.02})
+    with pytest.raises(ValueError, match='unknown estimator'):
+        fit_residual_striping(data, mask, 3, estimator='nope')
+    # Valid params produce a full triple.
+    h, v, diag = fit_residual_striping(
+        data, mask, 3, estimator='gp',
+        gp_params={'kernel_sigma': 0.02, 'rho': 80.0})
+    assert h.shape == SHAPE and v.shape == SHAPE and len(diag) == 4

--- a/pipeline/tests/test_nircam_skyfit.py
+++ b/pipeline/tests/test_nircam_skyfit.py
@@ -1,0 +1,38 @@
+"""Regression tests for skyfit helpers.
+
+Guards the byte-order bug in ``fit_sky``: the old ``byteswap(inplace=True)``
++ ``view`` idiom (used to give bottleneck a native-order array) only produced
+correct values from *non-native* input and silently corrupted an
+already-native array into garbage. The cal-frame striping step feeds it a
+native ``float64`` working copy, which turned the background into ~1e-315
+denormals (or huge values), wrecking the 1/f correction.
+"""
+
+import numpy as np
+
+from campfire_pipeline.nircam.skyfit import fit_sky
+
+
+def _flat_sky(seed=1, shape=(1024, 1024), noise=0.02):
+    rng = np.random.default_rng(seed)
+    # ~zero-mean (pedestal-subtracted) background, native float64
+    return (noise * rng.standard_normal(shape)).astype(np.float64)
+
+
+def test_fit_sky_native_byteorder_not_corrupted():
+    data = _flat_sky()
+    big = data.astype(data.dtype.newbyteorder('>'))  # big-endian copy
+
+    b_native = fit_sky(data.copy(), use_bottleneck=True)
+    b_big = fit_sky(big.copy(), use_bottleneck=True)
+    b_nobottle = fit_sky(data.copy(), use_bottleneck=False)
+
+    # None should be garbage (the bug produced ~1e-315 denormals or huge values).
+    for b in (b_native, b_big, b_nobottle):
+        assert np.isfinite(b).all()
+        assert np.nanmax(np.abs(b)) < 1.0
+
+    # The bottleneck path (any byte order) must match the plain path exactly —
+    # it only reorders bytes, it must not change values.
+    assert np.allclose(b_native, b_nobottle, atol=1e-6)
+    assert np.allclose(b_big, b_nobottle, atol=1e-6)


### PR DESCRIPTION
## Summary

Reworks the NIRCam 1/f ("striping") correction in two ways, both behind the
default-preserving config, plus a fix for an amp-boundary background artifact:

1. **Cal-frame move (Calibration).** Striping now runs **after `image2`** and
   fits + subtracts the 1/f in the flat-fielded cal frame. The legacy path fit
   on a flat-fielded *copy* but subtracted from the *un-flat* rate SCI, which
   `image2` then re-divided by the per-amp-structured flat — leaving a coherent
   per-amp DC step at the amp boundaries (`≈ N/g·(1−1/g)`, verified to reproduce
   at r=0.9997). This was the source of the amp-scale column-background steps
   visible even in median-method exposures.
2. **GP estimator (Algorithm).** New opt-in `[nircam.striping].estimator = "gp"`
   fits a 1-D Gaussian Process (celerite2 `SHOTerm`, `Q=1/√2`, CPU O(n)) along
   the slow axis *per amplifier*, weighting each amp-row by its sampling error
   and interpolating across source-masked rows **within the same amp** — instead
   of the production median's cross-amp full-row fallback, which mis-estimates
   the offset under bright/extended sources (the amp-boundary + slow-axis "box").

`estimator` defaults to `"median"` and the default config reproduces the current
pipeline exactly — **no output change unless `estimator` is set**.

## Results (rj0911 f444w, 8 LW exposures over a cluster)

Metrics are high-passed to isolate the 1/f from retained ICL.

**GP vs median** — GP wins across the board, slightly faster:

| metric | median | gp | Δ |
|---|---|---|---|
| amp-row 1/f residual | 7.39e-4 | 6.24e-4 | **−16%** |
| high-freq banding | 1.06e-3 | 8.74e-4 | **−18%** |
| clean rows | 6.08e-4 | 5.14e-4 | −15% |
| source rows | 8.73e-4 | 7.31e-4 | −16% |
| runtime (uncal→mosaic) | 312 s | 283 s | faster |

Background uniformity unchanged, photometry conserved (<0.05%), no negative
wings.

**clean_flicker_noise (evaluated, not adopted).** `fit_method="fft"` is
NIRSpec-only (jwst skips it for `NRC_IMAGE`); the `"median"` mode removes only
~13% of the amp-row 1/f (vs GP's ~68%) and introduces per-amp DC steps via
`fit_by_channel`. As a GP pre-pass it gives no amp-row gain and only a
detector-specific column gain at the cost of ramp-stage reprocessing.

## Changes

**Calibration**
- `striping` after `image2`; fit + apply in the cal frame; pedestal via
  `fit_sky_tot`; `[nircam.striping]` drops `apply_flat`/`use_custom_flat`.
- `subtract_background` is now a **fit-only** 2D detrend (default on,
  `box=32`/`filter=3`) — removes ICL from the fit but never from the output SCI.

**Algorithm**
- `estimator = {"median"(default), "gp", "none"}`; GP module
  `nircam/gp_striping.py`; frozen SW/LW hyperparameters (calibrate via
  `scripts/calibrate_gp_striping.py`). `"none"` = SRCMASK + rest of pipeline, no
  campfire 1/f.

**Infrastructure**
- `skyfit.fit_sky` gains `box_size`/`filter_size` + a native-byte-order guard
  (the bottleneck path corrupted native arrays in place → garbage background).
- `detector1` `clean_flicker_noise_opts` passthrough.
- `celerite2` dependency.

## Test plan
- `tests/test_nircam_gp_striping.py` (GP estimator) and
  `tests/test_nircam_skyfit.py` (byte-order regression) — new.
- `pytest -k "nircam or skyfit or config"` → **67 passed**.
- A/B testbed + harness in `experiments/oneoverf_gp/` (analysis code + README
  tracked; FITS/figs/logs gitignored).

Hyperparameters are frozen from one clean calibration; they should be
re-calibrated if the CRDS context or `jwst` version changes the 1/f character.

Generated with Claude Code
