### PR TITLE
fix(deploy): make deploy authentication coherent end-to-end

### DIFF
--- a/python/campfire/auth/_jwt.py
+++ b/python/campfire/auth/_jwt.py
@@ -1,0 +1,45 @@
+"""Lightweight JWT payload decoding (no signature verification).
+
+Used to read claims (``sub``, ``exp``) from CAMPFIRE access tokens and
+Supabase JWTs for routing/expiry decisions — NOT for trust decisions. The
+server verifies signatures; here we only need to read the payload locally.
+
+Kept in ``auth/`` (with no ``deploy/`` imports) so both layers can share it.
+"""
+
+import base64
+import json
+from typing import Optional
+
+
+def decode_payload(token: str) -> Optional[dict]:
+    """Return the decoded JWT payload (middle segment), or None on failure.
+
+    Does not verify the signature — for local claim inspection only.
+    """
+    if not token:
+        return None
+    try:
+        payload_b64 = token.split(".")[1]
+        payload_b64 += "=" * (-len(payload_b64) % 4)  # pad to a multiple of 4
+        return json.loads(base64.urlsafe_b64decode(payload_b64))
+    except Exception:
+        return None
+
+
+def get_sub(token: str) -> Optional[str]:
+    """Return the ``sub`` (subject / user_id) claim, or None."""
+    payload = decode_payload(token)
+    return payload.get("sub") if payload else None
+
+
+def get_exp(token: str) -> Optional[int]:
+    """Return the ``exp`` (expiry, Unix seconds) claim as int, or None."""
+    payload = decode_payload(token)
+    if not payload:
+        return None
+    exp = payload.get("exp")
+    try:
+        return int(exp) if exp is not None else None
+    except (ValueError, TypeError):
+        return None

--- a/python/campfire/auth/tokens.py
+++ b/python/campfire/auth/tokens.py
@@ -4,12 +4,14 @@ Token management for CAMPFIRE Python client.
 Handles token refresh and validation.
 """
 
+import time
 from datetime import datetime, timedelta
 from typing import Optional, Tuple
 
 import requests
 
 from ..exceptions import AuthenticationError
+from ._jwt import get_exp
 from .credentials import CredentialManager, StoredCredentials
 
 
@@ -208,8 +210,10 @@ class TokenManager:
         """
         Get a valid Supabase-compatible JWT.
 
-        The supabase_token shares the same expiry as the access token,
-        so refreshing one refreshes both.
+        When ``auto_refresh`` is set, this refreshes based on the *access*
+        token's expiry (:meth:`needs_refresh`). For refresh decisions keyed on
+        the Supabase JWT's own ``exp``, use :meth:`supabase_token_needs_refresh`
+        and :meth:`force_refresh_supabase_token` instead.
 
         Returns
         -------
@@ -223,6 +227,39 @@ class TokenManager:
             self.refresh_tokens()
 
         return self._cached_creds.supabase_token if self._cached_creds else None
+
+    def supabase_token_needs_refresh(self, buffer_minutes: int = 10) -> bool:
+        """
+        Whether the cached Supabase JWT is at or near expiry.
+
+        Unlike :meth:`needs_refresh` (which inspects the *access* token's
+        ``expires_at``), this decodes the Supabase JWT's own ``exp`` claim, so
+        refresh decisions don't depend on the access and Supabase tokens sharing
+        a lifetime. Falls back to :meth:`needs_refresh` when the token can't be
+        decoded (safe: both tokens are currently minted with the same 1 h TTL).
+        """
+        if not self.is_oauth():
+            return False
+        if not self._cached_creds or not self._cached_creds.supabase_token:
+            return True
+        exp = get_exp(self._cached_creds.supabase_token)
+        if exp is None:
+            return self.needs_refresh(buffer_minutes)
+        return time.time() + buffer_minutes * 60 >= exp
+
+    def force_refresh_supabase_token(self) -> Optional[str]:
+        """
+        Unconditionally refresh and return the new Supabase JWT.
+
+        ``get_supabase_token(auto_refresh=True)`` only refreshes when the
+        *access* token's :meth:`needs_refresh` fires — the wrong signal when the
+        Supabase JWT is the one near expiry. This forces a refresh via
+        :meth:`refresh_tokens` and returns the freshly-minted Supabase token.
+        """
+        if not self.is_oauth():
+            return None
+        self.refresh_tokens()
+        return self.get_supabase_token(auto_refresh=False)
 
     def get_user_email(self) -> Optional[str]:
         """Get the user's email if available."""

--- a/python/campfire/deploy/cli.py
+++ b/python/campfire/deploy/cli.py
@@ -33,7 +33,6 @@ Multiple observations are processed serially:
 import sys
 
 import click
-import requests
 
 from campfire.deploy.config import load_config, load_programs, resolve_imaging_config, resolve_photometry_config, resolve_tiles_dir
 
@@ -85,35 +84,46 @@ from campfire.deploy.deploy import (
 from campfire.deploy.supabase import get_supabase_client, upsert_programs, refresh_filter_options, refresh_programs_overview
 
 
-def _check_admin() -> None:
-    """Verify the logged-in user has admin privileges. Exits on failure."""
-    from campfire.api.session import resolve_base_url
-    from campfire.auth.tokens import TokenManager
+def _gate_admin(config: dict) -> None:
+    """Verify the deployer is an admin THROUGH the actual write client.
 
-    base_url = resolve_base_url()
+    Calls ``is_admin()`` via the same Supabase client the deploy will write
+    with, so the gate and the writes share one identity + target + token — a
+    gate pass therefore guarantees the writes pass. (The old gate hit
+    ``/auth/whoami`` with a separately-resolved token, which could pass while
+    the writes were rejected.)
+
+    Skipped for service-role / local clients: they bypass RLS (god-mode), and
+    ``is_admin()`` would falsely return false there because ``auth.uid()`` is
+    NULL under the service role.
+    """
+    from postgrest.exceptions import APIError
+    from campfire.deploy.supabase import get_supabase_client
+
+    mode = config.get('supabase', {}).get('_auth_mode')
+    if mode in ('service_role', 'local'):
+        return
+
+    client = get_supabase_client(config)
     try:
-        tm = TokenManager(base_url=base_url)
-        token = tm.get_valid_token(auto_refresh=True)
-    except Exception:
-        print("Error: Not logged in. Run: campfire login")
+        resp = client.rpc('is_admin').execute()
+    except APIError as e:
+        code = getattr(e, 'code', '') or ''
+        message = getattr(e, 'message', None) or str(e)
+        if code in ('PGRST301', 'PGRST303') or 'jwt' in message.lower():
+            print("Error: Your login session is invalid or expired. "
+                  "Run: campfire login")
+        else:
+            print(f"Error: Failed to verify admin status: {message}")
         sys.exit(1)
 
-    try:
-        resp = requests.get(
-            f"{base_url}/auth/whoami",
-            headers={"Authorization": f"Bearer {token}"},
-            timeout=10,
-        )
-        resp.raise_for_status()
-        data = resp.json()
-    except Exception as e:
-        print(f"Error: Failed to verify admin status: {e}")
-        sys.exit(1)
-
-    if not data.get("is_admin"):
-        print(f"Error: Deploy requires admin privileges.")
-        print(f"  Logged in as: {data.get('email', 'unknown')}")
-        print(f"  Contact an administrator to request access.")
+    if not resp.data:
+        tm = config.get('supabase', {}).get('_token_manager')
+        email = tm.get_user_email() if tm else None
+        print("Error: Deploy requires admin privileges.")
+        if email:
+            print(f"  Logged in as: {email}")
+        print("  Contact an administrator to request access.")
         sys.exit(1)
 
 
@@ -184,7 +194,9 @@ def deploy_group(ctx, config_path, obs, dry_run, source_ids, supabase_only,
     ctx.ensure_object(dict)
     ctx.obj['local'] = local
     if not local:
-        _check_admin()
+        # Gate once here (the group callback runs before every subcommand and
+        # subgroup), through the actual write client.
+        _gate_admin(load_config(config_path, local=local))
 
     # When invoked without a subcommand, --obs is required
     if ctx.invoked_subcommand is None:
@@ -195,6 +207,10 @@ def deploy_group(ctx, config_path, obs, dry_run, source_ids, supabase_only,
 
         config = load_config(config_path, local=local)
         multi = len(obs) > 1
+        if multi and config.get('supabase', {}).get('_auth_mode') == 'login':
+            print(f"  Note: deploying {len(obs)} observations on a user login "
+                  f"(token auto-refreshes). For large unattended batches, prefer "
+                  f"a service-role key (CAMPFIRE_SUPABASE_SERVICE_ROLE_KEY).")
         fields_needing_rebuild: set[str] = set()
 
         for obs_name in obs:

--- a/python/campfire/deploy/config.py
+++ b/python/campfire/deploy/config.py
@@ -121,18 +121,22 @@ def load_config(config_path: str | None = None, *, local: bool = False) -> dict:
     """
     Load deployment credentials (Supabase + R2).
 
-    Resolution order:
-      1. Environment variables (CAMPFIRE_SUPABASE_*, CAMPFIRE_R2_*)
-      2. Explicit --config path
-      3. $CAMPFIRE_ROOT/config/deploy.toml
+    Resolves Supabase auth into exactly ONE coherent mode, tagged on
+    ``config['supabase']['_auth_mode']``:
 
-    If ``local=True``, Supabase credentials are overridden to point to the
-    local instance (127.0.0.1:54321) with the standard Supabase CLI
-    service-role key. Other sections (R2, r2_tiles) are still resolved
-    normally from env vars / TOML so non-Supabase uploads keep working.
+      - ``local`` (``--local``): local instance (127.0.0.1:54321) with the
+        standard Supabase CLI service-role key.
+      - ``service_role``: env vars (``CAMPFIRE_SUPABASE_URL`` +
+        ``CAMPFIRE_SUPABASE_SERVICE_ROLE_KEY``) or a TOML ``[supabase]`` block
+        with ``service_role_key`` + ``url``. Bypasses RLS — the preferred path
+        for unattended / batch / CI deploys (no JWT expiry).
+      - ``login``: the logged-in user's Supabase credentials from
+        ``campfire login`` (url + anon_key + token + TokenManager, taken as a
+        matched set). Operates through RLS.
 
-    Environment variables take priority for core sections. Extra TOML
-    sections (e.g. r2_tiles) are merged in when not covered by env vars.
+    Precedence: ``--local`` > env service-role > TOML service-role > login.
+    When env or TOML supplies a service-role key, login credentials are NOT
+    injected. R2 / r2_tiles sections are always resolved from env vars / TOML.
     """
     if local:
         base = _config_from_env() or _find_toml(config_path) or {}
@@ -142,32 +146,36 @@ def load_config(config_path: str | None = None, *, local: bool = False) -> dict:
         base['supabase'].pop('supabase_token', None)
         base['supabase'].pop('anon_key', None)
         base['supabase'].pop('_token_manager', None)
+        base['supabase']['_auth_mode'] = 'local'
         print(f"  Using local Supabase at {_LOCAL_SUPABASE_URL}")
         return base
 
-    # Try env vars first
+    # 1. Environment service-role credentials. `_config_from_env` only returns a
+    #    config when both url and service_role_key are present, so this is always
+    #    service-role mode (used as-is, no login injection).
     env_config = _config_from_env()
     if env_config:
-        # Merge any extra sections from TOML that env vars don't cover
         toml_config = _find_toml(config_path)
         if toml_config:
             for key, val in toml_config.items():
                 if key not in env_config:
                     env_config[key] = val
-        return _inject_user_credentials(env_config)
+        env_config.setdefault('supabase', {})['_auth_mode'] = 'service_role'
+        return env_config
 
-    # Fall back to TOML file
+    # 2. TOML service-role credentials short-circuit (no login injection).
     toml_config = _find_toml(config_path)
     if toml_config:
-        return _inject_user_credentials(toml_config)
+        sb = toml_config.setdefault('supabase', {})
+        if sb.get('service_role_key') and sb.get('url'):
+            sb['_auth_mode'] = 'service_role'
+            return toml_config
 
-    # Try user credentials alone (no env vars or TOML needed if logged in)
-    # supabase_url and supabase_anon_key are stored at login time
-    user_config = _inject_user_credentials({})
-    if user_config.get('supabase', {}).get('supabase_token') and \
-       user_config.get('supabase', {}).get('url') and \
-       user_config.get('supabase', {}).get('anon_key'):
-        return user_config
+    # 3. Logged-in user credentials (matched set), merged onto any TOML (R2 etc.).
+    base = toml_config or {}
+    base = _inject_user_credentials(base)
+    if base.get('supabase', {}).get('_auth_mode') == 'login':
+        return base
 
     # Nothing found — show helpful error
     candidates = []
@@ -201,12 +209,19 @@ def load_config(config_path: str | None = None, *, local: bool = False) -> dict:
 
 def _inject_user_credentials(config: dict) -> dict:
     """
-    Enrich deploy config with the user's Supabase credentials from stored OAuth.
+    Inject the logged-in user's Supabase credentials as a coherent matched set.
 
-    If the user has logged in via ``campfire login``, their supabase_token,
-    supabase_url, and supabase_anon_key are injected into ``config['supabase']``.
-    This allows ``get_supabase_client()`` to use the user JWT path instead of
-    requiring a service_role_key — no env vars needed beyond ``campfire login``.
+    If the user has logged in via ``campfire login``, their ``supabase_url`` +
+    ``supabase_anon_key`` + ``supabase_token`` + ``TokenManager`` are injected
+    **together** (they are minted for the same project) and tagged
+    ``_auth_mode='login'``. The login URL/anon_key OVERWRITE any carried in from
+    TOML/env so a login token is never paired with a foreign URL — the exact
+    mismatch that lets an admin pass a gate yet be rejected on writes.
+
+    On no usable login session (not logged in, offline, or refresh failed) the
+    config is returned untouched and untagged; downstream resolution then
+    reports "no credentials". It can never degrade to an anon client because
+    ``get_supabase_client`` requires a complete login set.
     """
     try:
         from campfire.api.session import resolve_base_url
@@ -214,25 +229,31 @@ def _inject_user_credentials(config: dict) -> dict:
 
         base_url = resolve_base_url()
         tm = TokenManager(base_url=base_url)
-        if tm.is_oauth():
-            sb_token = tm.get_supabase_token(auto_refresh=True)
-            creds = tm._cached_creds
-            if sb_token and creds:
-                config.setdefault('supabase', {})
-                config['supabase']['supabase_token'] = sb_token
-                # Store TokenManager so the Supabase client can auto-refresh
-                config['supabase']['_token_manager'] = tm
-
-                # Use stored Supabase connection info from login
-                if creds.supabase_url:
-                    config['supabase'].setdefault('url', creds.supabase_url)
-                if creds.supabase_anon_key:
-                    config['supabase'].setdefault('anon_key', creds.supabase_anon_key)
+        if not tm.is_oauth():
+            return config
+        sb_token = tm.get_supabase_token(auto_refresh=True)
+        creds = tm._cached_creds
     except Exception:
-        # Auth not available or not configured — that's fine,
-        # fall back to service_role_key in get_supabase_client()
-        pass
+        # Auth layer unavailable / not logged in / refresh failed.
+        return config
 
+    if not (sb_token and creds and creds.supabase_url and creds.supabase_anon_key):
+        return config
+
+    sb = config.setdefault('supabase', {})
+    existing_url = sb.get('url')
+    if existing_url and existing_url != creds.supabase_url:
+        print(
+            f"  Note: ignoring configured Supabase url ({existing_url}); using "
+            f"the URL your login token was issued for ({creds.supabase_url})."
+        )
+    # Matched set from login — overwrite, never mix a login token with a
+    # foreign url/anon_key.
+    sb['url'] = creds.supabase_url
+    sb['anon_key'] = creds.supabase_anon_key
+    sb['supabase_token'] = sb_token
+    sb['_token_manager'] = tm
+    sb['_auth_mode'] = 'login'
     return config
 
 

--- a/python/campfire/deploy/supabase.py
+++ b/python/campfire/deploy/supabase.py
@@ -6,6 +6,35 @@ slit geometry deployment and filter cache refresh.
 """
 
 from supabase import create_client, Client
+from supabase.client import ClientOptions
+
+from campfire.auth._jwt import get_sub
+
+
+def _make_user_client(url: str, anon_key: str, supabase_token: str) -> Client:
+    """Build a Supabase client authenticated as a user (JWT) for RLS writes.
+
+    The user JWT **must** be baked into the client options headers at
+    construction. Authenticating via ``client.postgrest.auth(token)`` *after*
+    construction is unreliable in supabase-py 2.x: ``Client.postgrest`` is a
+    lazily-built, cached client constructed from ``options.headers``, and the
+    GoTrue auth-state listener resets that cache (``self._postgrest = None``)
+    and rewrites ``Authorization`` back to the anon key. When that race is
+    lost the user JWT silently never reaches the wire — requests go out as
+    role ``anon`` -> ``auth.uid()`` is NULL -> ``is_admin()`` is false -> admin
+    writes (e.g. the ``observations`` upsert) fail intermittently with a 42501
+    RLS error. Passing the token through ``options.headers`` makes every
+    (re)build of the postgrest client carry the user JWT.
+    """
+    if not supabase_token:
+        # A falsy token yields "Bearer None" — i.e. an effectively anon request.
+        # Refuse rather than silently deploy as anon and fail later with 42501.
+        raise ValueError(
+            "Refusing to build a user Supabase client without a Supabase token "
+            "(would authenticate as anon). Run 'campfire login' again."
+        )
+    options = ClientOptions(headers={"Authorization": f"Bearer {supabase_token}"})
+    return create_client(url, anon_key, options=options)
 
 
 class AutoRefreshClient:
@@ -13,18 +42,26 @@ class AutoRefreshClient:
 
     Deployments can run for hours, but Supabase JWTs expire after ~1 hour.
     This wrapper checks token expiry before every ``table()`` or ``rpc()``
-    call and transparently refreshes via the stored ``TokenManager``.
+    call and, when a refresh is needed, **rebuilds** the underlying client
+    with the fresh token baked into its options headers (see
+    ``_make_user_client`` for why a fresh build rather than
+    ``postgrest.auth()``).
     """
 
-    def __init__(self, client: Client, token_manager):
-        self._client = client
+    def __init__(self, url: str, anon_key: str, supabase_token: str, token_manager):
+        self._url = url
+        self._anon_key = anon_key
         self._token_manager = token_manager
+        self._client = _make_user_client(url, anon_key, supabase_token)
 
     def _ensure_valid_token(self):
-        if self._token_manager and self._token_manager.needs_refresh():
-            new_token = self._token_manager.get_supabase_token(auto_refresh=True)
+        # Decide on the Supabase JWT's OWN expiry, not the access token's, then
+        # force a refresh and rebuild the client so the fresh token is actually
+        # carried on the wire (a plain refresh leaves the old client in place).
+        if self._token_manager and self._token_manager.supabase_token_needs_refresh():
+            new_token = self._token_manager.force_refresh_supabase_token()
             if new_token:
-                self._client.postgrest.auth(new_token)
+                self._client = _make_user_client(self._url, self._anon_key, new_token)
 
     def table(self, *args, **kwargs):
         self._ensure_valid_token()
@@ -38,34 +75,51 @@ class AutoRefreshClient:
 def get_supabase_client(config: dict):
     """Create a Supabase client from deploy config.
 
-    Two authentication paths:
+    Dispatches on the auth mode resolved by ``load_config`` and tagged on
+    ``config['supabase']['_auth_mode']`` (one of ``service_role``, ``local``,
+    ``login``). When the tag is absent (e.g. a hand-built config in a test),
+    the mode is inferred from which keys are present.
 
-    1. **Service role** (``config['supabase']['service_role_key']``) — used
-       for ``--local`` deploys and env-var-driven CI. Bypasses RLS; no
-       refresh needed.
-    2. **User JWT** (``config['supabase']['supabase_token']`` +
-       ``anon_key``) — used for remote deploys authenticated via
-       ``campfire login``. Operates through RLS policies. When a
-       ``_token_manager`` is present, wraps the client in
-       ``AutoRefreshClient`` so long-running deploys survive the ~1 hour
-       JWT expiry.
+    - **service_role / local** — ``create_client(url, service_role_key)``.
+      Bypasses RLS; no refresh needed.
+    - **login** — user JWT from ``campfire login``. Operates through RLS. With
+      a ``_token_manager`` present the client is wrapped in
+      ``AutoRefreshClient`` so long-running deploys survive JWT expiry; the
+      token is always baked into the client headers (never falls back to anon).
     """
-    url = config['supabase']['url']
-    service_role_key = config['supabase'].get('service_role_key')
-    supabase_token = config['supabase'].get('supabase_token')
-    anon_key = config['supabase'].get('anon_key')
+    sb = config['supabase']
+    url = sb['url']
+    mode = sb.get('_auth_mode')
 
-    if service_role_key:
+    # Infer the mode for configs that weren't tagged by load_config.
+    if mode is None:
+        if sb.get('service_role_key'):
+            mode = 'service_role'
+        elif sb.get('supabase_token') and sb.get('anon_key'):
+            mode = 'login'
+
+    if mode in ('service_role', 'local'):
+        service_role_key = sb.get('service_role_key')
+        if not service_role_key:
+            raise ValueError(
+                f"Auth mode '{mode}' requires a Supabase service_role_key."
+            )
         return create_client(url, service_role_key)
 
-    if supabase_token and anon_key:
-        client = create_client(url, anon_key)
-        client.postgrest.auth(supabase_token)
-
-        token_manager = config['supabase'].get('_token_manager')
+    if mode == 'login':
+        supabase_token = sb.get('supabase_token')
+        anon_key = sb.get('anon_key')
+        if not (supabase_token and anon_key):
+            raise ValueError(
+                "Incomplete login credentials (need supabase_token + anon_key). "
+                "Run 'campfire login' again."
+            )
+        token_manager = sb.get('_token_manager')
         if token_manager:
-            return AutoRefreshClient(client, token_manager)
-        return client
+            return AutoRefreshClient(url, anon_key, supabase_token, token_manager)
+        # No manager (no auto-refresh) but still authenticated as the user —
+        # _make_user_client bakes the JWT in, so this is never an anon client.
+        return _make_user_client(url, anon_key, supabase_token)
 
     raise ValueError(
         "No Supabase credentials available. "
@@ -75,21 +129,9 @@ def get_supabase_client(config: dict):
 
 
 def get_user_id_from_token(config: dict) -> str | None:
-    """Extract user_id (sub claim) from the stored Supabase token."""
+    """Extract user_id (``sub`` claim) from the stored Supabase token."""
     token = config.get('supabase', {}).get('supabase_token')
-    if not token:
-        return None
-    try:
-        import json
-        import base64
-        # Decode JWT payload (second segment) without verification
-        payload_b64 = token.split('.')[1]
-        # Add padding
-        payload_b64 += '=' * (4 - len(payload_b64) % 4)
-        payload = json.loads(base64.urlsafe_b64decode(payload_b64))
-        return payload.get('sub')
-    except Exception:
-        return None
+    return get_sub(token) if token else None
 
 
 def insert_deployment(

--- a/python/tests/test_deploy_auth_mode.py
+++ b/python/tests/test_deploy_auth_mode.py
@@ -1,0 +1,212 @@
+"""Tests for coherent deploy auth-mode resolution, Supabase-token refresh, and
+the admin gate that runs through the actual write client.
+
+All offline: env/TOML are controlled via monkeypatch/tmp_path, and the login
+``TokenManager`` and Supabase client are faked.
+"""
+import base64
+import json
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from campfire.auth.credentials import StoredCredentials
+from campfire.auth.tokens import TokenManager
+from campfire.deploy.config import load_config
+from campfire.deploy.cli import _gate_admin
+
+_SUPABASE_ENV = (
+    "CAMPFIRE_SUPABASE_URL", "CAMPFIRE_SUPABASE_SERVICE_ROLE_KEY",
+    "CAMPFIRE_R2_ACCOUNT_ID", "CAMPFIRE_R2_ACCESS_KEY_ID",
+    "CAMPFIRE_R2_SECRET_ACCESS_KEY", "CAMPFIRE_R2_BUCKET_NAME",
+)
+
+
+def _clear_env(monkeypatch):
+    monkeypatch.delenv("CAMPFIRE_ROOT", raising=False)
+    for var in _SUPABASE_ENV:
+        monkeypatch.delenv(var, raising=False)
+
+
+# --------------------------------------------------------------------------
+# Supabase-token refresh keyed on the token's own exp
+# --------------------------------------------------------------------------
+
+def _jwt_with_exp(exp):
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"sub": "u", "exp": exp}).encode()
+    ).decode().rstrip("=")
+    return f"hdr.{payload}.sig"
+
+
+def _oauth_tm(supabase_token):
+    creds = StoredCredentials(
+        type="oauth", access_token="a", refresh_token="r",
+        supabase_token=supabase_token, supabase_url="https://x.supabase.co",
+        supabase_anon_key="anon", expires_at=None, user_email="e@x",
+    )
+    return TokenManager("https://api", credentials_manager=SimpleNamespace(load=lambda: creds))
+
+
+def test_supabase_refresh_true_inside_buffer():
+    tm = _oauth_tm(_jwt_with_exp(int(time.time()) + 60))      # expires in 1 min
+    assert tm.supabase_token_needs_refresh(buffer_minutes=10) is True
+
+
+def test_supabase_refresh_false_outside_buffer():
+    tm = _oauth_tm(_jwt_with_exp(int(time.time()) + 3600))    # 1 h out
+    assert tm.supabase_token_needs_refresh(buffer_minutes=10) is False
+
+
+def test_supabase_refresh_decode_failure_falls_back():
+    # Malformed token -> exp None -> falls back to needs_refresh() (expires_at
+    # None -> True) without raising.
+    tm = _oauth_tm("not-a-jwt")
+    assert tm.supabase_token_needs_refresh() is True
+
+
+# --------------------------------------------------------------------------
+# Auth-mode resolution
+# --------------------------------------------------------------------------
+
+class _LoginTM:
+    """Fake of a logged-in user's TokenManager."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def is_oauth(self):
+        return True
+
+    def get_supabase_token(self, auto_refresh=True):
+        return "login.jwt"
+
+    @property
+    def _cached_creds(self):
+        return SimpleNamespace(
+            supabase_url="https://login.supabase.co",
+            supabase_anon_key="login-anon",
+        )
+
+    def get_user_email(self):
+        return "e@x"
+
+
+def test_env_service_role_skips_login(monkeypatch):
+    _clear_env(monkeypatch)
+    for var in _SUPABASE_ENV:
+        monkeypatch.setenv(var, "x")
+    monkeypatch.setenv("CAMPFIRE_SUPABASE_URL", "https://prod.supabase.co")
+    monkeypatch.setenv("CAMPFIRE_SUPABASE_SERVICE_ROLE_KEY", "svc-key")
+    monkeypatch.setattr("campfire.auth.tokens.TokenManager", _LoginTM)
+
+    sb = load_config()["supabase"]
+    assert sb["_auth_mode"] == "service_role"
+    assert sb["service_role_key"] == "svc-key"
+    assert "supabase_token" not in sb
+    assert "_token_manager" not in sb
+
+
+def test_local_mode(monkeypatch):
+    _clear_env(monkeypatch)
+    sb = load_config(local=True)["supabase"]
+    assert sb["_auth_mode"] == "local"
+    assert sb["service_role_key"]
+    assert "supabase_token" not in sb
+    assert "_token_manager" not in sb
+
+
+def test_login_overwrites_foreign_toml_url(tmp_path, monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setattr("campfire.auth.tokens.TokenManager", _LoginTM)
+    toml = tmp_path / "deploy.toml"
+    toml.write_text('[supabase]\nurl = "https://foreign.supabase.co"\n')
+
+    sb = load_config(str(toml))["supabase"]
+    assert sb["_auth_mode"] == "login"
+    assert sb["url"] == "https://login.supabase.co"   # foreign url overwritten
+    assert sb["anon_key"] == "login-anon"
+    assert sb["supabase_token"] == "login.jwt"
+    assert sb["_token_manager"].__class__ is _LoginTM
+
+
+def test_toml_service_role_skips_login(tmp_path, monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setattr("campfire.auth.tokens.TokenManager", _LoginTM)
+    toml = tmp_path / "deploy.toml"
+    toml.write_text(
+        '[supabase]\nurl = "https://prod.supabase.co"\n'
+        'service_role_key = "svc-key"\n'
+    )
+
+    sb = load_config(str(toml))["supabase"]
+    assert sb["_auth_mode"] == "service_role"
+    assert "supabase_token" not in sb
+    assert "_token_manager" not in sb
+
+
+# --------------------------------------------------------------------------
+# Admin gate through the write client
+# --------------------------------------------------------------------------
+
+class _FakeRPC:
+    def __init__(self, data=None, exc=None):
+        self._data, self._exc = data, exc
+
+    def execute(self):
+        if self._exc:
+            raise self._exc
+        return SimpleNamespace(data=self._data)
+
+
+class _FakeClient:
+    def __init__(self, data=None, exc=None):
+        self._data, self._exc = data, exc
+        self.rpc_called = False
+
+    def rpc(self, name):
+        assert name == "is_admin"
+        self.rpc_called = True
+        return _FakeRPC(self._data, self._exc)
+
+
+def test_gate_skips_service_role_and_local(monkeypatch):
+    def _boom(_cfg):
+        raise AssertionError("service-role/local must not build a client to gate")
+    monkeypatch.setattr("campfire.deploy.supabase.get_supabase_client", _boom)
+    _gate_admin({"supabase": {"_auth_mode": "service_role"}})
+    _gate_admin({"supabase": {"_auth_mode": "local"}})
+
+
+def test_gate_passes_for_admin(monkeypatch):
+    client = _FakeClient(data=True)
+    monkeypatch.setattr(
+        "campfire.deploy.supabase.get_supabase_client", lambda _cfg: client
+    )
+    _gate_admin({"supabase": {"_auth_mode": "login"}})
+    assert client.rpc_called
+
+
+def test_gate_blocks_non_admin(monkeypatch):
+    client = _FakeClient(data=False)
+    monkeypatch.setattr(
+        "campfire.deploy.supabase.get_supabase_client", lambda _cfg: client
+    )
+    with pytest.raises(SystemExit):
+        _gate_admin({"supabase": {
+            "_auth_mode": "login",
+            "_token_manager": SimpleNamespace(get_user_email=lambda: "e@x"),
+        }})
+
+
+def test_gate_handles_expired_jwt(monkeypatch):
+    from postgrest.exceptions import APIError
+    err = APIError({"message": "JWT expired", "code": "PGRST303",
+                    "hint": None, "details": None})
+    client = _FakeClient(exc=err)
+    monkeypatch.setattr(
+        "campfire.deploy.supabase.get_supabase_client", lambda _cfg: client
+    )
+    with pytest.raises(SystemExit):
+        _gate_admin({"supabase": {"_auth_mode": "login"}})

--- a/python/tests/test_deploy_supabase_auth.py
+++ b/python/tests/test_deploy_supabase_auth.py
@@ -1,0 +1,101 @@
+"""Regression tests for the deploy Supabase client auth wiring.
+
+Guards the supabase-py 2.x failure mode where authenticating via
+``client.postgrest.auth(token)`` *after* construction silently leaves the
+anon key on the wire: ``Client.postgrest`` is a lazily-built, cached client
+constructed from ``options.headers``, and the GoTrue auth-state listener
+resets that cache, reverting ``Authorization`` to the anon key. Requests then
+run as role ``anon`` -> ``auth.uid()`` NULL -> ``is_admin()`` false -> admin
+writes (e.g. the ``observations`` upsert) fail intermittently with a 42501 RLS
+error. The fix bakes the user JWT into the client options headers at
+construction so every (re)build carries it.
+"""
+import pytest
+
+from campfire.deploy.supabase import (
+    _make_user_client,
+    get_supabase_client,
+    AutoRefreshClient,
+)
+
+URL = "https://example.supabase.co"
+ANON = "anon-key"
+JWT = "user-jwt-token"
+JWT2 = "refreshed-jwt-token"
+
+
+def _auth_header(client):
+    """Effective Authorization header the postgrest client will send."""
+    return client.postgrest.session.headers.get("Authorization")
+
+
+def test_make_user_client_sends_user_jwt():
+    c = _make_user_client(URL, ANON, JWT)
+    assert _auth_header(c) == f"Bearer {JWT}"
+
+
+def test_make_user_client_rejects_empty_token():
+    # A falsy token would yield "Bearer None"/"Bearer " (effectively anon).
+    with pytest.raises(ValueError):
+        _make_user_client(URL, ANON, None)
+    with pytest.raises(ValueError):
+        _make_user_client(URL, ANON, "")
+
+
+def test_login_mode_requires_token_and_anon():
+    # Missing anon_key or token must raise, never silently build an anon client.
+    with pytest.raises(ValueError):
+        get_supabase_client({"supabase": {"url": URL, "supabase_token": JWT,
+                                          "_auth_mode": "login"}})
+    with pytest.raises(ValueError):
+        get_supabase_client({"supabase": {"url": URL, "anon_key": ANON,
+                                          "_auth_mode": "login"}})
+
+
+def test_user_jwt_survives_postgrest_cache_reset():
+    # Reproduces the GoTrue auth-event reset (Client sets _postgrest=None);
+    # the user JWT must persist across the rebuild, not revert to the anon key.
+    c = _make_user_client(URL, ANON, JWT)
+    c._postgrest = None
+    assert _auth_header(c) == f"Bearer {JWT}"
+
+
+def test_get_supabase_client_user_path_is_not_anon():
+    config = {"supabase": {"url": URL, "anon_key": ANON, "supabase_token": JWT}}
+    c = get_supabase_client(config)
+    assert _auth_header(c) == f"Bearer {JWT}"
+    assert ANON not in (_auth_header(c) or "")
+
+
+class _FakeTokenManager:
+    def __init__(self, new_token):
+        self._new_token = new_token
+        self.refresh_calls = 0
+        self._needs = True
+
+    def supabase_token_needs_refresh(self, *args, **kwargs):
+        return self._needs
+
+    def force_refresh_supabase_token(self):
+        self.refresh_calls += 1
+        self._needs = False
+        return self._new_token
+
+
+def test_autorefresh_rebuilds_with_refreshed_token():
+    tm = _FakeTokenManager(JWT2)
+    client = AutoRefreshClient(URL, ANON, JWT, tm)
+    assert _auth_header(client._client) == f"Bearer {JWT}"
+    # First table() call detects expiry and rebuilds the client carrying JWT2.
+    client.table("observations")
+    assert tm.refresh_calls == 1
+    assert _auth_header(client._client) == f"Bearer {JWT2}"
+
+
+def test_factory_wraps_in_autorefresh_when_token_manager_present():
+    tm = _FakeTokenManager(JWT2)
+    config = {"supabase": {"url": URL, "anon_key": ANON,
+                           "supabase_token": JWT, "_token_manager": tm}}
+    c = get_supabase_client(config)
+    assert isinstance(c, AutoRefreshClient)
+    assert _auth_header(c._client) == f"Bearer {JWT}"


### PR DESCRIPTION
## Summary

Makes the `campfire deploy` authentication path coherent end-to-end, fixing an intermittent `42501` RLS failure where deploys silently authenticated as `anon`.

## Root cause

In supabase-py 2.28.3, `create_client(url, anon)` + `client.postgrest.auth(jwt)` leaves the anon key on the wire (proven offline) — the user JWT never applies. Deploy writes ran as role `anon` → `auth.uid()` NULL → `is_admin()` false → `42501` on the first INSERT (the `observations` upsert), while a pre-existing `programs` row absorbed it as a no-op UPDATE. It was intermittent (a race with supabase-py's GoTrue auth-state listener resetting the cached postgrest client back to anon). The `/auth/whoami` admin gate used a **separately-resolved** token, so it could pass for a genuine admin while their writes were still rejected.

## Changes

- **One explicit auth mode** — `load_config` resolves exactly one of `service_role | local | login`, tagged on the config (`_auth_mode`); client construction, refresh, and the admin gate all dispatch off it.
- **Never anon** — the user JWT is baked into `ClientOptions` headers at construction; `_make_user_client`/`get_supabase_client` refuse to build a client without a token.
- **Refresh correctness** — `AutoRefreshClient` refreshes on the **Supabase token's own `exp`** (not the access token's) and rebuilds the client so the fresh token is actually carried. This also removes the mid-deploy `PGRST303` described in #168 (the old `postgrest.auth()` refresh was a no-op, so the token aged out).
- **Coherent gate** — admin is verified **through the actual write client** (`rpc('is_admin')`), so a gate pass guarantees the writes pass. Skipped for service-role/local (where `auth.uid()` is NULL under the service role).
- **Matched credentials** — a login token can no longer pair with a foreign TOML/env URL; the login url/anon/token/manager are taken as one set.
- **Shared JWT decoder** in `auth/_jwt.py` (no `deploy/` imports).

## Behavior change ⚠️

When a `service_role_key` is present (env or TOML), it is now used as-is and login credentials are **not** injected (previously a login token would override). Intended — service-role is the right path for unattended/CI deploys (bypasses RLS + JWT expiry).

## Tests

`test_deploy_auth_mode.py` (new) + extended `test_deploy_supabase_auth.py`: anon-safety, mode resolution, exp-based refresh, and gate pass/block/expired-JWT. Full Python suite green (144 passed, 1 pre-existing skip).

## Verification still needed (network/creds)

- A real admin deploy (`campfire deploy --obs <obs>`) end-to-end — the original `42501` site (`observations` upsert) should now succeed.
- A non-admin login sees the gate fail fast with their email **before** any write.

Refs #168 — this resolves the token-refresh fragility on the user-JWT deploy path; the reconcile-atomicity half (ghost objects) is tracked separately.

Generated with Claude Code
