### PR TITLE
fix(rls): admins inherit access to all programs

### DIFF
--- a/supabase/migrations/20260618120000_admin_inherits_all_programs.sql
+++ b/supabase/migrations/20260618120000_admin_inherits_all_programs.sql
@@ -1,0 +1,37 @@
+-- Admins inherit access to every program.
+--
+-- Every program-gated RLS SELECT policy routes through
+-- accessible_program_slugs() (observations, targets, spectra, objects,
+-- object_photometry, ...). Previously admins were NOT granted all programs
+-- here, so a deploy that creates rows for a PRIVATE program the deployer has
+-- no explicit grant to could not read those rows back. PostgREST upserts use
+-- `Prefer: return=representation` (INSERT ... RETURNING), and PostgreSQL
+-- enforces the SELECT policy on the returned row, so the write failed with
+-- `42501 new row violates row-level security policy` even though the INSERT
+-- WITH CHECK (is_admin()) passed.
+--
+-- Granting admins all programs at this single function fixes read-back for
+-- every program-gated table at once and makes the access model consistent:
+-- a user can access a program if it is granted to them, OR it is public, OR
+-- they are an admin (admins already have this for programs/nircam_exposures).
+
+CREATE OR REPLACE FUNCTION public.accessible_program_slugs()
+RETURNS text[]
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT COALESCE(array_agg(DISTINCT slug), '{}')
+  FROM (
+    SELECT program_slug AS slug
+    FROM user_program_access
+    WHERE user_id = auth.uid()
+    UNION
+    SELECT slug
+    FROM programs
+    WHERE is_public = true
+    UNION
+    SELECT slug
+    FROM programs
+    WHERE public.is_admin()
+  ) sub;
+$$;

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -65,6 +65,15 @@ AS $$
     SELECT slug
     FROM programs
     WHERE is_public = true
+    UNION
+    -- Admins (the operators) inherit access to every program. This is the
+    -- single point where admin access is granted to all program-gated data:
+    -- every RLS SELECT policy routes through accessible_program_slugs(), so
+    -- this lets admins read back rows they deploy for private programs
+    -- (otherwise an upsert's RETURNING fails the SELECT policy -> 42501).
+    SELECT slug
+    FROM programs
+    WHERE public.is_admin()
   ) sub;
 $$;
 


### PR DESCRIPTION
## Summary

Fixes the **real** cause of the `42501` RLS failure when deploying an observation for a **private** program (e.g. `skyfire`) — distinct from, and on top of, the client-auth fix in #183.

## Root cause (proven server-side)

The deploy authenticates correctly as an admin (after #183), and the INSERT `WITH CHECK (is_admin())` passes. But PostgREST's upsert sends `Prefer: return=representation` → `INSERT ... RETURNING`, and PostgreSQL enforces the **SELECT** policy on the returned row. `observations` (and `targets`/`spectra`/`objects`/`object_photometry`) only have **access-gated** SELECT policies (`program_slug = ANY(accessible_program_slugs())`), with **no admin select-all** — unlike `programs`/`nircam_exposures`/`map_layers`. A brand-new private `skyfire` row isn't in the deployer's `accessible_program_slugs()`, so it can't be read back → `42501`.

Reproduced directly on production as the deploying user:
- plain `INSERT` → **SUCCEEDED** (WITH CHECK is_admin() passes)
- `INSERT ... RETURNING` → **BLOCKED 42501** (SELECT policy on the returned row)
- `skyfire.is_public = false`, and `skyfire ∉ accessible_program_slugs()` for the user

This is also why the `programs` upsert in the same deploy succeeded (it *has* `admin_programs_select`) while `observations` failed — the exact asymmetry.

## Fix

All five access-gated tables route their SELECT policy through the single function `accessible_program_slugs()` (22 references across `policies.sql`). Rather than add five separate `admin_*_select` policies, grant admins every program at that one function:

```sql
-- accessible_program_slugs() now UNIONs:
SELECT slug FROM programs WHERE public.is_admin()
```

The access model becomes consistent: **a user can access a program if it is granted to them, OR it is public, OR they are an admin.** Verified read-only on production with the proposed body under the deploying admin's claims: `skyfire` is now accessible (29/29 programs visible). Non-admins are unaffected (the new UNION branch returns nothing for them).

## Notes

- Both this **and** #183 are required for a working private-program deploy on a user login: #183 makes the client authenticate as the admin (INSERT `WITH CHECK` passes); this makes the admin able to read the row back (`RETURNING`/SELECT passes).
- Schema source of truth updated in `supabase/schemas/functions.sql`; migration `20260618120000_admin_inherits_all_programs.sql` is a plain `CREATE OR REPLACE FUNCTION` (idempotent). Docker was unavailable to run `supabase db diff`, so the migration is hand-authored — it's exactly what the diff would emit.
- Applies to production via the normal Supabase GitHub integration on merge (I did **not** apply it to prod out-of-band).

Generated with Claude Code
