### PR TITLE
fix(deploy): make object reconciliation apply atomic (#184)

### DIFF
--- a/python/campfire/deploy/reconcile.py
+++ b/python/campfire/deploy/reconcile.py
@@ -734,6 +734,13 @@ def apply_proposals(
         plus daughters), or merged (survivor). Soft-deleted orphans and
         merge losers are excluded — downstream consumers (e.g. photometry)
         don't need to re-process them.
+
+    Dispatch: the deploy path (inserts / revivals / updates / orphans — no
+    splits or merges, which are blocked pre-apply by abort_on_split_merge)
+    goes through the atomic ``apply_object_reconciliation`` RPC so the entire
+    apply is one transaction and can never strand ghost objects (GitHub #184).
+    The operator-only split/merge path keeps the legacy per-call apply, which
+    also migrates photometry and list membership in Python.
     """
     if proposals.complex_overlaps:
         raise RuntimeError(
@@ -742,6 +749,110 @@ def apply_proposals(
             "aborted before reaching this point."
         )
     now = datetime.now(timezone.utc).isoformat()
+    if proposals.splits or proposals.merges:
+        return _apply_proposals_legacy(client, field, proposals, now)
+    if not (
+        proposals.inserts or proposals.revivals
+        or proposals.updates or proposals.orphans
+    ):
+        return {}, set()
+    return _apply_proposals_rpc(client, field, proposals, now)
+
+
+def _agg_payload(agg: ClusterAggregates) -> dict:
+    """Serialize a ClusterAggregates to a JSON-safe dict for the apply RPC.
+
+    member_target_db_ids rides inside the element so the RPC can set FKs in
+    the same transaction as the insert. member_target_ids (a set) is dropped:
+    not JSON-serializable and not needed server-side.
+    """
+    return {
+        'object_id': agg.object_id,
+        'ra': agg.ra,
+        'dec': agg.dec,
+        'n_targets': agg.n_targets,
+        'n_spectra': agg.n_spectra,
+        'programs': agg.programs,
+        'gratings': agg.gratings,
+        'observations': agg.observations,
+        'max_snr': agg.max_snr,
+        'max_exposure_time': agg.max_exposure_time,
+        'member_target_db_ids': list(agg.member_target_db_ids),
+    }
+
+
+def _apply_proposals_rpc(
+    client: Client, field: str, proposals: Proposals, now: str,
+) -> tuple[dict[str, int], set[int]]:
+    """Atomic deploy-path apply via the apply_object_reconciliation RPC.
+
+    Builds the JSON-safe payload, makes a single RPC call (one transaction:
+    inserts + revivals + updates + orphan soft-deletes + all target FK
+    assignment), and parses the returned id maps back into the
+    (stats, changed_ids) contract.
+    """
+    inserts = [_agg_payload(p.aggregates) for p in proposals.inserts]
+    revivals = [
+        {**_agg_payload(r.aggregates), 'object_db_id': r.object['id']}
+        for r in proposals.revivals
+    ]
+    updates = [
+        {
+            **_agg_payload(u.aggregates),
+            'object_db_id': u.object['id'],
+            'staleness_reason': u.staleness_reason,
+            'reactivate': not u.object.get('is_active'),
+        }
+        for u in proposals.updates
+    ]
+    orphan_ids = [o.object['id'] for o in proposals.orphans]
+
+    resp = client.rpc('apply_object_reconciliation', {
+        'p_field': field,
+        'p_inserts': inserts,
+        'p_revivals': revivals,
+        'p_updates': updates,
+        'p_orphan_ids': orphan_ids,
+        'p_updated_at': now,
+    }).execute()
+
+    data = resp.data
+    if isinstance(data, list):  # defensive: some clients wrap scalar returns
+        data = data[0] if data else {}
+    data = data or {}
+
+    insert_id_map = data.get('insert_id_map') or {}
+    inserted_ids = [int(v) for v in insert_id_map.values()]
+    revived_ids = [int(x) for x in (data.get('revived_ids') or [])]
+    updated_ids = [int(x) for x in (data.get('updated_ids') or [])]
+
+    stats: dict[str, int] = defaultdict(int)
+    stats['inserted'] = len(inserted_ids)
+    stats['revived'] = len(revived_ids)
+    stats['updated'] = len(updated_ids)
+    stats['reactivated'] = int(data.get('reactivated_count') or 0)
+    stats['soft_deleted'] = int(data.get('orphaned_count') or 0)
+    stats['target_fks_set'] = int(data.get('target_fks_set') or 0)
+    # Per-staleness breakdown — computed Python-side to preserve the legacy
+    # stat keys (the RPC doesn't need them).
+    for u in proposals.updates:
+        if u.staleness_reason:
+            stats[f'staleness_{u.staleness_reason}'] += 1
+
+    changed_ids = set(inserted_ids) | set(revived_ids) | set(updated_ids)
+    return dict(stats), changed_ids
+
+
+def _apply_proposals_legacy(
+    client: Client, field: str, proposals: Proposals, now: str,
+) -> tuple[dict[str, int], set[int]]:
+    """Per-call apply for the operator split/merge path.
+
+    NOT atomic — retained for the interactive path because splits/merges also
+    migrate photometry and object_list_members in Python. Splits/merges never
+    reach this on the deploy path (abort_on_split_merge), where the atomic
+    _apply_proposals_rpc is used instead.
+    """
     stats = defaultdict(int)
 
     # The order matters: inserts must run before target FK updates that

--- a/python/tests/test_reconcile.py
+++ b/python/tests/test_reconcile.py
@@ -5,9 +5,19 @@ in batch_upsert_spectra."""
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
-from campfire.deploy.reconcile import classify
+from campfire.deploy import reconcile
+from campfire.deploy.reconcile import (
+    ClusterAggregates,
+    Insert,
+    Orphan,
+    Proposals,
+    Split,
+    Update,
+    apply_proposals,
+    classify,
+)
 from campfire.deploy.supabase import batch_upsert_spectra
 
 
@@ -261,6 +271,117 @@ def test_inactive_1to1_match_is_not_skipped():
 
     assert p.unchanged == 0
     assert len(p.updates) == 1
+
+
+def _agg(object_id='J1', ra=150.0, dec=2.0,
+         member_db_ids=(1,), member_ids=('t1',)):
+    return ClusterAggregates(
+        object_id=object_id, ra=ra, dec=dec,
+        n_targets=len(member_db_ids), n_spectra=0,
+        programs=['prog'], gratings=[], observations=['obs'],
+        max_snr=None, max_exposure_time=None,
+        member_target_db_ids=list(member_db_ids),
+        member_target_ids=set(member_ids),
+    )
+
+
+def test_apply_proposals_rpc_payload_and_parse():
+    # Deploy-path apply (no splits/merges) must go through the atomic RPC,
+    # send member_target_db_ids inside each element (so the FK assignment
+    # shares the transaction), drop the non-serializable member_target_ids
+    # set, and parse the returned id maps into (stats, changed_ids).
+    proposals = Proposals(
+        inserts=[Insert(cluster_idx=0,
+                        aggregates=_agg('JINS', member_db_ids=(10, 11),
+                                        member_ids=('t10', 't11')))],
+        updates=[Update(cluster_idx=1, object={'id': 500, 'is_active': True},
+                        aggregates=_agg('JUPD', member_db_ids=(20,),
+                                        member_ids=('t20',)),
+                        staleness_reason='new_target')],
+        orphans=[Orphan(object={'id': 900})],
+    )
+
+    client = MagicMock()
+    client.rpc.return_value.execute.return_value = MagicMock(data={
+        'insert_id_map': {'JINS': 1001},
+        'revived_ids': [],
+        'updated_ids': [500],
+        'inserted_count': 1,
+        'revived_count': 0,
+        'updated_count': 1,
+        'reactivated_count': 0,
+        'orphaned_count': 1,
+        'target_fks_set': 3,
+    })
+
+    stats, changed = apply_proposals(client, 'egs', proposals)
+
+    name, params = client.rpc.call_args[0]
+    assert name == 'apply_object_reconciliation'
+    assert params['p_field'] == 'egs'
+    assert params['p_orphan_ids'] == [900]
+    ins = params['p_inserts'][0]
+    assert ins['object_id'] == 'JINS'
+    assert ins['member_target_db_ids'] == [10, 11]
+    assert 'member_target_ids' not in ins
+    upd = params['p_updates'][0]
+    assert upd['object_db_id'] == 500
+    assert upd['staleness_reason'] == 'new_target'
+    assert upd['reactivate'] is False
+
+    assert stats['inserted'] == 1
+    assert stats['updated'] == 1
+    assert stats['soft_deleted'] == 1
+    assert stats['target_fks_set'] == 3
+    assert stats['staleness_new_target'] == 1
+    # changed_ids = inserted ∪ revived ∪ updated (orphans excluded).
+    assert changed == {1001, 500}
+
+
+def test_apply_proposals_rpc_reactivate_flag_for_inactive_update():
+    # An inactive 1:1 match carries reactivate=True so the RPC flips is_active.
+    proposals = Proposals(
+        updates=[Update(cluster_idx=0, object={'id': 7, 'is_active': False},
+                        aggregates=_agg('JX'), staleness_reason=None)],
+    )
+    client = MagicMock()
+    client.rpc.return_value.execute.return_value = MagicMock(data={
+        'insert_id_map': {}, 'revived_ids': [], 'updated_ids': [7],
+        'reactivated_count': 1, 'orphaned_count': 0, 'target_fks_set': 1,
+    })
+
+    _stats, changed = apply_proposals(client, 'egs', proposals)
+
+    assert client.rpc.call_args[0][1]['p_updates'][0]['reactivate'] is True
+    assert changed == {7}
+
+
+def test_apply_proposals_dispatches_to_legacy_when_splits_present():
+    # Splits/merges keep the legacy Python apply (photometry/list migration);
+    # they must NOT hit the atomic RPC path.
+    proposals = Proposals(
+        splits=[Split(object={'id': 1, 'ra': 150.0, 'dec': 2.0},
+                      daughters=[_agg('JD1'), _agg('JD2')],
+                      daughter_cluster_indices=[0, 1],
+                      inheritor_index=0)],
+    )
+    client = MagicMock()
+    with patch.object(reconcile, '_apply_proposals_legacy',
+                      return_value=({'split': 1}, {1})) as legacy, \
+            patch.object(reconcile, '_apply_proposals_rpc') as rpc:
+        stats, _changed = apply_proposals(client, 'egs', proposals)
+
+    legacy.assert_called_once()
+    rpc.assert_not_called()
+    assert stats == {'split': 1}
+
+
+def test_apply_proposals_empty_skips_rpc():
+    client = MagicMock()
+    stats, changed = apply_proposals(client, 'egs', Proposals())
+    client.rpc.assert_not_called()
+    assert stats == {}
+    assert changed == set()
 
 
 def test_independent_split_and_merge_both_apply():

--- a/supabase/migrations/20260618173853_add_apply_object_reconciliation_rpc.sql
+++ b/supabase/migrations/20260618173853_add_apply_object_reconciliation_rpc.sql
@@ -1,0 +1,272 @@
+-- Atomic object reconciliation apply (GitHub #184).
+--
+-- Hand-authored (not raw `supabase db diff` output). The diff for this change
+-- is contaminated by migra limitations: it emits spurious drop+recreate of the
+-- materialized views / views (mv_filter_options, mv_programs_overview,
+-- nircam_reduction_progress, spectrum_flag_summary) and an unrelated
+-- accessible_program_slugs redefinition, and it MISSES the compute_object_
+-- redshift_auto change (migra does not track a function's SET attributes, and
+-- that change only adds `SET statement_timeout`). This migration therefore
+-- carries exactly the three function changes made in supabase/schemas/functions.sql:
+--   1. apply_object_reconciliation  (new) — one-transaction reconcile apply
+--   2. bulk_set_target_object_fks   (changed) — statement_timeout + typed plan
+--   3. compute_object_redshift_auto (changed) — statement_timeout guard
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.apply_object_reconciliation(p_field text, p_inserts jsonb DEFAULT '[]'::jsonb, p_revivals jsonb DEFAULT '[]'::jsonb, p_updates jsonb DEFAULT '[]'::jsonb, p_orphan_ids integer[] DEFAULT '{}'::integer[], p_updated_at timestamp with time zone DEFAULT now())
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SET statement_timeout TO '300s'
+AS $function$
+DECLARE
+  v_insert_id_map JSONB := '{}'::jsonb;
+  v_revived_ids   INTEGER[] := '{}';
+  v_updated_ids   INTEGER[] := '{}';
+  v_orphaned      INTEGER := 0;
+  v_reactivated   INTEGER := 0;
+  v_fk_count      INTEGER := 0;
+BEGIN
+  -- 1. Orphans FIRST: soft-delete active objects that lost all members, but
+  --    EXCLUDE any whose object_id an insert is about to re-adopt. Ghost
+  --    recovery: a stranded active ghost is classified as an orphan while the
+  --    real new cluster is an insert holding the same IAU name; the upsert in
+  --    step 2 adopts that row, so it must not be soft-deleted out from under it.
+  UPDATE objects o SET
+    is_active = false,
+    last_data_change_at = p_updated_at,
+    staleness_reason = 'membership_changed',
+    updated_at = p_updated_at
+  WHERE o.id = ANY(p_orphan_ids)
+    AND o.is_active
+    AND o.object_id NOT IN (
+      SELECT x.object_id FROM jsonb_to_recordset(p_inserts) AS x(object_id TEXT)
+    );
+  GET DIAGNOSTICS v_orphaned = ROW_COUNT;
+
+  -- 2. Inserts (idempotent). ON CONFLICT re-adopts a ghost / soft-deleted row
+  --    holding this object_id. We deliberately do NOT touch version /
+  --    redshift_* / last_inspected_* so inspection state — and the triggers
+  --    scoped to those columns — stay untouched; a collision is only ever a
+  --    freshly stranded ghost with no inspection history.
+  WITH ins AS (
+    INSERT INTO objects (
+      object_id, field, ra, dec, n_targets, n_spectra,
+      programs, gratings, observations, max_snr, max_exposure_time, updated_at
+    )
+    SELECT x.object_id, p_field, x.ra, x.dec, x.n_targets, x.n_spectra,
+           x.programs, x.gratings, x.observations, x.max_snr,
+           x.max_exposure_time, p_updated_at
+    FROM jsonb_to_recordset(p_inserts) AS x(
+      object_id TEXT, ra DOUBLE PRECISION, dec DOUBLE PRECISION,
+      n_targets INTEGER, n_spectra INTEGER,
+      programs TEXT[], gratings TEXT[], observations TEXT[],
+      max_snr DOUBLE PRECISION, max_exposure_time DOUBLE PRECISION
+    )
+    ON CONFLICT (object_id) DO UPDATE SET
+      field = EXCLUDED.field,
+      ra = EXCLUDED.ra,
+      dec = EXCLUDED.dec,
+      n_targets = EXCLUDED.n_targets,
+      n_spectra = EXCLUDED.n_spectra,
+      programs = EXCLUDED.programs,
+      gratings = EXCLUDED.gratings,
+      observations = EXCLUDED.observations,
+      max_snr = EXCLUDED.max_snr,
+      max_exposure_time = EXCLUDED.max_exposure_time,
+      is_active = true,
+      last_data_change_at = p_updated_at,
+      staleness_reason = 'membership_changed',
+      updated_at = p_updated_at
+    RETURNING id, object_id
+  )
+  SELECT coalesce(jsonb_object_agg(object_id, id), '{}'::jsonb)
+  INTO v_insert_id_map
+  FROM ins;
+
+  -- 3. Revivals: reactivate inactive objects matched by position; refresh
+  --    centroid + aggregates.
+  WITH rev AS (
+    UPDATE objects o SET
+      is_active = true,
+      object_id = r.object_id,
+      ra = r.ra,
+      dec = r.dec,
+      n_targets = r.n_targets,
+      n_spectra = r.n_spectra,
+      programs = r.programs,
+      gratings = r.gratings,
+      observations = r.observations,
+      max_snr = r.max_snr,
+      max_exposure_time = r.max_exposure_time,
+      last_data_change_at = p_updated_at,
+      staleness_reason = 'membership_changed',
+      updated_at = p_updated_at
+    FROM jsonb_to_recordset(p_revivals) AS r(
+      object_db_id INTEGER, object_id TEXT, ra DOUBLE PRECISION,
+      dec DOUBLE PRECISION, n_targets INTEGER, n_spectra INTEGER,
+      programs TEXT[], gratings TEXT[], observations TEXT[],
+      max_snr DOUBLE PRECISION, max_exposure_time DOUBLE PRECISION
+    )
+    WHERE o.id = r.object_db_id
+    RETURNING o.id
+  )
+  SELECT coalesce(array_agg(id), '{}') INTO v_revived_ids FROM rev;
+
+  -- 4. Updates: refresh aggregates; set staleness only when provided;
+  --    reactivate a membership-matched inactive object when reactivate=true.
+  WITH upd AS (
+    UPDATE objects o SET
+      object_id = u.object_id,
+      ra = u.ra,
+      dec = u.dec,
+      n_targets = u.n_targets,
+      n_spectra = u.n_spectra,
+      programs = u.programs,
+      gratings = u.gratings,
+      observations = u.observations,
+      max_snr = u.max_snr,
+      max_exposure_time = u.max_exposure_time,
+      is_active = CASE WHEN u.reactivate THEN true ELSE o.is_active END,
+      staleness_reason = CASE
+        WHEN u.reactivate THEN 'membership_changed'
+        WHEN u.staleness_reason IS NOT NULL THEN u.staleness_reason
+        ELSE o.staleness_reason
+      END,
+      last_data_change_at = CASE
+        WHEN u.reactivate OR u.staleness_reason IS NOT NULL THEN p_updated_at
+        ELSE o.last_data_change_at
+      END,
+      updated_at = p_updated_at
+    FROM jsonb_to_recordset(p_updates) AS u(
+      object_db_id INTEGER, object_id TEXT, ra DOUBLE PRECISION,
+      dec DOUBLE PRECISION, n_targets INTEGER, n_spectra INTEGER,
+      programs TEXT[], gratings TEXT[], observations TEXT[],
+      max_snr DOUBLE PRECISION, max_exposure_time DOUBLE PRECISION,
+      staleness_reason TEXT, reactivate BOOLEAN
+    )
+    WHERE o.id = u.object_db_id
+    RETURNING o.id AS id, u.reactivate AS reactivated
+  )
+  SELECT coalesce(array_agg(id), '{}'),
+         coalesce(count(*) FILTER (WHERE reactivated), 0)
+  INTO v_updated_ids, v_reactivated
+  FROM upd;
+
+  -- 5. Target FK assignment — the actual fix. Derive (target, object) pairs
+  --    from each operation's member_target_db_ids (resolving insert object ids
+  --    via the RETURNING map) and apply them in ONE typed, index-friendly
+  --    UPDATE, inside this same transaction as the inserts above.
+  WITH pairs AS (
+    SELECT unnest(x.member_target_db_ids) AS target_id,
+           (v_insert_id_map ->> x.object_id)::INTEGER AS object_id
+    FROM jsonb_to_recordset(p_inserts)
+      AS x(object_id TEXT, member_target_db_ids INTEGER[])
+    UNION ALL
+    SELECT unnest(r.member_target_db_ids), r.object_db_id
+    FROM jsonb_to_recordset(p_revivals)
+      AS r(object_db_id INTEGER, member_target_db_ids INTEGER[])
+    UNION ALL
+    SELECT unnest(u.member_target_db_ids), u.object_db_id
+    FROM jsonb_to_recordset(p_updates)
+      AS u(object_db_id INTEGER, member_target_db_ids INTEGER[])
+  )
+  UPDATE targets t SET
+    object_id = p.object_id,
+    updated_at = p_updated_at
+  FROM pairs p
+  WHERE t.id = p.target_id;
+  GET DIAGNOSTICS v_fk_count = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'insert_id_map', v_insert_id_map,
+    'revived_ids', to_jsonb(v_revived_ids),
+    'updated_ids', to_jsonb(v_updated_ids),
+    'inserted_count', (SELECT count(*) FROM jsonb_object_keys(v_insert_id_map)),
+    'revived_count', coalesce(array_length(v_revived_ids, 1), 0),
+    'updated_count', coalesce(array_length(v_updated_ids, 1), 0),
+    'reactivated_count', v_reactivated,
+    'orphaned_count', v_orphaned,
+    'target_fks_set', v_fk_count
+  );
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.bulk_set_target_object_fks(p_pairs jsonb, p_updated_at timestamp with time zone DEFAULT now())
+ RETURNS void
+ LANGUAGE plpgsql
+ SET statement_timeout TO '300s'
+AS $function$
+BEGIN
+  UPDATE targets t SET
+    object_id = pair.object_id,
+    updated_at = p_updated_at
+  FROM jsonb_to_recordset(p_pairs) AS pair(target_id integer, object_id integer)
+  WHERE t.id = pair.target_id;
+END;
+$function$
+;
+
+GRANT EXECUTE ON FUNCTION public.apply_object_reconciliation(text, jsonb, jsonb, jsonb, integer[], timestamptz) TO service_role;
+
+GRANT EXECUTE ON FUNCTION public.bulk_set_target_object_fks(jsonb, timestamptz) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.compute_object_redshift_auto(p_field TEXT)
+ RETURNS INTEGER
+ LANGUAGE plpgsql
+ SET statement_timeout TO '300s'
+AS $function$
+DECLARE
+  n INTEGER;
+BEGIN
+  WITH computed AS (
+    SELECT o.id,
+           o.redshift_auto AS old_auto,
+           o.redshift_quality AS quality,
+           (
+             SELECT s.redshift_auto
+             FROM targets t
+             JOIN spectra s ON s.target_id = t.target_id
+             WHERE t.object_id = o.id
+               AND s.redshift_auto IS NOT NULL
+             ORDER BY
+               CASE
+                 WHEN s.grating = 'PRISM' THEN 0
+                 WHEN s.grating IN ('G140M', 'G235M', 'G395M') THEN 1
+                 WHEN s.grating IN ('G140H', 'G235H', 'G395H') THEN 2
+                 ELSE 3
+               END ASC,
+               s.exposure_time DESC NULLS LAST,
+               s.id ASC
+             LIMIT 1
+           ) AS new_val
+    FROM objects o
+    WHERE o.field = p_field
+  )
+  UPDATE objects o
+  SET redshift_auto = c.new_val,
+      staleness_reason = CASE
+        WHEN c.quality >= 2
+             AND c.old_auto IS DISTINCT FROM c.new_val
+        THEN 'reprocessed'
+        ELSE o.staleness_reason
+      END,
+      last_data_change_at = CASE
+        WHEN c.quality >= 2
+             AND c.old_auto IS DISTINCT FROM c.new_val
+        THEN NOW()
+        ELSE o.last_data_change_at
+      END,
+      updated_at = NOW()
+  FROM computed c
+  WHERE o.id = c.id
+    AND o.redshift_auto IS DISTINCT FROM c.new_val;
+
+  GET DIAGNOSTICS n = ROW_COUNT;
+  RETURN n;
+END;
+$function$
+;
+
+GRANT EXECUTE ON FUNCTION public.compute_object_redshift_auto(text) TO service_role;

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -2940,23 +2940,254 @@ GRANT ALL ON FUNCTION public.validate_refresh_token(text) TO service_role;
 -- Used by cfdeploy objects rebuild to set targets.object_id in bulk,
 -- avoiding per-object HTTP round-trips through PostgREST.
 
+-- A typed jsonb_to_recordset (not jsonb_array_elements + per-row ->>/cast)
+-- gives the planner real column types and a sane row estimate, so it
+-- hash-joins against targets_pkey instead of a misestimated nested loop.
+-- statement_timeout matches the other heavy reconcile RPCs: without it the
+-- function ran at the short role default, and large fields tripped 57014
+-- (canceling statement due to statement timeout) mid-apply — see #184.
 CREATE OR REPLACE FUNCTION public.bulk_set_target_object_fks(
   p_pairs JSONB,
   p_updated_at TIMESTAMPTZ DEFAULT now()
 )
 RETURNS void
 LANGUAGE plpgsql
+SET statement_timeout = '300s'
 AS $$
 BEGIN
   UPDATE targets t SET
-    object_id = (pair->>'object_id')::integer,
+    object_id = pair.object_id,
     updated_at = p_updated_at
-  FROM jsonb_array_elements(p_pairs) AS pair
-  WHERE t.id = (pair->>'target_id')::integer;
+  FROM jsonb_to_recordset(p_pairs) AS pair(target_id integer, object_id integer)
+  WHERE t.id = pair.target_id;
 END;
 $$;
 
 GRANT EXECUTE ON FUNCTION public.bulk_set_target_object_fks(JSONB, TIMESTAMPTZ) TO service_role;
+
+
+-- =============================================================================
+-- Atomic object-reconciliation apply (deploy path)
+-- =============================================================================
+-- Applies the deploy-path reconciliation proposal set — inserts, revivals,
+-- updates, orphan soft-deletes, and ALL target->object FK assignments — in a
+-- SINGLE transaction. Replaces the previous Python apply_proposals(), which
+-- issued each step as an independent, auto-committed PostgREST call: a failure
+-- (e.g. a statement timeout) anywhere between the object inserts (step 1) and
+-- the dead-last FK assignment (step 7) committed the new objects but never
+-- linked their targets, stranding "ghost" objects (active, valid object_id,
+-- ZERO member targets) that then collided with objects_object_id_key on every
+-- re-run. See GitHub #184.
+--
+-- One plpgsql function == one transaction, so any failure rolls the entire
+-- apply back: no partial state is ever possible. Inserts are additionally made
+-- idempotent (ON CONFLICT (object_id) DO UPDATE) so a re-run after any pre-
+-- existing ghost mess self-heals by re-adopting the stranded row instead of
+-- dying on the unique constraint.
+--
+-- Splits and merges are NOT handled here. They only occur on the interactive
+-- operator path (the deploy path aborts before apply when they are detected),
+-- and they carry photometry + list-membership migration that stays in Python.
+--
+-- Payload (all JSON-safe; member_target_db_ids travels INSIDE each element so
+-- FK assignment shares this transaction with the inserts):
+--   p_inserts:  [{object_id, ra, dec, n_targets, n_spectra, programs[],
+--                 gratings[], observations[], max_snr, max_exposure_time,
+--                 member_target_db_ids[]}]
+--   p_revivals: as p_inserts plus {object_db_id} (the inactive row to revive)
+--   p_updates:  as p_revivals plus {staleness_reason (nullable),
+--                 reactivate (bool)}
+--   p_orphan_ids: integer[] of object db ids to soft-delete.
+--
+-- Returns jsonb: {insert_id_map: {object_id: db_id}, revived_ids: [db_id],
+--   updated_ids: [db_id], inserted_count, revived_count, updated_count,
+--   reactivated_count, orphaned_count, target_fks_set}.
+CREATE OR REPLACE FUNCTION public.apply_object_reconciliation(
+  p_field       TEXT,
+  p_inserts     JSONB DEFAULT '[]'::jsonb,
+  p_revivals    JSONB DEFAULT '[]'::jsonb,
+  p_updates     JSONB DEFAULT '[]'::jsonb,
+  p_orphan_ids  INTEGER[] DEFAULT '{}',
+  p_updated_at  TIMESTAMPTZ DEFAULT now()
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SET statement_timeout = '300s'
+AS $$
+DECLARE
+  v_insert_id_map JSONB := '{}'::jsonb;
+  v_revived_ids   INTEGER[] := '{}';
+  v_updated_ids   INTEGER[] := '{}';
+  v_orphaned      INTEGER := 0;
+  v_reactivated   INTEGER := 0;
+  v_fk_count      INTEGER := 0;
+BEGIN
+  -- 1. Orphans FIRST: soft-delete active objects that lost all members, but
+  --    EXCLUDE any whose object_id an insert is about to re-adopt. Ghost
+  --    recovery: a stranded active ghost is classified as an orphan while the
+  --    real new cluster is an insert holding the same IAU name; the upsert in
+  --    step 2 adopts that row, so it must not be soft-deleted out from under it.
+  UPDATE objects o SET
+    is_active = false,
+    last_data_change_at = p_updated_at,
+    staleness_reason = 'membership_changed',
+    updated_at = p_updated_at
+  WHERE o.id = ANY(p_orphan_ids)
+    AND o.is_active
+    AND o.object_id NOT IN (
+      SELECT x.object_id FROM jsonb_to_recordset(p_inserts) AS x(object_id TEXT)
+    );
+  GET DIAGNOSTICS v_orphaned = ROW_COUNT;
+
+  -- 2. Inserts (idempotent). ON CONFLICT re-adopts a ghost / soft-deleted row
+  --    holding this object_id. We deliberately do NOT touch version /
+  --    redshift_* / last_inspected_* so inspection state — and the triggers
+  --    scoped to those columns — stay untouched; a collision is only ever a
+  --    freshly stranded ghost with no inspection history.
+  WITH ins AS (
+    INSERT INTO objects (
+      object_id, field, ra, dec, n_targets, n_spectra,
+      programs, gratings, observations, max_snr, max_exposure_time, updated_at
+    )
+    SELECT x.object_id, p_field, x.ra, x.dec, x.n_targets, x.n_spectra,
+           x.programs, x.gratings, x.observations, x.max_snr,
+           x.max_exposure_time, p_updated_at
+    FROM jsonb_to_recordset(p_inserts) AS x(
+      object_id TEXT, ra DOUBLE PRECISION, dec DOUBLE PRECISION,
+      n_targets INTEGER, n_spectra INTEGER,
+      programs TEXT[], gratings TEXT[], observations TEXT[],
+      max_snr DOUBLE PRECISION, max_exposure_time DOUBLE PRECISION
+    )
+    ON CONFLICT (object_id) DO UPDATE SET
+      field = EXCLUDED.field,
+      ra = EXCLUDED.ra,
+      dec = EXCLUDED.dec,
+      n_targets = EXCLUDED.n_targets,
+      n_spectra = EXCLUDED.n_spectra,
+      programs = EXCLUDED.programs,
+      gratings = EXCLUDED.gratings,
+      observations = EXCLUDED.observations,
+      max_snr = EXCLUDED.max_snr,
+      max_exposure_time = EXCLUDED.max_exposure_time,
+      is_active = true,
+      last_data_change_at = p_updated_at,
+      staleness_reason = 'membership_changed',
+      updated_at = p_updated_at
+    RETURNING id, object_id
+  )
+  SELECT coalesce(jsonb_object_agg(object_id, id), '{}'::jsonb)
+  INTO v_insert_id_map
+  FROM ins;
+
+  -- 3. Revivals: reactivate inactive objects matched by position; refresh
+  --    centroid + aggregates.
+  WITH rev AS (
+    UPDATE objects o SET
+      is_active = true,
+      object_id = r.object_id,
+      ra = r.ra,
+      dec = r.dec,
+      n_targets = r.n_targets,
+      n_spectra = r.n_spectra,
+      programs = r.programs,
+      gratings = r.gratings,
+      observations = r.observations,
+      max_snr = r.max_snr,
+      max_exposure_time = r.max_exposure_time,
+      last_data_change_at = p_updated_at,
+      staleness_reason = 'membership_changed',
+      updated_at = p_updated_at
+    FROM jsonb_to_recordset(p_revivals) AS r(
+      object_db_id INTEGER, object_id TEXT, ra DOUBLE PRECISION,
+      dec DOUBLE PRECISION, n_targets INTEGER, n_spectra INTEGER,
+      programs TEXT[], gratings TEXT[], observations TEXT[],
+      max_snr DOUBLE PRECISION, max_exposure_time DOUBLE PRECISION
+    )
+    WHERE o.id = r.object_db_id
+    RETURNING o.id
+  )
+  SELECT coalesce(array_agg(id), '{}') INTO v_revived_ids FROM rev;
+
+  -- 4. Updates: refresh aggregates; set staleness only when provided;
+  --    reactivate a membership-matched inactive object when reactivate=true.
+  WITH upd AS (
+    UPDATE objects o SET
+      object_id = u.object_id,
+      ra = u.ra,
+      dec = u.dec,
+      n_targets = u.n_targets,
+      n_spectra = u.n_spectra,
+      programs = u.programs,
+      gratings = u.gratings,
+      observations = u.observations,
+      max_snr = u.max_snr,
+      max_exposure_time = u.max_exposure_time,
+      is_active = CASE WHEN u.reactivate THEN true ELSE o.is_active END,
+      staleness_reason = CASE
+        WHEN u.reactivate THEN 'membership_changed'
+        WHEN u.staleness_reason IS NOT NULL THEN u.staleness_reason
+        ELSE o.staleness_reason
+      END,
+      last_data_change_at = CASE
+        WHEN u.reactivate OR u.staleness_reason IS NOT NULL THEN p_updated_at
+        ELSE o.last_data_change_at
+      END,
+      updated_at = p_updated_at
+    FROM jsonb_to_recordset(p_updates) AS u(
+      object_db_id INTEGER, object_id TEXT, ra DOUBLE PRECISION,
+      dec DOUBLE PRECISION, n_targets INTEGER, n_spectra INTEGER,
+      programs TEXT[], gratings TEXT[], observations TEXT[],
+      max_snr DOUBLE PRECISION, max_exposure_time DOUBLE PRECISION,
+      staleness_reason TEXT, reactivate BOOLEAN
+    )
+    WHERE o.id = u.object_db_id
+    RETURNING o.id AS id, u.reactivate AS reactivated
+  )
+  SELECT coalesce(array_agg(id), '{}'),
+         coalesce(count(*) FILTER (WHERE reactivated), 0)
+  INTO v_updated_ids, v_reactivated
+  FROM upd;
+
+  -- 5. Target FK assignment — the actual fix. Derive (target, object) pairs
+  --    from each operation's member_target_db_ids (resolving insert object ids
+  --    via the RETURNING map) and apply them in ONE typed, index-friendly
+  --    UPDATE, inside this same transaction as the inserts above.
+  WITH pairs AS (
+    SELECT unnest(x.member_target_db_ids) AS target_id,
+           (v_insert_id_map ->> x.object_id)::INTEGER AS object_id
+    FROM jsonb_to_recordset(p_inserts)
+      AS x(object_id TEXT, member_target_db_ids INTEGER[])
+    UNION ALL
+    SELECT unnest(r.member_target_db_ids), r.object_db_id
+    FROM jsonb_to_recordset(p_revivals)
+      AS r(object_db_id INTEGER, member_target_db_ids INTEGER[])
+    UNION ALL
+    SELECT unnest(u.member_target_db_ids), u.object_db_id
+    FROM jsonb_to_recordset(p_updates)
+      AS u(object_db_id INTEGER, member_target_db_ids INTEGER[])
+  )
+  UPDATE targets t SET
+    object_id = p.object_id,
+    updated_at = p_updated_at
+  FROM pairs p
+  WHERE t.id = p.target_id;
+  GET DIAGNOSTICS v_fk_count = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'insert_id_map', v_insert_id_map,
+    'revived_ids', to_jsonb(v_revived_ids),
+    'updated_ids', to_jsonb(v_updated_ids),
+    'inserted_count', (SELECT count(*) FROM jsonb_object_keys(v_insert_id_map)),
+    'revived_count', coalesce(array_length(v_revived_ids, 1), 0),
+    'updated_count', coalesce(array_length(v_updated_ids, 1), 0),
+    'reactivated_count', v_reactivated,
+    'orphaned_count', v_orphaned,
+    'target_fks_set', v_fk_count
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.apply_object_reconciliation(TEXT, JSONB, JSONB, JSONB, INTEGER[], TIMESTAMPTZ) TO service_role;
 
 
 -- =============================================================================
@@ -3040,6 +3271,11 @@ GRANT EXECUTE ON FUNCTION public.recompute_target_aggregates(TEXT[]) TO service_
 CREATE OR REPLACE FUNCTION public.compute_object_redshift_auto(p_field TEXT)
 RETURNS INTEGER
 LANGUAGE plpgsql
+-- Per-object correlated subquery over targets⋈spectra across the whole field
+-- (~7k objects on egs). Runs right after the reconcile apply; without an
+-- explicit guard it ran at the short role default and was a latent second
+-- timeout. Matches the other heavy reconcile RPCs. See #184.
+SET statement_timeout = '300s'
 AS $$
 DECLARE
   n INTEGER;


### PR DESCRIPTION
Closes #184.

## Problem

`apply_proposals` (`python/campfire/deploy/reconcile.py`) applied reconciliation as a sequence of **independent, auto-committed PostgREST calls**, with target→object FK assignment dead last. Two failures hit prod (`skyfire_p2` deploy / `egs` field, 2026-06-18):

1. A **statement timeout** (`57014`) fired during the FK step → 42 new objects committed but never linked → 42 **ghost objects** (active, valid `object_id`, zero member targets).
2. The re-run **died with `23505 duplicate key … objects_object_id_key`** — the ghosts hold the IAU names the re-run's inserts want, and the constraint is a plain (non-partial) `UNIQUE(object_id)`, so the reconciler couldn't self-heal.

## Fix

**Atomicity.** New plpgsql RPC `apply_object_reconciliation` performs the entire deploy-path apply — inserts, revivals, updates, orphan soft-deletes, **and all target FK assignment** — in **one transaction**. A failure anywhere rolls the whole thing back; no partial/ghost state is possible. Key design points:
- Inserts are idempotent (`ON CONFLICT (object_id) DO UPDATE`) → a re-run after any pre-existing ghost mess **self-heals** by re-adopting the stranded row.
- Orphans are soft-deleted **first** and **exclude** any `object_id` an insert will re-adopt, so the upsert is never clobbered.
- `member_target_db_ids` travels inside each element so FK assignment shares the transaction with the inserts.
- The `ON CONFLICT` branch deliberately does **not** touch `version` / `redshift_*` / `last_inspected_*`, so inspection state and its triggers are untouched.

Splits/merges (operator-only interactive path — blocked pre-apply on deploy by `abort_on_split_merge`) keep the legacy Python apply, which also migrates photometry/list membership. `apply_proposals` now dispatches between the two.

**Timeouts.** `bulk_set_target_object_fks` was the only heavy reconcile RPC with **no** `SET statement_timeout` and used a `jsonb_array_elements` join that misled the planner against the large `targets` table. Now: `SET statement_timeout = '300s'` + a typed `jsonb_to_recordset` plan (hash-joins `targets_pkey`). Same timeout guard added to `compute_object_redshift_auto` (a latent second timeout on large fields).

## Validation

- `pytest` (full deploy suite): **148 passed, 1 skipped**. New unit tests cover payload construction, dispatch (legacy on split/merge), and return parsing.
- Local Supabase (`db reset` → SQL + supabase-py): **happy path** (FKs set, no ghosts), **ghost recovery** (re-adopt by name, orphan exclusion, no dup-key), and **atomic rollback** (mid-function error undoes the prior insert).

## Notes

- The migration is **hand-authored**: `supabase db diff` emits spurious matview/view drop+recreate and an unrelated `accessible_program_slugs` redefinition, and **misses** the `compute_object_redshift_auto` change (migra doesn't track function `SET` attributes). The migration carries exactly the three function changes in `supabase/schemas/functions.sql`.
- Schema source of truth (`supabase/schemas/functions.sql`) and the generated migration are committed together.

Generated with Claude Code

https://claude.ai/code/session_016XWx6wYFA9yiDaVjfej6B1