### PR TITLE
fix(rls): scope object aggregate columns to viewer's accessible programs

### DIFF
--- a/supabase/migrations/20260618193520_scope_object_aggregates_by_access.sql
+++ b/supabase/migrations/20260618193520_scope_object_aggregates_by_access.sql
@@ -1,0 +1,801 @@
+-- Scope object aggregate columns to the viewer's accessible programs.
+--
+-- Object rows are visible by program-array overlap (RLS: programs && accessible),
+-- but their denormalized aggregate columns (programs, gratings, observations,
+-- n_targets, n_spectra, max_snr, max_exposure_time) are computed across ALL member
+-- programs at deploy time, leaking proprietary member metadata on mixed-program
+-- objects. New helper object_scoped_aggregates() recomputes them restricted to a
+-- slug set; the object read RPCs now return scoped values (display-only: filter
+-- and sort still use the global columns). Member-level payloads were already
+-- filtered. (MV/view drop+recreate emitted by migra was stripped — those objects
+-- are unchanged and migra does not track their indexes; see CLAUDE.md.)
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.object_scoped_aggregates(p_object_id integer, p_program_slugs text[])
+ RETURNS TABLE(programs text[], gratings text[], observations text[], n_targets integer, n_spectra integer, max_snr double precision, max_exposure_time double precision)
+ LANGUAGE sql
+ STABLE
+AS $function$
+  WITH m AS (
+    SELECT t.target_id, t.program_slug, t.observation
+    FROM targets t
+    WHERE t.object_id = p_object_id
+      AND t.program_slug = ANY(p_program_slugs)
+  ),
+  sp AS (
+    SELECT s.grating, s.signal_to_noise, s.exposure_time
+    FROM spectra s
+    WHERE s.target_id IN (SELECT target_id FROM m)
+  )
+  SELECT
+    COALESCE((SELECT array_agg(DISTINCT m.program_slug ORDER BY m.program_slug) FROM m), '{}')::text[],
+    COALESCE((SELECT array_agg(DISTINCT sp.grating ORDER BY sp.grating) FROM sp WHERE sp.grating IS NOT NULL), '{}')::text[],
+    COALESCE((SELECT array_agg(DISTINCT m.observation ORDER BY m.observation) FROM m WHERE m.observation IS NOT NULL), '{}')::text[],
+    (SELECT COUNT(*) FROM m)::integer,
+    (SELECT COUNT(*) FROM sp)::integer,
+    (SELECT MAX(sp.signal_to_noise) FROM sp),
+    (SELECT MAX(sp.exposure_time) FROM sp);
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.accessible_program_slugs()
+ RETURNS text[]
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  SELECT COALESCE(array_agg(DISTINCT slug), '{}')
+  FROM (
+    SELECT program_slug AS slug
+    FROM user_program_access
+    WHERE user_id = auth.uid()
+    UNION
+    SELECT slug
+    FROM programs
+    WHERE is_public = true
+    UNION
+    -- Admins (the operators) inherit access to every program. This is the
+    -- single point where admin access is granted to all program-gated data:
+    -- every RLS SELECT policy routes through accessible_program_slugs(), so
+    -- this lets admins read back rows they deploy for private programs
+    -- (otherwise an upsert's RETURNING fails the SELECT policy -> 42501).
+    SELECT slug
+    FROM programs
+    WHERE public.is_admin()
+  ) sub;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_csv_export_objects(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_list_ids integer[] DEFAULT NULL::integer[], p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_has_photometry boolean DEFAULT NULL::boolean, p_photo_z_min double precision DEFAULT NULL::double precision, p_photo_z_max double precision DEFAULT NULL::double precision, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_sort_column text DEFAULT 'object_id'::text, p_sort_direction text DEFAULT 'asc'::text)
+ RETURNS TABLE(object_id text, field text, ra double precision, "dec" double precision, redshift numeric, redshift_quality integer, redshift_inspected numeric, redshift_auto double precision, last_inspected_at timestamp with time zone, last_inspected_by text, last_data_change_at timestamp with time zone, staleness_reason text, version integer, n_targets integer, n_spectra integer, programs text, gratings text, max_snr double precision, max_exposure_time double precision, member_target_ids text, distance double precision, lists text, has_photometry boolean, photo_z double precision, photo_z_err_lo double precision, photo_z_err_hi double precision, photometry jsonb)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN v_gratings_mode := 'any'; END IF;
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time', 'photo_z'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs)) INTO v_filtered_program_slugs;
+  ELSE v_filtered_program_slugs := p_program_slugs; END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN RETURN; END IF;
+
+  RETURN QUERY
+  WITH member_targets AS (
+    SELECT t.object_id, string_agg(t.target_id, ';' ORDER BY t.target_id) AS member_target_ids
+    FROM targets t
+    WHERE t.program_slug = ANY(v_filtered_program_slugs)
+    GROUP BY t.object_id
+  ),
+  visible_lists AS (
+    SELECT olm.object_id, string_agg(ol.slug, ';' ORDER BY ol.slug) AS lists
+    FROM object_list_members olm
+    JOIN object_lists ol ON ol.id = olm.list_id
+    WHERE ol.created_by = auth.uid() OR ol.visibility IN ('public_read', 'public_edit')
+    GROUP BY olm.object_id
+  ),
+  filtered_objects AS (
+    SELECT o.object_id, o.field, o.ra, o.dec,
+      o.redshift, o.redshift_quality,
+      o.redshift_inspected, o.redshift_auto,
+      o.last_inspected_at, up.full_name AS last_inspected_by,
+      o.last_data_change_at, o.staleness_reason, o.version,
+      -- Aggregates scoped to accessible (+ filtered) programs so mixed-program
+      -- objects don't export proprietary member metadata. See
+      -- object_scoped_aggregates().
+      sa.n_targets, sa.n_spectra,
+      array_to_string(sa.programs, ';') AS programs,
+      array_to_string(sa.gratings, ';') AS gratings,
+      sa.max_snr, sa.max_exposure_time,
+      mt.member_target_ids,
+      CASE WHEN v_coord_search_active THEN
+        2 * DEGREES(ASIN(SQRT(POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) + COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) * POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2))))
+      ELSE NULL END AS distance,
+      vl.lists,
+      o.has_photometry, o.photo_z, o.photo_z_err_lo, o.photo_z_err_hi,
+      phot.photometry
+    FROM objects o
+    LEFT JOIN member_targets mt ON mt.object_id = o.id
+    LEFT JOIN visible_lists vl ON vl.object_id = o.id
+    LEFT JOIN user_profiles up ON up.user_id = o.last_inspected_by
+    LEFT JOIN LATERAL public.object_scoped_aggregates(o.id, v_filtered_program_slugs) sa ON true
+    LEFT JOIN LATERAL (
+      SELECT op.photometry FROM object_photometry op
+      WHERE op.object_id = o.id ORDER BY op.updated_at DESC LIMIT 1
+    ) phot ON true
+    WHERE o.programs && v_filtered_program_slugs
+      AND o.is_active = true
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+        OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+        OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+      )
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_search IS NULL OR o.object_id ILIKE '%' || p_search || '%'
+      OR EXISTS (SELECT 1 FROM targets t WHERE t.object_id = o.id AND t.target_id ILIKE '%' || p_search || '%'))
+      AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.redshift_quality > 0) OR (p_inspected_only = FALSE AND o.redshift_quality = 0))
+      AND (p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at))))
+      AND (NOT v_coord_search_active OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+      ))
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+      AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+      AND (
+        NOT v_comment_search_active
+        OR EXISTS (
+          SELECT 1 FROM comments c
+          WHERE c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+            AND (
+              c.object_id = o.id
+              OR c.target_id IN (SELECT t.id FROM targets t WHERE t.object_id = o.id)
+            )
+        )
+      )
+  ),
+  distance_filtered AS (SELECT fo.* FROM filtered_objects fo WHERE NOT v_coord_search_active OR fo.distance <= p_radius_degrees)
+  SELECT df.object_id, df.field, df.ra, df.dec,
+    df.redshift, df.redshift_quality,
+    df.redshift_inspected, df.redshift_auto,
+    df.last_inspected_at, df.last_inspected_by,
+    df.last_data_change_at, df.staleness_reason, df.version,
+    df.n_targets, df.n_spectra,
+    df.programs, df.gratings,
+    df.max_snr, df.max_exposure_time,
+    df.member_target_ids, df.distance, df.lists,
+    df.has_photometry, df.photo_z, df.photo_z_err_lo, df.photo_z_err_hi,
+    df.photometry
+  FROM distance_filtered df
+  ORDER BY
+    CASE WHEN v_coord_search_active THEN df.distance END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN df.object_id END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'desc' THEN df.object_id END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'asc' THEN df.field END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'desc' THEN df.field END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN df.ra END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN df.ra END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN df.dec END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN df.dec END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN df.redshift END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN df.redshift END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN df.redshift_quality END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN df.redshift_quality END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_targets' AND p_sort_direction = 'asc' THEN df.n_targets END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_targets' AND p_sort_direction = 'desc' THEN df.n_targets END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_spectra' AND p_sort_direction = 'asc' THEN df.n_spectra END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_spectra' AND p_sort_direction = 'desc' THEN df.n_spectra END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN df.max_snr END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN df.max_snr END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN df.max_exposure_time END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN df.max_exposure_time END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'photo_z' AND p_sort_direction = 'asc' THEN df.photo_z END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'photo_z' AND p_sort_direction = 'desc' THEN df.photo_z END DESC NULLS LAST,
+    df.object_id ASC;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_field_object_markers(p_field text)
+ RETURNS TABLE(object_id text, ra double precision, "dec" double precision, redshift double precision, redshift_quality integer, field text, n_targets integer, n_spectra integer, programs text[], member_target_ids text[])
+ LANGUAGE sql
+ STABLE
+AS $function$
+  -- programs, n_targets, n_spectra and member_target_ids are scoped to the
+  -- caller's accessible programs so mixed-program objects don't leak proprietary
+  -- member metadata on the map. redshift / redshift_quality stay visible (object
+  -- science, per the access policy). Object row visibility is enforced by RLS
+  -- (programs && accessible); this function is SECURITY INVOKER and additionally
+  -- gates the member CTEs by an explicit accessible_program_slugs() filter.
+  -- Set-based (not the per-row object_scoped_aggregates helper) because a field
+  -- can return up to ~5000 objects; the logic mirrors that helper.
+  WITH acc AS (
+    SELECT public.accessible_program_slugs() AS slugs
+  ),
+  mt AS (
+    SELECT t.object_id,
+           array_agg(t.target_id ORDER BY t.target_id)              AS member_target_ids,
+           array_agg(DISTINCT t.program_slug ORDER BY t.program_slug) AS programs,
+           COUNT(*)::int                                            AS n_targets
+    FROM public.targets t
+    CROSS JOIN acc
+    WHERE t.field = p_field
+      AND t.program_slug = ANY(acc.slugs)
+    GROUP BY t.object_id
+  ),
+  sp AS (
+    SELECT t.object_id, COUNT(*)::int AS n_spectra
+    FROM public.spectra s
+    JOIN public.targets t ON t.target_id = s.target_id
+    CROSS JOIN acc
+    WHERE t.field = p_field
+      AND t.program_slug = ANY(acc.slugs)
+    GROUP BY t.object_id
+  )
+  SELECT
+    o.object_id,
+    o.ra,
+    o.dec,
+    o.redshift::double precision,
+    o.redshift_quality,
+    o.field,
+    COALESCE(mt.n_targets, 0)                      AS n_targets,
+    COALESCE(sp.n_spectra, 0)                      AS n_spectra,
+    COALESCE(mt.programs, ARRAY[]::TEXT[])         AS programs,
+    COALESCE(mt.member_target_ids, ARRAY[]::TEXT[]) AS member_target_ids
+  FROM public.objects o
+  JOIN mt ON mt.object_id = o.id
+  LEFT JOIN sp ON sp.object_id = o.id
+  WHERE o.field = p_field
+    AND o.is_active
+  ORDER BY o.object_id;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_filtered_objects_paginated(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_list_ids integer[] DEFAULT NULL::integer[], p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_has_photometry boolean DEFAULT NULL::boolean, p_photo_z_min double precision DEFAULT NULL::double precision, p_photo_z_max double precision DEFAULT NULL::double precision, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_sort_column text DEFAULT 'object_id'::text, p_sort_direction text DEFAULT 'asc'::text, p_page integer DEFAULT 1, p_page_size integer DEFAULT 50)
+ RETURNS TABLE(targets jsonb, total_count bigint, page integer, page_size integer)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_offset INTEGER;
+  v_total_count BIGINT;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
+    v_gratings_mode := 'any';
+  END IF;
+
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN
+    p_sort_direction := 'asc';
+  END IF;
+
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time', 'photo_z'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+
+  IF v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN
+    p_sort_column := 'distance';
+  END IF;
+
+  v_offset := (COALESCE(p_page, 1) - 1) * COALESCE(p_page_size, 50);
+
+  -- Intersect user-accessible programs with filter selection
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(
+      SELECT unnest(p_program_slugs)
+      INTERSECT
+      SELECT unnest(p_filter_programs)
+    ) INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN QUERY SELECT '[]'::jsonb, 0::BIGINT, p_page, p_page_size;
+    RETURN;
+  END IF;
+
+  -- Step 1: count
+  SELECT COUNT(*) INTO v_total_count
+  FROM objects o
+  WHERE
+    -- Access control: object must have at least one accessible program
+    o.programs && v_filtered_program_slugs
+    AND o.is_active = true
+    AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+    AND (
+      NOT v_grating_filter_active
+      OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+      OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+      OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+    )
+    AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+    AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+    AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+    AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+    AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+    AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+    AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+    AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+    AND (p_search IS NULL OR o.object_id ILIKE '%' || p_search || '%'
+      OR EXISTS (SELECT 1 FROM targets t WHERE t.object_id = o.id AND t.target_id ILIKE '%' || p_search || '%'))
+    AND (
+      p_inspected_only IS NULL
+      OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+      OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+    )
+    AND (
+      p_needs_review IS NULL
+      OR (p_needs_review = TRUE
+          AND o.staleness_reason IS NOT NULL
+          AND o.last_inspected_at IS NOT NULL
+          AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+      OR (p_needs_review = FALSE
+          AND (o.staleness_reason IS NULL
+               OR o.last_inspected_at IS NULL
+               OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+    )
+    AND (
+      NOT v_coord_search_active
+      OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+        AND 2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) <= p_radius_degrees
+      )
+    )
+    AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+        SELECT olm.object_id FROM object_list_members olm
+        WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+    ))
+    AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+    AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+    AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+    AND (
+      NOT v_comment_search_active
+      OR EXISTS (
+        SELECT 1 FROM comments c
+        WHERE c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (
+            p_comment_search_scope = 'everyone'
+            OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+          )
+          AND (
+            c.object_id = o.id
+            OR c.target_id IN (SELECT t.id FROM targets t WHERE t.object_id = o.id)
+          )
+      )
+    );
+
+  -- Step 2: fetch page
+  RETURN QUERY
+  WITH filtered_objects AS (
+    SELECT
+      o.id,
+      o.object_id,
+      o.field,
+      o.ra,
+      o.dec,
+      o.n_targets,
+      o.n_spectra,
+      o.programs,
+      o.gratings,
+      o.max_snr,
+      o.max_exposure_time,
+      o.redshift,
+      o.redshift_quality,
+      o.redshift_inspected,
+      o.redshift_auto,
+      o.inspected_used_auto,
+      o.last_inspected_at,
+      o.last_inspected_by,
+      o.last_data_change_at,
+      o.staleness_reason,
+      o.version,
+      o.is_active,
+      o.photo_z,
+      o.has_photometry,
+      o.created_at,
+      CASE
+        WHEN v_coord_search_active THEN
+          2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+            POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+          )))
+        ELSE NULL
+      END AS distance
+    FROM objects o
+    WHERE
+      o.programs && v_filtered_program_slugs
+      AND o.is_active = true
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+        OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+        OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+      )
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_search IS NULL OR o.object_id ILIKE '%' || p_search || '%'
+      OR EXISTS (SELECT 1 FROM targets t WHERE t.object_id = o.id AND t.target_id ILIKE '%' || p_search || '%'))
+      AND (
+        p_inspected_only IS NULL
+        OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+        OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+      )
+      AND (
+        p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+      )
+      AND (
+        NOT v_coord_search_active
+        OR (
+          o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+          AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+          AND 2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+            POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+          ))) <= p_radius_degrees
+        )
+      )
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+      AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+      AND (
+        NOT v_comment_search_active
+        OR EXISTS (
+          SELECT 1 FROM comments c
+          WHERE c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+            AND (
+              c.object_id = o.id
+              OR c.target_id IN (SELECT t.id FROM targets t WHERE t.object_id = o.id)
+            )
+        )
+      )
+    ORDER BY
+      CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN
+        2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN
+        2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN o.object_id END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'desc' THEN o.object_id END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN o.field END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN o.field END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN o.ra END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN o.ra END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN o.dec END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN o.dec END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN o.redshift END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN o.redshift END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN o.redshift_quality END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN o.redshift_quality END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'asc' THEN o.n_targets END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'desc' THEN o.n_targets END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'asc' THEN o.n_spectra END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'desc' THEN o.n_spectra END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN o.max_snr END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN o.max_snr END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN o.max_exposure_time END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN o.max_exposure_time END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'asc' THEN o.photo_z END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'desc' THEN o.photo_z END DESC NULLS LAST,
+      o.object_id ASC
+    LIMIT p_page_size OFFSET v_offset
+  ),
+  with_members AS (
+    SELECT
+      jsonb_build_object(
+        'id', fo.id,
+        'object_id', fo.object_id,
+        'field', fo.field,
+        'ra', fo.ra,
+        'dec', fo.dec,
+        -- Aggregates scoped to the viewer's accessible (+ filtered) programs so
+        -- mixed-program objects don't leak proprietary member metadata. Filter
+        -- and sort above still run on the global o.* columns (display-only
+        -- scoping); the substitution happens only on the paginated result set.
+        'n_targets', sa.n_targets,
+        'n_spectra', sa.n_spectra,
+        'programs', sa.programs,
+        'gratings', sa.gratings,
+        'max_snr', sa.max_snr,
+        'max_exposure_time', sa.max_exposure_time,
+        'redshift', fo.redshift,
+        'redshift_quality', fo.redshift_quality,
+        'redshift_inspected', fo.redshift_inspected,
+        'redshift_auto', fo.redshift_auto,
+        'inspected_used_auto', fo.inspected_used_auto,
+        'last_inspected_at', fo.last_inspected_at,
+        'last_inspected_by', fo.last_inspected_by,
+        'last_data_change_at', fo.last_data_change_at,
+        'staleness_reason', fo.staleness_reason,
+        'version', fo.version,
+        'is_active', fo.is_active,
+        'photo_z', fo.photo_z,
+        'has_photometry', fo.has_photometry,
+        'created_at', fo.created_at,
+        'distance', fo.distance,
+        -- Phase D: member_targets becomes provenance only (target_id, program,
+        -- observation). Inspection state lives on the object now; redshift_auto
+        -- on targets is retained for transitional UI display until Phase E.
+        'member_targets', COALESCE(
+          (SELECT jsonb_agg(
+            jsonb_build_object(
+              'target_id', t.target_id,
+              'program_slug', t.program_slug,
+              'observation', t.observation,
+              'redshift_auto', t.redshift_auto
+            )
+          )
+          FROM targets t
+          WHERE t.object_id = fo.id
+            AND t.program_slug = ANY(v_filtered_program_slugs)
+          ),
+          '[]'::jsonb
+        ),
+        'lists', COALESCE(
+          (SELECT jsonb_agg(
+            jsonb_build_object(
+              'id', ol.id,
+              'name', ol.name,
+              'slug', ol.slug,
+              'icon', ol.icon,
+              'color', ol.color
+            ) ORDER BY ol.name
+          )
+          FROM object_list_members olm
+          JOIN object_lists ol ON ol.id = olm.list_id
+          WHERE olm.object_id = fo.id),
+          '[]'::jsonb
+        )
+      ) AS obj_json
+    FROM filtered_objects fo
+    LEFT JOIN LATERAL public.object_scoped_aggregates(fo.id, v_filtered_program_slugs) sa ON true
+  )
+  SELECT
+    COALESCE(jsonb_agg(wm.obj_json), '[]'::jsonb),
+    v_total_count,
+    p_page,
+    p_page_size
+  FROM with_members wm;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_objects_for_sync(p_program_slugs text[], p_user_id uuid DEFAULT NULL::uuid, p_updated_since timestamp with time zone DEFAULT NULL::timestamp with time zone, p_limit integer DEFAULT 1000, p_offset integer DEFAULT 0, p_include_counts boolean DEFAULT true)
+ RETURNS TABLE(objects jsonb, total_count bigint, total_accessible_count bigint)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+ SET statement_timeout TO '120s'
+AS $function$
+BEGIN
+  RETURN QUERY
+  -- matched is MATERIALIZED so the three aggregate CTEs below each see the
+  -- same ~p_limit-row set without re-evaluating the WHERE/ORDER/LIMIT.
+  WITH matched AS MATERIALIZED (
+    SELECT o.id, o.object_id, o.field, o.ra, o.dec,
+           o.n_targets, o.n_spectra, o.programs, o.gratings,
+           o.max_snr, o.max_exposure_time,
+           o.redshift, o.redshift_quality,
+           o.redshift_inspected, o.redshift_auto,
+           o.inspected_used_auto,
+           o.last_inspected_at, o.last_inspected_by,
+           o.last_data_change_at, o.staleness_reason,
+           o.version, o.is_active,
+           o.has_photometry, o.photo_z, o.photo_z_err_lo, o.photo_z_err_hi,
+           o.created_at, o.updated_at
+    FROM objects o
+    WHERE o.programs && p_program_slugs
+      -- Phase D: hide soft-deleted objects from sync. Reactivation rewrites
+      -- updated_at, so re-activated rows get re-synced naturally on next pull.
+      AND o.is_active = true
+      AND (p_updated_since IS NULL OR o.updated_at > p_updated_since)
+    ORDER BY o.object_id
+    LIMIT p_limit OFFSET p_offset
+  ),
+  member_targets_agg AS (
+    SELECT t.object_id,
+           jsonb_agg(t.target_id ORDER BY t.target_id) AS target_ids
+    FROM targets t
+    WHERE t.object_id IN (SELECT id FROM matched)
+      AND t.program_slug = ANY(p_program_slugs)
+    GROUP BY t.object_id
+  ),
+  -- Phase D: per-spectrum payload (per design doc) so the Python client
+  -- can render redshift_auto and dq_flags per grating without a second
+  -- round-trip.
+  spectra_agg AS (
+    SELECT t.object_id,
+           jsonb_agg(jsonb_build_object(
+             'id', s.id,
+             'target_id', s.target_id,
+             'grating', s.grating,
+             'signal_to_noise', s.signal_to_noise,
+             'exposure_time', s.exposure_time,
+             'redshift_auto', s.redshift_auto,
+             'dq_flags', s.dq_flags
+           ) ORDER BY s.target_id, s.grating) AS spectra
+    FROM spectra s
+    JOIN targets t ON t.target_id = s.target_id
+    WHERE t.object_id IN (SELECT id FROM matched)
+      AND t.program_slug = ANY(p_program_slugs)
+    GROUP BY t.object_id
+  ),
+  lists_agg AS (
+    SELECT olm.object_id,
+           jsonb_agg(ol.slug ORDER BY ol.slug) AS list_slugs
+    FROM object_list_members olm
+    JOIN object_lists ol ON ol.id = olm.list_id
+    WHERE olm.object_id IN (SELECT id FROM matched)
+      AND (ol.created_by = p_user_id
+           OR ol.visibility IN ('public_read', 'public_edit'))
+    GROUP BY olm.object_id
+  ),
+  -- Count CTEs are gated on p_include_counts; when FALSE the planner
+  -- collapses them to One-Time Filter: false and skips the scan.
+  total AS (
+    SELECT COUNT(*) AS cnt
+    FROM objects o
+    WHERE p_include_counts
+      AND o.programs && p_program_slugs
+      AND o.is_active = true
+      AND (p_updated_since IS NULL OR o.updated_at > p_updated_since)
+  ),
+  accessible AS (
+    SELECT COUNT(*) AS cnt
+    FROM objects o
+    WHERE p_include_counts
+      AND o.programs && p_program_slugs
+      AND o.is_active = true
+  )
+  SELECT
+    COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'id', m.id,
+        'object_id', m.object_id,
+        'field', m.field,
+        'ra', m.ra,
+        'dec', m.dec,
+        -- Aggregates scoped to the caller's accessible programs so a sync that
+        -- pulls a mixed-program object doesn't leak proprietary member metadata
+        -- into the Python catalog. See object_scoped_aggregates().
+        'n_targets', sa.n_targets,
+        'n_spectra', sa.n_spectra,
+        'programs', sa.programs,
+        'gratings', sa.gratings,
+        'max_snr', sa.max_snr,
+        'max_exposure_time', sa.max_exposure_time,
+        'redshift', m.redshift,
+        'redshift_quality', m.redshift_quality,
+        'redshift_inspected', m.redshift_inspected,
+        'redshift_auto', m.redshift_auto,
+        'inspected_used_auto', m.inspected_used_auto,
+        'last_inspected_at', m.last_inspected_at,
+        'last_inspected_by', m.last_inspected_by,
+        'last_data_change_at', m.last_data_change_at,
+        'staleness_reason', m.staleness_reason,
+        'version', m.version,
+        'is_active', m.is_active,
+        'has_photometry', m.has_photometry,
+        'photo_z', m.photo_z,
+        'photo_z_err_lo', m.photo_z_err_lo,
+        'photo_z_err_hi', m.photo_z_err_hi,
+        'created_at', m.created_at,
+        'updated_at', m.updated_at,
+        'member_target_ids', COALESCE(mt.target_ids, '[]'::jsonb),
+        'spectra',           COALESCE(sp.spectra,    '[]'::jsonb),
+        'lists',             COALESCE(la.list_slugs, '[]'::jsonb)
+      )
+    ), '[]'::jsonb),
+    COALESCE((SELECT cnt FROM total), 0)::BIGINT,
+    COALESCE((SELECT cnt FROM accessible), 0)::BIGINT
+  FROM matched m
+  LEFT JOIN member_targets_agg mt ON mt.object_id = m.id
+  LEFT JOIN spectra_agg         sp ON sp.object_id = m.id
+  LEFT JOIN lists_agg           la ON la.object_id = m.id
+  LEFT JOIN LATERAL public.object_scoped_aggregates(m.id, p_program_slugs) sa ON true;
+END;
+$function$
+;

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -81,6 +81,70 @@ GRANT EXECUTE ON FUNCTION public.accessible_program_slugs() TO authenticated;
 
 
 -- =============================================================================
+-- object_scoped_aggregates
+-- =============================================================================
+-- Viewer-scoped recompute of an object's aggregate columns.
+--
+-- The objects table stores aggregate columns (programs, gratings, observations,
+-- n_targets, n_spectra, max_snr, max_exposure_time) computed across ALL member
+-- targets at deploy time (see python/campfire/deploy/objects.py). Object row
+-- visibility is granted by array overlap (policies.sql: programs && accessible),
+-- so a viewer who can access only SOME member programs still sees the row — and
+-- the stored aggregates would leak the existence/metadata of proprietary members
+-- they cannot access (programs[] names them; counts/snr/exposure quantify them).
+--
+-- This helper recomputes those aggregates restricted to p_program_slugs, using
+-- the SAME semantics as the deploy-time builder so that a full-access viewer
+-- (p_program_slugs ⊇ the object's programs) gets values identical to the stored
+-- columns. Member-level payloads (member_targets, spectra) are already filtered
+-- in each read RPC; this covers the object's own columns.
+--
+-- Callers MUST pass an already-access-checked slug array (the caller's accessible
+-- set, optionally narrowed by an active program filter). Do not rely on RLS
+-- inside this function: it is SECURITY INVOKER, but when called from a
+-- SECURITY DEFINER context it would run as the owner with RLS bypassed — the
+-- explicit p_program_slugs filter is the access gate.
+CREATE OR REPLACE FUNCTION public.object_scoped_aggregates(
+  p_object_id INTEGER,
+  p_program_slugs TEXT[]
+)
+RETURNS TABLE(
+  programs          TEXT[],
+  gratings          TEXT[],
+  observations      TEXT[],
+  n_targets         INTEGER,
+  n_spectra         INTEGER,
+  max_snr           DOUBLE PRECISION,
+  max_exposure_time DOUBLE PRECISION
+)
+LANGUAGE sql STABLE
+AS $$
+  WITH m AS (
+    SELECT t.target_id, t.program_slug, t.observation
+    FROM targets t
+    WHERE t.object_id = p_object_id
+      AND t.program_slug = ANY(p_program_slugs)
+  ),
+  sp AS (
+    SELECT s.grating, s.signal_to_noise, s.exposure_time
+    FROM spectra s
+    WHERE s.target_id IN (SELECT target_id FROM m)
+  )
+  SELECT
+    COALESCE((SELECT array_agg(DISTINCT m.program_slug ORDER BY m.program_slug) FROM m), '{}')::text[],
+    COALESCE((SELECT array_agg(DISTINCT sp.grating ORDER BY sp.grating) FROM sp WHERE sp.grating IS NOT NULL), '{}')::text[],
+    COALESCE((SELECT array_agg(DISTINCT m.observation ORDER BY m.observation) FROM m WHERE m.observation IS NOT NULL), '{}')::text[],
+    (SELECT COUNT(*) FROM m)::integer,
+    (SELECT COUNT(*) FROM sp)::integer,
+    (SELECT MAX(sp.signal_to_noise) FROM sp),
+    (SELECT MAX(sp.exposure_time) FROM sp);
+$$;
+
+GRANT EXECUTE ON FUNCTION public.object_scoped_aggregates(INTEGER, TEXT[]) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.object_scoped_aggregates(INTEGER, TEXT[]) TO service_role;
+
+
+-- =============================================================================
 -- Device Code Auth
 -- =============================================================================
 
@@ -247,12 +311,15 @@ BEGIN
         'field', m.field,
         'ra', m.ra,
         'dec', m.dec,
-        'n_targets', m.n_targets,
-        'n_spectra', m.n_spectra,
-        'programs', m.programs,
-        'gratings', m.gratings,
-        'max_snr', m.max_snr,
-        'max_exposure_time', m.max_exposure_time,
+        -- Aggregates scoped to the caller's accessible programs so a sync that
+        -- pulls a mixed-program object doesn't leak proprietary member metadata
+        -- into the Python catalog. See object_scoped_aggregates().
+        'n_targets', sa.n_targets,
+        'n_spectra', sa.n_spectra,
+        'programs', sa.programs,
+        'gratings', sa.gratings,
+        'max_snr', sa.max_snr,
+        'max_exposure_time', sa.max_exposure_time,
         'redshift', m.redshift,
         'redshift_quality', m.redshift_quality,
         'redshift_inspected', m.redshift_inspected,
@@ -280,7 +347,8 @@ BEGIN
   FROM matched m
   LEFT JOIN member_targets_agg mt ON mt.object_id = m.id
   LEFT JOIN spectra_agg         sp ON sp.object_id = m.id
-  LEFT JOIN lists_agg           la ON la.object_id = m.id;
+  LEFT JOIN lists_agg           la ON la.object_id = m.id
+  LEFT JOIN LATERAL public.object_scoped_aggregates(m.id, p_program_slugs) sa ON true;
 END;
 $$;
 
@@ -1133,12 +1201,16 @@ BEGIN
         'field', fo.field,
         'ra', fo.ra,
         'dec', fo.dec,
-        'n_targets', fo.n_targets,
-        'n_spectra', fo.n_spectra,
-        'programs', fo.programs,
-        'gratings', fo.gratings,
-        'max_snr', fo.max_snr,
-        'max_exposure_time', fo.max_exposure_time,
+        -- Aggregates scoped to the viewer's accessible (+ filtered) programs so
+        -- mixed-program objects don't leak proprietary member metadata. Filter
+        -- and sort above still run on the global o.* columns (display-only
+        -- scoping); the substitution happens only on the paginated result set.
+        'n_targets', sa.n_targets,
+        'n_spectra', sa.n_spectra,
+        'programs', sa.programs,
+        'gratings', sa.gratings,
+        'max_snr', sa.max_snr,
+        'max_exposure_time', sa.max_exposure_time,
         'redshift', fo.redshift,
         'redshift_quality', fo.redshift_quality,
         'redshift_inspected', fo.redshift_inspected,
@@ -1189,6 +1261,7 @@ BEGIN
         )
       ) AS obj_json
     FROM filtered_objects fo
+    LEFT JOIN LATERAL public.object_scoped_aggregates(fo.id, v_filtered_program_slugs) sa ON true
   )
   SELECT
     COALESCE(jsonb_agg(wm.obj_json), '[]'::jsonb),
@@ -1905,10 +1978,13 @@ BEGIN
       o.redshift_inspected, o.redshift_auto,
       o.last_inspected_at, up.full_name AS last_inspected_by,
       o.last_data_change_at, o.staleness_reason, o.version,
-      o.n_targets, o.n_spectra,
-      array_to_string(o.programs, ';') AS programs,
-      array_to_string(o.gratings, ';') AS gratings,
-      o.max_snr, o.max_exposure_time,
+      -- Aggregates scoped to accessible (+ filtered) programs so mixed-program
+      -- objects don't export proprietary member metadata. See
+      -- object_scoped_aggregates().
+      sa.n_targets, sa.n_spectra,
+      array_to_string(sa.programs, ';') AS programs,
+      array_to_string(sa.gratings, ';') AS gratings,
+      sa.max_snr, sa.max_exposure_time,
       mt.member_target_ids,
       CASE WHEN v_coord_search_active THEN
         2 * DEGREES(ASIN(SQRT(POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) + COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) * POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2))))
@@ -1920,6 +1996,7 @@ BEGIN
     LEFT JOIN member_targets mt ON mt.object_id = o.id
     LEFT JOIN visible_lists vl ON vl.object_id = o.id
     LEFT JOIN user_profiles up ON up.user_id = o.last_inspected_by
+    LEFT JOIN LATERAL public.object_scoped_aggregates(o.id, v_filtered_program_slugs) sa ON true
     LEFT JOIN LATERAL (
       SELECT op.photometry FROM object_photometry op
       WHERE op.object_id = o.id ORDER BY op.updated_at DESC LIMIT 1
@@ -2363,6 +2440,37 @@ RETURNS TABLE (
 )
 LANGUAGE sql STABLE
 AS $$
+  -- programs, n_targets, n_spectra and member_target_ids are scoped to the
+  -- caller's accessible programs so mixed-program objects don't leak proprietary
+  -- member metadata on the map. redshift / redshift_quality stay visible (object
+  -- science, per the access policy). Object row visibility is enforced by RLS
+  -- (programs && accessible); this function is SECURITY INVOKER and additionally
+  -- gates the member CTEs by an explicit accessible_program_slugs() filter.
+  -- Set-based (not the per-row object_scoped_aggregates helper) because a field
+  -- can return up to ~5000 objects; the logic mirrors that helper.
+  WITH acc AS (
+    SELECT public.accessible_program_slugs() AS slugs
+  ),
+  mt AS (
+    SELECT t.object_id,
+           array_agg(t.target_id ORDER BY t.target_id)              AS member_target_ids,
+           array_agg(DISTINCT t.program_slug ORDER BY t.program_slug) AS programs,
+           COUNT(*)::int                                            AS n_targets
+    FROM public.targets t
+    CROSS JOIN acc
+    WHERE t.field = p_field
+      AND t.program_slug = ANY(acc.slugs)
+    GROUP BY t.object_id
+  ),
+  sp AS (
+    SELECT t.object_id, COUNT(*)::int AS n_spectra
+    FROM public.spectra s
+    JOIN public.targets t ON t.target_id = s.target_id
+    CROSS JOIN acc
+    WHERE t.field = p_field
+      AND t.program_slug = ANY(acc.slugs)
+    GROUP BY t.object_id
+  )
   SELECT
     o.object_id,
     o.ra,
@@ -2370,16 +2478,13 @@ AS $$
     o.redshift::double precision,
     o.redshift_quality,
     o.field,
-    o.n_targets,
-    o.n_spectra,
-    o.programs,
-    COALESCE(
-      (SELECT array_agg(t.target_id ORDER BY t.target_id)
-         FROM public.targets t
-        WHERE t.object_id = o.id),
-      ARRAY[]::TEXT[]
-    ) AS member_target_ids
+    COALESCE(mt.n_targets, 0)                      AS n_targets,
+    COALESCE(sp.n_spectra, 0)                      AS n_spectra,
+    COALESCE(mt.programs, ARRAY[]::TEXT[])         AS programs,
+    COALESCE(mt.member_target_ids, ARRAY[]::TEXT[]) AS member_target_ids
   FROM public.objects o
+  JOIN mt ON mt.object_id = o.id
+  LEFT JOIN sp ON sp.object_id = o.id
   WHERE o.field = p_field
     AND o.is_active
   ORDER BY o.object_id;

--- a/supabase/tests/check_object_aggregate_scoping.sql
+++ b/supabase/tests/check_object_aggregate_scoping.sql
@@ -1,0 +1,121 @@
+-- Guard: object aggregate columns must be scoped to the viewer's accessible
+-- programs.
+--
+-- Object rows are visible by program-array overlap (RLS: programs && accessible),
+-- but the denormalized aggregate columns (programs, gratings, observations,
+-- n_targets, n_spectra, max_snr, max_exposure_time) are computed across ALL
+-- member programs at deploy time. A mixed public+proprietary object is therefore
+-- visible to a viewer who can access only the public member, and the stored
+-- aggregates would leak the proprietary program's name / counts / snr / exposure
+-- / gratings. This asserts the canonical helper object_scoped_aggregates() and
+-- the primary catalog RPC get_filtered_objects_paginated() scope those columns.
+-- The other read paths (CSV export, Python sync, map markers, object detail)
+-- reuse the same helper or mirror its logic.
+--
+-- Run locally:
+--   eval "$(supabase status -o env | grep '^DB_URL=')"
+--   psql "$DB_URL" -v ON_ERROR_STOP=1 -f supabase/tests/check_object_aggregate_scoping.sql
+BEGIN;
+
+DO $$
+DECLARE
+  v_obj_id   INTEGER;
+  v_programs TEXT[];
+  v_gratings TEXT[];
+  v_obs      TEXT[];
+  v_nt       INTEGER;
+  v_ns       INTEGER;
+  v_snr      DOUBLE PRECISION;
+  v_exp      DOUBLE PRECISION;
+  v_json     JSONB;
+  v_row      JSONB;
+BEGIN
+  -- Fixtures: one public + one proprietary program, one object spanning both,
+  -- one target (with one spectrum) per program. Global stored aggregates on the
+  -- object deliberately span both programs.
+  INSERT INTO programs (slug, program_name, is_public) VALUES
+    ('zzz_test_pub',  'Scoping Test Public',  true),
+    ('zzz_test_prop', 'Scoping Test Private', false);
+
+  INSERT INTO observations (name, program_slug, jwst_program_id, field) VALUES
+    ('obs_pub',  'zzz_test_pub',  9991, 'zzz_test_field'),
+    ('obs_prop', 'zzz_test_prop', 9992, 'zzz_test_field');
+
+  INSERT INTO objects (object_id, field, ra, dec,
+                       n_targets, n_spectra, programs, gratings, observations,
+                       max_snr, max_exposure_time)
+  VALUES ('TEST-OBJ-SCOPING', 'zzz_test_field', 150.0, 2.0,
+          2, 2, ARRAY['zzz_test_prop','zzz_test_pub'],
+          ARRAY['G395M','PRISM'], ARRAY['obs_prop','obs_pub'],
+          30.0, 2000.0)
+  RETURNING id INTO v_obj_id;
+
+  INSERT INTO targets (target_id, field, ra, dec, program_slug, observation, object_id) VALUES
+    ('test-scoping-pub',  'zzz_test_field', 150.0, 2.0, 'zzz_test_pub',  'obs_pub',  v_obj_id),
+    ('test-scoping-prop', 'zzz_test_field', 150.0, 2.0, 'zzz_test_prop', 'obs_prop', v_obj_id);
+
+  INSERT INTO spectra (target_id, grating, fits_path, signal_to_noise, exposure_time) VALUES
+    ('test-scoping-pub',  'PRISM', '/tmp/pub_prism_spec.fits',  10.0, 1000.0),
+    ('test-scoping-prop', 'G395M', '/tmp/prop_g395m_spec.fits', 30.0, 2000.0);
+
+  -- 1) Helper, public-only viewer: the proprietary member must be fully excluded.
+  SELECT programs, gratings, observations, n_targets, n_spectra, max_snr, max_exposure_time
+    INTO v_programs, v_gratings, v_obs, v_nt, v_ns, v_snr, v_exp
+    FROM public.object_scoped_aggregates(v_obj_id, ARRAY['zzz_test_pub']);
+
+  IF v_programs <> ARRAY['zzz_test_pub'] THEN
+    RAISE EXCEPTION 'scoped programs leaked: got %', v_programs;
+  END IF;
+  IF v_gratings <> ARRAY['PRISM'] THEN
+    RAISE EXCEPTION 'scoped gratings leaked: got %', v_gratings;
+  END IF;
+  IF v_obs <> ARRAY['obs_pub'] THEN
+    RAISE EXCEPTION 'scoped observations leaked: got %', v_obs;
+  END IF;
+  IF v_nt <> 1 OR v_ns <> 1 THEN
+    RAISE EXCEPTION 'scoped counts leaked: n_targets=% n_spectra=%', v_nt, v_ns;
+  END IF;
+  IF v_snr <> 10.0 OR v_exp <> 1000.0 THEN
+    RAISE EXCEPTION 'scoped max_snr/exposure leaked: snr=% exp=%', v_snr, v_exp;
+  END IF;
+
+  -- 2) Helper, full access: must reproduce the global stored aggregates exactly.
+  SELECT programs, n_targets, n_spectra, max_snr, max_exposure_time
+    INTO v_programs, v_nt, v_ns, v_snr, v_exp
+    FROM public.object_scoped_aggregates(v_obj_id, ARRAY['zzz_test_pub','zzz_test_prop']);
+
+  IF v_programs <> ARRAY['zzz_test_prop','zzz_test_pub'] THEN
+    RAISE EXCEPTION 'full-access programs mismatch: got %', v_programs;
+  END IF;
+  IF v_nt <> 2 OR v_ns <> 2 OR v_snr <> 30.0 OR v_exp <> 2000.0 THEN
+    RAISE EXCEPTION 'full-access aggregates mismatch: nt=% ns=% snr=% exp=%', v_nt, v_ns, v_snr, v_exp;
+  END IF;
+
+  -- 3) Primary catalog RPC, public-only viewer: the returned row must be scoped.
+  SELECT targets INTO v_json
+    FROM public.get_filtered_objects_paginated(
+      p_program_slugs => ARRAY['zzz_test_pub'],
+      p_fields        => ARRAY['zzz_test_field']
+    );
+
+  v_row := v_json -> 0;
+  IF v_row IS NULL THEN
+    RAISE EXCEPTION 'object not returned to public-access viewer';
+  END IF;
+  IF v_row -> 'programs' @> '["zzz_test_prop"]'::jsonb THEN
+    RAISE EXCEPTION 'list RPC leaked proprietary program: %', v_row -> 'programs';
+  END IF;
+  IF NOT (v_row -> 'programs' @> '["zzz_test_pub"]'::jsonb) THEN
+    RAISE EXCEPTION 'list RPC dropped accessible program: %', v_row -> 'programs';
+  END IF;
+  IF (v_row ->> 'n_targets')::int <> 1 THEN
+    RAISE EXCEPTION 'list RPC leaked n_targets: %', v_row ->> 'n_targets';
+  END IF;
+  IF (v_row ->> 'max_snr')::float8 <> 10.0 THEN
+    RAISE EXCEPTION 'list RPC leaked max_snr: %', v_row ->> 'max_snr';
+  END IF;
+
+  RAISE NOTICE 'OK: object aggregate scoping holds (helper + list RPC).';
+END $$;
+
+ROLLBACK;

--- a/web/lib/actions/lists.ts
+++ b/web/lib/actions/lists.ts
@@ -503,11 +503,16 @@ export async function getListBySlug(
     creator_name: listFields.created_by ? nameMap.get(listFields.created_by) ?? null : null,
   };
 
-  // Fetch paginated members with joined object data
+  // Fetch paginated members with joined object data. NOTE: n_spectra / max_snr
+  // are NOT read off the objects row — those stored aggregates are computed
+  // across ALL member programs at deploy time, so reading them directly would
+  // leak proprietary member metadata on mixed-program objects (same class of
+  // leak fixed on the catalog/detail/CSV/map paths). redshift / redshift_quality
+  // stay visible (object science, per the access policy).
   const offset = (page - 1) * pageSize;
   const { data: membersData, error: membersError } = await supabase
     .from('object_list_members')
-    .select('*, object:objects(id, object_id, field, ra, dec, redshift, redshift_quality, n_spectra, max_snr)')
+    .select('*, object:objects(id, object_id, field, ra, dec, redshift, redshift_quality)')
     .eq('list_id', list.id)
     .order('added_at', { ascending: false })
     .range(offset, offset + pageSize - 1);
@@ -516,9 +521,42 @@ export async function getListBySlug(
     return { list, members: [], totalMembers, error: membersError.message };
   }
 
+  // Scope n_spectra / max_snr to the viewer's accessible programs by recomputing
+  // from member targets + spectra, which RLS filters to accessible programs
+  // (mirrors object_scoped_aggregates()). One extra query for the page.
+  const memberObjectIds = (membersData ?? [])
+    .map(m => (m.object as { id: number } | null)?.id)
+    .filter((id): id is number => id != null);
+
+  const scopedAgg = new Map<number, { n_spectra: number; max_snr: number | null }>();
+  if (memberObjectIds.length > 0) {
+    const { data: scopeRows } = await supabase
+      .from('targets')
+      .select('object_id, spectra(signal_to_noise)')
+      .in('object_id', memberObjectIds);
+    for (const t of (scopeRows ?? []) as { object_id: number | null; spectra: { signal_to_noise: number | null }[] | null }[]) {
+      if (t.object_id == null) continue;
+      const entry = scopedAgg.get(t.object_id) ?? { n_spectra: 0, max_snr: null };
+      for (const s of t.spectra ?? []) {
+        entry.n_spectra += 1;
+        if (s.signal_to_noise != null) {
+          entry.max_snr = entry.max_snr == null ? s.signal_to_noise : Math.max(entry.max_snr, s.signal_to_noise);
+        }
+      }
+      scopedAgg.set(t.object_id, entry);
+    }
+  }
+
+  const members: ObjectListMemberWithObject[] = (membersData ?? []).map(m => {
+    const obj = m.object as { id: number } | null;
+    if (!obj) return { ...m, object: null } as ObjectListMemberWithObject;
+    const agg = scopedAgg.get(obj.id) ?? { n_spectra: 0, max_snr: null };
+    return { ...m, object: { ...obj, n_spectra: agg.n_spectra, max_snr: agg.max_snr } } as ObjectListMemberWithObject;
+  });
+
   return {
     list,
-    members: (membersData ?? []) as ObjectListMemberWithObject[],
+    members,
     totalMembers,
   };
 }

--- a/web/lib/actions/spectra.ts
+++ b/web/lib/actions/spectra.ts
@@ -515,18 +515,40 @@ export async function getObjectById(objectId: string): Promise<{
       (b.max_snr || 0) - (a.max_snr || 0)
     );
 
+    // Display-only access scoping. The objects row stores aggregate columns
+    // (programs, gratings, counts, max_snr/exposure) computed across ALL member
+    // programs at deploy time. This object is visible because the viewer can
+    // access at least one member program (checked above), but the stored
+    // aggregates would leak metadata about proprietary members they cannot
+    // access. Recompute them from the already access-filtered member targets
+    // (members are fetched with .in('program_slug', accessibleProgramSlugs)).
+    // Mirrors the SQL helper object_scoped_aggregates() and the deploy-time
+    // builder in python/campfire/deploy/objects.py. Object-level science
+    // (redshift, photometry) intentionally stays visible.
+    const scopedSpectra = memberTargets.flatMap(m => m.spectra || []);
+    const scopedSnr = scopedSpectra.map(s => s.signal_to_noise).filter((v): v is number => v != null);
+    const scopedExp = scopedSpectra.map(s => s.exposure_time).filter((v): v is number => v != null);
+    const scoped = {
+      n_targets: memberTargets.length,
+      n_spectra: scopedSpectra.length,
+      programs: [...new Set(memberTargets.map(m => m.program_slug))].sort(),
+      gratings: [...new Set(scopedSpectra.map(s => s.grating).filter(Boolean))].sort(),
+      max_snr: scopedSnr.length ? Math.max(...scopedSnr) : null,
+      max_exposure_time: scopedExp.length ? Math.max(...scopedExp) : null,
+    };
+
     const objectDetail: ObjectDetail = {
       id: obj.id,
       object_id: obj.object_id,
       field: obj.field,
       ra: obj.ra,
       dec: obj.dec,
-      n_targets: obj.n_targets,
-      n_spectra: obj.n_spectra,
-      programs: obj.programs,
-      gratings: obj.gratings,
-      max_snr: obj.max_snr,
-      max_exposure_time: obj.max_exposure_time,
+      n_targets: scoped.n_targets,
+      n_spectra: scoped.n_spectra,
+      programs: scoped.programs,
+      gratings: scoped.gratings,
+      max_snr: scoped.max_snr,
+      max_exposure_time: scoped.max_exposure_time,
       redshift: obj.redshift ?? null,
       redshift_quality: obj.redshift_quality ?? 0,
       redshift_inspected: obj.redshift_inspected ?? null,


### PR DESCRIPTION
## Problem

Objects are cross-program aggregates: one sky position groups member targets from one *or more* programs. Row visibility is granted by array overlap (`policies.sql`: `programs && accessible_program_slugs()`) — correct for *existence* (you see the object if you can see any member). But the object's **denormalized aggregate columns are computed across all members**, and RLS can't mask columns. So a mixed public+proprietary object — visible because the viewer can access one public member — leaked the proprietary program's name and metadata through:

- `programs[]` — **names the proprietary program** (the headline leak)
- `gratings[]`, `observations[]`, `n_targets`, `n_spectra`, `max_snr`, `max_exposure_time` — quantify the proprietary observations

Member-level payloads (`member_targets`, `spectra`, member ids) were already filtered to accessible programs. This PR closes the remaining **object-level** leak.

This was **not** caused by PR #185 and is **independent of admin status** — the web computes the accessible slug set as `public ∪ explicit` for everyone on these paths, so revoking admin did not stop it.

## Fix — display-only scoping

New `object_scoped_aggregates(object_id, program_slugs)` helper recomputes the aggregates restricted to a slug set, matching the deploy-time semantics in `python/campfire/deploy/objects.py` (a full-access viewer gets values identical to the stored columns). Wired into every object read path. **Display-only**: filter/sort still run on the global columns, so query plans are unchanged; the scoped substitution happens only on the post-pagination result set.

- `get_filtered_objects_paginated` (list) — helper via `LATERAL`
- `get_csv_export_objects` (CSV) — helper via `LATERAL`
- `get_objects_for_sync` (Python client sync) — helper via `LATERAL`
- `get_field_object_markers` (map) — **set-based rewrite** (the only bulk, latency-sensitive path; only needs programs/n_targets/n_spectra)
- web `getObject()` detail page — recompute in TS from the already access-filtered members (no extra query)

Object-level **science** (redshift, photometry) intentionally stays visible — the viewer has independent access to the source, and hiding it would cripple the public experience and force an ugly "uninspected to public viewers" UX. (Policy choice confirmed with @hollisakins.)

The direct `.select('*')` API routes (cutout, shutters, photometry-pz) were checked: they use `programs` only for server-side access checks, never echo it. og-image/tile-thumbnail/inspect don't select leaky columns.

## Performance

Negligible on the hot path: the list RPC already joined to members per page; scoping adds one index-backed hop for 50 rows. Map was rewritten set-based so it stays linear. If any bulk path ever proves hot, a per-program `object_program_stats` breakdown table would collapse scoping to a sum over 1–few rows.

## Known limitation (pre-existing, out of scope)

Admin-all (PR #185) is enforced at DB RLS, but the web computes accessible slugs as `public ∪ explicit` and does **not** add admin-all for the list/detail/CSV paths. So admins without explicit grants are scoped the same as regular users in the web UI there (the map uses the DB-side `accessible_program_slugs()` and does honor admin-all). This is pre-existing; this PR doesn't change it. If admins should see proprietary aggregates in the web UI, the app-layer slug computation needs admin-all added separately.

## Verification

- `supabase db reset` applies cleanly; `supabase db diff` shows no function drift (only the perennial MV/view churn, stripped from the migration per CLAUDE.md)
- New `supabase/tests/check_object_aggregate_scoping.sql`: asserts a mixed public+proprietary object scopes the proprietary program / counts / snr / gratings out for a public-only viewer, via both the helper and the list RPC — **passes**
- `supabase/tests/check_mv_unique_indexes.sql` — passes
- `cd web && npm run build` — passes

Generated with Claude Code