### PR TITLE
perf(search): denormalized search_text columns to fix objects-list timeout

### DIFF
--- a/docs/db_audit_2026-06-19.md
+++ b/docs/db_audit_2026-06-19.md
@@ -1,0 +1,623 @@
+# CAMPFIRE Database Audit — Prioritized Findings
+
+## 1. Executive summary
+
+This database is **small and largely healthy**. At the current ~50k-row scale (33,965 objects / 36,564 targets / 49,600 spectra / 195,175 shutters), the schema is well-modeled: every sky coordinate is `double precision`, natural-key uniqueness is fully enforced, RLS coverage is complete across all 29 tables, and the live catalog matches `supabase/schemas/` with **zero meaningful drift**. There is no structural emergency. The genuine action items cluster in two places: (1) **two list-page count queries that recompute an exact `COUNT(*)` over a full join on every render** — the only real user-facing latency findings — and (2) **missing sort/filter indexes** on whitelisted spectra columns. The top three things to do, in order: **(a) gate the exact `COUNT(*)` behind a `p_include_count` flag in `get_filtered_spectra_paginated`** (high; turns ~384ms default renders into ~2ms for indexed sorts); **(b) add btree indexes on `spectra(signal_to_noise)` and `spectra(exposure_time)`** (high; a one-click UI sort currently full-scans + sorts 49,600 rows); **(c) add the `shutters(observation)` FK-covering index** (medium; every deploy delete/replace seq-scans 195k rows). Everything else is hygiene, at-scale insurance, or explicitly "do nothing" corrections to refuted assumptions. Convert timestamps to `timestamptz` when convenient (medium, but couples to a web client fix). Do **not** add naive `>= 0` SNR checks (prod already holds negative values) and do **not** apply the proposed correlated-`EXISTS` rewrite to `select_list_members` (verified 14x slower).
+
+## 2. Schema drift vs `supabase/schemas/`
+
+**No meaningful drift.** PROD (project `puyczxwyuzpnqvpachip`) matches the declarative source of truth across every object class verified by direct catalog inspection:
+
+- **Migrations:** all 68 applied; latest applied = newest file (`20260618173853_add_apply_object_reconciliation_rpc`). No pending/missing/extra.
+- **Tables/columns:** exactly 29 tables; every column type/nullability/default matches. Generated columns (`spectra.spectrum_id`, `targets.redshift`, `objects.redshift`) verified `GENERATED ALWAYS` with identical expressions; the intentional non-generated `targets.observation` (plain text) matches.
+- **Indexes:** all 136 PROD indexes map 1:1 to a declared name. The duplicate UNIQUE pair on `nircam_images` exists in **both** PROD and `tables.sql` — redundant by design, **not drift** (it is a separate finding, #10).
+- **Functions/triggers/views:** 57 functions = 57 declared; 9 triggers = 9; both views semantically identical. Zero overloads. Latest semantic changes (`accessible_program_slugs()` admin-inheritance UNION, `apply_object_reconciliation`) present verbatim.
+- **RLS/grants:** RLS enabled on all 29 tables; 93 policies = 93 declared. The asymmetric `nircam_exposures` grant matches intentionally.
+- **Migra blind spots cross-checked manually:** both materialized views (`mv_filter_options`, `mv_programs_overview`) and all constraints inspected directly against PROD — no hidden divergence; no partitions; no comment-only drift of concern.
+
+A clean `supabase db diff` alone would not *prove* the MVs match (migra doesn't track them), but direct inspection confirms they do.
+
+## 3. Priority table
+
+Sorted highest-impact / lowest-risk first; all `lens=now` above all `lens=at-scale`.
+
+| # | Title | Area | Lens (now/scale) | Severity | Effort | One-line fix |
+|---|-------|------|------------------|----------|--------|--------------|
+| 1 | `get_filtered_spectra_paginated` recomputes exact `COUNT(*)` over full join every render | queryplan | now | **high** | M | Add `p_include_count`; skip count on page>1 (must drop the 2nd CTE ref, not just return -1) |
+| 2 | Spectra sort by `signal_to_noise`/`exposure_time` full-scans + sorts 49.6k rows | queryplan | now | **high** | S | `CREATE INDEX … (signal_to_noise DESC NULLS LAST)` + `(exposure_time DESC NULLS LAST)` |
+| 3 | `shutters(observation)` FK uncovered — deploy delete/replace seq-scans 195k rows | indexing | now | medium | S | `CREATE INDEX idx_shutters_observation ON shutters(observation)` |
+| 4 | `objects.observations` GIN missing — admin/all-programs list+queue seq-scans | indexing | now | medium | S | `CREATE INDEX idx_objects_observations ON objects USING gin(observations)` |
+| 5 | `get_filtered_objects_paginated` count seq-scans on broad/admin program filter | queryplan | now | medium | M | Add `p_include_count`; skip count on page>1 (mirror sync RPCs) |
+| 6 | Event/audit timestamps are naive `timestamp` not `timestamptz` (12 columns) | datatypes | now | medium | M | `ALTER … TYPE timestamptz USING … AT TIME ZONE 'UTC'` **+ fix web activity page Z-append** |
+| 7 | `targets.object_id` FK is NO ACTION, inconsistent with SET-NULL relink model | constraints | now | low | S | `… ON DELETE SET NULL` (NOT VALID + VALIDATE) |
+| 8 | `spectra.target_id` FK is NO ACTION; delete-order enforced only in app code | constraints | now | low | S | Decide CASCADE vs interlock; if CASCADE, NOT VALID + VALIDATE |
+| 9 | `objects.redshift_quality` lacks CHECK despite fixed 0–4 domain | constraints | now | low | S | `CHECK (redshift_quality BETWEEN 0 AND 4)` NOT VALID + VALIDATE |
+| 10 | `nircam_images` two byte-identical UNIQUE constraints | indexing | now | low | S | `DROP CONSTRAINT nircam_images_unique` |
+| 11 | `redshift_inspected`/`redshift` numeric(10,6) vs `redshift_auto` double | datatypes | now | low | M | Defer to Phase E; retype to double |
+| 12 | DO NOT add naive `snr/max_snr >= 0` CHECK — prod holds negatives | constraints | now | low | — | No-op; only `exposure_time >= 0` is deployable |
+| 13 | KEEP 4 "unused" indexes (trgm search, dq_flags, gratings) — planner adopts them | indexing | now | low | — | No change |
+| 14 | Detail eq-lookups already btree-served (query-map claim is false) | queryplan | now | low | — | No change |
+| 15 | Natural-key uniqueness complete; do NOT add `(object_id, program_slug)` unique | constraints | now | low | — | No change (815 legit multi-target groups) |
+| 16 | All coordinates `double precision` — invariant satisfied | datatypes | now | low | — | No change |
+| 17 | RLS coverage complete; account_requests INSERT `WITH CHECK(true)` is by design | rls | now | low | — | No change (flag SELECT breadth to security track) |
+| 18 | `createList` does up to 20 serial slug-probe round-trips on collision | nplus1 | now | low | S | Single prefix-`LIKE` query, compute suffix in JS |
+| 19 | `check_existing_objects` runs twice per deploy | nplus1 | now | low | S | Thread `existing` set into `batch_upsert_objects` |
+| 20 | Access preamble (2 queries) duplicated across ~8 server actions + re-derived in RLS | nplus1 | now | low | S | React `cache()`-wrap a shared `getAccessiblePrograms` |
+| 21 | `get_field_object_markers` per-object correlated `array_agg` (N+1 in SQL) | queryplan | now | medium | M | Field-scoped `GROUP BY` pre-aggregation (NOT bare LATERAL) |
+| 22 | `get_field_shutters` scans 195k object_id index, discards 130k non-field rows | queryplan | now | low | S | `CREATE INDEX idx_shutters_field_object_id ON shutters(field, object_id)` |
+| 23 | 23 RLS policies call bare `auth.uid()` instead of `(select auth.uid())` | rls | at-scale | medium | M | Wrap all 23 in `(select …)` (DROP+CREATE POLICY) |
+| 24 | Deep OFFSET pagination (sync/CSV/id-fetch) reads+discards skipped rows | queryplan | at-scale | medium | M | Keyset on `_for_sync`; composite cursor for sorted RPCs |
+| 25 | `select_list_members` rebuilds full accessible-objects set per list read | rls | at-scale | low | — | Leave as-is OR cache slugs; **do NOT** use correlated EXISTS |
+| 26 | `admin_*` ⋃ `update_*_by_access` multiple-permissive on objects/targets/spectra | rls | at-scale | low | S | Fold admin into access policy (lint hygiene only) |
+| 27 | int4 PK sequences on churn tables — safe to ~100x | datatypes | at-scale | low | — | No action; document headroom math |
+| 28 | `spectra.date_obs` is text storing ISO date | datatypes | at-scale | low | S | `ALTER … TYPE date USING NULLIF(date_obs,'')::date` |
+| 29 | Deploy thumbnails per-spectrum UPDATE (standalone command only) | nplus1 | at-scale | low | S | Batch via `on_conflict(target_id,grating)` upsert |
+| 30 | Photometry split/reroute per-row UPDATEs | nplus1 | at-scale | low | S | Grouped `.in_('id', chunk)` or reuse `relink_photometry_for_field` |
+| — | VACUUM/visibility-map tuning on objects/spectra | queryplan | n/a (ops) | low | S | Operator: `VACUUM (ANALYZE)`; not a code change |
+
+---
+
+## 4. "Now" findings (current-size correctness/hygiene)
+
+### #1 — `get_filtered_spectra_paginated` recomputes exact `COUNT(*)` over the full join on every render — HIGH
+
+**What & why.** The default spectra-view render (all 29 program slugs, no filter, page 1, sort `spectrum_id`) runs ~384ms with temp spill to disk. The function carries a scalar `(SELECT COUNT(*) FROM distance_filtered)` (functions.sql:797) referencing the `distance_filtered` CTE a **second** time. Because the CTE is referenced twice, Postgres **materializes** it (~49,600 rows, hash joins + temp spill), which *blocks* the index-incremental-sort fast path the page-fetch would otherwise use. Hot path: `web/app/api/v1/spectra/list/route.ts:133` and `web/lib/actions/spectra.ts:101` on every render; FITS export (pageSize 200) and the Python v1 list endpoint share it.
+
+**Evidence (prod EXPLAIN ANALYZE).** Standalone count over targets×spectra×objects: Parallel Hash Left Join, dual Parallel Seq Scans on targets (rows=18282×2) and objects (rows=16982×2), `idx_spectra_target_grating` index-only scan with **Heap Fetches=21867**, 22,093 buffers, ~83ms. Removing the second CTE reference (single-reference → PG inlines) collapsed the **whole query to 2.1ms / 381 buffers, no temp spill**, using `idx_spectra_spectrum_id`. So the win is ~384ms → ~2ms for indexed-column sorts.
+
+**migration_sql** (declarative edit to `supabase/schemas/functions.sql`, `get_filtered_spectra_paginated` body):
+
+```sql
+-- Add a parameter and, when false, eliminate the SECOND reference to distance_filtered
+-- (returning -1 alone is NOT enough — the textual second reference still forces
+-- CTE materialization and blocks the incremental-sort path).
+CREATE OR REPLACE FUNCTION public.get_filtered_spectra_paginated(
+  ...existing args...,
+  p_include_count boolean DEFAULT true
+) RETURNS ... AS $$
+  ...
+  -- when p_include_count = false, build the result with a literal -1 in place of
+  -- the (SELECT COUNT(*) FROM distance_filtered) scalar so distance_filtered is
+  -- referenced exactly once and PG inlines it.
+$$ LANGUAGE sql STABLE;
+```
+`db diff` emits a full-body `CREATE OR REPLACE FUNCTION`. No table DDL.
+
+**Lock note.** `CREATE OR REPLACE FUNCTION` takes only a brief lock on the function; `concurrently` N/A.
+
+**Verify.** `EXPLAIN ANALYZE` the RPC with `p_include_count=false` on page>1 + indexed sort: confirm the 22k-buffer count aggregate is gone and only the ~381-buffer `idx_spectra_spectrum_id` page-fetch remains; page-1 count still equals a plain `COUNT(*)`.
+
+**Caveats.** The full win lands only for indexed-column sorts; sorts on non-indexed columns (`signal_to_noise`, `redshift`) still require a full sort regardless of the count (see #2). The web client must **cache the count across page changes** (count is filter-stable) for the flag to help on paging, and still fetch it on page 1 / filter change to drive the total-pages UI.
+
+---
+
+### #2 — Spectra sort by `signal_to_noise`/`exposure_time` forces full seq-scan + sort before LIMIT — HIGH
+
+**What & why.** `signal_to_noise` and `exposure_time` are whitelisted one-click UI sort columns (`web/lib/actions/spectra-types.ts`), but neither has an index. A sort-by-`signal_to_noise DESC` page-fetch cannot short-circuit the LIMIT — the planner scans and sorts all 49,600 rows to return the top 50.
+
+**Evidence (prod EXPLAIN ANALYZE).** Real RPC inner query, all programs, sort `signal_to_noise DESC`, LIMIT 50: planner constant-folds the ~30-term `CASE` ORDER BY chain to `Sort Key: s.signal_to_noise DESC NULLS LAST` → Parallel Seq Scan on spectra (24800×2) + quicksort → ~75ms warm (315ms cold). **Adoption proven by proxy:** the identical join shape sorted by the *indexed* `spectrum_id` (same all-programs join-side filter) does `Index Scan using idx_spectra_spectrum_id` reading only 51 rows via Memoize nested-loop → **1.87ms**. So an index on `signal_to_noise` *will* be adopted — the join-side filter does not defeat it in the broad/all-programs case. `signal_to_noise` has 8 NULLs, `exposure_time` 0 — `NULLS LAST` is an exact index match.
+
+**migration_sql** (`supabase/schemas/indexes.sql`, after the existing `idx_spectra_spectrum_id` sort index ~line 156):
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_spectra_signal_to_noise
+    ON public.spectra USING btree (signal_to_noise DESC NULLS LAST);
+CREATE INDEX IF NOT EXISTS idx_spectra_exposure_time
+    ON public.spectra USING btree (exposure_time DESC NULLS LAST);
+```
+`db diff` emits the same two statements.
+
+**Lock note.** `spectra` is a 77MB hot-write table during deploys → build with `CREATE INDEX CONCURRENTLY` out-of-band. **Important repo constraint:** the Supabase CLI migration runner wraps each file in a transaction (documented in migration `20260417184613`), so `CONCURRENTLY` cannot run inside a normal migration. Apply via a manual `supabase db push` step or a split migration, **or** use a plain `CREATE INDEX` (sub-second at 49.6k rows) accepting the brief SHARE lock outside a deploy window.
+
+**Verify.** `EXPLAIN ANALYZE` the `signal_to_noise`-sorted page: adopted iff the Sort/Parallel-Seq-Scan node is replaced by an Index Scan feeding the LIMIT (actual rows ~50–200, not 24800).
+
+**Caveat / unverified.** For a *narrow single-program* filter on the joined `targets` table the planner *might* prefer scan+sort; the broad/all-programs case (the proxy-proven one) is the dominant traffic. The objects-side equivalents (`max_snr`, `n_spectra`) were **not** tested and are out of this finding's scope.
+
+---
+
+### #3 — `shutters(observation)` FK uncovered; deploy delete/replace seq-scans 195k rows — MEDIUM
+
+**What & why.** `fk_shutters_observation` → `observations(name)` has no covering index. The deploy/remove lifecycle does `delete/count … WHERE observation = ?` (full obs-scoped replace) on every NIRSpec redeploy (`supabase.py:542`, `remove.py:85,150`).
+
+**Evidence (prod).** `SELECT id FROM shutters WHERE observation='ceers1'` → Seq Scan, Rows Removed 190748, 3429 buffers, 27.5ms, returns 4427 (0.4–2.3% selective — planner adopts btree now). `pg_stat_statements`: `DELETE … WHERE observation=$1` = ~248 calls, **~71s cumulative** (means 198ms & 557ms). Production per-call cost exceeds the warm 27ms EXPLAIN — the finding if anything understates it.
+
+**migration_sql** (`supabase/schemas/indexes.sql`, `-- shutters` section after `idx_shutters_ra_dec` ~line 233):
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_shutters_observation
+    ON public.shutters USING btree (observation);
+```
+
+**Lock note.** Hot write table (262k ins / 212k del) → `CREATE INDEX CONCURRENTLY` out-of-band (same CLI-transaction caveat as #2).
+
+**Verify.** Re-run the EXPLAIN; expect Index/Bitmap scan, buffers ~3431 → tens. Confirm `idx_scan` increments after a deploy/remove cycle.
+
+**Note (separate finding worth filing):** sister table `slit_regions` has the *identical* uncovered delete-by-observation pattern (`remove.py:151`, `supabase.py:521`) and also lacks an `observation` index.
+
+---
+
+### #4 — `objects.observations` array filter has no GIN; admin/all-programs list+queue seq-scans — MEDIUM
+
+**What & why.** All four objects RPCs apply `o.observations && p_observations` (functions.sql:909, 1029, 1303, 1509). `objects` has GIN on `programs`/`gratings`/`object_id` but **not** `observations`. The access gate `o.programs && v_filtered_program_slugs` is applied for *all* callers; for admins the web passes all 29 slugs, making `programs &&` **non-selective**, so the planner abandons `idx_objects_programs` and falls to a seq scan.
+
+**Evidence (prod EXPLAIN ANALYZE).** (1) observations-only: Seq Scan, 3010 buffers, 19.7ms. (2) selective program + observations: Bitmap Index Scan on `idx_objects_programs`, 1009 buffers, 7.3ms (fast path for non-admins). (3) **admin path** (all 29 slugs + observations): **Seq Scan, 3010 buffers, 36.7ms** — the program GIN is *not* chosen because it matches ~every row. A GIN on `observations` would be the only selective index in case (3) and **will** be adopted.
+
+**migration_sql** (`supabase/schemas/indexes.sql`, `-- objects` section after `idx_objects_gratings` ~line 61):
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_objects_observations
+    ON public.objects USING gin (observations);
+```
+
+**Lock note.** Hot table (ins=82,927 / upd=339,799) → `CREATE INDEX CONCURRENTLY` out-of-band (CLI-transaction caveat).
+
+**Verify.** `EXPLAIN` the admin-all path (all program slugs + `p_observations`): expect a Bitmap Index Scan on `idx_objects_observations` replacing the seq scan. Non-admins with a concrete program filter keep the existing fast bitmap path.
+
+**Scope.** Only bites the admin/all-programs list count+page and the inspection queue; modest but reproducible *today*.
+
+---
+
+### #5 — `get_filtered_objects_paginated` count seq-scans on broad/admin program filter — MEDIUM
+
+**What & why.** Same structural shape as #1 for the objects list. The RPC computes an unconditional `SELECT COUNT(*)` (functions.sql ~905) on every list render; the LIMIT page-fetch is cheap (LIMIT short-circuits), so ~80% of the function's time and ~57% of its buffers is the count.
+
+**Evidence (prod EXPLAIN ANALYZE).** Broad 29-slug count: Seq Scan on objects, 33965 rows, 3010 buffers, 36.8ms (GIN correctly *not* used — predicate is ~100% selective). Full RPC (admin/all, page 1): 46.3ms / 5313 buffers. Selective single-slug (`ceers`) count: Bitmap Index Scan, 2.0ms. Real traffic (`top_statements.txt`): the `get_filtered_object_ids/paginated` family is ~24,700 calls / ~6.3M ms — the 2nd-hottest RPC. The `p_include_counts` gating pattern **already exists** on the sync RPCs (`get_objects_for_sync`, functions.sql:148) — mirror it here (it is *not* present on the list RPC).
+
+**migration_sql** (`supabase/schemas/functions.sql`, `get_filtered_objects_paginated`):
+
+```sql
+CREATE OR REPLACE FUNCTION public.get_filtered_objects_paginated(
+  ..., p_include_count boolean DEFAULT true
+) ... -- skip the `SELECT COUNT(*) INTO v_total_count` block when false (return -1)
+```
+No btree/partial index — confirmed a btree would *not* be adopted for the ~100%-selective broad predicate; do **not** add a per-program btree.
+
+**Lock note.** `CREATE OR REPLACE FUNCTION` only. `concurrently` N/A.
+
+**Verify.** `EXPLAIN ANALYZE` the RPC on a page>1 request with the flag false: buffers drop ~5300 → ~50, time ~46ms → <1ms. Page-1 total still correct. Web must fetch the count only on page 1 / filter change and reuse across page nav (count is filter-stable, drives total-pages UI).
+
+**Follow-on.** `get_adjacent_objects` (functions.sql ~1485, MATERIALIZED CTE, ~5,375 prod calls) carries similar broad-case cost — separate fix.
+
+---
+
+### #6 — Event/audit timestamps are naive `timestamp` not `timestamptz` (12 columns) — MEDIUM
+
+**What & why.** Twelve event/audit columns are `timestamp without time zone`: `comments.created_at/edited_at`, `flag_audit_log.changed_at`, `spectra.created_at`, `targets.created_at/updated_at`, `user_profiles.created_at`, `user_program_access.granted_at`, `nircam_exposures.created_at/updated_at/date_obs`, `nircam_images.created_at` — while the rest of the schema is consistently `timestamptz` (note `spectra.updated_at` is already `timestamptz NOT NULL` while `spectra.created_at` is naive — same table, mixed). DB runs UTC (`SHOW timezone`=UTC), so the stored wall-clock *is* UTC but the type erases the offset. **This is a present-day (cosmetic) bug, not just hygiene:** non-compensating readers (`ObjectComments.tsx:106/153`, `CommentsPreview.tsx:118`, `email/resend.ts:30`, `profile/page.tsx:333`) do `new Date(created_at)` which JS parses as *local* time, rendering wrong on non-UTC clients today. The team already hit this — `admin/activity/page.tsx:113-115` has an explicit `…endsWith('Z') ? … : `${ts}Z`` workaround.
+
+**migration_sql** (`supabase/schemas/tables.sql`: change each listed column to `timestamp with time zone`, keep `DEFAULT now()`; `db diff` emits):
+
+```sql
+ALTER TABLE public.comments
+  ALTER COLUMN created_at TYPE timestamptz USING created_at AT TIME ZONE 'UTC',
+  ALTER COLUMN edited_at  TYPE timestamptz USING edited_at  AT TIME ZONE 'UTC';
+ALTER TABLE public.flag_audit_log
+  ALTER COLUMN changed_at TYPE timestamptz USING changed_at AT TIME ZONE 'UTC';
+ALTER TABLE public.spectra
+  ALTER COLUMN created_at TYPE timestamptz USING created_at AT TIME ZONE 'UTC';
+ALTER TABLE public.targets
+  ALTER COLUMN created_at TYPE timestamptz USING created_at AT TIME ZONE 'UTC',
+  ALTER COLUMN updated_at TYPE timestamptz USING updated_at AT TIME ZONE 'UTC';
+ALTER TABLE public.user_profiles
+  ALTER COLUMN created_at TYPE timestamptz USING created_at AT TIME ZONE 'UTC';
+ALTER TABLE public.user_program_access
+  ALTER COLUMN granted_at TYPE timestamptz USING granted_at AT TIME ZONE 'UTC';
+ALTER TABLE public.nircam_exposures
+  ALTER COLUMN created_at TYPE timestamptz USING created_at AT TIME ZONE 'UTC',
+  ALTER COLUMN updated_at TYPE timestamptz USING updated_at AT TIME ZONE 'UTC';
+ALTER TABLE public.nircam_images
+  ALTER COLUMN created_at TYPE timestamptz USING created_at AT TIME ZONE 'UTC';
+```
+
+**REQUIRED coupled web change (do not ship the ALTERs without it).** After conversion, values serialize as `…+00:00` (not ending in `Z`), so `admin/activity/page.tsx:115`'s `${ts}Z` append produces `…+00:00Z` → **Invalid Date → "NaN ago"** in the admin activity feed (which renders `comments.created_at` and `flag_audit_log.changed_at`). **Delete that Z-append workaround** (or match `downloads/page.tsx:146` which also checks `.includes('+')`). The non-compensating readers above are *fixed* by the conversion (they start receiving offset-bearing strings) — smoke-test them but no code change needed.
+
+**Lock note.** `ALTER … TYPE` takes ACCESS EXCLUSIVE and **rewrites** each table (not binary-coercible). `targets` (39MB/46k) and `spectra` (163MB/49.6k) rewrites are seconds-scale but block reads+writes. Run in a low-traffic window; do **not** batch into a deploy. No `CONCURRENTLY` for `ALTER TYPE`.
+
+**Verify.** `information_schema.columns … data_type='timestamp without time zone'` returns zero rows; a known row's UTC instant unchanged before/after.
+
+**Caveat.** No SQL-side `AT TIME ZONE` compensation exists in schemas/migrations/functions (grep clean), so the `AT TIME ZONE 'UTC'` USING clause preserves instants. `nircam_exposures.date_obs` is an observation timestamp, not a `now()`-defaulted audit column — converting it is arguably out of scope but harmless.
+
+---
+
+### #7 — `targets.object_id` FK is NO ACTION, inconsistent with the SET-NULL relink model — LOW
+
+**What & why.** `fk_targets_object` → `objects(id)` has no `ON DELETE` clause (`confdeltype='a'`), while **all four** sibling FKs to `objects` (`comments`, `flag_audit_log`, `object_list_members`, `object_photometry`) are `ON DELETE SET NULL` — and the documented model is coordinate-relink-after-rebuild (object_id "refreshed after each objects rebuild via coordinate cross-matching"). `targets` is the sole outlier. It has never bitten because reconcile **soft-deletes** (`is_active=false`), never hard-deletes; `objects.py:271-302` manually batch-nulls `targets.object_id` before deleting objects precisely because the FK would otherwise RESTRICT. Prod: 243/36,564 (0.66%) targets have `object_id IS NULL` legitimately (unreconciled), 0 dangling, 0 inactive.
+
+**migration_sql** (`supabase/schemas/tables.sql:1420` → `ON DELETE SET NULL`; `db diff`):
+
+```sql
+ALTER TABLE public.targets DROP CONSTRAINT fk_targets_object;
+ALTER TABLE public.targets
+  ADD CONSTRAINT fk_targets_object FOREIGN KEY (object_id)
+  REFERENCES public.objects(id) ON DELETE SET NULL NOT VALID;
+ALTER TABLE public.targets VALIDATE CONSTRAINT fk_targets_object;
+```
+Do **not** add `NOT NULL` (243 legit NULLs). `idx_targets_object_id` already backs the SET NULL action.
+
+**Lock note.** `ADD … NOT VALID` = brief ACCESS EXCLUSIVE (catalog row only); `VALIDATE` scans under SHARE UPDATE EXCLUSIVE without blocking writes. `concurrently` N/A for FK validate.
+
+**Verify.** `pg_constraint.confdeltype='n'`. On local reset, DELETE an object owning targets → targets get `object_id=NULL` (not an error); reconcile re-links on next deploy. Then drop the manual null-step in `objects.py:271-302`.
+
+**Caveats.** Cleanup, not a defect — 0 dangling rows, working soft-delete path. Whether to prefer RESTRICT as a deliberate interlock is a design call. The `objects.py:288` comment is *accurate* about `object_list_members` (which is SET NULL) — it is incomplete, not "false." 5 child FKs reference objects (not 3); targets is the lone NO-ACTION outlier.
+
+---
+
+### #8 — `spectra.target_id` FK is NO ACTION; delete ordering enforced only in app code — LOW
+
+**What & why.** `spectra_target_id_fkey` → `targets(target_id)` (the UNIQUE text natural key) has no `ON DELETE` clause. `remove.py:138-160` deletes spectra by `target_id IN(batch)` *before* deleting targets — correct order enforced in Python, not the DB. No live corruption risk (FK hard-fails rather than orphaning; 0 orphans on prod). Cross-FK context: `comments_target_id_fkey` is CASCADE, `flag_audit_log_target_id_fkey` is SET NULL — `spectra` alone is NO ACTION.
+
+**migration_sql** — only if you choose CASCADE (a product decision: spectra have no meaning without a target, so CASCADE matches the deploy-remove semantics and lets you drop the manual pre-delete):
+
+```sql
+ALTER TABLE public.spectra DROP CONSTRAINT spectra_target_id_fkey;
+ALTER TABLE public.spectra
+  ADD CONSTRAINT spectra_target_id_fkey FOREIGN KEY (target_id)
+  REFERENCES public.targets(target_id) ON DELETE CASCADE NOT VALID;
+ALTER TABLE public.spectra VALIDATE CONSTRAINT spectra_target_id_fkey;
+```
+Do **not** add `NOT NULL` (already NOT NULL). `idx_spectra_target_grating` provides an indexed cascade-delete lookup.
+
+**Lock note.** Same NOT VALID + VALIDATE pattern as #7.
+
+**Verify.** `confdeltype='c'`; orphan probe still 0; local reset DELETE a target → its spectra disappear; then drop the redundant pre-delete in `remove.py`.
+
+**Caveat (unverified).** CASCADE vs hard-fail-interlock is a product decision; keep NO ACTION if you want deletions to hard-fail as a safety interlock. No integrity bug today either way.
+
+---
+
+### #9 — `objects.redshift_quality` lacks a CHECK despite a fixed 0–4 domain — LOW
+
+**What & why.** `objects.redshift_quality integer NOT NULL DEFAULT 0` with documented domain (tables.sql:499: `0=uninspected … 4=Secure`), but no CHECK guards it. The generated `redshift` column branches on `redshift_quality=1` (Impossible) → an out-of-range write would silently corrupt generated-redshift semantics. Prod data is fully in-domain (`{0,1,2,3,4}`, 0 out-of-range), so VALIDATE succeeds. App-layer enum (`web/lib/flags.ts` `REDSHIFT_QUALITY`) already constrains the UI — this is defense-in-depth.
+
+**migration_sql** (`supabase/schemas/tables.sql`, objects body ~line 467):
+
+```sql
+ALTER TABLE public.objects
+  ADD CONSTRAINT objects_redshift_quality_check
+  CHECK (redshift_quality >= 0 AND redshift_quality <= 4) NOT VALID;
+ALTER TABLE public.objects VALIDATE CONSTRAINT objects_redshift_quality_check;
+```
+
+**Lock note.** `ADD … NOT VALID` = metadata-only under brief ACCESS EXCLUSIVE (no scan/rewrite); `VALIDATE` scans 33,965 rows under SHARE UPDATE EXCLUSIVE. Cheap.
+
+**Verify.** VALIDATE succeeds; `UPDATE … redshift_quality=5` rejected (then ROLLBACK).
+
+**Scope.** Skip the `targets` CHECK — that column is deprecated/nullable (drop in Phase E). If a future quality scheme adds a value >4, widen the CHECK in the same migration.
+
+---
+
+### #10 — `nircam_images` has two byte-identical UNIQUE constraints — LOW
+
+**What & why.** `nircam_images_unique` and `nircam_images_field_tile_filter_pixel_scale_version_extensi_key` are both `UNIQUE (field, tile, filter, pixel_scale, version, extension)`, each an 88 kB index (Supabase advisor lint 0009). `tables.sql:1193-1194` and `1203-1204` declare both.
+
+**migration_sql** (delete the `tables.sql:1203-1204` block; keep the auto-named `…_key`):
+
+```sql
+ALTER TABLE public.nircam_images DROP CONSTRAINT nircam_images_unique;
+-- (implicitly drops the backing index)
+```
+
+**Lock note.** **Correction to original evidence:** the table is **NOT empty** — it has 1,067 real rows (the `n_live_tup=0` was a stale planner stat). The drop is still safe: `DROP CONSTRAINT` on a UNIQUE takes a momentary ACCESS EXCLUSIVE to drop the backing index (metadata-only, no scan/rewrite, trivial at 1,067 rows); the surviving `…_key` keeps enforcing uniqueness; `DROP CONSTRAINT` cannot use `CONCURRENTLY` regardless. So `concurrently=false`, justified by "tiny low-write table, metadata-only drop," not "empty table."
+
+**Verify.** `\d nircam_images` shows a single UNIQUE on the 6 columns plus PK; violating inserts still fail.
+
+**Caveat (unverified).** If `supabase db diff` does not emit the `DROP CONSTRAINT` (migra constraint-drop gap), hand-author it.
+
+---
+
+### #11 — `redshift_inspected`/generated `redshift` are numeric(10,6) while `redshift_auto` is double — LOW
+
+**What & why.** The generated `redshift` COALESCEs `(redshift_inspected)::double precision` with `redshift_auto`, then stores into `numeric(10,6)` — a double→numeric round-trip on every recompute (write-time only, STORED). numeric(10,6) buys *zero* precision over double for these z values (prod: 0/13,618 inspected rows would differ). All web/CSV consumers re-format via `.toFixed()`, so numeric→double is non-breaking.
+
+**migration_sql** — **defer and bundle with Phase E** removal of deprecated `targets.redshift*`. For `objects` (the live tier), a generated column must be dropped + re-added:
+
+```sql
+ALTER TABLE public.objects DROP COLUMN redshift;  -- generated; must drop to retype its input
+ALTER TABLE public.objects ALTER COLUMN redshift_inspected TYPE double precision
+  USING redshift_inspected::double precision;
+ALTER TABLE public.objects ADD COLUMN redshift double precision GENERATED ALWAYS AS (
+  CASE WHEN redshift_quality = 1 THEN NULL
+       ELSE COALESCE(redshift_inspected, redshift_auto) END) STORED;
+```
+
+**Lock note.** Table rewrite under ACCESS EXCLUSIVE; **`idx_objects_redshift` exists on the generated column and is planner-adopted (Index Scan) — DROP/re-ADD cascades the index, so it must be recreated.** No `CONCURRENTLY` for `ALTER TYPE`.
+
+**Verify.** `\d objects` shows both as double; generated expression intact.
+
+**Recommendation.** Do **not** do this standalone — fold into Phase E.
+
+---
+
+### #12 — Do NOT add a naive `snr/max_snr >= 0` CHECK — prod already holds negatives — LOW (counter-evidence)
+
+**Why it matters.** A tempting `CHECK (signal_to_noise >= 0)` / `CHECK (max_snr >= 0)` would **fail VALIDATE** against live data. Prod: `spectra.signal_to_noise < 0` = 20 (down to −6.78); `objects.max_snr < 0` = 14 (`targets.max_snr < 0` = 15); `exposure_time < 0` = 0; `redshift < 0` = 0 **but** `redshift_inspected < 0` = 10 (targets)/15 (objects) — the "hypothetical" negative input is already present. So a `redshift >= 0` CHECK is fragile too (it passes only because `redshift_quality=1` nulls it or `redshift_auto` wins the COALESCE).
+
+**The only deployable guard** (`exposure_time`, 0 negatives, 0 nulls):
+
+```sql
+ALTER TABLE public.spectra
+  ADD CONSTRAINT spectra_exposure_time_nonneg
+  CHECK (exposure_time IS NULL OR exposure_time >= 0) NOT VALID;
+ALTER TABLE public.spectra VALIDATE CONSTRAINT spectra_exposure_time_nonneg;
+```
+
+**Open science question for Hollis:** are the 20 negative-SNR spectra / 14 negative-SNR objects legitimate (a flux-weighted statistic) or dirty pipeline data? This is a science-data decision, not a schema one — resolve *before* any SNR constraint; if dirty, clean via re-deploy, not a CHECK. (Minor doc note: a CHECK *is* legal on a generated column in PG — but don't constrain `redshift` anyway, because its input column already violates.)
+
+---
+
+### #13 — KEEP four "unused_index" advisor entries — the planner DOES adopt them — LOW (block unsafe drops)
+
+**Why it matters.** The advisor flags `idx_objects_object_id_trgm` (8.2MB), `idx_spectra_spectrum_id_trgm` (10MB), `idx_spectra_dq_flags`, `idx_objects_gratings` as `idx_scan=0`, but that reflects stat-age, not death. Prod EXPLAINs: ILIKE `'%cosmos%'` → Bitmap Index Scan on `idx_objects_object_id_trgm` (18 buffers); ILIKE `'%v0p3%'` → Bitmap Index Scan on `idx_spectra_spectrum_id_trgm` (121 buffers); `idx_objects_gratings` → Bitmap Index Scan for rare gratings (G140H, 323 rows / 1%; PRISM 81% correctly seq-scans). The two trgm indexes are the **only** thing making the search bar non-pathological at 33k/49k rows (RPCs use unanchored `ILIKE '%'||p_search||'%'` at functions.sql:676,926 — unservable by btree). **No change.** Do not act on the advisor's unused flag for these.
+
+**Caveat for downstream:** the *real* RPC DQ filter is bitmask `(dq_flags & X) != 0`, which seq-scans and does **not** use `idx_spectra_dq_flags` (the partial index only helps a bare `dq_flags <> 0`). Still KEEP it — 16 kB, planner-adoptable, no benefit to dropping. (Genuinely droppable advisor entries — `idx_object_photometry_coords`, `idx_download_log_download_type`, the empty-table `nircam_images` field/filter indexes — were *not* EXPLAIN-tested here, so no drop is proposed per the index rule.)
+
+---
+
+### #14 — Object/target detail eq-lookups are already btree-served (query-map claim is false) — LOW (correction)
+
+**Why it matters.** Both query maps assert `objects.object_id`/`targets.target_id` have "GIN trgm only, no btree eq index." **False.** `objects_object_id_key` and `targets_target_id_key` are UNIQUE btrees (227,564 and 5,076,035 scans). Prod EXPLAIN: `WHERE object_id=$1` → Index Scan using `objects_object_id_key` (0.17ms); `WHERE target_id=$1` → Index Scan using `targets_target_id_key` (0.14ms). The GIN trgm indexes serve ILIKE only. **No change.** Recorded so no one adds a redundant btree on these columns.
+
+---
+
+### #15 — Natural-key uniqueness is complete; do NOT add `(object_id, program_slug)` unique — LOW (clearing + anti-recommendation)
+
+**Why it matters.** DB-enforced dedup is complete: `spectra` UNIQUE `(target_id, grating)` (the deploy `on_conflict` target, supabase.py:443) + UNIQUE `spectrum_id` + UNIQUE `fits_path`; `targets` UNIQUE `(target_id)`; `objects` UNIQUE `(object_id)`; `object_list_members` UNIQUE `(list_id, ra, dec)`. All dup probes = 0 on prod. The Python source-id dedup is defense-in-depth, not the sole guarantee.
+
+**Anti-recommendation:** do **not** add UNIQUE `(object_id, program_slug)` or `(object_id, field, program_slug)` to targets — prod has **815** `(object_id, field, program_slug)` groups with >1 target (multiple pointings of the same physical source, each a distinct target_id, e.g. `…_p10_17724` vs `…_p11_17724`). Such a constraint would reject legitimate multi-pointing data. The `(list_id, ra, dec)` coordinate key on `object_list_members` is correct (durable across object rebuilds) — keep it over `(list_id, object_id)`. (Terminology nit: spectra uniqueness is enforced by unique *indexes*, not named constraints — harmless, since `ON CONFLICT` accepts unique indexes.)
+
+---
+
+### #16 — All sky coordinates are `double precision` — invariant satisfied — LOW (positive)
+
+Every `ra/dec/center_ra/center_dec/ra_min..dec_max` column is `double precision` (numeric_precision=53). Zero `real`/`float4` in public; `numeric(10,6)` used **only** for the four redshift columns; `position_angle` is double (correct for an angle). Required state for sub-arcsec astrometry (FoF reconcile matches at ~0.2″). **No change.** Invariant to preserve: any future sky-position column must be `double precision`, never `real`, never `numeric`.
+
+---
+
+### #17 — RLS coverage is complete — LOW (positive, with one security-track flag)
+
+All 29 public tables have RLS enabled; zero RLS-enabled-but-no-policy tables; no `rls_disabled_in_public` lint. `force=f` is expected (service_role bypasses RLS for deploys, `config.py:131`). **No coverage action.** One item belongs to the **security-review track, not this performance audit:** the `account_requests` SELECT policy "Users can check own request status" `USING(true)` (roles `authenticated, anon`) lets any user SELECT all rows — a potential anon data-exposure concern, flagged here only so it isn't mistaken for a coverage gap. (The INSERT `WITH CHECK(true)` is intentional public sign-up.)
+
+---
+
+### #18 — `createList` does up to 20 serial slug-probe round-trips on collision — LOW
+
+**What & why.** `web/lib/actions/lists.ts:291-302` awaits one DB round-trip per suffix attempt (MAX_SUFFIX=20) on auto-slug collision. Correctness is fine (INSERT has a 23505 race fallback at line 322). Rare trigger (slugs are username-namespaced; collision needs the same user re-using a name). Prod: `object_lists` = 11 rows, 0 suffixed — path essentially never hit.
+
+**Fix (client-only TS, no migration):** replace the serial loop with one `SELECT slug FROM object_lists WHERE slug LIKE '${base}%'`, compute the lowest free suffix in JS, then INSERT (keep the 23505 fallback). Collapses ≤21 round-trips to 1.
+
+**Verify.** Create two lists generating the same base slug; second resolves its `-2` suffix in a single SELECT.
+
+**Caveat.** At 11 rows the planner seq-scans regardless (cost 0.08ms) — the win is round-trip count, not index choice, and is future-proofing.
+
+---
+
+### #19 — `check_existing_objects` runs twice per deploy — LOW
+
+**What & why.** `deploy.py:294` calls `check_existing_objects` for the confirm prompt; `batch_upsert_objects` calls it **again** at `supabase.py:341` over the identical id set. Each batch is an Index Only Scan on `targets_target_id_key` (2.2ms, 0 heap fetches), so the redundancy is sub-3ms + 1–2 round-trips per deploy.
+
+**Fix (client-only, no migration):** thread an optional `existing: set[str] | None` into `batch_upsert_objects`, defaulting to re-query (a second caller, `deploy.py:761`, only pre-checks under `force_overwrite`, so the default must stay safe).
+
+**Scale correction.** `deploy_observation` is per-**observation**: max obs = 805 targets (ceers1), max COSMOS obs = 544 — **not** "10k targets / 20 round-trips." Real redundancy is 1–2 round-trips per deploy. `migration_sql`/`schema_file` fields in the source finding mislabeled this — it is a pure Python change, no DDL.
+
+---
+
+### #20 — Access preamble (2 queries) duplicated across ~8 server actions + re-derived in RLS — LOW
+
+**What & why.** The 2-query access resolution (`user_program_access` by user_id + `programs WHERE is_public`) appears at `spectra.ts:78,294,444,623,739,816`; `map.ts:209`; `download.ts:101`; `programs.ts:111,161,246` — preceding essentially every filtered read, with **no** React `cache()` wrapping it. RLS then independently re-resolves the same set via `accessible_program_slugs()` (STABLE SECURITY DEFINER, once per statement). Both halves are trivially cheap on prod: access query = Index Only Scan, 0.081ms; public-programs = Seq Scan, 0.077ms (tables are 95/29/11 rows). Chatty/redundant, not an N+1.
+
+**Fix (client/caching, no migration):** introduce a React `cache()`-wrapped `getAccessiblePrograms` helper used by **both** server actions and the `/api/v1` route. **Correction:** the `/api/v1` `getAccessiblePrograms` (`api-helpers.ts:36`) is **not** memoized — it is itself a duplication site (and creates a fresh service-role client each call), not a model to copy.
+
+**Caveat.** The 87M `idx_user_program_access_user_slug` scan count is dominated by *RLS* evaluation across all gated tables, not the JS preamble — so removing the preamble barely moves it. Honestly low. Do **not** change RLS.
+
+---
+
+### #21 — `get_field_object_markers` runs a per-object correlated `array_agg` (N+1 in SQL) — MEDIUM
+
+**What & why.** `functions.sql:2351-2381` projects `COALESCE((SELECT array_agg(t.target_id ORDER BY t.target_id) FROM targets t WHERE t.object_id=o.id), '{}')` as a scalar subquery — executed once per qualifying object. Called on every COSMOS map load (`map.ts:177/183`); `member_target_ids` is the live slit-filter bridge, not dead output.
+
+**Evidence (prod EXPLAIN ANALYZE, `p_field='cosmos'`).** Index Scan on objects (rows=13023) + SubPlan 1 `loops=13023`, each an Index Scan on `idx_targets_object_id`; subplan = 39,217 of 72,709 buffers; ~115–176ms. Cost split: outer scan ~37ms/33k buffers; inner subplan ~78ms/39k buffers (the larger half).
+
+**migration_sql** (`supabase/schemas/functions.sql`, full-body `CREATE OR REPLACE`) — use a **FIELD-SCOPED `GROUP BY`** pre-aggregation:
+
+```sql
+  FROM public.objects o
+  LEFT JOIN (
+    SELECT t.object_id, array_agg(t.target_id ORDER BY t.target_id) AS member_target_ids
+    FROM public.targets t
+    JOIN public.objects o2 ON o2.id = t.object_id
+    WHERE o2.field = p_field AND o2.is_active
+    GROUP BY t.object_id
+  ) m ON m.object_id = o.id
+  WHERE o.field = p_field AND o.is_active
+  ORDER BY o.object_id;
+```
+
+**Critical correction to the original recommendation.** A bare `LEFT JOIN LATERAL` produced a **byte-identical** plan (no improvement — LATERAL is the correlated subplan re-spelled), and an *unscoped* `GROUP BY` over all targets **regresses** (27k buffers, same 116ms). Only the field-scoped form wins: **5,027 buffers (14×) / ~92ms**, output verified identical (13,023 rows, 0 member-array mismatches, `'{}'` default preserved).
+
+**Lock note.** Function-body change only; no DDL/lock. `idx_targets_object_id` and `idx_objects_field` already exist; no new index needed.
+
+**Severity reality.** This is **medium**, not high: not in `top_statements.txt`, wall-clock improves only ~115ms→92ms (~20%) — the headline win is buffer/IO (14×) and CPU-at-scale, not a user-facing latency cliff (avg 1.01 targets/object). The optional `(field, object_id) WHERE is_active` composite saves only the outer 37ms half; once the function uses `idx_objects_field` for the scan its marginal value drops further. Prioritize the rewrite over the index.
+
+---
+
+### #22 — `get_field_shutters` scans 195k object_id index, discards 130k non-field rows — LOW
+
+**What & why.** `WHERE field=p_field ORDER BY object_id` forces `idx_shutters_object_id`, applying `field='cosmos'` (33% selective) as a post-filter. Prod EXPLAIN: Index Scan, **Rows Removed by Filter 130,294**, returns 64,881.
+
+**migration_sql** (`supabase/schemas/indexes.sql`):
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_shutters_field_object_id
+    ON public.shutters USING btree (field, object_id);
+```
+Serves both the equality filter and the ORDER BY; planner adoption near-certain.
+
+**Lock note.** **Use plain `CREATE INDEX`, NOT `CONCURRENTLY`.** The Supabase CLI wraps each migration file in a transaction (documented in migration `20260417184613`), so `CONCURRENTLY` breaks the runner; at 195k rows / ~5MB the non-concurrent build is sub-second, and the SHARE lock only contends with the brief per-obs delete+insert during deploys. (If deploy contention must be avoided, split into a manual `supabase db push`.)
+
+**Severity reality.** **Downgraded to low/now:** the 318ms in the original evidence was **cold-cache** (617 disk reads); warm steady-state is ~64ms, and the caller (`useFieldSlits.ts`) is a React Query with `staleTime=10min` per field — a low-frequency cacheable vector-overlay read, not "every map load." Still worth the trivial, correct index. `idx_shutters_field` likely becomes redundant for this query (follow-up drop).
+
+---
+
+## 5. "At scale" findings (10×–100× risk — not urgent today)
+
+### #23 — 23 RLS policies call bare `auth.uid()`/`current_setting()` instead of `(select …)` — MEDIUM (at-scale)
+
+**What & why.** The Supabase `auth_rls_initplan` lint flags exactly 23 policies using bare `auth.uid()`/`current_setting()` in USING/WITH CHECK, forcing per-row re-evaluation: `api_keys` ×4, `refresh_tokens` ×2, `code_redemptions` ×2, `download_log`, `password_reset_log`, `user_profiles` (self_update_profile), `user_program_access` (self_select_access), `programs` (accessible_programs_select), `pending_invites`, `object_lists` ×4, `object_list_members` ×4, `list_audit_log` (select_list_audit). **The hot program-gated tables (objects/targets/spectra/comments/photometry/flag_audit_log) are correctly NOT in this set** — their policies route through `accessible_program_slugs()`/`is_admin()`/`can_comment()`, all STABLE SECURITY DEFINER (functions.sql:15-78), single-evaluated per statement.
+
+**Evidence (prod).** EXPLAIN on `api_keys`: bare `auth.uid()=user_id` inlines `COALESCE(NULLIF(current_setting('request.jwt.claim.sub')))::uuid` into the per-row Index Cond (cost 2.39); wrapped `(select auth.uid())` produces a single InitPlan + Bitmap Index Scan (cost 3.43). IN-subquery forms (`accessible_programs_select`) are already hashed once — so the win there is plan-cleanliness, not speed. Largest flagged tables: `download_log`=4063, `object_list_members`=2486, `list_audit_log`=704; all others ≤95 rows. So no urgent hot-path cost today.
+
+**migration_sql** (`supabase/schemas/policies.sql`: wrap every bare `auth.uid()`→`(select auth.uid())`, `current_setting(...)`→`(select current_setting(...))`; `db diff` emits DROP+CREATE per policy):
+
+```sql
+DROP POLICY IF EXISTS "self_update_profile" ON public.user_profiles;
+CREATE POLICY "self_update_profile" ON public.user_profiles FOR UPDATE TO authenticated
+  USING (user_id = (select auth.uid())) WITH CHECK (user_id = (select auth.uid()));
+-- repeat the DROP+CREATE for each of the 23 flagged policies
+```
+
+**Lock note.** Brief ACCESS EXCLUSIVE on tiny tables; `concurrently` N/A for policies.
+
+**Verify.** Re-run `get_advisors(performance)`: `auth_rls_initplan` 23→0. EXPLAIN a representative authenticated read confirms an InitPlan computes the uid once.
+
+**Unverified.** Per-row penalty could not be measured under a real authenticated JWT (MCP runs `auth.uid()=NULL`, short-circuiting user-scoped predicates to 0 rows). The small-win claim rests on table sizes <5k + IN-subquery hashing. Strictly safer at 10–100× → lens at-scale.
+
+---
+
+### #24 — Deep OFFSET pagination (sync / CSV / id-fetch) reads and discards skipped rows — MEDIUM (at-scale)
+
+**What & why.** `get_objects_for_sync`/`_spectra`/`_photometry` use internal `LIMIT/OFFSET` (functions.sql:185,331,417); `get_objects_for_sync` already carries a comment requesting keyset and a bumped `statement_timeout=120s` because deep `--full-sync` pages "started tipping past the default." Prod: OFFSET 20000 LIMIT 50 reads 20,050 rows / 19,732 buffers / 20ms vs OFFSET 0 at 49 buffers / 0.25ms — linear in offset. A **literal-cursor** keyset (`WHERE object_id > 'J100032…'`) runs in 52 buffers / 0.4ms, matching page 1.
+
+**migration_sql** (`supabase/schemas/functions.sql`, full-body `CREATE OR REPLACE` of the `_for_sync` RPCs; client paginators in `web/lib/supabase/paginate.ts` + `python/campfire/api/client.py:240` pass the last key as cursor):
+
+```sql
+-- get_objects_for_sync etc.: add p_after_cursor TEXT DEFAULT NULL, replace OFFSET with
+WHERE ... AND (p_after_cursor IS NULL OR object_id > p_after_cursor)
+ORDER BY object_id LIMIT p_limit
+-- then drop the SET statement_timeout='120s'
+```
+No new index — `objects_object_id_key` provides the ordered seek.
+
+**Lock note.** `CREATE OR REPLACE FUNCTION` only. No table DDL.
+
+**Verify.** EXPLAIN the keyset variant at a deep cursor: buffers/time match page 1 instead of scaling with depth.
+
+**Adjustment (scope nuance).** The clean `object_id > cursor` keyset drops in cleanly **only for the three `_for_sync` RPCs**. `get_filtered_object_ids` and `get_csv_export_*` have **no internal OFFSET** — the OFFSET is applied client-side by `paginateRpc`'s `.range()`, which re-executes the *entire* RPC body per page (full filter+sort, then discards `offset` rows — arguably worse). Those sort by arbitrary `p_sort_column` (redshift, max_snr, distance, ra/dec, …), so they need a **composite `(sort_value, object_id)` cursor**, not the plain object_id keyset (the finding's own "unverified" note flags this). Current depths fine at 34k; degrades at 10–100×.
+
+---
+
+### #25 — `select_list_members` RLS rebuilds the full accessible-objects set per list read — LOW (at-scale)
+
+**What & why.** `policies.sql:344-362`: the USING SubPlan over `objects WHERE programs && accessible_program_slugs()` is **uncorrelated** to `list_id`, so reading one small list materializes the full accessible objects set. Prod (real `getListBySlug` page path, `lists.ts:508`, even with LIMIT 50): SubPlan 2 builds 23,742 objects (20.8ms, 2212 buffers) regardless of list size; total ~29ms / 2473 buffers. Hashed once per statement (not N+1), but O(all accessible objects) per list read. Acceptable now (2486 members, 34k objects).
+
+**DO NOT apply the proposed correlated-`EXISTS` rewrite.** Verified on prod: the `EXISTS (… WHERE o.id = object_list_members.object_id …)` form ran **406ms / 10,113 buffers — a 14× REGRESSION** vs the current 29ms/2473, because `accessible_program_slugs()` is a non-inlinable SECURITY DEFINER function re-evaluated per row (2464×). Hoisting it into a MATERIALIZED CTE just sends the planner back to building the full 23,742-row set. The correlated-probe premise does not hold at this data shape.
+
+**Correct remedy (defer).** Leave the current near-optimal IN/hashed form, **or** cache the accessible-slugs as a request-scoped constant array to cheapen the membership check. Keep on the radar before objects grows ~10×; no migration today.
+
+---
+
+### #26 — `admin_*` ⋃ `update_*_by_access` multiple-permissive on objects/targets/spectra UPDATE — LOW (at-scale)
+
+**What & why.** The `multiple_permissive_policies` lint reports 3 relevant cases: `targets`/`spectra`/`objects` UPDATE for role `authenticated`, OR-combining `admin_*_update` with `update_*_by_access`. On a **full-table** UPDATE the OR forces `program_slug` to a per-row Filter (prod: Seq Scan cost 37,334 vs single-policy Index Cond 2,568) — **but no caller issues a full-table UPDATE.** All real write paths are single-row by PK: spectra dq (`route.ts:54` `.eq('id', spectrumId)`), object inspect (`route.ts:157` `.eq('id', objectDbId)`); prod EXPLAIN of each is an Index Scan on the PK/unique index (cost ~3.4/3.3/2650), the OR collapsing to a Filter on the one fetched tuple. Deploy writes run as service_role (bypass RLS).
+
+**migration_sql** — **lint hygiene only** (`supabase/schemas/policies.sql`, fold admin into the access policy per table):
+
+```sql
+DROP POLICY IF EXISTS "update_targets_by_access" ON public.targets;
+DROP POLICY IF EXISTS "admin_targets_update" ON public.targets;
+CREATE POLICY "update_targets_by_access" ON public.targets FOR UPDATE TO authenticated
+  USING (public.is_admin()
+         OR (program_slug = ANY(public.accessible_program_slugs()) AND public.can_comment()))
+  WITH CHECK (public.is_admin()
+         OR (program_slug = ANY(public.accessible_program_slugs()) AND public.can_comment()));
+-- analogous merge for spectra and objects
+```
+
+**Lock note.** Plain policy DDL, brief lock. `concurrently` N/A. **Verify the column-scope triggers** (`enforce_object_user_update_scope`, `enforce_spectra_dq_user_update_scope`, keyed on `is_admin()`) still gate non-admin writes after the merge.
+
+**Adjustment.** Downgraded to **low/at-scale**. Clearing these removes **3** lints (37→34), not 6 (37→31). The evidence also mis-described two of three: `spectra` has no `program_slug` column (uses `target_id IN (subquery)`, whose subplan still index-scans), and `objects` uses GIN `programs &&` overlap, not a btree `program_slug`. Implement (b) as pure hygiene, not a perf fix. Do not over-engineer.
+
+---
+
+### #27 — int4 PK sequences on delete+reinsert tables — safe to ~100× — LOW (at-scale)
+
+**What & why.** int4 sequences (max 2.1B) on churn tables: `shutters_id_seq` last_value=541,955 (0.025% of max), `spectra_id_seq`=113,680, `targets_id_seq`=112,620, plus `slit_regions`/`flag_audit_log`. Deploy delete-all-for-obs + reinsert burns ids, so sequences run ~2.3–2.8× ahead of live rows. `objects_id_seq`, `object_photometry_id_seq`, `nircam_exposures_id_seq` are already bigint. **100× projection** (~5M spectra, ~20M shutters): seq ~11M / ~54M — both <3% of int4 max.
+
+**Recommendation: NO ACTION.** Document the churn-vs-headroom math. Reference-only future bigint promotion (do **not** apply): `ALTER SEQUENCE … AS bigint; ALTER TABLE … ALTER COLUMN id TYPE bigint` — **and the int4 FK columns must widen in lockstep:** `flag_audit_log.spectrum_id`→spectra.id, `flag_audit_log.target_id`→targets.id, `comments.target_id`→targets.id. (Note `spectra.target_id`→`targets.target_id` is a *text* FK, not the surrogate, so the targets-PK blast radius is small.)
+
+**Unverified.** Projection assumes constant churn ratio; a switch to full-field re-deploys would raise the multiplier — re-model then. Monitor `last/maxv`; revisit if >0.5.
+
+---
+
+### #28 — `spectra.date_obs` is `text` storing an ISO date — LOW (at-scale)
+
+**What & why.** `tables.sql:331 "date_obs" text` holds pure `YYYY-MM-DD` (the FITS `DATE-OBS`). Prod: 48,560 non-null, 135 distinct, **0 rows failing `^\d{4}-\d{2}-\d{2}$`, 0 with a time component, 0 empty**. Latent, not broken — ISO text sorts correctly by accident, and no RPC/sort/filter references it (display/provenance only). Contrast `nircam_exposures.date_obs` (a real timestamp).
+
+**migration_sql** (`supabase/schemas/tables.sql:331` → `"date_obs" date`):
+
+```sql
+ALTER TABLE public.spectra
+  ALTER COLUMN date_obs TYPE date USING NULLIF(date_obs, '')::date;
+```
+Deploy writer sources it from FITS `DATE-OBS` (a calendar date), so future inserts stay ISO; `NULLIF`/cast is belt-and-suspenders (0 malformed rows).
+
+**Lock note.** Rewrites the ~77MB heap under ACCESS EXCLUSIVE once. No index/constraint on the column to handle. No `CONCURRENTLY` for `ALTER TYPE`.
+
+**Verify.** Pre-flight `… WHERE date_obs !~ '^\d{4}-\d{2}-\d{2}$'` = 0; post: `\d spectra` shows `date`.
+
+**Lens.** at-scale/latent — the only benefit is *future* date-range filtering; no present degradation.
+
+---
+
+### #29 — Deploy thumbnails per-spectrum UPDATE (standalone command only) — LOW (at-scale)
+
+**What & why.** `deploy.py:811-825` (`campfire deploy thumbnails`): outer `for spec_path` × inner `for row in summary` linear match, then one `.update().eq('target_id').eq('grating')` per file (N round-trips + O(spec_paths×summary) match). **Not on the hot path** — the main deploy batches thumbnails into the spectra upsert (`deploy.py:374-388` + `supabase.py:440-444`). Operator-invoked, per-obs (max ceers1=1,559 spectra, typical 500–700 — not "thousands at a COSMOS field").
+
+**Fix (client-only, no migration):** (1) dict-index `summary` by spec_file (O(1) lookup); (2) batch via `on_conflict(target_id,grating)` upsert in chunks of 100–500. `idx_spectra_target_grating` (UNIQUE, 2.46M scans) already supports the upsert — no DDL.
+
+**Verify.** Count PostgREST requests before/after with `--local`: should be `ceil(n/batch)`, not `n`.
+
+---
+
+### #30 — Photometry split/reroute per-row UPDATEs — LOW (at-scale)
+
+**What & why.** `photometry.py:449-455` (reroute) and `reconcile.py:1142-1144` (split) issue one `.update().eq('id', row_id)` per row; deletes in the same functions are already batched. Each is a PK lookup (`object_photometry_pkey`). Prod: 28,121 photometry rows, ~1/object (max 96), so worst-case reroutes touch a handful of rows.
+
+**Fix (client-only, no migration):** group reroutes by destination and issue one `.update().in_('id', chunk)` per object_id, **or** reuse the existing `relink_photometry_for_field` RPC (functions.sql:3449) which already does set-based proximity re-linking with zero per-row round-trips. `idx_object_photometry_object_id` supports it.
+
+**Adjustment.** The finding labels both paths operator-only — **but `_reconcile_existing_rows` (photometry.py:449) runs in the normal per-deploy hot path** (`deploy.py:441`, `cli.py:261`). Only `_migrate_split_photometry` is operator-gated. Severity stays low (rare reroute trigger, PK lookups, tiny row counts).
+
+---
+
+### Operational (not a code finding) — VACUUM / visibility-map tuning — LOW, lens n/a
+
+`objects` (15.5% dead) and `spectra` (13.9% dead, last autovacuum 2026-04-21) carry deploy-churn dead tuples; the spectra count's index-only scan does 21,867 heap fetches (stale visibility map). **But:** both tables sit *below* the default autovacuum dead-tuple trigger (spectra 8007/9970, objects 6215/6843) — autovacuum not firing is expected, not neglect. The cited heavy-count plan is a *synthetic* query (absent from `top_statements.txt`); all buffers are cache hits (0 disk reads), so VACUUM yields CPU-only savings (~5ms) on a non-hot query. This is harmless operator housekeeping, not a now-vs-scale code tradeoff:
+
+```sql
+-- Operator action (writes — do NOT run from a read-only audit):
+VACUUM (ANALYZE) public.objects;
+VACUUM (ANALYZE) public.spectra;
+-- Optional, if deploy cadence warrants (reloptions NOT tracked by db diff — hand-author the migration):
+ALTER TABLE public.objects SET (autovacuum_vacuum_scale_factor = 0.05, autovacuum_analyze_scale_factor = 0.05);
+ALTER TABLE public.spectra SET (autovacuum_vacuum_scale_factor = 0.05);
+```
+
+---
+
+## 6. Verification gaps
+
+- **No `hypopg` on prod** → index *adoption* was reasoned from selectivity and (where possible) proxied with existing indexes of the same shape, not measured against a hypothetical index. This affects #2 (proxied via `idx_spectra_spectrum_id` — strong), #4, #22 (planner adoption "near-certain" but not hypopg-confirmed), and the objects-side sort equivalents (`max_snr`, `n_spectra`) which were **not tested at all**.
+- **MCP EXPLAIN ran without an end-user JWT** (`auth.uid()=NULL`), which short-circuits user-scoped RLS predicates to match 0 rows. So per-row RLS-path penalties in #23 (api_keys/refresh_tokens/download_log) and the authenticated inspection-UPDATE plan in #26 are **structural** (InitPlan vs inline, PK-index adoption) rather than runtime-measured. The index-choice conclusions hold because RLS adds a Filter, not a different scan path.
+- **Local DB too small to test plans** — all EXPLAINs were run against prod (`puyczxwyuzpnqvpachip`); 10×/100× plan-shape projections (#24, #27) are reasoned, not benchmarked at scale.
+- **Write paths could not be exercised on prod** — deploy/remove delete wall-clocks (#3 aggregate), the thumbnails/photometry/check_existing round-trip counts (#19, #29, #30), and the VACUUM buffer reduction were inferred from `pg_stat_statements` + code reads, not from a controlled write benchmark.
+- **migra blind spots** (MVs, comments, reloptions, partitions, constraint-drops) — drift was confirmed by *direct catalog inspection*, not by trusting `supabase db diff` alone; #10 (constraint drop) and the VACUUM reloptions may need hand-authored migrations if diff omits them.
+- **Coupled-client behavior** — #1/#5/#24 require web-client count-caching / cursor plumbing that is *not* implemented; the DB-only change alone does not land the full win. #6 requires the `admin/activity` Z-append fix or the feed breaks.
+- **`unused_index` drop candidates** (`idx_object_photometry_coords`, `idx_download_log_download_type`, empty-table `nircam_images` indexes, `idx_user_profiles_preferences`) were **not** EXPLAIN-tested, so no drop is proposed for them (only the *unsafe* drops in #13 are blocked).
+
+## 7. Discarded / false positives
+
+Three findings were refuted in verification; listing them so the rest is trustworthy:
+
+- **`photometry-catalog-id-nullable-in-unique`** — Claimed a NULL `catalog_id` would defeat the `(field, catalog_name, catalog_id)` UNIQUE dedup (NULLs-distinct). All *structural* claims are true (nullable column, NULLs-distinct, 0 NULL rows), **but the deploy path is structurally incapable of writing a NULL `catalog_id`**: `photometry.py:667-669` does `cat_row.get(id_col, cat_idx)` (defaults to an integer row index, never None) then unconditional `str(...)` (a masked value becomes the literal `'None'`, never SQL NULL), and line 705 always sets the key. The described failure mode cannot occur from the actual producer (the web route is GET-only; `store.py` is a separate local DuckDB mirror). At most someday-hygiene; the concrete defect does not exist.
+
+- **`objects-list-rpc-double-predicate-scan`** — Claimed the objects list RPC runs "2 full scans" per render and that `COUNT(*) OVER()` would fix it. The predicate text *is* duplicated, but the **page pass is NOT a second full scan**: on the default `object_id` sort the planner uses `Index Scan using objects_object_id_key` with LIMIT, early-terminating in 3.2ms over warm pages (~14% of the count's cost). The proposed `COUNT(*) OVER()` window-count was **measured slower on prod** (34.9ms vs 22.7ms) because it must materialize every filtered row, defeating the early-terminating index scan — the exact trap this codebase previously escaped when it moved *away* from `COUNT(*) OVER()` for spectra. (The real count-cost fix is #5's `p_include_count`, not a window count.)
+
+- **`adjacent-objects-third-predicate-eval`** — Claimed `get_adjacent_objects` "fires on every object detail page load" for a 3× predicate multiplier. **False:** the sole caller `ObjectNavigation.tsx:94` first checks `lookupInCache(...)` (`navigation-cache.ts`, sessionStorage populated by `SpectraTable.tsx`) and **returns at line 76 before the RPC** on a normal list→detail or detail→detail click. The RPC fires only on cache miss / page boundary / cold deep-link — exactly the mitigation the finding recommended as "future work," which already ships in production. The body-level predicate reuse is real but immaterial; no change warranted.

--- a/docs/db_recommendations_2026-06-19.md
+++ b/docs/db_recommendations_2026-06-19.md
@@ -1,0 +1,286 @@
+# CAMPFIRE DB — Consolidated Recommendations (2026-06-19)
+
+Prod-validated, read-only investigation. Project `puyczxwyuzpnqvpachip`.
+Scale: 33,965 objects / 46,060 targets / 49,600 spectra / 195,175 shutters.
+**Nothing has been applied to prod.** All EXPLAINs run against prod with real stats
+(local seed is ~100 rows and its planner is unrepresentative).
+
+This doc supersedes the severity calibration in `db_audit_2026-06-19.md` for the
+objects-search path: the original audit rated it medium/low because it measured the
+*default render* as a *privileged role* (no JWT). Re-measured under a real
+authenticated admin session, it is the **#1 user-facing problem**.
+
+---
+
+## 0. Headline: the objects-table search timeout
+
+### Root cause (measured, under a simulated authenticated admin session)
+
+`authenticated` role has `statement_timeout = 8s` (`anon` = 3s). `pg_stat_statements`
+shows `get_filtered_objects_paginated` (22,288 calls) with **max = 7,977 ms** — the
+fingerprint of the timeout firing. Reproduced and decomposed:
+
+| Path (you = admin, RLS live, warm) | Time | Buffers |
+|---|---|---|
+| Default render (no search) | 144 ms | — |
+| Sort by `max_snr` (no index → full sort) | 205 ms | — |
+| **Text search, current `OR/EXISTS` + `ORDER BY object_id LIMIT 50`** | **9,578 ms** | **282,613** |
+| Search rewritten as uncorrelated `UNION` (same conditions) | 133 ms | 13,954 |
+| Search as a single trgm-style column (`object_id ILIKE`, proxy) | 92 ms | 2,495 |
+
+**Mechanism.** The search predicate
+`object_id ILIKE '%x%' OR EXISTS(SELECT 1 FROM targets t WHERE t.object_id=o.id AND t.target_id ILIKE '%x%')`
+is a cross-table disjunction. The planner can't estimate it well (est. 7,787 rows;
+actual 9), so with `ORDER BY object_id LIMIT 50` it chooses to **walk
+`objects_object_id_key` in order and apply the search as a per-row filter**, expecting
+to fill 50 quickly. Because only ~9 of 34k rows match, it scans the *entire* table.
+For a non-admin, the `programs &&` gate is selective and shrinks the scan; **for an
+admin (all 29 programs) it scans everything → 9.6 s → 8 s timeout.** That is why *you*
+hit it and most users don't.
+
+(Self-correction from the live session: I initially attributed the cost to 34k per-row
+`accessible_program_slugs()` calls. Measured, the function is `STABLE` and largely
+cached; the real cost is the full 34k-row ordered index+heap walk. The RLS-function
+wrapping (§3) is hygiene, **not** the fix.)
+
+### Why it's *also* "often slow" without searching
+
+Baseline 144 ms (no search) decomposes into:
+- **Exact `COUNT(*)` over all 33,965 rows on every render** — ~54 ms (§2.1).
+- **Sorting by `max_snr`/`n_spectra`/`n_targets`/`max_exposure_time`/`photo_z`** —
+  full `top-N heapsort`, no index — ~58 ms (§2.2).
+- Per-page `member_targets` + `lists` correlated subqueries + JSONB assembly.
+
+---
+
+## 1. The fix: a `search_text` column on `objects` (recommended)
+
+A single denormalized, trgm-indexed text column. Validated: a single-column predicate
+escapes the ordered-scan trap (92 ms worst case vs 9,578 ms) **and** unifies the search
+surface you described (object ID, target ID, program, observation).
+
+### 1a. What goes in it
+
+Real data shows the tokens you want are spread across columns and **not always
+substrings of each other** — e.g. program `egs_bubbles` has target_ids like
+`mason_egs_p3_62859` (the slug isn't in the target_id). So concatenate all four sources:
+
+```
+search_text = lower( object_id
+                     ⧺ every member target_id          -- e.g. castellano3073_p10_16115
+                     ⧺ every distinct program_slug      -- e.g. egs_bubbles
+                     ⧺ every distinct observation )      -- e.g. castellano3073_p10
+```
+
+This makes all of your cases substring-matchable in one indexed predicate:
+search `J141934` (object id) · `castellano3073` (program) · `_p10` (observation/pointing)
+· `16115` (source id) · `1772` (partial). Size: avg 63.6 chars, max 364,
+total ~2.1 MB over 34k objects → trgm GIN ≈ 20–30 MB.
+
+**Comment text is intentionally excluded** (see §1e).
+
+### 1b. Schema + index (`supabase/schemas/tables.sql` + `indexes.sql`)
+
+```sql
+-- tables.sql, objects table body
+ALTER TABLE public.objects ADD COLUMN search_text text;
+
+-- indexes.sql, -- objects section
+CREATE INDEX IF NOT EXISTS idx_objects_search_text_trgm
+    ON public.objects USING gin (search_text gin_trgm_ops);
+```
+
+`db diff` emits the same. **Lock:** `objects` is a hot-write table (340k upd) — build
+the index with `CREATE INDEX CONCURRENTLY` out-of-band. ⚠️ The Supabase CLI wraps each
+migration file in a transaction (documented in migration `20260417184613`), so
+`CONCURRENTLY` cannot run inside a normal migration — apply it via a manual
+`supabase db push` step or a split migration. At 34k rows a plain `CREATE INDEX` is
+sub-second if you prefer a brief lock.
+
+### 1c. Population — in the reconcile pipeline, like every other object aggregate
+
+Object aggregates (`programs`, `observations`, `n_targets`, `max_snr`) are built in
+**Python during reconcile** (`reconcile.py:258-263`, `deploy/objects.py:234-239`) and
+batch-upserted — there are no SQL triggers for them. `search_text` belongs in exactly
+the same place (and changes only when membership changes, i.e. at reconcile — no
+trigger needed, no comments → no real-time freshness requirement):
+
+```python
+# reconcile.py _aggregate(...) and deploy/objects.py, alongside programs/observations
+search_text = " ".join(filter(None, [
+    object_id,
+    *sorted({m["target_id"]    for m in members}),
+    *programs,                       # already computed
+    *observations,                   # already computed
+])).lower()
+# add 'search_text': search_text to the upsert payload (objects.py ~321)
+```
+
+Ensure `target_id` is in the member projection used for aggregation (`program_slug`
+and `observation` already are).
+
+### 1d. One-time backfill for the 34k existing objects (reconcile only runs on deploy)
+
+```sql
+UPDATE public.objects o SET search_text = sub.txt
+FROM (
+  SELECT o2.id, lower(concat_ws(' ',
+           o2.object_id,
+           (SELECT string_agg(DISTINCT t.target_id,   ' ') FROM public.targets t WHERE t.object_id=o2.id),
+           (SELECT string_agg(DISTINCT t.program_slug, ' ') FROM public.targets t WHERE t.object_id=o2.id),
+           (SELECT string_agg(DISTINCT t.observation,  ' ') FROM public.targets t WHERE t.object_id=o2.id)
+         )) AS txt
+  FROM public.objects o2
+) sub
+WHERE sub.id = o.id;
+```
+
+Writes all 34k rows once. Runs as the migration role (bypasses the
+`enforce_object_user_update_scope` trigger, which only restricts non-admins). Build the
+trgm index *after* the backfill.
+
+### 1e. RPC change (`functions.sql`) — replaces the `OR/EXISTS` (and the §1-of-audit `UNION` patch)
+
+In `get_filtered_objects_paginated` (page CTE ~1037 **and** the count step ~926) and
+`get_filtered_object_ids`, replace the `OR/EXISTS` block with:
+
+```sql
+AND (p_search IS NULL OR o.search_text ILIKE '%' || p_search || '%')
+```
+
+`db diff` emits full-body `CREATE OR REPLACE FUNCTION`s.
+
+### 1f. Comment search stays separate — and that's correct
+
+The UI already separates the two (`filter-params.ts`: `p_search` is labeled
+`targetIdSearch`; `p_comment_search` is its own scoped control). Comment search must
+stay separate because it is (1) **user-scoped** (`just_me` vs `everyone` — can't be
+denormalized into a global column), (2) **mutable in real time** (would need triggers
+on `comments`), (3) on a tiny table (284 rows). If comment search is ever slow, fix it
+*in place* with the same materialize-the-id-set trick — `comments.content` already has
+`idx_comments_content_trgm`. Don't fold it into `search_text`.
+
+### 1g. Residual risk to verify post-deploy
+
+The proxy test used a *constant* pattern; the RPC uses `'%' || p_search || '%'`
+(parameterized). The RPC already sets `plan_cache_mode='force_custom_plan'`, which
+re-plans per call with the actual value, so it should behave like the 92 ms test. After
+deploy, `EXPLAIN ANALYZE` the RPC with a real `p_search` and confirm a `Bitmap`/`Sort`
+plan (not an `Index Scan using objects_object_id_key` that removes ~34k rows by filter).
+If `force_custom_plan` misfires, the fallback is dynamic SQL interpolating the pattern
+as a literal (`format(... ILIKE %L ...)`) so trigram extraction is guaranteed.
+Short searches (1–2 chars) can't use trgm — accept the scan or require ≥3 chars in the UI.
+
+### 1h. Ship sequence
+
+1. (Optional bleed-stopper, no schema change) the uncorrelated `UNION` rewrite of the
+   `OR/EXISTS` predicate — measured 9,578 ms → 133 ms. Use it only if you need relief
+   before the `search_text` work lands; `search_text` makes it obsolete.
+2. `search_text`: add column → backfill → build trgm index (CONCURRENTLY, out-of-band)
+   → swap the RPC predicate → add population to reconcile. Apply the predicate swap to
+   `get_filtered_objects_paginated`, `get_filtered_object_ids`. The spectra RPC
+   (`get_filtered_spectra_paginated`, `p_search` on `target_id`/`spectrum_id`, max 7,989 ms)
+   has the **same pattern** — give it the same treatment as a fast follow.
+
+---
+
+## 2. Other "now" findings (current-size, user-facing)
+
+### 2.1 Gate the exact `COUNT(*)` on the list RPCs — MEDIUM
+`get_filtered_objects_paginated` and `get_filtered_spectra_paginated` recompute an exact
+full-set `COUNT(*)` on every render (~54 ms objects; ~384 ms spectra, where a CTE is
+materialized twice). Add `p_include_count boolean DEFAULT true`; when false, skip the
+count (objects) / drop the second CTE reference (spectra — returning `-1` alone is not
+enough). The pattern already exists on the sync RPCs. Web must cache the count across
+page changes (count is filter-stable) and fetch it only on page 1 / filter change.
+
+### 2.2 Index the objects sort columns — MEDIUM (but lower-value than it looks)
+`max_snr`, `n_spectra`, `n_targets`, `max_exposure_time`, `photo_z` have no btree, so
+sorting by them does a full `top-N heapsort` (~58 ms at 34k). **Caveat:** for admin the
+`programs &&` gate is non-selective, so a btree on these may not be chosen (same gating
+as search); for non-admins the selective `programs &&` keeps the sort small. Net: fine
+today, a scaling concern. The analogous **spectra** sort columns `signal_to_noise` /
+`exposure_time` (audit #2) are higher-value — no such gating there:
+```sql
+CREATE INDEX IF NOT EXISTS idx_spectra_signal_to_noise ON public.spectra (signal_to_noise DESC NULLS LAST);
+CREATE INDEX IF NOT EXISTS idx_spectra_exposure_time   ON public.spectra (exposure_time   DESC NULLS LAST);
+```
+
+### 2.3 `shutters(observation)` FK-covering index — MEDIUM
+Deploy delete/replace seq-scans 195k rows; `pg_stat_statements` shows ~71 s cumulative
+on `DELETE … WHERE observation=$1`. `CREATE INDEX idx_shutters_observation ON shutters(observation);`
+(`slit_regions` has the identical uncovered pattern — file alongside.) CONCURRENTLY caveat applies.
+
+### 2.4 `objects.observations` GIN — MEDIUM
+All four objects RPCs apply `o.observations && p_observations`; no GIN → admin/all-programs
+seq-scans. `CREATE INDEX idx_objects_observations ON objects USING gin(observations);`
+
+### 2.5 `timestamptz` conversion (12 naive `timestamp` columns) — MEDIUM, coupled
+JS readers parse naive timestamps as local time (wrong on non-UTC clients). Convert the
+12 event/audit columns to `timestamptz … AT TIME ZONE 'UTC'`. **Must ship with** the web
+fix in `admin/activity/page.tsx` (its `${ts}Z` workaround breaks once values serialize
+`+00:00`). See `db_audit_2026-06-19.md` §#6 for the column list and ALTERs.
+
+### 2.6 Constraint hygiene — LOW
+`targets.object_id` FK → `ON DELETE SET NULL` (matches the relink model; lone outlier);
+`objects_redshift_quality_check (0–4)`; drop the duplicate `nircam_images_unique`. All
+via `NOT VALID` + `VALIDATE`. Details in `db_audit_2026-06-19.md` §#7–#10.
+**Do NOT** add `snr >= 0` checks (prod holds 20 negative-SNR spectra / 14 objects — open
+science question: legitimate flux-weighted values or dirty data?).
+
+---
+
+## 3. At-scale (10×–100×, not urgent today)
+
+- **Wrap RLS functions:** 9 policies call bare `accessible_program_slugs()` / `auth.uid()`;
+  wrap as `(select …)` to hoist `STABLE SECURITY DEFINER` calls to a once-per-query
+  InitPlan (audit #23 + Supabase advisor). Measured *incidental* to the timeout, but
+  cheap insurance that reduces per-row RLS overhead on every gated read at scale.
+- **The admin RLS full-scan:** the objects SELECT policy is `programs && accessible_program_slugs()`;
+  for admins this returns all slugs → the `programs` GIN always bitmaps the whole catalog.
+  Harmless now; at 10–100× consider an `is_admin() OR (programs && (select accessible_program_slugs()))`
+  short-circuit so admins skip the overlap. (Interacts with browse-vs-search index choice — measure first.)
+- **Deep OFFSET pagination** in the sync/CSV RPCs → keyset cursors (audit #24).
+- **int4 PK sequences** on churn tables — safe to ~100×; document the headroom (audit #27).
+- **`spectra.date_obs` text → date** (audit #28).
+
+---
+
+## 4. Consolidated priority
+
+| # | Item | Lens | Sev | Effort | Where |
+|---|------|------|-----|--------|-------|
+| 1 | `search_text` column + trgm GIN → fix objects search timeout | now | **high** | M | §1 |
+| 2 | Gate exact `COUNT(*)` on both list RPCs (+ client count cache) | now | med | M | §2.1 |
+| 3 | `shutters(observation)` + `slit_regions(observation)` indexes | now | med | S | §2.3 |
+| 4 | `objects.observations` GIN | now | med | S | §2.4 |
+| 5 | spectra `signal_to_noise` / `exposure_time` sort indexes | now | med | S | §2.2 |
+| 6 | `timestamptz` conversion + coupled web fix | now | med | M | §2.5 |
+| 7 | objects sort-column indexes (max_snr, n_spectra, …) | now/scale | low | S | §2.2 |
+| 8 | Constraint hygiene (FK SET NULL, redshift_quality check, dup unique) | now | low | S | §2.6 |
+| 9 | Wrap bare `auth.uid()`/`accessible_program_slugs()` in 9 policies | scale | med | M | §3 |
+| 10 | Keyset pagination on sync/CSV RPCs | scale | med | M | §3 |
+| — | DO NOT: `snr>=0` check · `COUNT(*) OVER()` · correlated-EXISTS for lists · drop trgm/grating "unused" indexes | — | — | — | audit §7 |
+
+### Schema cleanliness / drift
+No meaningful drift between prod and `supabase/schemas/` (68 migrations applied,
+29 tables / 136 indexes / 57 functions / 93 policies match). Coordinates are all
+`double precision`; natural-key uniqueness is fully enforced; RLS covers all 29 tables.
+
+### Suggested PR grouping
+- **PR A — objects search** (`search_text`): column + backfill migration + trgm index
+  (manual `db push` for CONCURRENTLY) + RPC predicate swap + reconcile population. Highest impact.
+- **PR B — index pack**: shutters/slit_regions(observation), objects.observations GIN,
+  spectra sort indexes. Pure adds, low risk.
+- **PR C — count gating** (RPCs + web count caching).
+- **PR D — timestamptz** (ALTERs + `admin/activity` web fix), low-traffic window.
+- **PR E — constraint hygiene** + **PR F — RLS `(select …)` wrap** (advisor-driven), independent.
+
+### Verification gaps (honest)
+- No `hypopg` on prod (install denied) → index *adoption* reasoned from selectivity +
+  proxied with existing same-shape indexes, not measured hypothetically.
+- The `search_text` RPC predicate was validated via a constant-pattern proxy on the
+  existing `object_id` trgm index; the parameterized-in-plpgsql case needs a post-deploy
+  `EXPLAIN` (§1g).
+- Per-row RLS penalties (§3) are structural (InitPlan vs inline), not benchmarked under
+  concurrency; 10–100× projections are reasoned, not load-tested.

--- a/python/campfire/deploy/objects.py
+++ b/python/campfire/deploy/objects.py
@@ -626,6 +626,14 @@ def rebuild_field_objects(
     n_fks = _set_target_fks(client, objects, object_id_to_db_id)
     print(f"    Updated {n_fks} targets")
 
+    # Targets are now relinked, so search_text resolves member target_ids /
+    # programs / observations. The reconcile path does this in-RPC (step 6 of
+    # apply_object_reconciliation); the rebuild escape hatch calls it explicitly.
+    print(f"  Refreshing object search_text...")
+    client.rpc('recompute_object_search_text', {
+        'p_object_ids': list(object_id_to_db_id.values()),
+    }).execute()
+
     print(f"  Re-linking list member FKs...")
     relink_result = _relink_list_members(client, field)
     n_relinked = relink_result.get('relinked', 0)

--- a/supabase/migrations/20260620025902_add_search_text_columns.sql
+++ b/supabase/migrations/20260620025902_add_search_text_columns.sql
@@ -1,0 +1,1566 @@
+-- Add denormalized search_text to objects (populated) and spectra (generated),
+-- with trgm GIN indexes, and swap every p_search predicate in the list/CSV/adjacent
+-- RPCs from the unindexable object_id-ILIKE-OR-EXISTS(targets) form to the single
+-- indexed column. objects.search_text is maintained by recompute_object_search_text()
+-- (step 6 of apply_object_reconciliation; the rebuild escape hatch calls it too).
+-- NOTE: hand-trimmed from `supabase db diff` to drop spurious view/MV/
+-- accessible_program_slugs churn that migra cascades from the table ADD COLUMN.
+
+
+
+
+
+alter table "public"."objects" add column "search_text" text;
+
+alter table "public"."spectra" add column "search_text" text generated always as (((target_id || ' '::text) || regexp_replace(regexp_replace(COALESCE(fits_path, ''::text), '^.*/'::text, ''::text), '_spec\.fits$'::text, ''::text, 'i'::text))) stored;
+
+CREATE INDEX idx_objects_search_text_trgm ON public.objects USING gin (search_text public.gin_trgm_ops);
+
+CREATE INDEX idx_spectra_search_text_trgm ON public.spectra USING gin (search_text public.gin_trgm_ops);
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.recompute_object_search_text(p_object_ids integer[] DEFAULT NULL::integer[])
+ RETURNS integer
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_count integer;
+BEGIN
+  WITH new_vals AS (
+    SELECT o.id,
+           concat_ws(' ',
+             o.object_id,
+             string_agg(DISTINCT t.target_id, ' '),
+             string_agg(DISTINCT t.program_slug, ' '),
+             string_agg(DISTINCT t.observation, ' ')
+           ) AS st
+    FROM objects o
+    LEFT JOIN targets t ON t.object_id = o.id
+    WHERE (p_object_ids IS NULL OR o.id = ANY(p_object_ids))
+    GROUP BY o.id, o.object_id
+  )
+  UPDATE objects o
+  SET search_text = nv.st
+  FROM new_vals nv
+  WHERE o.id = nv.id
+    AND o.search_text IS DISTINCT FROM nv.st;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$function$
+;
+
+GRANT EXECUTE ON FUNCTION public.recompute_object_search_text(integer[]) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.apply_object_reconciliation(p_field text, p_inserts jsonb DEFAULT '[]'::jsonb, p_revivals jsonb DEFAULT '[]'::jsonb, p_updates jsonb DEFAULT '[]'::jsonb, p_orphan_ids integer[] DEFAULT '{}'::integer[], p_updated_at timestamp with time zone DEFAULT now())
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SET statement_timeout TO '300s'
+AS $function$
+DECLARE
+  v_insert_id_map JSONB := '{}'::jsonb;
+  v_revived_ids   INTEGER[] := '{}';
+  v_updated_ids   INTEGER[] := '{}';
+  v_orphaned      INTEGER := 0;
+  v_reactivated   INTEGER := 0;
+  v_fk_count      INTEGER := 0;
+BEGIN
+  -- 1. Orphans FIRST: soft-delete active objects that lost all members, but
+  --    EXCLUDE any whose object_id an insert is about to re-adopt. Ghost
+  --    recovery: a stranded active ghost is classified as an orphan while the
+  --    real new cluster is an insert holding the same IAU name; the upsert in
+  --    step 2 adopts that row, so it must not be soft-deleted out from under it.
+  UPDATE objects o SET
+    is_active = false,
+    last_data_change_at = p_updated_at,
+    staleness_reason = 'membership_changed',
+    updated_at = p_updated_at
+  WHERE o.id = ANY(p_orphan_ids)
+    AND o.is_active
+    AND o.object_id NOT IN (
+      SELECT x.object_id FROM jsonb_to_recordset(p_inserts) AS x(object_id TEXT)
+    );
+  GET DIAGNOSTICS v_orphaned = ROW_COUNT;
+
+  -- 2. Inserts (idempotent). ON CONFLICT re-adopts a ghost / soft-deleted row
+  --    holding this object_id. We deliberately do NOT touch version /
+  --    redshift_* / last_inspected_* so inspection state — and the triggers
+  --    scoped to those columns — stay untouched; a collision is only ever a
+  --    freshly stranded ghost with no inspection history.
+  WITH ins AS (
+    INSERT INTO objects (
+      object_id, field, ra, dec, n_targets, n_spectra,
+      programs, gratings, observations, max_snr, max_exposure_time, updated_at
+    )
+    SELECT x.object_id, p_field, x.ra, x.dec, x.n_targets, x.n_spectra,
+           x.programs, x.gratings, x.observations, x.max_snr,
+           x.max_exposure_time, p_updated_at
+    FROM jsonb_to_recordset(p_inserts) AS x(
+      object_id TEXT, ra DOUBLE PRECISION, dec DOUBLE PRECISION,
+      n_targets INTEGER, n_spectra INTEGER,
+      programs TEXT[], gratings TEXT[], observations TEXT[],
+      max_snr DOUBLE PRECISION, max_exposure_time DOUBLE PRECISION
+    )
+    ON CONFLICT (object_id) DO UPDATE SET
+      field = EXCLUDED.field,
+      ra = EXCLUDED.ra,
+      dec = EXCLUDED.dec,
+      n_targets = EXCLUDED.n_targets,
+      n_spectra = EXCLUDED.n_spectra,
+      programs = EXCLUDED.programs,
+      gratings = EXCLUDED.gratings,
+      observations = EXCLUDED.observations,
+      max_snr = EXCLUDED.max_snr,
+      max_exposure_time = EXCLUDED.max_exposure_time,
+      is_active = true,
+      last_data_change_at = p_updated_at,
+      staleness_reason = 'membership_changed',
+      updated_at = p_updated_at
+    RETURNING id, object_id
+  )
+  SELECT coalesce(jsonb_object_agg(object_id, id), '{}'::jsonb)
+  INTO v_insert_id_map
+  FROM ins;
+
+  -- 3. Revivals: reactivate inactive objects matched by position; refresh
+  --    centroid + aggregates.
+  WITH rev AS (
+    UPDATE objects o SET
+      is_active = true,
+      object_id = r.object_id,
+      ra = r.ra,
+      dec = r.dec,
+      n_targets = r.n_targets,
+      n_spectra = r.n_spectra,
+      programs = r.programs,
+      gratings = r.gratings,
+      observations = r.observations,
+      max_snr = r.max_snr,
+      max_exposure_time = r.max_exposure_time,
+      last_data_change_at = p_updated_at,
+      staleness_reason = 'membership_changed',
+      updated_at = p_updated_at
+    FROM jsonb_to_recordset(p_revivals) AS r(
+      object_db_id INTEGER, object_id TEXT, ra DOUBLE PRECISION,
+      dec DOUBLE PRECISION, n_targets INTEGER, n_spectra INTEGER,
+      programs TEXT[], gratings TEXT[], observations TEXT[],
+      max_snr DOUBLE PRECISION, max_exposure_time DOUBLE PRECISION
+    )
+    WHERE o.id = r.object_db_id
+    RETURNING o.id
+  )
+  SELECT coalesce(array_agg(id), '{}') INTO v_revived_ids FROM rev;
+
+  -- 4. Updates: refresh aggregates; set staleness only when provided;
+  --    reactivate a membership-matched inactive object when reactivate=true.
+  WITH upd AS (
+    UPDATE objects o SET
+      object_id = u.object_id,
+      ra = u.ra,
+      dec = u.dec,
+      n_targets = u.n_targets,
+      n_spectra = u.n_spectra,
+      programs = u.programs,
+      gratings = u.gratings,
+      observations = u.observations,
+      max_snr = u.max_snr,
+      max_exposure_time = u.max_exposure_time,
+      is_active = CASE WHEN u.reactivate THEN true ELSE o.is_active END,
+      staleness_reason = CASE
+        WHEN u.reactivate THEN 'membership_changed'
+        WHEN u.staleness_reason IS NOT NULL THEN u.staleness_reason
+        ELSE o.staleness_reason
+      END,
+      last_data_change_at = CASE
+        WHEN u.reactivate OR u.staleness_reason IS NOT NULL THEN p_updated_at
+        ELSE o.last_data_change_at
+      END,
+      updated_at = p_updated_at
+    FROM jsonb_to_recordset(p_updates) AS u(
+      object_db_id INTEGER, object_id TEXT, ra DOUBLE PRECISION,
+      dec DOUBLE PRECISION, n_targets INTEGER, n_spectra INTEGER,
+      programs TEXT[], gratings TEXT[], observations TEXT[],
+      max_snr DOUBLE PRECISION, max_exposure_time DOUBLE PRECISION,
+      staleness_reason TEXT, reactivate BOOLEAN
+    )
+    WHERE o.id = u.object_db_id
+    RETURNING o.id AS id, u.reactivate AS reactivated
+  )
+  SELECT coalesce(array_agg(id), '{}'),
+         coalesce(count(*) FILTER (WHERE reactivated), 0)
+  INTO v_updated_ids, v_reactivated
+  FROM upd;
+
+  -- 5. Target FK assignment — the actual fix. Derive (target, object) pairs
+  --    from each operation's member_target_db_ids (resolving insert object ids
+  --    via the RETURNING map) and apply them in ONE typed, index-friendly
+  --    UPDATE, inside this same transaction as the inserts above.
+  WITH pairs AS (
+    SELECT unnest(x.member_target_db_ids) AS target_id,
+           (v_insert_id_map ->> x.object_id)::INTEGER AS object_id
+    FROM jsonb_to_recordset(p_inserts)
+      AS x(object_id TEXT, member_target_db_ids INTEGER[])
+    UNION ALL
+    SELECT unnest(r.member_target_db_ids), r.object_db_id
+    FROM jsonb_to_recordset(p_revivals)
+      AS r(object_db_id INTEGER, member_target_db_ids INTEGER[])
+    UNION ALL
+    SELECT unnest(u.member_target_db_ids), u.object_db_id
+    FROM jsonb_to_recordset(p_updates)
+      AS u(object_db_id INTEGER, member_target_db_ids INTEGER[])
+  )
+  UPDATE targets t SET
+    object_id = p.object_id,
+    updated_at = p_updated_at
+  FROM pairs p
+  WHERE t.id = p.target_id;
+  GET DIAGNOSTICS v_fk_count = ROW_COUNT;
+
+  -- 6. Refresh denormalized search_text for every object touched above. Targets
+  --    are relinked (step 5), so member target_ids / programs / observations
+  --    resolve. Scoped to the affected ids so it stays cheap per apply.
+  PERFORM public.recompute_object_search_text(
+    (SELECT coalesce(array_agg(value::int), '{}'::integer[])
+       FROM jsonb_each_text(v_insert_id_map))
+    || v_revived_ids
+    || v_updated_ids
+  );
+
+  RETURN jsonb_build_object(
+    'insert_id_map', v_insert_id_map,
+    'revived_ids', to_jsonb(v_revived_ids),
+    'updated_ids', to_jsonb(v_updated_ids),
+    'inserted_count', (SELECT count(*) FROM jsonb_object_keys(v_insert_id_map)),
+    'revived_count', coalesce(array_length(v_revived_ids, 1), 0),
+    'updated_count', coalesce(array_length(v_updated_ids, 1), 0),
+    'reactivated_count', v_reactivated,
+    'orphaned_count', v_orphaned,
+    'target_fks_set', v_fk_count
+  );
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.enforce_object_user_update_scope()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+BEGIN
+    -- Service role (no JWT) and admins can write any column.
+    IF auth.uid() IS NULL OR public.is_admin() THEN
+        RETURN NEW;
+    END IF;
+
+    -- Non-admin users may only touch the inspection set:
+    --   redshift_inspected, redshift_quality, last_inspected_at,
+    --   last_inspected_by. version and updated_at are maintained by sibling
+    --   triggers; we explicitly allow them to change so this trigger
+    --   doesn't reject writes that went through the legitimate path.
+    IF OLD.object_id IS DISTINCT FROM NEW.object_id
+       OR OLD.field IS DISTINCT FROM NEW.field
+       OR OLD.ra IS DISTINCT FROM NEW.ra
+       OR OLD.dec IS DISTINCT FROM NEW.dec
+       OR OLD.n_targets IS DISTINCT FROM NEW.n_targets
+       OR OLD.n_spectra IS DISTINCT FROM NEW.n_spectra
+       OR OLD.programs IS DISTINCT FROM NEW.programs
+       OR OLD.gratings IS DISTINCT FROM NEW.gratings
+       OR OLD.observations IS DISTINCT FROM NEW.observations
+       OR OLD.max_snr IS DISTINCT FROM NEW.max_snr
+       OR OLD.max_exposure_time IS DISTINCT FROM NEW.max_exposure_time
+       OR OLD.photo_z IS DISTINCT FROM NEW.photo_z
+       OR OLD.photo_z_err_lo IS DISTINCT FROM NEW.photo_z_err_lo
+       OR OLD.photo_z_err_hi IS DISTINCT FROM NEW.photo_z_err_hi
+       OR OLD.has_photometry IS DISTINCT FROM NEW.has_photometry
+       OR OLD.redshift_auto IS DISTINCT FROM NEW.redshift_auto
+       OR OLD.last_data_change_at IS DISTINCT FROM NEW.last_data_change_at
+       OR OLD.staleness_reason IS DISTINCT FROM NEW.staleness_reason
+       OR OLD.inspected_used_auto IS DISTINCT FROM NEW.inspected_used_auto
+       OR OLD.is_active IS DISTINCT FROM NEW.is_active
+       OR OLD.created_at IS DISTINCT FROM NEW.created_at
+       OR OLD.search_text IS DISTINCT FROM NEW.search_text
+    THEN
+        RAISE EXCEPTION 'Non-admin updates to objects may only change inspection fields (redshift_inspected, redshift_quality, last_inspected_at, last_inspected_by)'
+            USING ERRCODE = '42501';  -- insufficient_privilege
+    END IF;
+
+    RETURN NEW;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_adjacent_objects(p_current_object_id text, p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_list_ids integer[] DEFAULT NULL::integer[], p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_sort_column text DEFAULT 'object_id'::text, p_sort_direction text DEFAULT 'asc'::text, p_has_photometry boolean DEFAULT NULL::boolean, p_photo_z_min double precision DEFAULT NULL::double precision, p_photo_z_max double precision DEFAULT NULL::double precision, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid)
+ RETURNS TABLE(prev_object_id text, next_object_id text, current_index bigint, total_count bigint)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_sort_is_text BOOLEAN;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN v_gratings_mode := 'any'; END IF;
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+  IF v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN
+    p_sort_column := 'distance';
+    p_sort_direction := 'asc';
+  END IF;
+  v_sort_is_text := p_sort_column IN ('object_id', 'field');
+
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs))
+    INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN QUERY SELECT NULL::TEXT, NULL::TEXT, 0::BIGINT, 0::BIGINT;
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  WITH filtered_objects AS MATERIALIZED (
+    SELECT
+      o.object_id,
+      CASE WHEN v_coord_search_active THEN
+        2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        )))
+      ELSE NULL END AS distance,
+      o.field, o.ra, o.dec, o.redshift, o.redshift_quality,
+      o.n_targets, o.n_spectra, o.max_snr, o.max_exposure_time
+    FROM objects o
+    WHERE
+      o.programs && v_filtered_program_slugs
+      AND o.is_active = true
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+        OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+        OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+      )
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_search IS NULL OR o.search_text ILIKE '%' || p_search || '%')
+      AND (p_inspected_only IS NULL
+        OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+        OR (p_inspected_only = FALSE AND o.redshift_quality = 0))
+      AND (p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at))))
+      AND (NOT v_coord_search_active OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+      ))
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+      AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+      AND (
+        NOT v_comment_search_active
+        OR EXISTS (
+          SELECT 1 FROM comments c
+          WHERE c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+            AND (
+              c.object_id = o.id
+              OR c.target_id IN (SELECT t.id FROM targets t WHERE t.object_id = o.id)
+            )
+        )
+      )
+  ),
+  distance_filtered AS MATERIALIZED (
+    SELECT
+      fo.*,
+      CASE p_sort_column
+        WHEN 'object_id' THEN fo.object_id WHEN 'field' THEN fo.field ELSE NULL
+      END AS sort_text,
+      CASE p_sort_column
+        WHEN 'ra' THEN fo.ra WHEN 'dec' THEN fo.dec
+        WHEN 'redshift' THEN fo.redshift
+        WHEN 'redshift_quality' THEN fo.redshift_quality::DOUBLE PRECISION
+        WHEN 'n_targets' THEN fo.n_targets::DOUBLE PRECISION
+        WHEN 'n_spectra' THEN fo.n_spectra::DOUBLE PRECISION
+        WHEN 'max_snr' THEN fo.max_snr WHEN 'max_exposure_time' THEN fo.max_exposure_time
+        WHEN 'distance' THEN fo.distance ELSE NULL
+      END AS sort_num
+    FROM filtered_objects fo
+    WHERE NOT v_coord_search_active OR fo.distance <= p_radius_degrees
+  ),
+  current_obj AS (
+    SELECT df.sort_text, df.sort_num, df.object_id FROM distance_filtered df WHERE df.object_id = p_current_object_id
+  )
+  SELECT
+    (SELECT df.object_id FROM distance_filtered df, current_obj c
+     WHERE CASE WHEN v_sort_is_text THEN
+       (CASE WHEN p_sort_direction = 'asc' THEN df.sort_text < c.sort_text ELSE df.sort_text > c.sort_text END)
+       OR (df.sort_text IS NOT DISTINCT FROM c.sort_text AND df.object_id < c.object_id)
+       OR (df.sort_text IS NOT NULL AND c.sort_text IS NULL)
+     ELSE
+       (CASE WHEN p_sort_direction = 'asc' THEN df.sort_num < c.sort_num ELSE df.sort_num > c.sort_num END)
+       OR (df.sort_num IS NOT DISTINCT FROM c.sort_num AND df.object_id < c.object_id)
+       OR (df.sort_num IS NOT NULL AND c.sort_num IS NULL)
+     END
+     ORDER BY
+       CASE WHEN v_sort_is_text AND p_sort_direction = 'asc' THEN df.sort_text END DESC NULLS FIRST,
+       CASE WHEN v_sort_is_text AND p_sort_direction = 'desc' THEN df.sort_text END ASC NULLS FIRST,
+       CASE WHEN NOT v_sort_is_text AND p_sort_direction = 'asc' THEN df.sort_num END DESC NULLS FIRST,
+       CASE WHEN NOT v_sort_is_text AND p_sort_direction = 'desc' THEN df.sort_num END ASC NULLS FIRST,
+       df.object_id DESC
+     LIMIT 1
+    ) AS prev_object_id,
+    (SELECT df.object_id FROM distance_filtered df, current_obj c
+     WHERE CASE WHEN v_sort_is_text THEN
+       (CASE WHEN p_sort_direction = 'asc' THEN df.sort_text > c.sort_text ELSE df.sort_text < c.sort_text END)
+       OR (df.sort_text IS NOT DISTINCT FROM c.sort_text AND df.object_id > c.object_id)
+       OR (c.sort_text IS NOT NULL AND df.sort_text IS NULL)
+     ELSE
+       (CASE WHEN p_sort_direction = 'asc' THEN df.sort_num > c.sort_num ELSE df.sort_num < c.sort_num END)
+       OR (df.sort_num IS NOT DISTINCT FROM c.sort_num AND df.object_id > c.object_id)
+       OR (c.sort_num IS NOT NULL AND df.sort_num IS NULL)
+     END
+     ORDER BY
+       CASE WHEN v_sort_is_text AND p_sort_direction = 'asc' THEN df.sort_text END ASC NULLS LAST,
+       CASE WHEN v_sort_is_text AND p_sort_direction = 'desc' THEN df.sort_text END DESC NULLS LAST,
+       CASE WHEN NOT v_sort_is_text AND p_sort_direction = 'asc' THEN df.sort_num END ASC NULLS LAST,
+       CASE WHEN NOT v_sort_is_text AND p_sort_direction = 'desc' THEN df.sort_num END DESC NULLS LAST,
+       df.object_id ASC
+     LIMIT 1
+    ) AS next_object_id,
+    CASE WHEN EXISTS (SELECT 1 FROM current_obj) THEN (
+      SELECT COUNT(*) + 1
+      FROM distance_filtered df, current_obj c
+      WHERE CASE WHEN v_sort_is_text THEN
+        (CASE WHEN p_sort_direction = 'asc' THEN df.sort_text < c.sort_text ELSE df.sort_text > c.sort_text END)
+        OR (df.sort_text IS NOT DISTINCT FROM c.sort_text AND df.object_id < c.object_id)
+        OR (df.sort_text IS NOT NULL AND c.sort_text IS NULL)
+      ELSE
+        (CASE WHEN p_sort_direction = 'asc' THEN df.sort_num < c.sort_num ELSE df.sort_num > c.sort_num END)
+        OR (df.sort_num IS NOT DISTINCT FROM c.sort_num AND df.object_id < c.object_id)
+        OR (df.sort_num IS NOT NULL AND c.sort_num IS NULL)
+      END
+    )::BIGINT ELSE 0::BIGINT END AS current_index,
+    (SELECT COUNT(*) FROM distance_filtered)::BIGINT AS total_count;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_csv_export_objects(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_list_ids integer[] DEFAULT NULL::integer[], p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_has_photometry boolean DEFAULT NULL::boolean, p_photo_z_min double precision DEFAULT NULL::double precision, p_photo_z_max double precision DEFAULT NULL::double precision, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_sort_column text DEFAULT 'object_id'::text, p_sort_direction text DEFAULT 'asc'::text)
+ RETURNS TABLE(object_id text, field text, ra double precision, "dec" double precision, redshift numeric, redshift_quality integer, redshift_inspected numeric, redshift_auto double precision, last_inspected_at timestamp with time zone, last_inspected_by text, last_data_change_at timestamp with time zone, staleness_reason text, version integer, n_targets integer, n_spectra integer, programs text, gratings text, max_snr double precision, max_exposure_time double precision, member_target_ids text, distance double precision, lists text, has_photometry boolean, photo_z double precision, photo_z_err_lo double precision, photo_z_err_hi double precision, photometry jsonb)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN v_gratings_mode := 'any'; END IF;
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time', 'photo_z'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs)) INTO v_filtered_program_slugs;
+  ELSE v_filtered_program_slugs := p_program_slugs; END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN RETURN; END IF;
+
+  RETURN QUERY
+  WITH member_targets AS (
+    SELECT t.object_id, string_agg(t.target_id, ';' ORDER BY t.target_id) AS member_target_ids
+    FROM targets t
+    WHERE t.program_slug = ANY(v_filtered_program_slugs)
+    GROUP BY t.object_id
+  ),
+  visible_lists AS (
+    SELECT olm.object_id, string_agg(ol.slug, ';' ORDER BY ol.slug) AS lists
+    FROM object_list_members olm
+    JOIN object_lists ol ON ol.id = olm.list_id
+    WHERE ol.created_by = auth.uid() OR ol.visibility IN ('public_read', 'public_edit')
+    GROUP BY olm.object_id
+  ),
+  filtered_objects AS (
+    SELECT o.object_id, o.field, o.ra, o.dec,
+      o.redshift, o.redshift_quality,
+      o.redshift_inspected, o.redshift_auto,
+      o.last_inspected_at, up.full_name AS last_inspected_by,
+      o.last_data_change_at, o.staleness_reason, o.version,
+      o.n_targets, o.n_spectra,
+      array_to_string(o.programs, ';') AS programs,
+      array_to_string(o.gratings, ';') AS gratings,
+      o.max_snr, o.max_exposure_time,
+      mt.member_target_ids,
+      CASE WHEN v_coord_search_active THEN
+        2 * DEGREES(ASIN(SQRT(POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) + COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) * POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2))))
+      ELSE NULL END AS distance,
+      vl.lists,
+      o.has_photometry, o.photo_z, o.photo_z_err_lo, o.photo_z_err_hi,
+      phot.photometry
+    FROM objects o
+    LEFT JOIN member_targets mt ON mt.object_id = o.id
+    LEFT JOIN visible_lists vl ON vl.object_id = o.id
+    LEFT JOIN user_profiles up ON up.user_id = o.last_inspected_by
+    LEFT JOIN LATERAL (
+      SELECT op.photometry FROM object_photometry op
+      WHERE op.object_id = o.id ORDER BY op.updated_at DESC LIMIT 1
+    ) phot ON true
+    WHERE o.programs && v_filtered_program_slugs
+      AND o.is_active = true
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+        OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+        OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+      )
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_search IS NULL OR o.search_text ILIKE '%' || p_search || '%')
+      AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.redshift_quality > 0) OR (p_inspected_only = FALSE AND o.redshift_quality = 0))
+      AND (p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at))))
+      AND (NOT v_coord_search_active OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+      ))
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+      AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+      AND (
+        NOT v_comment_search_active
+        OR EXISTS (
+          SELECT 1 FROM comments c
+          WHERE c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+            AND (
+              c.object_id = o.id
+              OR c.target_id IN (SELECT t.id FROM targets t WHERE t.object_id = o.id)
+            )
+        )
+      )
+  ),
+  distance_filtered AS (SELECT fo.* FROM filtered_objects fo WHERE NOT v_coord_search_active OR fo.distance <= p_radius_degrees)
+  SELECT df.object_id, df.field, df.ra, df.dec,
+    df.redshift, df.redshift_quality,
+    df.redshift_inspected, df.redshift_auto,
+    df.last_inspected_at, df.last_inspected_by,
+    df.last_data_change_at, df.staleness_reason, df.version,
+    df.n_targets, df.n_spectra,
+    df.programs, df.gratings,
+    df.max_snr, df.max_exposure_time,
+    df.member_target_ids, df.distance, df.lists,
+    df.has_photometry, df.photo_z, df.photo_z_err_lo, df.photo_z_err_hi,
+    df.photometry
+  FROM distance_filtered df
+  ORDER BY
+    CASE WHEN v_coord_search_active THEN df.distance END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN df.object_id END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'desc' THEN df.object_id END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'asc' THEN df.field END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'desc' THEN df.field END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN df.ra END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN df.ra END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN df.dec END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN df.dec END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN df.redshift END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN df.redshift END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN df.redshift_quality END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN df.redshift_quality END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_targets' AND p_sort_direction = 'asc' THEN df.n_targets END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_targets' AND p_sort_direction = 'desc' THEN df.n_targets END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_spectra' AND p_sort_direction = 'asc' THEN df.n_spectra END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_spectra' AND p_sort_direction = 'desc' THEN df.n_spectra END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN df.max_snr END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN df.max_snr END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN df.max_exposure_time END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN df.max_exposure_time END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'photo_z' AND p_sort_direction = 'asc' THEN df.photo_z END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'photo_z' AND p_sort_direction = 'desc' THEN df.photo_z END DESC NULLS LAST,
+    df.object_id ASC;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_csv_export_spectra(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_dq_flags_include_any integer DEFAULT NULL::integer, p_dq_flags_include_all integer DEFAULT NULL::integer, p_dq_flags_exclude integer DEFAULT NULL::integer, p_list_ids integer[] DEFAULT NULL::integer[], p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_has_photometry boolean DEFAULT NULL::boolean, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_sort_column text DEFAULT 'target_id'::text, p_sort_direction text DEFAULT 'asc'::text)
+ RETURNS TABLE(spectrum_id text, target_id text, grating text, field text, ra double precision, "dec" double precision, redshift numeric, redshift_quality integer, redshift_auto double precision, signal_to_noise double precision, exposure_time double precision, fits_path text, program_slug text, program_name text, last_inspected_at timestamp with time zone, last_inspected_by text, distance double precision, dq_flags integer, lists text)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (p_comment_search IS NOT NULL AND p_comment_search != '' AND p_comment_search_scope IN ('just_me', 'everyone'));
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
+  IF NOT (p_sort_column IN ('target_id', 'spectrum_id', 'field', 'observation', 'ra', 'dec', 'redshift', 'redshift_quality', 'redshift_auto', 'signal_to_noise', 'exposure_time', 'grating')
+       OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'spectrum_id';
+  END IF;
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs)) INTO v_filtered_program_slugs;
+  ELSE v_filtered_program_slugs := p_program_slugs; END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN RETURN; END IF;
+
+  RETURN QUERY
+  WITH visible_lists AS (
+    SELECT olm.object_id, string_agg(ol.slug, ';' ORDER BY ol.slug) AS lists
+    FROM object_list_members olm
+    JOIN object_lists ol ON ol.id = olm.list_id
+    WHERE ol.created_by = auth.uid() OR ol.visibility IN ('public_read', 'public_edit')
+    GROUP BY olm.object_id
+  ),
+  filtered_spectra AS (
+    SELECT s.spectrum_id, t.target_id, s.grating, t.field, t.ra, t.dec,
+      o.redshift, o.redshift_quality,
+      s.redshift_auto,
+      s.signal_to_noise, s.exposure_time, s.fits_path, t.program_slug, t.observation,
+      o.last_inspected_at, o.last_inspected_by,
+      CASE WHEN v_coord_search_active THEN
+        2 * DEGREES(ASIN(SQRT(POWER(SIN(RADIANS(t.dec - p_coord_dec) / 2), 2) + COS(RADIANS(p_coord_dec)) * COS(RADIANS(t.dec)) * POWER(SIN(RADIANS(t.ra - p_coord_ra) / 2), 2))))
+      ELSE NULL END AS distance,
+      COALESCE(s.dq_flags, 0) AS dq_flags,
+      vl.lists
+    FROM targets t
+    JOIN spectra s ON s.target_id = t.target_id
+    LEFT JOIN objects o ON o.id = t.object_id
+    LEFT JOIN visible_lists vl ON vl.object_id = t.object_id
+    WHERE t.program_slug = ANY(v_filtered_program_slugs)
+      AND (o.id IS NULL OR o.is_active = true)
+      AND (NOT v_grating_filter_active OR s.grating = ANY(p_gratings))
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR t.field = ANY(p_fields))
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR t.observation = ANY(p_observations))
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min) AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR s.signal_to_noise >= p_max_snr_min) AND (p_max_snr_max IS NULL OR s.signal_to_noise <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR s.exposure_time >= p_max_exposure_time_min) AND (p_max_exposure_time_max IS NULL OR s.exposure_time <= p_max_exposure_time_max)
+      AND (p_dq_flags_include_any IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_any) != 0)
+      AND (p_dq_flags_include_all IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_all) = p_dq_flags_include_all)
+      AND (p_dq_flags_exclude IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_exclude) = 0)
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR t.object_id IN (
+          SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_search IS NULL OR s.search_text ILIKE '%' || p_search || '%')
+      AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.redshift_quality > 0) OR (p_inspected_only = FALSE AND COALESCE(o.redshift_quality, 0) = 0))
+      AND (p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at))))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (NOT v_comment_search_active OR EXISTS (
+        SELECT 1 FROM comments c WHERE c.target_id = t.id AND c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (p_comment_search_scope = 'everyone' OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id))))
+      AND (NOT v_coord_search_active OR (
+        t.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND t.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)))
+  ),
+  distance_filtered AS (SELECT fs.* FROM filtered_spectra fs WHERE NOT v_coord_search_active OR fs.distance <= p_radius_degrees)
+  SELECT df.spectrum_id, df.target_id, df.grating, df.field, df.ra, df.dec, df.redshift, df.redshift_quality, df.redshift_auto,
+    df.signal_to_noise, df.exposure_time, df.fits_path, df.program_slug,
+    pr.program_name, df.last_inspected_at, up.full_name AS last_inspected_by,
+    df.distance, df.dq_flags, df.lists
+  FROM distance_filtered df
+  LEFT JOIN programs pr ON pr.slug = df.program_slug
+  LEFT JOIN user_profiles up ON up.user_id = df.last_inspected_by
+  ORDER BY
+    CASE WHEN v_coord_search_active THEN df.distance END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'spectrum_id' AND p_sort_direction = 'asc' THEN df.spectrum_id END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'spectrum_id' AND p_sort_direction = 'desc' THEN df.spectrum_id END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'target_id' AND p_sort_direction = 'asc' THEN df.target_id END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'target_id' AND p_sort_direction = 'desc' THEN df.target_id END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'asc' THEN df.field END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'desc' THEN df.field END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'observation' AND p_sort_direction = 'asc' THEN df.observation END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'observation' AND p_sort_direction = 'desc' THEN df.observation END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN df.ra END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN df.ra END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN df.dec END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN df.dec END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN df.redshift END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN df.redshift END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN df.redshift_quality END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN df.redshift_quality END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_auto' AND p_sort_direction = 'asc' THEN df.redshift_auto END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_auto' AND p_sort_direction = 'desc' THEN df.redshift_auto END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'signal_to_noise' AND p_sort_direction = 'asc' THEN df.signal_to_noise END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'signal_to_noise' AND p_sort_direction = 'desc' THEN df.signal_to_noise END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'exposure_time' AND p_sort_direction = 'asc' THEN df.exposure_time END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'exposure_time' AND p_sort_direction = 'desc' THEN df.exposure_time END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'grating' AND p_sort_direction = 'asc' THEN df.grating END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'grating' AND p_sort_direction = 'desc' THEN df.grating END DESC NULLS LAST,
+    df.target_id ASC, df.grating ASC;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_filtered_object_ids(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_list_ids integer[] DEFAULT NULL::integer[], p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_has_photometry boolean DEFAULT NULL::boolean, p_photo_z_min double precision DEFAULT NULL::double precision, p_photo_z_max double precision DEFAULT NULL::double precision, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_sort_column text DEFAULT 'object_id'::text, p_sort_direction text DEFAULT 'asc'::text)
+ RETURNS TABLE(object_id text)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
+    v_gratings_mode := 'any';
+  END IF;
+
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN
+    p_sort_direction := 'asc';
+  END IF;
+
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time', 'photo_z'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+
+  -- Intersect user-accessible programs with filter selection
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(
+      SELECT unnest(p_program_slugs)
+      INTERSECT
+      SELECT unnest(p_filter_programs)
+    ) INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT o.object_id
+  FROM objects o
+  WHERE
+    o.programs && v_filtered_program_slugs
+    AND o.is_active = true
+    AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+    AND (
+      NOT v_grating_filter_active
+      OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+      OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+      OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+    )
+    AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+    AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+    AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+    AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+    AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+    AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+    AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+    AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+    AND (p_search IS NULL OR o.search_text ILIKE '%' || p_search || '%')
+    AND (
+      p_inspected_only IS NULL
+      OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+      OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+    )
+    AND (
+      p_needs_review IS NULL
+      OR (p_needs_review = TRUE
+          AND o.staleness_reason IS NOT NULL
+          AND o.last_inspected_at IS NOT NULL
+          AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+      OR (p_needs_review = FALSE
+          AND (o.staleness_reason IS NULL
+               OR o.last_inspected_at IS NULL
+               OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+    )
+    AND (
+      NOT v_coord_search_active
+      OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+        AND 2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) <= p_radius_degrees
+      )
+    )
+    AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+        SELECT olm.object_id FROM object_list_members olm
+        WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+    ))
+    AND (
+      NOT v_comment_search_active
+      OR EXISTS (
+        SELECT 1 FROM comments c
+        WHERE c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (
+            p_comment_search_scope = 'everyone'
+            OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+          )
+          AND (
+            c.object_id = o.id
+            OR c.target_id IN (SELECT t.id FROM targets t WHERE t.object_id = o.id)
+          )
+      )
+    )
+  ORDER BY
+    CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN
+      2 * DEGREES(ASIN(SQRT(
+        POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+        COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+        POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+      ))) END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN
+      2 * DEGREES(ASIN(SQRT(
+        POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+        COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+        POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+      ))) END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN o.object_id END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'desc' THEN o.object_id END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN o.field END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN o.field END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN o.ra END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN o.ra END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN o.dec END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN o.dec END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN o.redshift END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN o.redshift END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN o.redshift_quality END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN o.redshift_quality END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'asc' THEN o.n_targets END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'desc' THEN o.n_targets END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'asc' THEN o.n_spectra END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'desc' THEN o.n_spectra END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN o.max_snr END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN o.max_snr END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN o.max_exposure_time END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN o.max_exposure_time END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'asc' THEN o.photo_z END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'desc' THEN o.photo_z END DESC NULLS LAST,
+    o.object_id ASC;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_filtered_objects_paginated(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_list_ids integer[] DEFAULT NULL::integer[], p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_has_photometry boolean DEFAULT NULL::boolean, p_photo_z_min double precision DEFAULT NULL::double precision, p_photo_z_max double precision DEFAULT NULL::double precision, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_sort_column text DEFAULT 'object_id'::text, p_sort_direction text DEFAULT 'asc'::text, p_page integer DEFAULT 1, p_page_size integer DEFAULT 50)
+ RETURNS TABLE(targets jsonb, total_count bigint, page integer, page_size integer)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_offset INTEGER;
+  v_total_count BIGINT;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
+    v_gratings_mode := 'any';
+  END IF;
+
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN
+    p_sort_direction := 'asc';
+  END IF;
+
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time', 'photo_z'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+
+  IF v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN
+    p_sort_column := 'distance';
+  END IF;
+
+  v_offset := (COALESCE(p_page, 1) - 1) * COALESCE(p_page_size, 50);
+
+  -- Intersect user-accessible programs with filter selection
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(
+      SELECT unnest(p_program_slugs)
+      INTERSECT
+      SELECT unnest(p_filter_programs)
+    ) INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN QUERY SELECT '[]'::jsonb, 0::BIGINT, p_page, p_page_size;
+    RETURN;
+  END IF;
+
+  -- Step 1: count
+  SELECT COUNT(*) INTO v_total_count
+  FROM objects o
+  WHERE
+    -- Access control: object must have at least one accessible program
+    o.programs && v_filtered_program_slugs
+    AND o.is_active = true
+    AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+    AND (
+      NOT v_grating_filter_active
+      OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+      OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+      OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+    )
+    AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+    AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+    AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+    AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+    AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+    AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+    AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+    AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+    AND (p_search IS NULL OR o.search_text ILIKE '%' || p_search || '%')
+    AND (
+      p_inspected_only IS NULL
+      OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+      OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+    )
+    AND (
+      p_needs_review IS NULL
+      OR (p_needs_review = TRUE
+          AND o.staleness_reason IS NOT NULL
+          AND o.last_inspected_at IS NOT NULL
+          AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+      OR (p_needs_review = FALSE
+          AND (o.staleness_reason IS NULL
+               OR o.last_inspected_at IS NULL
+               OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+    )
+    AND (
+      NOT v_coord_search_active
+      OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+        AND 2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) <= p_radius_degrees
+      )
+    )
+    AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+        SELECT olm.object_id FROM object_list_members olm
+        WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+    ))
+    AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+    AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+    AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+    AND (
+      NOT v_comment_search_active
+      OR EXISTS (
+        SELECT 1 FROM comments c
+        WHERE c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (
+            p_comment_search_scope = 'everyone'
+            OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+          )
+          AND (
+            c.object_id = o.id
+            OR c.target_id IN (SELECT t.id FROM targets t WHERE t.object_id = o.id)
+          )
+      )
+    );
+
+  -- Step 2: fetch page
+  RETURN QUERY
+  WITH filtered_objects AS (
+    SELECT
+      o.id,
+      o.object_id,
+      o.field,
+      o.ra,
+      o.dec,
+      o.n_targets,
+      o.n_spectra,
+      o.programs,
+      o.gratings,
+      o.max_snr,
+      o.max_exposure_time,
+      o.redshift,
+      o.redshift_quality,
+      o.redshift_inspected,
+      o.redshift_auto,
+      o.inspected_used_auto,
+      o.last_inspected_at,
+      o.last_inspected_by,
+      o.last_data_change_at,
+      o.staleness_reason,
+      o.version,
+      o.is_active,
+      o.photo_z,
+      o.has_photometry,
+      o.created_at,
+      CASE
+        WHEN v_coord_search_active THEN
+          2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+            POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+          )))
+        ELSE NULL
+      END AS distance
+    FROM objects o
+    WHERE
+      o.programs && v_filtered_program_slugs
+      AND o.is_active = true
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+        OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+        OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+      )
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_search IS NULL OR o.search_text ILIKE '%' || p_search || '%')
+      AND (
+        p_inspected_only IS NULL
+        OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+        OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+      )
+      AND (
+        p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+      )
+      AND (
+        NOT v_coord_search_active
+        OR (
+          o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+          AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+          AND 2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+            POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+          ))) <= p_radius_degrees
+        )
+      )
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+      AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+      AND (
+        NOT v_comment_search_active
+        OR EXISTS (
+          SELECT 1 FROM comments c
+          WHERE c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+            AND (
+              c.object_id = o.id
+              OR c.target_id IN (SELECT t.id FROM targets t WHERE t.object_id = o.id)
+            )
+        )
+      )
+    ORDER BY
+      CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN
+        2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN
+        2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN o.object_id END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'desc' THEN o.object_id END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN o.field END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN o.field END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN o.ra END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN o.ra END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN o.dec END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN o.dec END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN o.redshift END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN o.redshift END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN o.redshift_quality END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN o.redshift_quality END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'asc' THEN o.n_targets END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'desc' THEN o.n_targets END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'asc' THEN o.n_spectra END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'desc' THEN o.n_spectra END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN o.max_snr END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN o.max_snr END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN o.max_exposure_time END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN o.max_exposure_time END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'asc' THEN o.photo_z END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'desc' THEN o.photo_z END DESC NULLS LAST,
+      o.object_id ASC
+    LIMIT p_page_size OFFSET v_offset
+  ),
+  with_members AS (
+    SELECT
+      jsonb_build_object(
+        'id', fo.id,
+        'object_id', fo.object_id,
+        'field', fo.field,
+        'ra', fo.ra,
+        'dec', fo.dec,
+        'n_targets', fo.n_targets,
+        'n_spectra', fo.n_spectra,
+        'programs', fo.programs,
+        'gratings', fo.gratings,
+        'max_snr', fo.max_snr,
+        'max_exposure_time', fo.max_exposure_time,
+        'redshift', fo.redshift,
+        'redshift_quality', fo.redshift_quality,
+        'redshift_inspected', fo.redshift_inspected,
+        'redshift_auto', fo.redshift_auto,
+        'inspected_used_auto', fo.inspected_used_auto,
+        'last_inspected_at', fo.last_inspected_at,
+        'last_inspected_by', fo.last_inspected_by,
+        'last_data_change_at', fo.last_data_change_at,
+        'staleness_reason', fo.staleness_reason,
+        'version', fo.version,
+        'is_active', fo.is_active,
+        'photo_z', fo.photo_z,
+        'has_photometry', fo.has_photometry,
+        'created_at', fo.created_at,
+        'distance', fo.distance,
+        -- Phase D: member_targets becomes provenance only (target_id, program,
+        -- observation). Inspection state lives on the object now; redshift_auto
+        -- on targets is retained for transitional UI display until Phase E.
+        'member_targets', COALESCE(
+          (SELECT jsonb_agg(
+            jsonb_build_object(
+              'target_id', t.target_id,
+              'program_slug', t.program_slug,
+              'observation', t.observation,
+              'redshift_auto', t.redshift_auto
+            )
+          )
+          FROM targets t
+          WHERE t.object_id = fo.id
+            AND t.program_slug = ANY(v_filtered_program_slugs)
+          ),
+          '[]'::jsonb
+        ),
+        'lists', COALESCE(
+          (SELECT jsonb_agg(
+            jsonb_build_object(
+              'id', ol.id,
+              'name', ol.name,
+              'slug', ol.slug,
+              'icon', ol.icon,
+              'color', ol.color
+            ) ORDER BY ol.name
+          )
+          FROM object_list_members olm
+          JOIN object_lists ol ON ol.id = olm.list_id
+          WHERE olm.object_id = fo.id),
+          '[]'::jsonb
+        )
+      ) AS obj_json
+    FROM filtered_objects fo
+  )
+  SELECT
+    COALESCE(jsonb_agg(wm.obj_json), '[]'::jsonb),
+    v_total_count,
+    p_page,
+    p_page_size
+  FROM with_members wm;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_filtered_spectra_paginated(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_dq_flags_include_any integer DEFAULT NULL::integer, p_dq_flags_include_all integer DEFAULT NULL::integer, p_dq_flags_exclude integer DEFAULT NULL::integer, p_list_ids integer[] DEFAULT NULL::integer[], p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_has_photometry boolean DEFAULT NULL::boolean, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_sort_column text DEFAULT 'target_id'::text, p_sort_direction text DEFAULT 'asc'::text, p_page integer DEFAULT 1, p_page_size integer DEFAULT 50, p_include_thumbnails boolean DEFAULT false)
+ RETURNS TABLE(targets jsonb, total_count bigint, page integer, page_size integer)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_offset INTEGER;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
+    v_gratings_mode := 'any';
+  END IF;
+
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN
+    p_sort_direction := 'asc';
+  END IF;
+
+  IF NOT (p_sort_column IN (
+    'target_id', 'spectrum_id', 'field', 'observation', 'program_slug', 'ra', 'dec', 'redshift',
+    'redshift_quality', 'redshift_auto', 'signal_to_noise', 'exposure_time', 'grating'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'spectrum_id';
+  END IF;
+
+  IF v_coord_search_active AND p_sort_column IN ('target_id', 'spectrum_id') AND p_sort_direction = 'asc' THEN
+    p_sort_column := 'distance';
+  END IF;
+
+  v_offset := (COALESCE(p_page, 1) - 1) * COALESCE(p_page_size, 50);
+
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(
+      SELECT unnest(p_program_slugs)
+      INTERSECT
+      SELECT unnest(p_filter_programs)
+    ) INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN QUERY SELECT '[]'::jsonb, 0::BIGINT, p_page, p_page_size;
+    RETURN;
+  END IF;
+
+  -- Single-pass CTE: filtered_spectra is referenced by both distance_filtered
+  -- and the count subquery, so PostgreSQL materializes it once.
+  RETURN QUERY
+  WITH filtered_spectra AS (
+    SELECT
+      t.id AS tgt_db_id,
+      t.target_id,
+      t.program_slug,
+      t.field,
+      t.observation,
+      t.ra,
+      t.dec,
+      -- Phase D: redshift / redshift_quality / inspected flags now live on the
+      -- parent object. LEFT JOIN so spectra whose target has no object FK
+      -- (shouldn't happen post-reconcile, but safe) still appear.
+      o.redshift,
+      o.redshift_quality,
+      o.redshift_inspected,
+      o.last_inspected_at,
+      o.last_inspected_by,
+      o.is_active AS object_is_active,
+      o.has_photometry AS object_has_photometry,
+      o.object_id AS parent_object_id,
+      t.max_snr,
+      t.max_exposure_time,
+      t.created_at,
+      t.updated_at,
+      s.id AS spectrum_pk,
+      s.spectrum_id,
+      s.grating,
+      s.fits_path,
+      s.signal_to_noise,
+      s.exposure_time,
+      s.redshift_auto,
+      COALESCE(s.dq_flags, 0) AS dq_flags,
+      s.file_hash,
+      s.file_size,
+      s.thumbnail_svg_fnu,
+      s.thumbnail_svg_flambda,
+      CASE
+        WHEN v_coord_search_active THEN
+          2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(t.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(t.dec)) *
+            POWER(SIN(RADIANS(t.ra - p_coord_ra) / 2), 2)
+          )))
+        ELSE NULL
+      END AS distance
+    FROM targets t
+    JOIN spectra s ON s.target_id = t.target_id
+    LEFT JOIN objects o ON o.id = t.object_id
+    WHERE
+      t.program_slug = ANY(v_filtered_program_slugs)
+      -- Hide spectra whose parent object was soft-deleted.
+      AND (o.id IS NULL OR o.is_active = true)
+      AND (NOT v_grating_filter_active OR s.grating = ANY(p_gratings))
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR t.field = ANY(p_fields))
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR t.observation = ANY(p_observations))
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR s.signal_to_noise >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR s.signal_to_noise <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR s.exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR s.exposure_time <= p_max_exposure_time_max)
+      AND (p_dq_flags_include_any IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_any) != 0)
+      AND (p_dq_flags_include_all IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_all) = p_dq_flags_include_all)
+      AND (p_dq_flags_exclude IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_exclude) = 0)
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR t.object_id IN (
+          SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_search IS NULL OR s.search_text ILIKE '%' || p_search || '%')
+      AND (
+        p_inspected_only IS NULL
+        OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+        OR (p_inspected_only = FALSE AND COALESCE(o.redshift_quality, 0) = 0)
+      )
+      AND (
+        p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+      )
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (
+        NOT v_comment_search_active
+        OR EXISTS (
+          SELECT 1 FROM comments c
+          WHERE c.target_id = t.id
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+        )
+      )
+      AND (
+        NOT v_coord_search_active
+        OR (
+          t.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+          AND t.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+        )
+      )
+  ),
+  distance_filtered AS (
+    SELECT fs.*
+    FROM filtered_spectra fs
+    WHERE NOT v_coord_search_active OR fs.distance <= p_radius_degrees
+  ),
+  page_rows AS (
+    SELECT *, ROW_NUMBER() OVER () as row_num
+    FROM (
+      SELECT * FROM distance_filtered
+      ORDER BY
+        CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN distance END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN distance END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'target_id' AND p_sort_direction = 'asc' THEN target_id END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'target_id' AND p_sort_direction = 'desc' THEN target_id END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'spectrum_id' AND p_sort_direction = 'asc' THEN spectrum_id END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'spectrum_id' AND p_sort_direction = 'desc' THEN spectrum_id END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN field END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN field END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'observation' AND p_sort_direction = 'asc' THEN observation END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'observation' AND p_sort_direction = 'desc' THEN observation END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'program_slug' AND p_sort_direction = 'asc' THEN program_slug END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'program_slug' AND p_sort_direction = 'desc' THEN program_slug END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN ra END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN ra END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN "dec" END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN "dec" END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN redshift END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN redshift END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN redshift_quality END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN redshift_quality END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift_auto' AND p_sort_direction = 'asc' THEN redshift_auto END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift_auto' AND p_sort_direction = 'desc' THEN redshift_auto END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'signal_to_noise' AND p_sort_direction = 'asc' THEN signal_to_noise END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'signal_to_noise' AND p_sort_direction = 'desc' THEN signal_to_noise END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'exposure_time' AND p_sort_direction = 'asc' THEN exposure_time END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'exposure_time' AND p_sort_direction = 'desc' THEN exposure_time END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'grating' AND p_sort_direction = 'asc' THEN grating END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'grating' AND p_sort_direction = 'desc' THEN grating END DESC NULLS LAST,
+        target_id ASC, grating ASC
+      LIMIT p_page_size OFFSET v_offset
+    ) sorted_page
+  )
+  SELECT
+    COALESCE(jsonb_agg(jsonb_build_object(
+      'id', r.tgt_db_id,
+      'target_id', r.target_id,
+      'parent_object_id', r.parent_object_id,
+      'program_slug', r.program_slug,
+      'program_name', pr.program_name,
+      'field', r.field,
+      'observation', r.observation,
+      'ra', r.ra,
+      'dec', r.dec,
+      -- Phase D: redshift fields are object-level reads
+      'redshift', r.redshift,
+      'redshift_inspected', r.redshift_inspected,
+      'redshift_quality', r.redshift_quality,
+      'last_inspected_at', r.last_inspected_at,
+      'last_inspected_by', r.last_inspected_by,
+      'max_snr', r.max_snr,
+      'max_exposure_time', r.max_exposure_time,
+      'created_at', r.created_at,
+      'updated_at', r.updated_at,
+      'distance', CASE WHEN v_coord_search_active THEN r.distance ELSE NULL END,
+      'spectra', jsonb_build_array(jsonb_build_object(
+        'id', r.spectrum_pk,
+        'spectrum_id', r.spectrum_id,
+        'target_id', r.target_id,
+        'grating', r.grating,
+        'fits_path', r.fits_path,
+        'signal_to_noise', r.signal_to_noise,
+        'exposure_time', r.exposure_time,
+        -- Phase D: per-spectrum auto-z and DQ
+        'redshift_auto', r.redshift_auto,
+        'dq_flags', r.dq_flags,
+        'file_hash', r.file_hash,
+        'file_size', r.file_size,
+        'thumbnail_svg_fnu', CASE WHEN p_include_thumbnails THEN r.thumbnail_svg_fnu ELSE NULL END,
+        'thumbnail_svg_flambda', CASE WHEN p_include_thumbnails THEN r.thumbnail_svg_flambda ELSE NULL END
+      ))
+    ) ORDER BY r.row_num), '[]'::jsonb),
+    (SELECT COUNT(*) FROM distance_filtered),
+    p_page,
+    p_page_size
+  FROM page_rows r
+  LEFT JOIN programs pr ON pr.slug = r.program_slug;
+END;
+$function$
+;
+
+
+-- Backfill search_text for all existing objects (reconcile only refreshes on deploy).
+-- spectra.search_text is generated, auto-populated by the ADD COLUMN above.
+SELECT public.recompute_object_search_text();

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -672,9 +672,7 @@ BEGIN
       AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR t.object_id IN (
           SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
       ))
-      AND (p_search IS NULL
-           OR t.target_id ILIKE '%' || p_search || '%'
-           OR s.spectrum_id ILIKE '%' || p_search || '%')
+      AND (p_search IS NULL OR s.search_text ILIKE '%' || p_search || '%')
       AND (
         p_inspected_only IS NULL
         OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
@@ -923,8 +921,7 @@ BEGIN
     AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
     AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
     AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
-    AND (p_search IS NULL OR o.object_id ILIKE '%' || p_search || '%'
-      OR EXISTS (SELECT 1 FROM targets t WHERE t.object_id = o.id AND t.target_id ILIKE '%' || p_search || '%'))
+    AND (p_search IS NULL OR o.search_text ILIKE '%' || p_search || '%')
     AND (
       p_inspected_only IS NULL
       OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
@@ -1034,8 +1031,7 @@ BEGIN
       AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
       AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
       AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
-      AND (p_search IS NULL OR o.object_id ILIKE '%' || p_search || '%'
-      OR EXISTS (SELECT 1 FROM targets t WHERE t.object_id = o.id AND t.target_id ILIKE '%' || p_search || '%'))
+      AND (p_search IS NULL OR o.search_text ILIKE '%' || p_search || '%')
       AND (
         p_inspected_only IS NULL
         OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
@@ -1308,8 +1304,7 @@ BEGIN
     AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
     AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
     AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
-    AND (p_search IS NULL OR o.object_id ILIKE '%' || p_search || '%'
-      OR EXISTS (SELECT 1 FROM targets t WHERE t.object_id = o.id AND t.target_id ILIKE '%' || p_search || '%'))
+    AND (p_search IS NULL OR o.search_text ILIKE '%' || p_search || '%')
     AND (
       p_inspected_only IS NULL
       OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
@@ -1514,8 +1509,7 @@ BEGIN
       AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
       AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
       AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
-      AND (p_search IS NULL OR o.object_id ILIKE '%' || p_search || '%'
-        OR EXISTS (SELECT 1 FROM targets t WHERE t.object_id = o.id AND t.target_id ILIKE '%' || p_search || '%'))
+      AND (p_search IS NULL OR o.search_text ILIKE '%' || p_search || '%')
       AND (p_inspected_only IS NULL
         OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
         OR (p_inspected_only = FALSE AND o.redshift_quality = 0))
@@ -1741,9 +1735,7 @@ BEGIN
       AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR t.object_id IN (
           SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
       ))
-      AND (p_search IS NULL
-           OR t.target_id ILIKE '%' || p_search || '%'
-           OR s.spectrum_id ILIKE '%' || p_search || '%')
+      AND (p_search IS NULL OR s.search_text ILIKE '%' || p_search || '%')
       AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.redshift_quality > 0) OR (p_inspected_only = FALSE AND COALESCE(o.redshift_quality, 0) = 0))
       AND (p_needs_review IS NULL
         OR (p_needs_review = TRUE
@@ -1940,8 +1932,7 @@ BEGIN
       AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
       AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
       AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
-      AND (p_search IS NULL OR o.object_id ILIKE '%' || p_search || '%'
-      OR EXISTS (SELECT 1 FROM targets t WHERE t.object_id = o.id AND t.target_id ILIKE '%' || p_search || '%'))
+      AND (p_search IS NULL OR o.search_text ILIKE '%' || p_search || '%')
       AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.redshift_quality > 0) OR (p_inspected_only = FALSE AND o.redshift_quality = 0))
       AND (p_needs_review IS NULL
         OR (p_needs_review = TRUE
@@ -3002,6 +2993,51 @@ GRANT EXECUTE ON FUNCTION public.bulk_set_target_object_fks(JSONB, TIMESTAMPTZ) 
 -- Returns jsonb: {insert_id_map: {object_id: db_id}, revived_ids: [db_id],
 --   updated_ids: [db_id], inserted_count, revived_count, updated_count,
 --   reactivated_count, orphaned_count, target_fks_set}.
+-- =============================================================================
+-- recompute_object_search_text
+--   Refresh the denormalized objects.search_text blob (object_id + member
+--   target_ids + program_slugs + observations) from currently-linked targets.
+--   Call with a list of object ids (the rows an apply touched) or NULL for all
+--   (one-time backfill). SECURITY DEFINER so deploy/service-role and migration
+--   callers write this aggregate column past enforce_object_user_update_scope
+--   (which lets auth.uid() IS NULL / admins through). The IS DISTINCT FROM guard
+--   avoids no-op writes (search_text has no updated_at trigger, but stay clean).
+-- =============================================================================
+CREATE OR REPLACE FUNCTION public.recompute_object_search_text(p_object_ids integer[] DEFAULT NULL)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_count integer;
+BEGIN
+  WITH new_vals AS (
+    SELECT o.id,
+           concat_ws(' ',
+             o.object_id,
+             string_agg(DISTINCT t.target_id, ' '),
+             string_agg(DISTINCT t.program_slug, ' '),
+             string_agg(DISTINCT t.observation, ' ')
+           ) AS st
+    FROM objects o
+    LEFT JOIN targets t ON t.object_id = o.id
+    WHERE (p_object_ids IS NULL OR o.id = ANY(p_object_ids))
+    GROUP BY o.id, o.object_id
+  )
+  UPDATE objects o
+  SET search_text = nv.st
+  FROM new_vals nv
+  WHERE o.id = nv.id
+    AND o.search_text IS DISTINCT FROM nv.st;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.recompute_object_search_text(integer[]) TO service_role;
+
+
 CREATE OR REPLACE FUNCTION public.apply_object_reconciliation(
   p_field       TEXT,
   p_inserts     JSONB DEFAULT '[]'::jsonb,
@@ -3172,6 +3208,16 @@ BEGIN
   FROM pairs p
   WHERE t.id = p.target_id;
   GET DIAGNOSTICS v_fk_count = ROW_COUNT;
+
+  -- 6. Refresh denormalized search_text for every object touched above. Targets
+  --    are relinked (step 5), so member target_ids / programs / observations
+  --    resolve. Scoped to the affected ids so it stays cheap per apply.
+  PERFORM public.recompute_object_search_text(
+    (SELECT coalesce(array_agg(value::int), '{}'::integer[])
+       FROM jsonb_each_text(v_insert_id_map))
+    || v_revived_ids
+    || v_updated_ids
+  );
 
   RETURN jsonb_build_object(
     'insert_id_map', v_insert_id_map,

--- a/supabase/schemas/indexes.sql
+++ b/supabase/schemas/indexes.sql
@@ -63,6 +63,12 @@ CREATE INDEX IF NOT EXISTS idx_objects_gratings
 CREATE INDEX IF NOT EXISTS idx_objects_object_id_trgm
     ON public.objects USING gin (object_id public.gin_trgm_ops);
 
+-- Unified p_search blob (object_id + member target_ids + programs + observations).
+-- Replaces the cross-table object_id-ILIKE-OR-EXISTS(targets) predicate, which the
+-- planner could not index and which full-scanned the catalog under ORDER BY + LIMIT.
+CREATE INDEX IF NOT EXISTS idx_objects_search_text_trgm
+    ON public.objects USING gin (search_text public.gin_trgm_ops);
+
 -- Phase A: support filtering/sorting by the new object-level inspection fields.
 CREATE INDEX IF NOT EXISTS idx_objects_redshift_quality
     ON public.objects USING btree (redshift_quality);
@@ -158,6 +164,11 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_spectra_spectrum_id
 -- Trigram index for substring (ILIKE) search on the search bar.
 CREATE INDEX IF NOT EXISTS idx_spectra_spectrum_id_trgm
     ON public.spectra USING gin (spectrum_id public.gin_trgm_ops);
+
+-- Unified p_search blob (target_id + spectrum_id). Replaces the cross-table
+-- target_id-ILIKE-OR-spectrum_id-ILIKE predicate with a single indexable column.
+CREATE INDEX IF NOT EXISTS idx_spectra_search_text_trgm
+    ON public.spectra USING gin (search_text public.gin_trgm_ops);
 
 CREATE INDEX IF NOT EXISTS idx_spectra_grating
     ON public.spectra USING btree (grating);

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -340,6 +340,17 @@ CREATE TABLE IF NOT EXISTS "public"."spectra" (
         regexp_replace("fits_path", '^.*/', ''),
         '_spec\.fits$', '', 'i'
       )
+    ) STORED,
+    -- Denormalized search blob for the spectra-list p_search path: target_id plus
+    -- the spectrum_id derivation. A generated column may not reference another
+    -- generated column (spectrum_id), so the fits_path regexp is mirrored here —
+    -- keep in sync with the spectrum_id expression above. trgm-indexed.
+    "search_text" "text" GENERATED ALWAYS AS (
+      "target_id" || ' ' ||
+      regexp_replace(
+        regexp_replace(COALESCE("fits_path", ''), '^.*/', ''),
+        '_spec\.fits$', '', 'i'
+      )
     ) STORED
 );
 
@@ -477,7 +488,13 @@ CREATE TABLE IF NOT EXISTS "public"."objects" (
     "last_data_change_at" timestamp with time zone,
     "staleness_reason" "text",
     "version" integer NOT NULL DEFAULT 1,
-    "is_active" boolean NOT NULL DEFAULT true
+    "is_active" boolean NOT NULL DEFAULT true,
+    -- Denormalized search blob: object_id + member target_ids + program_slugs +
+    -- observations. Cross-table (member targets), so it cannot be a generated
+    -- column; maintained by recompute_object_search_text() at the end of
+    -- apply_object_reconciliation (and the legacy objects.py rebuild). Backs the
+    -- trgm-indexed p_search path in get_filtered_objects_paginated / _object_ids.
+    "search_text" "text"
 );
 
 

--- a/supabase/schemas/triggers.sql
+++ b/supabase/schemas/triggers.sql
@@ -131,6 +131,7 @@ BEGIN
        OR OLD.inspected_used_auto IS DISTINCT FROM NEW.inspected_used_auto
        OR OLD.is_active IS DISTINCT FROM NEW.is_active
        OR OLD.created_at IS DISTINCT FROM NEW.created_at
+       OR OLD.search_text IS DISTINCT FROM NEW.search_text
     THEN
         RAISE EXCEPTION 'Non-admin updates to objects may only change inspection fields (redshift_inspected, redshift_quality, last_inspected_at, last_inspected_by)'
             USING ERRCODE = '42501';  -- insufficient_privilege

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -2145,3 +2145,9 @@ SELECT setval('public.comments_id_seq', 198, false);
 SELECT setval('public.flag_audit_log_id_seq', 18028, false);
 SELECT setval('public.object_lists_id_seq', COALESCE((SELECT MAX(id) FROM public.object_lists), 0) + 1, false);
 SELECT setval('public.object_list_members_id_seq', COALESCE((SELECT MAX(id) FROM public.object_list_members), 0) + 1, false);
+
+-- objects.search_text is maintained by reconcile in prod; the seed is a static
+-- snapshot, so backfill it here (after targets are linked) for the trgm-indexed
+-- search path on preview branches and local resets. spectra.search_text is
+-- a generated column, already populated by the inserts above.
+SELECT public.recompute_object_search_text();


### PR DESCRIPTION
## Problem

The objects list/CSV/adjacent RPCs searched via `o.object_id ILIKE '%x%' OR EXISTS(targets t WHERE t.object_id=o.id AND t.target_id ILIKE '%x%')`. Under `ORDER BY object_id LIMIT 50`, the planner walks the **full** `objects_object_id_key` index applying that cross-table disjunction as a per-row filter; because search is selective the LIMIT never fills, so it scans the whole catalog.

Measured as a real authenticated **admin** on prod (via `SET LOCAL ROLE authenticated` + injected JWT claims):

| | time | buffers |
|---|---|---|
| current `OR/EXISTS` + `ORDER BY object_id LIMIT 50` | **9,578 ms** | 282,613 |
| single trgm-indexed column (same conditions) | **133 ms** | 13,954 |

9.6 s exceeds the `authenticated` role's 8 s `statement_timeout` → the production "search times out" symptom (`pg_stat_statements` shows `get_filtered_objects_paginated` max pinned at 7,977 ms). Non-admins have a selective `programs &&` gate and don't hit it; admins (all programs) scan everything.

## Fix

Replace the unindexable OR/EXISTS with a single trgm-indexed `search_text` column:

- **`objects.search_text`** = `object_id` + member `target_id`s + `program_slug`s + `observation`s. Cross-table (member targets), so populated, not generated — maintained by a new `recompute_object_search_text()` called in **step 6 of `apply_object_reconciliation`** (after the target FK relink) and by the `objects.py` rebuild escape hatch. Backfilled in the migration + seed.
- **`spectra.search_text`** = `target_id` + `spectrum_id`, a `STORED` **generated** column (mirrors the `spectrum_id` `fits_path` regexp; auto-backfilled on `ADD COLUMN`).

Both get a `gin_trgm_ops` index. Predicate swapped in all 7 sites: `get_filtered_objects_paginated` (count + page), `get_filtered_object_ids`, `get_csv_export_objects`, `get_adjacent_objects`, `get_filtered_spectra_paginated`, `get_csv_export_spectra`.

**RPC signatures are unchanged → no web change required.** Search now also matches canonical `program_slug`/`observation` tokens that aren't substrings of the target_id (e.g. `egs_bubbles` → targets named `mason_egs_p3_*`).

## Validation

- Prod: 9.6 s → 133 ms (72×, 20× fewer buffers) via the existing `object_id` trgm index as a proxy, under the exact `ORDER BY` + `LIMIT` + admin-RLS conditions.
- Local: `supabase db reset` + seed applies clean; 148 Python tests pass; object / spectra / object_ids search verified across object-id, target-id, program, observation and source-id fragments; no-search regression intact (returns all active).
- `search_text` added to `enforce_object_user_update_scope` so non-admin PostgREST writes can't tamper with it.

## Notes

- Migration was hand-trimmed from `supabase db diff` to drop spurious view/MV/`accessible_program_slugs` churn that migra cascades from the table `ADD COLUMN` (avoids the `restore_mv_unique_indexes` class of incident).
- The `spectra.search_text` `ADD COLUMN` rewrites the spectra table once (generated column) — a brief `ACCESS EXCLUSIVE` on prod (~50k rows); run in a low-traffic window. The two trgm indexes build sub-second at current size (plain `CREATE INDEX`, per request).
- Design + full audit context: `docs/db_recommendations_2026-06-19.md`; raw multi-agent audit: `docs/db_audit_2026-06-19.md`.

Generated with Claude Code

https://claude.ai/code/session_01Gn6UNiTEE7MNcseKZjMASh