### PR TITLE
fix(search): semijoin so objects/spectra search stops timing out

### DIFF
--- a/supabase/migrations/20260620064622_fix_search_semijoin.sql
+++ b/supabase/migrations/20260620064622_fix_search_semijoin.sql
@@ -1,0 +1,1281 @@
+-- Fix: the bare `search_text ILIKE '%'||p_search||'%'` predicate (PR #188) let the
+-- planner mis-estimate ILIKE selectivity and fall back to walking objects_object_id_key
+-- under ORDER BY object_id + LIMIT (the original 9.6s full-scan trap). Wrap search as a
+-- semijoin `id IN (SELECT id FROM <table> WHERE search_text ILIKE ...)` so the candidate
+-- set is computed first; the ordered-scan gamble is no longer in the plan space.
+-- Validated on prod (read-only): 9.6s -> 88ms selective, 433ms broad (1273 matches).
+-- Hand-trimmed from `supabase db diff` to drop spurious view/MV/accessible churn.
+
+
+
+
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_adjacent_objects(p_current_object_id text, p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_list_ids integer[] DEFAULT NULL::integer[], p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_sort_column text DEFAULT 'object_id'::text, p_sort_direction text DEFAULT 'asc'::text, p_has_photometry boolean DEFAULT NULL::boolean, p_photo_z_min double precision DEFAULT NULL::double precision, p_photo_z_max double precision DEFAULT NULL::double precision, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid)
+ RETURNS TABLE(prev_object_id text, next_object_id text, current_index bigint, total_count bigint)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_sort_is_text BOOLEAN;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN v_gratings_mode := 'any'; END IF;
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+  IF v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN
+    p_sort_column := 'distance';
+    p_sort_direction := 'asc';
+  END IF;
+  v_sort_is_text := p_sort_column IN ('object_id', 'field');
+
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs))
+    INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN QUERY SELECT NULL::TEXT, NULL::TEXT, 0::BIGINT, 0::BIGINT;
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  WITH filtered_objects AS MATERIALIZED (
+    SELECT
+      o.object_id,
+      CASE WHEN v_coord_search_active THEN
+        2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        )))
+      ELSE NULL END AS distance,
+      o.field, o.ra, o.dec, o.redshift, o.redshift_quality,
+      o.n_targets, o.n_spectra, o.max_snr, o.max_exposure_time
+    FROM objects o
+    WHERE
+      o.programs && v_filtered_program_slugs
+      AND o.is_active = true
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+        OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+        OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+      )
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
+      AND (p_inspected_only IS NULL
+        OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+        OR (p_inspected_only = FALSE AND o.redshift_quality = 0))
+      AND (p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at))))
+      AND (NOT v_coord_search_active OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+      ))
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+      AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+      AND (
+        NOT v_comment_search_active
+        OR EXISTS (
+          SELECT 1 FROM comments c
+          WHERE c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+            AND (
+              c.object_id = o.id
+              OR c.target_id IN (SELECT t.id FROM targets t WHERE t.object_id = o.id)
+            )
+        )
+      )
+  ),
+  distance_filtered AS MATERIALIZED (
+    SELECT
+      fo.*,
+      CASE p_sort_column
+        WHEN 'object_id' THEN fo.object_id WHEN 'field' THEN fo.field ELSE NULL
+      END AS sort_text,
+      CASE p_sort_column
+        WHEN 'ra' THEN fo.ra WHEN 'dec' THEN fo.dec
+        WHEN 'redshift' THEN fo.redshift
+        WHEN 'redshift_quality' THEN fo.redshift_quality::DOUBLE PRECISION
+        WHEN 'n_targets' THEN fo.n_targets::DOUBLE PRECISION
+        WHEN 'n_spectra' THEN fo.n_spectra::DOUBLE PRECISION
+        WHEN 'max_snr' THEN fo.max_snr WHEN 'max_exposure_time' THEN fo.max_exposure_time
+        WHEN 'distance' THEN fo.distance ELSE NULL
+      END AS sort_num
+    FROM filtered_objects fo
+    WHERE NOT v_coord_search_active OR fo.distance <= p_radius_degrees
+  ),
+  current_obj AS (
+    SELECT df.sort_text, df.sort_num, df.object_id FROM distance_filtered df WHERE df.object_id = p_current_object_id
+  )
+  SELECT
+    (SELECT df.object_id FROM distance_filtered df, current_obj c
+     WHERE CASE WHEN v_sort_is_text THEN
+       (CASE WHEN p_sort_direction = 'asc' THEN df.sort_text < c.sort_text ELSE df.sort_text > c.sort_text END)
+       OR (df.sort_text IS NOT DISTINCT FROM c.sort_text AND df.object_id < c.object_id)
+       OR (df.sort_text IS NOT NULL AND c.sort_text IS NULL)
+     ELSE
+       (CASE WHEN p_sort_direction = 'asc' THEN df.sort_num < c.sort_num ELSE df.sort_num > c.sort_num END)
+       OR (df.sort_num IS NOT DISTINCT FROM c.sort_num AND df.object_id < c.object_id)
+       OR (df.sort_num IS NOT NULL AND c.sort_num IS NULL)
+     END
+     ORDER BY
+       CASE WHEN v_sort_is_text AND p_sort_direction = 'asc' THEN df.sort_text END DESC NULLS FIRST,
+       CASE WHEN v_sort_is_text AND p_sort_direction = 'desc' THEN df.sort_text END ASC NULLS FIRST,
+       CASE WHEN NOT v_sort_is_text AND p_sort_direction = 'asc' THEN df.sort_num END DESC NULLS FIRST,
+       CASE WHEN NOT v_sort_is_text AND p_sort_direction = 'desc' THEN df.sort_num END ASC NULLS FIRST,
+       df.object_id DESC
+     LIMIT 1
+    ) AS prev_object_id,
+    (SELECT df.object_id FROM distance_filtered df, current_obj c
+     WHERE CASE WHEN v_sort_is_text THEN
+       (CASE WHEN p_sort_direction = 'asc' THEN df.sort_text > c.sort_text ELSE df.sort_text < c.sort_text END)
+       OR (df.sort_text IS NOT DISTINCT FROM c.sort_text AND df.object_id > c.object_id)
+       OR (c.sort_text IS NOT NULL AND df.sort_text IS NULL)
+     ELSE
+       (CASE WHEN p_sort_direction = 'asc' THEN df.sort_num > c.sort_num ELSE df.sort_num < c.sort_num END)
+       OR (df.sort_num IS NOT DISTINCT FROM c.sort_num AND df.object_id > c.object_id)
+       OR (c.sort_num IS NOT NULL AND df.sort_num IS NULL)
+     END
+     ORDER BY
+       CASE WHEN v_sort_is_text AND p_sort_direction = 'asc' THEN df.sort_text END ASC NULLS LAST,
+       CASE WHEN v_sort_is_text AND p_sort_direction = 'desc' THEN df.sort_text END DESC NULLS LAST,
+       CASE WHEN NOT v_sort_is_text AND p_sort_direction = 'asc' THEN df.sort_num END ASC NULLS LAST,
+       CASE WHEN NOT v_sort_is_text AND p_sort_direction = 'desc' THEN df.sort_num END DESC NULLS LAST,
+       df.object_id ASC
+     LIMIT 1
+    ) AS next_object_id,
+    CASE WHEN EXISTS (SELECT 1 FROM current_obj) THEN (
+      SELECT COUNT(*) + 1
+      FROM distance_filtered df, current_obj c
+      WHERE CASE WHEN v_sort_is_text THEN
+        (CASE WHEN p_sort_direction = 'asc' THEN df.sort_text < c.sort_text ELSE df.sort_text > c.sort_text END)
+        OR (df.sort_text IS NOT DISTINCT FROM c.sort_text AND df.object_id < c.object_id)
+        OR (df.sort_text IS NOT NULL AND c.sort_text IS NULL)
+      ELSE
+        (CASE WHEN p_sort_direction = 'asc' THEN df.sort_num < c.sort_num ELSE df.sort_num > c.sort_num END)
+        OR (df.sort_num IS NOT DISTINCT FROM c.sort_num AND df.object_id < c.object_id)
+        OR (df.sort_num IS NOT NULL AND c.sort_num IS NULL)
+      END
+    )::BIGINT ELSE 0::BIGINT END AS current_index,
+    (SELECT COUNT(*) FROM distance_filtered)::BIGINT AS total_count;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_csv_export_objects(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_list_ids integer[] DEFAULT NULL::integer[], p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_has_photometry boolean DEFAULT NULL::boolean, p_photo_z_min double precision DEFAULT NULL::double precision, p_photo_z_max double precision DEFAULT NULL::double precision, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_sort_column text DEFAULT 'object_id'::text, p_sort_direction text DEFAULT 'asc'::text)
+ RETURNS TABLE(object_id text, field text, ra double precision, "dec" double precision, redshift numeric, redshift_quality integer, redshift_inspected numeric, redshift_auto double precision, last_inspected_at timestamp with time zone, last_inspected_by text, last_data_change_at timestamp with time zone, staleness_reason text, version integer, n_targets integer, n_spectra integer, programs text, gratings text, max_snr double precision, max_exposure_time double precision, member_target_ids text, distance double precision, lists text, has_photometry boolean, photo_z double precision, photo_z_err_lo double precision, photo_z_err_hi double precision, photometry jsonb)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN v_gratings_mode := 'any'; END IF;
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time', 'photo_z'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs)) INTO v_filtered_program_slugs;
+  ELSE v_filtered_program_slugs := p_program_slugs; END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN RETURN; END IF;
+
+  RETURN QUERY
+  WITH member_targets AS (
+    SELECT t.object_id, string_agg(t.target_id, ';' ORDER BY t.target_id) AS member_target_ids
+    FROM targets t
+    WHERE t.program_slug = ANY(v_filtered_program_slugs)
+    GROUP BY t.object_id
+  ),
+  visible_lists AS (
+    SELECT olm.object_id, string_agg(ol.slug, ';' ORDER BY ol.slug) AS lists
+    FROM object_list_members olm
+    JOIN object_lists ol ON ol.id = olm.list_id
+    WHERE ol.created_by = auth.uid() OR ol.visibility IN ('public_read', 'public_edit')
+    GROUP BY olm.object_id
+  ),
+  filtered_objects AS (
+    SELECT o.object_id, o.field, o.ra, o.dec,
+      o.redshift, o.redshift_quality,
+      o.redshift_inspected, o.redshift_auto,
+      o.last_inspected_at, up.full_name AS last_inspected_by,
+      o.last_data_change_at, o.staleness_reason, o.version,
+      o.n_targets, o.n_spectra,
+      array_to_string(o.programs, ';') AS programs,
+      array_to_string(o.gratings, ';') AS gratings,
+      o.max_snr, o.max_exposure_time,
+      mt.member_target_ids,
+      CASE WHEN v_coord_search_active THEN
+        2 * DEGREES(ASIN(SQRT(POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) + COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) * POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2))))
+      ELSE NULL END AS distance,
+      vl.lists,
+      o.has_photometry, o.photo_z, o.photo_z_err_lo, o.photo_z_err_hi,
+      phot.photometry
+    FROM objects o
+    LEFT JOIN member_targets mt ON mt.object_id = o.id
+    LEFT JOIN visible_lists vl ON vl.object_id = o.id
+    LEFT JOIN user_profiles up ON up.user_id = o.last_inspected_by
+    LEFT JOIN LATERAL (
+      SELECT op.photometry FROM object_photometry op
+      WHERE op.object_id = o.id ORDER BY op.updated_at DESC LIMIT 1
+    ) phot ON true
+    WHERE o.programs && v_filtered_program_slugs
+      AND o.is_active = true
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+        OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+        OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+      )
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
+      AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.redshift_quality > 0) OR (p_inspected_only = FALSE AND o.redshift_quality = 0))
+      AND (p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at))))
+      AND (NOT v_coord_search_active OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+      ))
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+      AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+      AND (
+        NOT v_comment_search_active
+        OR EXISTS (
+          SELECT 1 FROM comments c
+          WHERE c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+            AND (
+              c.object_id = o.id
+              OR c.target_id IN (SELECT t.id FROM targets t WHERE t.object_id = o.id)
+            )
+        )
+      )
+  ),
+  distance_filtered AS (SELECT fo.* FROM filtered_objects fo WHERE NOT v_coord_search_active OR fo.distance <= p_radius_degrees)
+  SELECT df.object_id, df.field, df.ra, df.dec,
+    df.redshift, df.redshift_quality,
+    df.redshift_inspected, df.redshift_auto,
+    df.last_inspected_at, df.last_inspected_by,
+    df.last_data_change_at, df.staleness_reason, df.version,
+    df.n_targets, df.n_spectra,
+    df.programs, df.gratings,
+    df.max_snr, df.max_exposure_time,
+    df.member_target_ids, df.distance, df.lists,
+    df.has_photometry, df.photo_z, df.photo_z_err_lo, df.photo_z_err_hi,
+    df.photometry
+  FROM distance_filtered df
+  ORDER BY
+    CASE WHEN v_coord_search_active THEN df.distance END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN df.object_id END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'desc' THEN df.object_id END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'asc' THEN df.field END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'desc' THEN df.field END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN df.ra END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN df.ra END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN df.dec END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN df.dec END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN df.redshift END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN df.redshift END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN df.redshift_quality END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN df.redshift_quality END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_targets' AND p_sort_direction = 'asc' THEN df.n_targets END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_targets' AND p_sort_direction = 'desc' THEN df.n_targets END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_spectra' AND p_sort_direction = 'asc' THEN df.n_spectra END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_spectra' AND p_sort_direction = 'desc' THEN df.n_spectra END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN df.max_snr END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN df.max_snr END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN df.max_exposure_time END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN df.max_exposure_time END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'photo_z' AND p_sort_direction = 'asc' THEN df.photo_z END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'photo_z' AND p_sort_direction = 'desc' THEN df.photo_z END DESC NULLS LAST,
+    df.object_id ASC;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_csv_export_spectra(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_dq_flags_include_any integer DEFAULT NULL::integer, p_dq_flags_include_all integer DEFAULT NULL::integer, p_dq_flags_exclude integer DEFAULT NULL::integer, p_list_ids integer[] DEFAULT NULL::integer[], p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_has_photometry boolean DEFAULT NULL::boolean, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_sort_column text DEFAULT 'target_id'::text, p_sort_direction text DEFAULT 'asc'::text)
+ RETURNS TABLE(spectrum_id text, target_id text, grating text, field text, ra double precision, "dec" double precision, redshift numeric, redshift_quality integer, redshift_auto double precision, signal_to_noise double precision, exposure_time double precision, fits_path text, program_slug text, program_name text, last_inspected_at timestamp with time zone, last_inspected_by text, distance double precision, dq_flags integer, lists text)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (p_comment_search IS NOT NULL AND p_comment_search != '' AND p_comment_search_scope IN ('just_me', 'everyone'));
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
+  IF NOT (p_sort_column IN ('target_id', 'spectrum_id', 'field', 'observation', 'ra', 'dec', 'redshift', 'redshift_quality', 'redshift_auto', 'signal_to_noise', 'exposure_time', 'grating')
+       OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'spectrum_id';
+  END IF;
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs)) INTO v_filtered_program_slugs;
+  ELSE v_filtered_program_slugs := p_program_slugs; END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN RETURN; END IF;
+
+  RETURN QUERY
+  WITH visible_lists AS (
+    SELECT olm.object_id, string_agg(ol.slug, ';' ORDER BY ol.slug) AS lists
+    FROM object_list_members olm
+    JOIN object_lists ol ON ol.id = olm.list_id
+    WHERE ol.created_by = auth.uid() OR ol.visibility IN ('public_read', 'public_edit')
+    GROUP BY olm.object_id
+  ),
+  filtered_spectra AS (
+    SELECT s.spectrum_id, t.target_id, s.grating, t.field, t.ra, t.dec,
+      o.redshift, o.redshift_quality,
+      s.redshift_auto,
+      s.signal_to_noise, s.exposure_time, s.fits_path, t.program_slug, t.observation,
+      o.last_inspected_at, o.last_inspected_by,
+      CASE WHEN v_coord_search_active THEN
+        2 * DEGREES(ASIN(SQRT(POWER(SIN(RADIANS(t.dec - p_coord_dec) / 2), 2) + COS(RADIANS(p_coord_dec)) * COS(RADIANS(t.dec)) * POWER(SIN(RADIANS(t.ra - p_coord_ra) / 2), 2))))
+      ELSE NULL END AS distance,
+      COALESCE(s.dq_flags, 0) AS dq_flags,
+      vl.lists
+    FROM targets t
+    JOIN spectra s ON s.target_id = t.target_id
+    LEFT JOIN objects o ON o.id = t.object_id
+    LEFT JOIN visible_lists vl ON vl.object_id = t.object_id
+    WHERE t.program_slug = ANY(v_filtered_program_slugs)
+      AND (o.id IS NULL OR o.is_active = true)
+      AND (NOT v_grating_filter_active OR s.grating = ANY(p_gratings))
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR t.field = ANY(p_fields))
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR t.observation = ANY(p_observations))
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min) AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR s.signal_to_noise >= p_max_snr_min) AND (p_max_snr_max IS NULL OR s.signal_to_noise <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR s.exposure_time >= p_max_exposure_time_min) AND (p_max_exposure_time_max IS NULL OR s.exposure_time <= p_max_exposure_time_max)
+      AND (p_dq_flags_include_any IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_any) != 0)
+      AND (p_dq_flags_include_all IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_all) = p_dq_flags_include_all)
+      AND (p_dq_flags_exclude IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_exclude) = 0)
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR t.object_id IN (
+          SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_search IS NULL OR s.id IN (SELECT __s.id FROM public.spectra __s WHERE __s.search_text ILIKE '%' || p_search || '%'))
+      AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.redshift_quality > 0) OR (p_inspected_only = FALSE AND COALESCE(o.redshift_quality, 0) = 0))
+      AND (p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at))))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (NOT v_comment_search_active OR EXISTS (
+        SELECT 1 FROM comments c WHERE c.target_id = t.id AND c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (p_comment_search_scope = 'everyone' OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id))))
+      AND (NOT v_coord_search_active OR (
+        t.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND t.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)))
+  ),
+  distance_filtered AS (SELECT fs.* FROM filtered_spectra fs WHERE NOT v_coord_search_active OR fs.distance <= p_radius_degrees)
+  SELECT df.spectrum_id, df.target_id, df.grating, df.field, df.ra, df.dec, df.redshift, df.redshift_quality, df.redshift_auto,
+    df.signal_to_noise, df.exposure_time, df.fits_path, df.program_slug,
+    pr.program_name, df.last_inspected_at, up.full_name AS last_inspected_by,
+    df.distance, df.dq_flags, df.lists
+  FROM distance_filtered df
+  LEFT JOIN programs pr ON pr.slug = df.program_slug
+  LEFT JOIN user_profiles up ON up.user_id = df.last_inspected_by
+  ORDER BY
+    CASE WHEN v_coord_search_active THEN df.distance END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'spectrum_id' AND p_sort_direction = 'asc' THEN df.spectrum_id END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'spectrum_id' AND p_sort_direction = 'desc' THEN df.spectrum_id END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'target_id' AND p_sort_direction = 'asc' THEN df.target_id END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'target_id' AND p_sort_direction = 'desc' THEN df.target_id END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'asc' THEN df.field END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'desc' THEN df.field END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'observation' AND p_sort_direction = 'asc' THEN df.observation END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'observation' AND p_sort_direction = 'desc' THEN df.observation END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN df.ra END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN df.ra END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN df.dec END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN df.dec END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN df.redshift END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN df.redshift END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN df.redshift_quality END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN df.redshift_quality END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_auto' AND p_sort_direction = 'asc' THEN df.redshift_auto END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_auto' AND p_sort_direction = 'desc' THEN df.redshift_auto END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'signal_to_noise' AND p_sort_direction = 'asc' THEN df.signal_to_noise END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'signal_to_noise' AND p_sort_direction = 'desc' THEN df.signal_to_noise END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'exposure_time' AND p_sort_direction = 'asc' THEN df.exposure_time END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'exposure_time' AND p_sort_direction = 'desc' THEN df.exposure_time END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'grating' AND p_sort_direction = 'asc' THEN df.grating END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'grating' AND p_sort_direction = 'desc' THEN df.grating END DESC NULLS LAST,
+    df.target_id ASC, df.grating ASC;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_filtered_object_ids(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_list_ids integer[] DEFAULT NULL::integer[], p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_has_photometry boolean DEFAULT NULL::boolean, p_photo_z_min double precision DEFAULT NULL::double precision, p_photo_z_max double precision DEFAULT NULL::double precision, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_sort_column text DEFAULT 'object_id'::text, p_sort_direction text DEFAULT 'asc'::text)
+ RETURNS TABLE(object_id text)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
+    v_gratings_mode := 'any';
+  END IF;
+
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN
+    p_sort_direction := 'asc';
+  END IF;
+
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time', 'photo_z'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+
+  -- Intersect user-accessible programs with filter selection
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(
+      SELECT unnest(p_program_slugs)
+      INTERSECT
+      SELECT unnest(p_filter_programs)
+    ) INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT o.object_id
+  FROM objects o
+  WHERE
+    o.programs && v_filtered_program_slugs
+    AND o.is_active = true
+    AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+    AND (
+      NOT v_grating_filter_active
+      OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+      OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+      OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+    )
+    AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+    AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+    AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+    AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+    AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+    AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+    AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+    AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+    AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
+    AND (
+      p_inspected_only IS NULL
+      OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+      OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+    )
+    AND (
+      p_needs_review IS NULL
+      OR (p_needs_review = TRUE
+          AND o.staleness_reason IS NOT NULL
+          AND o.last_inspected_at IS NOT NULL
+          AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+      OR (p_needs_review = FALSE
+          AND (o.staleness_reason IS NULL
+               OR o.last_inspected_at IS NULL
+               OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+    )
+    AND (
+      NOT v_coord_search_active
+      OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+        AND 2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) <= p_radius_degrees
+      )
+    )
+    AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+        SELECT olm.object_id FROM object_list_members olm
+        WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+    ))
+    AND (
+      NOT v_comment_search_active
+      OR EXISTS (
+        SELECT 1 FROM comments c
+        WHERE c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (
+            p_comment_search_scope = 'everyone'
+            OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+          )
+          AND (
+            c.object_id = o.id
+            OR c.target_id IN (SELECT t.id FROM targets t WHERE t.object_id = o.id)
+          )
+      )
+    )
+  ORDER BY
+    CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN
+      2 * DEGREES(ASIN(SQRT(
+        POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+        COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+        POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+      ))) END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN
+      2 * DEGREES(ASIN(SQRT(
+        POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+        COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+        POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+      ))) END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN o.object_id END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'desc' THEN o.object_id END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN o.field END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN o.field END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN o.ra END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN o.ra END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN o.dec END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN o.dec END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN o.redshift END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN o.redshift END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN o.redshift_quality END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN o.redshift_quality END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'asc' THEN o.n_targets END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'desc' THEN o.n_targets END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'asc' THEN o.n_spectra END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'desc' THEN o.n_spectra END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN o.max_snr END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN o.max_snr END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN o.max_exposure_time END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN o.max_exposure_time END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'asc' THEN o.photo_z END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'desc' THEN o.photo_z END DESC NULLS LAST,
+    o.object_id ASC;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_filtered_objects_paginated(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_list_ids integer[] DEFAULT NULL::integer[], p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_has_photometry boolean DEFAULT NULL::boolean, p_photo_z_min double precision DEFAULT NULL::double precision, p_photo_z_max double precision DEFAULT NULL::double precision, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_sort_column text DEFAULT 'object_id'::text, p_sort_direction text DEFAULT 'asc'::text, p_page integer DEFAULT 1, p_page_size integer DEFAULT 50)
+ RETURNS TABLE(targets jsonb, total_count bigint, page integer, page_size integer)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_offset INTEGER;
+  v_total_count BIGINT;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
+    v_gratings_mode := 'any';
+  END IF;
+
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN
+    p_sort_direction := 'asc';
+  END IF;
+
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time', 'photo_z'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+
+  IF v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN
+    p_sort_column := 'distance';
+  END IF;
+
+  v_offset := (COALESCE(p_page, 1) - 1) * COALESCE(p_page_size, 50);
+
+  -- Intersect user-accessible programs with filter selection
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(
+      SELECT unnest(p_program_slugs)
+      INTERSECT
+      SELECT unnest(p_filter_programs)
+    ) INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN QUERY SELECT '[]'::jsonb, 0::BIGINT, p_page, p_page_size;
+    RETURN;
+  END IF;
+
+  -- Step 1: count
+  SELECT COUNT(*) INTO v_total_count
+  FROM objects o
+  WHERE
+    -- Access control: object must have at least one accessible program
+    o.programs && v_filtered_program_slugs
+    AND o.is_active = true
+    AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+    AND (
+      NOT v_grating_filter_active
+      OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+      OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+      OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+    )
+    AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+    AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+    AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+    AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+    AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+    AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+    AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+    AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+    AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
+    AND (
+      p_inspected_only IS NULL
+      OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+      OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+    )
+    AND (
+      p_needs_review IS NULL
+      OR (p_needs_review = TRUE
+          AND o.staleness_reason IS NOT NULL
+          AND o.last_inspected_at IS NOT NULL
+          AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+      OR (p_needs_review = FALSE
+          AND (o.staleness_reason IS NULL
+               OR o.last_inspected_at IS NULL
+               OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+    )
+    AND (
+      NOT v_coord_search_active
+      OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+        AND 2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) <= p_radius_degrees
+      )
+    )
+    AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+        SELECT olm.object_id FROM object_list_members olm
+        WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+    ))
+    AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+    AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+    AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+    AND (
+      NOT v_comment_search_active
+      OR EXISTS (
+        SELECT 1 FROM comments c
+        WHERE c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (
+            p_comment_search_scope = 'everyone'
+            OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+          )
+          AND (
+            c.object_id = o.id
+            OR c.target_id IN (SELECT t.id FROM targets t WHERE t.object_id = o.id)
+          )
+      )
+    );
+
+  -- Step 2: fetch page
+  RETURN QUERY
+  WITH filtered_objects AS (
+    SELECT
+      o.id,
+      o.object_id,
+      o.field,
+      o.ra,
+      o.dec,
+      o.n_targets,
+      o.n_spectra,
+      o.programs,
+      o.gratings,
+      o.max_snr,
+      o.max_exposure_time,
+      o.redshift,
+      o.redshift_quality,
+      o.redshift_inspected,
+      o.redshift_auto,
+      o.inspected_used_auto,
+      o.last_inspected_at,
+      o.last_inspected_by,
+      o.last_data_change_at,
+      o.staleness_reason,
+      o.version,
+      o.is_active,
+      o.photo_z,
+      o.has_photometry,
+      o.created_at,
+      CASE
+        WHEN v_coord_search_active THEN
+          2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+            POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+          )))
+        ELSE NULL
+      END AS distance
+    FROM objects o
+    WHERE
+      o.programs && v_filtered_program_slugs
+      AND o.is_active = true
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+        OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+        OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+      )
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
+      AND (
+        p_inspected_only IS NULL
+        OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+        OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+      )
+      AND (
+        p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+      )
+      AND (
+        NOT v_coord_search_active
+        OR (
+          o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+          AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+          AND 2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+            POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+          ))) <= p_radius_degrees
+        )
+      )
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+      AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+      AND (
+        NOT v_comment_search_active
+        OR EXISTS (
+          SELECT 1 FROM comments c
+          WHERE c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+            AND (
+              c.object_id = o.id
+              OR c.target_id IN (SELECT t.id FROM targets t WHERE t.object_id = o.id)
+            )
+        )
+      )
+    ORDER BY
+      CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN
+        2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN
+        2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN o.object_id END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'desc' THEN o.object_id END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN o.field END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN o.field END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN o.ra END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN o.ra END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN o.dec END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN o.dec END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN o.redshift END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN o.redshift END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN o.redshift_quality END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN o.redshift_quality END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'asc' THEN o.n_targets END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'desc' THEN o.n_targets END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'asc' THEN o.n_spectra END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'desc' THEN o.n_spectra END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN o.max_snr END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN o.max_snr END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN o.max_exposure_time END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN o.max_exposure_time END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'asc' THEN o.photo_z END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'desc' THEN o.photo_z END DESC NULLS LAST,
+      o.object_id ASC
+    LIMIT p_page_size OFFSET v_offset
+  ),
+  with_members AS (
+    SELECT
+      jsonb_build_object(
+        'id', fo.id,
+        'object_id', fo.object_id,
+        'field', fo.field,
+        'ra', fo.ra,
+        'dec', fo.dec,
+        'n_targets', fo.n_targets,
+        'n_spectra', fo.n_spectra,
+        'programs', fo.programs,
+        'gratings', fo.gratings,
+        'max_snr', fo.max_snr,
+        'max_exposure_time', fo.max_exposure_time,
+        'redshift', fo.redshift,
+        'redshift_quality', fo.redshift_quality,
+        'redshift_inspected', fo.redshift_inspected,
+        'redshift_auto', fo.redshift_auto,
+        'inspected_used_auto', fo.inspected_used_auto,
+        'last_inspected_at', fo.last_inspected_at,
+        'last_inspected_by', fo.last_inspected_by,
+        'last_data_change_at', fo.last_data_change_at,
+        'staleness_reason', fo.staleness_reason,
+        'version', fo.version,
+        'is_active', fo.is_active,
+        'photo_z', fo.photo_z,
+        'has_photometry', fo.has_photometry,
+        'created_at', fo.created_at,
+        'distance', fo.distance,
+        -- Phase D: member_targets becomes provenance only (target_id, program,
+        -- observation). Inspection state lives on the object now; redshift_auto
+        -- on targets is retained for transitional UI display until Phase E.
+        'member_targets', COALESCE(
+          (SELECT jsonb_agg(
+            jsonb_build_object(
+              'target_id', t.target_id,
+              'program_slug', t.program_slug,
+              'observation', t.observation,
+              'redshift_auto', t.redshift_auto
+            )
+          )
+          FROM targets t
+          WHERE t.object_id = fo.id
+            AND t.program_slug = ANY(v_filtered_program_slugs)
+          ),
+          '[]'::jsonb
+        ),
+        'lists', COALESCE(
+          (SELECT jsonb_agg(
+            jsonb_build_object(
+              'id', ol.id,
+              'name', ol.name,
+              'slug', ol.slug,
+              'icon', ol.icon,
+              'color', ol.color
+            ) ORDER BY ol.name
+          )
+          FROM object_list_members olm
+          JOIN object_lists ol ON ol.id = olm.list_id
+          WHERE olm.object_id = fo.id),
+          '[]'::jsonb
+        )
+      ) AS obj_json
+    FROM filtered_objects fo
+  )
+  SELECT
+    COALESCE(jsonb_agg(wm.obj_json), '[]'::jsonb),
+    v_total_count,
+    p_page,
+    p_page_size
+  FROM with_members wm;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_filtered_spectra_paginated(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_dq_flags_include_any integer DEFAULT NULL::integer, p_dq_flags_include_all integer DEFAULT NULL::integer, p_dq_flags_exclude integer DEFAULT NULL::integer, p_list_ids integer[] DEFAULT NULL::integer[], p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_has_photometry boolean DEFAULT NULL::boolean, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_sort_column text DEFAULT 'target_id'::text, p_sort_direction text DEFAULT 'asc'::text, p_page integer DEFAULT 1, p_page_size integer DEFAULT 50, p_include_thumbnails boolean DEFAULT false)
+ RETURNS TABLE(targets jsonb, total_count bigint, page integer, page_size integer)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_offset INTEGER;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
+    v_gratings_mode := 'any';
+  END IF;
+
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN
+    p_sort_direction := 'asc';
+  END IF;
+
+  IF NOT (p_sort_column IN (
+    'target_id', 'spectrum_id', 'field', 'observation', 'program_slug', 'ra', 'dec', 'redshift',
+    'redshift_quality', 'redshift_auto', 'signal_to_noise', 'exposure_time', 'grating'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'spectrum_id';
+  END IF;
+
+  IF v_coord_search_active AND p_sort_column IN ('target_id', 'spectrum_id') AND p_sort_direction = 'asc' THEN
+    p_sort_column := 'distance';
+  END IF;
+
+  v_offset := (COALESCE(p_page, 1) - 1) * COALESCE(p_page_size, 50);
+
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(
+      SELECT unnest(p_program_slugs)
+      INTERSECT
+      SELECT unnest(p_filter_programs)
+    ) INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN QUERY SELECT '[]'::jsonb, 0::BIGINT, p_page, p_page_size;
+    RETURN;
+  END IF;
+
+  -- Single-pass CTE: filtered_spectra is referenced by both distance_filtered
+  -- and the count subquery, so PostgreSQL materializes it once.
+  RETURN QUERY
+  WITH filtered_spectra AS (
+    SELECT
+      t.id AS tgt_db_id,
+      t.target_id,
+      t.program_slug,
+      t.field,
+      t.observation,
+      t.ra,
+      t.dec,
+      -- Phase D: redshift / redshift_quality / inspected flags now live on the
+      -- parent object. LEFT JOIN so spectra whose target has no object FK
+      -- (shouldn't happen post-reconcile, but safe) still appear.
+      o.redshift,
+      o.redshift_quality,
+      o.redshift_inspected,
+      o.last_inspected_at,
+      o.last_inspected_by,
+      o.is_active AS object_is_active,
+      o.has_photometry AS object_has_photometry,
+      o.object_id AS parent_object_id,
+      t.max_snr,
+      t.max_exposure_time,
+      t.created_at,
+      t.updated_at,
+      s.id AS spectrum_pk,
+      s.spectrum_id,
+      s.grating,
+      s.fits_path,
+      s.signal_to_noise,
+      s.exposure_time,
+      s.redshift_auto,
+      COALESCE(s.dq_flags, 0) AS dq_flags,
+      s.file_hash,
+      s.file_size,
+      s.thumbnail_svg_fnu,
+      s.thumbnail_svg_flambda,
+      CASE
+        WHEN v_coord_search_active THEN
+          2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(t.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(t.dec)) *
+            POWER(SIN(RADIANS(t.ra - p_coord_ra) / 2), 2)
+          )))
+        ELSE NULL
+      END AS distance
+    FROM targets t
+    JOIN spectra s ON s.target_id = t.target_id
+    LEFT JOIN objects o ON o.id = t.object_id
+    WHERE
+      t.program_slug = ANY(v_filtered_program_slugs)
+      -- Hide spectra whose parent object was soft-deleted.
+      AND (o.id IS NULL OR o.is_active = true)
+      AND (NOT v_grating_filter_active OR s.grating = ANY(p_gratings))
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR t.field = ANY(p_fields))
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR t.observation = ANY(p_observations))
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR s.signal_to_noise >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR s.signal_to_noise <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR s.exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR s.exposure_time <= p_max_exposure_time_max)
+      AND (p_dq_flags_include_any IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_any) != 0)
+      AND (p_dq_flags_include_all IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_all) = p_dq_flags_include_all)
+      AND (p_dq_flags_exclude IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_exclude) = 0)
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR t.object_id IN (
+          SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_search IS NULL OR s.id IN (SELECT __s.id FROM public.spectra __s WHERE __s.search_text ILIKE '%' || p_search || '%'))
+      AND (
+        p_inspected_only IS NULL
+        OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+        OR (p_inspected_only = FALSE AND COALESCE(o.redshift_quality, 0) = 0)
+      )
+      AND (
+        p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+      )
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (
+        NOT v_comment_search_active
+        OR EXISTS (
+          SELECT 1 FROM comments c
+          WHERE c.target_id = t.id
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+        )
+      )
+      AND (
+        NOT v_coord_search_active
+        OR (
+          t.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+          AND t.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+        )
+      )
+  ),
+  distance_filtered AS (
+    SELECT fs.*
+    FROM filtered_spectra fs
+    WHERE NOT v_coord_search_active OR fs.distance <= p_radius_degrees
+  ),
+  page_rows AS (
+    SELECT *, ROW_NUMBER() OVER () as row_num
+    FROM (
+      SELECT * FROM distance_filtered
+      ORDER BY
+        CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN distance END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN distance END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'target_id' AND p_sort_direction = 'asc' THEN target_id END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'target_id' AND p_sort_direction = 'desc' THEN target_id END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'spectrum_id' AND p_sort_direction = 'asc' THEN spectrum_id END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'spectrum_id' AND p_sort_direction = 'desc' THEN spectrum_id END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN field END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN field END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'observation' AND p_sort_direction = 'asc' THEN observation END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'observation' AND p_sort_direction = 'desc' THEN observation END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'program_slug' AND p_sort_direction = 'asc' THEN program_slug END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'program_slug' AND p_sort_direction = 'desc' THEN program_slug END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN ra END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN ra END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN "dec" END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN "dec" END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN redshift END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN redshift END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN redshift_quality END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN redshift_quality END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift_auto' AND p_sort_direction = 'asc' THEN redshift_auto END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift_auto' AND p_sort_direction = 'desc' THEN redshift_auto END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'signal_to_noise' AND p_sort_direction = 'asc' THEN signal_to_noise END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'signal_to_noise' AND p_sort_direction = 'desc' THEN signal_to_noise END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'exposure_time' AND p_sort_direction = 'asc' THEN exposure_time END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'exposure_time' AND p_sort_direction = 'desc' THEN exposure_time END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'grating' AND p_sort_direction = 'asc' THEN grating END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'grating' AND p_sort_direction = 'desc' THEN grating END DESC NULLS LAST,
+        target_id ASC, grating ASC
+      LIMIT p_page_size OFFSET v_offset
+    ) sorted_page
+  )
+  SELECT
+    COALESCE(jsonb_agg(jsonb_build_object(
+      'id', r.tgt_db_id,
+      'target_id', r.target_id,
+      'parent_object_id', r.parent_object_id,
+      'program_slug', r.program_slug,
+      'program_name', pr.program_name,
+      'field', r.field,
+      'observation', r.observation,
+      'ra', r.ra,
+      'dec', r.dec,
+      -- Phase D: redshift fields are object-level reads
+      'redshift', r.redshift,
+      'redshift_inspected', r.redshift_inspected,
+      'redshift_quality', r.redshift_quality,
+      'last_inspected_at', r.last_inspected_at,
+      'last_inspected_by', r.last_inspected_by,
+      'max_snr', r.max_snr,
+      'max_exposure_time', r.max_exposure_time,
+      'created_at', r.created_at,
+      'updated_at', r.updated_at,
+      'distance', CASE WHEN v_coord_search_active THEN r.distance ELSE NULL END,
+      'spectra', jsonb_build_array(jsonb_build_object(
+        'id', r.spectrum_pk,
+        'spectrum_id', r.spectrum_id,
+        'target_id', r.target_id,
+        'grating', r.grating,
+        'fits_path', r.fits_path,
+        'signal_to_noise', r.signal_to_noise,
+        'exposure_time', r.exposure_time,
+        -- Phase D: per-spectrum auto-z and DQ
+        'redshift_auto', r.redshift_auto,
+        'dq_flags', r.dq_flags,
+        'file_hash', r.file_hash,
+        'file_size', r.file_size,
+        'thumbnail_svg_fnu', CASE WHEN p_include_thumbnails THEN r.thumbnail_svg_fnu ELSE NULL END,
+        'thumbnail_svg_flambda', CASE WHEN p_include_thumbnails THEN r.thumbnail_svg_flambda ELSE NULL END
+      ))
+    ) ORDER BY r.row_num), '[]'::jsonb),
+    (SELECT COUNT(*) FROM distance_filtered),
+    p_page,
+    p_page_size
+  FROM page_rows r
+  LEFT JOIN programs pr ON pr.slug = r.program_slug;
+END;
+$function$
+;

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -672,7 +672,7 @@ BEGIN
       AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR t.object_id IN (
           SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
       ))
-      AND (p_search IS NULL OR s.search_text ILIKE '%' || p_search || '%')
+      AND (p_search IS NULL OR s.id IN (SELECT __s.id FROM public.spectra __s WHERE __s.search_text ILIKE '%' || p_search || '%'))
       AND (
         p_inspected_only IS NULL
         OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
@@ -921,7 +921,7 @@ BEGIN
     AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
     AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
     AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
-    AND (p_search IS NULL OR o.search_text ILIKE '%' || p_search || '%')
+    AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
     AND (
       p_inspected_only IS NULL
       OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
@@ -1031,7 +1031,7 @@ BEGIN
       AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
       AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
       AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
-      AND (p_search IS NULL OR o.search_text ILIKE '%' || p_search || '%')
+      AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
       AND (
         p_inspected_only IS NULL
         OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
@@ -1304,7 +1304,7 @@ BEGIN
     AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
     AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
     AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
-    AND (p_search IS NULL OR o.search_text ILIKE '%' || p_search || '%')
+    AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
     AND (
       p_inspected_only IS NULL
       OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
@@ -1509,7 +1509,7 @@ BEGIN
       AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
       AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
       AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
-      AND (p_search IS NULL OR o.search_text ILIKE '%' || p_search || '%')
+      AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
       AND (p_inspected_only IS NULL
         OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
         OR (p_inspected_only = FALSE AND o.redshift_quality = 0))
@@ -1735,7 +1735,7 @@ BEGIN
       AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR t.object_id IN (
           SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
       ))
-      AND (p_search IS NULL OR s.search_text ILIKE '%' || p_search || '%')
+      AND (p_search IS NULL OR s.id IN (SELECT __s.id FROM public.spectra __s WHERE __s.search_text ILIKE '%' || p_search || '%'))
       AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.redshift_quality > 0) OR (p_inspected_only = FALSE AND COALESCE(o.redshift_quality, 0) = 0))
       AND (p_needs_review IS NULL
         OR (p_needs_review = TRUE
@@ -1932,7 +1932,7 @@ BEGIN
       AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
       AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
       AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
-      AND (p_search IS NULL OR o.search_text ILIKE '%' || p_search || '%')
+      AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
       AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.redshift_quality > 0) OR (p_inspected_only = FALSE AND o.redshift_quality = 0))
       AND (p_needs_review IS NULL
         OR (p_needs_review = TRUE


### PR DESCRIPTION
## Follow-up to #188 — that fix didn't actually clear the timeout

#188 added `search_text` + a trgm index and swapped the predicate to `o.search_text ILIKE '%'||p_search||'%'`. Verified on prod after merge: **search still timed out** — inner query **7.4 s**, full RPC **9.0 s**.

**Why:** the planner mis-estimates `ILIKE` selectivity (`est rows=124` for a 9-row match) and, under `ORDER BY object_id LIMIT 50`, falls back to walking `objects_object_id_key` and applying `search_text` as a per-row filter → full 34k-row scan → the same trap #188 was meant to kill. My pre-deploy proxy used `object_id ILIKE '%J001403%'` (`est rows=2`), which dodged the trap; `search_text` estimates higher and falls in. The proxy wasn't faithful to the real selectivity — my mistake.

## Fix

Compute the search candidate set first via a semijoin, so the ordered-scan gamble is no longer in the plan space:

```sql
id IN (SELECT id FROM <table> WHERE search_text ILIKE '%' || p_search || '%')
```

All 7 sites: objects ×5 (`get_filtered_objects_paginated` count + page, `get_filtered_object_ids`, `get_csv_export_objects`, `get_adjacent_objects`); spectra ×2 (`get_filtered_spectra_paginated`, `get_csv_export_spectra`).

## Validated on prod (read-only, your admin session, `ORDER BY object_id LIMIT 50`)

| term | matches | before (bare) | after (semijoin) |
|---|---|---|---|
| `1772` | 9 | 7,403 ms | **88 ms** |
| `227985` | 1 | (trap) | **88 ms** |
| `ceers` | 1,273 | — | **433 ms** |

Stable across selectivities — the semijoin forces the candidate set first, then sorts only those, so there is no `LIMIT`-ordered-scan gamble at any selectivity. (The trgm index works in isolation at 0.3 ms; under admin RLS the candidate scan still rides the `programs` GIN + filter because `programs &&` is non-selective for admins — the separate "admin scans full catalog" scale item, not this timeout.)

Local: `supabase db reset` + seed clean; search counts unchanged vs #188; no-search regression intact; adjacent RPC smoke-tested. RPC signatures unchanged → no web change. Migration hand-trimmed from `supabase db diff`.

Generated with Claude Code

https://claude.ai/code/session_01Gn6UNiTEE7MNcseKZjMASh