### PR TITLE
feat(nirspec): standalone fixed-slit reduction + aperture geometry across the stack

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -71,6 +71,26 @@ Release procedure: edit the `## Unreleased` section below, then run
   feature failed for fixed-slit sources.
 
 ### Algorithm
+- NIRSpec standalone **fixed-slit** (`NRS_FIXEDSLIT`) reduction is now supported
+  end-to-end (stage1→3). Previously only MSA exposures (`NRS_MSASPEC`) and the
+  fixed-slit-in-MSA hybrid were handled, because both describe their slits in the
+  MSA metadata file (`*_msa.fits`); standalone fixed-slit exposures carry no such
+  file. The pipeline now detects `NRS_FIXEDSLIT` from the exposure header and
+  routes around the MSA-metafile machinery, letting jwst's native fixed-slit path
+  (`assign_wcs.get_open_fixed_slits` → `extract_2d` selecting the primary slit by
+  name) build the WCS and extract the spectrum. Specifically: `Observation.glob`
+  accepts `NRS_FIXEDSLIT` uncals; a new `_run_stage2a_fixedslit` runs
+  `Spec2Pipeline` with `extract_2d.slit_names=[FXD_SLIT]` and emits a product keyed
+  on jwst's primary-slit `source_id=1` (`{root}_{nod}_{detector}_1`), so the
+  mode-agnostic nodded background subtraction (2b) and combination (3) consume it
+  unchanged; `group_files` handles fixed-slit along-slit nod patterns
+  (`*-NOD`, e.g. `3-POINT-NOD`); and the stage3 provenance table + Spec3 output
+  renaming tolerate the fixed-slit header set (no MSA `SHUTSTA`; slit-level
+  `SRCRA`/`SRCDEC` fall back to the target position) and slit-name-embedded Spec3
+  product names. stage1 (Detector1 + background subtraction) needed no changes —
+  the science region is already protected by the hardcoded fixed-slit detector
+  band. MSA reductions are byte-for-byte unaffected. Validated on program 1967
+  (z≈6 quasar census, S200A2/G395M-F290LP): full 2.85–5.29 µm spectra recovered.
 - NIRCam `striping`: new opt-in per-amp-row 1/f offset estimator selectable via
   `[nircam.striping].estimator` (default **`"median"`** — the production
   2σ-clipped median with full-row fallback, byte-for-byte unchanged). The new

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -91,6 +91,21 @@ Release procedure: edit the `## Unreleased` section below, then run
   the science region is already protected by the hardcoded fixed-slit detector
   band. MSA reductions are byte-for-byte unaffected. Validated on program 1967
   (z≈6 quasar census, S200A2/G395M-F290LP): full 2.85–5.29 µm spectra recovered.
+- NIRSpec fixed-slit provenance + slit-overlay geometry now propagate to the
+  deliverables. The stage-3 `EXPOSURES` HDU gains `fixed_slit` / `slit_name`
+  columns and the final `_spec.fits` primary header carries `CFFXSLT` /
+  `CFFSSLIT`, so a fixed-slit source is identifiable downstream (this also flags
+  fixed-slit sources observed *inside* MSA exposures, via the metafile
+  `fixed_slit` column). The shutters ECSV becomes self-describing: each row
+  carries `aperture_name`, `aperture_width_arcsec`, and `aperture_height_arcsec`,
+  and fixed-slit sources export a single aperture rectangle sized to the slit
+  (e.g. S200A2 = 0.2"x3.2") instead of MSA shutter geometry — which `slits.py`'s
+  `get_exposure_table` would have rejected outright. MSA rows keep their geometry
+  and now carry the existing 0.22"x0.46" dimensions explicitly. Aperture sizes
+  live in `nirspec/constants.py` (`FIXED_SLIT_SIZE_ARCSEC`,
+  `MSA_SHUTTER_SIZE_ARCSEC`). Consumed by the web/Python slit overlays (DB
+  column, `get_nearby_shutters`/`get_field_shutters` RPCs, deploy, and the
+  SVG/canvas/matplotlib renderers updated in lockstep).
 - NIRCam `striping`: new opt-in per-amp-row 1/f offset estimator selectable via
   `[nircam.striping].estimator` (default **`"median"`** — the production
   2σ-clipped median with full-row fallback, byte-for-byte unchanged). The new

--- a/pipeline/campfire_pipeline/metadata/shutters.py
+++ b/pipeline/campfire_pipeline/metadata/shutters.py
@@ -18,7 +18,18 @@ from astropy.io import fits
 from astropy.table import Table
 
 from campfire_pipeline.common.io import log
-from campfire_pipeline.nirspec.slits import compute_slit_centers, get_source_pos
+from campfire_pipeline.nirspec.slits import (
+    compute_slit_centers, compute_fixed_slit_apertures, get_source_pos,
+)
+
+
+def _is_fixed_slit(spec_file):
+    """True if the spec file's EXPOSURES HDU marks it as a fixed-slit source."""
+    try:
+        exp = Table.read(spec_file, hdu=7)
+        return 'fixed_slit' in exp.colnames and bool(exp['fixed_slit'][0])
+    except Exception:
+        return False
 
 
 def generate_shutters_table(obs_name, obs_dir, field):
@@ -80,10 +91,19 @@ def generate_shutters_table(obs_name, obs_dir, field):
             grating = _get_grating(spec_file)
 
             try:
-                slit_data = compute_slit_centers(
-                    [spec_file],
-                    corrected_pos=(source_ra, source_dec),
-                )
+                # Fixed-slit sources (standalone or inside an MSA exposure) are a
+                # single aperture, not a multi-shutter slitlet; MSA shutter
+                # geometry would be wrong for them.
+                if _is_fixed_slit(spec_file):
+                    slit_data = compute_fixed_slit_apertures(
+                        spec_file,
+                        corrected_pos=(source_ra, source_dec),
+                    )
+                else:
+                    slit_data = compute_slit_centers(
+                        [spec_file],
+                        corrected_pos=(source_ra, source_dec),
+                    )
             except Exception as e:
                 log(f"Warning: failed to compute slit centers for "
                     f"source {source_id} ({grating}): {e}")
@@ -102,6 +122,9 @@ def generate_shutters_table(obs_name, obs_dir, field):
                     'shutter_idx': sd['shutter_idx'],
                     'shutter_state': sd['shutter_state'],
                     'v3pa': sd['v3pa'],
+                    'aperture_name': sd['aperture_name'],
+                    'aperture_width_arcsec': sd['aperture_width_arcsec'],
+                    'aperture_height_arcsec': sd['aperture_height_arcsec'],
                 })
 
     if not rows:
@@ -112,6 +135,7 @@ def generate_shutters_table(obs_name, obs_dir, field):
         'object_id', 'source_id', 'observation', 'field', 'grating',
         'center_ra', 'center_dec', 'position_angle',
         'shutter_idx', 'shutter_state', 'v3pa',
+        'aperture_name', 'aperture_width_arcsec', 'aperture_height_arcsec',
     ]
     table_data = {col: [r[col] for r in rows] for col in col_order}
     table = Table(table_data)

--- a/pipeline/campfire_pipeline/nirspec/constants.py
+++ b/pipeline/campfire_pipeline/nirspec/constants.py
@@ -16,6 +16,30 @@ GRATINGS = [k.upper() for k in GRATING_LIMITS]
 
 
 # ---------------------------------------------------------------------------
+# Aperture geometry for slit/shutter sky overlays (shutters ECSV → web frontend)
+# ---------------------------------------------------------------------------
+# On-sky aperture dimensions in arcsec as (width, height), where width is the
+# across-slit (dispersion) direction and height is the along-slit (spatial)
+# direction. These are the single source of truth for the rectangles the web
+# frontend draws over imaging cutouts; the pipeline writes them per row into the
+# shutters ECSV so the frontend no longer hardcodes them.
+
+# MSA micro-shutter open area. Matches the value the web overlay historically
+# hardcoded (0.22 x 0.46), so MSA rendering is unchanged once the frontend reads
+# dimensions from the data.
+MSA_SHUTTER_SIZE_ARCSEC = (0.22, 0.46)
+
+# NIRSpec fixed-slit apertures (SIAF nominal open sizes), one rectangle each.
+FIXED_SLIT_SIZE_ARCSEC = {
+    "S200A1": (0.20, 3.20),
+    "S200A2": (0.20, 3.20),
+    "S400A1": (0.40, 3.65),
+    "S1600A1": (1.60, 1.60),
+    "S200B1": (0.20, 3.20),
+}
+
+
+# ---------------------------------------------------------------------------
 # Extended-wavelength reduction (G140M/F100LP, G235M/F170LP)
 # ---------------------------------------------------------------------------
 # Constants for the opt-in extended-wavelength feature

--- a/pipeline/campfire_pipeline/nirspec/metafile.py
+++ b/pipeline/campfire_pipeline/nirspec/metafile.py
@@ -201,6 +201,26 @@ class MetaFile:
             str(v).strip().upper() not in ('', 'NONE') for v in rows['fixed_slit']
         )
 
+    def fixed_slit_name(self, source_id):
+        """Return the fixed-slit aperture name (e.g. ``'S200A1'``) for *source_id*,
+        or ``''`` if it is not a fixed-slit source.
+
+        Reads the SHUTTER_INFO ``fixed_slit`` column — the same column
+        :meth:`is_fixed_slit` tests — so downstream stages can record *which*
+        slit a hybrid fixed-slit-in-MSA source was observed through.
+        """
+        if 'fixed_slit' not in self.shutter_table.colnames:
+            return ''
+        rows = self.shutter_table[
+            (self.shutter_table['source_id'] == source_id)
+            & (self.shutter_table['msa_metadata_id'] == self.msametid)
+        ]
+        for v in rows['fixed_slit']:
+            s = str(v).strip().upper()
+            if s not in ('', 'NONE'):
+                return s
+        return ''
+
     def filter_by_source_id(self,
             source_id,
             set_stellarity=False,

--- a/pipeline/campfire_pipeline/nirspec/observation.py
+++ b/pipeline/campfire_pipeline/nirspec/observation.py
@@ -20,6 +20,12 @@ from campfire_pipeline.common.io import log
 # "N-SHUTTER-SLITLET", so a 3-shutter slitlet is "3-SHUTTER-SLITLET".
 DEFAULT_NOD_TYPE = '3-SHUTTER-SLITLET'
 
+# NIRSpec spectroscopic exposure types the pipeline can reduce. MSA (MOS) is
+# the original mode; standalone fixed-slit (NRS_FIXEDSLIT) is handled via the
+# jwst native fixed-slit path (no MSA metadata file). Used to filter raw uncals
+# in glob(check_exp_type=True).
+SUPPORTED_EXP_TYPES = ('NRS_MSASPEC', 'NRS_FIXEDSLIT')
+
 
 def read_nod_type(hdr, filename):
     """Read NOD_TYPE from a primary header, defaulting if missing.
@@ -42,6 +48,12 @@ def read_nod_type(hdr, filename):
     """
     if 'NOD_TYPE' in hdr:
         return hdr['NOD_TYPE']
+    # Fixed-slit exposures don't use MSA shutter slitlets and routinely omit
+    # NOD_TYPE. Fall back to the dither pattern type (e.g. '3-POINT-NOD')
+    # instead of the MSA slitlet default — and don't warn, since absence is
+    # expected for this mode.
+    if str(hdr.get('EXP_TYPE', '')).upper() == 'NRS_FIXEDSLIT':
+        return hdr.get('PATTTYPE', 'FIXED-SLIT-NOD')
     log(f"WARNING: NOD_TYPE keyword missing from {os.path.basename(filename)}; "
         f"assuming {DEFAULT_NOD_TYPE}")
     return DEFAULT_NOD_TYPE
@@ -389,7 +401,7 @@ class Observation:
             resulti = glob.glob(pattern_path)
 
             if check_exp_type:
-                result += [r for r in resulti if fits.getheader(r)['EXP_TYPE'] == 'NRS_MSASPEC']
+                result += [r for r in resulti if fits.getheader(r)['EXP_TYPE'] in SUPPORTED_EXP_TYPES]
             else:
                 result += resulti
 
@@ -518,6 +530,15 @@ class Observation:
 
                     elif (files3['dither_pattern_type'][0] == '2-POINT-WITH-NIRCAM-SIZE2') and ('SHUTTER-SLITLET' in files3['nod_type'][0]) and (files3['subpixel_dither_points'][0] == 2):
                         subpx_dither = np.where(np.isin(files3['dither_position'], [1,3,5]), 1, 2)
+
+                    elif files3['dither_pattern_type'][0].endswith('-NOD') and files3['subpixel_dither_points'][0] == 1:
+                        # NIRSpec fixed-slit along-slit nodding (e.g. 2-POINT-NOD,
+                        # 3-POINT-NOD). Without sub-pixel dithering, every nod in
+                        # the config is mutually background for the others, so they
+                        # all share one bkg_group per detector (subpx_dither stays
+                        # 1). Leapfrog subtraction happens in stage2b, which
+                        # handles 2/3/5 exposures.
+                        pass
 
                     else:
                         raise NotImplementedError(f"File grouping for dither pattern {files3['dither_pattern_type'][0]} not implemented")

--- a/pipeline/campfire_pipeline/nirspec/slits.py
+++ b/pipeline/campfire_pipeline/nirspec/slits.py
@@ -11,6 +11,17 @@ from astropy.coordinates import SkyCoord
 import astropy.units as u
 import numpy as np
 
+from campfire_pipeline.nirspec.constants import (
+    FIXED_SLIT_SIZE_ARCSEC, MSA_SHUTTER_SIZE_ARCSEC,
+)
+
+# Sky-frame rotation applied to V3PA to get the aperture position angle
+# (V3IdlYAngle for NRS_FULL_MSA). The fixed slits share the focal-plane
+# orientation closely enough that this is reused for them; the residual
+# per-aperture SIAF difference is <~1 deg and below the visual tolerance of the
+# cutout overlay.
+_V3IDL_Y_ANGLE_DEG = 138.5
+
 
 def get_source_pos(spec_file):
     """Extract median source RA/Dec from HDU 7 exposure table."""
@@ -123,6 +134,65 @@ def compute_slit_centers(spec_files, corrected_pos=None):
                 'shutter_idx': shutter_idx,
                 'shutter_state': 'source' if char == 'x' else 'open',
                 'v3pa': float(t['v3pa']),
+                'aperture_name': 'MSA',
+                'aperture_width_arcsec': float(MSA_SHUTTER_SIZE_ARCSEC[0]),
+                'aperture_height_arcsec': float(MSA_SHUTTER_SIZE_ARCSEC[1]),
             })
+
+    return results
+
+
+def compute_fixed_slit_apertures(spec_file, corrected_pos=None):
+    """Compute the on-sky aperture rectangle(s) for a fixed-slit exposure set.
+
+    Fixed-slit exposures place the target in a single rectangular aperture
+    (e.g. S200A2), not a multi-shutter MSA slitlet, so there is one rectangle per
+    exposure row — centered on the source, sized by the slit's SIAF dimensions,
+    at the slit position angle. (Identical rows across nods are collapsed at
+    deploy time, the same way MSA dither positions are.)
+
+    Parameters
+    ----------
+    spec_file : str
+        Path to a ``*_spec.fits`` file whose EXPOSURES HDU carries the
+        ``fixed_slit`` / ``slit_name`` columns written by stage 3.
+    corrected_pos : tuple of (ra, dec), optional
+        Astrometrically-corrected source position. If None, reads from FITS.
+
+    Returns
+    -------
+    list of dict
+        Same keys as :func:`compute_slit_centers` plus ``aperture_name`` and the
+        per-slit ``aperture_width_arcsec`` / ``aperture_height_arcsec``.
+        ``shutter_idx`` is 0 and ``shutter_state`` is ``'source'`` for every row.
+    """
+    exp = Table.read(spec_file, hdu=7)
+
+    if corrected_pos is not None:
+        source_ra, source_dec = corrected_pos
+    else:
+        source_ra, source_dec = get_source_pos(spec_file)
+    source_c = SkyCoord(source_ra, source_dec, unit='deg')
+
+    results = []
+    for t in exp:
+        slit_name = (str(t['slit_name']).strip().upper()
+                     if 'slit_name' in exp.colnames else '')
+        width, height = FIXED_SLIT_SIZE_ARCSEC.get(
+            slit_name, (0.20, 3.20))  # default to the common 0.2x3.2 slit
+
+        pa = (t['v3pa'] - 360 + _V3IDL_Y_ANGLE_DEG) * u.deg
+
+        results.append({
+            'center_ra': float(source_c.ra.deg),
+            'center_dec': float(source_c.dec.deg),
+            'position_angle': float(pa.to('deg').value) % 360,
+            'shutter_idx': 0,
+            'shutter_state': 'source',
+            'v3pa': float(t['v3pa']),
+            'aperture_name': slit_name or 'FIXEDSLIT',
+            'aperture_width_arcsec': float(width),
+            'aperture_height_arcsec': float(height),
+        })
 
     return results

--- a/pipeline/campfire_pipeline/nirspec/stage2.py
+++ b/pipeline/campfire_pipeline/nirspec/stage2.py
@@ -474,6 +474,136 @@ def run_stage2b(obs, stage_config, source_ids='all', overwrite=False,
             )
 
 
+def _run_stage2a_fixedslit(
+        rate_file,
+        obs: Observation,
+        overwrite: bool = False,
+        wavecorr_override=None,
+        extended_refs=None,
+    ):
+    """Stage 2a for standalone NIRSpec fixed-slit (NRS_FIXEDSLIT) exposures.
+
+    Unlike MSA mode, fixed-slit exposures have no MSA metadata file: jwst's
+    ``assign_wcs`` builds the fixed-slit WCS from the instrument model and
+    ``extract_2d`` selects slits by name. We extract only the primary slit
+    (the ``FXD_SLIT`` header keyword), which jwst assigns ``source_id = 1``, and
+    emit a product keyed on ``source_id = 1`` so the mode-agnostic downstream
+    stages — nodded background subtraction (2b) and combination (3) — pick it up
+    unchanged. The product filename matches the MSA convention
+    ``{root}_{nod}_{detector}_{source_id}`` so :meth:`Observation.discover_files`
+    parses it identically.
+    """
+    from jwst.pipeline import Spec2Pipeline
+    from jwst.associations import asn_from_list
+    from jwst.assign_wcs.util import NoDataOnDetectorError
+
+    prev_cwd = os.getcwd()
+    os.chdir(obs.workspace_dir)
+
+    source_ids_processed = []
+    asn_file = None
+    try:
+        hdr = fits.getheader(rate_file)
+        primary_slit = str(hdr.get('FXD_SLIT', '')).strip()
+        if not primary_slit or primary_slit.upper() == 'NONE':
+            log(f'No FXD_SLIT primary slit defined for '
+                f'{os.path.basename(rate_file)}, skipping')
+            return []
+
+        # jwst hard-wires source_id=1 to the primary fixed slit; reuse that as
+        # the product key so the existing {..._source_id} naming carries through.
+        source_id = 1
+        prod_name = os.path.basename(rate_file).replace('_rate.fits', f'_{source_id}')
+
+        nodata_marker = f'{prod_name}_nodata'
+        if (os.path.exists(f'{prod_name}_cal.fits') or os.path.exists(nodata_marker)) and not overwrite:
+            log(f'Skipping stage2a for {prod_name}, overwrite=False')
+            return [source_id]
+        if os.path.exists(nodata_marker):
+            os.remove(nodata_marker)
+
+        # Extended-wavelength override for this config (grating-gated; typically
+        # None for fixed-slit gratings, but supported for consistency with MSA).
+        extended_override = None
+        if extended_refs:
+            extended_override = extended_refs.get((
+                str(hdr.get('DETECTOR', '')).strip(),
+                str(hdr.get('GRATING', '')).strip(),
+                str(hdr.get('FILTER', '')).strip(),
+            ))
+
+        cards = [
+            ('CFEXTWAV', extended_override is not None, 'Extended wavelength reduction applied'),
+            ('CFFXSLT', True, 'NIRSpec fixed-slit source'),
+            ('CFFSSLIT', primary_slit, 'NIRSpec fixed-slit aperture'),
+            ('STKSHTRS', 'N/A', 'Stuck shutters masked'),
+        ]
+
+        association = [(os.path.basename(rate_file), 'science')]
+        asn = asn_from_list.asn_from_list(association, with_exptype=True, product_name=prod_name)
+        suggested_name, serialization = asn.dump()
+        asn_file = f'{prod_name}.json'
+        with open(asn_file, 'w') as asn_out:
+            asn_out.write(serialization)
+
+        steps = {
+            # Extract only the primary fixed slit; the WCS exposes all open
+            # slits on a FULL-frame readout but only this one holds the target.
+            'extract_2d': {'slit_names': [primary_slit]},
+            'extract_1d': {'skip': True},
+            'barshadow': {'skip': True},
+            'bkg_subtract': {'skip': True},
+            'resample_spec': {'skip': True},
+        }
+        if wavecorr_override:
+            steps['wavecorr'] = {'override_wavecorr': wavecorr_override}
+        if extended_override:
+            from campfire_pipeline.config import get_extended_photom_path
+            steps['flat_field'] = {
+                'override_fflat': extended_override['fflat'],
+                'override_sflat': extended_override['sflat'],
+            }
+            steps['assign_wcs'] = {
+                'override_wavelengthrange': extended_override['wavelengthrange'],
+            }
+            steps['photom'] = {
+                'override_photom': get_extended_photom_path(fixed_slit=True),
+            }
+            log(f"Applying extended-wavelength overrides for {prod_name}")
+
+        log(f"Running Spec2Pipeline for {prod_name} (fixed slit {primary_slit})")
+        try:
+            Spec2Pipeline.call(asn_file, save_results=True, steps=steps)
+            log(f'Completed Spec2Pipeline for {prod_name}')
+            source_ids_processed.append(source_id)
+        except NoDataOnDetectorError:
+            log(f'No data on detector for {prod_name}')
+            with open(nodata_marker, 'w') as f:
+                f.write('NoDataOnDetectorError\n')
+
+        for ext in ['cal', 's2d']:
+            if os.path.exists(f'{prod_name}_{ext}.fits'):
+                with fits.open(f'{prod_name}_{ext}.fits', mode='update') as hdul:
+                    for card in cards:
+                        hdul['PRIMARY'].header[card[0]] = card[1:3]
+                    hdul.flush()
+
+    except KeyboardInterrupt:
+        return source_ids_processed
+
+    except Exception as e:
+        log(f"ERROR in fixed-slit stage2a for {os.path.basename(rate_file)}", e)
+        raise
+
+    finally:
+        # Clean up any ASN files for this rate file (matches the MSA path).
+        for stale in glob.glob(rate_file.replace('_rate.fits', '*.json')):
+            os.remove(stale)
+        os.chdir(prev_cwd)
+
+    return source_ids_processed
+
+
 def run_stage2a_single_rate(
         rate_file,
         obs: Observation,
@@ -486,6 +616,16 @@ def run_stage2a_single_rate(
     ):
 
     log(f'Starting stage2a for {os.path.basename(rate_file)}')
+
+    # Standalone fixed-slit exposures carry no MSA metadata file. jwst builds
+    # the fixed-slit WCS natively and extract_2d selects slits by name, so the
+    # whole MSAMETFL/per-source-metafile machinery below does not apply —
+    # dispatch to the dedicated fixed-slit path. The MSA branch is unchanged.
+    if str(fits.getheader(rate_file).get('EXP_TYPE', '')).upper() == 'NRS_FIXEDSLIT':
+        return _run_stage2a_fixedslit(
+            rate_file, obs, overwrite=overwrite,
+            wavecorr_override=wavecorr_override, extended_refs=extended_refs,
+        )
 
     from jwst.pipeline import Spec2Pipeline
     from jwst.associations import asn_from_list

--- a/pipeline/campfire_pipeline/nirspec/stage2.py
+++ b/pipeline/campfire_pipeline/nirspec/stage2.py
@@ -728,6 +728,9 @@ def run_stage2a_single_rate(
             # metadata so downstream stages can branch on it.
             source_is_fixed_slit = main_metafile.is_fixed_slit(source_id)
             cards.append(('CFFXSLT', source_is_fixed_slit, 'NIRSpec fixed-slit source'))
+            if source_is_fixed_slit:
+                cards.append(('CFFSSLIT', main_metafile.fixed_slit_name(source_id),
+                              'NIRSpec fixed-slit aperture'))
             if len(stuck) > 0:
                 cards.append(('STKSHTRS', str(stuck['shutters'][0]), 'Stuck shutters masked'))
                 for stuck_shutter in np.sort(stuck['shutters'][0])[::-1]:

--- a/pipeline/campfire_pipeline/nirspec/stage3.py
+++ b/pipeline/campfire_pipeline/nirspec/stage3.py
@@ -277,6 +277,13 @@ def run_stage3_single_source(
         exposures['source_xpos'] = [hdr.get('SRCXPOS', np.nan) for hdr in hdrs1]
         exposures['source_ypos'] = [hdr.get('SRCYPOS', np.nan) for hdr in hdrs1]
         exposures['v3pa'] = [hdr.get('PA_V3', np.nan) for hdr in hdrs1]
+        # Fixed-slit provenance (set by stage2a): whether the source was observed
+        # through a NIRSpec fixed slit and which one. Carried here so the shutters
+        # ECSV (which reads this HDU) can emit the correct aperture geometry, and
+        # so it lands in the final spec.fits. Applies to standalone NRS_FIXEDSLIT
+        # and to fixed-slit sources inside MSA exposures.
+        exposures['fixed_slit'] = [bool(hdr.get('CFFXSLT', False)) for hdr in hdrs0]
+        exposures['slit_name'] = [str(hdr.get('CFFSSLIT', '')) for hdr in hdrs0]
            
 
 
@@ -358,6 +365,18 @@ def opt_ext_single_source(
 
     ph['CMPFRTIM'] = (str(datetime.now()), 'Date/time of CAMPFIRE reduction')
     ph['CMPFRVER'] = (version, 'campfire-pipeline version (PEP 440)')
+
+    # Carry fixed-slit provenance from the EXPOSURES table into the primary header
+    # (the curated keyword copy above reads from x1d, which no longer carries the
+    # campfire CFxxx cards after Spec3).
+    try:
+        _exp = s2d['EXPOSURES'].data
+        if 'fixed_slit' in _exp.columns.names:
+            ph['CFFXSLT'] = (bool(np.any(_exp['fixed_slit'])), 'NIRSpec fixed-slit source')
+            if 'slit_name' in _exp.columns.names and str(_exp['slit_name'][0]):
+                ph['CFFSSLIT'] = (str(_exp['slit_name'][0]), 'NIRSpec fixed-slit aperture')
+    except (KeyError, IndexError):
+        pass
 
     primary = fits.PrimaryHDU(header=ph)
 

--- a/pipeline/campfire_pipeline/nirspec/stage3.py
+++ b/pipeline/campfire_pipeline/nirspec/stage3.py
@@ -238,10 +238,20 @@ def run_stage3_single_source(
             # steps={'extract_1d':{'override_extract1d':('jwst_nirspec_extract1d_4px.json')}}
         )
 
-        if os.path.exists(f'{product_name}_s{source_id:09d}_s2d.fits'):
-            os.rename(f'{product_name}_s{source_id:09d}_s2d.fits', f'{product_name}_s2d.fits')
-        if os.path.exists(f'{product_name}_s{source_id:09d}_x1d.fits'):
-            os.rename(f'{product_name}_s{source_id:09d}_x1d.fits', f'{product_name}_x1d.fits')
+        # Normalize Spec3's per-source output name to {product_name}_{ext}.fits.
+        # The naming differs by mode: MSA emits {product_name}_s{source_id:09d}_{ext}.fits,
+        # whereas fixed slit inserts the slit name
+        # ({product_name}_{slit}_s{source_id:09d}_{ext}.fits). Prefer the exact MSA
+        # name, then fall back to the slit-prefixed fixed-slit name.
+        for ext in ('s2d', 'x1d'):
+            target = f'{product_name}_{ext}.fits'
+            msa_name = f'{product_name}_s{source_id:09d}_{ext}.fits'
+            if os.path.exists(msa_name):
+                os.rename(msa_name, target)
+                continue
+            fs_matches = sorted(glob.glob(f'{product_name}_*_s{source_id:09d}_{ext}.fits'))
+            if fs_matches:
+                os.rename(fs_matches[0], target)
 
 
         # Create "exposures" table
@@ -255,12 +265,18 @@ def run_stage3_single_source(
         exposures['exptime'] = [hdr['EFFEXPTM'] for hdr in hdrs0]
         exposures['stuck_shutter_list'] = [hdr['STKSHTRS'] if 'STKSHTRS' in hdr else 'N/A' for hdr in hdrs0]
         hdrs1 = [fits.getheader(cal_file,ext=1) for cal_file in cal_files]
-        exposures['shutter_state'] = [hdr['SHUTSTA'] for hdr in hdrs1]
-        exposures['source_ra'] = [hdr['SRCRA'] for hdr in hdrs1]
-        exposures['source_dec'] = [hdr['SRCDEC'] for hdr in hdrs1]
-        exposures['source_xpos'] = [hdr['SRCXPOS'] for hdr in hdrs1]
-        exposures['source_ypos'] = [hdr['SRCYPOS'] for hdr in hdrs1]
-        exposures['v3pa'] = [hdr['PA_V3'] for hdr in hdrs1]
+        # Fixed-slit cal products omit the MSA-only SHUTSTA shutter state and the
+        # slit-level SRCRA/SRCDEC (the latter come from the MSA source catalog);
+        # default the shutter state and fall back to the target position, which is
+        # the source position for a fixed-slit exposure.
+        exposures['shutter_state'] = [hdr.get('SHUTSTA', 'N/A') for hdr in hdrs1]
+        exposures['source_ra'] = [h1.get('SRCRA', h0.get('TARG_RA', np.nan))
+                                  for h0, h1 in zip(hdrs0, hdrs1)]
+        exposures['source_dec'] = [h1.get('SRCDEC', h0.get('TARG_DEC', np.nan))
+                                   for h0, h1 in zip(hdrs0, hdrs1)]
+        exposures['source_xpos'] = [hdr.get('SRCXPOS', np.nan) for hdr in hdrs1]
+        exposures['source_ypos'] = [hdr.get('SRCYPOS', np.nan) for hdr in hdrs1]
+        exposures['v3pa'] = [hdr.get('PA_V3', np.nan) for hdr in hdrs1]
            
 
 

--- a/python/campfire/deploy/discover.py
+++ b/python/campfire/deploy/discover.py
@@ -112,6 +112,14 @@ def load_shutters_ecsv(ecsv_path: Path) -> list[dict]:
             'shutter_idx': int(row['shutter_idx']),
             'dither_id': int(row['dither_id']),
             'shutter_state': str(row['shutter_state']),
+            # Aperture geometry (per-row, so fixed-slit apertures and MSA shutters
+            # share one render path). Older ECSVs predate these columns — they are
+            # all MSA, so default to the MSA shutter dimensions.
+            'aperture_name': str(row['aperture_name']) if 'aperture_name' in row else 'MSA',
+            'aperture_width_arcsec': (float(row['aperture_width_arcsec'])
+                                      if 'aperture_width_arcsec' in row else 0.22),
+            'aperture_height_arcsec': (float(row['aperture_height_arcsec'])
+                                       if 'aperture_height_arcsec' in row else 0.46),
         })
     return records
 

--- a/python/campfire/imaging.py
+++ b/python/campfire/imaging.py
@@ -23,7 +23,8 @@ import math
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
-# NIRSpec shutter dimensions
+# Fallback MSA shutter dimensions, used when a shutter dict omits the
+# per-aperture aperture_width_arcsec / aperture_height_arcsec fields.
 SHUTTER_WIDTH_ARCSEC = 0.22
 SHUTTER_HEIGHT_ARCSEC = 0.46
 
@@ -238,15 +239,17 @@ def plot_cutout(
             # so the sign flips to +PA
             angle = shutter["position_angle"]
 
+            # Per-aperture dimensions: fixed slits (e.g. S200A2 = 0.2"x3.2")
+            # carry their own size; MSA shutters (and responses predating the
+            # aperture columns) fall back to the MSA shutter dimensions.
+            w = shutter.get("aperture_width_arcsec", SHUTTER_WIDTH_ARCSEC)
+            h = shutter.get("aperture_height_arcsec", SHUTTER_HEIGHT_ARCSEC)
+
             marker = style.get("marker", "box")
             if marker == "corners":
-                _draw_shutter_corners(ax, cx, cy,
-                                      SHUTTER_WIDTH_ARCSEC, SHUTTER_HEIGHT_ARCSEC,
-                                      angle, style)
+                _draw_shutter_corners(ax, cx, cy, w, h, angle, style)
             else:
-                _draw_shutter_box(ax, cx, cy,
-                                  SHUTTER_WIDTH_ARCSEC, SHUTTER_HEIGHT_ARCSEC,
-                                  angle, style)
+                _draw_shutter_box(ax, cx, cy, w, h, angle, style)
 
     # Draw scalebar
     if scalebar:

--- a/supabase/migrations/20260621152105_add_shutter_aperture_dimensions.sql
+++ b/supabase/migrations/20260621152105_add_shutter_aperture_dimensions.sql
@@ -1,0 +1,82 @@
+-- Add per-aperture geometry to the shutters table so the web overlay can render
+-- NIRSpec fixed-slit apertures (e.g. S200A2 = 0.2"x3.2") as well as MSA shutters
+-- from data, instead of hardcoding 0.22"x0.46" in the frontend.
+--
+-- Defaults match the MSA dimensions the frontend previously hardcoded, so every
+-- existing (MSA) row renders unchanged with no re-deploy.
+alter table "public"."shutters"
+  add column "aperture_name" text not null default 'MSA',
+  add column "aperture_width_arcsec" double precision not null default 0.22,
+  add column "aperture_height_arcsec" double precision not null default 0.46;
+
+-- get_nearby_shutters now returns the aperture columns. The RETURNS TABLE
+-- signature changes, so the function must be dropped and recreated (CREATE OR
+-- REPLACE cannot change a function's output columns).
+drop function if exists public.get_nearby_shutters(
+  double precision, double precision, double precision, text
+);
+
+create or replace function public.get_nearby_shutters(
+  p_ra double precision,
+  p_dec double precision,
+  p_radius_arcsec double precision default 5.0,
+  p_field text default null
+)
+returns table (
+  object_id text,
+  source_id integer,
+  center_ra double precision,
+  center_dec double precision,
+  position_angle double precision,
+  shutter_idx smallint,
+  dither_id smallint,
+  shutter_state text,
+  observation text,
+  aperture_name text,
+  aperture_width_arcsec double precision,
+  aperture_height_arcsec double precision
+)
+language sql stable as $$
+  select s.object_id, s.source_id, s.center_ra, s.center_dec,
+         s.position_angle, s.shutter_idx, s.dither_id, s.shutter_state, s.observation,
+         s.aperture_name, s.aperture_width_arcsec, s.aperture_height_arcsec
+  from shutters s
+  where (p_field is null or s.field = p_field)
+    and s.center_ra between p_ra - p_radius_arcsec / 3600.0 / cos(radians(p_dec))
+                        and p_ra + p_radius_arcsec / 3600.0 / cos(radians(p_dec))
+    and s.center_dec between p_dec - p_radius_arcsec / 3600.0
+                         and p_dec + p_radius_arcsec / 3600.0;
+$$;
+
+grant all on function public.get_nearby_shutters(double precision, double precision, double precision, text) to anon;
+grant all on function public.get_nearby_shutters(double precision, double precision, double precision, text) to authenticated;
+grant all on function public.get_nearby_shutters(double precision, double precision, double precision, text) to service_role;
+
+-- get_field_shutters (full map viewer) returns the aperture columns too.
+drop function if exists public.get_field_shutters(text);
+
+create or replace function public.get_field_shutters(p_field text)
+returns table (
+  object_id        text,
+  source_id        integer,
+  center_ra        double precision,
+  center_dec       double precision,
+  position_angle   double precision,
+  shutter_idx      smallint,
+  dither_id        smallint,
+  shutter_state    text,
+  observation      text,
+  aperture_name           text,
+  aperture_width_arcsec    double precision,
+  aperture_height_arcsec   double precision
+)
+language sql stable as $$
+  select s.object_id, s.source_id, s.center_ra, s.center_dec,
+         s.position_angle, s.shutter_idx, s.dither_id, s.shutter_state, s.observation,
+         s.aperture_name, s.aperture_width_arcsec, s.aperture_height_arcsec
+  from public.shutters s
+  where s.field = p_field
+  order by s.object_id;
+$$;
+
+grant execute on function public.get_field_shutters(text) to authenticated;

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -2444,11 +2444,15 @@ RETURNS TABLE (
   shutter_idx smallint,
   dither_id smallint,
   shutter_state text,
-  observation text
+  observation text,
+  aperture_name text,
+  aperture_width_arcsec double precision,
+  aperture_height_arcsec double precision
 )
 LANGUAGE sql STABLE AS $$
   SELECT s.object_id, s.source_id, s.center_ra, s.center_dec,
-         s.position_angle, s.shutter_idx, s.dither_id, s.shutter_state, s.observation
+         s.position_angle, s.shutter_idx, s.dither_id, s.shutter_state, s.observation,
+         s.aperture_name, s.aperture_width_arcsec, s.aperture_height_arcsec
   FROM shutters s
   WHERE (p_field IS NULL OR s.field = p_field)
     AND s.center_ra BETWEEN p_ra - p_radius_arcsec / 3600.0 / COS(RADIANS(p_dec))
@@ -2550,12 +2554,16 @@ RETURNS TABLE (
   shutter_idx      SMALLINT,
   dither_id        SMALLINT,
   shutter_state    TEXT,
-  observation      TEXT
+  observation      TEXT,
+  aperture_name           TEXT,
+  aperture_width_arcsec    DOUBLE PRECISION,
+  aperture_height_arcsec   DOUBLE PRECISION
 )
 LANGUAGE sql STABLE
 AS $$
   SELECT s.object_id, s.source_id, s.center_ra, s.center_dec,
-         s.position_angle, s.shutter_idx, s.dither_id, s.shutter_state, s.observation
+         s.position_angle, s.shutter_idx, s.dither_id, s.shutter_state, s.observation,
+         s.aperture_name, s.aperture_width_arcsec, s.aperture_height_arcsec
   FROM public.shutters s
   WHERE s.field = p_field
   ORDER BY s.object_id;

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -855,6 +855,9 @@ CREATE TABLE IF NOT EXISTS "public"."shutters" (
     "shutter_idx" smallint NOT NULL,
     "dither_id" smallint DEFAULT 0 NOT NULL,
     "shutter_state" "text" DEFAULT 'open'::"text" NOT NULL,
+    "aperture_name" "text" DEFAULT 'MSA'::"text" NOT NULL,
+    "aperture_width_arcsec" double precision DEFAULT 0.22 NOT NULL,
+    "aperture_height_arcsec" double precision DEFAULT 0.46 NOT NULL,
     "created_at" timestamp with time zone DEFAULT "now"()
 );
 

--- a/web/components/map/CanvasSlitLayer.tsx
+++ b/web/components/map/CanvasSlitLayer.tsx
@@ -173,8 +173,6 @@ export function CanvasSlitLayer(props: CanvasSlitLayerProps) {
       if (widthPx < 1.5) return;
 
       const items = preparedRef.current;
-      const halfW = widthPx / 2;
-      const halfH = heightPx / 2;
       const pitchPx = SHUTTER_PITCH_ARCSEC * pxPerArcsec;
 
       // Group shutters by slitlet so we can compute aligned positions
@@ -195,9 +193,14 @@ export function CanvasSlitLayer(props: CanvasSlitLayerProps) {
         paRad: number;
         color: string;
         isStuck: boolean;
+        widthPx: number;
+        heightPx: number;
       }
       const drawItems: DrawItem[] = [];
-      const margin = Math.max(widthPx, heightPx) + 4;
+      // Cull margin generous enough for the tallest fixed slit (~3.8") so an
+      // elongated aperture extending into view isn't dropped when its center is
+      // just off-screen.
+      const margin = Math.max(widthPx, heightPx, 4 * pxPerArcsec) + 4;
 
       for (const slitlet of slitletMap.values()) {
         // Use source shutter (idx=0) as reference, fall back to first
@@ -228,11 +231,16 @@ export function CanvasSlitLayer(props: CanvasSlitLayerProps) {
           if (pt.x < boundsMin.x - margin || pt.x > boundsMax.x + margin ||
               pt.y < boundsMin.y - margin || pt.y > boundsMax.y + margin) continue;
 
+          // Per-aperture dimensions: fixed slits carry their own size; MSA
+          // shutters (and legacy rows without the columns) use the defaults.
+          const sh = item.slit as Shutter;
           drawItems.push({
             pt,
             paRad: item.paRad,
             color: item.color,
             isStuck: item.isStuck || false,
+            widthPx: (sh.aperture_width_arcsec ?? SHUTTER_WIDTH_ARCSEC) * pxPerArcsec,
+            heightPx: (sh.aperture_height_arcsec ?? SHUTTER_HEIGHT_ARCSEC) * pxPerArcsec,
           });
         }
       }
@@ -258,7 +266,7 @@ export function CanvasSlitLayer(props: CanvasSlitLayerProps) {
           ctx!.save();
           ctx!.translate(item.pt.x, item.pt.y);
           ctx!.rotate(-item.paRad);
-          ctx!.fillRect(-halfW, -halfH, widthPx, heightPx);
+          ctx!.fillRect(-item.widthPx / 2, -item.heightPx / 2, item.widthPx, item.heightPx);
           ctx!.restore();
         }
 
@@ -272,7 +280,7 @@ export function CanvasSlitLayer(props: CanvasSlitLayerProps) {
           ctx!.lineWidth = item.isStuck ? 1.5 : 1;
           if (item.isStuck) ctx!.setLineDash([3, 2]);
           else ctx!.setLineDash([]);
-          ctx!.strokeRect(-halfW, -halfH, widthPx, heightPx);
+          ctx!.strokeRect(-item.widthPx / 2, -item.heightPx / 2, item.widthPx, item.heightPx);
           ctx!.restore();
         }
       }

--- a/web/lib/actions/map.ts
+++ b/web/lib/actions/map.ts
@@ -96,6 +96,12 @@ export interface Shutter {
   dither_id: number;
   shutter_state: 'source' | 'open' | 'stuck_closed';
   observation: string;
+  /** Aperture name (e.g. 'MSA', 'S200A2'). May be absent on legacy rows. */
+  aperture_name?: string;
+  /** Across-slit (dispersion) extent in arcsec; falls back to the MSA shutter width. */
+  aperture_width_arcsec?: number;
+  /** Along-slit (spatial) extent in arcsec; falls back to the MSA shutter height. */
+  aperture_height_arcsec?: number;
 }
 
 export interface ShuttersResult {

--- a/web/lib/utils/shutter-overlay.ts
+++ b/web/lib/utils/shutter-overlay.ts
@@ -8,9 +8,9 @@
  * for the FOVs used in practice (1–30 arcsec).
  */
 
-/** NIRSpec shutter width in arcseconds */
+/** Fallback MSA shutter width in arcseconds (used when a row omits aperture dims) */
 export const SHUTTER_WIDTH_ARCSEC = 0.22;
-/** NIRSpec shutter height in arcseconds */
+/** Fallback MSA shutter height in arcseconds (used when a row omits aperture dims) */
 export const SHUTTER_HEIGHT_ARCSEC = 0.46;
 
 export interface ShutterGeometry {
@@ -19,6 +19,12 @@ export interface ShutterGeometry {
   center_dec: number;
   position_angle: number;
   shutter_state: 'source' | 'open' | 'stuck_closed';
+  /** Aperture name (e.g. 'MSA', 'S200A2'); informational */
+  aperture_name?: string;
+  /** Across-slit (dispersion) extent in arcsec. Falls back to the MSA shutter width. */
+  aperture_width_arcsec?: number;
+  /** Along-slit (spatial) extent in arcsec. Falls back to the MSA shutter height. */
+  aperture_height_arcsec?: number;
 }
 
 export interface ShutterRect {
@@ -67,13 +73,15 @@ export function computeShutterRects(
   const cosDecFactor = Math.cos(centerDec * Math.PI / 180);
   const halfSize = displaySize / 2;
 
-  // Shutter dimensions in pixels
-  const wPx = SHUTTER_WIDTH_ARCSEC * pxPerArcsec;
-  const hPx = SHUTTER_HEIGHT_ARCSEC * pxPerArcsec;
-
   const rects: ShutterRect[] = [];
 
   for (const shutter of shutters) {
+    // Per-aperture dimensions in pixels: fixed slits (e.g. S200A2 = 0.2"x3.2")
+    // and MSA shutters carry their own size; fall back to the MSA shutter
+    // dimensions for rows that predate the aperture columns.
+    const wPx = (shutter.aperture_width_arcsec ?? SHUTTER_WIDTH_ARCSEC) * pxPerArcsec;
+    const hPx = (shutter.aperture_height_arcsec ?? SHUTTER_HEIGHT_ARCSEC) * pxPerArcsec;
+
     // Offset from center in arcseconds
     // RA increases to the left in sky coords, but in our image E is left
     // so positive dRA = negative pixel X offset (standard astronomical convention)


### PR DESCRIPTION
Adds support for standalone NIRSpec fixed-slit (`NRS_FIXEDSLIT`) spectroscopy and makes slit-overlay geometry self-describing end-to-end. Motivated by JWST PID 1967 (SHELLQs, z~6 quasars), all 12 of which reduce cleanly on this branch.

## 1. Standalone fixed-slit reduction (`3fb7b02`)
Previously only MSA (`NRS_MSASPEC`) and the fixed-slit-in-MSA hybrid worked, because both describe their slits in the MSA metadata file. Standalone fixed-slit exposures have none. jwst reduces fixed slit natively (`assign_wcs.get_open_fixed_slits` -> `extract_2d` by slit name), so the work was routing CAMPFIRE's MSA-metafile-centric stage2a around that:

- `Observation.glob` accepts `NRS_FIXEDSLIT`; `group_files` handles along-slit nod patterns (`*-NOD`).
- new `_run_stage2a_fixedslit`: runs `Spec2Pipeline` with `extract_2d.slit_names=[FXD_SLIT]`, product keyed on jwst's primary-slit `source_id=1`, so the mode-agnostic 2b/3 consume it unchanged.
- stage3 tolerates the fixed-slit header set + slit-name-embedded Spec3 output names.

stage1 needs no changes. **MSA reductions are unaffected.**

## 2. Aperture geometry propagation (`dfc1c6f`)
The shutters export encoded MSA shutter geometry for every source (wrong for a single fixed-slit aperture; `get_exposure_table` even rejected fixed-slit nod types). Now self-describing:

- stage3 EXPOSURES HDU gains `fixed_slit`/`slit_name`; `_spec.fits` carries `CFFXSLT`/`CFFSSLIT` (also flags fixed-slit sources inside MSA exposures).
- shutters ECSV/DB add per-row `aperture_name`/`aperture_width_arcsec`/`aperture_height_arcsec`; fixed slits emit one aperture rect (sizes in `nirspec/constants.py`), MSA rows carry 0.22x0.46 explicitly.
- **Supabase migration** adds the 3 columns (defaults match MSA, so existing rows are unchanged) + updates `get_nearby_shutters`/`get_field_shutters`.
- deploy + web (SVG overlay, map canvas) + python `imaging.py` render per-row dims.

## Validation
All 12 SHELLQs quasars reduced stage1->3 + summary, zero errors. Verified: correct target/aperture/position per object; the J0844 and J1146 coordinate-pairs land on distinct targets. DB RPC round-trip and `npm run build` pass.

CHANGELOG: two Algorithm (MINOR) entries.

Generated with Claude Code

https://claude.ai/code/session_01RBK2do4xpqtEGG3KAdNRaC