### PR TITLE
fix(nirspec): real source coords for fixed-slit summary/deploy (not 0,0)

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -71,6 +71,15 @@ Release procedure: edit the `## Unreleased` section below, then run
   feature failed for fixed-slit sources.
 
 ### Algorithm
+- NIRSpec fixed-slit: fixed the summary/deploy source position. Fixed-slit
+  products carry no catalog `SRCRA`/`SRCDEC` in the SCI header (those are
+  MSA-only), so the summary reader recorded `(0, 0)` for every fixed-slit
+  target — which collapsed all of them into a single object at the origin during
+  friends-of-friends clustering at deploy. The reader now falls back to the
+  EXPOSURES-table `source_ra`/`source_dec` (the target position), and stage3
+  writes `SRCRA`/`SRCDEC` into the `_spec.fits` SCI header from that table so the
+  product is self-describing. Existing fixed-slit products only need a `summary`
+  re-run (no re-reduction); MSA products are unaffected.
 - NIRSpec standalone **fixed-slit** (`NRS_FIXEDSLIT`) reduction is now supported
   end-to-end (stage1→3). Previously only MSA exposures (`NRS_MSASPEC`) and the
   fixed-slit-in-MSA hybrid were handled, because both describe their slits in the

--- a/pipeline/campfire_pipeline/metadata/reader.py
+++ b/pipeline/campfire_pipeline/metadata/reader.py
@@ -230,6 +230,24 @@ def read_fits_metadata(fits_path: Path, obs_name: str) -> dict:
 
         reduction_version = primary.get('CMPFRVER', 'v0.1')
 
+        # Source position. MSA products carry SRCRA/SRCDEC in the SCI header, but
+        # fixed-slit products do not (those are MSA-catalog-derived). Fall back to
+        # the EXPOSURES table source_ra/source_dec (the target position) so a
+        # fixed-slit source gets its real sky position rather than (0, 0) — which
+        # would otherwise collapse every fixed-slit target into one object at the
+        # origin during friends-of-friends clustering at deploy time.
+        ra = float(sci.get('SRCRA', 0) or 0)
+        dec = float(sci.get('SRCDEC', 0) or 0)
+        if ra == 0.0 and dec == 0.0 and 'EXPOSURES' in hdul:
+            ed = hdul['EXPOSURES'].data
+            cols = ed.columns.names
+            if 'source_ra' in cols and 'source_dec' in cols:
+                sra = ed['source_ra'][ed['source_ra'] != 0]
+                sdec = ed['source_dec'][ed['source_dec'] != 0]
+                if len(sra) and len(sdec):
+                    ra = float(np.nanmedian(sra))
+                    dec = float(np.nanmedian(sdec))
+
         return {
             'object_id': object_id,
             'source_id': parsed['source_id'],
@@ -244,8 +262,8 @@ def read_fits_metadata(fits_path: Path, obs_name: str) -> dict:
             'crds_context': primary.get('CRDS_CTX', ''),
             'reduction_version': reduction_version,
 
-            'ra': float(sci.get('SRCRA', 0)),
-            'dec': float(sci.get('SRCDEC', 0)),
+            'ra': ra,
+            'dec': dec,
 
             'redshift_auto': redshift_auto,
 

--- a/pipeline/campfire_pipeline/nirspec/stage3.py
+++ b/pipeline/campfire_pipeline/nirspec/stage3.py
@@ -464,6 +464,22 @@ def opt_ext_single_source(
         if keyword in s2d['SCI'].header:
             s2dh[keyword] = (s2d['SCI'].header[keyword], s2d['SCI'].header.comments[keyword])
 
+    # Fixed-slit products lack catalog SRCRA/SRCDEC; populate from the EXPOSURES
+    # table (target position) so the spec.fits is self-describing and the summary
+    # reader doesn't fall back to (0, 0).
+    if 'SRCRA' not in s2dh or 'SRCDEC' not in s2dh:
+        try:
+            ed = s2d['EXPOSURES'].data
+            if 'source_ra' in ed.columns.names:
+                sra = ed['source_ra'][ed['source_ra'] != 0]
+                sdec = ed['source_dec'][ed['source_dec'] != 0]
+                if len(sra) and 'SRCRA' not in s2dh:
+                    s2dh['SRCRA'] = (float(np.nanmedian(sra)), 'Source RA (target position)')
+                if len(sdec) and 'SRCDEC' not in s2dh:
+                    s2dh['SRCDEC'] = (float(np.nanmedian(sdec)), 'Source Dec (target position)')
+        except (KeyError, IndexError):
+            pass
+
     sci = fits.ImageHDU(data=s2d['SCI'].data, header=s2dh, name='SCI')
     err = fits.ImageHDU(data=s2d['ERR'].data, header=s2dh, name='ERR')
     wav = fits.ImageHDU(data=s2d['WAVELENGTH'].data, header=s2dh, name='WAVELENGTH')

--- a/python/campfire/deploy/reconcile.py
+++ b/python/campfire/deploy/reconcile.py
@@ -337,10 +337,19 @@ def classify(
         for tidx in indices:
             target_to_cluster[targets[tidx]['id']] = ci
 
-    # Existing object FK on each target row (may be None for new targets).
-    target_to_obj: dict[int, int | None] = {
-        t['id']: t.get('object_id') for t in targets
-    }
+    obj_by_id = {o['id']: o for o in existing_objects}
+
+    # Existing object FK on each target row (None for new targets). An
+    # object_id that isn't among this field's existing objects is a stale or
+    # cross-field membership — e.g. left behind when a prior deploy mis-placed
+    # targets onto an object in another field (the (0,0) coordinate collision
+    # incident, where every fixed-slit target collapsed onto one ghost object).
+    # Treat it as unassigned so the cluster is classified as an insert, instead
+    # of KeyError-ing on an obj_by_id lookup further down.
+    target_to_obj: dict[int, int | None] = {}
+    for t in targets:
+        oid = t.get('object_id')
+        target_to_obj[t['id']] = oid if oid in obj_by_id else None
 
     # For each existing object: the clusters its members went to.
     obj_clusters: dict[int, set[int]] = defaultdict(set)
@@ -358,8 +367,6 @@ def classify(
             oid = target_to_obj.get(tid)
             if oid is not None:
                 cluster_objects[ci].add(oid)
-
-    obj_by_id = {o['id']: o for o in existing_objects}
 
     # Pre-compute aggregates for every cluster.
     aggs: list[ClusterAggregates] = [

--- a/python/tests/test_reconcile.py
+++ b/python/tests/test_reconcile.py
@@ -113,6 +113,28 @@ def test_pure_merge_classifies_as_merge():
     assert {o['id'] for o in [p.merges[0].survivor] + p.merges[0].losers} == {100, 101}
 
 
+def test_stale_cross_field_membership_classifies_as_insert():
+    # Regression: a target whose object_id FK points to an object that is NOT
+    # among the field's existing_objects (a stale / cross-field membership left
+    # by a prior bad deploy — e.g. the (0,0) ghost that collapsed every
+    # fixed-slit target onto one object in another field). Must be treated as
+    # unassigned and classified as an Insert, not KeyError on obj_by_id[oid].
+    targets = [_target(1, 't1', 150.0, 2.0, 999999)]  # 999999 lives elsewhere
+    groups = [[0]]
+    existing: list[dict] = []  # ghost object not fetched for this field
+    members: dict[int, set[str]] = {}
+
+    p = classify(
+        groups=groups, targets=targets, existing_objects=existing,
+        members_by_obj=members, spectra_map={},
+        changed_hashes=set(),
+    )
+
+    assert len(p.inserts) == 1
+    assert p.splits == [] and p.merges == [] and p.complex_overlaps == []
+    assert p.orphans == []
+
+
 def test_split_plus_merge_overlap_is_detected_not_silently_dropped():
     # A splits into clusters X={t1,t4} and Y={t2,t3}. X also absorbs B={t4}.
     # Regression test for the pre-fix bug where merge step skipped X


### PR DESCRIPTION
Follow-up bugfix to the fixed-slit support (#193). Deploying the 12 SHELLQs observations put every quasar at ra,dec = (0,0), and friends-of-friends clustering merged all 12 into a single object at the origin.

**Cause:** fixed-slit products carry no catalog `SRCRA`/`SRCDEC` in the SCI header (those are MSA-catalog-derived). The summary reader (`reader.py`) read `sci.get('SRCRA', 0)` -> `0`. The correct position was already present in the spec.fits EXPOSURES HDU (`source_ra`/`source_dec` = target position), just not where the reader looked.

**Fix:**
- `reader.py` falls back to the EXPOSURES-table `source_ra`/`source_dec` when SRCRA/SRCDEC are absent/zero. This repairs **existing** products with only a `summary` re-run — no re-reduction.
- stage3 `opt_ext` writes `SRCRA`/`SRCDEC` into the `_spec.fits` SCI header from that table, so **future** fixed-slit products are self-describing.

MSA products are unaffected (SRCRA/SRCDEC present -> fallback never triggers).

**Verified:** re-ran `summary` on all 12 SHELLQs observations — ra/dec now match the target positions, 12/12 distinct (was 12/12 at the origin). After merge, re-deploy the 12 (and clean up the stale origin object).

Generated with Claude Code

https://claude.ai/code/session_01RBK2do4xpqtEGG3KAdNRaC