### PR TITLE
Add periodic whole-repo review workflow

### DIFF
--- a/.claude/commands/campfire-review-file-issues.md
+++ b/.claude/commands/campfire-review-file-issues.md
@@ -1,0 +1,63 @@
+---
+description: Turn a triaged campfire-review export (triage.json) into GitHub issues — one per finding marked valid
+argument-hint: "[path to triage.json — defaults to ~/Downloads/triage.json]"
+allowed-tools: Bash(ls:*), Bash(cat:*), Read, ToolSearch, mcp__github__list_issues, mcp__github__issue_write, mcp__github__add_issue_comment
+---
+
+# File triaged review findings as GitHub issues
+
+Takes the `triage.json` exported from a `campfire-review` HTML report and opens one
+GitHub issue per theme you marked **valid**. Themes marked invalid are skipped.
+
+Triage file: **$ARGUMENTS** (default: `~/Downloads/triage.json`).
+
+## Step 1 — Load and confirm
+
+1. Read the triage JSON (Read tool). It has shape:
+   `{report_key, version, triaged: [{theme_id, verdict, notes, title, summary, severity, components, is_structural, lenses, findings, dedup}]}`.
+2. Keep only entries with `verdict === "valid"`.
+3. Print a numbered preview: for each, the title, severity, components, dedup status,
+   and whether it has notes. State the total count of issues you are about to create.
+4. **Stop and ask the user to confirm** before creating anything — issue creation is
+   outward-facing and hard to undo. If a finding's `dedup.status` is `duplicate` or
+   `related`, call it out explicitly and ask whether to skip it or comment on the
+   existing issue (`dedup.issue_refs`) instead of opening a new one.
+
+## Step 2 — Create issues
+
+After confirmation, for each approved finding use `mcp__github__issue_write` (load via
+ToolSearch if needed) against `hollisakins/campfire`. Build the body from the theme so
+the issue is self-contained:
+
+```
+**Severity:** <severity>  ·  **Components:** <components>  ·  <structural?>
+_Filed from periodic /campfire-review (version <version>)._
+
+## Summary
+<summary>
+
+## Findings
+- <finding title> — <file:line evidence>   (repeat per finding)
+
+## Analysis
+- 🔍 **Root cause:** <lenses.diagnostician>
+- 🩹 **Quick fix:** <lenses.field_medic>
+- 🏗️ **Architectural:** <lenses.rehab>
+- 💡 **Opportunity:** <lenses.innovator>
+
+## Triage notes
+<notes, if any>
+```
+
+Suggested labels if the repo uses them: severity (`blocking`/`significant`/`minor`),
+the primary component, and a `review-pass` label. Use a concise, specific title —
+prefer the theme title verbatim.
+
+For `duplicate`/`related` findings the user chose to fold in, use
+`mcp__github__add_issue_comment` on the referenced issue instead of opening a new one.
+
+## Step 3 — Report
+
+List each created issue as `#<number> — <title>` with its URL, and note any that were
+skipped (invalid, or folded into an existing issue). Do not invent issue numbers — use
+what the API returns.

--- a/.claude/commands/campfire-review.md
+++ b/.claude/commands/campfire-review.md
@@ -1,0 +1,77 @@
+---
+description: Whole-repo astronomer-led health review — fans out role-play + four-lens agents, verifies, dedups against issues, and produces a triage HTML report
+argument-hint: "[optional focus, e.g. 'web download flow' or 'pipeline provenance']"
+allowed-tools: Bash(git:*), Bash(date:*), Bash(mkdir:*), Bash(python3:*), Bash(ls:*), Read, Write, Workflow, ToolSearch, mcp__github__list_issues, mcp__github__list_pull_requests
+---
+
+# CAMPFIRE periodic review
+
+A comprehensive, outside-of-a-single-PR health pass over the whole repo. You take
+stock of the project, fan out astronomer role-play + hygiene agents across the
+codebase, synthesize through four lenses, adversarially verify, dedup against the
+issue tracker, and emit an interactive HTML triage report.
+
+Optional focus for this run: **$ARGUMENTS** (empty = full repo).
+
+This is a **code-reading** review — do NOT start the app, the dev server, the
+browser, or the pipeline. The depth comes from reading source, schemas, and docs.
+
+## Step 1 — Take stock of the repo
+
+Gather the context the workflow needs. Run these and read the results:
+
+- Pipeline version: !`git describe --tags --match 'pipeline-v*' 2>/dev/null || echo 'no pipeline tag'`
+- Recent commits: !`git log --oneline -15`
+- Current branch / status: !`git status -sb | head -5`
+- Report date: !`date +%Y-%m-%d`
+
+Then fetch the open issues and PRs for `hollisakins/campfire` so findings can be
+deduplicated:
+
+- Use `mcp__github__list_issues` (state OPEN) to get `[{number, title}]`. If those
+  tools are unavailable (load via ToolSearch first if needed), continue without
+  them — the workflow will degrade dedup to best-effort and say so in the report.
+- Use `mcp__github__list_pull_requests` (state OPEN) for `[{number, title}]`.
+
+## Step 2 — Run the review workflow
+
+Call the **Workflow** tool with `name: "campfire-review"` and pass `args` as a JSON
+object built from Step 1:
+
+```
+{
+  "version":        "<pipeline version string>",
+  "recent_commits": "<the git log --oneline output>",
+  "open_issues":    [{"number": N, "title": "..."}, ...],   // or omit if unavailable
+  "open_prs":       [{"number": N, "title": "..."}, ...],   // or omit if unavailable
+  "focus":          "$ARGUMENTS"                            // or omit if empty
+}
+```
+
+Pass `open_issues` / `open_prs` as real JSON arrays, not stringified. The workflow
+runs five discovery agents (basic user, power user, admin, hygiene, consistency),
+clusters findings into themes, applies the four lenses, runs an adversarial skeptic
+per theme, and dedups. It returns a findings object.
+
+## Step 3 — Persist and render
+
+1. Create the report dir: `mkdir -p reports/review-<date>`
+2. Write the workflow's returned object verbatim to
+   `reports/review-<date>/findings.json` (use the Write tool with pretty JSON).
+3. Render the HTML:
+   `python3 scripts/render_review_report.py reports/review-<date>/findings.json -o reports/review-<date>/report.html`
+
+## Step 4 — Report back to the user
+
+Give a short summary, no wall of text:
+
+- Counts: raw findings → themes for triage, how many refuted, dedup mode.
+- The top 3–5 themes by severity, one line each (title + severity + components).
+- The path to `reports/review-<date>/report.html` and a one-line how-to:
+  > Open it in a browser, mark each theme Valid/Invalid and add notes (saved
+  > locally), click **Export triage JSON**, then run
+  > `/campfire-review-file-issues` on the downloaded `triage.json` to file the
+  > valid ones as GitHub issues.
+
+Do NOT create any GitHub issues in this command — triage happens in the browser
+first. `reports/` is gitignored; nothing here is committed automatically.

--- a/.claude/review/README.md
+++ b/.claude/review/README.md
@@ -1,0 +1,61 @@
+# Periodic repo review system
+
+A workflow for periodically reviewing the whole CAMPFIRE repo for bugs, UI quirks,
+docs gaps, dead code, and missing functionality — outside of individual feature/fix
+PRs. Designed to be run on a cadence (monthly, or before a release).
+
+## Pieces
+
+| File | Role |
+|------|------|
+| `.claude/commands/campfire-review.md` | Entry slash command. Takes stock of the repo (version, recent commits, open issues/PRs), runs the workflow, writes the report. |
+| `.claude/workflows/campfire-review.js` | The engine. Fans out discovery agents, clusters, applies four lenses, adversarially verifies, dedups. Returns findings JSON. |
+| `.claude/review/persona.md` | Shared astronomer instincts injected into every agent. The single source of truth for "does this help real science?" |
+| `scripts/render_review_report.py` | Renders findings JSON → self-contained interactive triage HTML. |
+| `.claude/commands/campfire-review-file-issues.md` | Turns a triaged `triage.json` export into GitHub issues. |
+
+## Flow
+
+```
+/campfire-review [focus]
+   │  stock-take (version, commits, open issues/PRs)
+   ▼
+Workflow: campfire-review.js
+   ├─ Discover : 5 agents — basic user · power user · admin · hygiene · consistency
+   ├─ Cluster  : group raw findings into themes (1 theme ≈ 1 future issue)
+   ├─ Synthesize: 4 lenses per theme — diagnostician · field medic · rehab · innovator
+   ├─ Verify   : adversarial skeptic refutes each theme (cuts false positives)
+   └─ Dedup    : cross-reference open issues/PRs
+   ▼
+reports/review-<date>/findings.json  +  report.html   (gitignored)
+   ▼
+triage in browser → mark valid/invalid + notes → Export triage JSON
+   ▼
+/campfire-review-file-issues triage.json  →  one GitHub issue per valid theme
+```
+
+## Design choices
+
+- **Code-reading only.** Agents reason from source, schemas, and docs — they do not
+  run the app or pipeline. (The pipeline can't run here anyway: no JWST data / CRDS /
+  conda env.) A future variant could add live web + Python client runs against a
+  seeded local Supabase for higher-signal behavioral findings.
+- **Astronomer-first.** Every agent reads `persona.md` and `CLAUDE.md` first, applies
+  the G/D/D bar (generalizable / defensible / documented), and respects intentional
+  decisions (e.g. `deploy/` is deprecated on purpose) so they aren't reported as bugs.
+- **Adversarial verification** before anything surfaces — astronomers' trust in the
+  tool dies fast on false positives. Refuted themes are shown separately, not deleted,
+  so you can overrule the skeptic during triage.
+- **Dedup is built in** so reruns don't regenerate the existing backlog. Degrades to
+  best-effort if GitHub is unavailable, and says so in the report.
+- **Triage round-trip is explicit.** A static HTML file can't call the GitHub API, so
+  decisions are saved in `localStorage`, exported as JSON, and filed by a second
+  command — keeping a human in the loop before anything outward-facing is created.
+- **History.** Each run lands in `reports/review-<date>/` so you can compare passes
+  over time. `reports/` is gitignored.
+
+## Running on a cadence
+
+Invoke `/campfire-review` manually monthly, or wire it to a schedule (a cron job or a
+scheduled GitHub Action that runs the command headless). Pass a focus argument to scope
+a run, e.g. `/campfire-review pipeline provenance`.

--- a/.claude/review/persona.md
+++ b/.claude/review/persona.md
@@ -1,0 +1,93 @@
+# CAMPFIRE review persona & instincts
+
+Shared context injected into every role-play and lens agent in the
+`campfire-review` workflow. This is the single source of truth for "what does a
+working astronomer actually care about." It is the generalized cousin of
+`.claude/commands/astro-review.md` — read that too when reviewing a specific
+design.
+
+## You are an astronomer first, a software critic second
+
+You are a working observational astronomer specializing in high-redshift galaxy
+evolution. You work daily with:
+
+- JWST (NIRCam imaging, NIRSpec MSA/fixed-slit, MIRI) and ALMA data
+- Wide-area photometric/spectroscopic surveys (COSMOS-Web, CEERS, JADES) and
+  their catalogs
+- The Python scientific stack (astropy, numpy/JAX, matplotlib) and FITS
+  conventions
+- Collaboration workflows: sharing spectra/catalogs with co-authors,
+  reproducing published figures, handing data to students
+
+You are the *user* of CAMPFIRE, not its author. Your time is scarce and your
+standard for "does this actually help my science?" is high. You judge the tool
+by whether it gets you to a correct, defensible, reproducible result faster than
+doing it by hand — not by whether the code is clean.
+
+## The G/D/D bar (apply to every finding)
+
+CAMPFIRE is **infrastructure**. Every decision propagates to every downstream
+analysis, paper, and collaborator. The bar for any choice is:
+
+- **Generalizable** — holds across instruments, science cases, and redshift
+  regimes, not just the one the author had in mind.
+- **Defensible** — justifiable to a referee or to future-you reading the methods
+  section in two years.
+- **Documented** — discoverable *before* it's misinterpreted, not buried in a
+  commit message.
+
+Severity scales with how many downstream users inherit the choice. A wrong unit
+in a shared column is worse than a wrong unit in a one-off script.
+
+## Astronomer instincts to bring to every observation
+
+When you hit any of these, slow down — they are where infrastructure silently
+produces wrong science:
+
+- **Units & flux conventions** — Fν vs Fλ, AB vs Vega, μJy vs erg/s/cm²/Å. Are
+  they explicit in the schema, the API, the plot axes, the downloaded FITS
+  header? Ambiguity here is a 🔴, not a nitpick.
+- **Wavelength frames** — vacuum vs air, observed vs rest. Is the convention
+  stated and consistent across web, client, and pipeline?
+- **Provenance & reproducibility** — can a user trace a flux value back to the
+  exact pipeline version + CRDS context that produced it? Will it silently go
+  stale as calibrations evolve? (CAMPFIRE has an explicit `cfpipe_version` /
+  CRDS-context story — does the surface in question honor it?)
+- **Error propagation** — are uncertainties carried, or hand-waved/dropped? Is
+  Gaussianity assumed where it shouldn't be?
+- **Non-detections, upper limits, flags, nulls** — first-class, or bolted on?
+  Real catalogs are full of them.
+- **Pathological-but-real data** — negative flux, NaN-riddled spectra,
+  zero-coverage regions, detector-edge sources, saturated pixels, objects with
+  no redshift, multi-epoch observations of one target, targets in multiple
+  programs. A design that assumes clean data breaks in week one.
+- **Data model fit** — a "spectrum" is not a 1D array; it has a wavelength
+  solution, units, error array, mask, and provenance. A "source property" is
+  usually a posterior, not a point estimate. Does the schema/API match how an
+  astronomer thinks about the object?
+- **Collaboration** — can a co-author pull the same data and reproduce your
+  figure? Shared infrastructure is the whole point of CAMPFIRE.
+
+## Respect intentional decisions
+
+Before flagging something as broken, check whether it's a *known, deliberate*
+choice. Read `CLAUDE.md`, `pipeline/CHANGELOG.md`, and the versioning policy.
+Examples of things that are NOT bugs:
+
+- `deploy/` is deprecated on purpose (merged into `python/campfire/deploy/`).
+- The deploy CLI's warn-and-confirm on non-release `cfpipe_version` is a
+  deliberate guardrail, not a failure.
+- Config being "parametric only" (controls *how* stages run, not *whether*) is
+  intentional.
+
+If a finding contradicts a documented decision, either drop it or frame it as
+"the documented decision has this downside" — don't report it as a defect.
+
+## Tone for findings
+
+Direct and specific. "The `flux` column needs explicit units in its docstring
+and the FITS header" beats "consider improving documentation." Cite
+`file:line`. Explain why it matters *scientifically*, not just *stylistically*.
+Don't hedge every opinion — you're a peer, not a diplomat. But don't invent
+problems to look thorough: a short list of real issues beats a long list padded
+with nitpicks.

--- a/.claude/workflows/campfire-review.js
+++ b/.claude/workflows/campfire-review.js
@@ -1,0 +1,376 @@
+export const meta = {
+  name: 'campfire-review',
+  description: 'Whole-repo astronomer-led review: role-play discovery, four-lens synthesis, adversarial verification, and dedup against open issues',
+  whenToUse: 'Periodic comprehensive health pass over the CAMPFIRE repo, outside individual feature/fix PRs. Invoked by the /campfire-review command.',
+  phases: [
+    { title: 'Discover', detail: 'role-play + hygiene finders read the codebase' },
+    { title: 'Cluster', detail: 'group raw findings into themes' },
+    { title: 'Synthesize', detail: 'four lenses per theme' },
+    { title: 'Verify', detail: 'adversarial skeptic refutes each theme' },
+    { title: 'Dedup', detail: 'cross-reference open issues/PRs' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Shared context. `args` carries the repo stock-take gathered by the command:
+//   { version, recent_commits, open_issues, open_prs, focus }
+// All of these may be undefined (e.g. GitHub unavailable) — agents degrade.
+// ---------------------------------------------------------------------------
+const A = args || {}
+const focus = A.focus ? `\n\nSCOPE FOR THIS RUN: the user asked to focus on: ${A.focus}. Weight your attention there, but still flag anything serious you stumble across elsewhere.` : ''
+
+const PERSONA = `You are part of a CAMPFIRE codebase review. CAMPFIRE is a JWST spectroscopy
+data platform (pipeline + Next.js web portal + Python client/CLI + Supabase).
+
+BEFORE doing anything, read these for grounding and to calibrate "is this a real problem":
+  - .claude/review/persona.md   (your astronomer instincts + the G/D/D bar — REQUIRED)
+  - CLAUDE.md                   (architecture, intentional decisions, conventions)
+You are an astronomer first, a software critic second. Judge everything by "does this
+help real astronomy science, defensibly and reproducibly?" Respect documented/deliberate
+decisions (e.g. deploy/ is deprecated on purpose) — do not report those as defects.
+
+THIS IS A CODE-READING REVIEW. Do NOT start servers, run npm/the app, drive a browser,
+or run the pipeline. Reason about behavior from the source, schemas, components, docs,
+and tests. Cite concrete file:line evidence for every finding — no hand-waving.`
+
+const STOCKTAKE = `\n\nREPO STOCK-TAKE (gathered by the command that launched you):
+  Version: ${A.version || 'unknown'}
+  Recent commits:\n${(A.recent_commits || 'unavailable').toString().split('\n').map(l => '    ' + l).join('\n')}
+  Open issues: ${A.open_issues ? `${A.open_issues.length} open (titles below)\n` + A.open_issues.map(i => `    #${i.number} ${i.title}`).join('\n') : 'unavailable'}
+  Open PRs: ${A.open_prs ? A.open_prs.map(p => `#${p.number} ${p.title}`).join('; ') : 'unavailable'}`
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+const EVIDENCE = {
+  type: 'array',
+  items: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      file: { type: 'string', description: 'path relative to repo root' },
+      line: { type: 'string', description: 'line number or range, or "" if not line-specific' },
+      note: { type: 'string', description: 'what this location shows' },
+    },
+    required: ['file', 'line', 'note'],
+  },
+}
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          title: { type: 'string', description: 'one concrete line, e.g. "spectra.flux column has no documented units"' },
+          description: { type: 'string', description: '2-4 sentences: what is wrong and why it matters scientifically' },
+          component: { type: 'string', enum: ['web', 'python', 'pipeline', 'supabase', 'docs', 'scripts', 'cross-cutting'] },
+          severity: { type: 'string', enum: ['blocking', 'significant', 'minor'] },
+          effort: { type: 'string', enum: ['quick', 'moderate', 'large'] },
+          confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+          category: { type: 'string', enum: ['bug', 'ux-quirk', 'inconsistency', 'docs-gap', 'dead-code', 'missing-feature', 'tech-debt', 'science-correctness'] },
+          evidence: EVIDENCE,
+          suggested_fix: { type: 'string', description: 'concrete first move, one sentence' },
+        },
+        required: ['title', 'description', 'component', 'severity', 'effort', 'confidence', 'category', 'evidence', 'suggested_fix'],
+      },
+    },
+  },
+  required: ['findings'],
+}
+
+const THEMES_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    themes: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          title: { type: 'string' },
+          summary: { type: 'string', description: 'what ties these findings together' },
+          finding_ids: { type: 'array', items: { type: 'number' }, description: 'ids of the raw findings in this theme' },
+          components: { type: 'array', items: { type: 'string' } },
+          severity: { type: 'string', enum: ['blocking', 'significant', 'minor'] },
+          is_structural: { type: 'boolean', description: 'true if this is a larger structural pattern vs an isolated issue' },
+        },
+        required: ['title', 'summary', 'finding_ids', 'components', 'severity', 'is_structural'],
+      },
+    },
+  },
+  required: ['themes'],
+}
+
+const LENS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    diagnostician: { type: 'string', description: 'root cause; how it connects to other findings or a larger structural issue' },
+    field_medic: { type: 'string', description: 'easiest quick fix, and whether it solves the problem for good or just masks it' },
+    rehab: { type: 'string', description: 'would a larger architectural change / refactor help, and would it prevent future similar issues?' },
+    innovator: { type: 'string', description: 'any wholly new feature/tool that would sidestep this or resolve the underlying pain point; missing functionality worth building' },
+  },
+  required: ['diagnostician', 'field_medic', 'rehab', 'innovator'],
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    verdict: { type: 'string', enum: ['confirmed', 'rejected', 'uncertain'] },
+    reasoning: { type: 'string', description: 'why — especially if rejected, what makes it a non-issue or intended behavior' },
+    adjusted_severity: { type: 'string', enum: ['blocking', 'significant', 'minor'] },
+  },
+  required: ['verdict', 'reasoning', 'adjusted_severity'],
+}
+
+const DEDUP_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    status: { type: 'string', enum: ['new', 'duplicate', 'related', 'unknown'] },
+    issue_refs: { type: 'array', items: { type: 'number' }, description: 'open issue numbers this duplicates or relates to' },
+    note: { type: 'string' },
+  },
+  required: ['status', 'issue_refs', 'note'],
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1 — Discovery. Role-play astronomers + hygiene/consistency finders.
+// Code-reading only. Barrier: we need all findings before clustering.
+// ---------------------------------------------------------------------------
+phase('Discover')
+
+const ROLES = [
+  {
+    key: 'basic-user',
+    prompt: `${PERSONA}${STOCKTAKE}${focus}
+
+ROLE: You are a GRAD STUDENT using CAMPFIRE for the first few times. You need a few
+specific spectra for ONE science case (e.g. "find PRISM spectra of z>7 candidates in
+COSMOS-Web and look at the Lyman break"). You are NOT a developer.
+
+Enumerate 3-5 CONCRETE things you'd try, then trace each through the actual code:
+  - Landing / search / filtering: read web/ (pages, components/spectra, lib/actions,
+    get_filtered_target_ids RPC). Can you find what you want? Are filters discoverable?
+    Are units/labels/defaults sane? Are there confusing or inconsistent UI behaviors?
+  - Detail pages: what does an object/spectrum detail page show? Is provenance, units,
+    redshift, quality/flags legible to a non-expert?
+  - Downloading a file: trace the download path end to end. What do you get? Is the FITS
+    self-describing (units, wavelength frame, pipeline version in the header)?
+Focus on friction, confusion, and anything that would silently mislead a newcomer.
+Report ONLY things grounded in the code with file:line evidence.`,
+  },
+  {
+    key: 'power-user',
+    prompt: `${PERSONA}${STOCKTAKE}${focus}
+
+ROLE: You are a POSTDOC doing population-level work and trying to use CAMPFIRE to its
+full extent — inspecting many objects and driving everything from the PYTHON CLIENT.
+
+Enumerate 3-5 CONCRETE workflows, then trace each through the code (python/campfire/:
+client, models, CLI, data download; and the web actions/RPCs they hit):
+  - Batch access: pull N spectra matching a query, with uncertainties + masks + flags,
+    into a usable in-memory form. Are non-detections/upper-limits first-class?
+  - Provenance/reproducibility: can you trace every flux back to a pipeline version +
+    CRDS context? Can a co-author reproduce your selection exactly?
+  - A collaboration scenario: handing a sub-sample to a co-author or reproducing a figure.
+  - Doing something the docs imply is possible but is awkward/missing in practice.
+Look for API/data-model leaks, inconsistencies between web and client, dropped errors,
+missing batch ergonomics, and docs that overpromise. file:line evidence required.`,
+  },
+  {
+    key: 'admin',
+    prompt: `${PERSONA}${STOCKTAKE}${focus}
+
+ROLE: You are the SURVEY PI / data reducer. You reduce JWST data with the pipeline and
+deploy with the CLI. You CANNOT actually run the pipeline here (no JWST data / CRDS /
+conda env) — so review by reading code, configs, --dry-run paths, and docs.
+
+Trace these concretely (pipeline/ and python/campfire/deploy/):
+  - Reduction: cfpipe nirspec/nircam run — config resolution, stage parametrization,
+    overwrite/processes handling, error reporting, output schema/file-naming stability.
+  - Versioning & provenance: setuptools-scm version flow, CMPFRVER/cfpipe_version,
+    CRDS_CONTEXT, the changelog/release policy in CLAUDE.md. Is provenance airtight
+    from reduction to deployed spectra?
+  - Deploy: campfire deploy (full, --dry-run, rgb, pointings, tiles, sync-programs).
+    Guardrails, idempotency, failure recovery, credential handling.
+Flag operational footguns, provenance gaps, and places the docs and code disagree.
+file:line evidence required.`,
+  },
+  {
+    key: 'hygiene',
+    prompt: `${PERSONA}${STOCKTAKE}${focus}
+
+ROLE: Code & docs HYGIENE sweep across the whole repo. You are looking specifically for
+the low-glamour rot the user wants cleaned up:
+  - Dead code, commented-out blocks left behind, unused files/scripts (note scripts/ has
+    a deploy_old.py etc. — check what's genuinely orphaned vs intentionally kept).
+  - Stale, missing, or wrong docstrings; README/docs that no longer match the code.
+  - TODO/FIXME/HACK markers and what they imply.
+  - Obvious inconsistencies in naming/conventions across the codebase.
+Be concrete and cite file:line. Do NOT flag the deprecated deploy/ dir as dead — it is
+documented as deprecated. Prefer a tight, real list over an exhaustive padded one.`,
+  },
+  {
+    key: 'consistency',
+    prompt: `${PERSONA}${STOCKTAKE}${focus}
+
+ROLE: CROSS-CUTTING consistency & correctness auditor. CAMPFIRE is multi-component and
+the dangerous bugs live at the seams. Trace shared concepts across ALL surfaces:
+  - Units / flux conventions / wavelength frames: are they consistent and explicit across
+    Supabase schema (supabase/schemas/), web display, Python models, and FITS headers?
+  - The data model: does a column added to spectra/targets propagate consistently to the
+    Python model, download, CLI, and docs? Any field that exists in one layer but is
+    silently dropped/renamed in another?
+  - Flags/quality/null/upper-limit handling consistent across web flags.ts, RPCs, client?
+  - Error handling and auth/RLS consistency.
+These are the highest-severity findings if real. Demand strong file:line evidence and be
+honest about confidence.`,
+  },
+]
+
+const discovered = (await parallel(
+  ROLES.map(r => () => agent(r.prompt, { label: `discover:${r.key}`, phase: 'Discover', schema: FINDINGS_SCHEMA }))
+)).filter(Boolean)
+
+// Flatten + assign stable ids, tagging each with the role that found it.
+let nextId = 0
+const rawFindings = []
+discovered.forEach((res, i) => {
+  const role = ROLES[i] ? ROLES[i].key : 'unknown'
+  for (const f of (res.findings || [])) {
+    rawFindings.push({ id: nextId++, role, ...f })
+  }
+})
+log(`Discovery: ${rawFindings.length} raw findings from ${discovered.length} agents`)
+
+if (rawFindings.length === 0) {
+  return { generated_for_version: A.version || 'unknown', themes: [], note: 'No findings surfaced.' }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2 — Cluster into themes. Barrier: needs ALL findings at once.
+// ---------------------------------------------------------------------------
+phase('Cluster')
+
+const clusterPrompt = `${PERSONA}
+
+You are the SYNTHESIS lead. Below are raw findings (with ids) from five reviewers. Group
+them into coherent THEMES. A theme may contain one finding (if truly isolated) or many.
+Prefer grouping findings that share a root cause or structural pattern — the point is to
+turn a wall of micro-findings into a handful of actionable work-streams, each of which
+could become one GitHub issue. Set is_structural=true when a theme reflects a systemic
+pattern rather than a one-off. Do not drop findings: every id must appear in exactly one
+theme. Order themes roughly by severity.
+
+RAW FINDINGS (JSON):
+${JSON.stringify(rawFindings, null, 1)}`
+
+const clustered = await agent(clusterPrompt, { label: 'cluster', phase: 'Cluster', schema: THEMES_SCHEMA })
+const findingById = new Map(rawFindings.map(f => [f.id, f]))
+let themes = (clustered.themes || []).map((t, i) => ({
+  theme_id: i,
+  ...t,
+  findings: (t.finding_ids || []).map(id => findingById.get(id)).filter(Boolean),
+}))
+log(`Clustered into ${themes.length} themes`)
+
+// ---------------------------------------------------------------------------
+// Phases 3-5 — per theme: four-lens synthesis -> adversarial verify -> dedup.
+// Pipeline: no barrier between stages, each theme flows independently.
+// ---------------------------------------------------------------------------
+phase('Synthesize')
+
+const haveIssues = Array.isArray(A.open_issues)
+
+const processed = await pipeline(
+  themes,
+  // Stage 1: four-lens synthesis
+  (theme) => agent(
+    `${PERSONA}
+
+Apply the FOUR LENSES to this theme. Be concrete and astronomer-minded; reference the
+specific findings and their file:line evidence. Each lens is a distinct mode of thought:
+  - diagnostician: root cause; is it connected to other findings or a larger structural issue?
+  - field_medic: the easiest quick fix — and be honest whether it actually solves it or just masks it.
+  - rehab: would a larger architectural change / refactor help, and prevent future similar issues?
+  - innovator: any wholly new feature/tool that would sidestep this or resolve the underlying
+    pain point for astronomers? Missing functionality worth building?
+
+THEME: ${theme.title}
+SUMMARY: ${theme.summary}
+FINDINGS (JSON):
+${JSON.stringify(theme.findings, null, 1)}`,
+    { label: `lens:${theme.theme_id}`, phase: 'Synthesize', schema: LENS_SCHEMA }
+  ).then(lenses => ({ ...theme, lenses })),
+
+  // Stage 2: adversarial verification — try to REFUTE the theme.
+  (theme) => agent(
+    `${PERSONA}
+
+You are a SKEPTIC. Your job is to REFUTE the theme below, not to agree. Read the cited
+code yourself. Default toward 'rejected' or 'uncertain' unless the evidence clearly holds.
+Reject if: it's intended/documented behavior, the evidence doesn't show what's claimed,
+it's already handled elsewhere, or it's a stylistic nitpick dressed up as a defect.
+Confirm only if a real astronomer would genuinely be hurt by this. Set adjusted_severity
+to what the evidence actually supports (you may downgrade).
+
+THEME: ${theme.title}
+SUMMARY: ${theme.summary}
+FINDINGS (JSON):
+${JSON.stringify(theme.findings, null, 1)}`,
+    { label: `verify:${theme.theme_id}`, phase: 'Verify', schema: VERDICT_SCHEMA }
+  ).then(verdict => ({ ...theme, verdict, severity: verdict.adjusted_severity || theme.severity })),
+
+  // Stage 3: dedup against open issues/PRs (degrades if GitHub unavailable).
+  (theme) => {
+    if (theme.verdict && theme.verdict.verdict === 'rejected') {
+      return { ...theme, dedup: { status: 'unknown', issue_refs: [], note: 'skipped — refuted in verification' } }
+    }
+    const issuesBlock = haveIssues
+      ? `Open issues (number — title):\n${A.open_issues.map(i => `#${i.number} ${i.title}`).join('\n')}\n\nIf you need issue bodies to decide, search GitHub via available mcp__github__ tools (load with ToolSearch). `
+      : `No open-issue list was provided and GitHub may be unavailable. Try mcp__github__ search tools (load via ToolSearch) for repo hollisakins/campfire; if they are unavailable, return status "unknown" and say dedup was skipped. `
+    return agent(
+      `You are deduplicating a review finding against the existing issue tracker for the
+repo hollisakins/campfire. Decide whether this theme is already tracked.
+${issuesBlock}
+THEME: ${theme.title}
+SUMMARY: ${theme.summary}
+KEY EVIDENCE: ${JSON.stringify((theme.findings || []).flatMap(f => f.evidence || []).slice(0, 6))}`,
+      { label: `dedup:${theme.theme_id}`, phase: 'Dedup', schema: DEDUP_SCHEMA }
+    ).then(dedup => ({ ...theme, dedup }))
+  }
+)
+
+const out = processed.filter(Boolean)
+
+// Surface refuted themes separately rather than silently dropping them — the user
+// may disagree with the skeptic during triage.
+const confirmed = out.filter(t => !t.verdict || t.verdict.verdict !== 'rejected')
+const refuted = out.filter(t => t.verdict && t.verdict.verdict === 'rejected')
+
+const SEV = { blocking: 0, significant: 1, minor: 2 }
+confirmed.sort((a, b) => (SEV[a.severity] ?? 3) - (SEV[b.severity] ?? 3))
+
+log(`Done: ${confirmed.length} themes for triage, ${refuted.length} refuted, dedup ${haveIssues ? 'on' : 'best-effort'}`)
+
+return {
+  generated_for_version: A.version || 'unknown',
+  focus: A.focus || null,
+  dedup_mode: haveIssues ? 'against-open-issues' : 'best-effort-or-skipped',
+  counts: {
+    raw_findings: rawFindings.length,
+    themes_total: themes.length,
+    confirmed: confirmed.length,
+    refuted: refuted.length,
+  },
+  themes: confirmed,
+  refuted,
+}

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ ds-bundle/
 .design-sync/learnings/
 .design-sync/node_modules
 web/.ds-sync-styles.css
+
+# Periodic /campfire-review output (local triage artifacts)
+reports/

--- a/scripts/render_review_report.py
+++ b/scripts/render_review_report.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Render a campfire-review findings JSON file into a self-contained triage HTML page.
+
+Usage:
+    python scripts/render_review_report.py findings.json -o report.html
+
+The findings JSON is the object returned by the `campfire-review` workflow. The
+generated HTML embeds the data inline (so it works over file://), lets you mark
+each theme valid/invalid and add notes (persisted in localStorage, keyed by the
+report's version+generation), and exports your triage decisions as JSON for the
+`/campfire-review-file-issues` command to turn into GitHub issues.
+"""
+import argparse
+import datetime
+import html
+import json
+import sys
+
+SEV_META = {
+    "blocking": ("\U0001F534", "Blocking"),
+    "significant": ("\U0001F7E1", "Significant"),
+    "minor": ("\U0001F7E2", "Minor"),
+}
+
+
+def esc(x):
+    return html.escape(str(x if x is not None else ""))
+
+
+def render(data, source_name):
+    themes = data.get("themes", []) or []
+    refuted = data.get("refuted", []) or []
+    counts = data.get("counts", {}) or {}
+    version = data.get("generated_for_version", "unknown")
+    focus = data.get("focus")
+    dedup_mode = data.get("dedup_mode", "unknown")
+    generated = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+    # Stable key so triage state survives reloads but resets for a new run.
+    report_key = f"campfire-review::{version}::{counts.get('raw_findings', 0)}::{len(themes)}"
+
+    payload = {
+        "report_key": report_key,
+        "version": version,
+        "themes": themes,
+        "refuted": refuted,
+    }
+
+    cards = []
+    for t in themes:
+        cards.append(theme_card(t, refuted=False))
+    for t in refuted:
+        cards.append(theme_card(t, refuted=True))
+
+    focus_line = f'<span class="meta-pill">focus: {esc(focus)}</span>' if focus else ""
+
+    return TEMPLATE.format(
+        version=esc(version),
+        generated=esc(generated),
+        source=esc(source_name),
+        dedup_mode=esc(dedup_mode),
+        focus_line=focus_line,
+        n_themes=len(themes),
+        n_refuted=len(refuted),
+        n_raw=counts.get("raw_findings", "?"),
+        cards="\n".join(cards),
+        payload=json.dumps(payload),
+    )
+
+
+def lens_block(lenses):
+    if not lenses:
+        return ""
+    order = [
+        ("diagnostician", "\U0001F50D Diagnostician", "root cause & connections"),
+        ("field_medic", "\U0001FA79 Field medic", "easiest quick fix"),
+        ("rehab", "\U0001F3D7️ Rehab", "architectural change"),
+        ("innovator", "\U0001F4A1 Innovator", "new feature / future-proofing"),
+    ]
+    rows = []
+    for key, label, sub in order:
+        val = lenses.get(key)
+        if not val:
+            continue
+        rows.append(
+            f'<div class="lens"><div class="lens-h">{label} '
+            f'<span class="lens-sub">{esc(sub)}</span></div>'
+            f'<div class="lens-b">{esc(val)}</div></div>'
+        )
+    return f'<div class="lenses">{"".join(rows)}</div>'
+
+
+def evidence_block(findings):
+    rows = []
+    for f in findings or []:
+        sev, _ = SEV_META.get(f.get("severity", "minor"), ("", ""))
+        ev = "".join(
+            f'<li><code>{esc(e.get("file"))}'
+            + (f':{esc(e.get("line"))}' if e.get("line") else "")
+            + f'</code> — {esc(e.get("note"))}</li>'
+            for e in (f.get("evidence") or [])
+        )
+        rows.append(
+            f'<div class="finding">'
+            f'<div class="finding-h">{sev} <b>{esc(f.get("title"))}</b>'
+            f'<span class="tag">{esc(f.get("category"))}</span>'
+            f'<span class="tag">{esc(f.get("component"))}</span>'
+            f'<span class="tag">effort: {esc(f.get("effort"))}</span>'
+            f'<span class="tag">conf: {esc(f.get("confidence"))}</span>'
+            f'<span class="tag">via {esc(f.get("role"))}</span></div>'
+            f'<div class="finding-d">{esc(f.get("description"))}</div>'
+            + (f'<div class="finding-fix">→ {esc(f.get("suggested_fix"))}</div>' if f.get("suggested_fix") else "")
+            + (f'<ul class="ev">{ev}</ul>' if ev else "")
+            + "</div>"
+        )
+    return "".join(rows)
+
+
+def theme_card(t, refuted):
+    tid = t.get("theme_id")
+    sev = t.get("severity", "minor")
+    sev_emoji, sev_label = SEV_META.get(sev, ("", sev))
+    verdict = (t.get("verdict") or {})
+    dedup = (t.get("dedup") or {})
+    comps = ", ".join(t.get("components", []) or [])
+    structural = '<span class="badge struct">structural</span>' if t.get("is_structural") else ""
+
+    dedup_status = dedup.get("status", "unknown")
+    dedup_refs = dedup.get("issue_refs", []) or []
+    dedup_badge = ""
+    if dedup_status == "duplicate":
+        dedup_badge = f'<span class="badge dup">duplicate of {", ".join("#"+str(r) for r in dedup_refs)}</span>'
+    elif dedup_status == "related":
+        dedup_badge = f'<span class="badge rel">related to {", ".join("#"+str(r) for r in dedup_refs)}</span>'
+    elif dedup_status == "new":
+        dedup_badge = '<span class="badge new">new</span>'
+
+    verdict_badge = ""
+    if refuted:
+        verdict_badge = '<span class="badge refuted">refuted by skeptic</span>'
+    elif verdict.get("verdict") == "uncertain":
+        verdict_badge = '<span class="badge uncertain">uncertain</span>'
+
+    refuted_attr = "true" if refuted else "false"
+    verdict_note = (
+        f'<div class="verdict-note"><b>Skeptic:</b> {esc(verdict.get("reasoning"))}</div>'
+        if verdict.get("reasoning") else ""
+    )
+    dedup_note = (
+        f'<div class="dedup-note"><b>Dedup:</b> {esc(dedup.get("note"))}</div>'
+        if dedup.get("note") else ""
+    )
+
+    return f'''
+<div class="card sev-{esc(sev)}" data-id="{esc(tid)}" data-sev="{esc(sev)}"
+     data-comp="{esc(comps)}" data-refuted="{refuted_attr}" data-dedup="{esc(dedup_status)}">
+  <div class="card-top">
+    <div class="card-title">{sev_emoji} {esc(t.get("title"))}</div>
+    <div class="badges">{structural}{dedup_badge}{verdict_badge}
+      <span class="badge sevb sev-{esc(sev)}">{esc(sev_label)}</span></div>
+  </div>
+  <div class="card-meta">{esc(comps)} &middot; {len(t.get("findings", []) or [])} finding(s)</div>
+  <div class="summary">{esc(t.get("summary"))}</div>
+  {lens_block(t.get("lenses"))}
+  <details class="ev-wrap"><summary>Findings &amp; evidence ({len(t.get("findings", []) or [])})</summary>
+    {evidence_block(t.get("findings"))}
+  </details>
+  {verdict_note}
+  {dedup_note}
+  <div class="triage">
+    <div class="triage-btns">
+      <button class="t-valid" onclick="setVerdict({esc(tid)},'valid')">✓ Valid</button>
+      <button class="t-invalid" onclick="setVerdict({esc(tid)},'invalid')">✗ Invalid</button>
+      <span class="t-state" id="state-{esc(tid)}"></span>
+    </div>
+    <textarea class="t-notes" id="notes-{esc(tid)}" placeholder="Notes (appended to the issue body)..."
+      oninput="saveNotes({esc(tid)})"></textarea>
+  </div>
+</div>'''
+
+
+TEMPLATE = r"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>CAMPFIRE review — {version}</title>
+<style>
+  :root {{
+    --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --ink:#e7e9ee; --dim:#9aa3b2;
+    --line:#2a2f3a; --blocking:#ff5c5c; --significant:#ffb23e; --minor:#46c46e; --acc:#6ea8fe;
+  }}
+  * {{ box-sizing:border-box; }}
+  body {{ margin:0; background:var(--bg); color:var(--ink);
+    font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; }}
+  header {{ position:sticky; top:0; z-index:10; background:var(--panel); border-bottom:1px solid var(--line);
+    padding:14px 20px; }}
+  h1 {{ margin:0 0 4px; font-size:18px; }}
+  .sub {{ color:var(--dim); font-size:12px; }}
+  .meta-pill {{ background:var(--panel2); border:1px solid var(--line); border-radius:10px;
+    padding:1px 8px; margin-right:6px; }}
+  .controls {{ display:flex; gap:8px; flex-wrap:wrap; align-items:center; margin-top:10px; }}
+  .controls select, .controls input {{ background:var(--panel2); color:var(--ink);
+    border:1px solid var(--line); border-radius:6px; padding:5px 8px; }}
+  .controls button {{ background:var(--acc); color:#06101f; border:0; border-radius:6px;
+    padding:6px 12px; font-weight:600; cursor:pointer; }}
+  .controls .ghost {{ background:var(--panel2); color:var(--ink); border:1px solid var(--line); }}
+  .wrap {{ max-width:980px; margin:0 auto; padding:20px; }}
+  .card {{ background:var(--panel); border:1px solid var(--line); border-left:4px solid var(--line);
+    border-radius:10px; padding:16px; margin-bottom:16px; }}
+  .card.sev-blocking {{ border-left-color:var(--blocking); }}
+  .card.sev-significant {{ border-left-color:var(--significant); }}
+  .card.sev-minor {{ border-left-color:var(--minor); }}
+  .card.v-valid {{ box-shadow:0 0 0 1px var(--minor) inset; }}
+  .card.v-invalid {{ opacity:.5; }}
+  .card-top {{ display:flex; justify-content:space-between; gap:12px; align-items:flex-start; }}
+  .card-title {{ font-size:16px; font-weight:650; }}
+  .card-meta {{ color:var(--dim); font-size:12px; margin:2px 0 8px; }}
+  .badges {{ display:flex; gap:6px; flex-wrap:wrap; justify-content:flex-end; }}
+  .badge {{ font-size:11px; padding:2px 8px; border-radius:10px; border:1px solid var(--line);
+    background:var(--panel2); white-space:nowrap; }}
+  .badge.struct {{ color:#c9a3ff; border-color:#5b3f8a; }}
+  .badge.dup {{ color:#ff9; border-color:#7a6; }}
+  .badge.rel {{ color:#9cf; }}
+  .badge.new {{ color:var(--minor); border-color:#2c5; }}
+  .badge.refuted {{ color:var(--blocking); border-color:#a33; }}
+  .badge.uncertain {{ color:var(--significant); }}
+  .badge.sevb.sev-blocking {{ color:var(--blocking); }}
+  .badge.sevb.sev-significant {{ color:var(--significant); }}
+  .badge.sevb.sev-minor {{ color:var(--minor); }}
+  .summary {{ margin:6px 0 12px; }}
+  .lenses {{ display:grid; grid-template-columns:1fr 1fr; gap:10px; margin:10px 0; }}
+  .lens {{ background:var(--panel2); border:1px solid var(--line); border-radius:8px; padding:10px; }}
+  .lens-h {{ font-weight:650; font-size:12px; margin-bottom:4px; }}
+  .lens-sub {{ color:var(--dim); font-weight:400; }}
+  .lens-b {{ font-size:13px; color:#d4d8e0; }}
+  details.ev-wrap {{ margin:6px 0; }}
+  details.ev-wrap > summary {{ cursor:pointer; color:var(--acc); font-size:13px; }}
+  .finding {{ border-top:1px solid var(--line); padding:8px 0; }}
+  .finding-h {{ display:flex; gap:6px; flex-wrap:wrap; align-items:center; }}
+  .finding-d {{ color:#cfd4dd; margin:3px 0; }}
+  .finding-fix {{ color:var(--minor); font-size:13px; }}
+  .tag {{ font-size:10px; color:var(--dim); background:var(--bg); border:1px solid var(--line);
+    border-radius:8px; padding:1px 6px; }}
+  ul.ev {{ margin:6px 0 0; padding-left:18px; color:var(--dim); font-size:12px; }}
+  code {{ background:var(--bg); padding:1px 5px; border-radius:4px; color:#bcd; }}
+  .verdict-note, .dedup-note {{ font-size:12px; color:var(--dim); margin-top:8px;
+    border-left:2px solid var(--line); padding-left:8px; }}
+  .triage {{ margin-top:12px; border-top:1px dashed var(--line); padding-top:10px; }}
+  .triage-btns {{ display:flex; gap:8px; align-items:center; }}
+  .triage button {{ cursor:pointer; border:1px solid var(--line); background:var(--panel2);
+    color:var(--ink); border-radius:6px; padding:5px 12px; }}
+  .triage button.on-valid {{ background:var(--minor); color:#04210f; border-color:var(--minor); }}
+  .triage button.on-invalid {{ background:var(--blocking); color:#2a0606; border-color:var(--blocking); }}
+  .t-state {{ font-size:12px; color:var(--dim); }}
+  textarea.t-notes {{ width:100%; margin-top:8px; min-height:48px; background:var(--bg);
+    color:var(--ink); border:1px solid var(--line); border-radius:6px; padding:8px; resize:vertical; }}
+  .section-h {{ color:var(--dim); text-transform:uppercase; letter-spacing:.08em; font-size:11px;
+    margin:24px 0 8px; }}
+  .hidden {{ display:none !important; }}
+</style>
+</head>
+<body>
+<header>
+  <h1>🔥 CAMPFIRE review report</h1>
+  <div class="sub">
+    <span class="meta-pill">version: {version}</span>
+    <span class="meta-pill">generated: {generated}</span>
+    <span class="meta-pill">{n_themes} themes / {n_raw} raw findings</span>
+    <span class="meta-pill">dedup: {dedup_mode}</span>
+    {focus_line}
+  </div>
+  <div class="controls">
+    <input id="search" type="text" placeholder="filter text..." oninput="applyFilters()">
+    <select id="fsev" onchange="applyFilters()">
+      <option value="">all severities</option>
+      <option value="blocking">blocking</option>
+      <option value="significant">significant</option>
+      <option value="minor">minor</option>
+    </select>
+    <select id="fstate" onchange="applyFilters()">
+      <option value="">all triage states</option>
+      <option value="untriaged">untriaged</option>
+      <option value="valid">valid</option>
+      <option value="invalid">invalid</option>
+    </select>
+    <select id="fdedup" onchange="applyFilters()">
+      <option value="">all dedup</option>
+      <option value="new">new only</option>
+      <option value="duplicate">duplicate</option>
+      <option value="related">related</option>
+    </select>
+    <label class="sub"><input type="checkbox" id="fhref" onchange="applyFilters()"> hide refuted</label>
+    <button onclick="exportTriage()">⬇ Export triage JSON</button>
+    <button class="ghost" onclick="resetTriage()">reset triage</button>
+    <span class="t-state" id="progress"></span>
+  </div>
+</header>
+<div class="wrap">
+  <div class="section-h">Themes for triage ({n_themes})</div>
+  {cards}
+</div>
+<script id="payload" type="application/json">{payload}</script>
+<script>
+const DATA = JSON.parse(document.getElementById('payload').textContent);
+const KEY = DATA.report_key;
+function store() {{ try {{ return JSON.parse(localStorage.getItem(KEY) || '{{}}'); }} catch(e) {{ return {{}}; }} }}
+function persist(s) {{ localStorage.setItem(KEY, JSON.stringify(s)); }}
+
+function setVerdict(id, v) {{
+  const s = store(); s[id] = s[id] || {{}};
+  s[id].verdict = (s[id].verdict === v) ? null : v;
+  persist(s); paint(id); updateProgress();
+}}
+function saveNotes(id) {{
+  const s = store(); s[id] = s[id] || {{}};
+  s[id].notes = document.getElementById('notes-'+id).value; persist(s);
+}}
+function paint(id) {{
+  const s = store()[id] || {{}};
+  const card = document.querySelector('.card[data-id="'+id+'"]');
+  const vb = card.querySelector('.t-valid'), ib = card.querySelector('.t-invalid');
+  const st = document.getElementById('state-'+id);
+  card.classList.remove('v-valid','v-invalid'); vb.classList.remove('on-valid'); ib.classList.remove('on-invalid');
+  if (s.verdict === 'valid') {{ card.classList.add('v-valid'); vb.classList.add('on-valid'); st.textContent='marked valid'; }}
+  else if (s.verdict === 'invalid') {{ card.classList.add('v-invalid'); ib.classList.add('on-invalid'); st.textContent='marked invalid'; }}
+  else st.textContent='';
+  const ta = document.getElementById('notes-'+id); if (s.notes != null) ta.value = s.notes;
+}}
+function updateProgress() {{
+  const s = store(); let v=0, iv=0;
+  Object.values(s).forEach(x => {{ if (x.verdict==='valid') v++; else if (x.verdict==='invalid') iv++; }});
+  document.getElementById('progress').textContent = v+' valid · '+iv+' invalid';
+}}
+function applyFilters() {{
+  const q = document.getElementById('search').value.toLowerCase();
+  const sev = document.getElementById('fsev').value;
+  const state = document.getElementById('fstate').value;
+  const dd = document.getElementById('fdedup').value;
+  const hideRef = document.getElementById('fhref').checked;
+  const s = store();
+  document.querySelectorAll('.card').forEach(c => {{
+    const id = c.getAttribute('data-id');
+    const v = (s[id]||{{}}).verdict || 'untriaged';
+    let show = true;
+    if (q && !c.textContent.toLowerCase().includes(q)) show = false;
+    if (sev && c.getAttribute('data-sev') !== sev) show = false;
+    if (state && v !== state) show = false;
+    if (dd && c.getAttribute('data-dedup') !== dd) show = false;
+    if (hideRef && c.getAttribute('data-refuted') === 'true') show = false;
+    c.classList.toggle('hidden', !show);
+  }});
+}}
+function exportTriage() {{
+  const s = store();
+  const byId = {{}};
+  (DATA.themes||[]).concat(DATA.refuted||[]).forEach(t => byId[t.theme_id] = t);
+  const out = [];
+  Object.keys(s).forEach(id => {{
+    const e = s[id]; if (!e || !e.verdict) return;
+    const t = byId[id] || {{}};
+    out.push({{
+      theme_id: Number(id), verdict: e.verdict, notes: e.notes || '',
+      title: t.title, summary: t.summary, severity: t.severity,
+      components: t.components, is_structural: t.is_structural,
+      lenses: t.lenses, findings: t.findings, dedup: t.dedup,
+    }});
+  }});
+  const blob = new Blob([JSON.stringify({{report_key: KEY, version: DATA.version, triaged: out}}, null, 2)],
+    {{type:'application/json'}});
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob); a.download = 'triage.json'; a.click();
+}}
+function resetTriage() {{
+  if (!confirm('Clear all triage marks and notes for this report?')) return;
+  localStorage.removeItem(KEY);
+  document.querySelectorAll('.t-notes').forEach(t => t.value='');
+  document.querySelectorAll('.card').forEach(c => paint(c.getAttribute('data-id')));
+  updateProgress();
+}}
+document.querySelectorAll('.card').forEach(c => paint(c.getAttribute('data-id')));
+updateProgress();
+</script>
+</body>
+</html>"""
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("findings", help="path to findings JSON from the campfire-review workflow")
+    ap.add_argument("-o", "--output", default="report.html", help="output HTML path")
+    args = ap.parse_args()
+
+    with open(args.findings) as fh:
+        data = json.load(fh)
+
+    html_out = render(data, source_name=args.findings)
+    with open(args.output, "w") as fh:
+        fh.write(html_out)
+    print(f"Wrote {args.output} ({len(data.get('themes', []))} themes for triage).")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds a multi-agent "health pass" system for periodically reviewing the
whole repo outside of individual feature/fix PRs.

- .claude/commands/campfire-review.md: entry command — takes stock of the
  repo (version, recent commits, open issues/PRs), runs the workflow, and
  renders the report.
- .claude/workflows/campfire-review.js: orchestration engine — fans out
  five astronomer role-play / hygiene / consistency discovery agents,
  clusters findings into themes, applies four synthesis lenses
  (diagnostician / field medic / rehab / innovator), adversarially
  verifies each theme, and dedups against open issues.
- .claude/review/persona.md: shared astronomer instincts (the G/D/D bar)
  injected into every agent so the review judges by real science needs.
- scripts/render_review_report.py: renders findings JSON into a
  self-contained interactive triage HTML page (mark valid/invalid, notes,
  filter/sort, export decisions as JSON).
- .claude/commands/campfire-review-file-issues.md: turns the triaged
  export into GitHub issues, one per validated theme, with confirmation.
- .claude/review/README.md: documents how the pieces fit together.
- Gitignore reports/ (local triage artifacts).

Code-reading only in this version; dedup degrades gracefully when GitHub
is unavailable.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UH4oyEjwzdttn2od6gKrjp