### PR TITLE
Fix: correct Object.redshift_quality docstring (inverted quality enum)

### DIFF
--- a/python/campfire/models.py
+++ b/python/campfire/models.py
@@ -700,7 +700,9 @@ class Object:
     redshift_inspected : float or None
         User-inspected redshift, if set.
     redshift_quality : int
-        Quality code (0=none, 1=tentative, … 4=secure).
+        Inspection quality code; see :class:`campfire.flags.RedshiftQuality`
+        (0=not inspected, 1=impossible, 2=tentative, 3=probable, 4=secure).
+        Note that 1 (impossible) forces :attr:`redshift` to ``None``.
     n_spectra : int
         Number of spectra associated with this object.
     programs : list of str

--- a/python/tests/test_flags.py
+++ b/python/tests/test_flags.py
@@ -1,6 +1,9 @@
 """Tests for flag query operators."""
 
-from campfire.flags import DQFlags, FlagQuery
+import re
+
+from campfire.flags import DQFlags, FlagQuery, RedshiftQuality
+from campfire.models import Object
 
 
 class TestFlagOperators:
@@ -90,3 +93,34 @@ class TestFlagQueryCombination:
         assert params == {"dq_flags_include_any": 1}
         assert "dq_flags_include_all" not in params
         assert "dq_flags_exclude" not in params
+
+
+class TestRedshiftQualityDocstring:
+    """Guard against the Object docstring drifting from the canonical enum.
+
+    The integer semantics of ``redshift_quality`` are restated in prose in the
+    ``Object`` dataclass docstring. This previously inverted the codes
+    (claiming ``1=tentative`` when 1 is Impossible — see issue #198). Assert the
+    documented ``N=label`` pairs match :class:`RedshiftQuality` so any future
+    inversion fails CI.
+    """
+
+    def _documented_pairs(self):
+        # Extract "<int>=<label>" pairs from the Object docstring, e.g. "1=impossible".
+        return {
+            int(value): label.strip()
+            for value, label in re.findall(r"(\d+)=([a-z ]+)", Object.__doc__)
+        }
+
+    def test_docstring_documents_every_enum_member(self):
+        documented = self._documented_pairs()
+        assert set(documented) == {member.value for member in RedshiftQuality}
+
+    def test_docstring_labels_match_enum(self):
+        documented = self._documented_pairs()
+        for member in RedshiftQuality:
+            expected_label = member.name.lower().replace("_", " ")
+            assert documented[member.value] == expected_label, (
+                f"redshift_quality={member.value} documented as "
+                f"{documented[member.value]!r}, expected {expected_label!r}"
+            )


### PR DESCRIPTION
Closes #198

## What was the bug?
The `Object` dataclass docstring documented `redshift_quality` as `0=none, 1=tentative, … 4=secure`, inverting the canonical `RedshiftQuality` enum where `1=Impossible, 2=Tentative, 3=Probable, 4=Secure`. Because `quality==1` (Impossible) forces `objects.redshift` to NULL, a Python user reading the docstring to choose a quality cut would retain "impossible" objects believing they were "tentative" while silently dropping the real Tentative (2) bucket — a science-filtering trap.

## Root cause
The integer semantics of `redshift_quality` are restated in prose in four places. Every authoritative surface agrees — `campfire/flags.py` (`RedshiftQuality`), `web/lib/flags.ts`, the DB generated `redshift` column in `supabase/schemas/tables.sql`, and the client docs at `web/lib/docs/content/api/python-client.md:238`. The lone outlier was the hand-written `Object` dataclass docstring (`python/campfire/models.py:703`), which re-declared the mapping instead of referencing the enum and had drifted.

## What I changed
- Rewrote the `Object.redshift_quality` docstring to point at `campfire.flags.RedshiftQuality` with the correct mapping (`0=not inspected, 1=impossible, 2=tentative, 3=probable, 4=secure`) and noted that `1` forces `redshift` to `None`.
- Added a guard test (`TestRedshiftQualityDocstring` in `python/tests/test_flags.py`) that parses the documented `N=label` pairs out of the `Object` docstring and asserts they match the `RedshiftQuality` enum members, so any future inversion fails CI.

## Testing
- `pytest tests/test_flags.py` → 15 passed (13 existing + 2 new guards).
- Verified the new guard fails against the original buggy docstring text (mismatches reported on values 0, 1, 2, 3), confirming it would have caught this bug.

This PR touches only `python/`, so no `pipeline/CHANGELOG.md` entry is required.

Generated with Claude Code