### PR TITLE
Fix: Python analysis API silently produced wrong science (no mask, no grating guard)

### DIFF
--- a/python/campfire/calibration.py
+++ b/python/campfire/calibration.py
@@ -319,7 +319,7 @@ class CalibrationResult:
         ax_spec, ax_mult = axes
 
         wave = self.original.wavelength
-        valid = np.isfinite(self.original.fnu)
+        valid = self.original.valid
 
         ax_spec.plot(
             wave[valid], self.original.fnu[valid],
@@ -610,7 +610,14 @@ def _fit_chebyshev(
         degree = min(3, n - 1)
     degree = max(0, min(degree, n - 1))
 
-    weights = 1.0 / ratio_err
+    with np.errstate(divide="ignore", invalid="ignore"):
+        weights = np.where(
+            np.isfinite(ratio_err) & (ratio_err > 0), 1.0 / ratio_err, 0.0
+        )
+    if not np.any(weights > 0):
+        # Every band ratio has zero/invalid error — fall back to unit weights
+        # rather than feeding inf/nan into chebfit.
+        weights = np.ones_like(ratio_err)
     coeffs = np.polynomial.chebyshev.chebfit(cheb_band, ratio, degree, w=weights)
     multiplier = np.polynomial.chebyshev.chebval(cheb_wave, coeffs)
 
@@ -644,8 +651,16 @@ def _fit_flat(
     )
     ratio_err = ratio * frac_err
 
-    weights = 1.0 / ratio_err**2
-    flat_ratio = np.sum(weights * ratio) / np.sum(weights)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        weights = np.where(
+            np.isfinite(ratio_err) & (ratio_err > 0), 1.0 / ratio_err**2, 0.0
+        )
+    w_sum = np.sum(weights)
+    if w_sum > 0:
+        flat_ratio = np.sum(weights * ratio) / w_sum
+    else:
+        # Every band ratio has zero/invalid error — unweighted mean.
+        flat_ratio = float(np.mean(ratio))
 
     return np.full_like(wave, flat_ratio)
 
@@ -685,6 +700,54 @@ def _resample(
 # Spectrum stacking
 # ---------------------------------------------------------------------------
 
+def _check_stack_gratings(spectra, wavelength_grid, warn_on_override: bool = True) -> None:
+    """Guard against silently stacking spectra of different gratings.
+
+    Stacking resamples every input onto one wavelength grid. Mixing
+    gratings (e.g. PRISM + G395H) therefore smears/aliases spectra of
+    different resolutions onto a single grid, producing a scientifically
+    meaningless result. We refuse to do this unless the caller has made a
+    deliberate choice by supplying an explicit ``wavelength_grid``.
+
+    Parameters
+    ----------
+    spectra : iterable
+        Spectra (or spectrum handles) carrying a ``grating`` attribute.
+    wavelength_grid : np.ndarray or None
+        The explicit grid the caller passed, if any.
+    warn_on_override : bool
+        When *True* (default), emit a warning in the explicit-grid override
+        path. Pass *False* to suppress it (e.g. when a later call will
+        already warn), while still raising on the no-grid case.
+
+    Raises
+    ------
+    ValueError
+        If the spectra span more than one grating and no explicit
+        ``wavelength_grid`` was provided.
+    """
+    gratings = sorted({getattr(s, "grating", None) for s in spectra} - {None})
+    if len(gratings) <= 1:
+        return
+
+    base = (
+        f"Spectra span multiple gratings {gratings}. Stacking resamples them "
+        "onto a single wavelength grid, mixing spectral resolutions and "
+        "producing a scientifically meaningless result."
+    )
+    if wavelength_grid is None:
+        raise ValueError(
+            base + " Filter to a single grating before stacking (e.g. "
+            "obj.spectra[obj.spectra.grating == 'PRISM']), or pass an explicit "
+            "wavelength_grid to override this guard."
+        )
+    if warn_on_override:
+        warnings.warn(
+            base + " Proceeding because an explicit wavelength_grid was provided.",
+            stacklevel=2,
+        )
+
+
 def stack_spectra(
     spectra: List[SpectrumData],
     method: str = "weighted_mean",
@@ -699,7 +762,8 @@ def stack_spectra(
     Parameters
     ----------
     spectra : list of SpectrumData
-        Spectra to stack. Should generally share the same grating.
+        Spectra to stack. Must share a single grating unless an explicit
+        ``wavelength_grid`` is provided (see Raises).
     method : str
         ``'weighted_mean'`` (default): inverse-variance weighted mean.
         ``'median'``: pixel-wise median (errors from MAD).
@@ -721,10 +785,15 @@ def stack_spectra(
     Raises
     ------
     ValueError
-        If fewer than 2 spectra are provided.
+        If fewer than 2 spectra are provided, or if the spectra span more
+        than one grating and no explicit ``wavelength_grid`` is given. When
+        an explicit grid *is* given, a multi-grating stack warns instead of
+        raising (the caller has opted in).
     """
     if len(spectra) < 2:
         raise ValueError("Need at least 2 spectra to stack.")
+
+    _check_stack_gratings(spectra, wavelength_grid)
 
     if wavelength_grid is None:
         ref = max(spectra, key=lambda s: len(s.wavelength))
@@ -879,12 +948,12 @@ class StackResult:
         wave = self.spectrum.wavelength
 
         for i, s in enumerate(self.input_spectra):
-            valid = np.isfinite(s.fnu)
+            valid = s.valid
             ax_overlay.plot(
                 s.wavelength[valid], s.fnu[valid],
                 alpha=0.4, lw=0.7, label=f"Spec {i+1}" if i < 5 else None,
             )
-        valid = np.isfinite(self.spectrum.fnu)
+        valid = self.spectrum.valid
         ax_overlay.plot(
             wave[valid], self.spectrum.fnu[valid],
             color="black", lw=1.5, label="Stacked",
@@ -968,6 +1037,11 @@ def calibrate_and_stack(
 
     if not spec_list:
         raise ValueError("No spectra provided.")
+
+    # Fail fast before the (expensive) per-spectrum calibration loop. The
+    # final stack_spectra() call emits the override warning, so suppress it
+    # here to avoid a duplicate.
+    _check_stack_gratings(spec_list, wavelength_grid, warn_on_override=False)
 
     calibrations = []
     calibrated_data = []

--- a/python/campfire/models.py
+++ b/python/campfire/models.py
@@ -1,6 +1,7 @@
 """Data models for the CAMPFIRE Python client."""
 
 import re
+import warnings
 from collections import namedtuple
 from dataclasses import dataclass, field as dc_field
 from pathlib import Path
@@ -54,6 +55,22 @@ class SpectrumData:
         Unit string for flam (default ``'erg/s/cm2/A'``).
     wave_units : str
         Unit string for wavelength (default ``'um'``).
+
+    Notes
+    -----
+    CAMPFIRE 1D products do not carry a separate per-pixel data-quality
+    (DQ) array. Instead, **masked / no-coverage pixels are encoded as a
+    non-finite flux or a non-positive** ``fnu_err`` (zero or negative).
+    Always select usable pixels with the :attr:`valid` property rather
+    than a bare ``np.isfinite(fnu)`` check — the latter misses the
+    ``fnu_err <= 0`` half of the convention and a naive ``1 / fnu_err**2``
+    weighting will hit infinite weight / divide-by-zero at those pixels::
+
+        v = spec.valid
+        chi2 = np.sum(((model - spec.fnu)[v] / spec.fnu_err[v]) ** 2)
+
+    See :meth:`to_specutils` for an export that carries this mask (and the
+    uncertainty) into the astropy/specutils ecosystem.
     """
 
     wavelength: np.ndarray
@@ -77,6 +94,32 @@ class SpectrumData:
             self.flam = self.fnu * 2.998e-19 / self.wavelength**2
         if self.flam_err is None:
             self.flam_err = self.fnu_err * 2.998e-19 / self.wavelength**2
+
+    @property
+    def valid(self) -> np.ndarray:
+        """Boolean mask of scientifically usable pixels.
+
+        A pixel is valid when both ``fnu`` and ``fnu_err`` are finite and
+        ``fnu_err`` is strictly positive. This is the single canonical place
+        the CAMPFIRE masking convention (see the class :class:`Notes
+        <SpectrumData>`) is applied; use it before any flux-weighted
+        operation to avoid the ``1 / fnu_err**2`` infinite-weight trap.
+
+        Because ``flam``/``flam_err`` derive from ``fnu``/``fnu_err`` by a
+        strictly positive factor (``c / λ²``), the same mask applies to the
+        ``flam`` representation.
+
+        Returns
+        -------
+        np.ndarray
+            Boolean array the same length as :attr:`wavelength`; ``True``
+            marks usable pixels.
+        """
+        return (
+            np.isfinite(self.fnu)
+            & np.isfinite(self.fnu_err)
+            & (self.fnu_err > 0)
+        )
 
     def __repr__(self) -> str:
         n = len(self.wavelength)
@@ -125,7 +168,7 @@ class SpectrumData:
             flux = self.fnu
             flux_err = self.fnu_err
 
-        valid = np.isfinite(flux)
+        valid = self.valid
         w = wave[valid]
         f = flux[valid]
 
@@ -144,6 +187,75 @@ class SpectrumData:
         ax.set_title(f"{self.spectrum_id}  {self.grating}")
 
         return ax
+
+    def to_specutils(self, flux_unit: str = "fnu"):
+        """Export as an astropy ``specutils`` spectrum.
+
+        Builds a ``specutils.Spectrum1D`` (or ``Spectrum`` on newer
+        specutils) with the spectral axis, flux, a
+        ``StdDevUncertainty``, and a boolean ``mask`` derived from
+        :attr:`valid`. specutils arithmetic, resampling, and continuum
+        fitting all respect the mask and uncertainty by construction, so a
+        downstream fit inherits correct weighting and masking instead of
+        re-deriving the CAMPFIRE sentinel convention by hand.
+
+        Parameters
+        ----------
+        flux_unit : str
+            ``'fnu'`` (default) exports f_ν in μJy; ``'flam'`` /
+            ``'flambda'`` exports f_λ in erg/s/cm²/Å.
+
+        Returns
+        -------
+        specutils.Spectrum1D
+            With ``spectral_axis``, ``flux``, ``uncertainty``, and ``mask``
+            populated. Following the astropy/specutils convention,
+            ``mask`` is ``True`` at *masked* (invalid) pixels — i.e.
+            ``~self.valid``.
+
+        Raises
+        ------
+        ImportError
+            If ``specutils`` is not installed
+            (``pip install specutils``).
+        """
+        try:
+            import astropy.units as u
+            from astropy.nddata import StdDevUncertainty
+            import specutils
+        except ImportError as exc:
+            raise ImportError(
+                "SpectrumData.to_specutils() requires the 'specutils' "
+                "package. Install it with `pip install specutils`."
+            ) from exc
+
+        # specutils renamed Spectrum1D -> Spectrum in v1.16 (Spectrum1D is now
+        # a deprecated alias). Prefer the new name; fall back for older
+        # specutils where only Spectrum1D exists.
+        spec_cls = getattr(specutils, "Spectrum", None) or getattr(
+            specutils, "Spectrum1D", None
+        )
+        if spec_cls is None:
+            raise ImportError(
+                "specutils is installed but exposes neither 'Spectrum1D' "
+                "nor 'Spectrum'."
+            )
+
+        if flux_unit in ("flam", "flambda"):
+            flux = self.flam
+            flux_err = self.flam_err
+            funit = u.erg / u.s / u.cm**2 / u.AA
+        else:
+            flux = self.fnu
+            flux_err = self.fnu_err
+            funit = u.uJy
+
+        return spec_cls(
+            spectral_axis=np.asarray(self.wavelength) * u.um,
+            flux=np.asarray(flux) * funit,
+            uncertainty=StdDevUncertainty(np.asarray(flux_err) * funit),
+            mask=~self.valid,  # specutils convention: True == masked
+        )
 
     @staticmethod
     def _parse_spectrum_id_from_filename(filename: str) -> str:
@@ -217,7 +329,13 @@ class SpectrumData:
                 elif "err" in col_names:
                     fnu_err = np.array(data["err"], dtype=float)
                 else:
-                    fnu_err = np.zeros_like(fnu)
+                    warnings.warn(
+                        f"No error column found in {fits_path}; filling "
+                        "fnu_err with NaN. These pixels will be treated as "
+                        "invalid (masked) by SpectrumData.valid.",
+                        stacklevel=2,
+                    )
+                    fnu_err = np.full_like(fnu, np.nan)
 
                 flam = None
                 if "flam" in col_names:
@@ -231,11 +349,26 @@ class SpectrumData:
                 if data.ndim == 2 and data.shape[0] >= 2:
                     wavelength = np.array(data[0], dtype=float)
                     fnu = np.array(data[1], dtype=float)
-                    fnu_err = np.array(data[2], dtype=float) if data.shape[0] > 2 else np.zeros_like(fnu)
+                    if data.shape[0] > 2:
+                        fnu_err = np.array(data[2], dtype=float)
+                    else:
+                        warnings.warn(
+                            f"No error row found in {fits_path}; filling "
+                            "fnu_err with NaN. These pixels will be treated "
+                            "as invalid (masked) by SpectrumData.valid.",
+                            stacklevel=2,
+                        )
+                        fnu_err = np.full_like(fnu, np.nan)
                 else:
+                    warnings.warn(
+                        f"No error data found in {fits_path}; filling fnu_err "
+                        "with NaN. These pixels will be treated as invalid "
+                        "(masked) by SpectrumData.valid.",
+                        stacklevel=2,
+                    )
                     wavelength = np.arange(len(data), dtype=float)
                     fnu = np.array(data, dtype=float)
-                    fnu_err = np.zeros_like(fnu)
+                    fnu_err = np.full_like(fnu, np.nan)
                 flam = None
                 flam_err = None
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -52,15 +52,19 @@ deploy = [
 plotting = [
     "plotly>=5.18.0",
 ]
+specutils = [
+    "specutils>=1.13",
+]
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "black>=23.0",
     "mypy>=1.0",
     "plotly>=5.18.0",
+    "specutils>=1.13",
 ]
 all = [
-    "campfire[deploy,plotting]",
+    "campfire[deploy,plotting,specutils]",
 ]
 
 [project.urls]

--- a/python/tests/test_calibration.py
+++ b/python/tests/test_calibration.py
@@ -1,9 +1,16 @@
 """Tests for calibration + stacking and new model dataclasses."""
 
+import warnings
+
 import numpy as np
 import pytest
 
-from campfire.calibration import stack_spectra
+from campfire.calibration import (
+    _fit_chebyshev,
+    _fit_flat,
+    calibrate_and_stack,
+    stack_spectra,
+)
 from campfire.models import (
     Band,
     Object,
@@ -250,3 +257,193 @@ class TestObjectFromDict:
         result = obj.spectra[0].open()
         assert result == "opened"
         assert called["id"] == "sid_1"
+
+
+# ---------------------------------------------------------------------------
+# SpectrumData.valid — the canonical pixel mask (issue #197, finding 4)
+# ---------------------------------------------------------------------------
+
+class TestSpectrumDataValid:
+    def _make(self, fnu, fnu_err):
+        n = len(fnu)
+        return SpectrumData(
+            wavelength=np.linspace(1.0, 5.0, n),
+            fnu=np.asarray(fnu, dtype=float),
+            fnu_err=np.asarray(fnu_err, dtype=float),
+            header={},
+            grating="PRISM",
+            spectrum_id="t_prism_1",
+        )
+
+    def test_valid_excludes_nonfinite_flux_and_nonpositive_error(self):
+        spec = self._make(
+            fnu=[1.0, np.nan, 2.0, 3.0, 4.0, 5.0],
+            fnu_err=[0.1, 0.1, 0.0, -0.5, np.nan, np.inf],
+        )
+        # idx 0 good; 1 (nan flux), 2 (zero err), 3 (neg err),
+        # 4 (nan err), 5 (inf err) all invalid.
+        np.testing.assert_array_equal(
+            spec.valid, [True, False, False, False, False, False]
+        )
+
+    def test_valid_matches_recipe_idiom(self):
+        rng = np.random.default_rng(0)
+        fnu = rng.normal(1.0, 0.2, 50)
+        fnu_err = np.abs(rng.normal(0.1, 0.02, 50))
+        fnu[5] = np.nan
+        fnu_err[10] = 0.0
+        spec = self._make(fnu, fnu_err)
+        expected = np.isfinite(fnu) & (fnu_err > 0)
+        np.testing.assert_array_equal(spec.valid, expected)
+
+    def test_plot_uses_valid_mask(self):
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        spec = self._make(
+            fnu=[1.0, 2.0, 3.0, 4.0],
+            fnu_err=[0.1, 0.0, 0.1, 0.1],  # idx 1 has zero error -> invalid
+        )
+        _, ax = plt.subplots()
+        spec.plot(ax=ax)
+        # bare isfinite would plot 4 points; valid drops the zero-error pixel.
+        line = ax.lines[0]
+        assert len(line.get_xdata()) == 3
+        plt.close("all")
+
+
+# ---------------------------------------------------------------------------
+# from_fits — missing error column warns + fills NaN (not zeros) (finding 4)
+# ---------------------------------------------------------------------------
+
+class TestFromFitsMissingError:
+    def test_missing_error_column_fills_nan_and_warns(self, tmp_path):
+        from astropy.io import fits
+
+        wave = np.linspace(1.0, 5.0, 10)
+        fnu = np.ones(10)
+        hdu0 = fits.PrimaryHDU()
+        hdu0.header["GRATING"] = "PRISM"
+        cols = fits.ColDefs([
+            fits.Column(name="wave", format="D", array=wave),
+            fits.Column(name="fnu", format="D", array=fnu),
+        ])
+        hdu1 = fits.BinTableHDU.from_columns(cols)
+        path = tmp_path / "nocols_spec.fits"
+        fits.HDUList([hdu0, hdu1]).writeto(path)
+
+        with pytest.warns(UserWarning, match="No error column"):
+            spec = SpectrumData.from_fits(str(path))
+
+        # Filled with NaN (not zeros), so every pixel is masked-out as invalid.
+        assert np.all(np.isnan(spec.fnu_err))
+        assert not spec.valid.any()
+
+
+# ---------------------------------------------------------------------------
+# to_specutils — specutils export carries mask + uncertainty (finding 4)
+# ---------------------------------------------------------------------------
+
+class TestToSpecutils:
+    def test_export_carries_mask_and_uncertainty(self):
+        pytest.importorskip("specutils")
+        import astropy.units as u
+
+        fnu = np.array([1.0, 2.0, np.nan, 4.0])
+        fnu_err = np.array([0.1, 0.0, 0.1, 0.2])  # idx 1 zero err, idx 2 nan flux
+        spec = SpectrumData(
+            wavelength=np.linspace(1.0, 4.0, 4),
+            fnu=fnu,
+            fnu_err=fnu_err,
+            header={},
+            grating="PRISM",
+            spectrum_id="t_prism_1",
+        )
+        s1d = spec.to_specutils()
+
+        # mask True == masked (invalid); matches ~spec.valid
+        np.testing.assert_array_equal(s1d.mask, ~spec.valid)
+        assert s1d.uncertainty is not None
+        np.testing.assert_allclose(s1d.flux.to_value(u.uJy), fnu, equal_nan=True)
+        np.testing.assert_allclose(
+            s1d.spectral_axis.to_value(u.um), spec.wavelength
+        )
+
+
+# ---------------------------------------------------------------------------
+# Grating guard for stacking (issue #197, finding 7)
+# ---------------------------------------------------------------------------
+
+class TestGratingGuard:
+    def _make_spec(self, grating, n=20, fnu_value=1.0):
+        wave = np.linspace(1.0, 5.0, n)
+        return SpectrumData(
+            wavelength=wave,
+            fnu=np.full(n, fnu_value),
+            fnu_err=np.full(n, 0.1),
+            header={},
+            grating=grating,
+            spectrum_id=f"a_{grating.lower()}_1",
+        )
+
+    def test_stack_mixed_gratings_raises_without_grid(self):
+        a = self._make_spec("PRISM")
+        b = self._make_spec("G395H")
+        with pytest.raises(ValueError, match="multiple gratings"):
+            stack_spectra([a, b])
+
+    def test_stack_same_grating_ok(self):
+        a = self._make_spec("PRISM", fnu_value=2.0)
+        b = self._make_spec("PRISM", fnu_value=4.0)
+        stacked = stack_spectra([a, b])
+        assert stacked.grating == "PRISM"
+
+    def test_stack_mixed_gratings_warns_with_explicit_grid(self):
+        a = self._make_spec("PRISM")
+        b = self._make_spec("G395H")
+        grid = np.linspace(1.0, 5.0, 20)
+        with pytest.warns(UserWarning, match="multiple gratings"):
+            stacked = stack_spectra([a, b], wavelength_grid=grid)
+        assert stacked is not None
+
+    def test_calibrate_and_stack_mixed_gratings_raises_early(self):
+        # SpectrumData inputs => no calibration; should still fail fast.
+        a = self._make_spec("PRISM")
+        b = self._make_spec("G140M")
+        with pytest.raises(ValueError, match="multiple gratings"):
+            calibrate_and_stack([a, b])
+
+
+# ---------------------------------------------------------------------------
+# Zero-guard in calibration weight computation (issue #197, finding 4)
+# ---------------------------------------------------------------------------
+
+class TestFitWeightZeroGuard:
+    def test_fit_flat_handles_zero_ratio_err(self):
+        # obs_err and synth_err both zero -> ratio_err == 0 -> would div-by-zero
+        wave = np.linspace(1.0, 5.0, 20)
+        obs_flux = np.array([2.0, 4.0])
+        synth_flux = np.array([1.0, 2.0])
+        zero_err = np.zeros(2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any RuntimeWarning becomes a failure
+            mult = _fit_flat(wave, obs_flux, zero_err, synth_flux, zero_err)
+        assert np.all(np.isfinite(mult))
+        # ratio is 2.0 for both bands -> unweighted mean fallback == 2.0
+        np.testing.assert_allclose(mult, 2.0)
+
+    def test_fit_chebyshev_handles_zero_ratio_err(self):
+        wave = np.linspace(1.0, 5.0, 20)
+        band_waves = np.array([1.5, 3.0, 4.5])
+        obs_flux = np.array([2.0, 2.0, 2.0])
+        synth_flux = np.array([1.0, 1.0, 1.0])
+        zero_err = np.zeros(3)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            mult = _fit_chebyshev(
+                wave, band_waves, obs_flux, zero_err, synth_flux, zero_err, degree=1
+            )
+        assert np.all(np.isfinite(mult))
+        # constant ratio 2.0 everywhere -> multiplier ~2.0
+        np.testing.assert_allclose(mult, 2.0, rtol=1e-6)

--- a/web/lib/docs/content/api/recipes.md
+++ b/web/lib/docs/content/api/recipes.md
@@ -211,7 +211,7 @@ phot = obj.photometry
 
 fig, ax = plt.subplots(figsize=(10, 5))
 
-good = np.isfinite(spec.fnu) & (spec.fnu_err > 0)
+good = spec.valid  # finite flux & positive error — the canonical mask
 ax.step(spec.wavelength[good], spec.fnu[good], where='mid',
         lw=0.6, color='k', alpha=0.7, label='PRISM spectrum')
 


### PR DESCRIPTION
Closes #197

## What was the bug?
The Python analysis layer (`campfire/models.py`, `campfire/calibration.py`) omitted two guards an astronomer assumes, so reasonable use silently yielded scientifically wrong results: `SpectrumData` carried no documented per-pixel validity mask (masked pixels are encoded only as non-finite flux **or** `fnu_err<=0`), and `stack_spectra`/`calibrate_and_stack` happily resampled spectra of different gratings (PRISM + G395H + G140M) onto a single grid with no warning.

## Root cause
`SpectrumData` is a bag of parallel arrays that never represented its two invisible invariants: (1) per-pixel validity, smuggled into sentinel flux/error values, and (2) spectral resolution, smuggled into a `grating` string nothing checked. The validity idiom (`isfinite(fnu) & fnu_err>0`) lived only in recipe docs — `plot()` itself only checked `isfinite`, `from_fits` filled a *missing* error column with **zeros** (an infinite-weight trap for `1/fnu_err**2`), and the two stacking entry points trusted `spectra[0].grating` with no guard.

## What I changed
- **`SpectrumData.valid` property** — `isfinite(fnu) & isfinite(fnu_err) & (fnu_err > 0)`, the single canonical mask. Documented the sentinel convention in the class docstring.
- **`plot()`** now uses `self.valid` instead of bare `isfinite` (so zero/negative-error pixels are dropped). Same change in the `CalibrationResult`/`StackResult` diagnostic plots for consistency.
- **`from_fits`** now fills a *missing* error column/row with **NaN + a warning** instead of zeros, so those pixels are masked out rather than becoming infinite-weight traps.
- **Zero-guard in `_fit_chebyshev` and `_fit_flat`** — `1/ratio_err[**2]` is computed under `errstate` with a `ratio_err>0` mask, falling back to unit/unweighted combination when every band error is invalid.
- **Grating guard in `stack_spectra` and `calibrate_and_stack`** — raise `ValueError` when the inputs span more than one grating and no explicit `wavelength_grid` is given; warn (not raise) when the caller opts in with an explicit grid. `calibrate_and_stack` fails fast before its per-spectrum calibration loop.
- **`SpectrumData.to_specutils()`** — exports an astropy `Spectrum1D`/`Spectrum` with `spectral_axis`, `flux`, `StdDevUncertainty`, and a `mask` (`~valid`), so downstream specutils workflows inherit correct masking + weighting. Added a `specutils` optional extra.
- Updated recipe 6 to use `spec.valid`.

Per the issue triage notes, I deliberately did **not** add a separate DQ array for the 1D products or a `stack_by_grating` helper.

## Testing
- Added unit tests in `python/tests/test_calibration.py` covering: `valid` masking (NaN flux, zero/negative/NaN/inf error), `plot()` using the mask, `from_fits` NaN-fill-and-warn on a missing error column, `to_specutils` mask/uncertainty round-trip (skipped if specutils absent), the grating guard (raise without grid, warn with grid, fail-fast in `calibrate_and_stack`), and the `_fit_*` zero-error guards.
- `conda run -n campfire python -m pytest python/tests/` → **162 passed, 1 skipped** (pre-existing skip; warnings are pre-existing supabase deprecations). Installed specutils locally to confirm the `to_specutils` test passes for real (21/21 in the calibration file).

Generated with Claude Code