### PR TITLE
Fix: FITS ZIP download silently truncates to 200 spectra in the default objects view

### DIFF
--- a/web/components/spectra/DownloadTableButtons.tsx
+++ b/web/components/spectra/DownloadTableButtons.tsx
@@ -4,6 +4,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import { Download, FileText, Package, Loader2, ChevronDown } from 'lucide-react';
 import { generateCSV, generateCsvFilename, generateFitsDownloadUrl } from '@/lib/actions/download';
 import type { SortColumn, SortDirection, ViewMode } from '@/lib/actions/spectra-types';
+import { FITS_DOWNLOAD_FILE_LIMIT } from '@/lib/actions/spectra-types';
 import { AdvancedFilterOptions } from './SpectraFilterBar';
 
 interface DownloadDropdownProps {
@@ -31,7 +32,13 @@ export const DownloadDropdown: React.FC<DownloadDropdownProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
 
   const CSV_LIMIT = 50000;
-  const FITS_LIMIT = 200;
+  // FITS_LIMIT is in spectra/file units. In spectra mode totalCount is already
+  // the spectra count, so this gate is exact. In objects mode totalCount is the
+  // object count — a loose lower bound on the spectra count (one object fans out
+  // to 2-3 gratings), so the gate disables correctly once objects exceed the
+  // limit but may stay enabled below it; the server action backstops that case
+  // by refusing the download with a clear error rather than truncating.
+  const FITS_LIMIT = FITS_DOWNLOAD_FILE_LIMIT;
   const csvWillTruncate = totalCount > CSV_LIMIT;
   const fitsDisabled = totalCount > FITS_LIMIT || loading;
 
@@ -235,7 +242,7 @@ export const DownloadDropdown: React.FC<DownloadDropdownProps> = ({
                 loading
                   ? 'Please wait while objects are loading'
                   : totalCount > FITS_LIMIT
-                    ? `Limited to ${FITS_LIMIT} objects. Please refine filters.`
+                    ? `Limited to ${FITS_LIMIT} FITS files. Please refine filters.`
                     : 'Download FITS files as ZIP'
               }
             >
@@ -270,7 +277,7 @@ export const DownloadDropdown: React.FC<DownloadDropdownProps> = ({
               {fitsDisabled && totalCount > FITS_LIMIT && (
                 <div className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800 rounded-md p-2">
                   <span className="flex-shrink-0 mt-0.5">⚠️</span>
-                  <span>FITS limited to {FITS_LIMIT} objects</span>
+                  <span>FITS download limited to {FITS_LIMIT} files</span>
                 </div>
               )}
 

--- a/web/lib/actions/download.ts
+++ b/web/lib/actions/download.ts
@@ -2,6 +2,7 @@
 
 import { getSpectra } from './spectra';
 import type { SortColumn, SortDirection, ViewMode } from './spectra-types';
+import { FITS_DOWNLOAD_FILE_LIMIT } from './spectra-types';
 import type { FilterOptions } from './filter-params';
 import { trackDownload } from './download-tracking';
 import { createClient } from '@/lib/supabase/server';
@@ -403,12 +404,13 @@ export async function generateFitsDownloadUrl(
     const supabase = await createClient();
     const { data: { user } } = await supabase.auth.getUser();
 
-    // Fetch filtered results (limit to 200 items) via spectra mode — that RPC
-    // returns one row per (target, grating) with the FITS path attached.
+    // Fetch filtered results via spectra mode — that RPC returns one row per
+    // (target, grating) with the FITS path attached, and result.total is the
+    // count over spectra (the same unit this download acts on).
     const result = await getSpectra(
       filters,
       1, // page
-      200, // pageSize
+      FITS_DOWNLOAD_FILE_LIMIT, // pageSize
       sortColumn === 'object_id' ? 'target_id' : sortColumn,
       sortDirection,
       'spectra'
@@ -416,6 +418,20 @@ export async function generateFitsDownloadUrl(
 
     if (result.error) {
       return { files: null, token: null, workerUrl: null, zipFilename: null, error: result.error };
+    }
+
+    // Guard against silent truncation. The UI gate is computed from the current
+    // view's count — in the default objects view that is the OBJECT count, but
+    // one object commonly fans out to 2-3 spectra, so the gate can stay enabled
+    // while the spectra total exceeds the page we fetched. result.total is the
+    // authoritative spectra count from the same RPC; if it exceeds what we
+    // pulled, refuse with a clear, actionable error rather than handing back a
+    // biased first-N-of-M ZIP that looks complete (a reproducibility hazard).
+    if (result.total > result.spectra.length) {
+      return {
+        files: null, token: null, workerUrl: null, zipFilename: null,
+        error: `This filter set has ${result.total.toLocaleString()} spectra, which exceeds the ${FITS_DOWNLOAD_FILE_LIMIT.toLocaleString()}-file ZIP limit. Refine your filters, or use the CSV export (which includes every fits_path) to fetch the full set.`,
+      };
     }
 
     // Extract all FITS file paths from spectra on each target

--- a/web/lib/actions/spectra-types.ts
+++ b/web/lib/actions/spectra-types.ts
@@ -5,6 +5,20 @@ export type SortDirection = 'asc' | 'desc';
 
 export type ViewMode = 'spectra' | 'objects';
 
+/**
+ * Maximum number of FITS files (spectra) bundled into a single in-browser ZIP.
+ *
+ * Expressed in spectra/file units — the unit the download actually acts on — NOT
+ * objects. One sky-object commonly spans 2-3 gratings (e.g. the PRISM + G395M
+ * EMBER/ZENITH pairing), so an objects-mode result of N objects can fan out to
+ * far more than N spectra. The server action (generateFitsDownloadUrl) enforces
+ * this cap and refuses — rather than silently truncating — when a filter set
+ * exceeds it, so a user never walks away with a biased first-N-of-M sample. The
+ * client gate imports the same constant so the button and the action can't
+ * disagree on the limit.
+ */
+export const FITS_DOWNLOAD_FILE_LIMIT = 500;
+
 // Spectra-mode sort columns (must match get_filtered_spectra_paginated whitelist)
 export const SPECTRA_SORT_COLUMNS = ['spectrum_id', 'target_id', 'field', 'observation', 'program_slug', 'ra', 'dec', 'redshift', 'redshift_quality', 'redshift_auto', 'signal_to_noise', 'exposure_time', 'grating', 'distance'] as const;
 


### PR DESCRIPTION
Closes #201

## What was the bug?
The "FITS ZIP" download button was gated on the current view's count — the **object** count in the default objects view — but the download itself always fetched in **spectra** units at a hardcoded page of 200 and never read that RPC's total. Because one object commonly spans 2-3 gratings (e.g. the PRISM + G395M EMBER/ZENITH pairing), a filtered set of ~150 objects can expand past 200 spectra: the button stays enabled (150 < 200), no "limited to 200" warning fires, and the user receives only the first 200 FITS — silently building an incomplete, ID-sorted sample. That's a reproducibility/completeness hazard for any paper using the result.

## Root cause
A units/granularity mismatch between the **gate** and the **fetch**, sitting on the objects/targets/spectra 3-tier model. The gate (`DownloadTableButtons` `totalCount`, fed by `SpectraTable`) is the object count in objects mode, while `generateFitsDownloadUrl` calls `getSpectra(..., 1, 200, 'spectra')` — one row per (target, grating) — and threw away `result.total` (the authoritative spectra count). The two counts are in different units, and nothing compared the fetched page against the true total, so "page 1 of 200" was trusted as "everything."

## What I changed
- **Server-side guard (the chokepoint fix):** `generateFitsDownloadUrl` now reads `result.total` from the same spectra-mode RPC it fetches and **refuses** with a clear, actionable error when the spectra total exceeds the fetched page — rather than returning a biased first-N-of-M ZIP that looks complete. The error points the user at refining filters or the CSV export (which already paginates every `fits_path`).
- **Single source of truth for the limit:** hoisted the cap into a shared `FITS_DOWNLOAD_FILE_LIMIT` constant in `spectra-types.ts` (a non-`"use server"` module both the action and the component can import), so the client gate and the server action can no longer disagree on the number.
- **Bumped the cap 200 → 500** (per the triage note) to cover the common multi-grating fan-out so realistic object counts still download in one ZIP.
- **Honest gate copy:** the button title/warning now say "FITS files", not "objects", since the limit is in file units. The gate stays a safe lower-bound in objects mode (objects ≤ spectra, so it disables correctly once objects exceed the cap); the server guard backstops the sub-cap case where spectra still overflow.

### Note on scope
This kills the data-integrity hazard at the single chokepoint every caller passes through. A precise *pre-click* gate in objects mode (disabling the button on the exact spectra total before the user clicks) would require surfacing a filter-scoped spectra total from the objects RPC — a larger change tracked as the architectural follow-up in the issue. With this fix the worst case is a clear refusal on click, never a silent incomplete download.

## Testing
- `cd web && npm run build` — passes (type-check + lint clean; no new warnings).
- The web package has no unit-test harness, so verification is via the build plus manual review of the guard logic. The guard triggers exactly when `result.total > result.spectra.length` (more matching spectra exist than were fetched), and returns 0 false positives on empty results (0 > 0 is false → falls through to the existing "No FITS files found" path).

Generated with Claude Code

https://claude.ai/code/session_01QMm3DuLALxzNtLBUQqPfkR