### PR TITLE
Centralize S3 backend resolution for data/tiles split

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ campfire deploy tiles --field cosmos --filter f444w      # map tiles
 campfire deploy sync-programs                            # upsert from programs.toml
 ```
 
-Credentials via env vars (`CAMPFIRE_SUPABASE_URL`, `CAMPFIRE_R2_*`) or gitignored `$CAMPFIRE_ROOT/config/deploy.toml`.
+Credentials via env vars (`CAMPFIRE_SUPABASE_URL`, `CAMPFIRE_S3_*`; legacy `CAMPFIRE_R2_*` accepted as aliases) or gitignored `$CAMPFIRE_ROOT/config/deploy.toml`. Storage endpoint/region/path-style are configurable per purpose (`CAMPFIRE_S3_*` for data, `CAMPFIRE_S3_TILES_*` for tiles); see `python/campfire/deploy/backend.py`.
 
 ## General Notes
 

--- a/python/campfire/deploy/backend.py
+++ b/python/campfire/deploy/backend.py
@@ -1,0 +1,191 @@
+"""
+Per-purpose S3 storage backend resolution.
+
+Centralizes S3 client construction so the **endpoint, region, and addressing
+style are config concerns**, not hardcoded Cloudflare R2 details. This is the
+foundation for the ``data → OSN`` / ``tiles → R2`` split: each logical
+*purpose* (``data`` or ``tiles``) resolves to its own backend block, and
+nothing else in the deploy code hand-builds an endpoint URL or a boto3 client.
+
+A *purpose* maps to a config-dict section:
+
+* ``data``  → ``config['r2']``        (spectra, rgb, sed, photometry, …)
+* ``tiles`` → ``config['r2_tiles']``  (map tiles; kept on R2 for the CDN edge)
+
+Each section may carry, in addition to the credentials
+(``access_key_id`` / ``secret_access_key`` / ``bucket_name``):
+
+* ``endpoint``         — explicit S3 endpoint URL. When absent it is derived
+                         from ``account_id`` as the Cloudflare R2 host, so
+                         existing R2 configs keep working unchanged.
+* ``region``           — SigV4 signing region (default ``'auto'``, the R2
+                         convention). OSN-style endpoints must set a real
+                         region, since presigned URLs bind to the signing
+                         host+region.
+* ``force_path_style`` — path-style addressing (``endpoint/bucket/key``).
+                         Required by some non-AWS S3 implementations.
+* ``backend``          — informational label (``'r2'`` | ``'osn'``). Inferred
+                         from the endpoint host when not given.
+* ``public_url_base``  — base URL for publicly-served objects (tiles).
+
+These keys are populated from TOML or the ``CAMPFIRE_S3_*`` / ``CAMPFIRE_R2_*``
+environment variables (see ``config.py``).
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+# Logical purpose -> config-dict section holding its backend config.
+PURPOSE_SECTIONS = {
+    'data': 'r2',
+    'tiles': 'r2_tiles',
+}
+
+# Default endpoint host for Cloudflare R2 when only an account id is supplied.
+R2_ENDPOINT_TEMPLATE = 'https://{account_id}.r2.cloudflarestorage.com'
+
+# Default signing region for R2 (Cloudflare-ism; non-R2 backends should set one).
+DEFAULT_REGION = 'auto'
+
+
+@dataclass(frozen=True)
+class BackendConfig:
+    """Resolved S3 backend configuration for a single logical purpose."""
+
+    purpose: str                       # 'data' | 'tiles'
+    backend: str                       # 'r2' | 'osn'
+    endpoint: str                      # full endpoint URL
+    region: str
+    bucket: str
+    access_key_id: str
+    secret_access_key: str
+    force_path_style: bool = False
+    public_url_base: Optional[str] = None
+
+
+def _coerce_bool(value) -> bool:
+    """Interpret a TOML/env value (str or bool) as a boolean flag."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in ('1', 'true', 'yes', 'on')
+
+
+def _infer_backend(endpoint: str) -> str:
+    """Best-effort backend label from the endpoint host."""
+    return 'r2' if 'r2.cloudflarestorage.com' in endpoint else 'osn'
+
+
+def _resolve_endpoint(section: dict, purpose: str) -> str:
+    """Resolve the endpoint URL: explicit ``endpoint`` wins, else R2-from-account."""
+    endpoint = section.get('endpoint')
+    if endpoint:
+        return str(endpoint).rstrip('/')
+
+    account_id = section.get('account_id')
+    if account_id:
+        return R2_ENDPOINT_TEMPLATE.format(account_id=account_id)
+
+    raise ValueError(
+        f"Cannot resolve S3 endpoint for '{purpose}' storage: set either "
+        f"'endpoint' (e.g. CAMPFIRE_S3_ENDPOINT) or 'account_id' "
+        f"(e.g. CAMPFIRE_R2_ACCOUNT_ID) in the config."
+    )
+
+
+def resolve_backend(config: dict, purpose: str = 'data') -> BackendConfig:
+    """
+    Resolve the :class:`BackendConfig` for a logical *purpose*.
+
+    Parameters
+    ----------
+    config : dict
+        Deploy config dict (as produced by ``config.load_config``).
+    purpose : str
+        ``'data'`` or ``'tiles'``.
+
+    Raises
+    ------
+    ValueError
+        If the purpose is unknown, its config section is missing, the
+        endpoint cannot be resolved, or credentials are absent.
+    """
+    section_key = PURPOSE_SECTIONS.get(purpose)
+    if section_key is None:
+        known = ', '.join(sorted(PURPOSE_SECTIONS))
+        raise ValueError(f"Unknown storage purpose '{purpose}'. Known: {known}.")
+
+    section = config.get(section_key)
+    if not section:
+        raise ValueError(
+            f"No [{section_key}] storage config found for '{purpose}'. "
+            f"Set CAMPFIRE_{'S3' if purpose == 'data' else 'S3_TILES'}_* env "
+            f"vars or add a [{section_key}] block to deploy.toml."
+        )
+
+    endpoint = _resolve_endpoint(section, purpose)
+
+    access_key_id = section.get('access_key_id')
+    secret_access_key = section.get('secret_access_key')
+    bucket = section.get('bucket_name')
+    missing = [
+        name for name, val in (
+            ('access_key_id', access_key_id),
+            ('secret_access_key', secret_access_key),
+            ('bucket_name', bucket),
+        ) if not val
+    ]
+    if missing:
+        raise ValueError(
+            f"Incomplete [{section_key}] storage config for '{purpose}': "
+            f"missing {', '.join(missing)}."
+        )
+
+    backend = section.get('backend') or _infer_backend(endpoint)
+    region = section.get('region') or DEFAULT_REGION
+    public_url_base = section.get('public_url_base')
+
+    return BackendConfig(
+        purpose=purpose,
+        backend=str(backend),
+        endpoint=endpoint,
+        region=str(region),
+        bucket=str(bucket),
+        access_key_id=str(access_key_id),
+        secret_access_key=str(secret_access_key),
+        force_path_style=_coerce_bool(section.get('force_path_style')),
+        public_url_base=str(public_url_base) if public_url_base else None,
+    )
+
+
+def make_s3_client(bcfg: BackendConfig, *, max_pool_connections: Optional[int] = None):
+    """
+    Build a boto3 S3 client from a resolved :class:`BackendConfig`.
+
+    boto3/botocore are imported lazily so this module (and ``resolve_backend``)
+    stay importable without the heavy AWS SDK installed.
+    """
+    import boto3
+    from botocore.config import Config
+
+    config_kwargs: dict = {'signature_version': 's3v4'}
+    if bcfg.force_path_style:
+        config_kwargs['s3'] = {'addressing_style': 'path'}
+    if max_pool_connections is not None:
+        config_kwargs['max_pool_connections'] = max_pool_connections
+
+    return boto3.client(
+        's3',
+        endpoint_url=bcfg.endpoint,
+        aws_access_key_id=bcfg.access_key_id,
+        aws_secret_access_key=bcfg.secret_access_key,
+        config=Config(**config_kwargs),
+        region_name=bcfg.region,
+    )
+
+
+def make_client_for(config: dict, purpose: str = 'data', **kwargs):
+    """Convenience: resolve *purpose* and build its boto3 client in one call."""
+    return make_s3_client(resolve_backend(config, purpose), **kwargs)

--- a/python/campfire/deploy/config.py
+++ b/python/campfire/deploy/config.py
@@ -3,10 +3,17 @@ Configuration loading, credential resolution, and path helpers.
 
 Credential resolution (env vars take priority over TOML):
   1. CAMPFIRE_SUPABASE_URL, CAMPFIRE_SUPABASE_SERVICE_ROLE_KEY,
-     CAMPFIRE_R2_ACCOUNT_ID, CAMPFIRE_R2_ACCESS_KEY_ID,
-     CAMPFIRE_R2_SECRET_ACCESS_KEY, CAMPFIRE_R2_BUCKET_NAME
+     CAMPFIRE_S3_ACCESS_KEY_ID, CAMPFIRE_S3_SECRET_ACCESS_KEY,
+     CAMPFIRE_S3_BUCKET_NAME, and either CAMPFIRE_S3_ENDPOINT or
+     CAMPFIRE_S3_ACCOUNT_ID (R2 host derived from the account id).
+     The legacy CAMPFIRE_R2_* names are accepted as aliases.
   2. Explicit --config flag -> TOML file
   3. $CAMPFIRE_ROOT/config/deploy.toml
+
+Storage backend tuning (optional, per purpose — data / tiles): CAMPFIRE_S3_*
+and CAMPFIRE_S3_TILES_* accept ENDPOINT, REGION, FORCE_PATH_STYLE, BACKEND,
+and PUBLIC_URL_BASE so OSN (or any S3-compatible store) is a config change.
+See ``backend.py`` for how these resolve into an S3 client.
 
 Programs resolution:
   $CAMPFIRE_ROOT/config/programs.toml
@@ -19,30 +26,59 @@ from pathlib import Path
 import tomllib
 
 
-# Environment variable names for credentials
-_ENV_VARS = {
-    'supabase': {
-        'url': 'CAMPFIRE_SUPABASE_URL',
-        'service_role_key': 'CAMPFIRE_SUPABASE_SERVICE_ROLE_KEY',
-    },
-    'r2': {
-        'account_id': 'CAMPFIRE_R2_ACCOUNT_ID',
-        'access_key_id': 'CAMPFIRE_R2_ACCESS_KEY_ID',
-        'secret_access_key': 'CAMPFIRE_R2_SECRET_ACCESS_KEY',
-        'bucket_name': 'CAMPFIRE_R2_BUCKET_NAME',
-    },
+# Environment-variable resolution for credentials + storage backend config.
+#
+# Each config key resolves from a list of env var names tried in order:
+# neutral ``CAMPFIRE_S3_*`` names are canonical; ``CAMPFIRE_R2_*`` names are
+# kept as backward-compatible aliases. Storage sections additionally accept
+# optional tuning keys (endpoint, region, force_path_style, backend,
+# public_url_base) so OSN — or any S3-compatible backend — is a config change,
+# not a code edit. See ``backend.py`` for how these are consumed.
+
+_SUPABASE_ENV = {
+    'url': ['CAMPFIRE_SUPABASE_URL'],
+    'service_role_key': ['CAMPFIRE_SUPABASE_SERVICE_ROLE_KEY'],
 }
 
-# Optional environment variable sections (not required for core commands)
-_OPTIONAL_ENV_VARS = {
-    'r2_tiles': {
-        'account_id': 'CAMPFIRE_R2_TILES_ACCOUNT_ID',
-        'access_key_id': 'CAMPFIRE_R2_TILES_ACCESS_KEY_ID',
-        'secret_access_key': 'CAMPFIRE_R2_TILES_SECRET_ACCESS_KEY',
-        'bucket_name': 'CAMPFIRE_R2_TILES_BUCKET_NAME',
-        'public_url_base': 'CAMPFIRE_R2_TILES_PUBLIC_URL_BASE',
-    },
+# Data storage backend -> config['r2'] section.
+_DATA_ENV = {
+    'account_id': ['CAMPFIRE_S3_ACCOUNT_ID', 'CAMPFIRE_R2_ACCOUNT_ID'],
+    'access_key_id': ['CAMPFIRE_S3_ACCESS_KEY_ID', 'CAMPFIRE_R2_ACCESS_KEY_ID'],
+    'secret_access_key': ['CAMPFIRE_S3_SECRET_ACCESS_KEY', 'CAMPFIRE_R2_SECRET_ACCESS_KEY'],
+    'bucket_name': ['CAMPFIRE_S3_BUCKET_NAME', 'CAMPFIRE_R2_BUCKET_NAME'],
+    'endpoint': ['CAMPFIRE_S3_ENDPOINT', 'CAMPFIRE_R2_ENDPOINT'],
+    'region': ['CAMPFIRE_S3_REGION', 'CAMPFIRE_R2_REGION'],
+    'force_path_style': ['CAMPFIRE_S3_FORCE_PATH_STYLE', 'CAMPFIRE_R2_FORCE_PATH_STYLE'],
+    'backend': ['CAMPFIRE_S3_BACKEND', 'CAMPFIRE_R2_BACKEND'],
+    'public_url_base': [
+        'CAMPFIRE_S3_PUBLIC_URL_BASE', 'CAMPFIRE_R2_PUBLIC_URL_BASE',
+        'CAMPFIRE_R2_PUBLIC_URL',
+    ],
 }
+
+# Tiles storage backend -> config['r2_tiles'] section.
+_TILES_ENV = {
+    'account_id': ['CAMPFIRE_S3_TILES_ACCOUNT_ID', 'CAMPFIRE_R2_TILES_ACCOUNT_ID'],
+    'access_key_id': ['CAMPFIRE_S3_TILES_ACCESS_KEY_ID', 'CAMPFIRE_R2_TILES_ACCESS_KEY_ID'],
+    'secret_access_key': [
+        'CAMPFIRE_S3_TILES_SECRET_ACCESS_KEY', 'CAMPFIRE_R2_TILES_SECRET_ACCESS_KEY',
+    ],
+    'bucket_name': ['CAMPFIRE_S3_TILES_BUCKET_NAME', 'CAMPFIRE_R2_TILES_BUCKET_NAME'],
+    'endpoint': ['CAMPFIRE_S3_TILES_ENDPOINT', 'CAMPFIRE_R2_TILES_ENDPOINT'],
+    'region': ['CAMPFIRE_S3_TILES_REGION', 'CAMPFIRE_R2_TILES_REGION'],
+    'force_path_style': [
+        'CAMPFIRE_S3_TILES_FORCE_PATH_STYLE', 'CAMPFIRE_R2_TILES_FORCE_PATH_STYLE',
+    ],
+    'backend': ['CAMPFIRE_S3_TILES_BACKEND', 'CAMPFIRE_R2_TILES_BACKEND'],
+    'public_url_base': [
+        'CAMPFIRE_S3_TILES_PUBLIC_URL_BASE', 'CAMPFIRE_R2_TILES_PUBLIC_URL_BASE',
+        'CAMPFIRE_R2_TILES_PUBLIC_URL',
+    ],
+}
+
+# A storage section is "usable" with credentials + a bucket + a way to resolve
+# its endpoint (an explicit endpoint, or an account_id to derive the R2 host).
+_STORAGE_REQUIRED = ('access_key_id', 'secret_access_key', 'bucket_name')
 
 
 def _load_toml(path: Path) -> dict:
@@ -51,41 +87,46 @@ def _load_toml(path: Path) -> dict:
         return tomllib.load(f)
 
 
+def _read_env_section(spec: dict[str, list[str]]) -> dict:
+    """Read each key whose env var (canonical-first, then aliases) is set."""
+    out: dict = {}
+    for key, names in spec.items():
+        for name in names:
+            val = os.environ.get(name)
+            if val:
+                out[key] = val
+                break
+    return out
+
+
+def _storage_section_complete(section: dict) -> bool:
+    """A storage section needs creds, a bucket, and a resolvable endpoint."""
+    if not all(section.get(k) for k in _STORAGE_REQUIRED):
+        return False
+    return bool(section.get('endpoint') or section.get('account_id'))
+
+
 def _config_from_env() -> dict | None:
     """
     Build a config dict from environment variables.
 
-    Returns a complete config dict if all required env vars are set,
-    or None if any are missing. Optional sections (e.g. r2_tiles) are
-    included when all their env vars are present, but never block loading.
+    Returns a config dict when Supabase service-role creds **and** a usable
+    ``data`` storage section are present, or None otherwise. The optional
+    ``tiles`` section is included when usable, but never blocks loading.
     """
-    config: dict = {}
-    all_present = True
-
-    for section, keys in _ENV_VARS.items():
-        config[section] = {}
-        for key, env_var in keys.items():
-            val = os.environ.get(env_var)
-            if val:
-                config[section][key] = val
-            else:
-                all_present = False
-
-    if not all_present:
+    supabase = _read_env_section(_SUPABASE_ENV)
+    if not all(supabase.get(k) for k in _SUPABASE_ENV):
         return None
 
-    # Populate optional sections if all their env vars are present
-    for section, keys in _OPTIONAL_ENV_VARS.items():
-        section_vals = {}
-        section_complete = True
-        for key, env_var in keys.items():
-            val = os.environ.get(env_var)
-            if val:
-                section_vals[key] = val
-            else:
-                section_complete = False
-        if section_complete:
-            config[section] = section_vals
+    data = _read_env_section(_DATA_ENV)
+    if not _storage_section_complete(data):
+        return None
+
+    config: dict = {'supabase': supabase, 'r2': data}
+
+    tiles = _read_env_section(_TILES_ENV)
+    if _storage_section_complete(tiles):
+        config['r2_tiles'] = tiles
 
     return config
 
@@ -160,6 +201,11 @@ def load_config(config_path: str | None = None, *, local: bool = False) -> dict:
             for key, val in toml_config.items():
                 if key not in env_config:
                     env_config[key] = val
+                elif isinstance(val, dict) and isinstance(env_config[key], dict):
+                    # env takes priority per-key; TOML fills any gaps (e.g. a
+                    # public_url_base configured in TOML alongside env creds).
+                    for subkey, subval in val.items():
+                        env_config[key].setdefault(subkey, subval)
         env_config.setdefault('supabase', {})['_auth_mode'] = 'service_role'
         return env_config
 
@@ -187,7 +233,11 @@ def load_config(config_path: str | None = None, *, local: bool = False) -> dict:
             candidates.append(str(Path(root) / 'config' / 'deploy.toml'))
 
     searched = ', '.join(candidates) if candidates else '(none)'
-    env_names = [v for keys in _ENV_VARS.values() for v in keys.values()]
+    # Show the canonical (neutral) env var names for the required sections.
+    env_names = (
+        [names[0] for names in _SUPABASE_ENV.values()]
+        + [_DATA_ENV[k][0] for k in _STORAGE_REQUIRED]
+    )
 
     print("Error: No deploy credentials found.")
     print()
@@ -197,6 +247,11 @@ def load_config(config_path: str | None = None, *, local: bool = False) -> dict:
     print("Option 2 — Set environment variables (service role):")
     for name in env_names:
         print(f"  export {name}=...")
+    # The endpoint can be given directly (OSN/MinIO/any S3) or derived from an
+    # R2 account id — one of the two is required, not both.
+    print(f"  export {_DATA_ENV['endpoint'][0]}=...        "
+          f"# e.g. https://<host>  (OSN / MinIO / S3)")
+    print(f"  # or, for Cloudflare R2:  export {_DATA_ENV['account_id'][0]}=...")
     print()
     print("Option 3 — Create a TOML config file:")
     if candidates:

--- a/python/campfire/deploy/r2.py
+++ b/python/campfire/deploy/r2.py
@@ -189,19 +189,14 @@ def upload_files_presigned(
 # ---------------------------------------------------------------------------
 
 def get_r2_client(config: dict):
-    """Create boto3 S3 client configured for Cloudflare R2."""
-    import boto3
-    from botocore.config import Config
+    """Create a boto3 S3 client for the ``data`` storage backend.
 
-    r2 = config['r2']
-    return boto3.client(
-        's3',
-        endpoint_url=f"https://{r2['account_id']}.r2.cloudflarestorage.com",
-        aws_access_key_id=r2['access_key_id'],
-        aws_secret_access_key=r2['secret_access_key'],
-        config=Config(signature_version='s3v4'),
-        region_name='auto',
-    )
+    Endpoint/region/addressing-style come from config via the per-purpose
+    backend factory (defaults to Cloudflare R2). Name kept for backward
+    compatibility with existing importers.
+    """
+    from campfire.deploy.backend import make_client_for
+    return make_client_for(config, 'data')
 
 
 def upload_to_r2(
@@ -317,27 +312,24 @@ def upload_files_parallel(
     if urls:
         return upload_files_presigned(urls, tasks, max_workers=max_workers, desc=desc)
 
-    # Fall back to direct boto3 upload
-    r2_config_key = 'r2_tiles' if bucket_id == 'tiles' else 'r2'
-    if r2_config_key not in config:
+    # Fall back to direct boto3 upload via the per-purpose backend factory.
+    from campfire.deploy.backend import (
+        PURPOSE_SECTIONS, make_s3_client, resolve_backend,
+    )
+
+    purpose = 'tiles' if bucket_id == 'tiles' else 'data'
+    if PURPOSE_SECTIONS[purpose] not in config:
         raise ValueError(
-            f"No R2 credentials available for '{bucket_id}' bucket. "
-            "Run 'campfire login' to use presigned URLs, or provide R2 credentials in deploy config."
+            f"No storage credentials available for the '{bucket_id}' bucket. "
+            "Run 'campfire login' to use presigned URLs, or provide storage "
+            "credentials in deploy config."
         )
 
-    import boto3
-    from botocore.config import Config
-
-    r2 = config[r2_config_key]
-    client = boto3.client(
-        's3',
-        endpoint_url=f"https://{r2['account_id']}.r2.cloudflarestorage.com",
-        aws_access_key_id=r2['access_key_id'],
-        aws_secret_access_key=r2['secret_access_key'],
-        config=Config(signature_version='s3v4'),
-        region_name='auto',
-    )
-    bucket_name = r2['bucket_name']
+    # A present-but-incomplete section surfaces resolve_backend's specific
+    # diagnostic (which key/endpoint is missing), not the generic message above.
+    backend_cfg = resolve_backend(config, purpose)
+    client = make_s3_client(backend_cfg)
+    bucket_name = backend_cfg.bucket
 
     # For direct mode, apply cache_control per-file
     if cache_control:

--- a/python/campfire/deploy/remove.py
+++ b/python/campfire/deploy/remove.py
@@ -161,11 +161,12 @@ def _delete_db_rows(sb: Client, obs_name: str, target_ids: list[str]) -> None:
 
 
 def _delete_r2_prefixes(config: dict, obs_name: str) -> dict[str, int]:
+    from campfire.deploy.backend import resolve_backend
     from campfire.deploy.r2 import get_r2_client
     from campfire.deploy.tiles import delete_r2_prefix
 
     client = get_r2_client(config)
-    bucket = config['r2']['bucket_name']
+    bucket = resolve_backend(config, 'data').bucket
     counts: dict[str, int] = {}
     for prefix in R2_PREFIXES:
         full = f"{prefix}/{obs_name}/"

--- a/python/campfire/deploy/tiles.py
+++ b/python/campfire/deploy/tiles.py
@@ -21,22 +21,13 @@ from campfire.deploy.r2 import UploadTask, upload_files_parallel
 
 
 def get_r2_tiles_client(config: dict):
-    """Create boto3 S3 client for the tiles R2 bucket (for delete operations)."""
-    import boto3
-    from botocore.config import Config as BotoConfig
+    """Create a boto3 S3 client for the ``tiles`` storage backend (delete ops).
 
-    r2_config = config['r2_tiles']
-    return boto3.client(
-        's3',
-        endpoint_url=f"https://{r2_config['account_id']}.r2.cloudflarestorage.com",
-        aws_access_key_id=r2_config['access_key_id'],
-        aws_secret_access_key=r2_config['secret_access_key'],
-        config=BotoConfig(
-            signature_version='s3v4',
-            max_pool_connections=50,
-        ),
-        region_name='auto',
-    )
+    Endpoint/region/addressing-style come from config via the per-purpose
+    backend factory (defaults to Cloudflare R2 for tiles).
+    """
+    from campfire.deploy.backend import make_client_for
+    return make_client_for(config, 'tiles', max_pool_connections=50)
 
 
 def _require_r2_tiles(config: dict) -> None:
@@ -166,8 +157,9 @@ def clean_tiles(
 ) -> None:
     """Delete existing R2 tiles for field/filter."""
     _require_r2_tiles(config)
+    from campfire.deploy.backend import resolve_backend
     r2_client = get_r2_tiles_client(config)
-    bucket = config['r2_tiles']['bucket_name']
+    bucket = resolve_backend(config, 'tiles').bucket
 
     fields_to_clean = []
     if filter_name:
@@ -202,8 +194,13 @@ def register_layers(
 ) -> None:
     """Register tile layers in Supabase map_layers table."""
     _require_r2_tiles(config)
-    r2_config = config['r2_tiles']
-    public_url_base = r2_config['public_url_base'].rstrip('/')
+    from campfire.deploy.backend import resolve_backend
+    public_url_base = resolve_backend(config, 'tiles').public_url_base
+    if not public_url_base:
+        print("Error: no 'public_url_base' configured for tiles storage.")
+        print("Set CAMPFIRE_R2_TILES_PUBLIC_URL_BASE or add public_url_base to [r2_tiles].")
+        sys.exit(1)
+    public_url_base = public_url_base.rstrip('/')
     supabase = _get_supabase_client(config)
 
     # Find stats files

--- a/python/tests/test_storage_backend.py
+++ b/python/tests/test_storage_backend.py
@@ -1,0 +1,253 @@
+"""Tests for the per-purpose S3 storage backend factory and its env resolution.
+
+Covers ``campfire.deploy.backend`` (pure resolution + boto3 client build) and
+the ``CAMPFIRE_S3_*`` / ``CAMPFIRE_R2_*`` environment resolution in
+``campfire.deploy.config``. Together these prove the PR-1 acceptance gate:
+endpoint / region / path-style are config-only concerns, with the data->OSN /
+tiles->R2 split selected by the factory.
+"""
+import pytest
+
+from campfire.deploy import backend
+from campfire.deploy.config import load_config
+
+
+# ---------------------------------------------------------------------------
+# resolve_backend — endpoint / region / backend / path-style resolution
+# ---------------------------------------------------------------------------
+
+def _data(**overrides) -> dict:
+    section = {
+        'access_key_id': 'k', 'secret_access_key': 's', 'bucket_name': 'data',
+    }
+    section.update(overrides)
+    return {'r2': section}
+
+
+def test_r2_default_endpoint_from_account_id():
+    b = backend.resolve_backend(_data(account_id='acct'), 'data')
+    assert b.endpoint == 'https://acct.r2.cloudflarestorage.com'
+    assert b.region == 'auto'
+    assert b.backend == 'r2'
+    assert b.force_path_style is False
+    assert b.public_url_base is None
+    assert b.bucket == 'data'
+
+
+def test_explicit_endpoint_overrides_account_and_strips_slash():
+    b = backend.resolve_backend(
+        _data(account_id='acct', endpoint='https://osn.example.org/'), 'data'
+    )
+    # explicit endpoint wins over the derived R2 host, trailing slash stripped
+    assert b.endpoint == 'https://osn.example.org'
+    assert b.backend == 'osn'   # inferred from non-R2 host
+
+
+def test_region_and_backend_label_honored():
+    b = backend.resolve_backend(
+        _data(endpoint='https://s3.example', region='us-east-1', backend='osn'),
+        'data',
+    )
+    assert b.region == 'us-east-1'
+    assert b.backend == 'osn'
+
+
+@pytest.mark.parametrize('value,expected', [
+    ('true', True), ('1', True), ('yes', True), ('on', True), (True, True),
+    ('false', False), ('0', False), ('', False), (None, False), (False, False),
+])
+def test_force_path_style_coercion(value, expected):
+    section = _data(account_id='acct')
+    if value is not None:
+        section['r2']['force_path_style'] = value
+    b = backend.resolve_backend(section, 'data')
+    assert b.force_path_style is expected
+
+
+def test_public_url_base_passthrough():
+    b = backend.resolve_backend(
+        _data(account_id='acct', public_url_base='https://cdn.example'), 'data'
+    )
+    assert b.public_url_base == 'https://cdn.example'
+
+
+def test_tiles_purpose_uses_r2_tiles_section():
+    config = {'r2_tiles': {
+        'account_id': 'tacct', 'access_key_id': 'k',
+        'secret_access_key': 's', 'bucket_name': 'tiles',
+        'public_url_base': 'https://tiles.example',
+    }}
+    b = backend.resolve_backend(config, 'tiles')
+    assert b.purpose == 'tiles'
+    assert b.bucket == 'tiles'
+    assert b.endpoint == 'https://tacct.r2.cloudflarestorage.com'
+    assert b.public_url_base == 'https://tiles.example'
+
+
+def test_unknown_purpose_raises():
+    with pytest.raises(ValueError, match='Unknown storage purpose'):
+        backend.resolve_backend(_data(account_id='a'), 'bogus')
+
+
+def test_missing_section_raises():
+    with pytest.raises(ValueError, match='No \\[r2_tiles\\]'):
+        backend.resolve_backend(_data(account_id='a'), 'tiles')
+
+
+def test_missing_credentials_raises_with_names():
+    with pytest.raises(ValueError, match='missing'):
+        backend.resolve_backend({'r2': {'account_id': 'a'}}, 'data')
+
+
+def test_no_endpoint_or_account_raises():
+    with pytest.raises(ValueError, match='Cannot resolve S3 endpoint'):
+        backend.resolve_backend(
+            {'r2': {'access_key_id': 'k', 'secret_access_key': 's',
+                    'bucket_name': 'b'}},
+            'data',
+        )
+
+
+# ---------------------------------------------------------------------------
+# make_s3_client — boto3 client carries the resolved endpoint/region/style
+# ---------------------------------------------------------------------------
+
+def test_make_s3_client_applies_endpoint_region_pathstyle():
+    boto3 = pytest.importorskip('boto3')  # noqa: F841
+    b = backend.resolve_backend(
+        _data(endpoint='https://osn.example.org', region='us-east-1',
+              force_path_style='true'),
+        'data',
+    )
+    client = backend.make_s3_client(b, max_pool_connections=7)
+    assert client.meta.endpoint_url == 'https://osn.example.org'
+    assert client.meta.region_name == 'us-east-1'
+    assert client.meta.config.s3.get('addressing_style') == 'path'
+    assert client.meta.config.max_pool_connections == 7
+
+
+def test_make_s3_client_r2_defaults():
+    pytest.importorskip('boto3')
+    b = backend.resolve_backend(_data(account_id='acct'), 'data')
+    client = backend.make_s3_client(b)
+    assert client.meta.endpoint_url == 'https://acct.r2.cloudflarestorage.com'
+    assert client.meta.region_name == 'auto'
+
+
+# ---------------------------------------------------------------------------
+# Environment resolution (config.py) — neutral S3 names + R2 aliases
+# ---------------------------------------------------------------------------
+
+_ALL_STORAGE_ENV = [
+    # supabase
+    'CAMPFIRE_SUPABASE_URL', 'CAMPFIRE_SUPABASE_SERVICE_ROLE_KEY',
+    # data (neutral + alias) and tuning
+    'CAMPFIRE_S3_ACCOUNT_ID', 'CAMPFIRE_S3_ACCESS_KEY_ID',
+    'CAMPFIRE_S3_SECRET_ACCESS_KEY', 'CAMPFIRE_S3_BUCKET_NAME',
+    'CAMPFIRE_S3_ENDPOINT', 'CAMPFIRE_S3_REGION',
+    'CAMPFIRE_S3_FORCE_PATH_STYLE', 'CAMPFIRE_S3_BACKEND',
+    'CAMPFIRE_S3_PUBLIC_URL_BASE',
+    'CAMPFIRE_R2_ACCOUNT_ID', 'CAMPFIRE_R2_ACCESS_KEY_ID',
+    'CAMPFIRE_R2_SECRET_ACCESS_KEY', 'CAMPFIRE_R2_BUCKET_NAME',
+    'CAMPFIRE_R2_ENDPOINT', 'CAMPFIRE_R2_PUBLIC_URL',
+    # tiles
+    'CAMPFIRE_S3_TILES_ACCOUNT_ID', 'CAMPFIRE_S3_TILES_ACCESS_KEY_ID',
+    'CAMPFIRE_S3_TILES_SECRET_ACCESS_KEY', 'CAMPFIRE_S3_TILES_BUCKET_NAME',
+    'CAMPFIRE_S3_TILES_PUBLIC_URL_BASE',
+    'CAMPFIRE_R2_TILES_ACCOUNT_ID', 'CAMPFIRE_R2_TILES_ACCESS_KEY_ID',
+    'CAMPFIRE_R2_TILES_SECRET_ACCESS_KEY', 'CAMPFIRE_R2_TILES_BUCKET_NAME',
+]
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    monkeypatch.delenv('CAMPFIRE_ROOT', raising=False)
+    for var in _ALL_STORAGE_ENV:
+        monkeypatch.delenv(var, raising=False)
+    return monkeypatch
+
+
+def _set_supabase(mp):
+    mp.setenv('CAMPFIRE_SUPABASE_URL', 'https://prod.supabase.co')
+    mp.setenv('CAMPFIRE_SUPABASE_SERVICE_ROLE_KEY', 'svc-key')
+
+
+def test_neutral_s3_env_resolves_to_backend(clean_env):
+    mp = clean_env
+    _set_supabase(mp)
+    mp.setenv('CAMPFIRE_S3_ACCESS_KEY_ID', 'ak')
+    mp.setenv('CAMPFIRE_S3_SECRET_ACCESS_KEY', 'sk')
+    mp.setenv('CAMPFIRE_S3_BUCKET_NAME', 'data')
+    mp.setenv('CAMPFIRE_S3_ENDPOINT', 'https://osn.example.org')
+    mp.setenv('CAMPFIRE_S3_REGION', 'us-east-1')
+    mp.setenv('CAMPFIRE_S3_FORCE_PATH_STYLE', 'true')
+
+    config = load_config()
+    assert config['supabase']['_auth_mode'] == 'service_role'
+
+    b = backend.resolve_backend(config, 'data')
+    assert b.endpoint == 'https://osn.example.org'
+    assert b.region == 'us-east-1'
+    assert b.force_path_style is True
+    assert b.backend == 'osn'
+    assert b.bucket == 'data'
+
+
+def test_legacy_r2_env_aliases_still_work(clean_env):
+    mp = clean_env
+    _set_supabase(mp)
+    mp.setenv('CAMPFIRE_R2_ACCOUNT_ID', 'acct')
+    mp.setenv('CAMPFIRE_R2_ACCESS_KEY_ID', 'ak')
+    mp.setenv('CAMPFIRE_R2_SECRET_ACCESS_KEY', 'sk')
+    mp.setenv('CAMPFIRE_R2_BUCKET_NAME', 'data')
+
+    config = load_config()
+    b = backend.resolve_backend(config, 'data')
+    assert b.endpoint == 'https://acct.r2.cloudflarestorage.com'
+    assert b.backend == 'r2'
+
+
+def test_endpoint_without_account_id_is_usable(clean_env):
+    mp = clean_env
+    _set_supabase(mp)
+    mp.setenv('CAMPFIRE_S3_ACCESS_KEY_ID', 'ak')
+    mp.setenv('CAMPFIRE_S3_SECRET_ACCESS_KEY', 'sk')
+    mp.setenv('CAMPFIRE_S3_BUCKET_NAME', 'data')
+    mp.setenv('CAMPFIRE_S3_ENDPOINT', 'https://osn.example.org')
+
+    config = load_config()  # must NOT fall through to "no credentials"
+    assert config['supabase']['_auth_mode'] == 'service_role'
+    assert 'account_id' not in config['r2']
+    assert backend.resolve_backend(config, 'data').endpoint == 'https://osn.example.org'
+
+
+def test_tiles_section_included_when_complete(clean_env):
+    mp = clean_env
+    _set_supabase(mp)
+    mp.setenv('CAMPFIRE_S3_ACCOUNT_ID', 'acct')
+    mp.setenv('CAMPFIRE_S3_ACCESS_KEY_ID', 'ak')
+    mp.setenv('CAMPFIRE_S3_SECRET_ACCESS_KEY', 'sk')
+    mp.setenv('CAMPFIRE_S3_BUCKET_NAME', 'data')
+    # tiles via R2 aliases
+    mp.setenv('CAMPFIRE_R2_TILES_ACCOUNT_ID', 'tacct')
+    mp.setenv('CAMPFIRE_R2_TILES_ACCESS_KEY_ID', 'tak')
+    mp.setenv('CAMPFIRE_R2_TILES_SECRET_ACCESS_KEY', 'tsk')
+    mp.setenv('CAMPFIRE_R2_TILES_BUCKET_NAME', 'tiles')
+
+    config = load_config()
+    assert 'r2_tiles' in config
+    assert backend.resolve_backend(config, 'tiles').bucket == 'tiles'
+
+
+def test_tiles_section_omitted_when_incomplete(clean_env):
+    mp = clean_env
+    _set_supabase(mp)
+    mp.setenv('CAMPFIRE_S3_ACCOUNT_ID', 'acct')
+    mp.setenv('CAMPFIRE_S3_ACCESS_KEY_ID', 'ak')
+    mp.setenv('CAMPFIRE_S3_SECRET_ACCESS_KEY', 'sk')
+    mp.setenv('CAMPFIRE_S3_BUCKET_NAME', 'data')
+    # only a partial tiles section -> dropped, never blocks loading
+    mp.setenv('CAMPFIRE_R2_TILES_ACCOUNT_ID', 'tacct')
+
+    config = load_config()
+    assert 'r2_tiles' not in config

--- a/scripts/backfill_hashes.py
+++ b/scripts/backfill_hashes.py
@@ -48,13 +48,24 @@ def load_config(scripts_dir: Path) -> dict:
 
 def get_r2_client(config: dict):
     r2_config = config['r2']
+    # Endpoint/region/path-style are configurable (mirrors the deploy backend
+    # factory); fall back to the Cloudflare R2 host derived from account_id.
+    endpoint = r2_config.get('endpoint') or (
+        f"https://{r2_config['account_id']}.r2.cloudflarestorage.com"
+    )
+    fps = r2_config.get('force_path_style', False)
+    if isinstance(fps, str):
+        fps = fps.strip().lower() in ('1', 'true', 'yes', 'on')
+    boto_kwargs = {'signature_version': 's3v4'}
+    if fps:
+        boto_kwargs['s3'] = {'addressing_style': 'path'}
     return boto3.client(
         's3',
-        endpoint_url=f"https://{r2_config['account_id']}.r2.cloudflarestorage.com",
+        endpoint_url=endpoint,
         aws_access_key_id=r2_config['access_key_id'],
         aws_secret_access_key=r2_config['secret_access_key'],
-        config=Config(signature_version='s3v4'),
-        region_name='auto',
+        config=Config(**boto_kwargs),
+        region_name=r2_config.get('region', 'auto'),
     )
 
 

--- a/web/README.md
+++ b/web/README.md
@@ -19,12 +19,23 @@ Create a `.env.local` file with the following:
 NEXT_PUBLIC_SUPABASE_URL=       # Supabase project URL
 NEXT_PUBLIC_SUPABASE_ANON_KEY=  # Supabase anon/public key
 SUPABASE_SERVICE_ROLE_KEY=      # Supabase service role key (server-only)
-R2_ACCOUNT_ID=                  # Cloudflare R2 account
-R2_ACCESS_KEY_ID=               # R2 access key
-R2_SECRET_ACCESS_KEY=           # R2 secret key
-R2_BUCKET_NAME=                 # R2 bucket name
-R2_PUBLIC_URL=                  # Public URL for R2 assets
+
+# Object storage — "data" bucket (spectra, RGB, SED, photometry, …).
+# Neutral S3_* names are canonical; R2_* names are accepted as aliases.
+S3_ACCESS_KEY_ID=               # access key   (alias: R2_ACCESS_KEY_ID)
+S3_SECRET_ACCESS_KEY=           # secret key   (alias: R2_SECRET_ACCESS_KEY)
+S3_BUCKET_NAME=                 # bucket name  (alias: R2_BUCKET_NAME)
+S3_ACCOUNT_ID=                  # R2 account (derives the endpoint; alias: R2_ACCOUNT_ID)
+# S3_ENDPOINT=                  # explicit endpoint URL (set this for OSN/MinIO instead of S3_ACCOUNT_ID)
+# S3_REGION=                    # SigV4 region (default "auto"; set a real region for non-R2 backends)
+# S3_FORCE_PATH_STYLE=          # "true" for path-style addressing (some non-AWS S3 stores)
+# S3_PUBLIC_URL_BASE=           # public URL base for served assets (alias: R2_PUBLIC_URL)
 ```
+
+The map **tiles** bucket is configured independently with the same keys carrying
+a `TILES_` infix (`S3_TILES_*` / `R2_TILES_*`), e.g. `S3_TILES_BUCKET_NAME`,
+`S3_TILES_ACCOUNT_ID`. Tiles stay on R2 (for the CDN edge cache) even when the
+data bucket points elsewhere.
 
 ### Local Supabase (optional)
 

--- a/web/app/api/download/route.ts
+++ b/web/app/api/download/route.ts
@@ -58,14 +58,6 @@ export async function GET(request: NextRequest) {
     // Generate signed URL (expires in 1 hour)
     const signedUrl = await generateDownloadUrl(fitsPath, 3600);
 
-    // Check if it's a placeholder URL (R2 not configured)
-    if (signedUrl.startsWith('#download-placeholder')) {
-      return NextResponse.json(
-        { error: 'Download service not configured. Please contact administrator.' },
-        { status: 503 }
-      );
-    }
-
     // Track download (fire-and-forget)
     const targetId = await extractTargetIdFromFitsPath(fitsPath);
     trackDownload({
@@ -152,15 +144,6 @@ export async function POST(request: NextRequest) {
     const urls: Record<string, string> = {};
     for (const path of paths) {
       const signedUrl = await generateDownloadUrl(path, 3600);
-
-      // Check if R2 is configured
-      if (signedUrl.startsWith('#download-placeholder')) {
-        return NextResponse.json(
-          { error: 'Download service not configured. Please contact administrator.' },
-          { status: 503 }
-        );
-      }
-
       urls[path] = signedUrl;
     }
 

--- a/web/app/api/nircam-preview/route.ts
+++ b/web/app/api/nircam-preview/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { GetObjectCommand } from '@aws-sdk/client-s3';
-import { r2Client } from '@/lib/r2';
+import { getS3Client, getBucketName } from '@/lib/storage';
 import { createClient } from '@/lib/supabase/server';
 
 /**
@@ -38,8 +38,8 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const obj = await r2Client.send(new GetObjectCommand({
-      Bucket: process.env.R2_BUCKET_NAME,
+    const obj = await getS3Client('data').send(new GetObjectCommand({
+      Bucket: getBucketName('data'),
       Key: key,
     }));
 

--- a/web/app/api/photometry-pz/route.ts
+++ b/web/app/api/photometry-pz/route.ts
@@ -54,13 +54,6 @@ export async function GET(request: NextRequest) {
     // Generate signed URL and fetch server-side (avoids CORS issues)
     const signedUrl = await generateDownloadUrl(pzPath, 3600);
 
-    if (signedUrl.startsWith('#download-placeholder')) {
-      return NextResponse.json(
-        { error: 'Download service not configured.' },
-        { status: 503 }
-      );
-    }
-
     const r2Response = await fetch(signedUrl);
     if (!r2Response.ok) {
       return NextResponse.json(

--- a/web/app/api/redshift-fit/route.ts
+++ b/web/app/api/redshift-fit/route.ts
@@ -65,14 +65,6 @@ export async function GET(request: NextRequest) {
     // Generate signed URL for the zfit JSON file
     const signedUrl = await generateDownloadUrl(zfitJsonPath, 3600);
 
-    // Check if R2 is configured
-    if (signedUrl.startsWith('#download-placeholder')) {
-      return NextResponse.json(
-        { error: 'Download service not configured' },
-        { status: 503 }
-      );
-    }
-
     // Fetch the zfit JSON data from R2
     const response = await fetch(signedUrl);
 

--- a/web/app/api/sed-plot/route.ts
+++ b/web/app/api/sed-plot/route.ts
@@ -60,13 +60,6 @@ export async function GET(request: NextRequest) {
     // Generate signed URL (expires in 1 hour)
     const signedUrl = await generateDownloadUrl(sedPlotPath, 3600);
 
-    // Check if it's a placeholder URL (R2 not configured)
-    if (signedUrl.startsWith('#download-placeholder')) {
-      return NextResponse.json(
-        { error: 'Download service not configured. Please contact administrator.' },
-        { status: 503 }
-      );
-    }
 
     return NextResponse.json({
       url: signedUrl,

--- a/web/app/api/spectrum-thumbnail/route.ts
+++ b/web/app/api/spectrum-thumbnail/route.ts
@@ -223,15 +223,6 @@ export async function GET(request: NextRequest) {
     // Generate signed URL for the JSON file
     const signedUrl = await generateDownloadUrl(jsonPath, 3600);
 
-    // Check if R2 is configured
-    if (signedUrl.startsWith('#download-placeholder')) {
-      return new Response(generateSVG([], color, false), {
-        headers: {
-          'Content-Type': 'image/svg+xml',
-          'Cache-Control': 'public, max-age=86400',
-        },
-      });
-    }
 
     // Fetch the JSON data from R2
     const response = await fetch(signedUrl);

--- a/web/app/api/spectrum/route.ts
+++ b/web/app/api/spectrum/route.ts
@@ -66,14 +66,6 @@ export async function GET(request: NextRequest) {
     // Generate signed URL for the JSON file
     const signedUrl = await generateDownloadUrl(jsonPath, 3600);
 
-    // Check if R2 is configured
-    if (signedUrl.startsWith('#download-placeholder')) {
-      return NextResponse.json(
-        { error: 'Download service not configured' },
-        { status: 503 }
-      );
-    }
-
     // Fetch the JSON data from R2
     const response = await fetch(signedUrl);
 

--- a/web/app/api/v1/deploy/presign/route.ts
+++ b/web/app/api/v1/deploy/presign/route.ts
@@ -1,59 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { validateAuth } from '@/lib/api-auth';
 import { createClient } from '@supabase/supabase-js';
+import { getS3Client, getBucketName, type StoragePurpose } from '@/lib/storage';
 
 const MAX_BATCH_SIZE = 500;
 const PRESIGN_EXPIRY_SECONDS = 3600; // 1 hour
-
-type BucketId = 'data' | 'tiles';
-
-interface BucketConfig {
-  client: S3Client;
-  bucket: string;
-}
-
-function getBucketConfig(bucketId: BucketId): BucketConfig {
-  if (bucketId === 'tiles') {
-    const accountId = process.env.R2_TILES_ACCOUNT_ID;
-    const accessKeyId = process.env.R2_TILES_ACCESS_KEY_ID;
-    const secretAccessKey = process.env.R2_TILES_SECRET_ACCESS_KEY;
-    const bucketName = process.env.R2_TILES_BUCKET_NAME;
-
-    if (!accountId || !accessKeyId || !secretAccessKey || !bucketName) {
-      throw new Error('R2 tiles credentials not configured');
-    }
-
-    return {
-      client: new S3Client({
-        region: 'auto',
-        endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
-        credentials: { accessKeyId, secretAccessKey },
-      }),
-      bucket: bucketName,
-    };
-  }
-
-  // Default: data bucket (spectra, rgb, sed, etc.)
-  const accountId = process.env.R2_ACCOUNT_ID;
-  const accessKeyId = process.env.R2_ACCESS_KEY_ID;
-  const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY;
-  const bucketName = process.env.R2_BUCKET_NAME;
-
-  if (!accountId || !accessKeyId || !secretAccessKey || !bucketName) {
-    throw new Error('R2 data credentials not configured');
-  }
-
-  return {
-    client: new S3Client({
-      region: 'auto',
-      endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
-      credentials: { accessKeyId, secretAccessKey },
-    }),
-    bucket: bucketName,
-  };
-}
 
 /**
  * POST /api/v1/deploy/presign
@@ -133,8 +86,10 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Get R2 client for the requested bucket
-    const { client, bucket } = getBucketConfig(bucketId);
+    // Resolve the storage client + bucket for the requested purpose.
+    const purpose = bucketId as StoragePurpose;
+    const client = getS3Client(purpose);
+    const bucket = getBucketName(purpose);
 
     // Generate presigned URLs in parallel
     const urlEntries = await Promise.all(

--- a/web/app/api/v1/redshift-fit/route.ts
+++ b/web/app/api/v1/redshift-fit/route.ts
@@ -144,14 +144,6 @@ export async function GET(request: NextRequest) {
     // Generate signed URL for the zfit JSON file
     const signedUrl = await generateDownloadUrl(zfitJsonPath, 3600);
 
-    // Check if R2 is configured
-    if (signedUrl.startsWith('#download-placeholder')) {
-      return NextResponse.json(
-        { error: 'Download service not configured' },
-        { status: 503 }
-      );
-    }
-
     // Fetch the zfit JSON data from R2
     const response = await fetch(signedUrl);
 

--- a/web/app/api/v1/spectra/route.ts
+++ b/web/app/api/v1/spectra/route.ts
@@ -87,13 +87,6 @@ export async function GET(request: NextRequest) {
     // Generate signed URL (expires in 1 hour)
     const signedUrl = await generateDownloadUrl(fitsPath, 3600);
 
-    // Check if it's a placeholder URL (R2 not configured)
-    if (signedUrl.startsWith('#download-placeholder')) {
-      return NextResponse.json(
-        { error: 'Download service not configured' },
-        { status: 503 }
-      );
-    }
 
     // Either redirect or return JSON
     if (shouldRedirect) {

--- a/web/app/api/v1/spectrum/route.ts
+++ b/web/app/api/v1/spectrum/route.ts
@@ -131,14 +131,6 @@ export async function GET(request: NextRequest) {
     // Generate signed URL for the JSON file
     const signedUrl = await generateDownloadUrl(jsonPath, 3600);
 
-    // Check if R2 is configured
-    if (signedUrl.startsWith('#download-placeholder')) {
-      return NextResponse.json(
-        { error: 'Download service not configured' },
-        { status: 503 }
-      );
-    }
-
     // Fetch the JSON data from R2
     const response = await fetch(signedUrl);
 

--- a/web/lib/r2.ts
+++ b/web/lib/r2.ts
@@ -1,47 +1,40 @@
-// Cloudflare R2 client setup
-// This is a placeholder for future integration with R2 storage
+// Storage client helpers for the `data` bucket (FITS, RGB, SED, …).
+//
+// Endpoint/region/addressing-style are resolved per-purpose by the storage
+// backend factory (`./storage`), so this layer is backend-agnostic
+// (R2 today, OSN later). The `data` client is built lazily on first use.
 
-import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
+import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { getS3Client, getBucketName } from './storage';
 
-// Placeholder credentials (will be replaced with environment variables)
-const R2_ACCOUNT_ID = process.env.R2_ACCOUNT_ID || 'placeholder';
-const R2_ACCESS_KEY_ID = process.env.R2_ACCESS_KEY_ID || 'placeholder';
-const R2_SECRET_ACCESS_KEY = process.env.R2_SECRET_ACCESS_KEY || 'placeholder';
-const R2_BUCKET_NAME = process.env.R2_BUCKET_NAME || 'campfire-fits';
-
-// Create R2 client (S3-compatible)
-export const r2Client = new S3Client({
-  region: 'auto',
-  endpoint: `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
-  credentials: {
-    accessKeyId: R2_ACCESS_KEY_ID,
-    secretAccessKey: R2_SECRET_ACCESS_KEY,
-  },
-});
+/** S3 client for the `data` storage backend (lazy, cached). */
+export function getDataClient() {
+  return getS3Client('data');
+}
 
 /**
- * Generate a signed URL for downloading a FITS file from R2
- * @param fitsPath - Path to the FITS file in R2 (e.g., "v1.0/object_id/PRISM.fits")
+ * Generate a signed URL for downloading a file from the data store.
+ * @param fitsPath - Object key (e.g., "spectra/obs_name/file.fits")
  * @param expiresIn - URL expiration time in seconds (default: 1 hour)
  * @returns Signed URL for downloading the file
+ * @throws if storage is misconfigured or signing fails — surfaced loudly so a
+ *   cutover misconfig is diagnosable rather than silently masked.
  */
 export async function generateDownloadUrl(
   fitsPath: string,
   expiresIn: number = 3600
 ): Promise<string> {
   const command = new GetObjectCommand({
-    Bucket: R2_BUCKET_NAME,
+    Bucket: getBucketName('data'),
     Key: fitsPath,
   });
 
   try {
-    const signedUrl = await getSignedUrl(r2Client, command, { expiresIn });
-    return signedUrl;
+    return await getSignedUrl(getDataClient(), command, { expiresIn });
   } catch (error) {
-    console.error('Error generating signed URL:', error);
-    // For now, return a placeholder URL
-    return `#download-placeholder-${fitsPath}`;
+    console.error(`Failed to sign download URL for "${fitsPath}":`, error);
+    throw new Error(`Failed to generate download URL for ${fitsPath}`);
   }
 }
 

--- a/web/lib/storage.ts
+++ b/web/lib/storage.ts
@@ -1,0 +1,130 @@
+// Per-purpose S3 storage backend resolution (web side).
+//
+// Centralizes S3 client construction so the endpoint, region, and addressing
+// style are config concerns, not hardcoded Cloudflare R2 details. Each logical
+// `purpose` ("data" or "tiles") resolves to its own backend block from
+// environment variables, enabling the data->OSN / tiles->R2 split.
+//
+// Env vars: neutral `S3_*` names are canonical; legacy `R2_*` names are kept
+// as backward-compatible aliases. For tiles, the names carry a `TILES_` infix
+// (`S3_TILES_*` / `R2_TILES_*`).
+//
+// Resolution is lazy (on first call) so importing this module — or building
+// the app without credentials — never throws.
+
+import { S3Client } from '@aws-sdk/client-s3';
+
+export type StoragePurpose = 'data' | 'tiles';
+
+export interface BackendConfig {
+  purpose: StoragePurpose;
+  backend: 'r2' | 'osn';
+  endpoint: string;
+  region: string;
+  bucket: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  forcePathStyle: boolean;
+  publicUrlBase?: string;
+}
+
+/** First non-empty value among the given env var names (canonical first). */
+function env(...names: string[]): string | undefined {
+  for (const name of names) {
+    const val = process.env[name];
+    if (val) return val;
+  }
+  return undefined;
+}
+
+function coerceBool(val: string | undefined): boolean {
+  if (!val) return false;
+  return ['1', 'true', 'yes', 'on'].includes(val.trim().toLowerCase());
+}
+
+function resolveEndpoint(
+  purpose: StoragePurpose,
+  accountId?: string,
+  endpoint?: string,
+): string {
+  if (endpoint) return endpoint.replace(/\/+$/, '');
+  if (accountId) return `https://${accountId}.r2.cloudflarestorage.com`;
+  throw new Error(
+    `Cannot resolve S3 endpoint for "${purpose}" storage: set either ` +
+      `S3${purpose === 'tiles' ? '_TILES' : ''}_ENDPOINT or ` +
+      `R2${purpose === 'tiles' ? '_TILES' : ''}_ACCOUNT_ID.`,
+  );
+}
+
+/**
+ * Resolve the backend configuration for a logical storage purpose.
+ * Throws if credentials are not configured.
+ */
+export function resolveBackend(purpose: StoragePurpose = 'data'): BackendConfig {
+  const p = purpose === 'tiles' ? 'TILES_' : '';
+
+  const accountId = env(`S3_${p}ACCOUNT_ID`, `R2_${p}ACCOUNT_ID`);
+  const endpointRaw = env(`S3_${p}ENDPOINT`, `R2_${p}ENDPOINT`);
+  const accessKeyId = env(`S3_${p}ACCESS_KEY_ID`, `R2_${p}ACCESS_KEY_ID`);
+  const secretAccessKey = env(`S3_${p}SECRET_ACCESS_KEY`, `R2_${p}SECRET_ACCESS_KEY`);
+  const bucket = env(`S3_${p}BUCKET_NAME`, `R2_${p}BUCKET_NAME`);
+  const region = env(`S3_${p}REGION`, `R2_${p}REGION`) || 'auto';
+  const forcePathStyle = coerceBool(env(`S3_${p}FORCE_PATH_STYLE`, `R2_${p}FORCE_PATH_STYLE`));
+  const publicUrlBase = env(
+    `S3_${p}PUBLIC_URL_BASE`,
+    `R2_${p}PUBLIC_URL_BASE`,
+    `R2_${p}PUBLIC_URL`,
+  );
+
+  if (!accessKeyId || !secretAccessKey || !bucket) {
+    throw new Error(`Storage "${purpose}" credentials not configured`);
+  }
+
+  const endpoint = resolveEndpoint(purpose, accountId, endpointRaw);
+  const backend =
+    (env(`S3_${p}BACKEND`, `R2_${p}BACKEND`) as 'r2' | 'osn' | undefined) ||
+    (endpoint.includes('r2.cloudflarestorage.com') ? 'r2' : 'osn');
+
+  return {
+    purpose,
+    backend,
+    endpoint,
+    region,
+    bucket,
+    accessKeyId,
+    secretAccessKey,
+    forcePathStyle,
+    publicUrlBase,
+  };
+}
+
+const _clients = new Map<StoragePurpose, S3Client>();
+
+/** Lazily-built, cached S3 client for a logical storage purpose. */
+export function getS3Client(purpose: StoragePurpose = 'data'): S3Client {
+  const cached = _clients.get(purpose);
+  if (cached) return cached;
+
+  const b = resolveBackend(purpose);
+  const client = new S3Client({
+    region: b.region,
+    endpoint: b.endpoint,
+    forcePathStyle: b.forcePathStyle,
+    credentials: {
+      accessKeyId: b.accessKeyId,
+      secretAccessKey: b.secretAccessKey,
+    },
+  });
+  _clients.set(purpose, client);
+  return client;
+}
+
+/** Bucket name for a logical storage purpose. */
+export function getBucketName(purpose: StoragePurpose = 'data'): string {
+  return resolveBackend(purpose).bucket;
+}
+
+/** Public URL base for a logical storage purpose, if configured. */
+export function getPublicUrlBase(purpose: StoragePurpose = 'data'): string | undefined {
+  return resolveBackend(purpose).publicUrlBase;
+}


### PR DESCRIPTION
## Summary

Introduces a per-purpose S3 storage backend factory that centralizes endpoint, region, and addressing-style configuration. This enables the **data → OSN / tiles → R2** split as a pure config concern, not a code change, and eliminates hardcoded Cloudflare R2 details from the deploy and web layers.

## Key Changes

**Python (`campfire.deploy.backend`)**
- New `backend.py` module with `resolve_backend()` and `make_s3_client()` functions
- `BackendConfig` dataclass holds resolved endpoint, region, bucket, credentials, and tuning flags
- Supports explicit `endpoint` (any S3-compatible store) or derives R2 host from `account_id`
- Configurable `region`, `force_path_style`, `backend` label, and `public_url_base`
- Two logical purposes: `'data'` → `config['r2']`, `'tiles'` → `config['r2_tiles']`

**Config resolution (`campfire.deploy.config`)**
- Expanded environment variable support: neutral `CAMPFIRE_S3_*` names (canonical) + legacy `CAMPFIRE_R2_*` aliases
- Per-purpose tuning: `ENDPOINT`, `REGION`, `FORCE_PATH_STYLE`, `BACKEND`, `PUBLIC_URL_BASE`
- Tiles section (`r2_tiles`) included only when complete; never blocks loading
- Backward compatible: existing `CAMPFIRE_R2_*` env vars and TOML configs work unchanged

**Web (`web/lib/storage.ts`)**
- New `storage.ts` module mirrors Python backend factory for TypeScript/Node.js
- `resolveBackend()` and `getS3Client()` with lazy caching
- Same env var resolution (neutral + aliases) and endpoint derivation
- Removed hardcoded R2 endpoint construction from presign route and data client

**Refactored callers**
- `campfire.deploy.r2.get_r2_client()` → delegates to `make_client_for(config, 'data')`
- `campfire.deploy.tiles.get_r2_tiles_client()` → delegates to `make_client_for(config, 'tiles')`
- `web/app/api/v1/deploy/presign/route.ts` → uses `getS3Client()` and `getBucketName()`
- `web/lib/r2.ts` → `getDataClient()` wraps `getS3Client('data')`
- Removed placeholder URL fallbacks; errors now surface loudly for misconfiguration

**Tests**
- Comprehensive test suite (`test_storage_backend.py`) covering:
  - Endpoint resolution (explicit vs. account_id-derived)
  - Region, backend label, path-style, and public URL passthrough
  - Purpose-to-section mapping and error cases
  - boto3 client construction with resolved config
  - Environment variable resolution (neutral + aliases, tiles optional)

## Implementation Details

- Boolean coercion handles TOML `true`/`false` and env string values (`'1'`, `'true'`, `'yes'`, `'on'`)
- Backend label inferred from endpoint host when not explicit (R2 if `r2.cloudflarestorage.com` present, else OSN)
- boto3 import deferred in `make_s3_client()` so `resolve_backend()` stays lightweight
- Web storage resolution is lazy (on first call) so app builds without credentials
- All placeholder URL checks removed; missing credentials now raise immediately

## Backward Compatibility

- Existing `CAMPFIRE_R2_*` env vars and TOML `[r2]` blocks work unchanged
- `get_r2_client()` and `get_r2_tiles_client()` retain their signatures
- Default region (`'auto'`) and endpoint derivation preserve R2 behavior
- Tiles section optional; incomplete sections silently dropped

https://claude.ai/code/session_01G8qF9wbz6PVYzBAeQgLj82