### PR TITLE
feat(nircam): intra-visit artifact removal + per-exposure 2D background (WIP, parked)

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -71,6 +71,20 @@ Release procedure: edit the `## Unreleased` section below, then run
   feature failed for fixed-slit sources.
 
 ### Algorithm
+- NIRCam: two new **opt-in** per-exposure steps that run after `image2` and
+  before `striping` (so smooth/structured artifacts are gone before the 1/f
+  amp-row offsets are measured), both **disabled by default** (no change to
+  default output). `background` (`CFP_BKG`): per-exposure 2D background
+  subtraction reusing the mosaic's tiered-mask + clipped-ring-median +
+  `Background2D` algorithm, tuned to preserve galaxy outskirts; sees both the
+  sky-fixed (ICL/zodi) and detector-fixed smooth components. `artifact`
+  (`CFP_ART`): intra-visit detector-fixed artifact removal by detector-frame
+  self-calibration — median-stacks the dithers of a `(visit, detector)` group
+  by pixel index so sky-fixed signal rejects via dither motion while
+  detector-fixed artifacts (persistence, scattered light, unique LW wisps)
+  survive, then subtracts the structured residual; self-gated by dither-count
+  safeguards (no-ops + stamps `CFP_ART="skipped (...)"` when unsafe). Enable
+  per field with `[<field>.background]`/`[<field>.artifact] enabled = true`.
 - NIRSpec fixed-slit: fixed the summary/deploy source position. Fixed-slit
   products carry no catalog `SRCRA`/`SRCDEC` in the SCI header (those are
   MSA-only), so the summary reader recorded `(0, 0)` for every fixed-slit

--- a/pipeline/campfire_pipeline/common/cfp.py
+++ b/pipeline/campfire_pipeline/common/cfp.py
@@ -28,6 +28,8 @@ CFP_KEYS = [
     'CFP_DET1',  # detector1
     'CFP_PERS',  # snowblind persistence
     'CFP_WISP',  # wisp template subtraction
+    'CFP_BKG',   # per-exposure 2D background subtraction
+    'CFP_ART',   # intra-visit detector-fixed artifact removal
     'CFP_1F',    # 1/f striping
     'CFP_IMG2',  # image2
     'CFP_EDGE',  # edge flagging
@@ -46,6 +48,8 @@ CFP_COMMENTS = {
     'CFP_DET1': 'campfire: detector1 done',
     'CFP_PERS': 'campfire: persistence flagged',
     'CFP_WISP': 'campfire: wisp template, scale',
+    'CFP_BKG':  'campfire: per-exposure 2D background',
+    'CFP_ART':  'campfire: intra-visit artifact removal',
     'CFP_1F':   'campfire: 1/f striping params',
     'CFP_IMG2': 'campfire: image2 done',
     'CFP_EDGE': 'campfire: edges flagged',

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -226,6 +226,152 @@
 [nircam.image2]
     use_custom_flat = false
 
+[nircam.background]
+    # Per-exposure 2D background subtraction. Runs after image2 and BEFORE
+    # artifact/striping so the smooth background — sky-fixed (ICL, zodi
+    # gradients) AND detector-fixed (smooth persistence / scattered light) — is
+    # gone before the 1/f amp-row offsets are measured. A per-exposure model
+    # (vs a sky-frame/drizzle one) is required: only it sees both the sky-fixed
+    # and detector-fixed smooth components as background. Reuses the nircamx
+    # SubtractBackground (tiered mask + clipped_ring_median + Background2D), the
+    # same algorithm the mosaic uses, tuned to preserve galaxy outskirts.
+    #
+    # Opt-in (a per-exposure 2D subtraction changes flux for every field, so
+    # the default reproduces current behaviour). Enable per field with
+    #     [<field>.background]
+    #         enabled = true
+    # Trade-off: a single exposure is shallower than the mosaic, so faint
+    # sources can leak into the model; bg_box_size and the clipped_ring_median
+    # ceiling bound it. Larger box = gentler on sources, less ICL removed.
+    enabled = false
+    # Background2D box / filter (px). 128/3 starts gentler than the mosaic's
+    # fine box (the per-exposure source mask is shallower); tune via the A/B
+    # photometry-conservation metric.
+    bg_box_size = 128
+    bg_filter_size = 3
+    bg_exclude_percentile = 90
+    bg_sigma = 3.0
+    bg_interpolator = "zoom"
+    # Clipped ring-median (large-scale source rejection for the mask).
+    ring_radius_in = 80
+    ring_width = 4
+    ring_clip_max_sigma = 5.0
+    ring_downsample = 4
+    # Tiered source masking (aggressive -> fine), as the mosaic bkgsub.
+    tier_kernel_size = [25, 15, 5, 2]
+    tier_npixels = [15, 10, 3, 1]
+    tier_nsigma = [1.5, 1.5, 1.5, 1.5]
+    tier_dilate_size = [33, 25, 21, 19]
+    plot = true
+
+[nircam.artifact]
+    # Intra-visit detector-fixed artifact removal (persistence, scattered
+    # light, unique LW wisps). Runs after image2 and BEFORE striping, so the
+    # artifacts are gone before the 1/f amp-row offsets are measured. Detector-
+    # frame self-calibration: median-stacks the dithers of a (visit, detector)
+    # group by pixel index, so sky-fixed signal (sources, ICL) rejects via the
+    # dither motion while detector-fixed artifacts survive; subtracts the
+    # structured residual. Opt-in (disabled by default), and additionally
+    # self-gated by the dither safeguards below — enable per field with
+    #     [<field>.artifact]
+    #         enabled = true
+    enabled = false
+    # Safeguards: the step no-ops + stamps CFP_ART = "skipped (...)" unless the
+    # group has >= min_dithers DISTINCT dither positions (co-located repeat
+    # exposures collapse to one) whose minimum pairwise throw is >=
+    # min_dither_spacing_pix. Below that, sources don't move far enough off a
+    # given detector pixel and would leak into the template (oversubtraction).
+    min_dithers = 4
+    min_dither_spacing_pix = 20
+    # Template pixels with fewer than this many unmasked dithers are left
+    # undefined (no correction applied there).
+    min_contributing = 2
+    # Source masking before the stack — belt-and-suspenders on top of dither
+    # rejection, for sources large enough to overlap across the dither throw.
+    # "standard" reuses striping's tiered source mask; "aggressive" grows the
+    # source mask further (it does NOT mask persistence/jump/sat DQ — those
+    # would erase the very artifacts we measure); "none" relies on dither
+    # rejection + the per-pixel sigma-clip only.
+    # Source-rejection strategy for the template stack:
+    #   "stationary" (default): per-exposure source mask + stationarity-aware
+    #       unmasking (below). Cheap, no WCS — but a sky source extended/bright
+    #       enough to overlap itself across the dither throw (cluster galaxies,
+    #       BCG) gets flagged in all dithers, read as detector-fixed, and leaks
+    #       into the template -> oversubtraction at those sources.
+    #   "skymodel": subtract a sky-aligned median (sky-fixed sources + ICL)
+    #       from each frame via the dither WCS, then build the template from the
+    #       source-free residuals. Robustly separates detector-fixed artifact
+    #       from sky-fixed sources (the only thing that can); needs each
+    #       exposure's WCS (the pre-jhat assign_wcs pointing is adequate for a
+    #       single dither sequence). The unmask_* / mask knobs are unused here.
+    source_rejection = "stationary"
+    mask = "standard"
+    # Stationarity-aware unmasking ("stationary" mode only). A real source MOVES
+    # between dithers (flagged at a given detector pixel in only one/few
+    # exposures); a detector-fixed artifact is flagged at the SAME pixel every
+    # exposure. Without this a bright artifact is detected as a "source" in all
+    # dithers and masked everywhere — erasing itself. Pixels flagged in >=
+    # unmask_min_frac * N_dithers are kept in the stack. 1.0 = require all.
+    unmask_stationary = true
+    unmask_min_frac = 1.0
+    sigma = 3.0
+    maxiters = 5
+    # Fill template gaps (pixels with < min_contributing dithers, e.g. under an
+    # extended source) by nearest-neighbour interpolation rather than zeroing.
+    # Zeroing leaves the artifact un-subtracted inside the gap while subtracted
+    # just outside, producing a hard step in the corrected background.
+    interpolate_gaps = true
+    # Optionally isolate the structured artifact from any smooth detector
+    # background by subtracting a large-box model of the stack. OFF by default:
+    # it also removes the broad artifact wings (the per-exposure scale fit then
+    # just multiplies the residual back up). Per-exposure pedestal removal +
+    # the downstream sky step already handle the smooth background.
+    isolate_background = false
+    isolate_box = 128
+    isolate_filter = 3
+    # Light Gaussian smoothing of the template (px); artifacts are smooth, so
+    # this suppresses the per-pixel stack noise that would otherwise be
+    # injected into every exposure. 0 disables.
+    template_smooth_sigma = 2.0
+    # Despike the median BEFORE smoothing: detector-fixed hot/warm pixels
+    # survive the cross-dither median (they're temporally constant, so the
+    # sigma-clip can't reject them) and would be smoothed into subtracted ~5px
+    # blobs. A size-despike_size median follows the smooth artifact and ignores
+    # point spikes, so positive outliers above despike_nsigma are replaced with
+    # the local median (the artifact level) — removing the hot pixel whether it
+    # sits on blank sky or on top of the artifact, while preserving the smooth
+    # artifact. despike_nsigma = 0 disables. The residual scale is measured by
+    # iteratively clipping the median-filter residual (so artifact edges / source
+    # cores don't inflate the threshold and hide marginal spikes), and each spike
+    # is grown by despike_dilate px before replacement to catch IPC charge-bleed
+    # wings (which the bare-peak replacement leaves and smoothing would spread).
+    despike_nsigma = 4.0
+    despike_size = 5
+    despike_dilate = 1
+    # Coverage-confidence gate: scale the APPLIED correction per pixel by how
+    # many dithers actually constrained it. The template shape is still built and
+    # gap-filled above (continuity + a well-posed scale fit), but this caps how
+    # much is subtracted, so a fabricated (inpainted) gap or a no-rejection
+    # 2-sample estimate — exactly where leaked source/ICL flux turns into
+    # over-subtraction — is never applied at full strength. Weight ramps 0->1
+    # over [coverage_n_lo, coverage_n_hi] contributing dithers (inpainted pixels
+    # below min_contributing forced to 0). Defaults: full trust at >=3 dithers,
+    # half at 2 (no cross-dither rejection), none for pure inpaint. Raise
+    # coverage_n_hi to 4 to be more aggressive (only full-coverage pixels fully
+    # corrected). coverage_smooth_sigma Gaussian-smooths the weight so the taper
+    # is gradual (no step at gap edges). coverage_weight = false disables.
+    coverage_weight = true
+    coverage_n_lo = 1
+    coverage_n_hi = 3
+    coverage_smooth_sigma = 3.0
+    # Per-exposure amplitude. "fit" scales the template per exposure by MAD
+    # minimization over its support (handles persistence decay across the
+    # dither sequence and zeros out exposures with no artifact); "fixed"
+    # subtracts the template unscaled.
+    scale = "fit"
+    c_max = 3.0
+    plot = true
+
 [nircam.diag_striping]
     # Opt-in scattered-light diagonal striping correction. Some exposures
     # show stripe-like artifacts from off-axis bright stars; the angle is

--- a/pipeline/campfire_pipeline/nircam/cli.py
+++ b/pipeline/campfire_pipeline/nircam/cli.py
@@ -39,7 +39,7 @@ from campfire_pipeline.nircam.refcat.cli import refcat as refcat_group
 # --from <step>` refuses these — the user must `--uncal` to redo them
 # correctly.
 _SCI_MUTATING_STEPS = {
-    'wisp', 'striping', 'image2', 'sky', 'variance',
+    'wisp', 'background', 'artifact', 'striping', 'image2', 'sky', 'variance',
 }
 
 # Short labels for the status command's column headers (max 4 chars).
@@ -49,6 +49,8 @@ _STEP_LABELS = {
     'wisp':        'wisp',
     'striping':    '1f',
     'image2':      'img2',
+    'background':  'bkg',
+    'artifact':    'art',
     'edge':        'edge',
     'sky':         'sky',
     'variance':    'var',

--- a/pipeline/campfire_pipeline/nircam/field.py
+++ b/pipeline/campfire_pipeline/nircam/field.py
@@ -257,8 +257,8 @@ class Field:
         # to recognize per-field step overrides and to exclude them from the
         # tile-detection loop below.
         known_steps = {
-            'detector1', 'persistence', 'wisp', 'striping',
-            'image2', 'diag_striping', 'edge', 'sky', 'variance',
+            'detector1', 'persistence', 'wisp', 'background', 'artifact',
+            'striping', 'image2', 'diag_striping', 'edge', 'sky', 'variance',
             'wcs_shift', 'jhat',
             'apply_mask', 'bad_pixel', 'outlier', 'resample',
         }

--- a/pipeline/campfire_pipeline/nircam/orchestrate.py
+++ b/pipeline/campfire_pipeline/nircam/orchestrate.py
@@ -46,6 +46,8 @@ PROCESS_STEPS = [
     ('persistence', 'CFP_PERS'),
     ('wisp',        'CFP_WISP'),
     ('image2',      'CFP_IMG2'),
+    ('background',  'CFP_BKG'),
+    ('artifact',    'CFP_ART'),
     ('striping',    'CFP_1F'),
     ('edge',        'CFP_EDGE'),
     ('sky',         'CFP_SKY'),
@@ -131,6 +133,25 @@ def _group_by_visit(exposure_files):
         visit = os.path.basename(f).split('_')[0]
         visits.setdefault(visit, []).append(f)
     return visits
+
+
+def _group_by_dither_sequence(exposure_files):
+    """Return ``{key: [paths...]}`` for one dither sequence per detector.
+
+    Keyed on ``(visit, exposure-spec, detector)`` — the leading ``jw...``
+    token, the ``<visitgrp><seq><act>`` token, and the detector token — so
+    each group is exactly the exposures of a single dither pattern on a single
+    detector (they share both leading tokens and differ only in exposure
+    number). This is the self-calibration unit for the artifact step: the
+    detector-fixed artifact is constant across these and only these frames.
+    """
+    groups = {}
+    for f in exposure_files:
+        parts = os.path.basename(f).removesuffix('.fits').split('_')
+        # jw..._<spec>_<expnum>_<detector>; group on (visit, spec, detector).
+        key = f'{parts[0]}_{parts[1]}_{parts[3]}'
+        groups.setdefault(key, []).append(f)
+    return groups
 
 
 def _read_sregions(exposure_files):
@@ -309,6 +330,69 @@ def _run_diag_striping(field, config, filtname, n_processes, overwrite, status):
              field=field, step_config=cfg, overwrite=overwrite,
              status=status)
     status.mark_all(pending, 'CFP_DIAG')
+
+
+def _run_background(field, config, filtname, n_processes, overwrite, status):
+    """Per-exposure 2D background subtraction (opt-in). Disabled unless
+    ``[nircam.background].enabled = true`` (or a per-field override) — a 2D
+    subtraction changes flux for every field, so the default is off. Plain
+    per-exposure dispatch once enabled."""
+    cfg = get_nircam_step_config('background', config, field)
+    if not cfg.get('enabled', False):
+        log(f"background: disabled by config; skipping {filtname}")
+        return
+    exposures = field.get_exposure_files(filtname)
+    if not exposures:
+        log(f"background: no exposures for {filtname}")
+        return
+    pending, _ = _filter_pending('background', exposures, 'CFP_BKG', status,
+                                 overwrite)
+    if not pending:
+        return
+    from campfire_pipeline.nircam.steps.background import background_step
+    pending = _detector_sorted(pending)
+    log(f"background: dispatching {len(pending)} exposures for {filtname}")
+    dispatch(background_step, pending, n_processes=n_processes,
+             field=field, step_config=cfg, overwrite=overwrite, status=status)
+    status.mark_all(pending, 'CFP_BKG')
+
+
+def _run_artifact(field, config, filtname, n_processes, overwrite, status):
+    """Intra-visit detector-fixed artifact removal (opt-in, per-(visit,
+    detector) ensemble). Disabled unless ``[nircam.artifact].enabled = true``
+    (or a per-field override sets it). Each dither-sequence group is
+    independent — it reads only its own members and writes only its own
+    files — so groups are dispatched in parallel like the outlier step.
+    """
+    cfg = get_nircam_step_config('artifact', config, field)
+    if not cfg.get('enabled', False):
+        log(f"artifact: disabled by config; skipping {filtname}")
+        return
+    exposures = field.get_exposure_files(filtname)
+    if not exposures:
+        log(f"artifact: no exposures for {filtname}")
+        return
+    groups = _group_by_dither_sequence(exposures)
+
+    pending = {}
+    for key, files in groups.items():
+        if not overwrite and all(status.has(f, 'CFP_ART') for f in files):
+            continue
+        pending[key] = files
+    skipped = len(groups) - len(pending)
+    if skipped:
+        log(f"artifact: {skipped}/{len(groups)} groups already done for "
+            f"{filtname}; skipping those")
+    if not pending:
+        return
+
+    from campfire_pipeline.nircam.steps.artifact import artifact_step
+    tasks = [(key, files) for key, files in sorted(pending.items())]
+    log(f"artifact: dispatching {len(tasks)} dither groups for {filtname}")
+    dispatch(artifact_step, tasks, n_processes=n_processes, use_starmap=True,
+             field=field, step_config=cfg, overwrite=overwrite, status=status)
+    for _, files in pending.items():
+        status.mark_all(files, 'CFP_ART')
 
 
 def _run_wcs_shift(field, config, filtname, n_processes, overwrite, status):
@@ -523,6 +607,8 @@ _RUNNERS = {
     'wisp':        functools.partial(_run_per_exposure, 'wisp'),
     'striping':    functools.partial(_run_per_exposure, 'striping'),
     'image2':      functools.partial(_run_per_exposure, 'image2'),
+    'background':  _run_background,
+    'artifact':    _run_artifact,
     'diag_striping': _run_diag_striping,
     'edge':        functools.partial(_run_per_exposure, 'edge'),
     'sky':         functools.partial(_run_per_exposure, 'sky'),

--- a/pipeline/campfire_pipeline/nircam/steps/artifact.py
+++ b/pipeline/campfire_pipeline/nircam/steps/artifact.py
@@ -1,0 +1,899 @@
+"""
+artifact: intra-visit detector-fixed artifact removal via dither self-calibration.
+
+Per-(visit, detector) **ensemble** step. Runs **after ``image2`` and before
+``striping``** (order: ... wisp -> image2 -> artifact -> striping -> ...) so
+the artifacts are gone before the 1/f stripe offsets are measured — an
+artifact sitting in an amp-row otherwise biases that row's clipped-median
+offset and the striping step subtracts the wrong DC level.
+
+The idea is detector-frame self-calibration. Stack the dithers of one
+(visit, detector) group **by pixel index, with no WCS alignment**:
+
+* Real sky signal (point sources, galaxy wings, ICL / diffuse emission) is
+  fixed in *sky* coordinates, so the dither motion lands it on a *different*
+  detector pixel each dither -> a robust per-pixel statistic across the stack
+  **rejects** it. The dither throw itself is what protects the science.
+* 1/f striping is positionally detector-fixed but its amplitude is a fresh
+  draw each integration, so it **averages down**.
+* Detector-fixed artifacts — persistence, scattered light, unique LW wisps —
+  sit at the *same* detector pixel every dither, so they **survive**.
+
+What survives the masked-robust stack is therefore (detector-fixed artifacts)
++ (a smooth detector/zodi pedestal). Subtracting a smooth model of the stack
+isolates the structured artifact template, which subtracts identically from
+every dither (optionally scaled per exposure to track persistence decay).
+
+This is additive to the combine-phase ``outlier`` step: that one works in
+*sky* coordinates, only flags DQ (punching holes), catches just the
+high-contrast core, and runs far too late to help the stripe fit. This step
+*subtracts* the detector-fixed component early and *keeps* the pixels.
+
+**Safeguards.** Self-calibration needs enough dither positions, spread far
+enough apart, that a source at a given detector pixel in one dither has moved
+away in the others. The step reads the commanded dither geometry
+(``XOFFSET``/``YOFFSET``, falling back to ``RA_REF``/``DEC_REF``) and no-ops
+(stamping ``CFP_ART = 'skipped (...)'``) when there are too few distinct
+positions or the minimum pairwise throw is too small. Disabled by default
+(opt-in via ``[nircam.artifact].enabled = true`` or a per-field override).
+
+The numerical core (``dither_positions_and_spacing``,
+``build_artifact_template``, ``fit_template_scale``) is split into pure
+functions so it is unit-testable without the jwst stack; ``artifact_step``
+wraps them with ImageModel I/O and the shared tiered source mask.
+"""
+
+import os
+import warnings
+from datetime import datetime
+
+import numpy as np
+from astropy.io import fits
+from astropy.stats import median_absolute_deviation, sigma_clip
+
+from campfire_pipeline.common.io import log, atomic_save
+from campfire_pipeline.common import cfp
+
+
+# NIRCam pixel scales (arcsec/pix). Used only to convert the commanded dither
+# throw into detector pixels for the spacing safeguard, so the nominal
+# per-channel values are plenty accurate (the WCS-derived scale varies by
+# <0.5% across the field).
+PIXSCALE_ARCSEC = {'SHORT': 0.0311, 'LONG': 0.0630}
+
+_VALID_MASK = ('none', 'standard', 'aggressive')
+_VALID_SCALE = ('fit', 'fixed')
+_VALID_SOURCE_REJECTION = ('stationary', 'skymodel')
+
+
+def _channel_of(detector):
+    """'SHORT' or 'LONG' from a detector token (e.g. 'nrcalong' -> 'LONG')."""
+    return 'LONG' if detector.lower().endswith('long') else 'SHORT'
+
+
+# ---------------------------------------------------------------------------
+# Pure numerical core (no jwst dependency — unit-testable directly)
+# ---------------------------------------------------------------------------
+
+def dither_positions_and_spacing(xoffsets, yoffsets, pixscale,
+                                 round_arcsec=0.05):
+    """Distinct dither positions and the minimum pairwise throw (in pixels).
+
+    Repeat exposures at the *same* commanded offset (NEXP/NINTS > 1) do not
+    help reject moving sources, so they are collapsed to a single position by
+    rounding to ``round_arcsec`` before counting. The gate quantity is the
+    minimum pairwise separation among the *distinct* positions — the worst
+    case for a source failing to move off a given detector pixel.
+
+    Parameters
+    ----------
+    xoffsets, yoffsets : array-like
+        Commanded ideal-frame dither offsets (arcsec), one per exposure.
+    pixscale : float
+        Detector pixel scale (arcsec/pix).
+    round_arcsec : float
+        Clustering tolerance for collapsing co-located exposures.
+
+    Returns
+    -------
+    n_positions : int
+        Number of distinct dither positions.
+    min_spacing_pix : float
+        Minimum pairwise separation among distinct positions, in detector
+        pixels. ``inf`` when there is only one position (no pair to measure).
+    """
+    xy = np.column_stack([np.asarray(xoffsets, float),
+                          np.asarray(yoffsets, float)])
+    # Cluster by rounding to the tolerance grid, then take unique rows.
+    keys = np.round(xy / round_arcsec).astype(np.int64)
+    _, idx = np.unique(keys, axis=0, return_index=True)
+    pos = xy[np.sort(idx)]
+    n_positions = len(pos)
+    if n_positions < 2:
+        return n_positions, np.inf
+    # Pairwise Euclidean distances among distinct positions.
+    diff = pos[:, None, :] - pos[None, :, :]
+    dist = np.sqrt((diff ** 2).sum(-1))
+    iu = np.triu_indices(n_positions, k=1)
+    min_spacing_arcsec = float(dist[iu].min())
+    return n_positions, min_spacing_arcsec / pixscale
+
+
+def inpaint_nan(arr, sigma0=3.0, growth=2.0, max_iters=8):
+    """Fill NaNs by iterated normalized Gaussian convolution (smooth diffusion).
+
+    Each pass replaces NaNs with a Gaussian-weighted average of the surrounding
+    *finite* pixels (``gaussian_filter(filled) / gaussian_filter(weights)``),
+    growing the kernel each iteration so large gaps fill from progressively
+    wider context. This diffuses the surrounding level smoothly across a gap —
+    a gap inside the artifact fills with ~the local artifact level, a gap in
+    clean background with ~0 — keeping the correction continuous (no hard step
+    at gap boundaries, the failure mode of zero-filling).
+
+    This replaces a nearest-valid-neighbour (EDT) fill, which tiled gaps with
+    blocky Voronoi plateaus that showed through the template as spurious
+    structure. Returns a copy; an all-NaN input returns zeros.
+    """
+    from scipy.ndimage import gaussian_filter
+    out = arr.astype(np.float64, copy=True)
+    if not (~np.isfinite(out)).any():
+        return out
+    if (~np.isfinite(out)).all():
+        return np.zeros_like(out)
+    sigma = sigma0
+    for _ in range(max_iters):
+        nan = ~np.isfinite(out)
+        if not nan.any():
+            break
+        filled = np.where(nan, 0.0, out)
+        w = (~nan).astype(np.float64)
+        num = gaussian_filter(filled, sigma, mode='nearest')
+        den = gaussian_filter(w, sigma, mode='nearest')
+        with np.errstate(invalid='ignore', divide='ignore'):
+            interp = num / den
+        good_interp = nan & np.isfinite(interp) & (den > 1e-8)
+        out[good_interp] = interp[good_interp]
+        sigma *= growth
+    out[~np.isfinite(out)] = 0.0
+    return out
+
+
+def despike(image, size=5, nsigma=4.0, maxiters=3, dilate=1):
+    """Replace point-like positive outliers (hot/warm pixels) with the local median.
+
+    Detector-fixed warm/hot pixels survive the cross-dither median (they're
+    *temporally constant*, so a per-pixel sigma-clip across dithers can't reject
+    them) and, once smoothed, become subtracted Gaussian blobs. They are
+    point-like, whereas the artifact is smooth — so a size-``size`` median
+    filter follows the artifact and ignores the spikes, and ``image -
+    median_filter(image)`` isolates them *wherever they sit*, on blank
+    background OR on top of the extended artifact (the failure mode of a
+    segment-membership filter). Flagged pixels (residual > ``nsigma`` x the
+    robust residual scale) are replaced with the local median — the artifact
+    level there — so the spike is removed and the smooth artifact is preserved.
+
+    The residual scale is estimated by **iteratively** sigma-clipping the
+    median-filter residual itself (``maxiters`` passes, re-measuring ``mad_std``
+    with the spikes excluded). A single global ``mad_std`` is inflated by sharp
+    artifact edges / leaked source cores, which raises the threshold and lets
+    marginal hot pixels through; excluding the spikes from the scale converges
+    on the *clean* residual level and catches them. Each flagged spike is then
+    grown by ``dilate`` px before replacement, since hot pixels carry IPC
+    charge-bleed wings that the bare-peak replacement leaves behind (and
+    smoothing would spread).
+
+    Must run BEFORE smoothing, while spikes are still ~1 px; after smoothing
+    each is a ~5 px Gaussian that no longer reads as a point outlier. Returns
+    ``(despiked_image, n_spikes)`` where ``n_spikes`` counts the peak pixels
+    (pre-dilation).
+    """
+    from astropy.stats import mad_std
+    from scipy.ndimage import median_filter, binary_dilation
+    finite = np.isfinite(image)
+    if not finite.any():
+        return image.copy(), 0
+    work = np.where(finite, image, float(np.median(image[finite])))
+    local = median_filter(work, size=int(size))
+    resid = work - local
+    # Iteratively measure the residual scale with the spikes excluded, so a
+    # textured artifact / source cores don't inflate it and hide marginal spikes.
+    keep = finite.copy()
+    spikes = np.zeros_like(finite)
+    for _ in range(max(1, int(maxiters))):
+        sig = mad_std(resid[keep])
+        if not np.isfinite(sig) or sig == 0:
+            break
+        new_spikes = finite & (resid > nsigma * sig)
+        if np.array_equal(new_spikes, spikes):
+            break
+        spikes = new_spikes
+        keep = finite & ~spikes
+    if not spikes.any():
+        return image.copy(), 0
+    # Grow each spike by `dilate` px to catch IPC wings; replace with the local
+    # median (the artifact level there), so the smooth artifact is preserved.
+    repl = spikes
+    if dilate and dilate > 0:
+        repl = finite & binary_dilation(spikes, iterations=int(dilate))
+    out = image.copy()
+    out[repl] = local[repl]
+    return out, int(spikes.sum())
+
+
+def build_artifact_template(frames, masks, sigma=3.0, maxiters=5,
+                            min_contributing=2, interpolate_gaps=True,
+                            isolate_background=False, isolate_box=128,
+                            isolate_filter=3, smooth_sigma=2.0,
+                            despike_nsigma=4.0, despike_size=5, despike_dilate=1,
+                            coverage_weight=True, coverage_n_lo=1,
+                            coverage_n_hi=3, coverage_smooth_sigma=3.0):
+    """Build the detector-fixed artifact template from a dither stack.
+
+    Pure function. Each frame is pedestal-matched (its own robust background
+    median is subtracted) so the stack shares a common zero, then combined
+    with a per-pixel sigma-clipped median over the unmasked samples. Sky-fixed
+    signal has been masked or moved away by the dither, so what survives is the
+    detector-fixed structure on a near-zero baseline.
+
+    Pixels with too few contributing dithers (source-crowded / extended-source
+    overlap) are interpolated across — not zeroed — so the resulting correction
+    is spatially continuous. An optional large-box smooth model can then be
+    subtracted to isolate the *structured* artifact from any smooth detector
+    background (off by default: it removes the broad artifact wings too, which
+    the per-exposure scale fit then has to undo), and the result is lightly
+    smoothed to suppress per-pixel stack noise.
+
+    Finally a **coverage-confidence map** ``w(n_contributing) in [0, 1]`` is
+    computed (smooth, -> 0 where too few dithers contributed) and returned in
+    ``diag`` — but the template itself is returned *ungated*. The caller fits
+    the per-exposure amplitude on the full template (continuity + an
+    amplitude-stable fit) and multiplies only the *applied* correction by this
+    weight, so a fabricated (inpainted) gap or a no-rejection 2-sample estimate
+    is never subtracted at full strength — where leaked source/ICL flux
+    otherwise turns into over-subtraction — without changing the correction in
+    the well-covered field. This trades a little artifact removal in the
+    lowest-coverage regions (crowded cluster cores) for not subtracting an
+    unreliable correction there.
+
+    Parameters
+    ----------
+    frames : list of (H, W) ndarray
+        Pedestal-unmatched SCI arrays (cal-stage, flat-fielded), one per dither.
+    masks : list of (H, W) bool ndarray
+        True where a pixel must be excluded (DQ + moving-source mask), per frame.
+    sigma, maxiters : float, int
+        Per-pixel sigma-clip across the stack (rejects unmasked CRs / source
+        residual that slipped through the mask).
+    min_contributing : int
+        Pixels with fewer than this many unmasked dithers are treated as gaps.
+    interpolate_gaps : bool
+        Fill gaps by nearest-neighbour inpainting (default). When ``False``,
+        gaps are zeroed (no correction there) — kept for comparison only; it
+        leaves hard steps at gap boundaries.
+    isolate_background : bool
+        Subtract a large-box background model of the (gap-filled) stack so only
+        structure finer than ``isolate_box`` survives. Default ``False``.
+    isolate_box, isolate_filter : int
+        ``skyfit.fit_sky`` box / filter sizes for the isolation background.
+    smooth_sigma : float
+        Gaussian smoothing sigma (px) applied to the template; 0 disables.
+        Artifacts are smooth/extended, so this trades a little resolution for
+        much lower per-pixel noise injected into every exposure.
+    despike_nsigma, despike_size, despike_dilate : float, int, int
+        Despike the median before smoothing (see ``despike``): replace positive
+        point outliers (hot/warm pixels) above ``despike_nsigma`` x the
+        iteratively-clipped residual scale with the local ``despike_size``
+        median, growing each spike by ``despike_dilate`` px (IPC wings).
+        ``despike_nsigma = 0`` disables.
+    coverage_weight : bool
+        Compute the coverage-confidence weight map (default ``True``). When
+        ``False``, ``diag['coverage_confidence']`` is ``None`` and the caller
+        applies the template ungated (legacy behaviour).
+    coverage_n_lo, coverage_n_hi : int
+        Confidence ramp endpoints in units of contributing dithers: weight is 0
+        at ``n_contributing <= coverage_n_lo``, ramps linearly to 1 at
+        ``n_contributing >= coverage_n_hi``. Pixels below ``min_contributing``
+        (inpainted) are forced to weight 0 regardless. Defaults ``(1, 3)``:
+        full trust at >=3 dithers, half at 2 (no cross-dither rejection), none
+        for pure inpaint.
+    coverage_smooth_sigma : float
+        Gaussian sigma (px) smoothing the weight map so the gate tapers
+        gradually at gap edges (no step) and a salt-and-pepper coverage map
+        can't re-inject structure into the correction. 0 disables smoothing.
+
+    Returns
+    -------
+    template : (H, W) ndarray
+        Artifact template (ungated). Fit the amplitude on this; multiply by
+        ``diag['coverage_confidence']`` before subtracting.
+    n_contributing : (H, W) int ndarray
+        Number of unmasked dithers per pixel.
+    pedestals : list of float
+        The per-frame pedestal subtracted before stacking.
+    diag : dict
+        ``{'undefined_frac', 'n_despiked', 'coverage_confidence'}`` — fraction
+        of pixels with too few contributing dithers, the number of hot-pixel
+        spikes removed, and the coverage weight map to apply (``None`` when the
+        gate is off).
+    """
+    n = len(frames)
+    h, w = frames[0].shape
+    pedestals = []
+    stack = np.full((n, h, w), np.nan, dtype=np.float64)
+    for i, (f, m) in enumerate(zip(frames, masks)):
+        finite = np.isfinite(f) & ~m
+        ped = float(np.median(f[finite])) if finite.any() else 0.0
+        pedestals.append(ped)
+        layer = f.astype(np.float64) - ped
+        layer[~finite] = np.nan
+        stack[i] = layer
+
+    ma = np.ma.masked_invalid(stack)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', category=RuntimeWarning)
+        clipped = sigma_clip(ma, sigma=sigma, maxiters=maxiters, axis=0,
+                             masked=True, cenfunc='median', stdfunc='mad_std')
+        n_contributing = (~np.ma.getmaskarray(clipped)).sum(axis=0).astype(int)
+        template = np.ma.median(clipped, axis=0).filled(np.nan)
+    template[n_contributing < min_contributing] = np.nan
+    undefined_frac = float(np.mean(n_contributing < min_contributing))
+
+    # Fill gaps BEFORE isolation so fit_sky never sees zeros (which ring around
+    # the bright artifact and dig a negative trough).
+    if interpolate_gaps:
+        template = inpaint_nan(template)
+
+    # Despike BEFORE smoothing: remove detector-fixed hot/warm pixels (which the
+    # cross-dither median can't reject) while they're still point-like, so
+    # smoothing doesn't spread them into subtracted blobs. Works whether the
+    # spike sits on blank sky or on top of the artifact.
+    n_despiked = 0
+    if despike_nsigma and despike_nsigma > 0:
+        template, n_despiked = despike(template, size=despike_size,
+                                       nsigma=despike_nsigma,
+                                       dilate=despike_dilate)
+
+    if isolate_background:
+        # Lazy import: skyfit pulls in scipy/photutils helpers; keep the
+        # pure-numpy parts of this module importable without them.
+        from campfire_pipeline.nircam.skyfit import fit_sky
+        bg_input = np.where(np.isfinite(template), template, 0.0)
+        try:
+            bg = fit_sky(bg_input, box_size=isolate_box,
+                         filter_size=isolate_filter)
+            template = template - bg
+        except Exception as e:  # noqa: BLE001 — fall back to no isolation
+            log(f"artifact: background isolation failed ({e}); "
+                f"using raw stack template")
+
+    if smooth_sigma and smooth_sigma > 0:
+        from astropy.convolution import Gaussian2DKernel, convolve
+        template = convolve(template, Gaussian2DKernel(smooth_sigma),
+                            nan_treatment='interpolate', preserve_nan=False)
+
+    # Any residual NaN (e.g. interpolate_gaps=False) -> 0: no correction there.
+    template = np.where(np.isfinite(template), template, 0.0)
+
+    # Coverage-confidence map: how many dithers actually constrained each pixel,
+    # as a smooth weight in [0, 1]. The TEMPLATE is returned ungated — the caller
+    # fits the per-exposure amplitude on this full template (continuity + a
+    # well-posed, amplitude-stable fit) and multiplies only the *applied*
+    # correction by this weight. A fabricated gap or a 2-sample (no-rejection)
+    # estimate is therefore never subtracted at full strength — that is where
+    # leaked source/ICL flux becomes over-subtraction — without changing the
+    # correction in the well-covered field. Ramp 0->1 over
+    # [coverage_n_lo, coverage_n_hi]; inpainted pixels (< min_contributing) are
+    # forced to 0; Gaussian-smoothed so the taper is gradual (no step at gap
+    # edges) and a peppery coverage map can't re-inject structure.
+    coverage_confidence = None
+    if coverage_weight:
+        if coverage_n_hi <= coverage_n_lo:
+            raise ValueError(
+                f"coverage_n_hi ({coverage_n_hi}) must exceed coverage_n_lo "
+                f"({coverage_n_lo})")
+        w = np.clip((n_contributing - coverage_n_lo)
+                    / float(coverage_n_hi - coverage_n_lo), 0.0, 1.0)
+        w[n_contributing < min_contributing] = 0.0
+        if coverage_smooth_sigma and coverage_smooth_sigma > 0:
+            from scipy.ndimage import gaussian_filter
+            w = np.clip(gaussian_filter(w.astype(np.float64),
+                                        coverage_smooth_sigma, mode='nearest'),
+                        0.0, 1.0)
+        coverage_confidence = w
+
+    return template, n_contributing, pedestals, {
+        'undefined_frac': undefined_frac, 'n_despiked': n_despiked,
+        'coverage_confidence': coverage_confidence}
+
+
+def artifact_dq_mask(dq):
+    """Pixels always excluded from the artifact stack: DO_NOT_USE + SATURATED.
+
+    SATURATED carries no valid flux, so it must not enter the template (the
+    cross-dither sigma-clip catches most but is marginal at N=4). We
+    deliberately do NOT mask JUMP_DET — it is ramp-corrected (fine for
+    estimation) and can blanket a whole frame (>97% of pixels on bright-target
+    MSATA exposures) — nor PERSISTENCE, which is itself an artifact we want to
+    *measure*. Transient cosmic rays are rejected by the sigma-clip across
+    dithers and by the moving-source mask.
+    """
+    from jwst.datamodels import dqflags
+    bits = dqflags.pixel['DO_NOT_USE'] | dqflags.pixel['SATURATED']
+    return np.bitwise_and(dq, bits) != 0
+
+
+def build_sky_model(frames, shifts):
+    """Per-frame sky model via a sky-aligned median (detector-fixed rejected).
+
+    Each frame is shifted by ``shifts[i] = (dy, dx)`` onto frame 0's *sky* grid
+    and median-combined: sky-fixed signal (sources, ICL) aligns across frames
+    and survives the median, while the detector-fixed artifact lands at a
+    different place in each shifted frame and is rejected. That sky median is
+    reprojected back to each frame's detector grid and returned, so
+    ``frame - sky_model`` is a source-free residual carrying the artifact.
+
+    Pure (numpy + ``scipy.ndimage.shift``). Order-1 shifts spread NaNs by ~1 px
+    at gaps/edges and leave small dipole residuals at sharp sources under
+    imperfect (pre-jhat) alignment — both move between frames, so they reject
+    in the downstream detector-frame median.
+
+    Returns a list of per-frame sky models (NaN where unaligned/undefined).
+    """
+    from scipy.ndimage import shift as ndshift
+    aligned = []
+    for f, (dy, dx) in zip(frames, shifts):
+        aligned.append(ndshift(np.asarray(f, dtype=np.float64), (dy, dx),
+                               order=1, cval=np.nan, mode='constant',
+                               prefilter=False))
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', category=RuntimeWarning)
+        sky_ref = np.nanmedian(np.stack(aligned), axis=0)
+    out = []
+    for (dy, dx) in shifts:
+        out.append(ndshift(sky_ref, (-dy, -dx), order=1, cval=np.nan,
+                           mode='constant', prefilter=False))
+    return out
+
+
+def sky_source_mask(sky, nsigma=2.0, npixels=5, dilate=4):
+    """Source mask from a sky model (sources present, artifact absent).
+
+    Detecting on the sky model — not the science frame — is the trick that lets
+    the skymodel path mask the source-subtraction *dipole residuals* (left by
+    imperfect order-1 alignment) without masking the detector-fixed artifact,
+    which by construction is not in the sky model. Dilated to cover the dipole
+    wings.
+    """
+    from photutils.segmentation import detect_sources, detect_threshold
+    from scipy.ndimage import binary_dilation
+    finite = np.isfinite(sky)
+    if not finite.any():
+        return np.zeros(sky.shape, dtype=bool)
+    data = np.where(finite, sky, 0.0)
+    thr = detect_threshold(data, nsigma=nsigma, mask=~finite)
+    seg = detect_sources(data, thr, npixels=npixels, mask=~finite)
+    if seg is None:
+        return np.zeros(sky.shape, dtype=bool)
+    return binary_dilation(seg.data > 0, iterations=int(dilate))
+
+
+def stationary_pixels(segs, k_unmask):
+    """Detector-stationary segmentation pixels: flagged in >= ``k_unmask`` frames.
+
+    A real source moves between dithers, so its segment is flagged at a given
+    detector pixel in only one (or, for extended sources at a small throw, a
+    few) exposures. A detector-fixed artifact is flagged at the *same* pixel in
+    every exposure. Pixels flagged in at least ``k_unmask`` of the per-exposure
+    segmentation masks are therefore the artifact (or static features) and are
+    *unmasked* — kept in the stack so the artifact is measured rather than
+    erased by its own detection. With ``k_unmask = N`` (all frames) only
+    perfectly-stationary structure is unmasked; a compact moving source at a
+    realistic dither throw never reaches it.
+
+    Parameters
+    ----------
+    segs : list of (H, W) bool ndarray
+        Per-exposure source-segmentation masks (True where flagged).
+    k_unmask : int
+        Minimum number of frames a pixel must be flagged in to count as
+        detector-stationary.
+
+    Returns
+    -------
+    (H, W) bool ndarray
+        True where the segmentation is detector-stationary (to be unmasked).
+    """
+    count = np.zeros(segs[0].shape, dtype=int)
+    for s in segs:
+        count += s.astype(bool)
+    return count >= k_unmask
+
+
+def fit_template_scale(data, template, mask, c_max=3.0, support_nsigma=1.5,
+                       clip_sigma=3.0, maxiters=5):
+    """Per-exposure template amplitude by robust weighted least-squares.
+
+    Solves ``c = Σ(d·t) / Σ(t²)`` over the template's support (pixels where
+    ``|template|`` exceeds a robust threshold, so the fit keys on the actual
+    artifact and not the vast clean background), iteratively sigma-clipping the
+    residual to reject any source flux that leaked into the support. Unlike a
+    MAD-of-residual minimization this stays well-posed for a *flat* artifact
+    (smooth persistence / scattered light) — exactly the low-structure case
+    where minimizing residual spread is degenerate. Clamped to ``[0, c_max]``:
+    a missing artifact gives ``c -> 0`` (no subtraction), never a spurious
+    negative that would *add* the template.
+
+    Parameters
+    ----------
+    data : (H, W) ndarray
+        Pedestal-subtracted SCI for this exposure.
+    template : (H, W) ndarray
+        Artifact template (0 outside its support).
+    mask : (H, W) bool ndarray
+        True where the pixel must be excluded (DQ + source mask).
+    c_max : float
+        Upper clamp on the fitted amplitude.
+    support_nsigma : float
+        Template support threshold in units of the MAD of the nonzero template
+        values (0 for a flat template -> the full nonzero footprint).
+    clip_sigma, maxiters : float, int
+        Residual sigma-clip rejecting leaked source flux from the fit.
+
+    Returns
+    -------
+    c : float
+        Fitted amplitude in ``[0, c_max]`` (0 when no usable support).
+    """
+    nonzero = template[template != 0]
+    if nonzero.size < 50:
+        return 0.0
+    tcut = support_nsigma * median_absolute_deviation(nonzero, ignore_nan=True)
+    support = ((np.abs(template) > tcut) & ~mask
+               & np.isfinite(data) & np.isfinite(template))
+    if support.sum() < 50:
+        return 0.0
+
+    d = data[support].astype(np.float64)
+    t = template[support].astype(np.float64)
+    keep = np.ones(d.shape, dtype=bool)
+    c = 0.0
+    for _ in range(maxiters):
+        denom = np.sum(t[keep] ** 2)
+        if denom <= 0:
+            return 0.0
+        c = float(np.sum(d[keep] * t[keep]) / denom)
+        resid = d - c * t
+        # MAD -> Gaussian-equivalent sigma via the 1.4826 factor.
+        sigma = 1.4826 * median_absolute_deviation(resid[keep], ignore_nan=True)
+        if not np.isfinite(sigma) or sigma == 0:
+            break
+        newkeep = np.abs(resid) < clip_sigma * sigma
+        if newkeep.sum() < 50 or np.array_equal(newkeep, keep):
+            break
+        keep = newkeep
+    return float(np.clip(c, 0.0, c_max))
+
+
+# ---------------------------------------------------------------------------
+# Step wrapper (ImageModel I/O + shared tiered source mask)
+# ---------------------------------------------------------------------------
+
+def _read_dither_geometry(group_files):
+    """Per-exposure ``(xoffset, yoffset)`` arcsec from canonical headers.
+
+    Primary path is the commanded ideal-frame ``XOFFSET``/``YOFFSET`` (ext 0).
+    Falls back to the ``RA_REF``/``DEC_REF`` pointing (ext 1, SCI header),
+    projected to a local tangent plane in arcsec, when the commanded offsets
+    are absent. Returns ``None`` if neither is available on all files.
+    """
+    xs, ys = [], []
+    have_offset = True
+    for f in group_files:
+        h0 = fits.getheader(f, ext=0)
+        xo, yo = h0.get('XOFFSET'), h0.get('YOFFSET')
+        if xo is None or yo is None:
+            have_offset = False
+            break
+        xs.append(float(xo))
+        ys.append(float(yo))
+    if have_offset:
+        return np.array(xs), np.array(ys)
+
+    # Fallback: RA_REF/DEC_REF projected to arcsec about the group mean.
+    ras, decs = [], []
+    for f in group_files:
+        h1 = fits.getheader(f, ext=('SCI', 1))
+        ra, dec = h1.get('RA_REF'), h1.get('DEC_REF')
+        if ra is None or dec is None:
+            return None
+        ras.append(float(ra))
+        decs.append(float(dec))
+    ras = np.array(ras)
+    decs = np.array(decs)
+    dec0 = np.deg2rad(decs.mean())
+    x = (ras - ras.mean()) * np.cos(dec0) * 3600.0
+    y = (decs - decs.mean()) * 3600.0
+    return x, y
+
+
+def _dither_shifts(models):
+    """Per-model ``(dy, dx)`` px shift aligning each frame onto model[0]'s sky.
+
+    Uses each exposure's GWCS (``meta.wcs``, from image2's assign_wcs — the
+    commanded pointing, pre-jhat) to map frame 0's centre sky position into
+    every frame's detector pixel; the offset is the translation that aligns
+    the sky. A pure translation is adequate for a single dither sequence (same
+    detector, negligible relative roll).
+    """
+    ny, nx = models[0].data.shape
+    xc, yc = nx / 2.0, ny / 2.0
+    ra0, dec0 = models[0].meta.wcs.pixel_to_world_values(xc, yc)
+    shifts = []
+    for m in models:
+        xi, yi = m.meta.wcs.world_to_pixel_values(ra0, dec0)
+        shifts.append((yc - float(yi), xc - float(xi)))
+    return shifts
+
+
+def _stamp_skip(group_files, reason):
+    """Stamp ``CFP_ART = 'skipped (<reason>)'`` without touching SCI."""
+    from jwst.datamodels import ImageModel
+    log(f"artifact: skipping group — {reason}")
+    for f in group_files:
+        with ImageModel(f, memmap=False) as m:
+            atomic_save(m, f,
+                        header_updates=cfp.format(CFP_ART=f'skipped ({reason})'))
+
+
+def artifact_step(group_key, group_files, field, step_config, overwrite=False,
+                  status=None):
+    """Remove detector-fixed artifacts from one (visit, detector) dither group.
+
+    Parameters
+    ----------
+    group_key : str
+        ``'<visit>_<spec>_<detector>'`` label for logging.
+    group_files : list of str
+        Canonical ``<rootname>.fits`` paths for the group's dithers.
+    field : Field
+    step_config : dict
+        ``[nircam.artifact]`` block.
+    overwrite : bool
+    status : StepStatus, optional
+        Pre-scanned CFP_* status cache.
+    """
+    # --- config + validation ------------------------------------------------
+    min_dithers = int(step_config.get('min_dithers', 4))
+    min_spacing = float(step_config.get('min_dither_spacing_pix', 20))
+    min_contributing = int(step_config.get('min_contributing', 2))
+    mask_level = step_config.get('mask', 'standard')
+    if mask_level not in _VALID_MASK:
+        raise ValueError(f"[nircam.artifact].mask = {mask_level!r} invalid "
+                         f"(expected one of {_VALID_MASK})")
+    scale_mode = step_config.get('scale', 'fit')
+    if scale_mode not in _VALID_SCALE:
+        raise ValueError(f"[nircam.artifact].scale = {scale_mode!r} invalid "
+                         f"(expected one of {_VALID_SCALE})")
+    source_rejection = step_config.get('source_rejection', 'stationary')
+    if source_rejection not in _VALID_SOURCE_REJECTION:
+        raise ValueError(
+            f"[nircam.artifact].source_rejection = {source_rejection!r} invalid "
+            f"(expected one of {_VALID_SOURCE_REJECTION})")
+    sigma = float(step_config.get('sigma', 3.0))
+    maxiters = int(step_config.get('maxiters', 5))
+    unmask_stationary = bool(step_config.get('unmask_stationary', True))
+    unmask_min_frac = float(step_config.get('unmask_min_frac', 1.0))
+    interpolate_gaps = bool(step_config.get('interpolate_gaps', True))
+    isolate_background = bool(step_config.get('isolate_background', False))
+    isolate_box = int(step_config.get('isolate_box', 128))
+    isolate_filter = int(step_config.get('isolate_filter', 3))
+    smooth_sigma = float(step_config.get('template_smooth_sigma', 2.0))
+    despike_nsigma = float(step_config.get('despike_nsigma', 4.0))
+    despike_size = int(step_config.get('despike_size', 5))
+    despike_dilate = int(step_config.get('despike_dilate', 1))
+    coverage_weight = bool(step_config.get('coverage_weight', True))
+    coverage_n_lo = int(step_config.get('coverage_n_lo', 1))
+    coverage_n_hi = int(step_config.get('coverage_n_hi', 3))
+    coverage_smooth_sigma = float(step_config.get('coverage_smooth_sigma', 3.0))
+    c_max = float(step_config.get('c_max', 3.0))
+    do_plot = bool(step_config.get('plot', True))
+
+    # Skip when every member already carries CFP_ART (ensemble: all-or-none).
+    if not overwrite:
+        done = (all(status.has(f, 'CFP_ART') for f in group_files)
+                if status is not None
+                else all(cfp.has_step(f, 'CFP_ART') for f in group_files))
+        if done:
+            log(f"artifact: {group_key} already done (CFP_ART on all "
+                f"{len(group_files)} members); skipping")
+            return
+
+    detector = os.path.basename(group_files[0]).removesuffix('.fits').split('_')[3]
+    channel = _channel_of(detector)
+    pixscale = PIXSCALE_ARCSEC[channel]
+
+    # --- safeguards ---------------------------------------------------------
+    geom = _read_dither_geometry(group_files)
+    if geom is None:
+        _stamp_skip(group_files, 'no dither geometry (XOFFSET/RA_REF missing)')
+        return
+    xoff, yoff = geom
+    n_pos, spacing_pix = dither_positions_and_spacing(xoff, yoff, pixscale)
+    patttype = fits.getheader(group_files[0], ext=0).get('PATTTYPE', '?')
+    log(f"artifact: {group_key} — {len(group_files)} files, {n_pos} distinct "
+        f"dither positions ({patttype}), min throw {spacing_pix:.1f} px "
+        f"({channel} @ {pixscale:.4f}\"/px)")
+    if n_pos < min_dithers:
+        _stamp_skip(group_files,
+                    f'{n_pos} positions < min_dithers={min_dithers}')
+        return
+    if spacing_pix < min_spacing:
+        _stamp_skip(group_files,
+                    f'spacing {spacing_pix:.1f}px < {min_spacing}px')
+        return
+
+    # --- load frames + build the template stack -----------------------------
+    from jwst.datamodels import ImageModel, dqflags
+
+    log(f"artifact: building template for {group_key} "
+        f"(source_rejection={source_rejection}, scale={scale_mode})")
+    models = [ImageModel(f, memmap=False) for f in group_files]
+    sci_before = [m.data.copy() for m in models]
+
+    # DO_NOT_USE + SATURATED are always masked (see artifact_dq_mask for why
+    # JUMP_DET and PERSISTENCE are intentionally left in).
+    dq_masks = [artifact_dq_mask(m.dq) for m in models]
+
+    # The template is built from ``stack_frames`` (masked by ``stack_masks``).
+    # The output always subtracts c*template from the raw cal SCI; only the
+    # template-construction differs between the two source-rejection modes.
+    if source_rejection == 'skymodel':
+        # Subtract a sky-aligned median (sky-fixed sources + ICL) from each
+        # frame, then build the template from the residuals — which carry the
+        # detector-fixed artifact and no sources. The dither WCS does the
+        # separation, so no source mask / stationarity heuristic is needed.
+        shifts = _dither_shifts(models)
+        log(f"artifact: {group_key} sky-model shifts (dy,dx) px: "
+            + ', '.join(f'({dy:+.0f},{dx:+.0f})' for dy, dx in shifts))
+        sky_models = build_sky_model(sci_before, shifts)
+        stack_frames = [s - sk for s, sk in zip(sci_before, sky_models)]
+        # Mask source positions (detected on the sky model, so the artifact is
+        # not masked) to drop the alignment dipole residuals from the stack.
+        src_masks = [sky_source_mask(sk) for sk in sky_models]
+        nsrc = int(np.mean([m.mean() for m in src_masks]) * 100)
+        log(f"artifact: {group_key} skymodel masking ~{nsrc}% (source dipoles)")
+        stack_masks = [dq | sm for dq, sm in zip(dq_masks, src_masks)]
+    else:  # 'stationary'
+        from campfire_pipeline.nircam.steps.striping import _build_srcmask
+        if mask_level == 'none':
+            stack_masks = dq_masks
+        else:
+            extra = 4 if mask_level == 'aggressive' else 0
+            segs = [_build_srcmask(m, extra_dilation=extra) > 0 for m in models]
+            if unmask_stationary:
+                # Keep detector-stationary segments (the artifact) in the stack;
+                # mask only segments that move between dithers (real sources).
+                k_unmask = max(2, int(np.ceil(unmask_min_frac * len(segs))))
+                stationary = stationary_pixels(segs, k_unmask)
+                log(f"artifact: {group_key} unmasking "
+                    f"{int(stationary.sum())} detector-stationary px "
+                    f"(flagged in >= {k_unmask}/{len(segs)} dithers)")
+                stack_masks = [dq | (s & ~stationary)
+                               for dq, s in zip(dq_masks, segs)]
+            else:
+                stack_masks = [dq | s for dq, s in zip(dq_masks, segs)]
+        stack_frames = sci_before
+
+    template, n_contrib, pedestals, diag = build_artifact_template(
+        stack_frames, stack_masks, sigma=sigma, maxiters=maxiters,
+        min_contributing=min_contributing, interpolate_gaps=interpolate_gaps,
+        isolate_background=isolate_background, isolate_box=isolate_box,
+        isolate_filter=isolate_filter, smooth_sigma=smooth_sigma,
+        despike_nsigma=despike_nsigma, despike_size=despike_size,
+        despike_dilate=despike_dilate,
+        coverage_weight=coverage_weight, coverage_n_lo=coverage_n_lo,
+        coverage_n_hi=coverage_n_hi, coverage_smooth_sigma=coverage_smooth_sigma,
+    )
+    log(f"artifact: {group_key} template built; undefined "
+        f"{diag['undefined_frac'] * 100:.1f}% of pixels; "
+        f"despiked {diag['n_despiked']} hot pixels")
+    # The coverage gate scales only the APPLIED correction (not the fit): the
+    # amplitude is fit on the full ungated template (stable, unchanged from the
+    # no-gate case) and the gated template is what's subtracted, so the
+    # well-covered field is untouched and only low-coverage regions taper off.
+    conf = diag.get('coverage_confidence')
+    applied_template = template if conf is None else template * conf
+    if conf is not None:
+        log(f"artifact: {group_key} coverage gate — "
+            f"{np.mean(conf < 0.5) * 100:.1f}% of pixels weight<0.5, "
+            f"{np.mean(conf <= 0.0) * 100:.1f}% fully gated")
+
+    # --- subtract (optionally per-exposure scaled) + write ------------------
+    # Fit the amplitude on the same frame the template was built from
+    # (residual for skymodel, raw for stationary), then subtract from raw SCI.
+    bpflag = dqflags.pixel['DO_NOT_USE']
+    coeffs = []
+    for m, raw, fitframe, mask, ped, f in zip(
+            models, sci_before, stack_frames, stack_masks, pedestals,
+            group_files):
+        if scale_mode == 'fit':
+            c = fit_template_scale(fitframe.astype(np.float64) - ped, template,
+                                   mask, c_max=c_max)
+        else:
+            c = 1.0
+        coeffs.append(c)
+
+        outsci = raw - c * applied_template
+        outsci[raw == 0] = 0
+        wnan = np.isnan(outsci)
+        outsci[wnan] = 0
+        m.dq[wnan] = np.bitwise_or(m.dq[wnan], bpflag)
+        m.data = outsci
+
+        from stdatamodels import util as stutil
+        now = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        m.history.append(stutil.create_history_entry(
+            f'Removed intra-visit artifact template (scale={scale_mode}, '
+            f'c={c:.3f}); {now}'))
+
+        cfp_value = (f'srcrej={source_rejection}, scale={scale_mode}, '
+                     f'c={c:.3f}, N={n_pos}, spacing={spacing_pix:.1f}px, '
+                     f'interp={int(interpolate_gaps)}, '
+                     f'isolate={int(isolate_background)}, '
+                     f'cov={int(coverage_weight)}')
+        atomic_save(m, f, header_updates=cfp.format(CFP_ART=cfp_value))
+        log(f"artifact: {os.path.basename(f)} — c={c:.3f}")
+
+    rootbase = '_'.join(os.path.basename(group_files[0])
+                        .removesuffix('.fits').split('_')[:2] + [detector])
+    out_dir = os.path.dirname(group_files[0])
+
+    # Write the applied (coverage-gated) template as a QA reference product (not
+    # a jw* file, so the field exposure globs ignore it) — this is exactly what
+    # was subtracted, per unit c.
+    tmpl_path = os.path.join(out_dir, f'artifact_template_{rootbase}.fits')
+    fits.PrimaryHDU(applied_template.astype(np.float32)).writeto(
+        tmpl_path, overwrite=True)
+
+    if do_plot:
+        _plot_artifact(group_key, sci_before, applied_template, coeffs,
+                       n_contrib,
+                       os.path.join(out_dir, f'artifact_{rootbase}.pdf'))
+
+    for m in models:
+        m.close()
+    log(f"artifact: {group_key} done — c={[f'{c:.2f}' for c in coeffs]}")
+
+
+def _plot_artifact(group_key, sci_before, template, coeffs, n_contrib,
+                   save_file):
+    """Diagnostic: representative before/after, template, coverage map."""
+    import matplotlib.pyplot as plt
+    from astropy.visualization import ImageNormalize, ZScaleInterval
+
+    # Representative exposure = the one with the largest fitted amplitude.
+    i = int(np.argmax(coeffs)) if len(coeffs) else 0
+    before = sci_before[i]
+    after = before - coeffs[i] * template
+
+    norm = ImageNormalize(before, interval=ZScaleInterval())
+    tnorm = ImageNormalize(template, interval=ZScaleInterval())
+    fig, axes = plt.subplots(2, 2, figsize=(10, 10), tight_layout=True)
+    for ax in axes.ravel():
+        ax.axis('off')
+    axes[0, 0].imshow(before, origin='lower', cmap='Greys', norm=norm,
+                      interpolation='none')
+    axes[0, 0].set_title(f'before (c={coeffs[i]:.2f})')
+    axes[0, 1].imshow(after, origin='lower', cmap='Greys', norm=norm,
+                      interpolation='none')
+    axes[0, 1].set_title('after')
+    axes[1, 0].imshow(template, origin='lower', cmap='RdBu_r', norm=tnorm,
+                      interpolation='none')
+    axes[1, 0].set_title('artifact template')
+    axes[1, 1].imshow(n_contrib, origin='lower', cmap='viridis',
+                      interpolation='none')
+    axes[1, 1].set_title('contributing dithers')
+    fig.suptitle(group_key)
+    fig.savefig(save_file)
+    plt.close(fig)
+    log(f"artifact: saved {os.path.basename(save_file)}")

--- a/pipeline/campfire_pipeline/nircam/steps/background.py
+++ b/pipeline/campfire_pipeline/nircam/steps/background.py
@@ -1,0 +1,111 @@
+"""
+background: per-exposure 2D background subtraction.
+
+Per-exposure step. Runs **after ``image2`` and before ``artifact``/``striping``**
+(order: ... image2 -> background -> artifact -> striping -> ...) so the smooth
+background — sky-fixed (ICL, zodi gradients) *and* detector-fixed (smooth
+persistence / scattered light) — is removed before the 1/f stripe offsets are
+measured. A non-uniform background biases the per-amp-row clipped medians; the
+striping step's own fit-only detrend mitigates but doesn't eliminate it, so
+removing it for real upstream is strictly better.
+
+Why per-exposure (not a sky-frame / drizzle background): only a model built in
+the exposure's *own* frame sees both the sky-fixed ICL and the detector-fixed
+smooth component as background. A sky-frame median/drizzle would capture only
+the sky-fixed part and leave detector-fixed persistence behind.
+
+Reuses the nircamx ``SubtractBackground`` (``bkgsub.py``) — the same tiered-
+mask + ``clipped_ring_median`` + ``Background2D`` algorithm the mosaic uses,
+explicitly tuned to preserve galaxy outskirts — so the per-exposure and mosaic
+backgrounds are consistent. ``SubtractBackground.compute`` does all the work in
+memory and returns ``sci - background``; this step writes that back to the
+canonical SCI and stamps ``CFP_BKG``.
+
+Opt-in: disabled unless ``[nircam.background].enabled = true`` (a per-exposure
+2D subtraction changes flux for every field, so the default reproduces current
+behaviour). The shallow-vs-deep mask trade-off (single exposure is shallower
+than the mosaic, so faint sources can leak into the model) is the known cost;
+the box size and the ``clipped_ring_median`` ceiling bound it, and the A/B's
+photometry-conservation metric sets the box.
+"""
+
+import os
+from datetime import datetime
+
+import numpy as np
+
+from campfire_pipeline.common.io import log, atomic_save
+from campfire_pipeline.common import cfp
+
+
+def background_step(exposure_file, field, step_config, overwrite=False,
+                    status=None):
+    """Subtract a per-exposure 2D background from a single canonical exposure.
+
+    Parameters
+    ----------
+    exposure_file : str
+        Canonical ``<rootname>.fits`` path (post-image2, cal-stage).
+    field : Field
+    step_config : dict
+        ``[nircam.background]`` block. Keys matching ``SubtractBackground``
+        dataclass fields (``bg_box_size``, ``bg_filter_size``, ``ring_*``,
+        ``tier_*`` ...) are forwarded to it; ``enabled`` / ``plot`` are read here.
+    overwrite : bool
+    status : StepStatus, optional
+        Pre-scanned CFP_* status cache.
+    """
+    plot = step_config.get('plot', True)
+    rootname = os.path.basename(exposure_file).removesuffix('.fits')
+
+    if cfp.should_skip(exposure_file, 'CFP_BKG', rootname,
+                       'background', status, overwrite):
+        return
+
+    log(f"Running background subtraction on {rootname}")
+
+    from jwst.datamodels import ImageModel, dqflags
+    from campfire_pipeline.nircam.bkgsub import SubtractBackground
+
+    # Build from the config section (unknown keys ignored) and run the
+    # tiered-mask + Background2D estimate in memory.
+    bg = SubtractBackground.from_config(step_config)
+    bkgsub_sci, _mask_final, _bitmask = bg.compute(exposure_file)
+
+    model = ImageModel(exposure_file, memmap=False)
+    sci_before = model.data.copy()
+    bg_model = sci_before - bkgsub_sci
+
+    # Mirror striping's output hygiene: keep blank pixels blank, flag any NaN
+    # the subtraction produced as DO_NOT_USE (the bg model is finite, so NaNs
+    # come from NaN SCI input).
+    outsci = bkgsub_sci.astype(model.data.dtype, copy=True)
+    outsci[sci_before == 0] = 0
+    wnan = np.isnan(outsci)
+    outsci[wnan] = 0
+    model.dq[wnan] = np.bitwise_or(model.dq[wnan], dqflags.pixel['DO_NOT_USE'])
+    model.data = outsci
+
+    from stdatamodels import util as stutil
+    now = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    model.history.append(stutil.create_history_entry(
+        f'Subtracted per-exposure 2D background '
+        f'(SubtractBackground, box={bg.bg_box_size}); {now}'))
+
+    cfp_value = (f'SubtractBackground box={bg.bg_box_size}, '
+                 f'filter={bg.bg_filter_size}, ring_radius={bg.ring_radius_in}, '
+                 f'exclude_pct={bg.bg_exclude_percentile}')
+    atomic_save(model, exposure_file,
+                header_updates=cfp.format(CFP_BKG=cfp_value))
+    sci_after = model.data.copy()
+    model.close()
+    log(f"Background subtracted: {rootname}")
+
+    if plot:
+        from campfire_pipeline.nircam.steps._plots import plot_two
+        bkg_pdf = os.path.join(os.path.dirname(exposure_file),
+                               f'{rootname}_background.pdf')
+        plot_two(sci_after, bg_model,
+                 title1='Background subtracted', title2='2D background model',
+                 save_file=bkg_pdf)
+        log(f"Saved {os.path.basename(bkg_pdf)}")

--- a/pipeline/tests/test_nircam_artifact.py
+++ b/pipeline/tests/test_nircam_artifact.py
@@ -1,0 +1,456 @@
+"""Tests for the intra-visit detector-fixed artifact step's numerical core.
+
+Synthesizes dither stacks with a known detector-fixed artifact plus bright
+sources that *move* between dithers (as real sky sources do under a dither
+pattern) and verifies that the pure functions:
+
+1. Count distinct dither positions and the minimum pairwise throw correctly,
+   collapsing co-located repeat exposures.
+2. Recover the detector-fixed artifact while rejecting the moving sources —
+   the whole premise of the method — using dither rejection alone and with a
+   source mask.
+3. Isolate a compact artifact from a smooth large-scale background.
+4. Leave pixels undefined where too few dithers contribute.
+5. Fit the per-exposure template amplitude, returning ~0 for an absent
+   artifact and clamping to ``[0, c_max]``.
+
+The full step (ImageModel I/O + tiered source mask + write-back) is exercised
+by the A/B pipeline runs on rj0911, per the experiments workflow.
+"""
+
+import numpy as np
+import pytest
+
+from campfire_pipeline.nircam.steps.artifact import (
+    artifact_dq_mask,
+    build_artifact_template,
+    build_sky_model,
+    despike,
+    dither_positions_and_spacing,
+    fit_template_scale,
+    inpaint_nan,
+    stationary_pixels,
+)
+
+LW_SCALE = 0.0630  # arcsec/pix
+
+
+def _make_stack(artifact, src_positions, src_flux=50.0, noise=0.1, seed=0):
+    """Stack of frames sharing ``artifact``; a bright source at each position."""
+    rng = np.random.default_rng(seed)
+    h, w = artifact.shape
+    frames, masks = [], []
+    for (sy, sx) in src_positions:
+        f = rng.normal(0.0, noise, (h, w)) + artifact
+        f[sy - 3:sy + 3, sx - 3:sx + 3] += src_flux
+        frames.append(f)
+        masks.append(np.zeros((h, w), dtype=bool))
+    return frames, masks
+
+
+# --- dither geometry --------------------------------------------------------
+
+def test_box_dither_geometry():
+    # rj0911 INTRAMODULEBOX F444W commanded offsets (arcsec).
+    xo = np.array([-92.9, -93.1, -87.1, -86.9])
+    yo = np.array([-3.1, 2.9, 3.1, -2.9])
+    npos, sp = dither_positions_and_spacing(xo, yo, LW_SCALE)
+    assert npos == 4
+    # ~6" box at 0.063"/px -> ~95 px between adjacent corners.
+    assert 80.0 < sp < 160.0
+
+
+def test_colocated_repeats_collapse():
+    # Two physical positions, each visited twice (NEXP=2 style).
+    npos, sp = dither_positions_and_spacing(
+        [0.0, 0.001, 5.0, 5.001], [0.0, 0.0, 0.0, 0.0], LW_SCALE)
+    assert npos == 2
+    assert sp == pytest.approx(5.0 / LW_SCALE, rel=1e-3)
+
+
+def test_single_position_infinite_spacing():
+    npos, sp = dither_positions_and_spacing([1.0], [2.0], LW_SCALE)
+    assert npos == 1
+    assert np.isinf(sp)
+
+
+# --- template construction --------------------------------------------------
+
+def _blob(h=200, w=200, val=5.0):
+    a = np.zeros((h, w))
+    a[90:110, 90:110] = val
+    return a
+
+
+def test_recovers_artifact_rejects_moving_sources():
+    artifact = _blob(val=5.0)
+    # Source in a different corner each dither.
+    frames, masks = _make_stack(artifact, [(20, 20), (20, 170),
+                                           (170, 20), (170, 170)])
+    tmpl, nc, peds, diag = build_artifact_template(
+        frames, masks, isolate_background=False, smooth_sigma=0.0,
+        min_contributing=2)
+    # Artifact core recovered.
+    assert tmpl[95:105, 95:105].mean() == pytest.approx(5.0, abs=0.5)
+    # Moving sources rejected — no residual where any single source sat.
+    for (sy, sx) in [(20, 20), (20, 170), (170, 20), (170, 170)]:
+        assert np.abs(tmpl[sy - 2:sy + 2, sx - 2:sx + 2]).mean() < 0.5
+    assert diag['undefined_frac'] == 0.0
+
+
+def test_isolation_removes_smooth_background_keeps_blob():
+    h = w = 200
+    yy, xx = np.mgrid[0:h, 0:w]
+    smooth = 0.01 * xx + 0.008 * yy          # large-scale gradient (detector-fixed)
+    artifact = _blob(val=5.0) + smooth
+    frames, masks = _make_stack(artifact, [(20, 20), (20, 170),
+                                           (170, 20), (170, 170)])
+    tmpl_iso, _, _, _ = build_artifact_template(
+        frames, masks, isolate_background=True, isolate_box=64,
+        isolate_filter=3, smooth_sigma=0.0, min_contributing=2)
+    # Compact blob survives; the smooth ramp is largely removed away from it.
+    assert tmpl_iso[95:105, 95:105].mean() > 3.0
+    corner = tmpl_iso[160:180, 160:180].mean()
+    assert abs(corner) < 1.0
+
+
+def test_undefined_accounting_and_zero_fill_path():
+    artifact = _blob(val=5.0)
+    frames, masks = _make_stack(artifact, [(20, 20), (20, 170),
+                                           (170, 20), (170, 170)])
+    # Mask a clean patch in 3 of 4 frames -> only 1 contributes there.
+    for m in masks[:3]:
+        m[50:60, 50:60] = True
+    # interpolate_gaps=False exercises the legacy zero-fill path.
+    tmpl, nc, peds, diag = build_artifact_template(
+        frames, masks, isolate_background=False, smooth_sigma=0.0,
+        min_contributing=2, interpolate_gaps=False)
+    assert nc[55, 55] == 1                       # coverage tracked correctly
+    assert tmpl[55, 55] == 0.0                   # zero-filled (no correction)
+    assert diag['undefined_frac'] > 0.0
+
+
+def test_template_smoothing_reduces_noise():
+    artifact = _blob(val=5.0)
+    frames, masks = _make_stack(artifact, [(20, 20), (20, 170),
+                                           (170, 20), (170, 170)], noise=0.3)
+    raw, _, _, _ = build_artifact_template(
+        frames, masks, isolate_background=False, smooth_sigma=0.0)
+    sm, _, _, _ = build_artifact_template(
+        frames, masks, isolate_background=False, smooth_sigma=2.0)
+    # Off-artifact noise is suppressed by smoothing.
+    assert np.std(sm[150:190, 10:50]) < np.std(raw[150:190, 10:50])
+
+
+# --- per-exposure scale fit -------------------------------------------------
+
+def test_scale_fit_recovers_amplitude():
+    rng = np.random.default_rng(1)
+    tmpl = _blob(val=1.0)
+    data = 1.7 * tmpl + rng.normal(0, 0.05, tmpl.shape)
+    c = fit_template_scale(data, tmpl, np.zeros_like(tmpl, bool), c_max=3.0)
+    assert c == pytest.approx(1.7, abs=0.1)
+
+
+def test_scale_fit_zero_when_no_artifact():
+    rng = np.random.default_rng(2)
+    tmpl = _blob(val=1.0)
+    data = rng.normal(0, 0.05, tmpl.shape)    # pure noise, no artifact
+    c = fit_template_scale(data, tmpl, np.zeros_like(tmpl, bool), c_max=3.0)
+    assert c == pytest.approx(0.0, abs=0.05)
+
+
+def test_scale_fit_clamps_and_never_negative():
+    tmpl = _blob(val=1.0)
+    # Anti-correlated data would want c<0; clamp keeps it at 0 (never adds).
+    c_neg = fit_template_scale(-2.0 * tmpl, tmpl,
+                               np.zeros_like(tmpl, bool), c_max=3.0)
+    assert c_neg == 0.0
+    # Beyond the grid ceiling clamps to c_max.
+    c_hi = fit_template_scale(10.0 * tmpl, tmpl,
+                              np.zeros_like(tmpl, bool), c_max=3.0)
+    assert c_hi == pytest.approx(3.0, abs=1e-6)
+
+
+def test_scale_fit_empty_support_returns_zero():
+    tmpl = np.zeros((200, 200))               # no support at all
+    data = np.ones((200, 200))
+    c = fit_template_scale(data, tmpl, np.zeros_like(tmpl, bool))
+    assert c == 0.0
+
+
+# --- stationarity-aware masking ---------------------------------------------
+
+def test_artifact_dq_mask_saturated_yes_jump_persistence_no():
+    from jwst.datamodels import dqflags
+    dq = np.zeros((2, 4), dtype=np.uint32)
+    dq[0, 0] = dqflags.pixel['DO_NOT_USE']
+    dq[0, 1] = dqflags.pixel['SATURATED']
+    dq[0, 2] = dqflags.pixel['JUMP_DET']
+    dq[0, 3] = dqflags.pixel['PERSISTENCE']
+    m = artifact_dq_mask(dq)
+    assert m[0, 0] and m[0, 1]                  # DO_NOT_USE + SATURATED masked
+    assert not m[0, 2] and not m[0, 3]          # JUMP_DET, PERSISTENCE kept
+    # A pixel carrying SATURATED among other (kept) bits is still masked.
+    combo = dqflags.pixel['SATURATED'] | dqflags.pixel['JUMP_DET']
+    assert artifact_dq_mask(np.array([[combo]], dtype=np.uint32))[0, 0]
+
+
+def test_stationary_pixels_keeps_artifact_drops_moving_sources():
+    h = w = 100
+    # Artifact flagged at the same pixels in all 4 frames; a source flagged at
+    # a *different* corner each frame (it moves).
+    segs = []
+    corners = [(10, 10), (10, 80), (80, 10), (80, 80)]
+    for (sy, sx) in corners:
+        s = np.zeros((h, w), dtype=bool)
+        s[45:55, 45:55] = True            # detector-fixed artifact (all frames)
+        s[sy:sy + 5, sx:sx + 5] = True    # moving source (this frame only)
+        segs.append(s)
+    stat = stationary_pixels(segs, k_unmask=len(segs))
+    # Artifact unmasked (stationary); moving sources are not.
+    assert stat[45:55, 45:55].all()
+    for (sy, sx) in corners:
+        assert not stat[sy:sy + 5, sx:sx + 5].any()
+
+
+def test_stationary_pixels_threshold():
+    h = w = 20
+    s1 = np.zeros((h, w), bool); s1[5:8, 5:8] = True
+    s2 = np.zeros((h, w), bool); s2[5:8, 5:8] = True
+    s3 = np.zeros((h, w), bool)           # absent in the third frame
+    # k=3 -> the patch (present in 2/3) is NOT stationary; k=2 -> it is.
+    assert not stationary_pixels([s1, s2, s3], k_unmask=3)[6, 6]
+    assert stationary_pixels([s1, s2, s3], k_unmask=2)[6, 6]
+
+
+# --- gap interpolation ------------------------------------------------------
+
+# --- sky-model source rejection ---------------------------------------------
+
+def test_build_sky_model_keeps_artifact_removes_sky_source():
+    h = w = 120
+    artifact = np.zeros((h, w))
+    artifact[55:65, 55:65] = 4.0                 # detector-fixed (all frames)
+    # shifts[i] aligns frame i onto frame 0; a sky-fixed source sits at
+    # detector (20-dy, 20-dx) in frame i so the shifts co-locate it.
+    shifts = [(0, 0), (0, 30), (30, 0), (30, 30)]
+    frames = []
+    for dy, dx in shifts:
+        f = artifact.copy()
+        sy, sx = 20 - dy, 20 - dx
+        f[sy - 3:sy + 3, sx - 3:sx + 3] += 30.0  # bright sky-fixed source
+        frames.append(f)
+
+    sky = build_sky_model(frames, shifts)
+    resid0 = frames[0] - sky[0]
+    # artifact (detector-fixed) survives in the residual...
+    assert resid0[57:63, 57:63].mean() == pytest.approx(4.0, abs=0.6)
+    # ...the sky-fixed source is removed at its frame-0 detector position.
+    assert abs(resid0[17:23, 17:23].mean()) < 1.0
+
+
+def test_despike_removes_hot_pixel_on_top_of_artifact():
+    # The case the segment filter failed: a hot pixel sitting ON the smooth
+    # artifact. Despike must remove it and leave the artifact intact.
+    rng = np.random.default_rng(3)
+    h = w = 120
+    img = np.zeros((h, w))
+    img[40:80, 40:80] = 0.5                    # smooth extended artifact
+    img += rng.normal(0, 0.01, (h, w))
+    img[60, 60] += 5.0                         # hot pixel on the artifact
+    img[20, 100] += 5.0                        # hot pixel on blank sky
+    out, n = despike(img, size=5, nsigma=5.0)
+    assert n >= 2
+    assert out[60, 60] == pytest.approx(0.5, abs=0.1)   # spike -> artifact level
+    assert out[20, 100] == pytest.approx(0.0, abs=0.1)  # spike -> blank level
+    # the smooth artifact away from the spike is untouched
+    assert out[50, 50] == pytest.approx(img[50, 50], abs=1e-6)
+
+
+def test_despike_preserves_clean_image():
+    rng = np.random.default_rng(4)
+    img = 0.3 + rng.normal(0, 0.01, (100, 100))     # smooth + noise, no spikes
+    out, n = despike(img, size=5, nsigma=5.0)
+    assert n == 0
+    assert np.allclose(out, img)
+
+
+def test_despike_dilation_removes_subthreshold_ipc_wing():
+    # A bright hot pixel with a sub-threshold IPC wing one px over. The wing is
+    # below the per-pixel cut on its own, so only the dilation reaches it — which
+    # matters because smoothing would otherwise spread the leftover wing.
+    rng = np.random.default_rng(8)
+    img = rng.normal(0, 0.05, (120, 120))
+    img[60, 60] += 5.0            # bright hot pixel
+    img[60, 61] += 0.15          # IPC wing, below ~4*0.05 = 0.2 threshold
+    out0, _ = despike(img, size=5, nsigma=4.0, maxiters=1, dilate=0)
+    out1, _ = despike(img, size=5, nsigma=4.0, maxiters=1, dilate=1)
+    assert abs(out1[60, 60]) < 0.1                       # peak removed
+    assert abs(out1[60, 61]) < 0.1                       # wing removed (dilation)
+    assert out0[60, 61] == pytest.approx(0.15, abs=0.08)  # wing survives w/o it
+
+
+def test_despike_lower_nsigma_catches_more():
+    # A population of spikes spanning 4.2-6 sigma: the lower threshold catches
+    # strictly more of the marginal ones (single pass isolates the threshold).
+    rng = np.random.default_rng(9)
+    img = rng.normal(0, 0.02, (200, 200))
+    ys = rng.integers(10, 190, 50)
+    xs = rng.integers(10, 190, 50)
+    amps = np.linspace(4.2, 6.0, 50) * 0.02
+    for y, x, a in zip(ys, xs, amps):
+        img[y, x] += a
+    _, n4 = despike(img, size=5, nsigma=4.0, maxiters=1, dilate=0)
+    _, n6 = despike(img, size=5, nsigma=6.0, maxiters=1, dilate=0)
+    assert n4 > n6
+
+
+def test_build_template_despikes_hot_pixels():
+    # End-to-end: a detector-fixed hot pixel (same in all dithers) must not
+    # survive into the template as a blob.
+    artifact = _blob(val=5.0)
+    frames, masks = _make_stack(artifact, [(20, 20), (20, 170),
+                                           (170, 20), (170, 170)], noise=0.05)
+    for f in frames:                            # detector-fixed hot pixel
+        f[150, 50] += 30.0
+    tmpl, _, _, diag = build_artifact_template(
+        frames, masks, isolate_background=False, smooth_sigma=2.0,
+        despike_nsigma=5.0)
+    assert diag['n_despiked'] >= 1
+    assert abs(tmpl[150, 50]) < 0.5             # hot pixel removed from template
+    assert tmpl[95:105, 95:105].mean() == pytest.approx(5.0, abs=0.6)  # artifact kept
+
+
+def test_source_rejection_default_and_domain():
+    from campfire_pipeline.config import load_config
+    from campfire_pipeline.nircam.steps.artifact import _VALID_SOURCE_REJECTION
+    cfg = load_config()['nircam']['artifact']
+    assert cfg['source_rejection'] == 'stationary'      # default = current path
+    assert set(_VALID_SOURCE_REJECTION) == {'stationary', 'skymodel'}
+
+
+def test_inpaint_fills_gaps_continuously():
+    arr = np.ones((50, 50)) * 3.0
+    arr[20:30, 20:30] = np.nan           # interior gap surrounded by 3.0
+    filled = inpaint_nan(arr)
+    assert np.isfinite(filled).all()
+    # Uniform surroundings -> gap fills with that level (no zero hole).
+    assert filled[25, 25] == pytest.approx(3.0, abs=1e-3)
+
+
+def test_inpaint_smooth_not_blocky():
+    # A gap inside a smooth ramp should fill smoothly (monotone across the gap),
+    # not with the blocky nearest-neighbour plateaus the EDT fill produced.
+    yy, xx = np.mgrid[0:60, 0:60]
+    arr = 0.1 * xx.astype(float)
+    arr[25:35, 25:35] = np.nan
+    filled = inpaint_nan(arr)
+    assert np.isfinite(filled).all()
+    row = filled[30, 25:35]
+    # values increase left->right across the filled gap (no flat plateau / step)
+    assert np.all(np.diff(row) > 0)
+    assert abs(filled[30, 30] - 0.1 * 30) < 0.3   # tracks the underlying ramp
+
+
+def test_inpaint_fills_near_local_level():
+    # Gap inside the artifact (value 5) fills close to 5, not 0 — smooth fill
+    # blends slightly toward a nearby boundary but stays artifact-side.
+    arr = np.zeros((40, 40))
+    arr[:, :20] = 5.0
+    arr[5:15, 2:12] = np.nan
+    filled = inpaint_nan(arr)
+    assert np.isfinite(filled).all()
+    assert filled[10, 7] > 4.0           # clearly the artifact level, not 0
+
+
+def test_zero_fill_vs_interpolate_differ_at_gap():
+    artifact = _blob(val=5.0)
+    frames, masks = _make_stack(artifact, [(20, 20), (20, 170),
+                                           (170, 20), (170, 170)])
+    # Force a gap inside the artifact: mask its core in 3 of 4 frames.
+    for m in masks[:3]:
+        m[95:105, 95:105] = True
+    tmpl_zero, _, _, _ = build_artifact_template(
+        frames, masks, interpolate_gaps=False, isolate_background=False,
+        smooth_sigma=0.0, min_contributing=2)
+    tmpl_interp, _, _, _ = build_artifact_template(
+        frames, masks, interpolate_gaps=True, isolate_background=False,
+        smooth_sigma=0.0, min_contributing=2)
+    # Zero-fill leaves a hole in the blob core; interpolation fills it.
+    assert tmpl_zero[100, 100] == pytest.approx(0.0, abs=0.3)
+    assert tmpl_interp[100, 100] == pytest.approx(5.0, abs=0.7)
+
+
+# --- coverage-confidence gate -----------------------------------------------
+# The template is returned UNGATED; build exposes the weight map in
+# diag['coverage_confidence'] and the step applies it only to the subtraction
+# (so the per-exposure amplitude fit stays keyed on the full template).
+
+def test_coverage_confidence_downweights_low_coverage():
+    # A blob pixel constrained by only 2 dithers (no cross-dither rejection)
+    # gets weight ~0.5; a full-coverage pixel gets 1.0. Applying the weight
+    # down-weights only the low-coverage core.
+    artifact = _blob(val=5.0)
+    frames, masks = _make_stack(artifact, [(20, 20), (20, 170),
+                                           (170, 20), (170, 170)], noise=0.01)
+    for m in masks[:2]:                       # mask part of the core in 2/4
+        m[95:105, 95:105] = True
+    ungated, _, _, d_off = build_artifact_template(
+        frames, masks, isolate_background=False, smooth_sigma=0.0,
+        min_contributing=2, coverage_weight=False)
+    tmpl, nc, _, d_on = build_artifact_template(
+        frames, masks, isolate_background=False, smooth_sigma=0.0,
+        min_contributing=2, coverage_weight=True, coverage_smooth_sigma=0.0)
+    assert nc[100, 100] == 2 and nc[92, 92] == 4
+    assert d_off['coverage_confidence'] is None
+    w = d_on['coverage_confidence']
+    assert w[100, 100] == pytest.approx(0.5, abs=0.05)   # n=2 -> half
+    assert w[92, 92] == pytest.approx(1.0, abs=1e-6)      # n=4 -> full
+    assert np.allclose(tmpl, ungated)          # template returned ungated
+    applied = tmpl * w
+    assert applied[100, 100] == pytest.approx(0.5 * tmpl[100, 100], rel=0.1)
+    assert applied[92, 92] == pytest.approx(tmpl[92, 92], rel=1e-3)
+
+
+def test_coverage_confidence_zeros_inpainted_gap():
+    # Pixels below min_contributing are inpainted for continuity, but the weight
+    # there is 0, so applying it subtracts nothing (the over-subtraction fix).
+    artifact = _blob(val=5.0)
+    frames, masks = _make_stack(artifact, [(20, 20), (20, 170),
+                                           (170, 20), (170, 170)], noise=0.01)
+    for m in masks[:3]:                       # mask the core in 3/4 -> n=1
+        m[95:105, 95:105] = True
+    tmpl, nc, _, diag = build_artifact_template(
+        frames, masks, isolate_background=False, smooth_sigma=0.0,
+        min_contributing=2, interpolate_gaps=True, coverage_weight=True,
+        coverage_smooth_sigma=0.0)
+    assert nc[100, 100] == 1
+    assert tmpl[100, 100] > 3.0               # inpaint fabricates ~5
+    w = diag['coverage_confidence']
+    assert w[100, 100] == 0.0                  # but weight is 0 there
+    assert abs((tmpl * w)[100, 100]) < 0.2     # so nothing is subtracted
+
+
+def test_coverage_confidence_unit_at_full_coverage():
+    # Full coverage everywhere -> weight all ones; template identical to the
+    # no-gate build. Noiseless so sigma-clip rejects nothing (n >= 3 everywhere).
+    artifact = _blob(val=5.0)
+    frames, masks = _make_stack(artifact, [(20, 20), (20, 170),
+                                           (170, 20), (170, 170)], noise=0.0)
+    a, _, _, da = build_artifact_template(frames, masks, smooth_sigma=2.0,
+                                          coverage_weight=False)
+    b, _, _, db = build_artifact_template(frames, masks, smooth_sigma=2.0,
+                                          coverage_weight=True)
+    assert da['coverage_confidence'] is None
+    assert np.all(db['coverage_confidence'] == 1.0)
+    assert np.allclose(a, b)                    # template never gated in build
+
+
+def test_coverage_gate_rejects_bad_ramp():
+    artifact = _blob(val=5.0)
+    frames, masks = _make_stack(artifact, [(20, 20), (20, 170),
+                                           (170, 20), (170, 170)])
+    with pytest.raises(ValueError):
+        build_artifact_template(frames, masks, coverage_weight=True,
+                                coverage_n_lo=3, coverage_n_hi=3)

--- a/pipeline/tests/test_nircam_background.py
+++ b/pipeline/tests/test_nircam_background.py
@@ -1,0 +1,91 @@
+"""Tests for the per-exposure 2D background step.
+
+The scientific content lives in nircamx ``SubtractBackground`` (reused); these
+tests pin the behaviour the ``background`` step relies on — a smooth ramp is
+removed while a compact source's peak is conserved — plus the orchestrator /
+provenance wiring (ordering, CFP chain, reset guard).
+"""
+
+import numpy as np
+import pytest
+from astropy.io import fits
+
+
+def _synthetic_exposure(tmp_path, ramp_amp=0.1, src_amp=5.0):
+    """Write a small SCI/ERR/DQ FITS: linear ramp + Gaussian source + noise."""
+    rng = np.random.default_rng(0)
+    n = 256
+    yy, xx = np.mgrid[0:n, 0:n]
+    ramp = ramp_amp * (xx / n) + 0.5 * ramp_amp * (yy / n)
+    src = src_amp * np.exp(-((xx - 128) ** 2 + (yy - 128) ** 2) / (2 * 3.0 ** 2))
+    sci = (ramp + src + rng.normal(0, 0.01, (n, n))).astype(np.float32)
+    err = np.full((n, n), 0.01, np.float32)
+    err[:4, :] = np.nan          # off-detector border
+    dq = np.zeros((n, n), np.int32)
+    path = tmp_path / 'exp.fits'
+    fits.HDUList([
+        fits.PrimaryHDU(),
+        fits.ImageHDU(sci, name='SCI'),
+        fits.ImageHDU(err, name='ERR'),
+        fits.ImageHDU(dq, name='DQ'),
+    ]).writeto(path, overwrite=True)
+    return str(path), ramp, src
+
+
+# Small-image-safe config (Background2D grids must accommodate filter_size).
+_CFG = dict(bg_box_size=32, bg_filter_size=3, ring_radius_in=20, ring_width=3,
+            ring_clip_box_size=64, ring_clip_filter_size=3, ring_downsample=1,
+            tier_dilate_size=[10, 8, 6, 4])
+
+
+def test_background_removes_ramp_conserves_source(tmp_path):
+    from campfire_pipeline.nircam.bkgsub import SubtractBackground
+    path, ramp, src = _synthetic_exposure(tmp_path)
+    bg = SubtractBackground.from_config(_CFG)
+    sub, mask, bitmask = bg.compute(path)
+
+    # Ramp removed: in a source-free, on-detector region the residual is ~flat
+    # about zero (the input there was the ramp, ~0.05-0.1).
+    blank = np.zeros((256, 256), bool)
+    blank[200:250, 20:230] = True
+    blank &= ~mask & np.isfinite(sub)
+    assert abs(np.median(sub[blank])) < 0.01           # ramp gone (~0)
+    assert np.std(sub[blank]) < 0.02                   # flat
+
+    # Source peak conserved (only the local background, ~0.075, is removed).
+    peak_in = float(src[128, 128])                     # ~5.0
+    peak_out = float(sub[126:131, 126:131].max())
+    assert peak_out > peak_in - 0.2
+
+
+def test_from_config_forwards_known_keys_only():
+    from campfire_pipeline.nircam.bkgsub import SubtractBackground
+    bg = SubtractBackground.from_config(
+        dict(enabled=True, plot=False, bg_box_size=77, bogus='x'))
+    assert bg.bg_box_size == 77          # forwarded
+    assert not hasattr(bg, 'enabled')    # non-field keys ignored, no crash
+
+
+def test_orchestrator_and_cfp_wiring():
+    from campfire_pipeline.nircam import orchestrate as o
+    from campfire_pipeline.common import cfp
+    from campfire_pipeline.nircam.cli import _SCI_MUTATING_STEPS
+
+    names = [s for s, _ in o.PROCESS_STEPS]
+    assert ('background', 'CFP_BKG') in o.PROCESS_STEPS
+    # Order: image2 -> background -> artifact -> striping.
+    assert (names.index('image2') < names.index('background')
+            < names.index('artifact') < names.index('striping'))
+    assert o._RUNNERS['background'] is o._run_background
+    assert 'background' in _SCI_MUTATING_STEPS
+
+    # clear_from(CFP_BKG) must cascade through artifact + striping + image2.
+    chain = cfp.CFP_KEYS[cfp.CFP_KEYS.index('CFP_BKG'):]
+    assert {'CFP_ART', 'CFP_1F', 'CFP_IMG2', 'CFP_OUT'} <= set(chain)
+    assert cfp.format(CFP_BKG='box=128')['CFP_BKG'][0] == 'box=128'
+
+
+def test_background_disabled_by_default():
+    from campfire_pipeline.config import load_config
+    cfg = load_config()['nircam']['background']
+    assert cfg['enabled'] is False       # opt-in


### PR DESCRIPTION
**WIP — parked from the working tree to unblock #212.** Not yet reviewed.

Two new **opt-in** per-exposure NIRCam steps, both **disabled by default** (no change to default pipeline output), running after `image2` and before `striping` so smooth/structured artifacts are removed before the 1/f amp-row offsets are measured:

- **`background`** (`CFP_BKG`): per-exposure 2D background subtraction reusing the mosaic's tiered-mask + `clipped_ring_median` + `Background2D` algorithm, tuned to preserve galaxy outskirts. Removes the smooth sky-fixed (ICL/zodi) **and** detector-fixed components.
- **`artifact`** (`CFP_ART`): intra-visit detector-fixed artifact removal via detector-frame self-calibration — median-stacks the dithers of a `(visit, detector)` group by pixel index (sky-fixed signal rejects via dither motion; detector-fixed artifacts survive), then subtracts the structured residual. Self-gated by dither-count safeguards.

Wires both into `orchestrate.PROCESS_STEPS` (+ `_group_by_dither_sequence`), `field.known_steps`, the `CFP_*` chain, the nircam CLI, and the `config_default.toml` `[nircam.background]`/`[nircam.artifact]` blocks. Adds unit tests + a CHANGELOG Algorithm entry.

### Notes
- The `experiments/intravisit_artifact/` development scratch is intentionally **left untracked**.
- Expect a `cfp.py` merge conflict with #212 (which refactors `CFP_KEYS` into per-instrument keysets); resolution is to place `CFP_BKG`/`CFP_ART` into the NIRCam keyset.
- Tests not yet run to green; this is a parking checkpoint.

Generated with Claude Code

https://claude.ai/code/session_01QMm3DuLALxzNtLBUQqPfkR