### PR TITLE
feat(213): layout & key contract (campfire_layout) — PR-2 of epic #210

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,11 +5,14 @@ Guidance for Claude Code when working in this repository.
 ## Project Overview
 
 Monorepo with several main components — see each directory's README for details:
+- **`layout/`** — `campfire-layout`: the single, zero-dependency authority for the directory/key contract (local paths, storage keys, key↔path bijection, tree lifecycle). Pure-python core depended on by both `pipeline/` and `python/`; mirrored in TypeScript at `web/lib/layout.ts`. **Install this first** (it's not on PyPI).
 - **`pipeline/`** — JWST data reduction (NIRSpec + NIRCam). Local-only, no cloud dependencies.
 - **`web/`** — Next.js web portal. Deployed on Vercel.
 - **`python/`** — Unified Python package: API client, CLI, and deployment tools (including the `campfire deploy` CLI). Install with `pip install -e ".[deploy]"` for full functionality.
 
 Supporting: `supabase/` (migrations), `scripts/` (one-off utilities)
+
+**Editable install order** (in the `campfire` conda env): `pip install -e ./layout && pip install -e ./pipeline && pip install -e ./python` — `campfire-layout` must precede the two packages that depend on it.
 
 ## Pipeline
 

--- a/layout/README.md
+++ b/layout/README.md
@@ -1,0 +1,56 @@
+# campfire-layout
+
+The single authority for the CAMPFIRE directory/key contract — issue #213, PR-2 of
+epic #210 (intermediate products & cloud-as-source-of-truth).
+
+The `$CAMPFIRE_ROOT/` tree is a three-way contract between the **pipeline** (which
+creates it), the **CLI/deploy client** (which mirrors it on download and builds
+storage keys on deploy), and the **cloud + web** (whose keys must round-trip to
+it). Historically that contract was re-derived independently in each codebase and
+nothing forced agreement. This package collapses it into one tested module.
+
+## What it owns
+
+- **Local paths** — `local_path`/`local_relpath`/`dir_for` for any product under
+  `$CAMPFIRE_ROOT`, plus the tree helpers (`reference_dir`, `shared_reference_dir`,
+  `raw_dir`, `cache_path`) the pipeline workspace setup uses.
+- **Storage keys** — `storage_key`/`key_prefix`/`bucket_for`, with two schemes:
+  `LEGACY` (today's bare `spectra/<obs>/…` keys; the default through the F0/pre-OSN
+  window) and `CANONICAL` (`data/` + local relpath; flipped at the OSN cutover).
+- **The bijection** — `key_to_relpath` / `relpath_to_key` (total + reversible per
+  scheme), plus `parse_key`, `parse_relpath`, `derive_sibling`, and `is_known_key`
+  (the presign/proxy allowlist).
+- **Lifecycle** — `tree_class` classifies any path/key as cloud-product /
+  user-state / shared-calibration / external-MAST / regenerable / cli-local,
+  resolving via the product registry first (so e.g. NIRSpec manual masks are
+  user-state even though they live under `products/`).
+
+The whole contract is data: see `campfire_layout/products.py`, the declarative
+`PRODUCTS` registry. Everything else reads it.
+
+## Design constraints
+
+- **Zero runtime dependencies** (stdlib only), `requires-python >= 3.11`, so both
+  the local-only pipeline (`campfire-pipeline`, py≥3.12) and the client
+  (`campfire`, py≥3.11) can depend on it without coupling reduction to the cloud
+  client.
+- **Mirrored in TypeScript** at `web/lib/layout.ts` for the web portal. The shared
+  golden fixture `conformance/layout_golden.json` is checked by **both** the python
+  test (`pipeline/tests/test_layout.py`) and the TS test (`web/lib/layout.test.ts`),
+  so python↔TS drift fails CI.
+
+## Install (editable dev)
+
+```bash
+conda activate campfire
+pip install -e ./layout      # this package first
+pip install -e ./pipeline
+pip install -e ./python
+```
+
+## Test
+
+```bash
+conda run -n campfire python -m pytest pipeline/tests/test_layout.py -q   # python arm
+cd web && npx vitest run lib/layout.test.ts                                # TS arm
+```

--- a/layout/campfire_layout/__init__.py
+++ b/layout/campfire_layout/__init__.py
@@ -1,0 +1,69 @@
+"""campfire_layout — the single authority for the CAMPFIRE directory/key contract.
+
+One tested, zero-dependency module shared by the pipeline (``campfire_pipeline``),
+the client/deploy package (``campfire``), and — mirrored in TypeScript — the web
+portal. It owns:
+
+  (i)   the local path of any product under ``$CAMPFIRE_ROOT``;
+  (ii)  its storage key (LEGACY today, CANONICAL after the OSN re-key);
+  (iii) the bijection key ↔ local-relpath (total + reversible per scheme);
+  (iv)  a lifecycle class per top-level tree.
+
+Nobody hand-builds a path or a key: deploy/download/pipeline/web all call here.
+"""
+
+from __future__ import annotations
+
+from .bijection import (
+    ParsedKey,
+    derive_sibling,
+    is_known_key,
+    key_to_relpath,
+    parse_key,
+    parse_relpath,
+    relpath_to_key,
+)
+from .keys import bucket_for, key_prefix, storage_key
+from .lifecycle import tree_class
+from .paths import (
+    Roots,
+    cache_path,
+    campfire_root,
+    dir_for,
+    glob_pattern,
+    local_path,
+    local_relpath,
+    raw_dir,
+    raw_path,
+    reference_dir,
+    roots,
+    shared_reference_dir,
+)
+from .products import PRODUCTS, ProductSpec, get
+from .scope import (
+    Instrument,
+    KeyScheme,
+    LayoutError,
+    LifecycleClass,
+    Scope,
+)
+
+__all__ = [
+    # vocabulary
+    "Instrument", "KeyScheme", "LayoutError", "LifecycleClass", "Scope",
+    # registry
+    "PRODUCTS", "ProductSpec", "get",
+    # paths
+    "Roots", "roots", "campfire_root", "dir_for", "local_path", "local_relpath",
+    "reference_dir", "shared_reference_dir", "raw_dir", "raw_path", "cache_path",
+    "glob_pattern",
+    # keys
+    "bucket_for", "key_prefix", "storage_key",
+    # bijection
+    "ParsedKey", "parse_key", "parse_relpath", "key_to_relpath", "relpath_to_key",
+    "derive_sibling", "is_known_key",
+    # lifecycle
+    "tree_class",
+]
+
+__version__ = "0.1.0"

--- a/layout/campfire_layout/bijection.py
+++ b/layout/campfire_layout/bijection.py
@@ -1,0 +1,260 @@
+"""The key ↔ local-relpath bijection (total + reversible per scheme).
+
+The forward builders (:mod:`paths`, :mod:`keys`) and these reverse parsers must
+agree exactly — the golden conformance test pins the round-trip. The legacy
+asymmetry the parsers encode: ``spectra/``, ``rgb/``, ``sed/`` keys all map to the
+*same* disk dir ``products/nirspec/<obs>/`` and are told apart only by the
+filename suffix, so ``key_to_relpath`` dispatches on key *prefix* while
+``relpath_to_key`` dispatches on basename *suffix*.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+from . import keys as _keys
+from . import paths as _paths
+from . import products
+from .scope import KeyScheme, LayoutError, Scope
+
+
+@dataclass(frozen=True)
+class ParsedKey:
+    product_type: str
+    scope: Scope
+    filename: str
+
+
+# Ordered suffix tables (most specific first). Within one directory context, a
+# filename is matched against these to recover its product_type.
+_NIRSPEC_OBS_SUFFIXES = (
+    ("_spec.fits", "nirspec_spec"),
+    ("_spec.json", "spectrum_json"),
+    ("_zfit.json", "zfit"),
+    ("_rgb.png", "rgb"),
+    ("_sed.pdf", "sed"),
+    ("_summary.ecsv", "summary"),
+    ("_pointings.ecsv", "pointings"),
+    ("_shutters.ecsv", "shutters"),
+    ("_config.toml", "nirspec_config"),
+)
+_NIRCAM_FILTER_SUFFIXES = (
+    ("_preview.png", "nircam_exposure_preview"),
+    ("_full.png", "nircam_exposure_full"),
+)
+_EXPOSURE_RE = re.compile(r"_nrs[12]_\d+\.fits$")
+_TILE_RE = re.compile(r"^(?P<field>[^/]+)/(?P<filt>[^/]+)/(?P<z>\d+)/(?P<x>\d+)/(?P<y>\d+)\.png$")
+
+
+def _dispatch(fname: str, table, fallback: Optional[str] = None) -> Optional[str]:
+    for suffix, ptype in table:
+        if fname.endswith(suffix):
+            return ptype
+    return fallback
+
+
+def _nirspec_obs_product(fname: str) -> str:
+    ptype = _dispatch(fname, _NIRSPEC_OBS_SUFFIXES)
+    if ptype:
+        return ptype
+    if fname.endswith(".fits"):
+        return "nirspec_spectrum_exposure"
+    raise LayoutError(f"unrecognized NIRSpec product filename '{fname}'")
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def _reject_unsafe(key: str) -> None:
+    if not key or key.startswith("/") or "\\" in key:
+        raise LayoutError(f"unsafe key '{key}'")
+    parts = key.split("/")
+    if any(p in ("", ".", "..") for p in parts):
+        raise LayoutError(f"unsafe key '{key}' (empty or traversal segment)")
+
+
+# ---------------------------------------------------------------------------
+# Relpath parsing (for canonical keys + download placement)
+# ---------------------------------------------------------------------------
+
+def parse_relpath(relpath: str) -> ParsedKey:
+    """Recover (product_type, scope, filename) from a local relpath."""
+    _reject_unsafe(relpath)
+    seg = relpath.split("/")
+    tree = seg[0]
+
+    if tree == "products" and len(seg) >= 4 and seg[1] == "nirspec":
+        obs = seg[2]
+        if len(seg) == 5 and seg[3] == "manual_masks":
+            return ParsedKey("nirspec_manual_mask", Scope(obs=obs), seg[4])
+        if len(seg) == 4:
+            fname = seg[3]
+            return ParsedKey(_nirspec_obs_product(fname), Scope(obs=obs), fname)
+
+    if tree == "products" and len(seg) >= 4 and seg[1] == "nircam":
+        field = seg[2]
+        if len(seg) == 4 and seg[3].endswith("_rgb.png"):
+            return ParsedKey("nircam_rgb", Scope(field=field), seg[3])
+        if len(seg) == 5 and seg[3] == "expmaps":
+            return ParsedKey("nircam_expmap", Scope(field=field), seg[4])
+        if len(seg) == 5:
+            filt, fname = seg[3], seg[4]
+            scope = Scope(field=field, filt=filt)
+            ptype = _dispatch(fname, _NIRCAM_FILTER_SUFFIXES)
+            if ptype:
+                return ParsedKey(ptype, scope, fname)
+            if fname.startswith("mosaic"):
+                return ParsedKey("nircam_mosaic", scope, fname)
+            if fname.endswith(".fits"):
+                return ParsedKey("nircam_exposure", scope, fname)
+
+    if tree == "reference" and len(seg) >= 4 and seg[1] == "nirspec":
+        obs = seg[2]
+        fname = seg[-1]
+        if fname == "stuck_closed_shutters.toml":
+            return ParsedKey("nirspec_stuck_shutters", Scope(obs=obs), fname)
+        if fname == "nodded_background_overrides.toml":
+            return ParsedKey("nirspec_bkg_override", Scope(obs=obs), fname)
+
+    if tree == "reference" and len(seg) >= 4 and seg[1] == "nircam":
+        if seg[2] == "shared" and len(seg) == 5:
+            fname = seg[4]
+            if seg[3] == "flats":
+                return ParsedKey("nircam_flat", Scope(), fname)
+            if seg[3] == "wisps":
+                return ParsedKey("nircam_wisp", Scope(), fname)
+        else:
+            field = seg[2]
+            kind = seg[3] if len(seg) >= 4 else None
+            fname = seg[-1]
+            if kind == "masks":
+                return ParsedKey("nircam_mask", Scope(field=field), fname)
+            if kind == "astrom_cats":
+                return ParsedKey("nircam_astrom_cat", Scope(field=field), fname)
+            if kind == "bad_pixels":
+                return ParsedKey("nircam_bad_pixel", Scope(field=field), fname)
+
+    if tree == "tiles" and len(seg) == 6 and seg[5].endswith(".png"):
+        return ParsedKey(
+            "tile",
+            Scope(field=seg[1], filt=seg[2], zoom=int(seg[3]), x=int(seg[4]),
+                  y=int(seg[5].removesuffix(".png"))),
+            seg[5],
+        )
+
+    if tree == "raw" and len(seg) >= 4 and seg[1] == "nirspec":
+        return ParsedKey("raw_nirspec", Scope(data_subdir=seg[2]), seg[-1])
+    if tree == "raw" and len(seg) >= 5 and seg[1] == "nircam":
+        return ParsedKey("raw_nircam", Scope(pid=seg[2], filt=seg[3]), seg[-1])
+
+    raise LayoutError(f"unrecognized relpath '{relpath}'")
+
+
+# ---------------------------------------------------------------------------
+# Key parsing
+# ---------------------------------------------------------------------------
+
+def parse_key(key: str, *, bucket: Optional[str] = None) -> ParsedKey:
+    """Recover (product_type, scope, filename) from a storage key.
+
+    Handles canonical (``data/…``) keys, today's legacy keys, and tile keys.
+    """
+    _reject_unsafe(key)
+
+    # Canonical data-bucket key: 'data/' + relpath (mirrored products), or
+    # 'data/' + legacy-form prefix (key-only products like photometry, which have
+    # no local relpath to mirror).
+    if key.startswith("data/"):
+        rest = key[len("data/"):]
+        try:
+            return parse_relpath(rest)
+        except LayoutError:
+            return _parse_legacy_key(rest, bucket=bucket)
+
+    return _parse_legacy_key(key, bucket=bucket)
+
+
+def _parse_legacy_key(key: str, *, bucket: Optional[str] = None) -> ParsedKey:
+    """Dispatch a today's-scheme (legacy) key on its prefix."""
+    seg = key.split("/")
+
+    # Legacy data-bucket keys (prefix dispatch).
+    if seg[0] == "spectra" and len(seg) == 3:
+        return ParsedKey(_nirspec_obs_product(seg[2]), Scope(obs=seg[1]), seg[2])
+    if seg[0] == "rgb" and len(seg) == 3:
+        return ParsedKey("rgb", Scope(obs=seg[1]), seg[2])
+    if seg[0] == "sed" and len(seg) == 3:
+        return ParsedKey("sed", Scope(obs=seg[1]), seg[2])
+    if seg[0] == "nircam" and len(seg) == 5 and seg[1] == "exposures":
+        ptype = _dispatch(seg[4], _NIRCAM_FILTER_SUFFIXES)
+        if ptype:
+            return ParsedKey(ptype, Scope(field=seg[2], filt=seg[3]), seg[4])
+    if seg[0] == "photometry" and len(seg) == 3:
+        return ParsedKey("photometry_pz", Scope(field=seg[1], object_id=seg[2].removesuffix("_pz.json")), seg[2])
+
+    # Tile keys (separate bucket, no prefix).
+    if bucket == "tiles" or _TILE_RE.match(key):
+        m = _TILE_RE.match(key)
+        if m:
+            return ParsedKey(
+                "tile",
+                Scope(field=m["field"], filt=m["filt"], zoom=int(m["z"]), x=int(m["x"]), y=int(m["y"])),
+                f'{m["y"]}.png',
+            )
+
+    raise LayoutError(f"unrecognized storage key '{key}'")
+
+
+# ---------------------------------------------------------------------------
+# Public bijection API
+# ---------------------------------------------------------------------------
+
+def key_to_relpath(key: str, *, bucket: str = "data") -> str:
+    """Map a storage key to its local relpath (raises for key-only products)."""
+    pk = parse_key(key, bucket=bucket)
+    return _paths.local_relpath(pk.product_type, pk.scope, pk.filename)
+
+
+def relpath_to_key(relpath: str, *, scheme: KeyScheme = KeyScheme.LEGACY) -> str:
+    """Map a local relpath to its storage key under the given scheme."""
+    pk = parse_relpath(relpath)
+    return _keys.storage_key(pk.product_type, pk.scope, pk.filename, scheme=scheme)
+
+
+def derive_sibling(key: str, target_product_type: str, *, bucket: Optional[str] = None) -> str:
+    """Co-located sibling key, e.g. a spec key → its zfit/json key.
+
+    Preserves the source key's prefix and scheme; only the filename suffix changes.
+    """
+    pk = parse_key(key, bucket=bucket)
+    src = products.get(pk.product_type)
+    tgt = products.get(target_product_type)
+    if src.suffix is None or tgt.suffix is None:
+        raise LayoutError(
+            f"cannot derive sibling between '{pk.product_type}' and "
+            f"'{target_product_type}' (a suffix discriminator is undefined)"
+        )
+    base = pk.filename[: -len(src.suffix)]
+    new_fname = f"{base}{tgt.suffix}"
+    prefix = key.rsplit("/", 1)[0]
+    return f"{prefix}/{new_fname}"
+
+
+def is_known_key(key: str, *, bucket: Optional[str] = None) -> bool:
+    """True iff *key* parses to a cloud-backed product (presign/proxy allowlist).
+
+    Rejects traversal/unsafe keys and keys that resolve to non-cloud products.
+    """
+    try:
+        pk = parse_key(key, bucket=bucket)
+    except LayoutError:
+        return False
+    spec = products.get(pk.product_type)
+    if spec.bucket is None:
+        return False
+    if bucket is not None and spec.bucket != bucket:
+        return False
+    return True

--- a/layout/campfire_layout/keys.py
+++ b/layout/campfire_layout/keys.py
@@ -1,0 +1,68 @@
+"""Storage-key construction.
+
+A storage key is the object's address in a bucket. Two schemes coexist (see
+:class:`~campfire_layout.scope.KeyScheme`):
+
+* ``LEGACY`` — today's bare keys (``spectra/<obs>/…``) for products that already
+  have them; reserved products fall back to the canonical form.
+* ``CANONICAL`` — data-bucket key is ``data/`` + the local relpath; tiles keys are
+  unchanged (they stay on R2).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from . import products
+from .scope import KeyScheme, LayoutError, Scope
+
+
+def bucket_for(product_type: str) -> str:
+    """Return the bucket ('data' | 'tiles') for a cloud-backed product."""
+    spec = products.get(product_type)
+    if spec.bucket is None:
+        raise LayoutError(
+            f"product '{product_type}' is not cloud-backed (no storage key)"
+        )
+    return spec.bucket
+
+
+def key_prefix(product_type: str, scope: Scope, *,
+               scheme: KeyScheme = KeyScheme.LEGACY) -> str:
+    """Key prefix (everything before the filename) — for list/delete/clean.
+
+    No trailing slash; callers that prefix-list add one.
+    """
+    spec = products.get(product_type)
+    if spec.bucket is None:
+        raise LayoutError(f"product '{product_type}' is not cloud-backed (no storage key)")
+    spec.validate(scope)
+
+    # Tiles are scheme-invariant and never gain a 'data/' prefix (they stay on R2).
+    if spec.scheme_invariant:
+        return spec.legacy_prefix(scope)
+
+    # Legacy scheme reproduces today's key for products that already have one.
+    if scheme is KeyScheme.LEGACY and spec.legacy_prefix is not None:
+        return spec.legacy_prefix(scope)
+
+    # CANONICAL (or a reserved product, which adopts the canonical form in both
+    # schemes since there is no legacy key to preserve).
+    if spec.mirrored:
+        # data-bucket canonical key = 'data/' + local relative dir.
+        return f"data/{spec.rel_dir(scope)}"
+    if spec.legacy_prefix is not None:
+        # key-only product (no disk relpath to mirror): canonical = 'data/' + legacy prefix.
+        return f"data/{spec.legacy_prefix(scope)}"
+    raise LayoutError(
+        f"product '{product_type}' has neither a local path nor a legacy key — "
+        f"cannot form a canonical storage key"
+    )
+
+
+def storage_key(product_type: str, scope: Scope, filename: Optional[str] = None, *,
+                scheme: KeyScheme = KeyScheme.LEGACY) -> str:
+    """Full storage key for a single object."""
+    spec = products.get(product_type)
+    fname = spec.resolve_filename(scope, filename)
+    return f"{key_prefix(product_type, scope, scheme=scheme)}/{fname}"

--- a/layout/campfire_layout/lifecycle.py
+++ b/layout/campfire_layout/lifecycle.py
@@ -1,0 +1,41 @@
+"""Lifecycle classification of a tree / path / key.
+
+Resolves via the registry first (so a product is classified by *what it is*, not
+merely which top-level dir it sits in — e.g. NIRSpec manual masks live under
+``products/`` but are USER_STATE, which ``delete-local`` must never treat as a
+regenerable product). Falls back to a top-level-dir heuristic for paths the
+registry doesn't recognize.
+"""
+
+from __future__ import annotations
+
+from . import bijection, products
+from .scope import LayoutError, LifecycleClass
+
+# Top-level-dir fallback for unrecognized paths/keys.
+_TREE_FALLBACK = {
+    "products": LifecycleClass.CLOUD_PRODUCT,
+    "tiles": LifecycleClass.CLOUD_PRODUCT,
+    "reference": LifecycleClass.USER_STATE,
+    "raw": LifecycleClass.EXTERNAL_MAST,
+    "cache": LifecycleClass.REGENERABLE,
+    "meta": LifecycleClass.CLI_LOCAL,
+    "cutouts": LifecycleClass.CLI_LOCAL,
+}
+
+
+def tree_class(path_or_key: str) -> LifecycleClass:
+    """Lifecycle class for a relpath or a storage key."""
+    # Registry-first: try relpath, then key.
+    for parse in (bijection.parse_relpath, bijection.parse_key):
+        try:
+            pk = parse(path_or_key)
+        except LayoutError:
+            continue
+        return products.get(pk.product_type).lifecycle
+
+    # Fallback: classify by the top-level tree segment.
+    top = path_or_key.split("/", 1)[0]
+    if top in _TREE_FALLBACK:
+        return _TREE_FALLBACK[top]
+    raise LayoutError(f"cannot classify lifecycle for '{path_or_key}'")

--- a/layout/campfire_layout/paths.py
+++ b/layout/campfire_layout/paths.py
@@ -1,0 +1,171 @@
+"""Local filesystem path resolution under ``$CAMPFIRE_ROOT``.
+
+Every path the pipeline writes/globs and the client mirrors on download resolves
+here. Results are absolute ``Path`` objects (joined onto the resolved root) unless
+a ``*_relpath`` helper is used, which returns the POSIX-relative form the storage
+keys and the conformance fixture compare against.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path, PurePosixPath
+from typing import Mapping, Optional
+
+from . import products
+from .scope import Instrument, LayoutError, Scope
+
+
+def campfire_root(env: Optional[Mapping[str, str]] = None) -> Path:
+    """Resolve ``$CAMPFIRE_ROOT`` (default ``~/campfire``).
+
+    Accepts an explicit env mapping for testability; defaults to ``os.environ``.
+    """
+    e = os.environ if env is None else env
+    return Path(e.get("CAMPFIRE_ROOT") or (Path.home() / "campfire"))
+
+
+# Top-level tree segments, keyed by the name the registry uses.
+_TREES = ("raw", "products", "reference", "cache", "tiles", "meta", "cutouts")
+
+
+class Roots:
+    """The resolved top-level directories under one ``$CAMPFIRE_ROOT``."""
+
+    __slots__ = ("campfire_root", *_TREES)
+
+    def __init__(self, root: Path):
+        self.campfire_root = root
+        for tree in _TREES:
+            setattr(self, tree, root / tree)
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return f"Roots({self.campfire_root})"
+
+
+def roots(root: Optional[Path] = None, *, env: Optional[Mapping[str, str]] = None) -> Roots:
+    """Return the :class:`Roots` for ``root`` (or the resolved CAMPFIRE_ROOT)."""
+    return Roots(Path(root) if root is not None else campfire_root(env))
+
+
+def _instrument_value(instrument) -> str:
+    return instrument.value if isinstance(instrument, Instrument) else str(instrument)
+
+
+# ---------------------------------------------------------------------------
+# Product paths
+# ---------------------------------------------------------------------------
+
+def local_relpath(product_type: str, scope: Scope, filename: Optional[str] = None) -> str:
+    """POSIX path of a product relative to ``$CAMPFIRE_ROOT``.
+
+    Raises :class:`LayoutError` for key-only products (``mirrored=False``).
+    """
+    spec = products.get(product_type)
+    if not spec.mirrored:
+        raise LayoutError(
+            f"product '{product_type}' has no local path (it is key-only: "
+            f"generated at deploy and stored only in the bucket)"
+        )
+    fname = spec.resolve_filename(scope, filename)
+    return f"{spec.rel_dir(scope)}/{fname}"
+
+
+def dir_for(product_type: str, scope: Scope, *, root: Optional[Path] = None) -> Path:
+    """Absolute directory holding a product type for the given scope."""
+    spec = products.get(product_type)
+    if not spec.mirrored:
+        raise LayoutError(f"product '{product_type}' has no local directory (key-only)")
+    return roots(root).campfire_root / PurePosixPath(spec.rel_dir(scope))
+
+
+def local_path(product_type: str, scope: Scope, filename: Optional[str] = None,
+               *, root: Optional[Path] = None) -> Path:
+    """Absolute path of a single product file."""
+    return roots(root).campfire_root / PurePosixPath(local_relpath(product_type, scope, filename))
+
+
+# ---------------------------------------------------------------------------
+# Tree-level helpers (span products, used by Observation/Field setup)
+# ---------------------------------------------------------------------------
+
+def reference_dir(instrument, scope: Scope, *, root: Optional[Path] = None) -> Path:
+    """Per-scope reducer-decision reference dir (``reference/<inst>/<scope>``)."""
+    inst = _instrument_value(instrument)
+    if inst == Instrument.NIRSPEC.value:
+        scope.require("obs")
+        rel = f"reference/nirspec/{scope.obs}"
+    elif inst == Instrument.NIRCAM.value:
+        scope.require("field")
+        rel = f"reference/nircam/{scope.field}"
+    else:
+        raise LayoutError(f"unknown instrument '{inst}'")
+    return roots(root).campfire_root / PurePosixPath(rel)
+
+
+def shared_reference_dir(instrument, *, root: Optional[Path] = None) -> Path:
+    """Shared (de-fielded) calibration-reference dir (``reference/<inst>/shared``)."""
+    inst = _instrument_value(instrument)
+    if inst != Instrument.NIRCAM.value:
+        raise LayoutError(f"no shared reference tree for instrument '{inst}'")
+    return roots(root).campfire_root / "reference" / "nircam" / "shared"
+
+
+def raw_dir(instrument=None, scope: Optional[Scope] = None, *,
+            root: Optional[Path] = None) -> Path:
+    """Raw (MAST) directory.
+
+    With no instrument: the ``raw/`` root. With an instrument + scope: the
+    instrument-partitioned raw dir the pipeline globs and the downloader writes
+    (NIRSpec by ``data_subdir``, NIRCam by ``(pid, filt)``).
+    """
+    base = roots(root).campfire_root / "raw"
+    if instrument is None:
+        return base
+    inst = _instrument_value(instrument)
+    if inst == Instrument.NIRSPEC.value:
+        scope = scope or Scope()
+        if scope.data_subdir is None:
+            return base / "nirspec"
+        return base / "nirspec" / scope.data_subdir
+    if inst == Instrument.NIRCAM.value:
+        scope = scope or Scope()
+        if scope.pid is None:
+            return base / "nircam"
+        sub = base / "nircam" / scope.pid
+        return sub / scope.filt if scope.filt is not None else sub
+    raise LayoutError(f"unknown instrument '{inst}'")
+
+
+def raw_path(instrument, scope: Scope, filename: str, *, root: Optional[Path] = None) -> Path:
+    """Absolute path of a single raw file (where download writes / pipeline reads)."""
+    return raw_dir(instrument, scope, root=root) / filename
+
+
+# Cache sub-kinds the contract governs under cache/. (Other regenerable caches
+# with idiosyncratic flat names — e.g. empirical wavecorr / extended-wavelength
+# asdf — are intentionally left to their call sites; they are not part of the
+# layout contract and relocating them would change behavior for no benefit.)
+_CACHE_KINDS = {
+    "crds": "crds",
+    "templates": "templates",
+}
+
+
+def cache_path(kind: str, filename: Optional[str] = None, *,
+               root: Optional[Path] = None) -> Path:
+    """Absolute path under ``cache/`` for a regenerable artifact."""
+    if kind not in _CACHE_KINDS:
+        raise LayoutError(f"unknown cache kind '{kind}'. Known: {sorted(_CACHE_KINDS)}")
+    base = roots(root).campfire_root / "cache" / _CACHE_KINDS[kind]
+    return base / filename if filename else base
+
+
+def glob_pattern(product_type: str, scope: Scope, suffix: str, *,
+                 root: Optional[Path] = None) -> str:
+    """Absolute glob pattern for files of a product type in a scope's dir.
+
+    ``suffix`` is appended to the product directory (caller supplies the wildcard,
+    e.g. ``'*_uncal.fits'``).
+    """
+    return str(dir_for(product_type, scope, root=root) / suffix)

--- a/layout/campfire_layout/products.py
+++ b/layout/campfire_layout/products.py
@@ -1,0 +1,285 @@
+"""The product registry — the single declarative table the whole contract reads.
+
+One :class:`ProductSpec` per ``product_type``. Everything else (paths, keys, the
+bijection, lifecycle classification) is computed from this table, so adding or
+changing a product is a one-line edit here plus a golden-fixture row.
+
+Naming aligns to the planned ``storage_objects.product_type`` enum where one
+exists, with clear new names where it does not (the enum is incomplete for real
+products — see design §5.1). Products fall into three key tiers:
+
+* **legacy-keyed** — uploaded today under a bare key (``spectra/``, ``rgb/``,
+  ``sed/``, ``nircam/exposures/``, ``photometry/``, and tiles). ``legacy_prefix``
+  is set; the LEGACY scheme reproduces today's key exactly.
+* **reserved** — has a local home but is not in the bucket yet (NIRSpec/NIRCam
+  exposure intermediates, all of ``reference/``). ``legacy_prefix`` is ``None``;
+  ``storage_key`` returns the CANONICAL form in both schemes (no legacy key to
+  preserve), so F1/B2 can adopt it later without a rename.
+* **not cloud-backed** — ``bucket is None`` (raw → MAST, cache → regenerable,
+  meta/cutouts → CLI-local). No storage key; ``storage_key`` raises.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+from .scope import Instrument, LayoutError, LifecycleClass, Scope
+
+# A subdir/filename builder takes a (validated) Scope and returns a POSIX path
+# fragment with no leading or trailing slash.
+_Builder = Callable[[Scope], str]
+
+
+@dataclass(frozen=True)
+class ProductSpec:
+    name: str
+    tree: str                            # top-level: products|reference|raw|cache|tiles|meta|cutouts
+    lifecycle: LifecycleClass
+    scope_keys: tuple[str, ...]
+    subdir: _Builder                     # dir under the tree, e.g. 'nirspec/<obs>'
+    instrument: Optional[Instrument] = None
+    bucket: Optional[str] = None         # 'data' | 'tiles' | None (not cloud-backed)
+    suffix: Optional[str] = None         # filename discriminator for reverse dispatch
+    legacy_prefix: Optional[_Builder] = None   # legacy key prefix, or None (reserved)
+    filename: Optional[_Builder] = None  # builder for fully-scoped products (tile, photometry)
+    mirrored: bool = True                # has a local relpath (False = key-only, e.g. photometry)
+    scheme_invariant: bool = False       # key identical across schemes (tiles stay on R2)
+
+    def validate(self, scope: Scope) -> None:
+        scope.require(*self.scope_keys)
+
+    def rel_dir(self, scope: Scope) -> str:
+        """Local directory relative to ``$CAMPFIRE_ROOT`` (incl. tree segment)."""
+        self.validate(scope)
+        sub = self.subdir(scope)
+        return f"{self.tree}/{sub}" if sub else self.tree
+
+    def resolve_filename(self, scope: Scope, filename: Optional[str]) -> str:
+        if filename is not None:
+            return filename
+        if self.filename is not None:
+            return self.filename(scope)
+        raise LayoutError(
+            f"product '{self.name}' requires an explicit filename "
+            f"(it has no scope-derived filename builder)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+NS = Instrument.NIRSPEC
+NC = Instrument.NIRCAM
+LC = LifecycleClass
+
+PRODUCTS: dict[str, ProductSpec] = {}
+
+
+def _register(spec: ProductSpec) -> ProductSpec:
+    if spec.name in PRODUCTS:
+        raise LayoutError(f"duplicate product_type '{spec.name}'")
+    PRODUCTS[spec.name] = spec
+    return spec
+
+
+def _nirspec_obs_dir(s: Scope) -> str:
+    return f"nirspec/{s.obs}"
+
+
+def _nircam_field_filter_dir(s: Scope) -> str:
+    return f"nircam/{s.field}/{s.filt}"
+
+
+def _nircam_field_dir(s: Scope) -> str:
+    return f"nircam/{s.field}"
+
+
+# --- NIRSpec products/ (the spectrum family shares products/nirspec/<obs>/) -------
+
+_register(ProductSpec(
+    name="nirspec_spec", instrument=NS, tree="products", bucket="data",
+    lifecycle=LC.CLOUD_PRODUCT, scope_keys=("obs",), subdir=_nirspec_obs_dir,
+    suffix="_spec.fits", legacy_prefix=lambda s: f"spectra/{s.obs}",
+))
+_register(ProductSpec(
+    name="spectrum_json", instrument=NS, tree="products", bucket="data",
+    lifecycle=LC.CLOUD_PRODUCT, scope_keys=("obs",), subdir=_nirspec_obs_dir,
+    suffix="_spec.json", legacy_prefix=lambda s: f"spectra/{s.obs}",
+))
+_register(ProductSpec(
+    name="zfit", instrument=NS, tree="products", bucket="data",
+    lifecycle=LC.CLOUD_PRODUCT, scope_keys=("obs",), subdir=_nirspec_obs_dir,
+    suffix="_zfit.json", legacy_prefix=lambda s: f"spectra/{s.obs}",
+))
+# The 4->1 canonical spectrum-exposure (#212). A reduction intermediate, not yet
+# deployed: reserved key, real local home (bare '<root>_<nrsN>_<source>.fits').
+_register(ProductSpec(
+    name="nirspec_spectrum_exposure", instrument=NS, tree="products", bucket="data",
+    lifecycle=LC.CLOUD_PRODUCT, scope_keys=("obs",), subdir=_nirspec_obs_dir,
+    suffix=".fits", legacy_prefix=None,
+))
+# Per-object visualizations, keyed by obs (legacy keys live in their own prefixes
+# but mirror locally into the obs products dir).
+_register(ProductSpec(
+    name="rgb", instrument=NS, tree="products", bucket="data",
+    lifecycle=LC.CLOUD_PRODUCT, scope_keys=("obs",), subdir=_nirspec_obs_dir,
+    suffix="_rgb.png", legacy_prefix=lambda s: f"rgb/{s.obs}",
+))
+_register(ProductSpec(
+    name="sed", instrument=NS, tree="products", bucket="data",
+    lifecycle=LC.CLOUD_PRODUCT, scope_keys=("obs",), subdir=_nirspec_obs_dir,
+    suffix="_sed.pdf", legacy_prefix=lambda s: f"sed/{s.obs}",
+))
+
+# --- NIRCam products/ -----------------------------------------------------------
+
+# Canonical per-exposure FITS (mutated in place). Reserved key (PNGs are what
+# ship today); real local home under products/nircam/<field>/<filter>/.
+_register(ProductSpec(
+    name="nircam_exposure", instrument=NC, tree="products", bucket="data",
+    lifecycle=LC.CLOUD_PRODUCT, scope_keys=("field", "filt"),
+    subdir=_nircam_field_filter_dir, suffix=".fits", legacy_prefix=None,
+))
+_register(ProductSpec(
+    name="nircam_exposure_preview", instrument=NC, tree="products", bucket="data",
+    lifecycle=LC.CLOUD_PRODUCT, scope_keys=("field", "filt"),
+    subdir=_nircam_field_filter_dir, suffix="_preview.png",
+    legacy_prefix=lambda s: f"nircam/exposures/{s.field}/{s.filt}",
+))
+_register(ProductSpec(
+    name="nircam_exposure_full", instrument=NC, tree="products", bucket="data",
+    lifecycle=LC.CLOUD_PRODUCT, scope_keys=("field", "filt"),
+    subdir=_nircam_field_filter_dir, suffix="_full.png",
+    legacy_prefix=lambda s: f"nircam/exposures/{s.field}/{s.filt}",
+))
+# Drizzled mosaic outputs + their JSON manifests (mosaic_*). Reserved key.
+_register(ProductSpec(
+    name="nircam_mosaic", instrument=NC, tree="products", bucket="data",
+    lifecycle=LC.CLOUD_PRODUCT, scope_keys=("field", "filt"),
+    subdir=_nircam_field_filter_dir, suffix=None, legacy_prefix=None,
+))
+# Field-tile RGB (distinct product from the per-object 'rgb' above).
+_register(ProductSpec(
+    name="nircam_rgb", instrument=NC, tree="products", bucket="data",
+    lifecycle=LC.CLOUD_PRODUCT, scope_keys=("field",), subdir=_nircam_field_dir,
+    suffix="_rgb.png", legacy_prefix=None,
+))
+# Exposure-coverage maps.
+_register(ProductSpec(
+    name="nircam_expmap", instrument=NC, tree="products", bucket="data",
+    lifecycle=LC.CLOUD_PRODUCT, scope_keys=("field",),
+    subdir=lambda s: f"nircam/{s.field}/expmaps", suffix=None, legacy_prefix=None,
+))
+
+# --- Map tiles (separate 'tiles' bucket, scheme-invariant, stays on R2) ---------
+
+_register(ProductSpec(
+    name="tile", instrument=NC, tree="tiles", bucket="tiles",
+    lifecycle=LC.CLOUD_PRODUCT, scope_keys=("field", "filt", "zoom", "x", "y"),
+    subdir=lambda s: f"{s.field}/{s.filt}/{s.zoom}/{s.x}",
+    filename=lambda s: f"{s.y}.png", suffix=".png",
+    legacy_prefix=lambda s: f"{s.field}/{s.filt}/{s.zoom}/{s.x}",
+    scheme_invariant=True,
+))
+
+# --- Photometry (key-only: generated at deploy, no durable local home) ----------
+
+_register(ProductSpec(
+    name="photometry_pz", instrument=None, tree="products", bucket="data",
+    lifecycle=LC.CLOUD_PRODUCT, scope_keys=("field", "object_id"),
+    subdir=lambda s: f"photometry/{s.field}",
+    filename=lambda s: f"{s.object_id}_pz.json", suffix="_pz.json",
+    legacy_prefix=lambda s: f"photometry/{s.field}", mirrored=False,
+))
+
+# --- Metadata (Postgres-resident / CLI-local; no storage key) -------------------
+
+for _name, _suffix in (
+    ("summary", "_summary.ecsv"),
+    ("pointings", "_pointings.ecsv"),
+    ("shutters", "_shutters.ecsv"),
+    ("nirspec_config", "_config.toml"),
+):
+    _register(ProductSpec(
+        name=_name, instrument=NS, tree="products", bucket=None,
+        lifecycle=LC.CLOUD_PRODUCT, scope_keys=("obs",), subdir=_nirspec_obs_dir,
+        suffix=_suffix, filename=(lambda s, _sfx=_suffix: f"{s.obs}{_sfx}"),
+    ))
+
+# --- reducer-decision reference state (user-state; reserved cloud key) -----------
+
+_register(ProductSpec(
+    name="nirspec_manual_mask", instrument=NS, tree="products", bucket="data",
+    lifecycle=LC.USER_STATE, scope_keys=("obs",),
+    subdir=lambda s: f"nirspec/{s.obs}/manual_masks", suffix=".reg",
+    legacy_prefix=None,
+))
+_register(ProductSpec(
+    name="nirspec_stuck_shutters", instrument=NS, tree="reference", bucket="data",
+    lifecycle=LC.USER_STATE, scope_keys=("obs",), subdir=_nirspec_obs_dir,
+    suffix="stuck_closed_shutters.toml",
+    filename=lambda s: "stuck_closed_shutters.toml", legacy_prefix=None,
+))
+_register(ProductSpec(
+    name="nirspec_bkg_override", instrument=NS, tree="reference", bucket="data",
+    lifecycle=LC.USER_STATE, scope_keys=("obs",), subdir=_nirspec_obs_dir,
+    suffix="nodded_background_overrides.toml",
+    filename=lambda s: "nodded_background_overrides.toml", legacy_prefix=None,
+))
+_register(ProductSpec(
+    name="nircam_mask", instrument=NC, tree="reference", bucket="data",
+    lifecycle=LC.USER_STATE, scope_keys=("field",),
+    subdir=lambda s: f"nircam/{s.field}/masks", legacy_prefix=None,
+))
+_register(ProductSpec(
+    name="nircam_astrom_cat", instrument=NC, tree="reference", bucket="data",
+    lifecycle=LC.USER_STATE, scope_keys=("field",),
+    subdir=lambda s: f"nircam/{s.field}/astrom_cats", legacy_prefix=None,
+))
+_register(ProductSpec(
+    name="nircam_bad_pixel", instrument=NC, tree="reference", bucket="data",
+    lifecycle=LC.USER_STATE, scope_keys=("field",),
+    subdir=lambda s: f"nircam/{s.field}/bad_pixels", legacy_prefix=None,
+))
+
+# --- shared calibration references (detector/filter-scoped, deduped by hash) -----
+
+_register(ProductSpec(
+    name="nircam_flat", instrument=NC, tree="reference", bucket="data",
+    lifecycle=LC.SHARED_CALIBRATION, scope_keys=(),
+    subdir=lambda s: "nircam/shared/flats", legacy_prefix=None,
+))
+_register(ProductSpec(
+    name="nircam_wisp", instrument=NC, tree="reference", bucket="data",
+    lifecycle=LC.SHARED_CALIBRATION, scope_keys=(),
+    subdir=lambda s: "nircam/shared/wisps", legacy_prefix=None,
+))
+
+# --- raw (external/MAST; not cloud-backed) --------------------------------------
+
+_register(ProductSpec(
+    name="raw_nirspec", instrument=NS, tree="raw", bucket=None,
+    lifecycle=LC.EXTERNAL_MAST, scope_keys=("data_subdir",),
+    subdir=lambda s: f"nirspec/{s.data_subdir}",
+))
+_register(ProductSpec(
+    name="raw_nircam", instrument=NC, tree="raw", bucket=None,
+    lifecycle=LC.EXTERNAL_MAST, scope_keys=("pid", "filt"),
+    subdir=lambda s: f"nircam/{s.pid}/{s.filt}",
+))
+
+
+# ---------------------------------------------------------------------------
+# Lookup helpers
+# ---------------------------------------------------------------------------
+
+def get(product_type: str) -> ProductSpec:
+    try:
+        return PRODUCTS[product_type]
+    except KeyError:
+        raise LayoutError(
+            f"unknown product_type '{product_type}'. "
+            f"Known: {sorted(PRODUCTS)}"
+        ) from None

--- a/layout/campfire_layout/scope.py
+++ b/layout/campfire_layout/scope.py
@@ -1,0 +1,96 @@
+"""Vocabulary for the CAMPFIRE layout contract.
+
+This module is the bottom of the dependency graph: pure enums + the ``Scope``
+identity record + the package error type. No other ``campfire_layout`` module is
+imported here, so it is safe for everything else to import from it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from enum import Enum
+
+
+class LayoutError(ValueError):
+    """Raised when a product/scope/key/path cannot be resolved by the contract.
+
+    A subclass of ``ValueError`` so existing ``except ValueError`` call sites keep
+    working, while callers that care can catch the specific type.
+    """
+
+
+class Instrument(str, Enum):
+    NIRSPEC = "nirspec"
+    NIRCAM = "nircam"
+
+
+class LifecycleClass(str, Enum):
+    """Per-tree lifecycle, driving ``download --intermediate`` / ``delete-local``.
+
+    Mirrors the table in design-intermediate-products.md §3 PR-2.
+    """
+
+    CLOUD_PRODUCT = "cloud-backed-product"   # products/, tiles/ — re-fetchable from cloud
+    USER_STATE = "user-state"                # reducer decisions (masks, overrides, catalogs)
+    SHARED_CALIBRATION = "shared-calibration"  # reference/nircam/shared/{flats,wisps}
+    EXTERNAL_MAST = "external-MAST"          # raw/ — re-fetchable from MAST
+    REGENERABLE = "regenerable"              # cache/ — recomputable
+    CLI_LOCAL = "cli-local"                  # meta/, cutouts/ — exist only on the client
+
+
+class KeyScheme(str, Enum):
+    """Which storage-key vocabulary to emit.
+
+    ``LEGACY`` is the scheme live today (and at F0, before the OSN re-key): bare
+    ``spectra/<obs>/…`` / ``rgb/<obs>/…`` keys that diverge from the disk tree.
+    ``CANONICAL`` is the post-re-key scheme where a data-bucket key is just
+    ``data/`` + the local relpath (near-identity). The cutover flips the default;
+    until then ``CANONICAL`` is implemented and tested but inert.
+    """
+
+    LEGACY = "legacy"
+    CANONICAL = "canonical"
+
+
+@dataclass(frozen=True)
+class Scope:
+    """Identifying coordinates of a product, instrument-agnostic.
+
+    Only the fields a given ``product_type`` declares as required are consulted;
+    the rest stay ``None``. Frozen + hashable so scopes can key caches/sets.
+    """
+
+    obs: str | None = None              # NIRSpec observation name (products/raw/reference unit)
+    field: str | None = None            # NIRCam field name (products/reference unit)
+    filt: str | None = None             # filter, e.g. 'f444w'
+    pid: str | None = None              # JWST program id (raw/nircam partition)
+    data_subdir: str | None = None      # raw/nirspec partition (obs-declared)
+    source_id: str | None = None        # NIRSpec source / slit id
+    detector: str | None = None         # 'nrs1','nrs2','nrcalong',...
+    exposure: str | None = None         # exposure rootname
+    object_id: str | None = None        # cross-program object / target id (rgb/sed/photometry)
+    catalog_id: str | None = None       # photometry catalog id
+    tile: str | None = None             # NIRCam mosaic/RGB tile name
+    pixel_scale: str | None = None      # e.g. '30mas'
+    zoom: int | None = None             # map tile z
+    x: int | None = None                # map tile x
+    y: int | None = None                # map tile y
+
+    def require(self, *names: str) -> None:
+        """Raise ``LayoutError`` unless every named field is set (non-None)."""
+        missing = [n for n in names if getattr(self, n) is None]
+        if missing:
+            raise LayoutError(
+                f"Scope missing required field(s) {missing} "
+                f"(have: { {f.name: getattr(self, f.name) for f in fields(self) if getattr(self, f.name) is not None} })"
+            )
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Scope":
+        """Build a Scope from a plain dict, ignoring unknown keys.
+
+        Used by the shared golden fixture (which carries scopes as JSON objects)
+        and by web → python parity checks.
+        """
+        known = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in d.items() if k in known})

--- a/layout/conformance/layout_golden.json
+++ b/layout/conformance/layout_golden.json
@@ -1,0 +1,305 @@
+{
+  "_comment": "Golden conformance fixture for the CAMPFIRE layout contract (issue #213, PR-2). Single source of truth consumed by BOTH the python test (pipeline/tests/test_layout.py) and the TS test (web/lib/layout.test.ts). A mismatch fails both arms, so python<->TS drift cannot merge. Fields: filename=null => scope-derived; relpath=null => key-only (no local home); key_legacy=null => reserved (no legacy key, adopts canonical form); key_canonical=null/bucket=null => not cloud-backed (no storage key).",
+  "cases": [
+    {
+      "product_type": "nirspec_spec",
+      "scope": {"obs": "ember_egs_p1"},
+      "filename": "ember_egs_p1_prism_clear_15182_spec.fits",
+      "relpath": "products/nirspec/ember_egs_p1/ember_egs_p1_prism_clear_15182_spec.fits",
+      "key_legacy": "spectra/ember_egs_p1/ember_egs_p1_prism_clear_15182_spec.fits",
+      "key_canonical": "data/products/nirspec/ember_egs_p1/ember_egs_p1_prism_clear_15182_spec.fits",
+      "bucket": "data",
+      "tree_class": "cloud-backed-product"
+    },
+    {
+      "product_type": "spectrum_json",
+      "scope": {"obs": "ember_egs_p1"},
+      "filename": "ember_egs_p1_prism_clear_15182_spec.json",
+      "relpath": "products/nirspec/ember_egs_p1/ember_egs_p1_prism_clear_15182_spec.json",
+      "key_legacy": "spectra/ember_egs_p1/ember_egs_p1_prism_clear_15182_spec.json",
+      "key_canonical": "data/products/nirspec/ember_egs_p1/ember_egs_p1_prism_clear_15182_spec.json",
+      "bucket": "data",
+      "tree_class": "cloud-backed-product"
+    },
+    {
+      "product_type": "zfit",
+      "scope": {"obs": "ember_egs_p1"},
+      "filename": "ember_egs_p1_prism_clear_15182_zfit.json",
+      "relpath": "products/nirspec/ember_egs_p1/ember_egs_p1_prism_clear_15182_zfit.json",
+      "key_legacy": "spectra/ember_egs_p1/ember_egs_p1_prism_clear_15182_zfit.json",
+      "key_canonical": "data/products/nirspec/ember_egs_p1/ember_egs_p1_prism_clear_15182_zfit.json",
+      "bucket": "data",
+      "tree_class": "cloud-backed-product"
+    },
+    {
+      "product_type": "nirspec_spectrum_exposure",
+      "scope": {"obs": "ember_egs_p1"},
+      "filename": "jw07076020001_04101_00003_nrs1_15182.fits",
+      "relpath": "products/nirspec/ember_egs_p1/jw07076020001_04101_00003_nrs1_15182.fits",
+      "key_legacy": null,
+      "key_canonical": "data/products/nirspec/ember_egs_p1/jw07076020001_04101_00003_nrs1_15182.fits",
+      "bucket": "data",
+      "tree_class": "cloud-backed-product"
+    },
+    {
+      "product_type": "rgb",
+      "scope": {"obs": "ember_egs_p1"},
+      "filename": "ember_egs_p1_15182_rgb.png",
+      "relpath": "products/nirspec/ember_egs_p1/ember_egs_p1_15182_rgb.png",
+      "key_legacy": "rgb/ember_egs_p1/ember_egs_p1_15182_rgb.png",
+      "key_canonical": "data/products/nirspec/ember_egs_p1/ember_egs_p1_15182_rgb.png",
+      "bucket": "data",
+      "tree_class": "cloud-backed-product"
+    },
+    {
+      "product_type": "sed",
+      "scope": {"obs": "ember_egs_p1"},
+      "filename": "ember_egs_p1_15182_sed.pdf",
+      "relpath": "products/nirspec/ember_egs_p1/ember_egs_p1_15182_sed.pdf",
+      "key_legacy": "sed/ember_egs_p1/ember_egs_p1_15182_sed.pdf",
+      "key_canonical": "data/products/nirspec/ember_egs_p1/ember_egs_p1_15182_sed.pdf",
+      "bucket": "data",
+      "tree_class": "cloud-backed-product"
+    },
+    {
+      "product_type": "nircam_exposure",
+      "scope": {"field": "cosmos", "filt": "f444w"},
+      "filename": "jw01727028001_04101_00003_nrcalong.fits",
+      "relpath": "products/nircam/cosmos/f444w/jw01727028001_04101_00003_nrcalong.fits",
+      "key_legacy": null,
+      "key_canonical": "data/products/nircam/cosmos/f444w/jw01727028001_04101_00003_nrcalong.fits",
+      "bucket": "data",
+      "tree_class": "cloud-backed-product"
+    },
+    {
+      "product_type": "nircam_exposure_preview",
+      "scope": {"field": "cosmos", "filt": "f444w"},
+      "filename": "jw01727028001_04101_00003_nrcalong_preview.png",
+      "relpath": "products/nircam/cosmos/f444w/jw01727028001_04101_00003_nrcalong_preview.png",
+      "key_legacy": "nircam/exposures/cosmos/f444w/jw01727028001_04101_00003_nrcalong_preview.png",
+      "key_canonical": "data/products/nircam/cosmos/f444w/jw01727028001_04101_00003_nrcalong_preview.png",
+      "bucket": "data",
+      "tree_class": "cloud-backed-product"
+    },
+    {
+      "product_type": "nircam_exposure_full",
+      "scope": {"field": "cosmos", "filt": "f444w"},
+      "filename": "jw01727028001_04101_00003_nrcalong_full.png",
+      "relpath": "products/nircam/cosmos/f444w/jw01727028001_04101_00003_nrcalong_full.png",
+      "key_legacy": "nircam/exposures/cosmos/f444w/jw01727028001_04101_00003_nrcalong_full.png",
+      "key_canonical": "data/products/nircam/cosmos/f444w/jw01727028001_04101_00003_nrcalong_full.png",
+      "bucket": "data",
+      "tree_class": "cloud-backed-product"
+    },
+    {
+      "product_type": "nircam_rgb",
+      "scope": {"field": "cosmos"},
+      "filename": "A1_30mas_rgb.png",
+      "relpath": "products/nircam/cosmos/A1_30mas_rgb.png",
+      "key_legacy": null,
+      "key_canonical": "data/products/nircam/cosmos/A1_30mas_rgb.png",
+      "bucket": "data",
+      "tree_class": "cloud-backed-product"
+    },
+    {
+      "product_type": "nircam_expmap",
+      "scope": {"field": "cosmos"},
+      "filename": "cosmos_f444w_expmap.fits",
+      "relpath": "products/nircam/cosmos/expmaps/cosmos_f444w_expmap.fits",
+      "key_legacy": null,
+      "key_canonical": "data/products/nircam/cosmos/expmaps/cosmos_f444w_expmap.fits",
+      "bucket": "data",
+      "tree_class": "cloud-backed-product"
+    },
+    {
+      "product_type": "nircam_mosaic",
+      "scope": {"field": "cosmos", "filt": "f444w"},
+      "filename": "mosaic_cosmos_f444w_30mas_sci.fits",
+      "relpath": "products/nircam/cosmos/f444w/mosaic_cosmos_f444w_30mas_sci.fits",
+      "key_legacy": null,
+      "key_canonical": "data/products/nircam/cosmos/f444w/mosaic_cosmos_f444w_30mas_sci.fits",
+      "bucket": "data",
+      "tree_class": "cloud-backed-product"
+    },
+    {
+      "product_type": "tile",
+      "scope": {"field": "cosmos", "filt": "f444w", "zoom": 3, "x": 1, "y": 2},
+      "filename": null,
+      "relpath": "tiles/cosmos/f444w/3/1/2.png",
+      "key_legacy": "cosmos/f444w/3/1/2.png",
+      "key_canonical": "cosmos/f444w/3/1/2.png",
+      "bucket": "tiles",
+      "tree_class": "cloud-backed-product"
+    },
+    {
+      "product_type": "photometry_pz",
+      "scope": {"field": "cosmos", "object_id": "12345"},
+      "filename": null,
+      "relpath": null,
+      "key_legacy": "photometry/cosmos/12345_pz.json",
+      "key_canonical": "data/photometry/cosmos/12345_pz.json",
+      "bucket": "data",
+      "tree_class": "cloud-backed-product"
+    },
+    {
+      "product_type": "nirspec_manual_mask",
+      "scope": {"obs": "ember_egs_p1"},
+      "filename": "jw07076020001_04101_00003_nrs1_rate.reg",
+      "relpath": "products/nirspec/ember_egs_p1/manual_masks/jw07076020001_04101_00003_nrs1_rate.reg",
+      "key_legacy": null,
+      "key_canonical": "data/products/nirspec/ember_egs_p1/manual_masks/jw07076020001_04101_00003_nrs1_rate.reg",
+      "bucket": "data",
+      "tree_class": "user-state"
+    },
+    {
+      "product_type": "nirspec_stuck_shutters",
+      "scope": {"obs": "ember_egs_p1"},
+      "filename": null,
+      "relpath": "reference/nirspec/ember_egs_p1/stuck_closed_shutters.toml",
+      "key_legacy": null,
+      "key_canonical": "data/reference/nirspec/ember_egs_p1/stuck_closed_shutters.toml",
+      "bucket": "data",
+      "tree_class": "user-state"
+    },
+    {
+      "product_type": "nirspec_bkg_override",
+      "scope": {"obs": "ember_egs_p1"},
+      "filename": null,
+      "relpath": "reference/nirspec/ember_egs_p1/nodded_background_overrides.toml",
+      "key_legacy": null,
+      "key_canonical": "data/reference/nirspec/ember_egs_p1/nodded_background_overrides.toml",
+      "bucket": "data",
+      "tree_class": "user-state"
+    },
+    {
+      "product_type": "nircam_flat",
+      "scope": {},
+      "filename": "flat_nircam_f444w_nrcalong_CLEAR.fits",
+      "relpath": "reference/nircam/shared/flats/flat_nircam_f444w_nrcalong_CLEAR.fits",
+      "key_legacy": null,
+      "key_canonical": "data/reference/nircam/shared/flats/flat_nircam_f444w_nrcalong_CLEAR.fits",
+      "bucket": "data",
+      "tree_class": "shared-calibration"
+    },
+    {
+      "product_type": "nircam_wisp",
+      "scope": {},
+      "filename": "WISP_NRCA1_F444W_CLEAR_1.fits",
+      "relpath": "reference/nircam/shared/wisps/WISP_NRCA1_F444W_CLEAR_1.fits",
+      "key_legacy": null,
+      "key_canonical": "data/reference/nircam/shared/wisps/WISP_NRCA1_F444W_CLEAR_1.fits",
+      "bucket": "data",
+      "tree_class": "shared-calibration"
+    },
+    {
+      "product_type": "nircam_mask",
+      "scope": {"field": "cosmos"},
+      "filename": "cosmos_f444w_mask.reg",
+      "relpath": "reference/nircam/cosmos/masks/cosmos_f444w_mask.reg",
+      "key_legacy": null,
+      "key_canonical": "data/reference/nircam/cosmos/masks/cosmos_f444w_mask.reg",
+      "bucket": "data",
+      "tree_class": "user-state"
+    },
+    {
+      "product_type": "nircam_astrom_cat",
+      "scope": {"field": "cosmos"},
+      "filename": "gaia_cosmos.fits",
+      "relpath": "reference/nircam/cosmos/astrom_cats/gaia_cosmos.fits",
+      "key_legacy": null,
+      "key_canonical": "data/reference/nircam/cosmos/astrom_cats/gaia_cosmos.fits",
+      "bucket": "data",
+      "tree_class": "user-state"
+    },
+    {
+      "product_type": "nircam_bad_pixel",
+      "scope": {"field": "cosmos"},
+      "filename": "badpix_nrcalong.fits",
+      "relpath": "reference/nircam/cosmos/bad_pixels/badpix_nrcalong.fits",
+      "key_legacy": null,
+      "key_canonical": "data/reference/nircam/cosmos/bad_pixels/badpix_nrcalong.fits",
+      "bucket": "data",
+      "tree_class": "user-state"
+    },
+    {
+      "product_type": "raw_nirspec",
+      "scope": {"data_subdir": "7076"},
+      "filename": "jw07076020001_04101_00003_nrs1_uncal.fits",
+      "relpath": "raw/nirspec/7076/jw07076020001_04101_00003_nrs1_uncal.fits",
+      "key_legacy": null,
+      "key_canonical": null,
+      "bucket": null,
+      "tree_class": "external-MAST"
+    },
+    {
+      "product_type": "raw_nircam",
+      "scope": {"pid": "1727", "filt": "f444w"},
+      "filename": "jw01727028001_04101_00003_nrcalong_uncal.fits",
+      "relpath": "raw/nircam/1727/f444w/jw01727028001_04101_00003_nrcalong_uncal.fits",
+      "key_legacy": null,
+      "key_canonical": null,
+      "bucket": null,
+      "tree_class": "external-MAST"
+    },
+    {
+      "product_type": "summary",
+      "scope": {"obs": "ember_egs_p1"},
+      "filename": null,
+      "relpath": "products/nirspec/ember_egs_p1/ember_egs_p1_summary.ecsv",
+      "key_legacy": null,
+      "key_canonical": null,
+      "bucket": null,
+      "tree_class": "cloud-backed-product"
+    },
+    {
+      "product_type": "pointings",
+      "scope": {"obs": "ember_egs_p1"},
+      "filename": null,
+      "relpath": "products/nirspec/ember_egs_p1/ember_egs_p1_pointings.ecsv",
+      "key_legacy": null,
+      "key_canonical": null,
+      "bucket": null,
+      "tree_class": "cloud-backed-product"
+    },
+    {
+      "product_type": "shutters",
+      "scope": {"obs": "ember_egs_p1"},
+      "filename": null,
+      "relpath": "products/nirspec/ember_egs_p1/ember_egs_p1_shutters.ecsv",
+      "key_legacy": null,
+      "key_canonical": null,
+      "bucket": null,
+      "tree_class": "cloud-backed-product"
+    },
+    {
+      "product_type": "nirspec_config",
+      "scope": {"obs": "ember_egs_p1"},
+      "filename": null,
+      "relpath": "products/nirspec/ember_egs_p1/ember_egs_p1_config.toml",
+      "key_legacy": null,
+      "key_canonical": null,
+      "bucket": null,
+      "tree_class": "cloud-backed-product"
+    }
+  ],
+  "siblings": [
+    {"from": "spectra/ember_egs_p1/ember_egs_p1_prism_clear_15182_spec.fits", "to": "zfit", "expect": "spectra/ember_egs_p1/ember_egs_p1_prism_clear_15182_zfit.json"},
+    {"from": "spectra/ember_egs_p1/ember_egs_p1_prism_clear_15182_spec.fits", "to": "spectrum_json", "expect": "spectra/ember_egs_p1/ember_egs_p1_prism_clear_15182_spec.json"},
+    {"from": "data/products/nirspec/ember_egs_p1/ember_egs_p1_prism_clear_15182_spec.fits", "to": "zfit", "expect": "data/products/nirspec/ember_egs_p1/ember_egs_p1_prism_clear_15182_zfit.json"}
+  ],
+  "known_keys": [
+    "spectra/ember_egs_p1/ember_egs_p1_prism_clear_15182_spec.fits",
+    "rgb/ember_egs_p1/ember_egs_p1_15182_rgb.png",
+    "nircam/exposures/cosmos/f444w/jw01727028001_04101_00003_nrcalong_preview.png",
+    "photometry/cosmos/12345_pz.json",
+    "data/products/nirspec/ember_egs_p1/jw07076020001_04101_00003_nrs1_15182.fits"
+  ],
+  "unknown_keys": [
+    "spectra/../etc/passwd",
+    "/spectra/ember_egs_p1/x_spec.fits",
+    "data/raw/nirspec/7076/jw_uncal.fits",
+    "totally/made/up/key.bin",
+    "spectra/ember_egs_p1/",
+    ""
+  ]
+}

--- a/layout/pyproject.toml
+++ b/layout/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "campfire-layout"
+version = "0.1.0"
+description = "The single authority for the CAMPFIRE directory/key contract (paths, storage keys, key↔path bijection, tree lifecycle)."
+requires-python = ">=3.11"
+authors = [{ name = "CAMPFIRE Team" }]
+# Intentionally zero runtime dependencies: stdlib only, so both the local-only
+# pipeline (campfire-pipeline) and the client (campfire) can depend on it without
+# dragging in heavy or cloud-specific packages.
+dependencies = []
+
+[project.optional-dependencies]
+test = ["pytest>=7"]
+
+[tool.setuptools.packages.find]
+include = ["campfire_layout*"]
+
+[tool.setuptools.package-data]
+campfire_layout = ["py.typed"]

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -203,6 +203,23 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- **Layout & key contract (`campfire_layout`, #213, PR-2 of epic #210).** The
+  `$CAMPFIRE_ROOT/` directory tree — previously a three-way contract re-derived
+  independently in the pipeline, the deploy/download client, and the web portal —
+  is now owned by one tested, zero-dependency package (`layout/campfire_layout/`,
+  mirrored in TypeScript at `web/lib/layout.ts`). It is the single authority for
+  every product's local path, its storage key, the key↔path bijection, and a
+  per-tree lifecycle class; a shared golden fixture
+  (`layout/conformance/layout_golden.json`) keeps the python and TS arms in
+  lockstep. Pipeline workspace/raw/reference/cache path construction
+  (`config.resolve_paths`, `Observation.setup_workspace_directory`,
+  `Field.setup_workspace`, `common.query._output_path_for`) now routes through
+  the module. **No change to scientific output**; the local tree shape is
+  unchanged (it encodes the #212 PR-4 layout). Fixes two latent bugs the swaps
+  surfaced: the download/sync client wrote/read `products/<obs>/` without the
+  PR-4 `nirspec/` segment, and the raw-NIRSpec download writer and the
+  Observation reader are now single-sourced on one partition key. `campfire-layout`
+  is a new dependency — install it first (`pip install -e ./layout`).
 - Provenance is now carried verbatim from the FITS primary header through to the
   catalog and Python client, fixing four ways it was dropped or distorted
   (closes #202). (1) `cfpipe_version` is the single pipeline-version string,

--- a/pipeline/campfire_pipeline/common/query.py
+++ b/pipeline/campfire_pipeline/common/query.py
@@ -23,6 +23,8 @@ from pathlib import Path
 import requests
 from tqdm import tqdm
 
+from campfire_layout import Scope, raw_dir as layout_raw_dir, raw_path
+
 BASE_URL = "https://mast.stsci.edu/search/jwst/api/v0.1"
 
 
@@ -412,16 +414,19 @@ def _output_path_for(file_info, download_root, instrument):
     NIRSpec: ``{download_root}/nirspec/{PID}/{filename}``  (per-PID).
     NIRCam:  ``{download_root}/nircam/{PID}/{filter}/{filename}``.
 
-    Issue #212 (PR-4): the NIRSpec branch gained the ``nirspec/`` segment to
-    match the reader (``Observation.setup_workspace_directory`` globs
-    ``raw/nirspec/<data_subdir>/``); NIRCam already wrote under ``nircam/``.
+    Issue #213 (PR-2): resolved through the shared layout contract, the single
+    authority shared with the reader (``Observation.raw_dir``). For NIRSpec, the
+    PID *is* the raw ``data_subdir`` partition — so the download writer and the
+    reader's glob are now one definition; an observation that sets a non-default
+    ``data_subdir`` must keep it equal to its PID for downloaded files to be found.
     """
     filename = file_info["filename"]
     pid = file_info["program_id"]
+    root = Path(download_root).parent  # download_root == $CAMPFIRE_ROOT/raw
     if instrument == "NIRCAM":
         filt = (file_info.get("filter") or "unknown").lower()
-        return Path(download_root) / "nircam" / pid / filt / filename
-    return Path(download_root) / "nirspec" / pid / filename
+        return raw_path("nircam", Scope(pid=pid, filt=filt), filename, root=root)
+    return raw_path("nirspec", Scope(data_subdir=pid), filename, root=root)
 
 
 # ---------------------------------------------------------------------------
@@ -503,7 +508,8 @@ def _write_nircam_manifest(download_root, program_id, rows):
     if not rows:
         return
     from astropy.table import Table, vstack
-    manifest_dir = Path(download_root) / "nircam" / program_id
+    manifest_dir = layout_raw_dir("nircam", Scope(pid=program_id),
+                                  root=Path(download_root).parent)
     manifest_dir.mkdir(parents=True, exist_ok=True)
     manifest_path = manifest_dir / "manifest.ecsv"
 

--- a/pipeline/campfire_pipeline/config.py
+++ b/pipeline/campfire_pipeline/config.py
@@ -11,14 +11,20 @@ from pathlib import Path
 
 import toml
 
+from campfire_layout import cache_path, campfire_root as _layout_campfire_root, roots
+
 
 # ---------------------------------------------------------------------------
 # CAMPFIRE_ROOT resolution
 # ---------------------------------------------------------------------------
 
 def _get_campfire_root():
-    """Return $CAMPFIRE_ROOT, defaulting to ~/campfire if unset."""
-    return os.environ.get('CAMPFIRE_ROOT') or str(Path.home() / 'campfire')
+    """Return $CAMPFIRE_ROOT, defaulting to ~/campfire if unset.
+
+    Delegates to the shared layout contract (``campfire_layout``) so the pipeline,
+    the deploy/download client, and the contract all resolve one root identically.
+    """
+    return str(_layout_campfire_root())
 
 
 # ---------------------------------------------------------------------------
@@ -134,7 +140,7 @@ def setup_environment(config):
 
         # Only set CRDS_PATH fallback if not in config and not already in env
         if 'CRDS_PATH' not in env and 'CRDS_PATH' not in os.environ:
-            env['CRDS_PATH'] = os.path.join(_get_campfire_root(), 'cache', 'crds')
+            env['CRDS_PATH'] = str(cache_path('crds'))
 
         for key, value in env.items():
             if key == 'CRDS_PATH' and 'CRDS_PATH' in os.environ:
@@ -154,11 +160,11 @@ def resolve_paths(config=None):
     on a different filesystem. (``config`` is accepted and ignored for
     backward compatibility with existing call sites.)
     """
-    campfire_root = _get_campfire_root()
+    r = roots()
     result = {
-        'data_dir': os.path.join(campfire_root, 'raw'),
-        'products_dir': os.path.join(campfire_root, 'products'),
-        'reference_dir': os.path.join(campfire_root, 'reference'),
+        'data_dir': str(r.raw),
+        'products_dir': str(r.products),
+        'reference_dir': str(r.reference),
     }
     for d in result.values():
         os.makedirs(d, exist_ok=True)
@@ -382,14 +388,12 @@ def resolve_template_grid_paths(config):
     If a path in template_grids.*.file is relative, resolve it relative
     to $CAMPFIRE_ROOT/cache/templates/. Absolute paths are used as-is.
     """
-    campfire_root = _get_campfire_root()
     template_grids = config.get('nirspec', {}).get('template_grids', {})
 
     for name, grid_config in template_grids.items():
         filepath = grid_config.get('file', '')
         if filepath and not os.path.isabs(filepath):
-            grid_config['file'] = os.path.join(
-                campfire_root, 'cache', 'templates', filepath)
+            grid_config['file'] = str(cache_path('templates', filepath))
 
     return template_grids
 

--- a/pipeline/campfire_pipeline/nircam/field.py
+++ b/pipeline/campfire_pipeline/nircam/field.py
@@ -18,6 +18,14 @@ from typing import List, Optional
 import toml
 import numpy as np
 
+from campfire_layout import (
+    Scope,
+    dir_for,
+    raw_dir as layout_raw_dir,
+    reference_dir as layout_reference_dir,
+    roots,
+    shared_reference_dir as layout_shared_reference_dir,
+)
 from campfire_pipeline.common.io import log
 from campfire_pipeline.nircam.constants import SW_FILTERS, LW_FILTERS
 
@@ -326,15 +334,18 @@ class Field:
             from campfire_pipeline.config import _get_campfire_root
             campfire_root = _get_campfire_root()
 
+        # Issue #213 (PR-2): resolve the workspace tree through the shared layout
+        # contract (campfire_layout), the single authority shared with deploy.
         self.campfire_root = campfire_root
-        self.raw_root = os.path.join(campfire_root, 'raw', 'nircam')
-        self.products_dir = os.path.join(campfire_root, 'products', 'nircam', self.name)
-        self.reference_dir = os.path.join(campfire_root, 'reference', 'nircam', self.name)
+        scope = Scope(field=self.name)
+        self.raw_root = str(layout_raw_dir('nircam', root=campfire_root))
+        self.products_dir = str(roots(campfire_root).products / 'nircam' / self.name)
+        self.reference_dir = str(layout_reference_dir('nircam', scope, root=campfire_root))
 
         # Reducer-decision reference state is per-field.
-        self.bad_pixel_dir = os.path.join(self.reference_dir, 'bad_pixels')
-        self.refcat_dir = os.path.join(self.reference_dir, 'astrom_cats')
-        self.mask_dir = os.path.join(self.reference_dir, 'masks')
+        self.bad_pixel_dir = str(dir_for('nircam_bad_pixel', scope, root=campfire_root))
+        self.refcat_dir = str(dir_for('nircam_astrom_cat', scope, root=campfire_root))
+        self.mask_dir = str(dir_for('nircam_mask', scope, root=campfire_root))
 
         # Shared calibration references are detector/filter-scoped, NOT per-field
         # (issue #212 PR-4): custom flats (flat_nircam_<FILT>_<DET>_CLEAR.fits) and
@@ -348,10 +359,9 @@ class Field:
         # had an empty wisp_dir (intentionally skipping wisp) would start running
         # wisp on shared templates. Preserve that opt-out per-field if templates
         # are ever populated in shared/.
-        self.shared_reference_dir = os.path.join(campfire_root, 'reference',
-                                                 'nircam', 'shared')
-        self.wisp_dir = os.path.join(self.shared_reference_dir, 'wisps')
-        self.flats_dir = os.path.join(self.shared_reference_dir, 'flats')
+        self.shared_reference_dir = str(layout_shared_reference_dir('nircam', root=campfire_root))
+        self.wisp_dir = str(dir_for('nircam_wisp', Scope(), root=campfire_root))
+        self.flats_dir = str(dir_for('nircam_flat', Scope(), root=campfire_root))
 
         # One flat directory per filter holds everything for that filter:
         # canonical exposures, drizzled mosaic tiles, split extensions,
@@ -374,7 +384,8 @@ class Field:
         """
         if self.products_dir is None:
             raise RuntimeError("setup_workspace() must be called first")
-        return os.path.join(self.products_dir, filter_name)
+        return str(dir_for('nircam_exposure', Scope(field=self.name, filt=filter_name),
+                           root=self.campfire_root))
 
     def get_uncal_files(self, filter_name, skip=None):
         """Get uncal files from PID-organized raw directories.

--- a/pipeline/campfire_pipeline/nirspec/observation.py
+++ b/pipeline/campfire_pipeline/nirspec/observation.py
@@ -14,6 +14,12 @@ from textwrap import dedent
 from astropy.io import fits
 from astropy.table import Table
 
+from campfire_layout import (
+    Scope,
+    dir_for,
+    raw_dir as layout_raw_dir,
+    reference_dir as layout_reference_dir,
+)
 from campfire_pipeline.common.io import log
 
 # Default slitlet assumed when a file is missing the NOD_TYPE keyword.
@@ -199,15 +205,15 @@ class Observation:
         --------
         str : Path to the workspace directory
         """
-        # Issue #212 (PR-4): instrument-parity layout —
-        #   products/nirspec/<obs>/ , raw/nirspec/<subdir>/ ,
-        #   reference/nirspec/<obs>/ (reducer-decision state: stuck shutters,
-        #   bkg overrides, masks). reference is anchored to $CAMPFIRE_ROOT
-        #   (the single data root), matching NIRCam's field.setup_workspace.
-        from campfire_pipeline.config import _get_campfire_root
-        self.workspace_dir = os.path.join(product_dir, 'nirspec', self.name)
-        self.reference_dir = os.path.join(_get_campfire_root(), 'reference',
-                                          'nirspec', self.name)
+        # Issue #213 (PR-2): the instrument-parity layout (#212 PR-4) is now
+        # resolved through the single shared layout contract (campfire_layout),
+        # the one authority shared with the deploy/download client. ``product_dir``
+        # and ``data_dir`` are ``$CAMPFIRE_ROOT/{products,raw}``; their parent is
+        # the data root the contract anchors on (reference/ shares that root).
+        scope = Scope(obs=self.name)
+        root = os.path.dirname(os.path.abspath(product_dir))
+        self.workspace_dir = str(dir_for('nirspec_spec', scope, root=root))
+        self.reference_dir = str(layout_reference_dir('nirspec', scope, root=root))
 
         # Create workspace directory
         if os.path.exists(self.workspace_dir) and overwrite:
@@ -219,7 +225,9 @@ class Observation:
             log(f"Created workspace directory: {self.workspace_dir}")
         os.makedirs(self.reference_dir, exist_ok=True)
 
-        self.raw_dir = os.path.join(data_dir, 'nirspec', self.data_subdir)
+        self.raw_dir = str(layout_raw_dir(
+            'nirspec', Scope(data_subdir=self.data_subdir),
+            root=os.path.dirname(os.path.abspath(data_dir))))
         self.rate_files = self.glob('_rate.fits')
 
         self.directories_setup = True

--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -4,6 +4,7 @@ description = "JWST data reduction pipeline"
 requires-python = ">=3.12"
 dynamic = ["version"]
 dependencies = [
+    "campfire-layout",  # shared directory/key contract (#213); install from ./layout (not on PyPI)
     "jwst>=1.20,<1.21",
     "astropy>=6.1",
     "numpy>=2.0",

--- a/pipeline/tests/test_layout.py
+++ b/pipeline/tests/test_layout.py
@@ -1,0 +1,129 @@
+"""Golden conformance test for the campfire_layout contract (issue #213, PR-2).
+
+Runs the *same* fixture the TS arm (``web/lib/layout.test.ts``) checks, so a
+python↔TS divergence fails both. Also asserts the cross-package agreement that
+``test_layout_212.py`` established: the layout module, the deploy resolver, and
+the pipeline ``Observation`` all resolve the NIRSpec products dir identically.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import campfire_layout as L
+from campfire_layout import KeyScheme, LayoutError, Scope
+
+_FIXTURE = Path(__file__).parents[2] / "layout" / "conformance" / "layout_golden.json"
+
+
+def _load():
+    with open(_FIXTURE) as f:
+        return json.load(f)
+
+
+GOLDEN = _load()
+
+
+def _ids(cases):
+    return [c["product_type"] for c in cases]
+
+
+@pytest.mark.parametrize("case", GOLDEN["cases"], ids=_ids(GOLDEN["cases"]))
+def test_case(case):
+    pt = case["product_type"]
+    scope = Scope.from_dict(case["scope"])
+    fn = case["filename"]
+
+    # --- storage keys ---
+    if case["key_legacy"] is not None:
+        assert L.storage_key(pt, scope, fn, scheme=KeyScheme.LEGACY) == case["key_legacy"]
+    if case["key_canonical"] is not None:
+        assert L.storage_key(pt, scope, fn, scheme=KeyScheme.CANONICAL) == case["key_canonical"]
+
+    # --- local relpath (or raises for key-only products) ---
+    if case["relpath"] is not None:
+        assert L.local_relpath(pt, scope, fn) == case["relpath"]
+        # parse_relpath recovers the same product and rebuilds the same relpath.
+        pk = L.parse_relpath(case["relpath"])
+        assert pk.product_type == pt
+        assert L.local_relpath(pk.product_type, pk.scope, pk.filename) == case["relpath"]
+    else:
+        with pytest.raises(LayoutError):
+            L.local_relpath(pt, scope, fn)
+
+    # --- bucket ---
+    if case["bucket"] is not None:
+        assert L.bucket_for(pt) == case["bucket"]
+    else:
+        with pytest.raises(LayoutError):
+            L.bucket_for(pt)
+
+    # --- lifecycle ---
+    ref = case["relpath"] or case["key_legacy"] or case["key_canonical"]
+    assert L.tree_class(ref).value == case["tree_class"]
+
+    # --- bijection round-trips ---
+    bkt = case["bucket"] or "data"
+    if case["key_legacy"] is not None and case["relpath"] is not None:
+        assert L.key_to_relpath(case["key_legacy"], bucket=bkt) == case["relpath"]
+        assert L.relpath_to_key(case["relpath"], scheme=KeyScheme.LEGACY) == case["key_legacy"]
+    if case["key_canonical"] is not None and case["relpath"] is not None:
+        assert L.key_to_relpath(case["key_canonical"], bucket=bkt) == case["relpath"]
+        assert L.relpath_to_key(case["relpath"], scheme=KeyScheme.CANONICAL) == case["key_canonical"]
+    # Reserved products (no legacy key) emit the canonical form even in LEGACY scheme.
+    if case["key_legacy"] is None and case["key_canonical"] is not None and case["relpath"] is not None:
+        assert L.relpath_to_key(case["relpath"], scheme=KeyScheme.LEGACY) == case["key_canonical"]
+
+    # parse_key recovers the product for ANY cloud-backed key (legacy + canonical),
+    # including key-only products like photometry whose canonical form is
+    # 'data/' + legacy prefix rather than 'data/' + relpath.
+    for key in (case["key_legacy"], case["key_canonical"]):
+        if key is not None:
+            assert L.parse_key(key, bucket=bkt).product_type == pt
+
+
+def test_siblings():
+    for sib in GOLDEN["siblings"]:
+        assert L.derive_sibling(sib["from"], sib["to"]) == sib["expect"]
+
+
+def test_known_keys():
+    for key in GOLDEN["known_keys"]:
+        assert L.is_known_key(key) is True, key
+
+
+def test_unknown_keys():
+    for key in GOLDEN["unknown_keys"]:
+        assert L.is_known_key(key) is False, key
+
+
+def test_presign_allowlist_rejects_traversal():
+    # The presign route's hardening: a fuzzed traversal key must never be signed.
+    assert L.is_known_key("spectra/ember/../../secret.fits") is False
+    assert L.is_known_key("data/../../../etc/passwd") is False
+
+
+def test_every_product_has_a_golden_case():
+    # Guards against adding a product to the registry without a fixture row.
+    covered = {c["product_type"] for c in GOLDEN["cases"]}
+    missing = set(L.PRODUCTS) - covered
+    assert not missing, f"products with no golden case: {sorted(missing)}"
+
+
+def test_cross_package_agreement(tmp_path, monkeypatch):
+    """The module, deploy resolver, and pipeline Observation agree on the NIRSpec
+    products dir — the contract the three-way footgun used to violate."""
+    monkeypatch.setenv("CAMPFIRE_ROOT", str(tmp_path))
+    obs = "ember_egs_p1"
+    expected = L.dir_for("nirspec_spec", Scope(obs=obs))
+
+    from campfire.deploy import config as dconfig
+    (tmp_path / "products" / "nirspec" / obs).mkdir(parents=True)
+    assert dconfig.resolve_obs_dir(obs) == expected
+
+    from campfire_pipeline.nirspec.observation import Observation
+    o = Observation(name=obs, field="egs", program="ember", program_id=7076,
+                    data_subdir="7076", files=["jw*"], gratings=["PRISM"])
+    o.setup_workspace_directory(str(tmp_path / "raw"), str(tmp_path / "products"))
+    assert Path(o.workspace_dir) == expected

--- a/python/campfire/client.py
+++ b/python/campfire/client.py
@@ -680,10 +680,11 @@ class Campfire:
         filename = Path(fits_path).name
 
         if self._local and self._products_dir:
-            observation = spec_info.get("observation") or ""
-            obs_dir = self._products_dir / observation if observation else self._products_dir
-            obs_dir.mkdir(parents=True, exist_ok=True)
-            dest = obs_dir / filename
+            from .config import products_relpath
+            # Land the file where the pipeline writes and deploy reads it, via the
+            # shared layout contract (products/nirspec/<obs>/…), not products/<obs>/.
+            dest = self._products_dir / products_relpath(fits_path)
+            dest.parent.mkdir(parents=True, exist_ok=True)
         else:
             import tempfile
             dest = Path(tempfile.mkdtemp(prefix="campfire_")) / filename
@@ -707,8 +708,8 @@ class Campfire:
             raise DownloadError(f"Failed to download spectrum: {e}")
 
         if self._local and self._products_dir:
-            observation = spec_info.get("observation") or ""
-            local_rel_path = f"{observation}/{filename}" if observation else filename
+            from .config import products_relpath
+            local_rel_path = products_relpath(fits_path)
             st = dest.stat()
             self._local.mark_synced(
                 spectrum_id=spectrum_id,

--- a/python/campfire/config.py
+++ b/python/campfire/config.py
@@ -14,6 +14,8 @@ Credentials are stored separately in ``~/.campfire/credentials``.
 import os
 from pathlib import Path
 
+from campfire_layout import key_to_relpath
+
 
 CAMPFIRE_DIR = Path.home() / ".campfire"
 
@@ -32,6 +34,20 @@ def resolve_data_dir() -> Path:
 def products_dir(data_dir: Path = None) -> Path:
     """Products directory for FITS files."""
     return (data_dir or resolve_data_dir()) / "products"
+
+
+def products_relpath(storage_key: str) -> str:
+    """Local path of a downloaded object relative to the products dir.
+
+    Maps a storage key (e.g. ``spectra/<obs>/x_spec.fits``) to its place under
+    ``products/`` (e.g. ``nirspec/<obs>/x_spec.fits``) via the shared layout
+    contract. This is the single source of the download-destination layout —
+    routing through it fixes the prior client/pipeline drift where the client
+    wrote to ``products/<obs>/`` (missing the PR-4 ``nirspec/`` segment).
+    """
+    rel = key_to_relpath(storage_key)
+    prefix = "products/"
+    return rel[len(prefix):] if rel.startswith(prefix) else rel
 
 
 def meta_dir(data_dir: Path = None) -> Path:

--- a/python/campfire/db/store.py
+++ b/python/campfire/db/store.py
@@ -1041,6 +1041,7 @@ class LocalStore:
         show_progress: bool = False,
     ) -> dict:
         """Reconcile DB sync state with the local filesystem."""
+        from ..config import products_relpath
         from ..sync import compute_file_hash
 
         now = datetime.now(timezone.utc).isoformat()
@@ -1111,11 +1112,12 @@ class LocalStore:
 
         discovered = 0
         for row in untracked_rows:
-            filename = Path(row["fits_path"]).name
-            obs_name = row["observation"]
-            local_path = products_dir / obs_name / filename
+            # Resolve the local destination via the layout contract (the same
+            # mapping the downloader uses), so rediscovery looks where files are
+            # actually written: products/nirspec/<obs>/… (PR-4), not products/<obs>/.
+            rel_path = products_relpath(row["fits_path"])
+            local_path = products_dir / rel_path
             if local_path.exists():
-                rel_path = f"{obs_name}/{filename}"
                 st = local_path.stat()
                 actual_hash = compute_file_hash(local_path)
                 self._conn.execute(

--- a/python/campfire/deploy/config.py
+++ b/python/campfire/deploy/config.py
@@ -25,6 +25,8 @@ from pathlib import Path
 
 import tomllib
 
+from campfire_layout import Scope, dir_for, reference_dir, roots
+
 
 # Environment-variable resolution for credentials + storage backend config.
 #
@@ -405,15 +407,13 @@ def resolve_field(obs_name: str) -> str:
 
 def resolve_products_dir() -> Path:
     """
-    Return the products directory.
+    Return the products directory (``$CAMPFIRE_ROOT/products``).
 
-    Uses $CAMPFIRE_ROOT/products/ if CAMPFIRE_ROOT is set,
-    otherwise falls back to ./products/.
+    Delegates to the shared layout contract (``campfire_layout.roots``), which
+    resolves ``$CAMPFIRE_ROOT`` (default ``~/campfire``) identically to the
+    pipeline — collapsing the prior deploy-only ``./products`` fallback.
     """
-    root = os.environ.get('CAMPFIRE_ROOT')
-    if root:
-        return Path(root) / 'products'
-    return Path('products')
+    return roots().products
 
 
 def resolve_obs_dir(obs_name: str) -> Path:
@@ -421,10 +421,10 @@ def resolve_obs_dir(obs_name: str) -> Path:
     Return the NIRSpec observation products directory, raising if it doesn't exist.
 
     Issue #212 (PR-4): NIRSpec products live under ``products/nirspec/<obs>/``
-    (instrument-parity layout), kept in lockstep with the pipeline's
-    ``Observation.setup_workspace_directory``.
+    (instrument-parity layout). Resolved via the shared layout contract
+    (``campfire_layout.dir_for``), the single authority shared with the pipeline.
     """
-    obs_dir = resolve_products_dir() / 'nirspec' / obs_name
+    obs_dir = dir_for('nirspec_spec', Scope(obs=obs_name))
     if not obs_dir.exists():
         print(f"Error: Observation directory not found: {obs_dir}")
         print(f"Set $CAMPFIRE_ROOT or run from a directory containing products/nirspec/{obs_name}/")
@@ -436,14 +436,10 @@ def resolve_reference_dir() -> Path:
     """
     Return the reference directory (reducer-decision state).
 
-    Uses $CAMPFIRE_ROOT/reference/ if CAMPFIRE_ROOT is set, otherwise falls
-    back to ./reference/ — the sibling of the products root, matching the
-    pipeline's ``Observation.setup_workspace_directory``.
+    Delegates to the shared layout contract (``campfire_layout.roots``):
+    ``$CAMPFIRE_ROOT/reference`` (default ``~/campfire``), matching the pipeline.
     """
-    root = os.environ.get('CAMPFIRE_ROOT')
-    if root:
-        return Path(root) / 'reference'
-    return Path('reference')
+    return roots().reference
 
 
 def resolve_reference_obs_dir(obs_name: str) -> Path:
@@ -451,11 +447,12 @@ def resolve_reference_obs_dir(obs_name: str) -> Path:
     Return the NIRSpec observation reference directory (issue #212 PR-4).
 
     Reducer-decision state (stuck-shutter / nodded-bkg-override TOMLs) lives
-    under ``reference/nirspec/<obs>/``, kept in lockstep with the pipeline's
-    ``Observation.setup_workspace_directory``. Unlike :func:`resolve_obs_dir`
-    this does not require the directory to exist — the TOMLs are optional.
+    under ``reference/nirspec/<obs>/``. Resolved via the shared layout contract
+    (``campfire_layout.reference_dir``), the single authority shared with the
+    pipeline. Unlike :func:`resolve_obs_dir` this does not require the directory
+    to exist — the TOMLs are optional.
     """
-    return resolve_reference_dir() / 'nirspec' / obs_name
+    return reference_dir('nirspec', Scope(obs=obs_name))
 
 
 def resolve_tiles_dir(tile_dir: str | None = None) -> Path:

--- a/python/campfire/deploy/deploy.py
+++ b/python/campfire/deploy/deploy.py
@@ -33,6 +33,7 @@ from campfire.deploy.generate import (
     generate_thumbnails_from_fits,
     generate_zfit_json,
 )
+from campfire_layout import Scope, storage_key
 from campfire.deploy.r2 import UploadTask, upload_files_parallel
 from campfire.deploy.supabase import (
     batch_upsert_objects,
@@ -367,30 +368,30 @@ def deploy_observation(
 
     try:
         upload_tasks: list[UploadTask] = []
-        r2_prefix = f"spectra/{obs_name}"
+        scope = Scope(obs=obs_name)
 
         if not supabase_only:
             print("Generating content...")
             for spec_path in tqdm(spec_paths, desc="Processing", unit="file"):
                 # FITS file
-                upload_tasks.append(UploadTask(spec_path, f"{r2_prefix}/{spec_path.name}", 'application/fits'))
+                upload_tasks.append(UploadTask(spec_path, storage_key('nirspec_spec', scope, spec_path.name), 'application/fits'))
 
                 # Spectrum JSON
                 json_path = generate_spectrum_json(spec_path, temp_dir)
-                upload_tasks.append(UploadTask(json_path, f"{r2_prefix}/{json_path.name}", 'application/json'))
+                upload_tasks.append(UploadTask(json_path, storage_key('spectrum_json', scope, json_path.name), 'application/json'))
 
             # Zfit JSONs
             for zfit_path in zfit_paths:
                 zfit_json = generate_zfit_json(zfit_path, temp_dir)
-                upload_tasks.append(UploadTask(zfit_json, f"{r2_prefix}/{zfit_json.name}", 'application/json'))
+                upload_tasks.append(UploadTask(zfit_json, storage_key('zfit', scope, zfit_json.name), 'application/json'))
 
             # RGB images
             for rgb_path in rgb_files:
-                upload_tasks.append(UploadTask(rgb_path, f"rgb/{obs_name}/{rgb_path.name}", 'image/png'))
+                upload_tasks.append(UploadTask(rgb_path, storage_key('rgb', scope, rgb_path.name), 'image/png'))
 
             # SED plots
             for sed_path in sed_files:
-                upload_tasks.append(UploadTask(sed_path, f"sed/{obs_name}/{sed_path.name}", 'application/pdf'))
+                upload_tasks.append(UploadTask(sed_path, storage_key('sed', scope, sed_path.name), 'application/pdf'))
 
             print(f"Uploading {len(upload_tasks)} files...")
             success, failed, failed_msgs = upload_files_parallel(config, upload_tasks, desc="R2 uploads")
@@ -603,12 +604,12 @@ def deploy_rgb(
     if dry_run:
         print("=== DRY RUN ===")
         for path in rgb_files[:5]:
-            print(f"  {path.name} -> rgb/{obs_name}/{path.name}")
+            print(f"  {path.name} -> {storage_key('rgb', Scope(obs=obs_name), path.name)}")
         if len(rgb_files) > 5:
             print(f"  ... and {len(rgb_files) - 5} more")
         return
 
-    tasks = [UploadTask(p, f"rgb/{obs_name}/{p.name}", 'image/png') for p in rgb_files]
+    tasks = [UploadTask(p, storage_key('rgb', Scope(obs=obs_name), p.name), 'image/png') for p in rgb_files]
     success, failed, failed_msgs = upload_files_parallel(config, tasks, desc="RGB images")
 
     if failed_msgs:
@@ -655,13 +656,13 @@ def deploy_sed(
     if dry_run:
         print("=== DRY RUN ===")
         for path in sed_files[:5]:
-            print(f"  {path.name} -> sed/{obs_name}/{path.name}")
+            print(f"  {path.name} -> {storage_key('sed', Scope(obs=obs_name), path.name)}")
         if len(sed_files) > 5:
             print(f"  ... and {len(sed_files) - 5} more")
         print(f"Would set has_sed_plot=true for {len(objects_with_sed)} objects")
         return
 
-    tasks = [UploadTask(p, f"sed/{obs_name}/{p.name}", 'application/pdf') for p in sed_files]
+    tasks = [UploadTask(p, storage_key('sed', Scope(obs=obs_name), p.name), 'application/pdf') for p in sed_files]
     success, failed, failed_msgs = upload_files_parallel(config, tasks, desc="SED plots")
 
     if failed_msgs:
@@ -702,7 +703,7 @@ def deploy_json(
     if dry_run:
         print("=== DRY RUN ===")
         for path in spec_paths[:5]:
-            print(f"  {path.name} -> spectra/{obs_name}/{path.stem}.json")
+            print(f"  {path.name} -> {storage_key('spectrum_json', Scope(obs=obs_name), f'{path.stem}.json')}")
         if len(spec_paths) > 5:
             print(f"  ... and {len(spec_paths) - 5} more")
         return
@@ -715,7 +716,7 @@ def deploy_json(
         tasks = []
         for path in tqdm(spec_paths, desc="Generating", unit="file"):
             json_path = generate_spectrum_json(path, temp_dir)
-            tasks.append(UploadTask(json_path, f"spectra/{obs_name}/{json_path.name}", 'application/json'))
+            tasks.append(UploadTask(json_path, storage_key('spectrum_json', Scope(obs=obs_name), json_path.name), 'application/json'))
 
         print("Uploading...")
         success, failed, failed_msgs = upload_files_parallel(config, tasks, desc="JSON files")
@@ -774,7 +775,7 @@ def deploy_zfit(
         tasks = []
         for path in zfit_paths:
             json_path = generate_zfit_json(path, temp_dir)
-            tasks.append(UploadTask(json_path, f"spectra/{obs_name}/{json_path.name}", 'application/json'))
+            tasks.append(UploadTask(json_path, storage_key('zfit', Scope(obs=obs_name), json_path.name), 'application/json'))
 
         print("Uploading...")
         success, failed, failed_msgs = upload_files_parallel(config, tasks, desc="Zfit JSON")

--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 from astropy.io import fits
 
+from campfire_layout import Scope, storage_key
 from campfire.deploy.r2 import UploadTask, upload_files_parallel
 from campfire.deploy.supabase import get_supabase_client
 
@@ -205,7 +206,7 @@ def build_upload_tasks(dirs, field, filters):
             continue
         for png_path in sorted(png_dir.glob('jw*_preview.png')):
             basename = png_path.name.removesuffix('_preview.png')
-            r2_key = f'nircam/exposures/{field}/{filtname}/{png_path.name}'
+            r2_key = storage_key('nircam_exposure_preview', Scope(field=field, filt=filtname), png_path.name)
             tasks.append((
                 UploadTask(local_path=png_path, r2_key=r2_key,
                            content_type='image/png'),
@@ -213,7 +214,7 @@ def build_upload_tasks(dirs, field, filters):
             ))
         for png_path in sorted(png_dir.glob('jw*_full.png')):
             basename = png_path.name.removesuffix('_full.png')
-            r2_key = f'nircam/exposures/{field}/{filtname}/{png_path.name}'
+            r2_key = storage_key('nircam_exposure_full', Scope(field=field, filt=filtname), png_path.name)
             tasks.append((
                 UploadTask(local_path=png_path, r2_key=r2_key,
                            content_type='image/png'),

--- a/python/campfire/deploy/photometry.py
+++ b/python/campfire/deploy/photometry.py
@@ -26,6 +26,7 @@ from astropy.table import Table
 import astropy.units as u
 from supabase import Client
 
+from campfire_layout import Scope, storage_key
 from campfire.deploy.r2 import UploadTask, upload_files_parallel
 
 
@@ -689,7 +690,7 @@ def deploy_field_photometry(
                 if sidecar is not None:
                     has_pz = True
                     n_pz += 1
-                    r2_key = f"photometry/{field}/{obj['object_id']}_pz.json"
+                    r2_key = storage_key('photometry_pz', Scope(field=field, object_id=obj['object_id']))
                     local_path = Path(tmpdir) / f"{obj['object_id']}_pz.json"
                     local_path.write_text(
                         json.dumps(sidecar, separators=(',', ':')),

--- a/python/campfire/deploy/remove.py
+++ b/python/campfire/deploy/remove.py
@@ -18,6 +18,7 @@ removed via the existing ``ON DELETE CASCADE`` foreign-key constraints.
 
 from supabase import Client
 
+from campfire_layout import Scope, key_prefix
 from campfire.deploy.supabase import (
     get_supabase_client,
     refresh_filter_options,
@@ -28,7 +29,9 @@ from campfire.deploy.supabase import (
 BATCH_SIZE = 500
 PAGE_SIZE = 1000
 
-R2_PREFIXES = ('spectra', 'rgb', 'sed')
+# (display label, product_type) — the per-observation key prefixes hard-delete
+# removes. The label keeps the report readable; the product_type drives the key.
+R2_REMOVE_PRODUCTS = (('spectra', 'nirspec_spec'), ('rgb', 'rgb'), ('sed', 'sed'))
 
 INSPECTION_FIELDS = (
     'target_id, id, redshift_quality, redshift_inspected, '
@@ -167,10 +170,11 @@ def _delete_r2_prefixes(config: dict, obs_name: str) -> dict[str, int]:
 
     client = get_r2_client(config)
     bucket = resolve_backend(config, 'data').bucket
+    scope = Scope(obs=obs_name)
     counts: dict[str, int] = {}
-    for prefix in R2_PREFIXES:
-        full = f"{prefix}/{obs_name}/"
-        counts[prefix] = delete_r2_prefix(client, bucket, full)
+    for label, product_type in R2_REMOVE_PRODUCTS:
+        full = f"{key_prefix(product_type, scope)}/"
+        counts[label] = delete_r2_prefix(client, bucket, full)
     return counts
 
 
@@ -252,10 +256,11 @@ def remove_observation(
             summary += f", {n_comments} comments"
         prompt = f"\nProceed with deleting {summary}"
         if not supabase_only:
-            prompt += (
-                f"\n  + R2 prefixes: "
-                f"spectra/{obs_name}/, rgb/{obs_name}/, sed/{obs_name}/"
+            scope = Scope(obs=obs_name)
+            prefixes = ', '.join(
+                f"{key_prefix(pt, scope)}/" for _label, pt in R2_REMOVE_PRODUCTS
             )
+            prompt += f"\n  + R2 prefixes: {prefixes}"
         prompt += "? [y/N] "
         response = input(prompt)
         if response.lower() != 'y':

--- a/python/campfire/deploy/summary.py
+++ b/python/campfire/deploy/summary.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 from astropy.table import Table
 
+from campfire_layout import Scope, storage_key
+
 
 def _finite_or_none(value) -> float | None:
     """Coerce a scalar to a JSON-safe float, mapping non-finite to None.
@@ -161,7 +163,7 @@ def get_spectra_records(summary: Table, obs_name: str) -> list[dict]:
 
     records = []
     for row in summary:
-        r2_key = f"spectra/{obs_name}/{row['fits_filename']}"
+        r2_key = storage_key('nirspec_spec', Scope(obs=obs_name), row['fits_filename'])
         rec = {
             'target_id': row['object_id'],
             'grating': row['grating'],

--- a/python/campfire/deploy/tiles.py
+++ b/python/campfire/deploy/tiles.py
@@ -17,6 +17,7 @@ from tqdm import tqdm
 logger = logging.getLogger(__name__)
 
 
+from campfire_layout import relpath_to_key
 from campfire.deploy.r2 import UploadTask, upload_files_parallel
 
 
@@ -113,7 +114,9 @@ def upload_tiles(
         tasks = []
         for png_path in png_files:
             rel_path = png_path.relative_to(tile_dir)
-            r2_key = str(rel_path)
+            # The tiles-bucket key is the path under the tiles tree; route through
+            # the layout bijection (scheme-invariant for tiles — they stay on R2).
+            r2_key = relpath_to_key(f"tiles/{rel_path.as_posix()}")
             tasks.append(UploadTask(png_path, r2_key, 'image/png'))
 
         if dry_run:

--- a/python/campfire/sync.py
+++ b/python/campfire/sync.py
@@ -13,6 +13,8 @@ from typing import Dict, List, Optional, Tuple
 import requests
 from tqdm import tqdm
 
+from campfire_layout import parse_key
+
 from .api.session import create_download_session
 from .exceptions import DownloadError
 
@@ -237,13 +239,20 @@ def compute_download_plan(
 
 def download_and_verify(
     spec: dict,
-    obs_dir: Path,
     products_dir: Path,
     download_session: requests.Session,
 ) -> dict:
-    """Download a single file, verify checksum, return result dict."""
-    filename = Path(spec["fits_path"]).name
-    local_path = obs_dir / filename
+    """Download a single file, verify checksum, return result dict.
+
+    The local destination is derived from the object's storage key via the shared
+    layout contract (``products_relpath``), so it always lands in the same tree
+    the pipeline writes and deploy reads (``products/nirspec/<obs>/…``).
+    """
+    from .config import products_relpath
+
+    rel = products_relpath(spec["fits_path"])
+    local_path = products_dir / rel
+    local_path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = local_path.with_suffix(".tmp")
 
     try:
@@ -273,7 +282,7 @@ def download_and_verify(
             "id": spec.get("spectra_id"),
             "spectrum_id": spec.get("spectrum_id"),
             "target_id": spec.get("target_id"),
-            "observation": spec.get("observation", obs_dir.name),
+            "observation": spec.get("observation") or parse_key(spec["fits_path"]).scope.obs,
             "grating": spec["grating"],
             "fits_path": spec["fits_path"],
             "local_path": str(local_path.relative_to(products_dir)),
@@ -334,8 +343,10 @@ def download_observation(
     if dry_run or not to_download:
         return stats
 
-    obs_dir = products_dir / obs_name
-    obs_dir.mkdir(parents=True, exist_ok=True)
+    # Destinations are resolved per-file from each object's storage key (via the
+    # layout contract), so no obs_dir is precomputed here — download_and_verify
+    # creates parents under products/nirspec/<obs>/ as needed.
+    products_dir.mkdir(parents=True, exist_ok=True)
 
     dl_session = download_session or create_download_session(max_workers)
 
@@ -344,7 +355,7 @@ def download_observation(
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         future_to_spec = {
-            executor.submit(download_and_verify, spec, obs_dir, products_dir, dl_session): spec
+            executor.submit(download_and_verify, spec, products_dir, dl_session): spec
             for spec in to_download
         }
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,6 +24,8 @@ classifiers = [
 ]
 
 dependencies = [
+    # Shared directory/key contract (#213); install from ./layout (not on PyPI)
+    "campfire-layout",
     # Core (auth, API client, CLI)
     "click>=8.0",
     "requests>=2.28.0",

--- a/python/tests/test_local_first.py
+++ b/python/tests/test_local_first.py
@@ -72,7 +72,7 @@ def local_store(tmp_path):
             "target_id": "test_obj_100",
             "object_id": "TEST-OBJ-100",
             "grating": "PRISM",
-            "fits_path": "test_obs/test_obs_prism_100_spec.fits",
+            "fits_path": "spectra/test_obs/test_obs_prism_100_spec.fits",
             "file_hash": "sha256:abc",
             "file_size": 1024,
             "signal_to_noise": 15.0,
@@ -86,7 +86,7 @@ def local_store(tmp_path):
             "target_id": "test_obj_200",
             "object_id": "TEST-OBJ-200",
             "grating": "PRISM",
-            "fits_path": "test_obs/test_obs_prism_200_spec.fits",
+            "fits_path": "spectra/test_obs/test_obs_prism_200_spec.fits",
             "file_hash": "sha256:def",
             "file_size": 1024,
             "signal_to_noise": 5.0,
@@ -224,14 +224,14 @@ class TestOpenSpectrum:
     def test_returns_local_file(self, local_client):
         client, mock_session, store, tmp_path = local_client
 
-        obs_dir = tmp_path / "products" / "test_obs"
+        obs_dir = tmp_path / "products" / "nirspec" / "test_obs"
         obs_dir.mkdir(parents=True, exist_ok=True)
         fits_file = obs_dir / "test_obs_prism_100_spec.fits"
         fits_file.write_bytes(self._make_fits_bytes(50))
 
         store.mark_synced(
             spectrum_id="test_obs_prism_100",
-            local_path="test_obs/test_obs_prism_100_spec.fits",
+            local_path="nirspec/test_obs/test_obs_prism_100_spec.fits",
             file_hash="sha256:abc",
             file_size=fits_file.stat().st_size,
         )
@@ -260,7 +260,7 @@ class TestOpenSpectrum:
         assert isinstance(spec, SpectrumData)
         assert spec.wavelength.shape == (30,)
 
-        cached = tmp_path / "products" / "test_obs" / "test_obs_prism_100_spec.fits"
+        cached = tmp_path / "products" / "nirspec" / "test_obs" / "test_obs_prism_100_spec.fits"
         assert cached.exists()
         assert store.find_local_path("test_obs_prism_100") is not None
 

--- a/web/app/api/nircam-preview/route.ts
+++ b/web/app/api/nircam-preview/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { getS3Client, getBucketName } from '@/lib/storage';
 import { createClient } from '@/lib/supabase/server';
+import { isKnownKey, parseKey } from '@/lib/layout';
 
 /**
  * GET /api/nircam-preview?key=<r2_key>
@@ -33,7 +34,13 @@ export async function GET(request: NextRequest) {
   }
 
   const key = request.nextUrl.searchParams.get('key');
-  if (!key || !key.startsWith('nircam/exposures/') || key.includes('..')) {
+  // Validate against the layout contract: a known data-bucket key (rejects
+  // traversal/unsafe), restricted to NIRCam exposure preview/full PNGs.
+  if (!key || !isKnownKey(key, { bucket: 'data' })) {
+    return new Response('Invalid key', { status: 400 });
+  }
+  const productType = parseKey(key).productType;
+  if (productType !== 'nircam_exposure_preview' && productType !== 'nircam_exposure_full') {
     return new Response('Invalid key', { status: 400 });
   }
 

--- a/web/app/api/photometry-pz/route.ts
+++ b/web/app/api/photometry-pz/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { generateDownloadUrl } from '@/lib/r2';
+import { storageKey } from '@/lib/layout';
 
 /**
  * GET /api/photometry-pz?object_id=<object_id>
@@ -48,8 +49,8 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Construct P(z) sidecar path using DB-derived field
-    const pzPath = `photometry/${obj.field}/${objectId}_pz.json`;
+    // Construct P(z) sidecar key via the shared layout contract (DB-derived field)
+    const pzPath = storageKey('photometry_pz', { field: obj.field, object_id: objectId });
 
     // Generate signed URL and fetch server-side (avoids CORS issues)
     const signedUrl = await generateDownloadUrl(pzPath, 3600);

--- a/web/app/api/redshift-fit/route.ts
+++ b/web/app/api/redshift-fit/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { generateDownloadUrl } from '@/lib/r2';
+import { deriveSibling } from '@/lib/layout';
 
 export interface RedshiftFitData {
   redshift: number;
@@ -57,10 +58,8 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Convert FITS path to zfit JSON path
-    // spectra/{obs_name}/{obs_name}_{grating}_{filter}_{source_id}_spec.fits
-    // → spectra/{obs_name}/{obs_name}_{grating}_{filter}_{source_id}_zfit.json
-    const zfitJsonPath = fitsPath.replace('_spec.fits', '_zfit.json');
+    // Derive the zfit-JSON sibling key via the shared layout contract
+    const zfitJsonPath = deriveSibling(fitsPath, 'zfit');
 
     // Generate signed URL for the zfit JSON file
     const signedUrl = await generateDownloadUrl(zfitJsonPath, 3600);

--- a/web/app/api/sed-plot/route.ts
+++ b/web/app/api/sed-plot/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { generateDownloadUrl } from '@/lib/r2';
+import { storageKey } from '@/lib/layout';
 
 /**
  * GET /api/sed-plot?target_id=<target_id>
@@ -54,8 +55,8 @@ export async function GET(request: NextRequest) {
     // Pattern: {observation}_{srcid} e.g., "ember_cosmos_p1_12345"
     const observation = target.observation || targetId.substring(0, targetId.lastIndexOf('_'));
 
-    // Construct SED plot path in R2
-    const sedPlotPath = `sed/${observation}/${targetId}_sed.pdf`;
+    // Construct SED plot key via the shared layout contract
+    const sedPlotPath = storageKey('sed', { obs: observation }, `${targetId}_sed.pdf`);
 
     // Generate signed URL (expires in 1 hour)
     const signedUrl = await generateDownloadUrl(sedPlotPath, 3600);

--- a/web/app/api/spectrum-thumbnail/route.ts
+++ b/web/app/api/spectrum-thumbnail/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { generateDownloadUrl } from '@/lib/r2';
+import { deriveSibling } from '@/lib/layout';
 
 // Grating priority order
 const GRATING_PRIORITY = ['PRISM', 'G395M', 'G235M', 'G140M'];
@@ -217,8 +218,8 @@ export async function GET(request: NextRequest) {
     }
 
     // Fallback to R2 fetch for missing thumbnails (backward compatibility)
-    // Get JSON path from FITS path
-    const jsonPath = selectedSpectrum.fits_path.replace('.fits', '.json');
+    // Derive the spectrum-JSON sibling key via the shared layout contract
+    const jsonPath = deriveSibling(selectedSpectrum.fits_path, 'spectrum_json');
 
     // Generate signed URL for the JSON file
     const signedUrl = await generateDownloadUrl(jsonPath, 3600);

--- a/web/app/api/spectrum/route.ts
+++ b/web/app/api/spectrum/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { generateDownloadUrl } from '@/lib/r2';
+import { deriveSibling } from '@/lib/layout';
 
 export interface SpectrumData {
   wave: number[];
@@ -60,8 +61,8 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Convert FITS path to JSON path
-    const jsonPath = fitsPath.replace('.fits', '.json');
+    // Derive the spectrum-JSON sibling key via the shared layout contract
+    const jsonPath = deriveSibling(fitsPath, 'spectrum_json');
 
     // Generate signed URL for the JSON file
     const signedUrl = await generateDownloadUrl(jsonPath, 3600);

--- a/web/app/api/v1/deploy/presign/route.ts
+++ b/web/app/api/v1/deploy/presign/route.ts
@@ -4,6 +4,7 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { validateAuth } from '@/lib/api-auth';
 import { createClient } from '@supabase/supabase-js';
 import { getS3Client, getBucketName, type StoragePurpose } from '@/lib/storage';
+import { isKnownKey } from '@/lib/layout';
 
 const MAX_BATCH_SIZE = 500;
 const PRESIGN_EXPIRY_SECONDS = 3600; // 1 hour
@@ -82,6 +83,19 @@ export async function POST(request: NextRequest) {
     if (bucketId !== 'data' && bucketId !== 'tiles') {
       return NextResponse.json(
         { error: 'invalid_request', error_description: 'bucket must be "data" or "tiles"' },
+        { status: 400 }
+      );
+    }
+
+    // Allowlist: every key must be a contract-valid key for the requested bucket.
+    // Rejects traversal/unsafe keys and anything outside the layout contract, so
+    // a presign can never sign an arbitrary or out-of-tree object.
+    const badUpload = uploads.find(
+      (u: { key?: string }) => !u.key || !isKnownKey(u.key, { bucket: bucketId })
+    );
+    if (badUpload) {
+      return NextResponse.json(
+        { error: 'invalid_request', error_description: `key not permitted by layout contract: ${badUpload.key}` },
         { status: 400 }
       );
     }

--- a/web/app/api/v1/redshift-fit/route.ts
+++ b/web/app/api/v1/redshift-fit/route.ts
@@ -3,6 +3,7 @@ import { createClient } from '@supabase/supabase-js';
 import { validateAuth } from '@/lib/api-auth';
 import { getAccessiblePrograms } from '@/lib/api-helpers';
 import { generateDownloadUrl } from '@/lib/r2';
+import { deriveSibling } from '@/lib/layout';
 
 export interface RedshiftFitData {
   redshift: number;
@@ -136,10 +137,8 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Convert FITS path to zfit JSON path
-    // spectra/{obs_name}/{obs_name}_{grating}_{filter}_{source_id}_spec.fits
-    // -> spectra/{obs_name}/{obs_name}_{grating}_{filter}_{source_id}_zfit.json
-    const zfitJsonPath = fitsPath.replace('_spec.fits', '_zfit.json');
+    // Derive the zfit-JSON sibling key via the shared layout contract
+    const zfitJsonPath = deriveSibling(fitsPath, 'zfit');
 
     // Generate signed URL for the zfit JSON file
     const signedUrl = await generateDownloadUrl(zfitJsonPath, 3600);

--- a/web/app/api/v1/spectrum/route.ts
+++ b/web/app/api/v1/spectrum/route.ts
@@ -3,6 +3,7 @@ import { createClient } from '@supabase/supabase-js';
 import { validateAuth } from '@/lib/api-auth';
 import { getAccessiblePrograms } from '@/lib/api-helpers';
 import { generateDownloadUrl } from '@/lib/r2';
+import { deriveSibling } from '@/lib/layout';
 
 export interface SpectrumData {
   wave: number[];
@@ -125,8 +126,8 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Convert FITS path to JSON path
-    const jsonPath = fitsPath.replace('.fits', '.json');
+    // Derive the spectrum-JSON sibling key via the shared layout contract
+    const jsonPath = deriveSibling(fitsPath, 'spectrum_json');
 
     // Generate signed URL for the JSON file
     const signedUrl = await generateDownloadUrl(jsonPath, 3600);

--- a/web/lib/layout.test.ts
+++ b/web/lib/layout.test.ts
@@ -1,0 +1,98 @@
+// TS arm of the layout conformance test. Reads the SAME golden fixture as the
+// python arm (pipeline/tests/test_layout.py); any divergence fails both.
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import { describe, it, expect } from 'vitest';
+import {
+  storageKey,
+  bucketFor,
+  parseKey,
+  deriveSibling,
+  isKnownKey,
+  PRODUCTS,
+  type Scope,
+} from './layout';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = resolve(here, '../../layout/conformance/layout_golden.json');
+const golden = JSON.parse(readFileSync(FIXTURE, 'utf-8'));
+
+interface Case {
+  product_type: string;
+  scope: Scope;
+  filename: string | null;
+  relpath: string | null;
+  key_legacy: string | null;
+  key_canonical: string | null;
+  bucket: string | null;
+  tree_class: string;
+}
+
+describe('layout golden conformance', () => {
+  for (const c of golden.cases as Case[]) {
+    const fn = c.filename ?? undefined;
+
+    it(`${c.product_type}: storage keys`, () => {
+      if (c.key_legacy !== null) {
+        expect(storageKey(c.product_type, c.scope, fn, 'legacy')).toBe(c.key_legacy);
+      }
+      if (c.key_canonical !== null) {
+        expect(storageKey(c.product_type, c.scope, fn, 'canonical')).toBe(c.key_canonical);
+      }
+    });
+
+    it(`${c.product_type}: bucket`, () => {
+      if (c.bucket !== null) {
+        expect(bucketFor(c.product_type)).toBe(c.bucket);
+      } else {
+        expect(() => bucketFor(c.product_type)).toThrow();
+      }
+    });
+
+    it(`${c.product_type}: parse round-trips`, () => {
+      if (c.key_legacy !== null) {
+        const pk = parseKey(c.key_legacy);
+        expect(pk.productType).toBe(c.product_type);
+        expect(storageKey(pk.productType, pk.scope, pk.filename, 'legacy')).toBe(c.key_legacy);
+      }
+      if (c.key_canonical !== null) {
+        const pk = parseKey(c.key_canonical);
+        expect(pk.productType).toBe(c.product_type);
+        expect(storageKey(pk.productType, pk.scope, pk.filename, 'canonical')).toBe(c.key_canonical);
+      }
+    });
+  }
+});
+
+describe('siblings', () => {
+  for (const s of golden.siblings as { from: string; to: string; expect: string }[]) {
+    it(`${s.from} -> ${s.to}`, () => {
+      expect(deriveSibling(s.from, s.to)).toBe(s.expect);
+    });
+  }
+});
+
+describe('presign allowlist', () => {
+  it('accepts known keys', () => {
+    for (const key of golden.known_keys as string[]) {
+      expect(isKnownKey(key)).toBe(true);
+    }
+  });
+  it('rejects unknown / unsafe keys', () => {
+    for (const key of golden.unknown_keys as string[]) {
+      expect(isKnownKey(key)).toBe(false);
+    }
+    expect(isKnownKey('spectra/ember/../../secret.fits')).toBe(false);
+    expect(isKnownKey('data/../../../etc/passwd')).toBe(false);
+  });
+});
+
+describe('registry parity', () => {
+  it('every cloud-backed product has a golden case', () => {
+    const covered = new Set((golden.cases as Case[]).map((c) => c.product_type));
+    const missing = Object.keys(PRODUCTS).filter((p) => !covered.has(p));
+    expect(missing).toEqual([]);
+  });
+});

--- a/web/lib/layout.ts
+++ b/web/lib/layout.ts
@@ -1,0 +1,343 @@
+// campfire_layout — TypeScript mirror of the CAMPFIRE directory/key contract.
+//
+// This is the web side of the single layout authority. The python core lives in
+// `layout/campfire_layout/`; both are kept in lockstep by the shared golden
+// fixture (`layout/conformance/layout_golden.json`), checked by this package's
+// `layout.test.ts` AND `pipeline/tests/test_layout.py` — so python↔TS drift
+// fails CI.
+//
+// Web never touches the filesystem, so this mirror omits the local-path helpers
+// (roots/dir_for/local_path/cache_path/…) and keeps only what the portal needs:
+// storage keys, the key→sibling derivation, key parsing, and the presign/proxy
+// allowlist. Scope field names are snake_case to match the contract + fixture
+// exactly (fidelity over JS idiom).
+
+export type Bucket = 'data' | 'tiles';
+export type KeyScheme = 'legacy' | 'canonical';
+
+export class LayoutError extends Error {}
+
+export interface Scope {
+  obs?: string;
+  field?: string;
+  filt?: string;
+  pid?: string;
+  data_subdir?: string;
+  source_id?: string;
+  detector?: string;
+  exposure?: string;
+  object_id?: string;
+  catalog_id?: string;
+  tile?: string;
+  pixel_scale?: string;
+  zoom?: number;
+  x?: number;
+  y?: number;
+}
+
+type Builder = (s: Scope) => string;
+
+interface ProductSpec {
+  name: string;
+  tree: string; // products | reference | raw | cache | tiles | meta | cutouts
+  bucket: Bucket | null;
+  scopeKeys: (keyof Scope)[];
+  subdir: Builder;
+  suffix: string | null;
+  legacyPrefix: Builder | null;
+  filename: Builder | null;
+  mirrored: boolean;
+  schemeInvariant: boolean;
+}
+
+function spec(p: Partial<ProductSpec> & Pick<ProductSpec, 'name' | 'tree' | 'scopeKeys' | 'subdir'>): ProductSpec {
+  return {
+    bucket: null,
+    suffix: null,
+    legacyPrefix: null,
+    filename: null,
+    mirrored: true,
+    schemeInvariant: false,
+    ...p,
+  };
+}
+
+const nirspecObs: Builder = (s) => `nirspec/${s.obs}`;
+const nircamFieldFilter: Builder = (s) => `nircam/${s.field}/${s.filt}`;
+
+export const PRODUCTS: Record<string, ProductSpec> = {};
+function reg(p: ProductSpec) {
+  PRODUCTS[p.name] = p;
+}
+
+// --- NIRSpec products (spectrum family shares products/nirspec/<obs>/) ---
+reg(spec({ name: 'nirspec_spec', tree: 'products', bucket: 'data', scopeKeys: ['obs'], subdir: nirspecObs, suffix: '_spec.fits', legacyPrefix: (s) => `spectra/${s.obs}` }));
+reg(spec({ name: 'spectrum_json', tree: 'products', bucket: 'data', scopeKeys: ['obs'], subdir: nirspecObs, suffix: '_spec.json', legacyPrefix: (s) => `spectra/${s.obs}` }));
+reg(spec({ name: 'zfit', tree: 'products', bucket: 'data', scopeKeys: ['obs'], subdir: nirspecObs, suffix: '_zfit.json', legacyPrefix: (s) => `spectra/${s.obs}` }));
+reg(spec({ name: 'nirspec_spectrum_exposure', tree: 'products', bucket: 'data', scopeKeys: ['obs'], subdir: nirspecObs, suffix: '.fits' }));
+reg(spec({ name: 'rgb', tree: 'products', bucket: 'data', scopeKeys: ['obs'], subdir: nirspecObs, suffix: '_rgb.png', legacyPrefix: (s) => `rgb/${s.obs}` }));
+reg(spec({ name: 'sed', tree: 'products', bucket: 'data', scopeKeys: ['obs'], subdir: nirspecObs, suffix: '_sed.pdf', legacyPrefix: (s) => `sed/${s.obs}` }));
+
+// --- NIRCam products ---
+reg(spec({ name: 'nircam_exposure', tree: 'products', bucket: 'data', scopeKeys: ['field', 'filt'], subdir: nircamFieldFilter, suffix: '.fits' }));
+reg(spec({ name: 'nircam_exposure_preview', tree: 'products', bucket: 'data', scopeKeys: ['field', 'filt'], subdir: nircamFieldFilter, suffix: '_preview.png', legacyPrefix: (s) => `nircam/exposures/${s.field}/${s.filt}` }));
+reg(spec({ name: 'nircam_exposure_full', tree: 'products', bucket: 'data', scopeKeys: ['field', 'filt'], subdir: nircamFieldFilter, suffix: '_full.png', legacyPrefix: (s) => `nircam/exposures/${s.field}/${s.filt}` }));
+reg(spec({ name: 'nircam_mosaic', tree: 'products', bucket: 'data', scopeKeys: ['field', 'filt'], subdir: nircamFieldFilter, suffix: null }));
+reg(spec({ name: 'nircam_rgb', tree: 'products', bucket: 'data', scopeKeys: ['field'], subdir: (s) => `nircam/${s.field}`, suffix: '_rgb.png' }));
+reg(spec({ name: 'nircam_expmap', tree: 'products', bucket: 'data', scopeKeys: ['field'], subdir: (s) => `nircam/${s.field}/expmaps`, suffix: null }));
+
+// --- Map tiles (separate bucket, scheme-invariant) ---
+reg(spec({
+  name: 'tile', tree: 'tiles', bucket: 'tiles', scopeKeys: ['field', 'filt', 'zoom', 'x', 'y'],
+  subdir: (s) => `${s.field}/${s.filt}/${s.zoom}/${s.x}`, filename: (s) => `${s.y}.png`,
+  suffix: '.png', legacyPrefix: (s) => `${s.field}/${s.filt}/${s.zoom}/${s.x}`, schemeInvariant: true,
+}));
+
+// --- Photometry (key-only) ---
+reg(spec({
+  name: 'photometry_pz', tree: 'products', bucket: 'data', scopeKeys: ['field', 'object_id'],
+  subdir: (s) => `photometry/${s.field}`, filename: (s) => `${s.object_id}_pz.json`,
+  suffix: '_pz.json', legacyPrefix: (s) => `photometry/${s.field}`, mirrored: false,
+}));
+
+// --- Metadata (Postgres-resident; no storage key) ---
+for (const [name, suffix] of [['summary', '_summary.ecsv'], ['pointings', '_pointings.ecsv'], ['shutters', '_shutters.ecsv'], ['nirspec_config', '_config.toml']] as const) {
+  reg(spec({ name, tree: 'products', bucket: null, scopeKeys: ['obs'], subdir: nirspecObs, suffix, filename: (s) => `${s.obs}${suffix}` }));
+}
+
+// --- Reducer-decision reference state (user-state) ---
+reg(spec({ name: 'nirspec_manual_mask', tree: 'products', bucket: 'data', scopeKeys: ['obs'], subdir: (s) => `nirspec/${s.obs}/manual_masks`, suffix: '.reg' }));
+reg(spec({ name: 'nirspec_stuck_shutters', tree: 'reference', bucket: 'data', scopeKeys: ['obs'], subdir: nirspecObs, suffix: 'stuck_closed_shutters.toml', filename: () => 'stuck_closed_shutters.toml' }));
+reg(spec({ name: 'nirspec_bkg_override', tree: 'reference', bucket: 'data', scopeKeys: ['obs'], subdir: nirspecObs, suffix: 'nodded_background_overrides.toml', filename: () => 'nodded_background_overrides.toml' }));
+reg(spec({ name: 'nircam_mask', tree: 'reference', bucket: 'data', scopeKeys: ['field'], subdir: (s) => `nircam/${s.field}/masks` }));
+reg(spec({ name: 'nircam_astrom_cat', tree: 'reference', bucket: 'data', scopeKeys: ['field'], subdir: (s) => `nircam/${s.field}/astrom_cats` }));
+reg(spec({ name: 'nircam_bad_pixel', tree: 'reference', bucket: 'data', scopeKeys: ['field'], subdir: (s) => `nircam/${s.field}/bad_pixels` }));
+
+// --- Shared calibration references ---
+reg(spec({ name: 'nircam_flat', tree: 'reference', bucket: 'data', scopeKeys: [], subdir: () => 'nircam/shared/flats' }));
+reg(spec({ name: 'nircam_wisp', tree: 'reference', bucket: 'data', scopeKeys: [], subdir: () => 'nircam/shared/wisps' }));
+
+// --- Raw (external/MAST; not cloud-backed) ---
+reg(spec({ name: 'raw_nirspec', tree: 'raw', bucket: null, scopeKeys: ['data_subdir'], subdir: (s) => `nirspec/${s.data_subdir}` }));
+reg(spec({ name: 'raw_nircam', tree: 'raw', bucket: null, scopeKeys: ['pid', 'filt'], subdir: (s) => `nircam/${s.pid}/${s.filt}` }));
+
+function get(productType: string): ProductSpec {
+  const s = PRODUCTS[productType];
+  if (!s) throw new LayoutError(`unknown product_type '${productType}'`);
+  return s;
+}
+
+function validate(s: ProductSpec, scope: Scope): void {
+  const missing = s.scopeKeys.filter((k) => scope[k] === undefined || scope[k] === null);
+  if (missing.length) throw new LayoutError(`scope missing required field(s) ${missing.join(', ')} for '${s.name}'`);
+}
+
+function relDir(s: ProductSpec, scope: Scope): string {
+  const sub = s.subdir(scope);
+  return sub ? `${s.tree}/${sub}` : s.tree;
+}
+
+function resolveFilename(s: ProductSpec, scope: Scope, filename?: string): string {
+  if (filename !== undefined) return filename;
+  if (s.filename) return s.filename(scope);
+  throw new LayoutError(`product '${s.name}' requires an explicit filename`);
+}
+
+// ---------------------------------------------------------------------------
+// Storage keys
+// ---------------------------------------------------------------------------
+
+export function bucketFor(productType: string): Bucket {
+  const s = get(productType);
+  if (!s.bucket) throw new LayoutError(`product '${productType}' is not cloud-backed`);
+  return s.bucket;
+}
+
+export function keyPrefix(productType: string, scope: Scope, scheme: KeyScheme = 'legacy'): string {
+  const s = get(productType);
+  if (!s.bucket) throw new LayoutError(`product '${productType}' is not cloud-backed`);
+  validate(s, scope);
+  if (s.schemeInvariant) return s.legacyPrefix!(scope);
+  if (scheme === 'legacy' && s.legacyPrefix) return s.legacyPrefix(scope);
+  if (s.mirrored) return `data/${relDir(s, scope)}`;
+  if (s.legacyPrefix) return `data/${s.legacyPrefix(scope)}`;
+  throw new LayoutError(`product '${productType}' has no resolvable storage key`);
+}
+
+export function storageKey(productType: string, scope: Scope, filename?: string, scheme: KeyScheme = 'legacy'): string {
+  const s = get(productType);
+  return `${keyPrefix(productType, scope, scheme)}/${resolveFilename(s, scope, filename)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Parsing (key → product/scope/filename)
+// ---------------------------------------------------------------------------
+
+export interface ParsedKey {
+  productType: string;
+  scope: Scope;
+  filename: string;
+}
+
+const NIRSPEC_OBS_SUFFIXES: [string, string][] = [
+  ['_spec.fits', 'nirspec_spec'],
+  ['_spec.json', 'spectrum_json'],
+  ['_zfit.json', 'zfit'],
+  ['_rgb.png', 'rgb'],
+  ['_sed.pdf', 'sed'],
+  ['_summary.ecsv', 'summary'],
+  ['_pointings.ecsv', 'pointings'],
+  ['_shutters.ecsv', 'shutters'],
+  ['_config.toml', 'nirspec_config'],
+];
+const NIRCAM_FILTER_SUFFIXES: [string, string][] = [
+  ['_preview.png', 'nircam_exposure_preview'],
+  ['_full.png', 'nircam_exposure_full'],
+];
+const TILE_RE = /^([^/]+)\/([^/]+)\/(\d+)\/(\d+)\/(\d+)\.png$/;
+
+function dispatch(fname: string, table: [string, string][]): string | null {
+  for (const [suffix, pt] of table) if (fname.endsWith(suffix)) return pt;
+  return null;
+}
+
+function nirspecObsProduct(fname: string): string {
+  const pt = dispatch(fname, NIRSPEC_OBS_SUFFIXES);
+  if (pt) return pt;
+  if (fname.endsWith('.fits')) return 'nirspec_spectrum_exposure';
+  throw new LayoutError(`unrecognized NIRSpec product filename '${fname}'`);
+}
+
+function rejectUnsafe(key: string): void {
+  if (!key || key.startsWith('/') || key.includes('\\')) throw new LayoutError(`unsafe key '${key}'`);
+  if (key.split('/').some((p) => p === '' || p === '.' || p === '..')) throw new LayoutError(`unsafe key '${key}'`);
+}
+
+export function parseRelpath(relpath: string): ParsedKey {
+  rejectUnsafe(relpath);
+  const seg = relpath.split('/');
+  const tree = seg[0];
+
+  if (tree === 'products' && seg.length >= 4 && seg[1] === 'nirspec') {
+    const obs = seg[2];
+    if (seg.length === 5 && seg[3] === 'manual_masks') return { productType: 'nirspec_manual_mask', scope: { obs }, filename: seg[4] };
+    if (seg.length === 4) return { productType: nirspecObsProduct(seg[3]), scope: { obs }, filename: seg[3] };
+  }
+  if (tree === 'products' && seg.length >= 4 && seg[1] === 'nircam') {
+    const field = seg[2];
+    if (seg.length === 4 && seg[3].endsWith('_rgb.png')) return { productType: 'nircam_rgb', scope: { field }, filename: seg[3] };
+    if (seg.length === 5 && seg[3] === 'expmaps') return { productType: 'nircam_expmap', scope: { field }, filename: seg[4] };
+    if (seg.length === 5) {
+      const filt = seg[3];
+      const fname = seg[4];
+      const pt = dispatch(fname, NIRCAM_FILTER_SUFFIXES);
+      if (pt) return { productType: pt, scope: { field, filt }, filename: fname };
+      if (fname.startsWith('mosaic')) return { productType: 'nircam_mosaic', scope: { field, filt }, filename: fname };
+      if (fname.endsWith('.fits')) return { productType: 'nircam_exposure', scope: { field, filt }, filename: fname };
+    }
+  }
+  if (tree === 'reference' && seg.length >= 4 && seg[1] === 'nirspec') {
+    const obs = seg[2];
+    const fname = seg[seg.length - 1];
+    if (fname === 'stuck_closed_shutters.toml') return { productType: 'nirspec_stuck_shutters', scope: { obs }, filename: fname };
+    if (fname === 'nodded_background_overrides.toml') return { productType: 'nirspec_bkg_override', scope: { obs }, filename: fname };
+  }
+  if (tree === 'reference' && seg.length >= 4 && seg[1] === 'nircam') {
+    const fname = seg[seg.length - 1];
+    if (seg[2] === 'shared' && seg.length === 5) {
+      if (seg[3] === 'flats') return { productType: 'nircam_flat', scope: {}, filename: fname };
+      if (seg[3] === 'wisps') return { productType: 'nircam_wisp', scope: {}, filename: fname };
+    } else {
+      const field = seg[2];
+      const kind = seg[3];
+      if (kind === 'masks') return { productType: 'nircam_mask', scope: { field }, filename: fname };
+      if (kind === 'astrom_cats') return { productType: 'nircam_astrom_cat', scope: { field }, filename: fname };
+      if (kind === 'bad_pixels') return { productType: 'nircam_bad_pixel', scope: { field }, filename: fname };
+    }
+  }
+  if (tree === 'tiles' && seg.length === 6 && seg[5].endsWith('.png')) {
+    return { productType: 'tile', scope: { field: seg[1], filt: seg[2], zoom: +seg[3], x: +seg[4], y: +seg[5].slice(0, -4) }, filename: seg[5] };
+  }
+  if (tree === 'raw' && seg.length >= 4 && seg[1] === 'nirspec') return { productType: 'raw_nirspec', scope: { data_subdir: seg[2] }, filename: seg[seg.length - 1] };
+  if (tree === 'raw' && seg.length >= 5 && seg[1] === 'nircam') return { productType: 'raw_nircam', scope: { pid: seg[2], filt: seg[3] }, filename: seg[seg.length - 1] };
+
+  throw new LayoutError(`unrecognized relpath '${relpath}'`);
+}
+
+export function parseKey(key: string, opts?: { bucket?: Bucket }): ParsedKey {
+  rejectUnsafe(key);
+  // Canonical 'data/' key: relpath (mirrored products) or 'data/' + legacy-form
+  // prefix (key-only products like photometry, with no local relpath to mirror).
+  if (key.startsWith('data/')) {
+    const rest = key.slice('data/'.length);
+    try {
+      return parseRelpath(rest);
+    } catch {
+      return parseLegacyKey(rest, opts);
+    }
+  }
+  return parseLegacyKey(key, opts);
+}
+
+function parseLegacyKey(key: string, opts?: { bucket?: Bucket }): ParsedKey {
+  const seg = key.split('/');
+  if (seg[0] === 'spectra' && seg.length === 3) return { productType: nirspecObsProduct(seg[2]), scope: { obs: seg[1] }, filename: seg[2] };
+  if (seg[0] === 'rgb' && seg.length === 3) return { productType: 'rgb', scope: { obs: seg[1] }, filename: seg[2] };
+  if (seg[0] === 'sed' && seg.length === 3) return { productType: 'sed', scope: { obs: seg[1] }, filename: seg[2] };
+  if (seg[0] === 'nircam' && seg.length === 5 && seg[1] === 'exposures') {
+    const pt = dispatch(seg[4], NIRCAM_FILTER_SUFFIXES);
+    if (pt) return { productType: pt, scope: { field: seg[2], filt: seg[3] }, filename: seg[4] };
+  }
+  if (seg[0] === 'photometry' && seg.length === 3) {
+    return { productType: 'photometry_pz', scope: { field: seg[1], object_id: seg[2].replace(/_pz\.json$/, '') }, filename: seg[2] };
+  }
+
+  if (opts?.bucket === 'tiles' || TILE_RE.test(key)) {
+    const m = TILE_RE.exec(key);
+    if (m) return { productType: 'tile', scope: { field: m[1], filt: m[2], zoom: +m[3], x: +m[4], y: +m[5] }, filename: `${m[5]}.png` };
+  }
+
+  throw new LayoutError(`unrecognized storage key '${key}'`);
+}
+
+// ---------------------------------------------------------------------------
+// Public bijection-lite API (web subset)
+// ---------------------------------------------------------------------------
+
+/** Co-located sibling key, e.g. a spec key → its zfit/json key. Preserves the
+ * source key's prefix and scheme; only the filename suffix changes. */
+export function deriveSibling(key: string, targetProductType: string, opts?: { bucket?: Bucket }): string {
+  const pk = parseKey(key, opts);
+  const src = get(pk.productType);
+  const tgt = get(targetProductType);
+  if (src.suffix === null || tgt.suffix === null) {
+    throw new LayoutError(`cannot derive sibling between '${pk.productType}' and '${targetProductType}'`);
+  }
+  const base = pk.filename.slice(0, -src.suffix.length);
+  const prefix = key.slice(0, key.lastIndexOf('/'));
+  return `${prefix}/${base}${tgt.suffix}`;
+}
+
+/** True iff *key* parses to a cloud-backed product — the presign/proxy allowlist.
+ * Rejects traversal/unsafe keys and keys resolving to non-cloud products. */
+export function isKnownKey(key: string, opts?: { bucket?: Bucket }): boolean {
+  let pk: ParsedKey;
+  try {
+    pk = parseKey(key, opts);
+  } catch {
+    return false;
+  }
+  const s = PRODUCTS[pk.productType];
+  if (!s || !s.bucket) return false;
+  if (opts?.bucket && s.bucket !== opts.bucket) return false;
+  return true;
+}
+
+/** Observation name for a NIRSpec object key (replaces extractObservationName). */
+export function observationFromKey(key: string): string | null {
+  try {
+    return parseKey(key).scope.obs ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/web/lib/r2.ts
+++ b/web/lib/r2.ts
@@ -7,6 +7,7 @@
 import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { getS3Client, getBucketName } from './storage';
+import { storageKey } from './layout';
 
 /** S3 client for the `data` storage backend (lazy, cached). */
 export function getDataClient() {
@@ -80,7 +81,7 @@ export function extractObservationName(targetId: string): string {
  */
 export function generateRGBImagePath(targetId: string): string {
   const observation = extractObservationName(targetId);
-  return `rgb/${observation}/${targetId}_rgb.png`;
+  return storageKey('rgb', { obs: observation }, `${targetId}_rgb.png`);
 }
 
 /**
@@ -106,6 +107,6 @@ export async function generateRGBImageUrl(
  */
 export function generateSEDPlotPath(targetId: string): string {
   const observation = extractObservationName(targetId);
-  return `sed/${observation}/${targetId}_sed.pdf`;
+  return storageKey('sed', { obs: observation }, `${targetId}_sed.pdf`);
 }
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -44,7 +44,8 @@
         "eslint-config-next": "^15.0.3",
         "postcss": "^8.4.49",
         "tailwindcss": "^3.4.1",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^3.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1552,7 +1553,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1569,7 +1569,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1586,7 +1585,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1603,7 +1601,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1620,7 +1617,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1637,7 +1633,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1654,7 +1649,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1671,7 +1665,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1688,7 +1681,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1705,7 +1697,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1722,7 +1713,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1739,7 +1729,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1756,7 +1745,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1773,7 +1761,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1790,7 +1777,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1807,7 +1793,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1824,7 +1809,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1841,7 +1825,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1858,7 +1841,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1875,7 +1857,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1892,7 +1873,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1909,7 +1889,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1926,7 +1905,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1943,7 +1921,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1960,7 +1937,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1977,7 +1953,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5106,8 +5081,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.53.3",
@@ -5120,8 +5094,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.53.3",
@@ -5134,8 +5107,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.53.3",
@@ -5148,8 +5120,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.53.3",
@@ -5162,8 +5133,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.53.3",
@@ -5176,8 +5146,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.53.3",
@@ -5190,8 +5159,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.53.3",
@@ -5204,8 +5172,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.53.3",
@@ -5218,8 +5185,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.53.3",
@@ -5232,8 +5198,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.53.3",
@@ -5246,8 +5211,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.53.3",
@@ -5260,8 +5224,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.53.3",
@@ -5274,8 +5237,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.53.3",
@@ -5288,8 +5250,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.53.3",
@@ -5302,8 +5263,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.53.3",
@@ -5316,8 +5276,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.53.3",
@@ -5330,8 +5289,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.53.3",
@@ -5344,8 +5302,7 @@
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.53.3",
@@ -5358,8 +5315,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.53.3",
@@ -5372,8 +5328,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.53.3",
@@ -5386,8 +5341,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.53.3",
@@ -5400,8 +5354,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -6428,6 +6381,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -6436,6 +6400,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -7334,6 +7305,131 @@
         "vue": "^3.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@volar/language-core": {
       "version": "2.4.23",
       "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.23.tgz",
@@ -8155,6 +8251,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-kit": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.2.0.tgz",
@@ -8652,7 +8758,6 @@
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8779,6 +8884,23 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -8834,6 +8956,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -9924,6 +10056,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -10504,8 +10646,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -10625,7 +10766,6 @@
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -11263,6 +11403,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exsolve": {
@@ -13987,6 +14137,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lowlight": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
@@ -14048,7 +14205,6 @@
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
@@ -16650,8 +16806,17 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
       "license": "MIT",
-      "peer": true
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/pbf": {
       "version": "3.3.0",
@@ -18220,7 +18385,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
       "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -18763,6 +18927,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -18922,6 +19093,13 @@
         "node": "*"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
@@ -18962,8 +19140,7 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -19318,7 +19495,6 @@
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
       "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "js-tokens": "^9.0.1"
       },
@@ -19330,8 +19506,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/strnum": {
       "version": "2.1.1",
@@ -19797,6 +19972,13 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
@@ -19858,11 +20040,41 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
     "node_modules/tinyqueue": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
       "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
       "license": "ISC"
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/to-float32": {
       "version": "1.1.0",
@@ -20948,7 +21160,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.6.tgz",
       "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -21339,7 +21550,6 @@
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -21357,12 +21567,127 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vscode-uri": {
@@ -21580,6 +21905,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.932.0",
@@ -45,6 +46,7 @@
     "eslint-config-next": "^15.0.3",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3.0.0"
   }
 }


### PR DESCRIPTION
Closes #213 (epic #210, Foundation F0 · PR-2). Encodes the new post-#225 (PR-4)
layout into **one tested module** that is the sole authority for the directory/key
contract — killing the three-way (pipeline ↔ CLI ↔ cloud) footgun. Additive + call-site
swaps; **no change to scientific output**; ships `scheme=LEGACY` active (today's keys),
with `CANONICAL` implemented but inert until the OSN re-key (#215).

## The module
New standalone zero-dependency **`campfire-layout`** package (`layout/`, stdlib only,
py≥3.11), mirrored in TypeScript at `web/lib/layout.ts`. It owns:
- **local paths** — `dir_for`/`local_path`/`reference_dir`/`raw_dir`/`cache_path`
- **storage keys** — `storage_key`/`key_prefix`/`bucket_for` (LEGACY + CANONICAL schemes)
- **the bijection** — `key_to_relpath`/`relpath_to_key`/`parse_key`/`derive_sibling`/`is_known_key`
- **lifecycle** — `tree_class` (registry-first, so e.g. NIRSpec manual masks are *user-state* even though they live under `products/`)

The declarative `PRODUCTS` registry (`products.py`) is the single source; everything reads it.
Both `campfire-pipeline` and `campfire` depend on it — **install `./layout` first** (not on PyPI).

## Conformance gate
One shared golden fixture (`layout/conformance/layout_golden.json`) is checked by **both**
`pipeline/tests/test_layout.py` (pytest) and `web/lib/layout.test.ts` (vitest — web's first
test runner), so python↔TS drift fails CI. The python arm also asserts the module, the deploy
resolver, and the pipeline `Observation` agree on the NIRSpec products dir.

## Call sites swapped (no ad-hoc key/path building remains)
- **Deploy** — every `storage_key`/`key_prefix` in deploy/summary (authoritative `fits_path`)/nircam/photometry/tiles/remove; deploy/config resolvers unified on `roots()`/`dir_for()`.
- **Download/sync** — placement via `products_relpath()` (`key_to_relpath` minus `products/`).
- **Pipeline** — `config.resolve_paths`, `Observation.setup_workspace_directory`, `Field.setup_workspace`/`filter_dir`, `common.query._output_path_for` + manifest.
- **Web** — `r2.ts` rgb/sed builders, the spec→json/zfit sibling derivations across 5 routes, sed-plot/photometry-pz key construction.

## Bugs fixed (decision: fix the surfaced bugs)
1. **Client layout drift** — download/sync wrote & read `products/<obs>/` *without* the PR-4 `nirspec/` segment (`sync`, `client.open_spectrum`, `db.store` rediscovery). Now single-sourced.
2. **Raw-NIRSpec writer/reader divergence** — writer (by PID) vs reader (by `data_subdir`) unified on one partition.
3. **Hardening** — the presign route gained its previously-**missing** key allowlist (`is_known_key`, also rejects traversal); `nircam-preview` validates via the contract.

## Deploy / behavior notes
- `CHANGELOG.md` entry under Unreleased → **Infrastructure** (no scientific impact).
- The deploy-only `./products` fallback for an unset `$CAMPFIRE_ROOT` is gone — now `~/campfire`, matching the pipeline.
- Out of scope (later epic steps): flipping `KeyScheme.CANONICAL` active at the OSN cutover (#215); `storage_objects` registry rows (#214); a doc fix for the §3 PR-2 NIRSpec mask location.

## Validation
- `399 passed, 1 skipped` (full python suite) · `34` python conformance · `90` vitest · `npm run build` ✓ · grep gate clean (only a docstring references old prefixes).

Generated with Claude Code

https://claude.ai/code/session_01QMm3DuLALxzNtLBUQqPfkR
