### PR TITLE
feat(217): deploy_status lifecycle enforcement (B1)

### DIFF
--- a/python/tests/sql/b1_deploy_status_leak.sql
+++ b/python/tests/sql/b1_deploy_status_leak.sql
@@ -1,0 +1,128 @@
+-- =============================================================================
+-- B1 (#217) deploy_status leak harness  —  the lifecycle-enforcement exit gate.
+-- =============================================================================
+-- Proves, against a freshly `supabase db reset` local DB, that:
+--   1. A NON-ADMIN authenticated user (with full program access) gets ZERO
+--      in_prep/revoked spectra/objects/targets through RLS, while a published
+--      control row stays visible.
+--   2. An ADMIN sees the unpublished rows (the `OR is_admin()` branch).
+--   3. The service-role RPC predicate `p_include_unpublished` gates: false hides
+--      the unpublished objects, true reveals them (this is the gate the /api/v1
+--      REST routes rely on, where RLS is bypassed).
+--
+-- Everything runs in one transaction and is ROLLBACK'd — no persistence. The
+-- fixture sets has_published_spectrum=false by hand because B1 ships no
+-- population logic (that is B2); the value is always true in normal B1 operation.
+--
+-- Run:  docker exec -i supabase_db_campfire psql -U postgres -d postgres \
+--          -v ON_ERROR_STOP=1 -f python/tests/sql/b1_deploy_status_leak.sql
+-- A RAISE (leak) makes psql exit non-zero; success prints the PASS marker.
+-- Seed-anchored: user@=2222…, admin@=1111…, victims = objects 1 & 2 in the
+-- public program castellano3073, control = object 3 (published).
+-- =============================================================================
+\set ON_ERROR_STOP on
+BEGIN;
+
+-- ---- fixtures (run as the bootstrap superuser, bypasses RLS) ----------------
+CREATE TEMP TABLE _vobj (oid int, st text);
+INSERT INTO _vobj VALUES (1, 'in_prep'), (2, 'revoked');
+
+CREATE TEMP TABLE _vtgt AS
+  SELECT t.id, t.target_id, v.st
+  FROM public.targets t JOIN _vobj v ON t.object_id = v.oid;
+
+CREATE TEMP TABLE _vspec AS
+  SELECT s.id, s.spectrum_id, vt.st
+  FROM public.spectra s JOIN _vtgt vt ON s.target_id = vt.target_id;
+
+CREATE TEMP TABLE _vobjid AS
+  SELECT object_id FROM public.objects WHERE id IN (SELECT oid FROM _vobj);
+
+DO $$ BEGIN
+  IF (SELECT count(*) FROM _vspec) = 0 THEN
+    RAISE EXCEPTION 'FIXTURE EMPTY: victim objects have no member spectra — seed shape changed';
+  END IF;
+  IF (SELECT count(*) FROM public.objects WHERE id = 3 AND has_published_spectrum) = 0 THEN
+    RAISE EXCEPTION 'FIXTURE: control object 3 is not a published object — seed shape changed';
+  END IF;
+END $$;
+
+-- Simulate B2 state: victims become unpublished.
+UPDATE public.spectra s SET deploy_status = vs.st FROM _vspec vs WHERE s.id = vs.id;
+UPDATE public.objects SET has_published_spectrum = false WHERE id IN (SELECT oid FROM _vobj);
+UPDATE public.targets SET has_published_spectrum = false WHERE id IN (SELECT id FROM _vtgt);
+
+-- The non-superuser roles need to read the victim-id scratch tables (these hold
+-- only ids and are not RLS-protected); the base-table reads below stay RLS-gated.
+GRANT SELECT ON _vobj, _vtgt, _vspec, _vobjid TO authenticated, service_role;
+
+-- =========================================================================
+-- 1. RLS as NON-ADMIN (user@, public-program access) -> zero leak
+-- =========================================================================
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claims',
+  json_build_object('sub', '22222222-2222-2222-2222-222222222222', 'role', 'authenticated')::text, true);
+
+DO $$
+DECLARE n int;
+BEGIN
+  SELECT count(*) INTO n FROM public.spectra WHERE id IN (SELECT id FROM _vspec);
+  IF n <> 0 THEN RAISE EXCEPTION 'RLS LEAK: non-admin sees % in_prep/revoked spectra (expected 0)', n; END IF;
+
+  SELECT count(*) INTO n FROM public.objects WHERE id IN (SELECT oid FROM _vobj);
+  IF n <> 0 THEN RAISE EXCEPTION 'RLS LEAK: non-admin sees % unpublished objects (expected 0)', n; END IF;
+
+  SELECT count(*) INTO n FROM public.targets WHERE id IN (SELECT id FROM _vtgt);
+  IF n <> 0 THEN RAISE EXCEPTION 'RLS LEAK: non-admin sees % unpublished targets (expected 0)', n; END IF;
+
+  -- Regression guard: a published object in the SAME program stays visible.
+  SELECT count(*) INTO n FROM public.objects WHERE id = 3;
+  IF n <> 1 THEN RAISE EXCEPTION 'REGRESSION: non-admin cannot see published control object (got %, expected 1)', n; END IF;
+END $$;
+
+-- =========================================================================
+-- 2. RLS as ADMIN (admin@) -> unpublished rows ARE visible
+-- =========================================================================
+SELECT set_config('request.jwt.claims',
+  json_build_object('sub', '11111111-1111-1111-1111-111111111111', 'role', 'authenticated')::text, true);
+
+DO $$
+DECLARE n int; v int;
+BEGIN
+  SELECT count(*) INTO v FROM _vspec;
+  SELECT count(*) INTO n FROM public.spectra WHERE id IN (SELECT id FROM _vspec);
+  IF n <> v THEN RAISE EXCEPTION 'ADMIN BLOCKED: admin sees %/% unpublished spectra', n, v; END IF;
+
+  SELECT count(*) INTO n FROM public.objects WHERE id IN (SELECT oid FROM _vobj);
+  IF n <> 2 THEN RAISE EXCEPTION 'ADMIN BLOCKED: admin sees %/2 unpublished objects', n; END IF;
+END $$;
+
+-- =========================================================================
+-- 3. RPC predicate as SERVICE_ROLE (RLS bypassed) -> p_include_unpublished gates
+-- =========================================================================
+RESET ROLE;
+SET LOCAL ROLE service_role;
+SELECT set_config('request.jwt.claims', '', true);
+
+DO $$
+DECLARE leaked int; shown int;
+BEGIN
+  SELECT count(*) INTO leaked
+    FROM public.get_filtered_object_ids(ARRAY['castellano3073']::text[], p_include_unpublished := false) g
+    WHERE g.object_id IN (SELECT object_id FROM _vobjid);
+  IF leaked <> 0 THEN
+    RAISE EXCEPTION 'RPC LEAK: get_filtered_object_ids(p_include_unpublished=false) returns % unpublished objects (expected 0)', leaked;
+  END IF;
+
+  SELECT count(*) INTO shown
+    FROM public.get_filtered_object_ids(ARRAY['castellano3073']::text[], p_include_unpublished := true) g
+    WHERE g.object_id IN (SELECT object_id FROM _vobjid);
+  IF shown <> 2 THEN
+    RAISE EXCEPTION 'RPC SWITCH BROKEN: get_filtered_object_ids(p_include_unpublished=true) returns %/2 unpublished objects', shown;
+  END IF;
+END $$;
+
+RESET ROLE;
+SELECT '✅ B1 DEPLOY_STATUS LEAK HARNESS: ALL ASSERTIONS PASSED' AS result;
+
+ROLLBACK;

--- a/python/tests/test_deploy_status_rls.py
+++ b/python/tests/test_deploy_status_rls.py
@@ -1,0 +1,62 @@
+"""B1 (#217) deploy_status lifecycle-enforcement leak gate.
+
+DB-backed integration test: runs ``sql/b1_deploy_status_leak.sql`` against the
+local Supabase Postgres via ``docker exec ... psql`` and asserts the harness
+reaches its PASS marker. The SQL marks seed rows in_prep/revoked inside a
+transaction (rolled back) and asserts a non-admin sees ZERO of them through RLS
+and the service-role RPC predicate, while an admin does — the B1 exit criterion.
+
+Skips automatically when the local Supabase DB container is not reachable (so it
+is a no-op in environments without ``supabase start``). In CI it runs after
+``supabase db reset``. The unit-level RLS guarantees themselves do not depend on
+this test running, but it is the regression gate that proves the predicate
+threading actually hides unpublished science data.
+"""
+import subprocess
+from pathlib import Path
+
+import pytest
+
+CONTAINER = "supabase_db_campfire"
+SQL_FILE = Path(__file__).parent / "sql" / "b1_deploy_status_leak.sql"
+PASS_MARKER = "ALL ASSERTIONS PASSED"
+
+
+def _docker_psql_available() -> bool:
+    """True iff the local Supabase Postgres container answers a trivial query."""
+    try:
+        r = subprocess.run(
+            ["docker", "exec", "-i", CONTAINER,
+             "psql", "-U", "postgres", "-d", "postgres", "-tA", "-c", "SELECT 1"],
+            capture_output=True, text=True, timeout=15,
+        )
+        return r.returncode == 0 and r.stdout.strip().startswith("1")
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return False
+
+
+requires_local_db = pytest.mark.skipif(
+    not _docker_psql_available(),
+    reason=f"local Supabase container '{CONTAINER}' not reachable (run `supabase start` + `supabase db reset`)",
+)
+
+
+@requires_local_db
+def test_deploy_status_no_leak_to_non_admin():
+    """Non-admin gets zero in_prep/revoked rows (RLS + RPC); admin sees them."""
+    sql = SQL_FILE.read_text()
+    result = subprocess.run(
+        ["docker", "exec", "-i", CONTAINER,
+         "psql", "-U", "postgres", "-d", "postgres", "-v", "ON_ERROR_STOP=1", "-f", "-"],
+        input=sql, capture_output=True, text=True, timeout=120,
+    )
+    combined = result.stdout + result.stderr
+    # A leak/regression RAISEs inside a DO block -> ON_ERROR_STOP -> non-zero exit.
+    assert result.returncode == 0, (
+        f"B1 leak harness FAILED (psql exit {result.returncode}).\n"
+        f"This means a reader exposed an in_prep/revoked row to a non-admin, or a "
+        f"published control row regressed. Output:\n{combined}"
+    )
+    assert PASS_MARKER in result.stdout, (
+        f"B1 leak harness did not reach its PASS marker.\nOutput:\n{combined}"
+    )

--- a/supabase/migrations/20260629014642_add_deploy_status_lifecycle.sql
+++ b/supabase/migrations/20260629014642_add_deploy_status_lifecycle.sql
@@ -1,0 +1,2276 @@
+drop policy "select_comments_by_access" on "public"."comments";
+
+drop policy "insert_audit_by_access" on "public"."flag_audit_log";
+
+drop policy "select_audit_by_access" on "public"."flag_audit_log";
+
+drop policy "select_list_members" on "public"."object_list_members";
+
+drop policy "select_object_photometry_by_access" on "public"."object_photometry";
+
+drop policy "select_objects_by_access" on "public"."objects";
+
+drop policy "update_objects_by_access" on "public"."objects";
+
+drop policy "Authenticated users can view shutters" on "public"."shutters";
+
+drop policy "Authenticated users can view slit regions" on "public"."slit_regions";
+
+drop policy "select_spectra_by_access" on "public"."spectra";
+
+drop policy "update_spectra_dq_by_access" on "public"."spectra";
+
+drop policy "select_targets_by_access" on "public"."targets";
+
+drop policy "update_targets_by_access" on "public"."targets";
+
+drop function if exists "public"."get_adjacent_objects"(p_current_object_id text, p_program_slugs text[], p_filter_programs text[], p_fields text[], p_gratings text[], p_gratings_mode text, p_observations text[], p_redshift_quality integer[], p_redshift_min double precision, p_redshift_max double precision, p_max_snr_min double precision, p_max_snr_max double precision, p_max_exposure_time_min double precision, p_max_exposure_time_max double precision, p_search text, p_inspected_only boolean, p_needs_review boolean, p_list_ids integer[], p_coord_ra double precision, p_coord_dec double precision, p_radius_degrees double precision, p_sort_column text, p_sort_direction text, p_has_photometry boolean, p_photo_z_min double precision, p_photo_z_max double precision, p_comment_search text, p_comment_search_scope text, p_comment_user_id uuid);
+
+drop function if exists "public"."get_csv_export_objects"(p_program_slugs text[], p_filter_programs text[], p_fields text[], p_gratings text[], p_gratings_mode text, p_redshift_quality integer[], p_redshift_min double precision, p_redshift_max double precision, p_max_snr_min double precision, p_max_snr_max double precision, p_max_exposure_time_min double precision, p_max_exposure_time_max double precision, p_search text, p_inspected_only boolean, p_needs_review boolean, p_list_ids integer[], p_coord_ra double precision, p_coord_dec double precision, p_radius_degrees double precision, p_has_photometry boolean, p_photo_z_min double precision, p_photo_z_max double precision, p_comment_search text, p_comment_search_scope text, p_comment_user_id uuid, p_sort_column text, p_sort_direction text);
+
+drop function if exists "public"."get_csv_export_spectra"(p_program_slugs text[], p_filter_programs text[], p_fields text[], p_gratings text[], p_gratings_mode text, p_observations text[], p_redshift_quality integer[], p_redshift_min double precision, p_redshift_max double precision, p_max_snr_min double precision, p_max_snr_max double precision, p_max_exposure_time_min double precision, p_max_exposure_time_max double precision, p_dq_flags_include_any integer, p_dq_flags_include_all integer, p_dq_flags_exclude integer, p_list_ids integer[], p_search text, p_inspected_only boolean, p_needs_review boolean, p_has_photometry boolean, p_comment_search text, p_comment_search_scope text, p_comment_user_id uuid, p_coord_ra double precision, p_coord_dec double precision, p_radius_degrees double precision, p_sort_column text, p_sort_direction text);
+
+drop function if exists "public"."get_database_overview"();
+
+drop function if exists "public"."get_field_object_markers"(p_field text);
+
+drop function if exists "public"."get_filtered_object_ids"(p_program_slugs text[], p_filter_programs text[], p_fields text[], p_gratings text[], p_gratings_mode text, p_observations text[], p_redshift_quality integer[], p_redshift_min double precision, p_redshift_max double precision, p_max_snr_min double precision, p_max_snr_max double precision, p_max_exposure_time_min double precision, p_max_exposure_time_max double precision, p_search text, p_inspected_only boolean, p_needs_review boolean, p_list_ids integer[], p_coord_ra double precision, p_coord_dec double precision, p_radius_degrees double precision, p_has_photometry boolean, p_photo_z_min double precision, p_photo_z_max double precision, p_comment_search text, p_comment_search_scope text, p_comment_user_id uuid, p_sort_column text, p_sort_direction text);
+
+drop function if exists "public"."get_filtered_objects_paginated"(p_program_slugs text[], p_filter_programs text[], p_fields text[], p_gratings text[], p_gratings_mode text, p_observations text[], p_redshift_quality integer[], p_redshift_min double precision, p_redshift_max double precision, p_max_snr_min double precision, p_max_snr_max double precision, p_max_exposure_time_min double precision, p_max_exposure_time_max double precision, p_search text, p_inspected_only boolean, p_needs_review boolean, p_list_ids integer[], p_coord_ra double precision, p_coord_dec double precision, p_radius_degrees double precision, p_has_photometry boolean, p_photo_z_min double precision, p_photo_z_max double precision, p_comment_search text, p_comment_search_scope text, p_comment_user_id uuid, p_sort_column text, p_sort_direction text, p_page integer, p_page_size integer);
+
+drop function if exists "public"."get_filtered_spectra_paginated"(p_program_slugs text[], p_filter_programs text[], p_fields text[], p_gratings text[], p_gratings_mode text, p_observations text[], p_redshift_quality integer[], p_redshift_min double precision, p_redshift_max double precision, p_max_snr_min double precision, p_max_snr_max double precision, p_max_exposure_time_min double precision, p_max_exposure_time_max double precision, p_dq_flags_include_any integer, p_dq_flags_include_all integer, p_dq_flags_exclude integer, p_list_ids integer[], p_search text, p_inspected_only boolean, p_needs_review boolean, p_has_photometry boolean, p_comment_search text, p_comment_search_scope text, p_comment_user_id uuid, p_coord_ra double precision, p_coord_dec double precision, p_radius_degrees double precision, p_sort_column text, p_sort_direction text, p_page integer, p_page_size integer, p_include_thumbnails boolean);
+
+drop function if exists "public"."get_lists_for_sync"(p_user_id uuid);
+
+drop function if exists "public"."get_objects_for_sync"(p_program_slugs text[], p_user_id uuid, p_updated_since timestamp with time zone, p_limit integer, p_offset integer, p_include_counts boolean);
+
+drop function if exists "public"."get_observation_manifest"(p_obs_name text, p_program_slugs text[]);
+
+drop function if exists "public"."get_observation_stats"(p_program_slugs text[]);
+
+drop function if exists "public"."get_observations_overview"(p_program_slugs text[]);
+
+drop function if exists "public"."get_photometry_for_sync"(p_program_slugs text[], p_updated_since timestamp with time zone, p_limit integer, p_offset integer);
+
+drop function if exists "public"."get_spectra_for_sync"(p_program_slugs text[], p_user_id uuid, p_updated_since timestamp with time zone, p_limit integer, p_offset integer, p_include_counts boolean);
+
+drop function if exists "public"."get_targets_in_viewport"(p_ra_min double precision, p_ra_max double precision, p_dec_min double precision, p_dec_max double precision, p_field text, p_limit integer);
+
+drop function if exists "public"."object_scoped_aggregates"(p_object_id integer, p_program_slugs text[]);
+
+drop materialized view if exists "public"."mv_filter_options";
+
+drop materialized view if exists "public"."mv_programs_overview";
+
+drop view if exists "public"."nircam_reduction_progress";
+
+drop view if exists "public"."spectrum_flag_summary";
+
+alter table "public"."objects" add column "has_published_spectrum" boolean not null default true;
+
+alter table "public"."spectra" add column "deploy_status" text not null default 'published'::text;
+
+alter table "public"."targets" add column "has_published_spectrum" boolean not null default true;
+
+CREATE INDEX idx_spectra_deploy_status ON public.spectra USING btree (deploy_status) WHERE (deploy_status <> 'published'::text);
+
+alter table "public"."spectra" add constraint "spectra_deploy_status_check" CHECK ((deploy_status = ANY (ARRAY['in_prep'::text, 'published'::text, 'revoked'::text]))) not valid;
+
+alter table "public"."spectra" validate constraint "spectra_deploy_status_check";
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_adjacent_objects(p_current_object_id text, p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_list_ids integer[] DEFAULT NULL::integer[], p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_sort_column text DEFAULT 'object_id'::text, p_sort_direction text DEFAULT 'asc'::text, p_has_photometry boolean DEFAULT NULL::boolean, p_photo_z_min double precision DEFAULT NULL::double precision, p_photo_z_max double precision DEFAULT NULL::double precision, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_include_unpublished boolean DEFAULT false)
+ RETURNS TABLE(prev_object_id text, next_object_id text, current_index bigint, total_count bigint)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_sort_is_text BOOLEAN;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN v_gratings_mode := 'any'; END IF;
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+  IF v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN
+    p_sort_column := 'distance';
+    p_sort_direction := 'asc';
+  END IF;
+  v_sort_is_text := p_sort_column IN ('object_id', 'field');
+
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs))
+    INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN QUERY SELECT NULL::TEXT, NULL::TEXT, 0::BIGINT, 0::BIGINT;
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  WITH filtered_objects AS MATERIALIZED (
+    SELECT
+      o.object_id,
+      CASE WHEN v_coord_search_active THEN
+        2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        )))
+      ELSE NULL END AS distance,
+      o.field, o.ra, o.dec, o.redshift, o.redshift_quality,
+      o.n_targets, o.n_spectra, o.max_snr, o.max_exposure_time
+    FROM objects o
+    WHERE
+      o.programs && v_filtered_program_slugs
+      AND o.is_active = true
+      AND (p_include_unpublished OR o.has_published_spectrum)
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+        OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+        OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+      )
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
+      AND (p_inspected_only IS NULL
+        OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+        OR (p_inspected_only = FALSE AND o.redshift_quality = 0))
+      AND (p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at))))
+      AND (NOT v_coord_search_active OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+      ))
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+      AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+      AND (
+        NOT v_comment_search_active
+        -- Uncorrelated semijoin; see get_filtered_objects_paginated for rationale.
+        OR o.id IN (
+          SELECT c.object_id FROM comments c
+          WHERE c.object_id IS NOT NULL
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+          UNION
+          SELECT t.object_id FROM comments c
+          JOIN targets t ON t.id = c.target_id
+          WHERE c.target_id IS NOT NULL
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+        )
+      )
+  ),
+  distance_filtered AS MATERIALIZED (
+    SELECT
+      fo.*,
+      CASE p_sort_column
+        WHEN 'object_id' THEN fo.object_id WHEN 'field' THEN fo.field ELSE NULL
+      END AS sort_text,
+      CASE p_sort_column
+        WHEN 'ra' THEN fo.ra WHEN 'dec' THEN fo.dec
+        WHEN 'redshift' THEN fo.redshift
+        WHEN 'redshift_quality' THEN fo.redshift_quality::DOUBLE PRECISION
+        WHEN 'n_targets' THEN fo.n_targets::DOUBLE PRECISION
+        WHEN 'n_spectra' THEN fo.n_spectra::DOUBLE PRECISION
+        WHEN 'max_snr' THEN fo.max_snr WHEN 'max_exposure_time' THEN fo.max_exposure_time
+        WHEN 'distance' THEN fo.distance ELSE NULL
+      END AS sort_num
+    FROM filtered_objects fo
+    WHERE NOT v_coord_search_active OR fo.distance <= p_radius_degrees
+  ),
+  current_obj AS (
+    SELECT df.sort_text, df.sort_num, df.object_id FROM distance_filtered df WHERE df.object_id = p_current_object_id
+  )
+  SELECT
+    (SELECT df.object_id FROM distance_filtered df, current_obj c
+     WHERE CASE WHEN v_sort_is_text THEN
+       (CASE WHEN p_sort_direction = 'asc' THEN df.sort_text < c.sort_text ELSE df.sort_text > c.sort_text END)
+       OR (df.sort_text IS NOT DISTINCT FROM c.sort_text AND df.object_id < c.object_id)
+       OR (df.sort_text IS NOT NULL AND c.sort_text IS NULL)
+     ELSE
+       (CASE WHEN p_sort_direction = 'asc' THEN df.sort_num < c.sort_num ELSE df.sort_num > c.sort_num END)
+       OR (df.sort_num IS NOT DISTINCT FROM c.sort_num AND df.object_id < c.object_id)
+       OR (df.sort_num IS NOT NULL AND c.sort_num IS NULL)
+     END
+     ORDER BY
+       CASE WHEN v_sort_is_text AND p_sort_direction = 'asc' THEN df.sort_text END DESC NULLS FIRST,
+       CASE WHEN v_sort_is_text AND p_sort_direction = 'desc' THEN df.sort_text END ASC NULLS FIRST,
+       CASE WHEN NOT v_sort_is_text AND p_sort_direction = 'asc' THEN df.sort_num END DESC NULLS FIRST,
+       CASE WHEN NOT v_sort_is_text AND p_sort_direction = 'desc' THEN df.sort_num END ASC NULLS FIRST,
+       df.object_id DESC
+     LIMIT 1
+    ) AS prev_object_id,
+    (SELECT df.object_id FROM distance_filtered df, current_obj c
+     WHERE CASE WHEN v_sort_is_text THEN
+       (CASE WHEN p_sort_direction = 'asc' THEN df.sort_text > c.sort_text ELSE df.sort_text < c.sort_text END)
+       OR (df.sort_text IS NOT DISTINCT FROM c.sort_text AND df.object_id > c.object_id)
+       OR (c.sort_text IS NOT NULL AND df.sort_text IS NULL)
+     ELSE
+       (CASE WHEN p_sort_direction = 'asc' THEN df.sort_num > c.sort_num ELSE df.sort_num < c.sort_num END)
+       OR (df.sort_num IS NOT DISTINCT FROM c.sort_num AND df.object_id > c.object_id)
+       OR (c.sort_num IS NOT NULL AND df.sort_num IS NULL)
+     END
+     ORDER BY
+       CASE WHEN v_sort_is_text AND p_sort_direction = 'asc' THEN df.sort_text END ASC NULLS LAST,
+       CASE WHEN v_sort_is_text AND p_sort_direction = 'desc' THEN df.sort_text END DESC NULLS LAST,
+       CASE WHEN NOT v_sort_is_text AND p_sort_direction = 'asc' THEN df.sort_num END ASC NULLS LAST,
+       CASE WHEN NOT v_sort_is_text AND p_sort_direction = 'desc' THEN df.sort_num END DESC NULLS LAST,
+       df.object_id ASC
+     LIMIT 1
+    ) AS next_object_id,
+    CASE WHEN EXISTS (SELECT 1 FROM current_obj) THEN (
+      SELECT COUNT(*) + 1
+      FROM distance_filtered df, current_obj c
+      WHERE CASE WHEN v_sort_is_text THEN
+        (CASE WHEN p_sort_direction = 'asc' THEN df.sort_text < c.sort_text ELSE df.sort_text > c.sort_text END)
+        OR (df.sort_text IS NOT DISTINCT FROM c.sort_text AND df.object_id < c.object_id)
+        OR (df.sort_text IS NOT NULL AND c.sort_text IS NULL)
+      ELSE
+        (CASE WHEN p_sort_direction = 'asc' THEN df.sort_num < c.sort_num ELSE df.sort_num > c.sort_num END)
+        OR (df.sort_num IS NOT DISTINCT FROM c.sort_num AND df.object_id < c.object_id)
+        OR (df.sort_num IS NOT NULL AND c.sort_num IS NULL)
+      END
+    )::BIGINT ELSE 0::BIGINT END AS current_index,
+    (SELECT COUNT(*) FROM distance_filtered)::BIGINT AS total_count;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_csv_export_objects(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_list_ids integer[] DEFAULT NULL::integer[], p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_has_photometry boolean DEFAULT NULL::boolean, p_photo_z_min double precision DEFAULT NULL::double precision, p_photo_z_max double precision DEFAULT NULL::double precision, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_sort_column text DEFAULT 'object_id'::text, p_sort_direction text DEFAULT 'asc'::text, p_include_unpublished boolean DEFAULT false)
+ RETURNS TABLE(object_id text, field text, ra double precision, "dec" double precision, redshift numeric, redshift_quality integer, redshift_inspected numeric, redshift_auto double precision, last_inspected_at timestamp with time zone, last_inspected_by text, last_data_change_at timestamp with time zone, staleness_reason text, version integer, n_targets integer, n_spectra integer, programs text, gratings text, max_snr double precision, max_exposure_time double precision, member_target_ids text, distance double precision, lists text, has_photometry boolean, photo_z double precision, photo_z_err_lo double precision, photo_z_err_hi double precision, photometry jsonb)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN v_gratings_mode := 'any'; END IF;
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time', 'photo_z'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs)) INTO v_filtered_program_slugs;
+  ELSE v_filtered_program_slugs := p_program_slugs; END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN RETURN; END IF;
+
+  RETURN QUERY
+  WITH member_targets AS (
+    SELECT t.object_id, string_agg(t.target_id, ';' ORDER BY t.target_id) AS member_target_ids
+    FROM targets t
+    WHERE t.program_slug = ANY(v_filtered_program_slugs)
+    GROUP BY t.object_id
+  ),
+  visible_lists AS (
+    SELECT olm.object_id, string_agg(ol.slug, ';' ORDER BY ol.slug) AS lists
+    FROM object_list_members olm
+    JOIN object_lists ol ON ol.id = olm.list_id
+    WHERE ol.created_by = auth.uid() OR ol.visibility IN ('public_read', 'public_edit')
+    GROUP BY olm.object_id
+  ),
+  filtered_objects AS (
+    SELECT o.object_id, o.field, o.ra, o.dec,
+      o.redshift, o.redshift_quality,
+      o.redshift_inspected, o.redshift_auto,
+      o.last_inspected_at, up.full_name AS last_inspected_by,
+      o.last_data_change_at, o.staleness_reason, o.version,
+      -- Aggregates scoped to accessible (+ filtered) programs so mixed-program
+      -- objects don't export proprietary member metadata. See
+      -- object_scoped_aggregates().
+      sa.n_targets, sa.n_spectra,
+      array_to_string(sa.programs, ';') AS programs,
+      array_to_string(sa.gratings, ';') AS gratings,
+      sa.max_snr, sa.max_exposure_time,
+      mt.member_target_ids,
+      CASE WHEN v_coord_search_active THEN
+        2 * DEGREES(ASIN(SQRT(POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) + COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) * POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2))))
+      ELSE NULL END AS distance,
+      vl.lists,
+      o.has_photometry, o.photo_z, o.photo_z_err_lo, o.photo_z_err_hi,
+      phot.photometry
+    FROM objects o
+    LEFT JOIN member_targets mt ON mt.object_id = o.id
+    LEFT JOIN visible_lists vl ON vl.object_id = o.id
+    LEFT JOIN user_profiles up ON up.user_id = o.last_inspected_by
+    LEFT JOIN LATERAL public.object_scoped_aggregates(o.id, v_filtered_program_slugs, p_include_unpublished) sa ON true
+    LEFT JOIN LATERAL (
+      SELECT op.photometry FROM object_photometry op
+      WHERE op.object_id = o.id ORDER BY op.updated_at DESC LIMIT 1
+    ) phot ON true
+    WHERE o.programs && v_filtered_program_slugs
+      AND o.is_active = true
+      AND (p_include_unpublished OR o.has_published_spectrum)
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+        OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+        OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+      )
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
+      AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.redshift_quality > 0) OR (p_inspected_only = FALSE AND o.redshift_quality = 0))
+      AND (p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at))))
+      AND (NOT v_coord_search_active OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+      ))
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+      AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+      AND (
+        NOT v_comment_search_active
+        -- Uncorrelated semijoin; see get_filtered_objects_paginated for rationale.
+        OR o.id IN (
+          SELECT c.object_id FROM comments c
+          WHERE c.object_id IS NOT NULL
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+          UNION
+          SELECT t.object_id FROM comments c
+          JOIN targets t ON t.id = c.target_id
+          WHERE c.target_id IS NOT NULL
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+        )
+      )
+  ),
+  distance_filtered AS (SELECT fo.* FROM filtered_objects fo WHERE NOT v_coord_search_active OR fo.distance <= p_radius_degrees)
+  SELECT df.object_id, df.field, df.ra, df.dec,
+    df.redshift, df.redshift_quality,
+    df.redshift_inspected, df.redshift_auto,
+    df.last_inspected_at, df.last_inspected_by,
+    df.last_data_change_at, df.staleness_reason, df.version,
+    df.n_targets, df.n_spectra,
+    df.programs, df.gratings,
+    df.max_snr, df.max_exposure_time,
+    df.member_target_ids, df.distance, df.lists,
+    df.has_photometry, df.photo_z, df.photo_z_err_lo, df.photo_z_err_hi,
+    df.photometry
+  FROM distance_filtered df
+  ORDER BY
+    CASE WHEN v_coord_search_active THEN df.distance END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN df.object_id END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'desc' THEN df.object_id END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'asc' THEN df.field END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'desc' THEN df.field END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN df.ra END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN df.ra END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN df.dec END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN df.dec END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN df.redshift END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN df.redshift END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN df.redshift_quality END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN df.redshift_quality END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_targets' AND p_sort_direction = 'asc' THEN df.n_targets END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_targets' AND p_sort_direction = 'desc' THEN df.n_targets END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_spectra' AND p_sort_direction = 'asc' THEN df.n_spectra END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_spectra' AND p_sort_direction = 'desc' THEN df.n_spectra END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN df.max_snr END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN df.max_snr END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN df.max_exposure_time END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN df.max_exposure_time END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'photo_z' AND p_sort_direction = 'asc' THEN df.photo_z END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'photo_z' AND p_sort_direction = 'desc' THEN df.photo_z END DESC NULLS LAST,
+    df.object_id ASC;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_csv_export_spectra(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_dq_flags_include_any integer DEFAULT NULL::integer, p_dq_flags_include_all integer DEFAULT NULL::integer, p_dq_flags_exclude integer DEFAULT NULL::integer, p_list_ids integer[] DEFAULT NULL::integer[], p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_has_photometry boolean DEFAULT NULL::boolean, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_sort_column text DEFAULT 'target_id'::text, p_sort_direction text DEFAULT 'asc'::text, p_include_unpublished boolean DEFAULT false)
+ RETURNS TABLE(spectrum_id text, target_id text, grating text, field text, ra double precision, "dec" double precision, redshift numeric, redshift_quality integer, redshift_auto double precision, signal_to_noise double precision, exposure_time double precision, fits_path text, program_slug text, program_name text, last_inspected_at timestamp with time zone, last_inspected_by text, distance double precision, dq_flags integer, lists text)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (p_comment_search IS NOT NULL AND p_comment_search != '' AND p_comment_search_scope IN ('just_me', 'everyone'));
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
+  IF NOT (p_sort_column IN ('target_id', 'spectrum_id', 'field', 'observation', 'ra', 'dec', 'redshift', 'redshift_quality', 'redshift_auto', 'signal_to_noise', 'exposure_time', 'grating')
+       OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'spectrum_id';
+  END IF;
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs)) INTO v_filtered_program_slugs;
+  ELSE v_filtered_program_slugs := p_program_slugs; END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN RETURN; END IF;
+
+  RETURN QUERY
+  WITH visible_lists AS (
+    SELECT olm.object_id, string_agg(ol.slug, ';' ORDER BY ol.slug) AS lists
+    FROM object_list_members olm
+    JOIN object_lists ol ON ol.id = olm.list_id
+    WHERE ol.created_by = auth.uid() OR ol.visibility IN ('public_read', 'public_edit')
+    GROUP BY olm.object_id
+  ),
+  filtered_spectra AS (
+    SELECT s.spectrum_id, t.target_id, s.grating, t.field, t.ra, t.dec,
+      o.redshift, o.redshift_quality,
+      s.redshift_auto,
+      s.signal_to_noise, s.exposure_time, s.fits_path, t.program_slug, t.observation,
+      o.last_inspected_at, o.last_inspected_by,
+      CASE WHEN v_coord_search_active THEN
+        2 * DEGREES(ASIN(SQRT(POWER(SIN(RADIANS(t.dec - p_coord_dec) / 2), 2) + COS(RADIANS(p_coord_dec)) * COS(RADIANS(t.dec)) * POWER(SIN(RADIANS(t.ra - p_coord_ra) / 2), 2))))
+      ELSE NULL END AS distance,
+      COALESCE(s.dq_flags, 0) AS dq_flags,
+      vl.lists
+    FROM targets t
+    JOIN spectra s ON s.target_id = t.target_id
+    LEFT JOIN objects o ON o.id = t.object_id
+    LEFT JOIN visible_lists vl ON vl.object_id = t.object_id
+    WHERE t.program_slug = ANY(v_filtered_program_slugs)
+      AND (o.id IS NULL OR o.is_active = true)
+      AND (NOT v_grating_filter_active OR s.grating = ANY(p_gratings))
+      -- B1: hide unpublished spectra (fail-closed; admin opt-in only).
+      AND (p_include_unpublished OR s.deploy_status = 'published')
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR t.field = ANY(p_fields))
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR t.observation = ANY(p_observations))
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min) AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR s.signal_to_noise >= p_max_snr_min) AND (p_max_snr_max IS NULL OR s.signal_to_noise <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR s.exposure_time >= p_max_exposure_time_min) AND (p_max_exposure_time_max IS NULL OR s.exposure_time <= p_max_exposure_time_max)
+      AND (p_dq_flags_include_any IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_any) != 0)
+      AND (p_dq_flags_include_all IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_all) = p_dq_flags_include_all)
+      AND (p_dq_flags_exclude IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_exclude) = 0)
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR t.object_id IN (
+          SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_search IS NULL OR s.id IN (SELECT __s.id FROM public.spectra __s WHERE __s.search_text ILIKE '%' || p_search || '%'))
+      AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.redshift_quality > 0) OR (p_inspected_only = FALSE AND COALESCE(o.redshift_quality, 0) = 0))
+      AND (p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at))))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (NOT v_comment_search_active OR t.id IN (
+        SELECT c.target_id FROM comments c WHERE c.target_id IS NOT NULL AND c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (p_comment_search_scope = 'everyone' OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id))))
+      AND (NOT v_coord_search_active OR (
+        t.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND t.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)))
+  ),
+  distance_filtered AS (SELECT fs.* FROM filtered_spectra fs WHERE NOT v_coord_search_active OR fs.distance <= p_radius_degrees)
+  SELECT df.spectrum_id, df.target_id, df.grating, df.field, df.ra, df.dec, df.redshift, df.redshift_quality, df.redshift_auto,
+    df.signal_to_noise, df.exposure_time, df.fits_path, df.program_slug,
+    pr.program_name, df.last_inspected_at, up.full_name AS last_inspected_by,
+    df.distance, df.dq_flags, df.lists
+  FROM distance_filtered df
+  LEFT JOIN programs pr ON pr.slug = df.program_slug
+  LEFT JOIN user_profiles up ON up.user_id = df.last_inspected_by
+  ORDER BY
+    CASE WHEN v_coord_search_active THEN df.distance END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'spectrum_id' AND p_sort_direction = 'asc' THEN df.spectrum_id END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'spectrum_id' AND p_sort_direction = 'desc' THEN df.spectrum_id END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'target_id' AND p_sort_direction = 'asc' THEN df.target_id END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'target_id' AND p_sort_direction = 'desc' THEN df.target_id END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'asc' THEN df.field END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'desc' THEN df.field END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'observation' AND p_sort_direction = 'asc' THEN df.observation END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'observation' AND p_sort_direction = 'desc' THEN df.observation END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN df.ra END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN df.ra END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN df.dec END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN df.dec END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN df.redshift END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN df.redshift END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN df.redshift_quality END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN df.redshift_quality END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_auto' AND p_sort_direction = 'asc' THEN df.redshift_auto END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_auto' AND p_sort_direction = 'desc' THEN df.redshift_auto END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'signal_to_noise' AND p_sort_direction = 'asc' THEN df.signal_to_noise END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'signal_to_noise' AND p_sort_direction = 'desc' THEN df.signal_to_noise END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'exposure_time' AND p_sort_direction = 'asc' THEN df.exposure_time END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'exposure_time' AND p_sort_direction = 'desc' THEN df.exposure_time END DESC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'grating' AND p_sort_direction = 'asc' THEN df.grating END ASC NULLS LAST,
+    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'grating' AND p_sort_direction = 'desc' THEN df.grating END DESC NULLS LAST,
+    df.target_id ASC, df.grating ASC;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_database_overview(p_include_unpublished boolean DEFAULT false)
+ RETURNS TABLE(n_programs bigint, n_observations bigint, n_pointings bigint, n_targets bigint, n_spectra bigint, total_size_bytes bigint, latest_deployed_at timestamp with time zone, latest_cfpipe_version text)
+ LANGUAGE sql
+ STABLE
+AS $function$
+  WITH latest AS (
+    SELECT d.deployed_at, d.cfpipe_version
+    FROM public.deployments d
+    WHERE d.source_ids_filter IS NULL
+    ORDER BY d.deployed_at DESC
+    LIMIT 1
+  )
+  SELECT
+    (SELECT COUNT(*)::bigint FROM public.programs) AS n_programs,
+    (SELECT COUNT(*)::bigint FROM public.observations) AS n_observations,
+    (SELECT COALESCE(SUM(jsonb_array_length(pointings)), 0)::bigint
+       FROM public.observations
+       WHERE pointings IS NOT NULL) AS n_pointings,
+    (SELECT COUNT(*)::bigint FROM public.targets) AS n_targets,
+    -- B1: gate spectra count/size on publish status (no alias param available).
+    (SELECT COUNT(*)::bigint FROM public.spectra
+       WHERE p_include_unpublished OR deploy_status = 'published') AS n_spectra,
+    (SELECT COALESCE(SUM(file_size), 0)::bigint FROM public.spectra
+       WHERE p_include_unpublished OR deploy_status = 'published') AS total_size_bytes,
+    (SELECT deployed_at FROM latest) AS latest_deployed_at,
+    (SELECT cfpipe_version FROM latest) AS latest_cfpipe_version;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_field_object_markers(p_field text, p_include_unpublished boolean DEFAULT false)
+ RETURNS TABLE(object_id text, ra double precision, "dec" double precision, redshift double precision, redshift_quality integer, field text, n_targets integer, n_spectra integer, programs text[], member_target_ids text[])
+ LANGUAGE sql
+ STABLE
+AS $function$
+  -- programs, n_targets, n_spectra and member_target_ids are scoped to the
+  -- caller's accessible programs so mixed-program objects don't leak proprietary
+  -- member metadata on the map. redshift / redshift_quality stay visible (object
+  -- science, per the access policy). Object row visibility is enforced by RLS
+  -- (programs && accessible); this function is SECURITY INVOKER and additionally
+  -- gates the member CTEs by an explicit accessible_program_slugs() filter.
+  -- Set-based (not the per-row object_scoped_aggregates helper) because a field
+  -- can return up to ~5000 objects; the logic mirrors that helper.
+  WITH acc AS (
+    SELECT public.accessible_program_slugs() AS slugs
+  ),
+  mt AS (
+    SELECT t.object_id,
+           array_agg(t.target_id ORDER BY t.target_id)              AS member_target_ids,
+           array_agg(DISTINCT t.program_slug ORDER BY t.program_slug) AS programs,
+           COUNT(*)::int                                            AS n_targets
+    FROM public.targets t
+    CROSS JOIN acc
+    WHERE t.field = p_field
+      AND t.program_slug = ANY(acc.slugs)
+      -- B1: mirror object_scoped_aggregates -- only count targets that
+      -- contribute a published spectrum so draft-only members vanish (the
+      -- final JOIN mt is inner, so objects with zero published members drop out).
+      AND (p_include_unpublished OR t.has_published_spectrum)
+    GROUP BY t.object_id
+  ),
+  sp AS (
+    SELECT t.object_id, COUNT(*)::int AS n_spectra
+    FROM public.spectra s
+    JOIN public.targets t ON t.target_id = s.target_id
+    CROSS JOIN acc
+    WHERE t.field = p_field
+      AND t.program_slug = ANY(acc.slugs)
+      AND (p_include_unpublished OR s.deploy_status = 'published')
+    GROUP BY t.object_id
+  )
+  SELECT
+    o.object_id,
+    o.ra,
+    o.dec,
+    o.redshift::double precision,
+    o.redshift_quality,
+    o.field,
+    COALESCE(mt.n_targets, 0)                      AS n_targets,
+    COALESCE(sp.n_spectra, 0)                      AS n_spectra,
+    COALESCE(mt.programs, ARRAY[]::TEXT[])         AS programs,
+    COALESCE(mt.member_target_ids, ARRAY[]::TEXT[]) AS member_target_ids
+  FROM public.objects o
+  JOIN mt ON mt.object_id = o.id
+  LEFT JOIN sp ON sp.object_id = o.id
+  WHERE o.field = p_field
+    AND o.is_active
+  ORDER BY o.object_id;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_filtered_object_ids(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_list_ids integer[] DEFAULT NULL::integer[], p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_has_photometry boolean DEFAULT NULL::boolean, p_photo_z_min double precision DEFAULT NULL::double precision, p_photo_z_max double precision DEFAULT NULL::double precision, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_sort_column text DEFAULT 'object_id'::text, p_sort_direction text DEFAULT 'asc'::text, p_include_unpublished boolean DEFAULT false)
+ RETURNS TABLE(object_id text)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
+    v_gratings_mode := 'any';
+  END IF;
+
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN
+    p_sort_direction := 'asc';
+  END IF;
+
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time', 'photo_z'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+
+  -- Intersect user-accessible programs with filter selection
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(
+      SELECT unnest(p_program_slugs)
+      INTERSECT
+      SELECT unnest(p_filter_programs)
+    ) INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT o.object_id
+  FROM objects o
+  WHERE
+    o.programs && v_filtered_program_slugs
+    AND o.is_active = true
+    AND (p_include_unpublished OR o.has_published_spectrum)
+    AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+    AND (
+      NOT v_grating_filter_active
+      OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+      OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+      OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+    )
+    AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+    AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+    AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+    AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+    AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+    AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+    AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+    AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+    AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
+    AND (
+      p_inspected_only IS NULL
+      OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+      OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+    )
+    AND (
+      p_needs_review IS NULL
+      OR (p_needs_review = TRUE
+          AND o.staleness_reason IS NOT NULL
+          AND o.last_inspected_at IS NOT NULL
+          AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+      OR (p_needs_review = FALSE
+          AND (o.staleness_reason IS NULL
+               OR o.last_inspected_at IS NULL
+               OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+    )
+    AND (
+      NOT v_coord_search_active
+      OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+        AND 2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) <= p_radius_degrees
+      )
+    )
+    AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+        SELECT olm.object_id FROM object_list_members olm
+        WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+    ))
+    AND (
+      NOT v_comment_search_active
+      -- Uncorrelated semijoin; see get_filtered_objects_paginated for rationale.
+      OR o.id IN (
+        SELECT c.object_id FROM comments c
+        WHERE c.object_id IS NOT NULL
+          AND c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (
+            p_comment_search_scope = 'everyone'
+            OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+          )
+        UNION
+        SELECT t.object_id FROM comments c
+        JOIN targets t ON t.id = c.target_id
+        WHERE c.target_id IS NOT NULL
+          AND c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (
+            p_comment_search_scope = 'everyone'
+            OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+          )
+      )
+    )
+  ORDER BY
+    CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN
+      2 * DEGREES(ASIN(SQRT(
+        POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+        COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+        POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+      ))) END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN
+      2 * DEGREES(ASIN(SQRT(
+        POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+        COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+        POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+      ))) END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN o.object_id END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'desc' THEN o.object_id END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN o.field END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN o.field END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN o.ra END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN o.ra END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN o.dec END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN o.dec END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN o.redshift END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN o.redshift END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN o.redshift_quality END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN o.redshift_quality END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'asc' THEN o.n_targets END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'desc' THEN o.n_targets END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'asc' THEN o.n_spectra END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'desc' THEN o.n_spectra END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN o.max_snr END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN o.max_snr END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN o.max_exposure_time END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN o.max_exposure_time END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'asc' THEN o.photo_z END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'desc' THEN o.photo_z END DESC NULLS LAST,
+    o.object_id ASC;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_filtered_objects_paginated(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_list_ids integer[] DEFAULT NULL::integer[], p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_has_photometry boolean DEFAULT NULL::boolean, p_photo_z_min double precision DEFAULT NULL::double precision, p_photo_z_max double precision DEFAULT NULL::double precision, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_sort_column text DEFAULT 'object_id'::text, p_sort_direction text DEFAULT 'asc'::text, p_page integer DEFAULT 1, p_page_size integer DEFAULT 50, p_include_unpublished boolean DEFAULT false)
+ RETURNS TABLE(targets jsonb, total_count bigint, page integer, page_size integer)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_offset INTEGER;
+  v_total_count BIGINT;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
+    v_gratings_mode := 'any';
+  END IF;
+
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN
+    p_sort_direction := 'asc';
+  END IF;
+
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time', 'photo_z'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+
+  IF v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN
+    p_sort_column := 'distance';
+  END IF;
+
+  v_offset := (COALESCE(p_page, 1) - 1) * COALESCE(p_page_size, 50);
+
+  -- Intersect user-accessible programs with filter selection
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(
+      SELECT unnest(p_program_slugs)
+      INTERSECT
+      SELECT unnest(p_filter_programs)
+    ) INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN QUERY SELECT '[]'::jsonb, 0::BIGINT, p_page, p_page_size;
+    RETURN;
+  END IF;
+
+  -- Step 1: count
+  SELECT COUNT(*) INTO v_total_count
+  FROM objects o
+  WHERE
+    -- Access control: object must have at least one accessible program
+    o.programs && v_filtered_program_slugs
+    AND o.is_active = true
+    -- B1: hide objects with no published spectrum (fail-closed).
+    AND (p_include_unpublished OR o.has_published_spectrum)
+    AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+    AND (
+      NOT v_grating_filter_active
+      OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+      OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+      OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+    )
+    AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+    AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+    AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+    AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+    AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+    AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+    AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+    AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+    AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
+    AND (
+      p_inspected_only IS NULL
+      OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+      OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+    )
+    AND (
+      p_needs_review IS NULL
+      OR (p_needs_review = TRUE
+          AND o.staleness_reason IS NOT NULL
+          AND o.last_inspected_at IS NOT NULL
+          AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+      OR (p_needs_review = FALSE
+          AND (o.staleness_reason IS NULL
+               OR o.last_inspected_at IS NULL
+               OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+    )
+    AND (
+      NOT v_coord_search_active
+      OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+        AND 2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) <= p_radius_degrees
+      )
+    )
+    AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+        SELECT olm.object_id FROM object_list_members olm
+        WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+    ))
+    AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+    AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+    AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+    AND (
+      NOT v_comment_search_active
+      -- Uncorrelated semijoin: collect the object_ids that have a matching
+      -- comment ONCE (object-level comments directly + target-level comments
+      -- mapped through their parent object), then probe o.id IN (...). The old
+      -- correlated EXISTS-inside-OR re-ran a per-object targets subquery for
+      -- every (object x matching-comment) pair -> 271k subplan executions /
+      -- ~870ms here, multi-second on broad terms or cold cache.
+      OR o.id IN (
+        SELECT c.object_id FROM comments c
+        WHERE c.object_id IS NOT NULL
+          AND c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (
+            p_comment_search_scope = 'everyone'
+            OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+          )
+        UNION
+        SELECT t.object_id FROM comments c
+        JOIN targets t ON t.id = c.target_id
+        WHERE c.target_id IS NOT NULL
+          AND c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (
+            p_comment_search_scope = 'everyone'
+            OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+          )
+      )
+    );
+
+  -- Step 2: fetch page
+  RETURN QUERY
+  WITH filtered_objects AS (
+    SELECT
+      o.id,
+      o.object_id,
+      o.field,
+      o.ra,
+      o.dec,
+      o.n_targets,
+      o.n_spectra,
+      o.programs,
+      o.gratings,
+      o.max_snr,
+      o.max_exposure_time,
+      o.redshift,
+      o.redshift_quality,
+      o.redshift_inspected,
+      o.redshift_auto,
+      o.inspected_used_auto,
+      o.last_inspected_at,
+      o.last_inspected_by,
+      o.last_data_change_at,
+      o.staleness_reason,
+      o.version,
+      o.is_active,
+      o.photo_z,
+      o.has_photometry,
+      o.created_at,
+      CASE
+        WHEN v_coord_search_active THEN
+          2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+            POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+          )))
+        ELSE NULL
+      END AS distance
+    FROM objects o
+    WHERE
+      o.programs && v_filtered_program_slugs
+      AND o.is_active = true
+      AND (p_include_unpublished OR o.has_published_spectrum)
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+        OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+        OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+      )
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
+      AND (
+        p_inspected_only IS NULL
+        OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+        OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+      )
+      AND (
+        p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+      )
+      AND (
+        NOT v_coord_search_active
+        OR (
+          o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+          AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+          AND 2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+            POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+          ))) <= p_radius_degrees
+        )
+      )
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+      AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+      AND (
+        NOT v_comment_search_active
+        -- Uncorrelated semijoin; see the count query above for the rationale.
+        OR o.id IN (
+          SELECT c.object_id FROM comments c
+          WHERE c.object_id IS NOT NULL
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+          UNION
+          SELECT t.object_id FROM comments c
+          JOIN targets t ON t.id = c.target_id
+          WHERE c.target_id IS NOT NULL
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+        )
+      )
+    ORDER BY
+      CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN
+        2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN
+        2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN o.object_id END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'desc' THEN o.object_id END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN o.field END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN o.field END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN o.ra END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN o.ra END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN o.dec END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN o.dec END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN o.redshift END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN o.redshift END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN o.redshift_quality END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN o.redshift_quality END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'asc' THEN o.n_targets END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'desc' THEN o.n_targets END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'asc' THEN o.n_spectra END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'desc' THEN o.n_spectra END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN o.max_snr END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN o.max_snr END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN o.max_exposure_time END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN o.max_exposure_time END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'asc' THEN o.photo_z END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'desc' THEN o.photo_z END DESC NULLS LAST,
+      o.object_id ASC
+    LIMIT p_page_size OFFSET v_offset
+  ),
+  with_members AS (
+    SELECT
+      jsonb_build_object(
+        'id', fo.id,
+        'object_id', fo.object_id,
+        'field', fo.field,
+        'ra', fo.ra,
+        'dec', fo.dec,
+        -- Aggregates scoped to the viewer's accessible (+ filtered) programs so
+        -- mixed-program objects don't leak proprietary member metadata. Filter
+        -- and sort above still run on the global o.* columns (display-only
+        -- scoping); the substitution happens only on the paginated result set.
+        'n_targets', sa.n_targets,
+        'n_spectra', sa.n_spectra,
+        'programs', sa.programs,
+        'gratings', sa.gratings,
+        'max_snr', sa.max_snr,
+        'max_exposure_time', sa.max_exposure_time,
+        'redshift', fo.redshift,
+        'redshift_quality', fo.redshift_quality,
+        'redshift_inspected', fo.redshift_inspected,
+        'redshift_auto', fo.redshift_auto,
+        'inspected_used_auto', fo.inspected_used_auto,
+        'last_inspected_at', fo.last_inspected_at,
+        'last_inspected_by', fo.last_inspected_by,
+        'last_data_change_at', fo.last_data_change_at,
+        'staleness_reason', fo.staleness_reason,
+        'version', fo.version,
+        'is_active', fo.is_active,
+        'photo_z', fo.photo_z,
+        'has_photometry', fo.has_photometry,
+        'created_at', fo.created_at,
+        'distance', fo.distance,
+        -- Phase D: member_targets becomes provenance only (target_id, program,
+        -- observation). Inspection state lives on the object now; redshift_auto
+        -- on targets is retained for transitional UI display until Phase E.
+        'member_targets', COALESCE(
+          (SELECT jsonb_agg(
+            jsonb_build_object(
+              'target_id', t.target_id,
+              'program_slug', t.program_slug,
+              'observation', t.observation,
+              'redshift_auto', t.redshift_auto
+            )
+          )
+          FROM targets t
+          WHERE t.object_id = fo.id
+            AND t.program_slug = ANY(v_filtered_program_slugs)
+          ),
+          '[]'::jsonb
+        ),
+        'lists', COALESCE(
+          (SELECT jsonb_agg(
+            jsonb_build_object(
+              'id', ol.id,
+              'name', ol.name,
+              'slug', ol.slug,
+              'icon', ol.icon,
+              'color', ol.color
+            ) ORDER BY ol.name
+          )
+          FROM object_list_members olm
+          JOIN object_lists ol ON ol.id = olm.list_id
+          WHERE olm.object_id = fo.id),
+          '[]'::jsonb
+        )
+      ) AS obj_json
+    FROM filtered_objects fo
+    LEFT JOIN LATERAL public.object_scoped_aggregates(fo.id, v_filtered_program_slugs, p_include_unpublished) sa ON true
+  )
+  SELECT
+    COALESCE(jsonb_agg(wm.obj_json), '[]'::jsonb),
+    v_total_count,
+    p_page,
+    p_page_size
+  FROM with_members wm;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_filtered_spectra_paginated(p_program_slugs text[], p_filter_programs text[] DEFAULT NULL::text[], p_fields text[] DEFAULT NULL::text[], p_gratings text[] DEFAULT NULL::text[], p_gratings_mode text DEFAULT 'any'::text, p_observations text[] DEFAULT NULL::text[], p_redshift_quality integer[] DEFAULT NULL::integer[], p_redshift_min double precision DEFAULT NULL::double precision, p_redshift_max double precision DEFAULT NULL::double precision, p_max_snr_min double precision DEFAULT NULL::double precision, p_max_snr_max double precision DEFAULT NULL::double precision, p_max_exposure_time_min double precision DEFAULT NULL::double precision, p_max_exposure_time_max double precision DEFAULT NULL::double precision, p_dq_flags_include_any integer DEFAULT NULL::integer, p_dq_flags_include_all integer DEFAULT NULL::integer, p_dq_flags_exclude integer DEFAULT NULL::integer, p_list_ids integer[] DEFAULT NULL::integer[], p_search text DEFAULT NULL::text, p_inspected_only boolean DEFAULT NULL::boolean, p_needs_review boolean DEFAULT NULL::boolean, p_has_photometry boolean DEFAULT NULL::boolean, p_comment_search text DEFAULT NULL::text, p_comment_search_scope text DEFAULT NULL::text, p_comment_user_id uuid DEFAULT NULL::uuid, p_coord_ra double precision DEFAULT NULL::double precision, p_coord_dec double precision DEFAULT NULL::double precision, p_radius_degrees double precision DEFAULT NULL::double precision, p_sort_column text DEFAULT 'target_id'::text, p_sort_direction text DEFAULT 'asc'::text, p_page integer DEFAULT 1, p_page_size integer DEFAULT 50, p_include_thumbnails boolean DEFAULT false, p_include_unpublished boolean DEFAULT false)
+ RETURNS TABLE(targets jsonb, total_count bigint, page integer, page_size integer)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+AS $function$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_offset INTEGER;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
+    v_gratings_mode := 'any';
+  END IF;
+
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN
+    p_sort_direction := 'asc';
+  END IF;
+
+  IF NOT (p_sort_column IN (
+    'target_id', 'spectrum_id', 'field', 'observation', 'program_slug', 'ra', 'dec', 'redshift',
+    'redshift_quality', 'redshift_auto', 'signal_to_noise', 'exposure_time', 'grating'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'spectrum_id';
+  END IF;
+
+  IF v_coord_search_active AND p_sort_column IN ('target_id', 'spectrum_id') AND p_sort_direction = 'asc' THEN
+    p_sort_column := 'distance';
+  END IF;
+
+  v_offset := (COALESCE(p_page, 1) - 1) * COALESCE(p_page_size, 50);
+
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(
+      SELECT unnest(p_program_slugs)
+      INTERSECT
+      SELECT unnest(p_filter_programs)
+    ) INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN QUERY SELECT '[]'::jsonb, 0::BIGINT, p_page, p_page_size;
+    RETURN;
+  END IF;
+
+  -- Single-pass CTE: filtered_spectra is referenced by both distance_filtered
+  -- and the count subquery, so PostgreSQL materializes it once.
+  RETURN QUERY
+  WITH filtered_spectra AS (
+    SELECT
+      t.id AS tgt_db_id,
+      t.target_id,
+      t.program_slug,
+      t.field,
+      t.observation,
+      t.ra,
+      t.dec,
+      -- Phase D: redshift / redshift_quality / inspected flags now live on the
+      -- parent object. LEFT JOIN so spectra whose target has no object FK
+      -- (shouldn't happen post-reconcile, but safe) still appear.
+      o.redshift,
+      o.redshift_quality,
+      o.redshift_inspected,
+      o.last_inspected_at,
+      o.last_inspected_by,
+      o.is_active AS object_is_active,
+      o.has_photometry AS object_has_photometry,
+      o.object_id AS parent_object_id,
+      t.max_snr,
+      t.max_exposure_time,
+      t.created_at,
+      t.updated_at,
+      s.id AS spectrum_pk,
+      s.spectrum_id,
+      s.grating,
+      s.fits_path,
+      s.signal_to_noise,
+      s.exposure_time,
+      s.redshift_auto,
+      COALESCE(s.dq_flags, 0) AS dq_flags,
+      s.file_hash,
+      s.file_size,
+      s.thumbnail_svg_fnu,
+      s.thumbnail_svg_flambda,
+      CASE
+        WHEN v_coord_search_active THEN
+          2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(t.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(t.dec)) *
+            POWER(SIN(RADIANS(t.ra - p_coord_ra) / 2), 2)
+          )))
+        ELSE NULL
+      END AS distance
+    FROM targets t
+    JOIN spectra s ON s.target_id = t.target_id
+    LEFT JOIN objects o ON o.id = t.object_id
+    WHERE
+      t.program_slug = ANY(v_filtered_program_slugs)
+      -- Hide spectra whose parent object was soft-deleted.
+      AND (o.id IS NULL OR o.is_active = true)
+      AND (NOT v_grating_filter_active OR s.grating = ANY(p_gratings))
+      -- B1: hide unpublished spectra (fail-closed; admin opt-in only).
+      AND (p_include_unpublished OR s.deploy_status = 'published')
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR t.field = ANY(p_fields))
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR t.observation = ANY(p_observations))
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR s.signal_to_noise >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR s.signal_to_noise <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR s.exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR s.exposure_time <= p_max_exposure_time_max)
+      AND (p_dq_flags_include_any IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_any) != 0)
+      AND (p_dq_flags_include_all IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_all) = p_dq_flags_include_all)
+      AND (p_dq_flags_exclude IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_exclude) = 0)
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR t.object_id IN (
+          SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_search IS NULL OR s.id IN (SELECT __s.id FROM public.spectra __s WHERE __s.search_text ILIKE '%' || p_search || '%'))
+      AND (
+        p_inspected_only IS NULL
+        OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+        OR (p_inspected_only = FALSE AND COALESCE(o.redshift_quality, 0) = 0)
+      )
+      AND (
+        p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+      )
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (
+        NOT v_comment_search_active
+        -- Uncorrelated semijoin: build the set of matching target_ids ONCE
+        -- (trgm/seq scan over the tiny comments table) instead of re-probing
+        -- comments per outer row. Correlated EXISTS-inside-OR can't be pulled
+        -- up and re-executes per spectrum -> timeouts on broad access. See the
+        -- objects path below for the object-level analogue.
+        OR t.id IN (
+          SELECT c.target_id FROM comments c
+          WHERE c.target_id IS NOT NULL
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+        )
+      )
+      AND (
+        NOT v_coord_search_active
+        OR (
+          t.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+          AND t.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+        )
+      )
+  ),
+  distance_filtered AS (
+    SELECT fs.*
+    FROM filtered_spectra fs
+    WHERE NOT v_coord_search_active OR fs.distance <= p_radius_degrees
+  ),
+  page_rows AS (
+    SELECT *, ROW_NUMBER() OVER () as row_num
+    FROM (
+      SELECT * FROM distance_filtered
+      ORDER BY
+        CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN distance END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN distance END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'target_id' AND p_sort_direction = 'asc' THEN target_id END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'target_id' AND p_sort_direction = 'desc' THEN target_id END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'spectrum_id' AND p_sort_direction = 'asc' THEN spectrum_id END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'spectrum_id' AND p_sort_direction = 'desc' THEN spectrum_id END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN field END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN field END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'observation' AND p_sort_direction = 'asc' THEN observation END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'observation' AND p_sort_direction = 'desc' THEN observation END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'program_slug' AND p_sort_direction = 'asc' THEN program_slug END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'program_slug' AND p_sort_direction = 'desc' THEN program_slug END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN ra END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN ra END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN "dec" END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN "dec" END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN redshift END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN redshift END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN redshift_quality END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN redshift_quality END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift_auto' AND p_sort_direction = 'asc' THEN redshift_auto END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift_auto' AND p_sort_direction = 'desc' THEN redshift_auto END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'signal_to_noise' AND p_sort_direction = 'asc' THEN signal_to_noise END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'signal_to_noise' AND p_sort_direction = 'desc' THEN signal_to_noise END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'exposure_time' AND p_sort_direction = 'asc' THEN exposure_time END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'exposure_time' AND p_sort_direction = 'desc' THEN exposure_time END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'grating' AND p_sort_direction = 'asc' THEN grating END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'grating' AND p_sort_direction = 'desc' THEN grating END DESC NULLS LAST,
+        target_id ASC, grating ASC
+      LIMIT p_page_size OFFSET v_offset
+    ) sorted_page
+  )
+  SELECT
+    COALESCE(jsonb_agg(jsonb_build_object(
+      'id', r.tgt_db_id,
+      'target_id', r.target_id,
+      'parent_object_id', r.parent_object_id,
+      'program_slug', r.program_slug,
+      'program_name', pr.program_name,
+      'field', r.field,
+      'observation', r.observation,
+      'ra', r.ra,
+      'dec', r.dec,
+      -- Phase D: redshift fields are object-level reads
+      'redshift', r.redshift,
+      'redshift_inspected', r.redshift_inspected,
+      'redshift_quality', r.redshift_quality,
+      'last_inspected_at', r.last_inspected_at,
+      'last_inspected_by', r.last_inspected_by,
+      'max_snr', r.max_snr,
+      'max_exposure_time', r.max_exposure_time,
+      'created_at', r.created_at,
+      'updated_at', r.updated_at,
+      'distance', CASE WHEN v_coord_search_active THEN r.distance ELSE NULL END,
+      'spectra', jsonb_build_array(jsonb_build_object(
+        'id', r.spectrum_pk,
+        'spectrum_id', r.spectrum_id,
+        'target_id', r.target_id,
+        'grating', r.grating,
+        'fits_path', r.fits_path,
+        'signal_to_noise', r.signal_to_noise,
+        'exposure_time', r.exposure_time,
+        -- Phase D: per-spectrum auto-z and DQ
+        'redshift_auto', r.redshift_auto,
+        'dq_flags', r.dq_flags,
+        'file_hash', r.file_hash,
+        'file_size', r.file_size,
+        'thumbnail_svg_fnu', CASE WHEN p_include_thumbnails THEN r.thumbnail_svg_fnu ELSE NULL END,
+        'thumbnail_svg_flambda', CASE WHEN p_include_thumbnails THEN r.thumbnail_svg_flambda ELSE NULL END
+      ))
+    ) ORDER BY r.row_num), '[]'::jsonb),
+    (SELECT COUNT(*) FROM distance_filtered),
+    p_page,
+    p_page_size
+  FROM page_rows r
+  LEFT JOIN programs pr ON pr.slug = r.program_slug;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_lists_for_sync(p_user_id uuid DEFAULT NULL::uuid, p_include_unpublished boolean DEFAULT false)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE
+AS $function$
+BEGIN
+  RETURN COALESCE(
+    (SELECT jsonb_agg(jsonb_build_object(
+      'id', ol.id,
+      'slug', ol.slug,
+      'name', ol.name,
+      'description', ol.description,
+      'visibility', ol.visibility,
+      'is_system', ol.is_system,
+      'created_by', ol.created_by,
+      'created_at', ol.created_at,
+      'updated_at', ol.updated_at,
+      -- B1: count only members whose object has a published spectrum (unlinked
+      -- coordinate-keyed members, object_id IS NULL, still count). Fail-closed.
+      'member_count', (
+        SELECT COUNT(*) FROM object_list_members olm
+        LEFT JOIN objects o ON o.id = olm.object_id
+        WHERE olm.list_id = ol.id
+          AND (p_include_unpublished OR olm.object_id IS NULL OR o.has_published_spectrum)
+      )
+    ) ORDER BY ol.is_system DESC, ol.name)
+    FROM object_lists ol
+    WHERE ol.created_by = p_user_id
+       OR ol.visibility IN ('public_read', 'public_edit')),
+    '[]'::jsonb
+  );
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_objects_for_sync(p_program_slugs text[], p_user_id uuid DEFAULT NULL::uuid, p_updated_since timestamp with time zone DEFAULT NULL::timestamp with time zone, p_limit integer DEFAULT 1000, p_offset integer DEFAULT 0, p_include_counts boolean DEFAULT true, p_include_unpublished boolean DEFAULT false)
+ RETURNS TABLE(objects jsonb, total_count bigint, total_accessible_count bigint)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+ SET statement_timeout TO '120s'
+AS $function$
+BEGIN
+  RETURN QUERY
+  -- matched is MATERIALIZED so the three aggregate CTEs below each see the
+  -- same ~p_limit-row set without re-evaluating the WHERE/ORDER/LIMIT.
+  WITH matched AS MATERIALIZED (
+    SELECT o.id, o.object_id, o.field, o.ra, o.dec,
+           o.n_targets, o.n_spectra, o.programs, o.gratings,
+           o.max_snr, o.max_exposure_time,
+           o.redshift, o.redshift_quality,
+           o.redshift_inspected, o.redshift_auto,
+           o.inspected_used_auto,
+           o.last_inspected_at, o.last_inspected_by,
+           o.last_data_change_at, o.staleness_reason,
+           o.version, o.is_active,
+           o.has_photometry, o.photo_z, o.photo_z_err_lo, o.photo_z_err_hi,
+           o.created_at, o.updated_at
+    FROM objects o
+    WHERE o.programs && p_program_slugs
+      -- Phase D: hide soft-deleted objects from sync. Reactivation rewrites
+      -- updated_at, so re-activated rows get re-synced naturally on next pull.
+      AND o.is_active = true
+      -- B1: drop objects with no published spectrum (fail-closed).
+      AND (p_include_unpublished OR o.has_published_spectrum)
+      AND (p_updated_since IS NULL OR o.updated_at > p_updated_since)
+    ORDER BY o.object_id
+    LIMIT p_limit OFFSET p_offset
+  ),
+  member_targets_agg AS (
+    SELECT t.object_id,
+           jsonb_agg(t.target_id ORDER BY t.target_id) AS target_ids
+    FROM targets t
+    WHERE t.object_id IN (SELECT id FROM matched)
+      AND t.program_slug = ANY(p_program_slugs)
+    GROUP BY t.object_id
+  ),
+  -- Phase D: per-spectrum payload (per design doc) so the Python client
+  -- can render redshift_auto and dq_flags per grating without a second
+  -- round-trip.
+  spectra_agg AS (
+    SELECT t.object_id,
+           jsonb_agg(jsonb_build_object(
+             'id', s.id,
+             'target_id', s.target_id,
+             'grating', s.grating,
+             'signal_to_noise', s.signal_to_noise,
+             'exposure_time', s.exposure_time,
+             'redshift_auto', s.redshift_auto,
+             'dq_flags', s.dq_flags
+           ) ORDER BY s.target_id, s.grating) AS spectra
+    FROM spectra s
+    JOIN targets t ON t.target_id = s.target_id
+    WHERE t.object_id IN (SELECT id FROM matched)
+      AND t.program_slug = ANY(p_program_slugs)
+      AND (p_include_unpublished OR s.deploy_status = 'published')
+    GROUP BY t.object_id
+  ),
+  lists_agg AS (
+    SELECT olm.object_id,
+           jsonb_agg(ol.slug ORDER BY ol.slug) AS list_slugs
+    FROM object_list_members olm
+    JOIN object_lists ol ON ol.id = olm.list_id
+    WHERE olm.object_id IN (SELECT id FROM matched)
+      AND (ol.created_by = p_user_id
+           OR ol.visibility IN ('public_read', 'public_edit'))
+    GROUP BY olm.object_id
+  ),
+  -- Count CTEs are gated on p_include_counts; when FALSE the planner
+  -- collapses them to One-Time Filter: false and skips the scan.
+  total AS (
+    SELECT COUNT(*) AS cnt
+    FROM objects o
+    WHERE p_include_counts
+      AND o.programs && p_program_slugs
+      AND o.is_active = true
+      AND (p_include_unpublished OR o.has_published_spectrum)
+      AND (p_updated_since IS NULL OR o.updated_at > p_updated_since)
+  ),
+  accessible AS (
+    SELECT COUNT(*) AS cnt
+    FROM objects o
+    WHERE p_include_counts
+      AND o.programs && p_program_slugs
+      AND o.is_active = true
+      AND (p_include_unpublished OR o.has_published_spectrum)
+  )
+  SELECT
+    COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'id', m.id,
+        'object_id', m.object_id,
+        'field', m.field,
+        'ra', m.ra,
+        'dec', m.dec,
+        -- Aggregates scoped to the caller's accessible programs so a sync that
+        -- pulls a mixed-program object doesn't leak proprietary member metadata
+        -- into the Python catalog. See object_scoped_aggregates().
+        'n_targets', sa.n_targets,
+        'n_spectra', sa.n_spectra,
+        'programs', sa.programs,
+        'gratings', sa.gratings,
+        'max_snr', sa.max_snr,
+        'max_exposure_time', sa.max_exposure_time,
+        'redshift', m.redshift,
+        'redshift_quality', m.redshift_quality,
+        'redshift_inspected', m.redshift_inspected,
+        'redshift_auto', m.redshift_auto,
+        'inspected_used_auto', m.inspected_used_auto,
+        'last_inspected_at', m.last_inspected_at,
+        'last_inspected_by', m.last_inspected_by,
+        'last_data_change_at', m.last_data_change_at,
+        'staleness_reason', m.staleness_reason,
+        'version', m.version,
+        'is_active', m.is_active,
+        'has_photometry', m.has_photometry,
+        'photo_z', m.photo_z,
+        'photo_z_err_lo', m.photo_z_err_lo,
+        'photo_z_err_hi', m.photo_z_err_hi,
+        'created_at', m.created_at,
+        'updated_at', m.updated_at,
+        'member_target_ids', COALESCE(mt.target_ids, '[]'::jsonb),
+        'spectra',           COALESCE(sp.spectra,    '[]'::jsonb),
+        'lists',             COALESCE(la.list_slugs, '[]'::jsonb)
+      )
+    ), '[]'::jsonb),
+    COALESCE((SELECT cnt FROM total), 0)::BIGINT,
+    COALESCE((SELECT cnt FROM accessible), 0)::BIGINT
+  FROM matched m
+  LEFT JOIN member_targets_agg mt ON mt.object_id = m.id
+  LEFT JOIN spectra_agg         sp ON sp.object_id = m.id
+  LEFT JOIN lists_agg           la ON la.object_id = m.id
+  LEFT JOIN LATERAL public.object_scoped_aggregates(m.id, p_program_slugs, p_include_unpublished) sa ON true;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_observation_manifest(p_obs_name text, p_program_slugs text[], p_include_unpublished boolean DEFAULT false)
+ RETURNS TABLE(spectra_id integer, spectrum_id text, target_id text, grating text, fits_path text, file_hash text, file_size bigint, signal_to_noise double precision, cfpipe_version text)
+ LANGUAGE plpgsql
+ STABLE
+AS $function$
+BEGIN
+  RETURN QUERY
+  SELECT s.id, s.spectrum_id, s.target_id, s.grating, s.fits_path, s.file_hash, s.file_size,
+         s.signal_to_noise, s.cfpipe_version
+  FROM spectra s
+  JOIN targets t ON t.target_id = s.target_id
+  WHERE t.observation = p_obs_name AND t.program_slug = ANY(p_program_slugs)
+    -- B1: fail-closed; admin sync passes p_include_unpublished => true.
+    AND (p_include_unpublished OR s.deploy_status = 'published')
+  ORDER BY s.spectrum_id;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_observation_stats(p_program_slugs text[], p_include_unpublished boolean DEFAULT false)
+ RETURNS TABLE(observation text, program_slug text, program_name text, field text, target_count bigint, spectrum_count bigint, total_size_bytes bigint, pointings jsonb, crds_context text, cfpipe_version text, jwst_version text, reduced_at timestamp with time zone, deployed_at timestamp with time zone, deployed_by_username text, deployed_by_full_name text, n_patches_since_full integer, last_patch_at timestamp with time zone)
+ LANGUAGE sql
+ STABLE
+AS $function$
+  WITH stats AS (
+    SELECT t.observation, t.program_slug, p.program_name, t.field,
+      COUNT(DISTINCT t.target_id) AS target_count,
+      COUNT(s.id) AS spectrum_count,
+      COALESCE(SUM(s.file_size), 0)::bigint AS total_size_bytes
+    FROM targets t
+    JOIN programs p ON p.slug = t.program_slug
+    LEFT JOIN spectra s ON s.target_id = t.target_id
+      -- B1: unpublished spectra don't contribute to counts/size (targets still appear).
+      AND (p_include_unpublished OR s.deploy_status = 'published')
+    WHERE t.program_slug = ANY(p_program_slugs)
+    GROUP BY t.observation, t.program_slug, p.program_name, t.field
+  )
+  SELECT s.observation, s.program_slug, s.program_name, s.field,
+    s.target_count, s.spectrum_count, s.total_size_bytes,
+    o.pointings,
+    full_dep.crds_context,
+    full_dep.cfpipe_version, full_dep.jwst_version,
+    full_dep.reduced_at, full_dep.deployed_at,
+    full_dep.deployed_by_username, full_dep.deployed_by_full_name,
+    COALESCE(patches.n_patches, 0)::integer AS n_patches_since_full,
+    patches.last_patch_at
+  FROM stats s
+  LEFT JOIN observations o ON o.name = s.observation
+  LEFT JOIN LATERAL (
+    SELECT d.crds_context, d.cfpipe_version, d.jwst_version,
+           d.reduced_at, d.deployed_at,
+           up.username AS deployed_by_username,
+           up.full_name AS deployed_by_full_name
+    FROM public.deployments d
+    LEFT JOIN public.user_profiles up ON up.user_id = d.deployed_by
+    WHERE d.observation = s.observation AND d.source_ids_filter IS NULL
+    ORDER BY d.deployed_at DESC
+    LIMIT 1
+  ) full_dep ON true
+  LEFT JOIN LATERAL (
+    SELECT COUNT(*)::integer AS n_patches, MAX(d.deployed_at) AS last_patch_at
+    FROM public.deployments d
+    WHERE d.observation = s.observation
+      AND d.source_ids_filter IS NOT NULL
+      AND (full_dep.deployed_at IS NULL OR d.deployed_at > full_dep.deployed_at)
+  ) patches ON true
+  ORDER BY s.observation;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_observations_overview(p_program_slugs text[], p_include_unpublished boolean DEFAULT false)
+ RETURNS TABLE(observation text, program_slug text, program_name text, field text, cycle integer, gratings text[], pointing_count integer, pointings jsonb, target_count bigint, spectrum_count bigint, total_size_bytes bigint, crds_context text, cfpipe_version text, jwst_version text, reduced_at timestamp with time zone, deployed_at timestamp with time zone, deployed_by_username text, deployed_by_full_name text, n_patches_since_full integer, last_patch_at timestamp with time zone)
+ LANGUAGE sql
+ STABLE
+AS $function$
+  WITH stats AS (
+    SELECT t.observation, t.program_slug,
+      COUNT(DISTINCT t.target_id) AS target_count,
+      COUNT(s.id) AS spectrum_count,
+      COALESCE(SUM(s.file_size), 0)::bigint AS total_size_bytes,
+      ARRAY_AGG(DISTINCT s.grating ORDER BY s.grating)
+        FILTER (WHERE s.grating IS NOT NULL) AS gratings
+    FROM public.targets t
+    LEFT JOIN public.spectra s ON s.target_id = t.target_id
+      -- B1: unpublished spectra don't contribute to counts/size/gratings.
+      AND (p_include_unpublished OR s.deploy_status = 'published')
+    WHERE t.program_slug = ANY(p_program_slugs)
+    GROUP BY t.observation, t.program_slug
+  )
+  SELECT
+    o.name AS observation,
+    o.program_slug,
+    p.program_name,
+    o.field,
+    p.cycle,
+    CASE
+      WHEN COALESCE(array_length(s.gratings, 1), 0) > 0 THEN s.gratings
+      ELSE COALESCE(o.gratings, ARRAY[]::text[])
+    END AS gratings,
+    COALESCE(jsonb_array_length(o.pointings), 0) AS pointing_count,
+    o.pointings,
+    COALESCE(s.target_count, 0)::bigint AS target_count,
+    COALESCE(s.spectrum_count, 0)::bigint AS spectrum_count,
+    COALESCE(s.total_size_bytes, 0)::bigint AS total_size_bytes,
+    full_dep.crds_context,
+    full_dep.cfpipe_version, full_dep.jwst_version,
+    full_dep.reduced_at, full_dep.deployed_at,
+    full_dep.deployed_by_username, full_dep.deployed_by_full_name,
+    COALESCE(patches.n_patches, 0)::integer AS n_patches_since_full,
+    patches.last_patch_at
+  FROM public.observations o
+  JOIN public.programs p ON p.slug = o.program_slug
+  LEFT JOIN stats s ON s.observation = o.name AND s.program_slug = o.program_slug
+  LEFT JOIN LATERAL (
+    SELECT d.crds_context, d.cfpipe_version, d.jwst_version,
+           d.reduced_at, d.deployed_at,
+           up.username AS deployed_by_username,
+           up.full_name AS deployed_by_full_name
+    FROM public.deployments d
+    LEFT JOIN public.user_profiles up ON up.user_id = d.deployed_by
+    WHERE d.observation = o.name AND d.source_ids_filter IS NULL
+    ORDER BY d.deployed_at DESC
+    LIMIT 1
+  ) full_dep ON true
+  LEFT JOIN LATERAL (
+    SELECT COUNT(*)::integer AS n_patches, MAX(d.deployed_at) AS last_patch_at
+    FROM public.deployments d
+    WHERE d.observation = o.name
+      AND d.source_ids_filter IS NOT NULL
+      AND (full_dep.deployed_at IS NULL OR d.deployed_at > full_dep.deployed_at)
+  ) patches ON true
+  WHERE o.program_slug = ANY(p_program_slugs)
+  ORDER BY o.program_slug, o.name;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_photometry_for_sync(p_program_slugs text[], p_updated_since timestamp with time zone DEFAULT NULL::timestamp with time zone, p_limit integer DEFAULT 1000, p_offset integer DEFAULT 0, p_include_unpublished boolean DEFAULT false)
+ RETURNS TABLE(photometry_records jsonb, total_count bigint)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+ SET statement_timeout TO '120s'
+AS $function$
+BEGIN
+  RETURN QUERY
+  WITH matched AS (
+    SELECT op.id, o.object_id, op.field, op.catalog_name, op.catalog_id,
+           op.match_distance_arcsec, op.photometry, op.photo_z,
+           op.photo_z_err_lo, op.photo_z_err_hi, op.has_pz,
+           op.created_at, op.updated_at
+    FROM object_photometry op
+    JOIN objects o ON o.id = op.object_id
+    WHERE o.programs && p_program_slugs
+      -- B1: fail-closed publish gate (this RPC always bypasses RLS).
+      AND (p_include_unpublished OR o.has_published_spectrum)
+      AND (p_updated_since IS NULL OR op.updated_at > p_updated_since)
+    ORDER BY op.id
+    LIMIT p_limit OFFSET p_offset
+  ),
+  total AS (
+    SELECT COUNT(*) AS cnt
+    FROM object_photometry op
+    JOIN objects o ON o.id = op.object_id
+    WHERE o.programs && p_program_slugs
+      AND (p_include_unpublished OR o.has_published_spectrum)
+      AND (p_updated_since IS NULL OR op.updated_at > p_updated_since)
+  )
+  SELECT
+    COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'id', m.id,
+        'object_id', m.object_id,
+        'field', m.field,
+        'catalog_name', m.catalog_name,
+        'catalog_id', m.catalog_id,
+        'match_distance_arcsec', m.match_distance_arcsec,
+        'photometry', m.photometry,
+        'photo_z', m.photo_z,
+        'photo_z_err_lo', m.photo_z_err_lo,
+        'photo_z_err_hi', m.photo_z_err_hi,
+        'has_pz', m.has_pz,
+        'created_at', m.created_at,
+        'updated_at', m.updated_at
+      )
+    ), '[]'::jsonb),
+    COALESCE((SELECT cnt FROM total), 0)::BIGINT
+  FROM matched m;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_spectra_for_sync(p_program_slugs text[], p_user_id uuid DEFAULT NULL::uuid, p_updated_since timestamp with time zone DEFAULT NULL::timestamp with time zone, p_limit integer DEFAULT 1000, p_offset integer DEFAULT 0, p_include_counts boolean DEFAULT true, p_include_unpublished boolean DEFAULT false)
+ RETURNS TABLE(spectra jsonb, total_count bigint, total_accessible_count bigint)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+ SET statement_timeout TO '120s'
+AS $function$
+BEGIN
+  RETURN QUERY
+  WITH matched AS MATERIALIZED (
+    SELECT s.id, s.spectrum_id, s.target_id, o.object_id AS object_id,
+           s.grating, s.fits_path, s.file_hash, s.file_size,
+           s.signal_to_noise, s.exposure_time,
+           s.cfpipe_version, s.crds_context, s.jwst_version, s.date_obs, s.reduced_at,
+           s.redshift_auto, s.dq_flags,
+           t.program_slug, t.observation, t.field,
+           s.created_at, s.updated_at
+    FROM spectra s
+    JOIN targets t ON t.target_id = s.target_id
+    LEFT JOIN objects o ON o.id = t.object_id
+    WHERE t.program_slug = ANY(p_program_slugs)
+      AND (o.id IS NULL OR o.is_active = true)
+      -- B1: fail-closed publish gate (this RPC always bypasses RLS).
+      AND (p_include_unpublished OR s.deploy_status = 'published')
+      AND (p_updated_since IS NULL OR s.updated_at > p_updated_since)
+    ORDER BY s.spectrum_id
+    LIMIT p_limit OFFSET p_offset
+  ),
+  -- Count CTEs are gated on p_include_counts; when FALSE the planner
+  -- collapses them to One-Time Filter: false and skips the scan/join.
+  total AS (
+    SELECT COUNT(*) AS cnt
+    FROM spectra s
+    JOIN targets t ON t.target_id = s.target_id
+    LEFT JOIN objects o ON o.id = t.object_id
+    WHERE p_include_counts
+      AND t.program_slug = ANY(p_program_slugs)
+      AND (o.id IS NULL OR o.is_active = true)
+      AND (p_include_unpublished OR s.deploy_status = 'published')
+      AND (p_updated_since IS NULL OR s.updated_at > p_updated_since)
+  ),
+  accessible AS (
+    SELECT COUNT(*) AS cnt
+    FROM spectra s
+    JOIN targets t ON t.target_id = s.target_id
+    LEFT JOIN objects o ON o.id = t.object_id
+    WHERE p_include_counts
+      AND t.program_slug = ANY(p_program_slugs)
+      AND (o.id IS NULL OR o.is_active = true)
+      AND (p_include_unpublished OR s.deploy_status = 'published')
+  )
+  SELECT
+    COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'id', m.id,
+        'spectrum_id', m.spectrum_id,
+        'target_id', m.target_id,
+        'object_id', m.object_id,
+        'grating', m.grating,
+        'fits_path', m.fits_path,
+        'file_hash', m.file_hash,
+        'file_size', m.file_size,
+        'signal_to_noise', m.signal_to_noise,
+        'exposure_time', m.exposure_time,
+        'cfpipe_version', m.cfpipe_version,
+        'crds_context', m.crds_context,
+        'jwst_version', m.jwst_version,
+        'date_obs', m.date_obs,
+        'reduced_at', m.reduced_at,
+        'redshift_auto', m.redshift_auto,
+        'dq_flags', m.dq_flags,
+        'program_slug', m.program_slug,
+        'observation', m.observation,
+        'field', m.field,
+        'created_at', m.created_at,
+        'updated_at', m.updated_at
+      )
+    ), '[]'::jsonb),
+    COALESCE((SELECT cnt FROM total), 0)::BIGINT,
+    COALESCE((SELECT cnt FROM accessible), 0)::BIGINT
+  FROM matched m;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_targets_in_viewport(p_ra_min double precision, p_ra_max double precision, p_dec_min double precision, p_dec_max double precision, p_field text DEFAULT NULL::text, p_limit integer DEFAULT 5000, p_include_unpublished boolean DEFAULT false)
+ RETURNS TABLE(target_id text, ra double precision, "dec" double precision, redshift double precision, redshift_quality integer, field text, program_slug text)
+ LANGUAGE plpgsql
+ STABLE
+AS $function$
+BEGIN
+  RETURN QUERY
+  SELECT t.target_id, t.ra, t.dec, t.redshift::double precision, t.redshift_quality, t.field, t.program_slug
+  FROM public.targets t
+  WHERE t.ra BETWEEN p_ra_min AND p_ra_max AND t.dec BETWEEN p_dec_min AND p_dec_max
+    AND (p_field IS NULL OR t.field = p_field)
+    -- B1: hide targets with no published spectrum (fail-closed).
+    AND (p_include_unpublished OR t.has_published_spectrum)
+  ORDER BY t.ra LIMIT p_limit;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.object_scoped_aggregates(p_object_id integer, p_program_slugs text[], p_include_unpublished boolean DEFAULT false)
+ RETURNS TABLE(programs text[], gratings text[], observations text[], n_targets integer, n_spectra integer, max_snr double precision, max_exposure_time double precision)
+ LANGUAGE sql
+ STABLE
+AS $function$
+  WITH m AS (
+    SELECT t.target_id, t.program_slug, t.observation
+    FROM targets t
+    WHERE t.object_id = p_object_id
+      AND t.program_slug = ANY(p_program_slugs)
+      -- B1: only count targets that contribute a published spectrum so
+      -- n_targets / programs / observations don't include draft-only members.
+      AND (p_include_unpublished OR t.has_published_spectrum)
+  ),
+  sp AS (
+    SELECT s.grating, s.signal_to_noise, s.exposure_time
+    FROM spectra s
+    WHERE s.target_id IN (SELECT target_id FROM m)
+      AND (p_include_unpublished OR s.deploy_status = 'published')
+  )
+  SELECT
+    COALESCE((SELECT array_agg(DISTINCT m.program_slug ORDER BY m.program_slug) FROM m), '{}')::text[],
+    COALESCE((SELECT array_agg(DISTINCT sp.grating ORDER BY sp.grating) FROM sp WHERE sp.grating IS NOT NULL), '{}')::text[],
+    COALESCE((SELECT array_agg(DISTINCT m.observation ORDER BY m.observation) FROM m WHERE m.observation IS NOT NULL), '{}')::text[],
+    (SELECT COUNT(*) FROM m)::integer,
+    (SELECT COUNT(*) FROM sp)::integer,
+    (SELECT MAX(sp.signal_to_noise) FROM sp),
+    (SELECT MAX(sp.exposure_time) FROM sp);
+$function$
+;
+
+-- B1 (#217): migra also emitted CREATE OR REPLACE for can_inspect() and
+-- handle_new_user() here — that is PRE-EXISTING #195 search_path drift between
+-- the migration history and the schema files (tracked in issue #228), NOT part
+-- of the deploy_status work. Stripped to keep this migration single-purpose; the
+-- drift remains for #228 to resolve.
+
+create materialized view "public"."mv_filter_options" as  SELECT 1 AS id,
+    ARRAY( SELECT DISTINCT targets.field
+           FROM public.targets
+          WHERE targets.has_published_spectrum
+          ORDER BY targets.field) AS fields,
+    ARRAY( SELECT DISTINCT targets.observation
+           FROM public.targets
+          WHERE ((targets.observation IS NOT NULL) AND targets.has_published_spectrum)
+          ORDER BY targets.observation) AS observations,
+    ARRAY( SELECT DISTINCT spectra.grating
+           FROM public.spectra
+          WHERE (spectra.deploy_status = 'published'::text)
+          ORDER BY spectra.grating) AS gratings;
+
+-- B1 (#217): migra drops the matview and does NOT re-emit its unique index;
+-- restore it (REFRESH MATERIALIZED VIEW CONCURRENTLY requires it). Grants are
+-- auto-restored by default privileges on the recreated matview.
+CREATE UNIQUE INDEX mv_filter_options_id ON public.mv_filter_options USING btree (id);
+
+
+create materialized view "public"."mv_programs_overview" as  SELECT p.slug,
+    p.program_name,
+    p.pi_name,
+    p.description,
+    p.is_public,
+    p.cycle,
+    COALESCE(stats.target_count, (0)::bigint) AS target_count,
+    COALESCE(stats.gratings, ARRAY[]::text[]) AS gratings,
+    COALESCE(stats.fields, ARRAY[]::text[]) AS fields,
+    COALESCE(stats.observations, ARRAY[]::text[]) AS observations,
+    COALESCE(pids.jwst_pids, ARRAY[]::integer[]) AS jwst_pids,
+    COALESCE(pids.n_observations, (0)::bigint) AS n_observations,
+    last_red.last_reduced_at
+   FROM (((public.programs p
+     LEFT JOIN ( SELECT t.program_slug,
+            count(DISTINCT t.target_id) AS target_count,
+            array_agg(DISTINCT s.grating ORDER BY s.grating) FILTER (WHERE (s.grating IS NOT NULL)) AS gratings,
+            array_agg(DISTINCT t.field ORDER BY t.field) AS fields,
+            array_agg(DISTINCT t.observation ORDER BY t.observation) AS observations
+           FROM (public.targets t
+             LEFT JOIN public.spectra s ON (((s.target_id = t.target_id) AND (s.deploy_status = 'published'::text))))
+          GROUP BY t.program_slug) stats ON ((p.slug = stats.program_slug)))
+     LEFT JOIN ( SELECT observations.program_slug,
+            array_agg(DISTINCT observations.jwst_program_id ORDER BY observations.jwst_program_id) AS jwst_pids,
+            count(*) AS n_observations
+           FROM public.observations
+          GROUP BY observations.program_slug) pids ON ((p.slug = pids.program_slug)))
+     LEFT JOIN ( SELECT o.program_slug,
+            max(d.reduced_at) AS last_reduced_at
+           FROM (public.observations o
+             JOIN public.deployments d ON ((d.observation = o.name)))
+          WHERE (d.source_ids_filter IS NULL)
+          GROUP BY o.program_slug) last_red ON ((p.slug = last_red.program_slug)));
+
+-- B1 (#217): restore the matview unique index migra omitted (see above).
+CREATE UNIQUE INDEX mv_programs_overview_slug ON public.mv_programs_overview USING btree (slug);
+
+
+-- B1 (#217): security_invoker restored (migra drops the view option). Without it
+-- this plain view bypasses the admin-only RLS on nircam_exposures, leaking QA
+-- aggregates to all authenticated users.
+create or replace view "public"."nircam_reduction_progress"
+  with (security_invoker = true) as  SELECT field,
+    filter,
+    count(*) AS total,
+    count(*) FILTER (WHERE (stage = 'uncal'::text)) AS at_uncal,
+    count(*) FILTER (WHERE (stage = 'detector1'::text)) AS at_detector1,
+    count(*) FILTER (WHERE (stage = 'persistence'::text)) AS at_persistence,
+    count(*) FILTER (WHERE (stage = 'wisp'::text)) AS at_wisp,
+    count(*) FILTER (WHERE (stage = 'striping'::text)) AS at_striping,
+    count(*) FILTER (WHERE (stage = 'image2'::text)) AS at_image2,
+    count(*) FILTER (WHERE (stage = 'edge'::text)) AS at_edge,
+    count(*) FILTER (WHERE (stage = 'sky'::text)) AS at_sky,
+    count(*) FILTER (WHERE (stage = 'diag_striping'::text)) AS at_diag_striping,
+    count(*) FILTER (WHERE (stage = 'variance'::text)) AS at_variance,
+    count(*) FILTER (WHERE (stage = 'wcs_shift'::text)) AS at_wcs_shift,
+    count(*) FILTER (WHERE (stage = 'preview'::text)) AS at_preview,
+    count(*) FILTER (WHERE (stage = 'jhat'::text)) AS at_jhat,
+    count(*) FILTER (WHERE (stage = 'apply_mask'::text)) AS at_apply_mask,
+    count(*) FILTER (WHERE (stage = 'bad_pixel'::text)) AS at_bad_pixel,
+    count(*) FILTER (WHERE (stage = 'outlier'::text)) AS at_outlier,
+    count(*) FILTER (WHERE (review_status = 'pending'::text)) AS pending_review,
+    count(*) FILTER (WHERE (review_status = 'approved'::text)) AS approved,
+    count(*) FILTER (WHERE (review_status = 'excluded'::text)) AS excluded,
+    count(*) FILTER (WHERE (masking = 'needed'::text)) AS needs_masking,
+    count(*) FILTER (WHERE (correction = 'needed'::text)) AS needs_correction
+   FROM public.nircam_exposures
+  GROUP BY field, filter;
+
+
+-- B1 (#217): security_invoker restored (migra drops the view option) so caller
+-- RLS on spectra applies; combined with the WHERE published-or-admin predicate.
+create or replace view "public"."spectrum_flag_summary"
+  with (security_invoker = true) as  SELECT s.id,
+    s.target_id,
+    s.grating,
+    array_agg(DISTINCT fd.label) FILTER (WHERE ((fd.category = 'dq_flags'::text) AND ((s.dq_flags & fd.value) > 0))) AS dq_flags_labels
+   FROM (public.spectra s
+     CROSS JOIN public.flag_definitions fd)
+  WHERE ((s.deploy_status = 'published'::text) OR public.is_admin())
+  GROUP BY s.id, s.target_id, s.grating;
+
+
+
+  create policy "select_comments_by_access"
+  on "public"."comments"
+  as permissive
+  for select
+  to public
+using ((((target_id IS NOT NULL) AND (target_id IN ( SELECT t.id
+   FROM public.targets t
+  WHERE ((t.program_slug = ANY (( SELECT public.accessible_program_slugs() AS accessible_program_slugs)::text[])) AND (t.has_published_spectrum OR ( SELECT public.is_admin() AS is_admin)))))) OR ((target_id IS NULL) AND (object_id IS NOT NULL) AND (object_id IN ( SELECT o.id
+   FROM public.objects o
+  WHERE ((o.programs && ( SELECT public.accessible_program_slugs() AS accessible_program_slugs)) AND (o.has_published_spectrum OR ( SELECT public.is_admin() AS is_admin))))))));
+
+
+
+  create policy "insert_audit_by_access"
+  on "public"."flag_audit_log"
+  as permissive
+  for insert
+  to authenticated
+with check ((((target_id IS NOT NULL) AND (target_id IN ( SELECT t.id
+   FROM public.targets t
+  WHERE ((t.program_slug = ANY (( SELECT public.accessible_program_slugs() AS accessible_program_slugs)::text[])) AND (t.has_published_spectrum OR ( SELECT public.is_admin() AS is_admin)))))) OR ((object_id IS NOT NULL) AND (object_id IN ( SELECT o.id
+   FROM public.objects o
+  WHERE ((o.programs && ( SELECT public.accessible_program_slugs() AS accessible_program_slugs)) AND (o.has_published_spectrum OR ( SELECT public.is_admin() AS is_admin)))))) OR ((spectrum_id IS NOT NULL) AND (spectrum_id IN ( SELECT s.id
+   FROM (public.spectra s
+     JOIN public.targets t ON ((t.target_id = s.target_id)))
+  WHERE ((t.program_slug = ANY (( SELECT public.accessible_program_slugs() AS accessible_program_slugs)::text[])) AND ((s.deploy_status = 'published'::text) OR ( SELECT public.is_admin() AS is_admin))))))));
+
+
+
+  create policy "select_audit_by_access"
+  on "public"."flag_audit_log"
+  as permissive
+  for select
+  to public
+using ((((target_id IS NOT NULL) AND (target_id IN ( SELECT t.id
+   FROM public.targets t
+  WHERE ((t.program_slug = ANY (( SELECT public.accessible_program_slugs() AS accessible_program_slugs)::text[])) AND (t.has_published_spectrum OR ( SELECT public.is_admin() AS is_admin)))))) OR ((object_id IS NOT NULL) AND (object_id IN ( SELECT o.id
+   FROM public.objects o
+  WHERE ((o.programs && ( SELECT public.accessible_program_slugs() AS accessible_program_slugs)) AND (o.has_published_spectrum OR ( SELECT public.is_admin() AS is_admin)))))) OR ((spectrum_id IS NOT NULL) AND (spectrum_id IN ( SELECT s.id
+   FROM (public.spectra s
+     JOIN public.targets t ON ((t.target_id = s.target_id)))
+  WHERE ((t.program_slug = ANY (( SELECT public.accessible_program_slugs() AS accessible_program_slugs)::text[])) AND ((s.deploy_status = 'published'::text) OR ( SELECT public.is_admin() AS is_admin))))))));
+
+
+
+  create policy "select_list_members"
+  on "public"."object_list_members"
+  as permissive
+  for select
+  to authenticated
+using (((list_id IN ( SELECT object_lists.id
+   FROM public.object_lists
+  WHERE ((object_lists.created_by = ( SELECT auth.uid() AS uid)) OR (object_lists.visibility = ANY (ARRAY['public_read'::text, 'public_edit'::text]))))) AND (((object_id IS NULL) AND (list_id IN ( SELECT object_lists.id
+   FROM public.object_lists
+  WHERE ((object_lists.created_by = ( SELECT auth.uid() AS uid)) OR (object_lists.visibility = 'public_edit'::text))))) OR (object_id IN ( SELECT o.id
+   FROM public.objects o
+  WHERE ((o.programs && ( SELECT public.accessible_program_slugs() AS accessible_program_slugs)) AND (o.has_published_spectrum OR ( SELECT public.is_admin() AS is_admin))))))));
+
+
+
+  create policy "select_object_photometry_by_access"
+  on "public"."object_photometry"
+  as permissive
+  for select
+  to public
+using ((object_id IN ( SELECT o.id
+   FROM public.objects o
+  WHERE ((o.programs && ( SELECT public.accessible_program_slugs() AS accessible_program_slugs)) AND (o.has_published_spectrum OR ( SELECT public.is_admin() AS is_admin))))));
+
+
+
+  create policy "select_objects_by_access"
+  on "public"."objects"
+  as permissive
+  for select
+  to public
+using (((programs && ( SELECT public.accessible_program_slugs() AS accessible_program_slugs)) AND (has_published_spectrum OR ( SELECT public.is_admin() AS is_admin))));
+
+
+
+  create policy "update_objects_by_access"
+  on "public"."objects"
+  as permissive
+  for update
+  to public
+using (((programs && ( SELECT public.accessible_program_slugs() AS accessible_program_slugs)) AND ( SELECT public.can_inspect() AS can_inspect) AND (has_published_spectrum OR ( SELECT public.is_admin() AS is_admin))))
+with check (((programs && ( SELECT public.accessible_program_slugs() AS accessible_program_slugs)) AND ( SELECT public.can_inspect() AS can_inspect) AND (has_published_spectrum OR ( SELECT public.is_admin() AS is_admin))));
+
+
+
+  create policy "Authenticated users can view shutters"
+  on "public"."shutters"
+  as permissive
+  for select
+  to authenticated
+using ((( SELECT public.is_admin() AS is_admin) OR (NOT (EXISTS ( SELECT 1
+   FROM public.objects o
+  WHERE ((o.object_id = shutters.object_id) AND (o.has_published_spectrum = false)))))));
+
+
+
+  create policy "Authenticated users can view slit regions"
+  on "public"."slit_regions"
+  as permissive
+  for select
+  to authenticated
+using ((( SELECT public.is_admin() AS is_admin) OR (NOT (EXISTS ( SELECT 1
+   FROM public.objects o
+  WHERE ((o.object_id = slit_regions.object_id) AND (o.has_published_spectrum = false)))))));
+
+
+
+  create policy "select_spectra_by_access"
+  on "public"."spectra"
+  as permissive
+  for select
+  to public
+using (((target_id IN ( SELECT t.target_id
+   FROM public.targets t
+  WHERE (t.program_slug = ANY (( SELECT public.accessible_program_slugs() AS accessible_program_slugs)::text[])))) AND ((deploy_status = 'published'::text) OR ( SELECT public.is_admin() AS is_admin))));
+
+
+
+  create policy "update_spectra_dq_by_access"
+  on "public"."spectra"
+  as permissive
+  for update
+  to authenticated
+using ((( SELECT public.can_inspect() AS can_inspect) AND (target_id IN ( SELECT t.target_id
+   FROM public.targets t
+  WHERE (t.program_slug = ANY (( SELECT public.accessible_program_slugs() AS accessible_program_slugs)::text[])))) AND ((deploy_status = 'published'::text) OR ( SELECT public.is_admin() AS is_admin))))
+with check ((( SELECT public.can_inspect() AS can_inspect) AND (target_id IN ( SELECT t.target_id
+   FROM public.targets t
+  WHERE (t.program_slug = ANY (( SELECT public.accessible_program_slugs() AS accessible_program_slugs)::text[])))) AND ((deploy_status = 'published'::text) OR ( SELECT public.is_admin() AS is_admin))));
+
+
+
+  create policy "select_targets_by_access"
+  on "public"."targets"
+  as permissive
+  for select
+  to public
+using (((program_slug = ANY (( SELECT public.accessible_program_slugs() AS accessible_program_slugs)::text[])) AND (has_published_spectrum OR ( SELECT public.is_admin() AS is_admin))));
+
+
+
+  create policy "update_targets_by_access"
+  on "public"."targets"
+  as permissive
+  for update
+  to public
+using (((program_slug = ANY (( SELECT public.accessible_program_slugs() AS accessible_program_slugs)::text[])) AND ( SELECT public.can_inspect() AS can_inspect) AND (has_published_spectrum OR ( SELECT public.is_admin() AS is_admin))));
+
+
+

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -121,9 +121,12 @@ GRANT EXECUTE ON FUNCTION public.accessible_program_slugs() TO authenticated;
 -- inside this function: it is SECURITY INVOKER, but when called from a
 -- SECURITY DEFINER context it would run as the owner with RLS bypassed — the
 -- explicit p_program_slugs filter is the access gate.
+DROP FUNCTION IF EXISTS public.object_scoped_aggregates(INTEGER, TEXT[]);
+
 CREATE OR REPLACE FUNCTION public.object_scoped_aggregates(
   p_object_id INTEGER,
-  p_program_slugs TEXT[]
+  p_program_slugs TEXT[],
+  p_include_unpublished BOOLEAN DEFAULT false
 )
 RETURNS TABLE(
   programs          TEXT[],
@@ -141,11 +144,15 @@ AS $$
     FROM targets t
     WHERE t.object_id = p_object_id
       AND t.program_slug = ANY(p_program_slugs)
+      -- B1: only count targets that contribute a published spectrum so
+      -- n_targets / programs / observations don't include draft-only members.
+      AND (p_include_unpublished OR t.has_published_spectrum)
   ),
   sp AS (
     SELECT s.grating, s.signal_to_noise, s.exposure_time
     FROM spectra s
     WHERE s.target_id IN (SELECT target_id FROM m)
+      AND (p_include_unpublished OR s.deploy_status = 'published')
   )
   SELECT
     COALESCE((SELECT array_agg(DISTINCT m.program_slug ORDER BY m.program_slug) FROM m), '{}')::text[],
@@ -157,8 +164,8 @@ AS $$
     (SELECT MAX(sp.exposure_time) FROM sp);
 $$;
 
-GRANT EXECUTE ON FUNCTION public.object_scoped_aggregates(INTEGER, TEXT[]) TO authenticated;
-GRANT EXECUTE ON FUNCTION public.object_scoped_aggregates(INTEGER, TEXT[]) TO service_role;
+GRANT EXECUTE ON FUNCTION public.object_scoped_aggregates(INTEGER, TEXT[], BOOLEAN) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.object_scoped_aggregates(INTEGER, TEXT[], BOOLEAN) TO service_role;
 
 
 -- =============================================================================
@@ -218,7 +225,7 @@ GRANT ALL ON FUNCTION public.check_device_code_status(text) TO service_role;
 -- (lightweight bulk fetch for Python client objects catalog sync)
 -- =============================================================================
 
-DROP FUNCTION IF EXISTS public.get_objects_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER);
+DROP FUNCTION IF EXISTS public.get_objects_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN);
 
 CREATE OR REPLACE FUNCTION public.get_objects_for_sync(
   p_program_slugs TEXT[],
@@ -226,7 +233,8 @@ CREATE OR REPLACE FUNCTION public.get_objects_for_sync(
   p_updated_since TIMESTAMPTZ DEFAULT NULL,
   p_limit INTEGER DEFAULT 1000,
   p_offset INTEGER DEFAULT 0,
-  p_include_counts BOOLEAN DEFAULT TRUE
+  p_include_counts BOOLEAN DEFAULT TRUE,
+  p_include_unpublished BOOLEAN DEFAULT false
 )
 RETURNS TABLE(objects JSONB, total_count BIGINT, total_accessible_count BIGINT)
 LANGUAGE plpgsql STABLE
@@ -261,6 +269,8 @@ BEGIN
       -- Phase D: hide soft-deleted objects from sync. Reactivation rewrites
       -- updated_at, so re-activated rows get re-synced naturally on next pull.
       AND o.is_active = true
+      -- B1: drop objects with no published spectrum (fail-closed).
+      AND (p_include_unpublished OR o.has_published_spectrum)
       AND (p_updated_since IS NULL OR o.updated_at > p_updated_since)
     ORDER BY o.object_id
     LIMIT p_limit OFFSET p_offset
@@ -291,6 +301,7 @@ BEGIN
     JOIN targets t ON t.target_id = s.target_id
     WHERE t.object_id IN (SELECT id FROM matched)
       AND t.program_slug = ANY(p_program_slugs)
+      AND (p_include_unpublished OR s.deploy_status = 'published')
     GROUP BY t.object_id
   ),
   lists_agg AS (
@@ -311,6 +322,7 @@ BEGIN
     WHERE p_include_counts
       AND o.programs && p_program_slugs
       AND o.is_active = true
+      AND (p_include_unpublished OR o.has_published_spectrum)
       AND (p_updated_since IS NULL OR o.updated_at > p_updated_since)
   ),
   accessible AS (
@@ -319,6 +331,7 @@ BEGIN
     WHERE p_include_counts
       AND o.programs && p_program_slugs
       AND o.is_active = true
+      AND (p_include_unpublished OR o.has_published_spectrum)
   )
   SELECT
     COALESCE(jsonb_agg(
@@ -365,12 +378,12 @@ BEGIN
   LEFT JOIN member_targets_agg mt ON mt.object_id = m.id
   LEFT JOIN spectra_agg         sp ON sp.object_id = m.id
   LEFT JOIN lists_agg           la ON la.object_id = m.id
-  LEFT JOIN LATERAL public.object_scoped_aggregates(m.id, p_program_slugs) sa ON true;
+  LEFT JOIN LATERAL public.object_scoped_aggregates(m.id, p_program_slugs, p_include_unpublished) sa ON true;
 END;
 $$;
 
-GRANT EXECUTE ON FUNCTION public.get_objects_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN) TO authenticated;
-GRANT EXECUTE ON FUNCTION public.get_objects_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN) TO service_role;
+GRANT EXECUTE ON FUNCTION public.get_objects_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_objects_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN) TO service_role;
 
 
 -- =============================================================================
@@ -380,7 +393,7 @@ GRANT EXECUTE ON FUNCTION public.get_objects_for_sync(TEXT[], UUID, TIMESTAMPTZ,
 -- spectra fields only)
 -- =============================================================================
 
-DROP FUNCTION IF EXISTS public.get_spectra_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER);
+DROP FUNCTION IF EXISTS public.get_spectra_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN);
 
 CREATE OR REPLACE FUNCTION public.get_spectra_for_sync(
   p_program_slugs TEXT[],
@@ -388,7 +401,8 @@ CREATE OR REPLACE FUNCTION public.get_spectra_for_sync(
   p_updated_since TIMESTAMPTZ DEFAULT NULL,
   p_limit INTEGER DEFAULT 1000,
   p_offset INTEGER DEFAULT 0,
-  p_include_counts BOOLEAN DEFAULT TRUE
+  p_include_counts BOOLEAN DEFAULT TRUE,
+  p_include_unpublished BOOLEAN DEFAULT false
 )
 RETURNS TABLE(spectra JSONB, total_count BIGINT, total_accessible_count BIGINT)
 LANGUAGE plpgsql STABLE
@@ -412,6 +426,8 @@ BEGIN
     LEFT JOIN objects o ON o.id = t.object_id
     WHERE t.program_slug = ANY(p_program_slugs)
       AND (o.id IS NULL OR o.is_active = true)
+      -- B1: fail-closed publish gate (this RPC always bypasses RLS).
+      AND (p_include_unpublished OR s.deploy_status = 'published')
       AND (p_updated_since IS NULL OR s.updated_at > p_updated_since)
     ORDER BY s.spectrum_id
     LIMIT p_limit OFFSET p_offset
@@ -426,6 +442,7 @@ BEGIN
     WHERE p_include_counts
       AND t.program_slug = ANY(p_program_slugs)
       AND (o.id IS NULL OR o.is_active = true)
+      AND (p_include_unpublished OR s.deploy_status = 'published')
       AND (p_updated_since IS NULL OR s.updated_at > p_updated_since)
   ),
   accessible AS (
@@ -436,6 +453,7 @@ BEGIN
     WHERE p_include_counts
       AND t.program_slug = ANY(p_program_slugs)
       AND (o.id IS NULL OR o.is_active = true)
+      AND (p_include_unpublished OR s.deploy_status = 'published')
   )
   SELECT
     COALESCE(jsonb_agg(
@@ -470,8 +488,8 @@ BEGIN
 END;
 $$;
 
-GRANT EXECUTE ON FUNCTION public.get_spectra_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN) TO authenticated;
-GRANT EXECUTE ON FUNCTION public.get_spectra_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN) TO service_role;
+GRANT EXECUTE ON FUNCTION public.get_spectra_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_spectra_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN) TO service_role;
 
 
 -- =============================================================================
@@ -479,11 +497,14 @@ GRANT EXECUTE ON FUNCTION public.get_spectra_for_sync(TEXT[], UUID, TIMESTAMPTZ,
 -- (bulk fetch for Python client photometry sync)
 -- =============================================================================
 
+DROP FUNCTION IF EXISTS public.get_photometry_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER);
+
 CREATE OR REPLACE FUNCTION public.get_photometry_for_sync(
   p_program_slugs TEXT[],
   p_updated_since TIMESTAMPTZ DEFAULT NULL,
   p_limit INTEGER DEFAULT 1000,
-  p_offset INTEGER DEFAULT 0
+  p_offset INTEGER DEFAULT 0,
+  p_include_unpublished BOOLEAN DEFAULT false
 )
 RETURNS TABLE(photometry_records JSONB, total_count BIGINT)
 LANGUAGE plpgsql STABLE
@@ -502,6 +523,8 @@ BEGIN
     FROM object_photometry op
     JOIN objects o ON o.id = op.object_id
     WHERE o.programs && p_program_slugs
+      -- B1: fail-closed publish gate (this RPC always bypasses RLS).
+      AND (p_include_unpublished OR o.has_published_spectrum)
       AND (p_updated_since IS NULL OR op.updated_at > p_updated_since)
     ORDER BY op.id
     LIMIT p_limit OFFSET p_offset
@@ -511,6 +534,7 @@ BEGIN
     FROM object_photometry op
     JOIN objects o ON o.id = op.object_id
     WHERE o.programs && p_program_slugs
+      AND (p_include_unpublished OR o.has_published_spectrum)
       AND (p_updated_since IS NULL OR op.updated_at > p_updated_since)
   )
   SELECT
@@ -536,8 +560,8 @@ BEGIN
 END;
 $$;
 
-GRANT EXECUTE ON FUNCTION public.get_photometry_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER) TO authenticated;
-GRANT EXECUTE ON FUNCTION public.get_photometry_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER) TO service_role;
+GRANT EXECUTE ON FUNCTION public.get_photometry_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_photometry_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN) TO service_role;
 
 
 -- =============================================================================
@@ -545,8 +569,11 @@ GRANT EXECUTE ON FUNCTION public.get_photometry_for_sync(TEXT[], TIMESTAMPTZ, IN
 -- (returns all list metadata for Python client sync)
 -- =============================================================================
 
+DROP FUNCTION IF EXISTS public.get_lists_for_sync(UUID);
+
 CREATE OR REPLACE FUNCTION public.get_lists_for_sync(
-  p_user_id UUID DEFAULT NULL
+  p_user_id UUID DEFAULT NULL,
+  p_include_unpublished BOOLEAN DEFAULT false
 )
 RETURNS JSONB
 LANGUAGE plpgsql STABLE
@@ -563,7 +590,14 @@ BEGIN
       'created_by', ol.created_by,
       'created_at', ol.created_at,
       'updated_at', ol.updated_at,
-      'member_count', (SELECT COUNT(*) FROM object_list_members olm WHERE olm.list_id = ol.id)
+      -- B1: count only members whose object has a published spectrum (unlinked
+      -- coordinate-keyed members, object_id IS NULL, still count). Fail-closed.
+      'member_count', (
+        SELECT COUNT(*) FROM object_list_members olm
+        LEFT JOIN objects o ON o.id = olm.object_id
+        WHERE olm.list_id = ol.id
+          AND (p_include_unpublished OR olm.object_id IS NULL OR o.has_published_spectrum)
+      )
     ) ORDER BY ol.is_system DESC, ol.name)
     FROM object_lists ol
     WHERE ol.created_by = p_user_id
@@ -573,8 +607,8 @@ BEGIN
 END;
 $$;
 
-GRANT EXECUTE ON FUNCTION public.get_lists_for_sync(UUID) TO authenticated;
-GRANT EXECUTE ON FUNCTION public.get_lists_for_sync(UUID) TO service_role;
+GRANT EXECUTE ON FUNCTION public.get_lists_for_sync(UUID, BOOLEAN) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_lists_for_sync(UUID, BOOLEAN) TO service_role;
 
 
 -- =============================================================================
@@ -630,7 +664,8 @@ CREATE OR REPLACE FUNCTION public.get_filtered_spectra_paginated(
   p_sort_direction TEXT DEFAULT 'asc',
   p_page INTEGER DEFAULT 1,
   p_page_size INTEGER DEFAULT 50,
-  p_include_thumbnails BOOLEAN DEFAULT false
+  p_include_thumbnails BOOLEAN DEFAULT false,
+  p_include_unpublished BOOLEAN DEFAULT false
 )
 RETURNS TABLE(targets JSONB, total_count BIGINT, page INTEGER, page_size INTEGER)
 LANGUAGE plpgsql STABLE
@@ -747,6 +782,8 @@ BEGIN
       -- Hide spectra whose parent object was soft-deleted.
       AND (o.id IS NULL OR o.is_active = true)
       AND (NOT v_grating_filter_active OR s.grating = ANY(p_gratings))
+      -- B1: hide unpublished spectra (fail-closed; admin opt-in only).
+      AND (p_include_unpublished OR s.deploy_status = 'published')
       AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR t.field = ANY(p_fields))
       AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR t.observation = ANY(p_observations))
       AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
@@ -934,7 +971,8 @@ CREATE OR REPLACE FUNCTION public.get_filtered_objects_paginated(
   p_sort_column TEXT DEFAULT 'object_id',
   p_sort_direction TEXT DEFAULT 'asc',
   p_page INTEGER DEFAULT 1,
-  p_page_size INTEGER DEFAULT 50
+  p_page_size INTEGER DEFAULT 50,
+  p_include_unpublished BOOLEAN DEFAULT false
 )
 RETURNS TABLE(targets JSONB, total_count BIGINT, page INTEGER, page_size INTEGER)
 LANGUAGE plpgsql STABLE
@@ -1001,6 +1039,8 @@ BEGIN
     -- Access control: object must have at least one accessible program
     o.programs && v_filtered_program_slugs
     AND o.is_active = true
+    -- B1: hide objects with no published spectrum (fail-closed).
+    AND (p_include_unpublished OR o.has_published_spectrum)
     AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
     AND (
       NOT v_grating_filter_active
@@ -1124,6 +1164,7 @@ BEGIN
     WHERE
       o.programs && v_filtered_program_slugs
       AND o.is_active = true
+      AND (p_include_unpublished OR o.has_published_spectrum)
       AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
       AND (
         NOT v_grating_filter_active
@@ -1305,7 +1346,7 @@ BEGIN
         )
       ) AS obj_json
     FROM filtered_objects fo
-    LEFT JOIN LATERAL public.object_scoped_aggregates(fo.id, v_filtered_program_slugs) sa ON true
+    LEFT JOIN LATERAL public.object_scoped_aggregates(fo.id, v_filtered_program_slugs, p_include_unpublished) sa ON true
   )
   SELECT
     COALESCE(jsonb_agg(wm.obj_json), '[]'::jsonb),
@@ -1353,7 +1394,8 @@ CREATE OR REPLACE FUNCTION public.get_filtered_object_ids(
   p_comment_search_scope TEXT DEFAULT NULL,
   p_comment_user_id UUID DEFAULT NULL,
   p_sort_column TEXT DEFAULT 'object_id',
-  p_sort_direction TEXT DEFAULT 'asc'
+  p_sort_direction TEXT DEFAULT 'asc',
+  p_include_unpublished BOOLEAN DEFAULT false
 )
 RETURNS TABLE(object_id TEXT)
 LANGUAGE plpgsql STABLE
@@ -1410,6 +1452,7 @@ BEGIN
   WHERE
     o.programs && v_filtered_program_slugs
     AND o.is_active = true
+    AND (p_include_unpublished OR o.has_published_spectrum)
     AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
     AND (
       NOT v_grating_filter_active
@@ -1559,7 +1602,8 @@ CREATE OR REPLACE FUNCTION public.get_adjacent_objects(
   p_photo_z_max DOUBLE PRECISION DEFAULT NULL,
   p_comment_search TEXT DEFAULT NULL,
   p_comment_search_scope TEXT DEFAULT NULL,
-  p_comment_user_id UUID DEFAULT NULL
+  p_comment_user_id UUID DEFAULT NULL,
+  p_include_unpublished BOOLEAN DEFAULT false
 )
 RETURNS TABLE(prev_object_id TEXT, next_object_id TEXT, current_index BIGINT, total_count BIGINT)
 LANGUAGE plpgsql STABLE
@@ -1623,6 +1667,7 @@ BEGIN
     WHERE
       o.programs && v_filtered_program_slugs
       AND o.is_active = true
+      AND (p_include_unpublished OR o.has_published_spectrum)
       AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
       AND (
         NOT v_grating_filter_active
@@ -1802,7 +1847,8 @@ CREATE OR REPLACE FUNCTION public.get_csv_export_spectra(
   p_comment_user_id UUID DEFAULT NULL,
   p_coord_ra DOUBLE PRECISION DEFAULT NULL, p_coord_dec DOUBLE PRECISION DEFAULT NULL,
   p_radius_degrees DOUBLE PRECISION DEFAULT NULL,
-  p_sort_column TEXT DEFAULT 'target_id', p_sort_direction TEXT DEFAULT 'asc'
+  p_sort_column TEXT DEFAULT 'target_id', p_sort_direction TEXT DEFAULT 'asc',
+  p_include_unpublished BOOLEAN DEFAULT false
 )
 RETURNS TABLE(
   spectrum_id TEXT, target_id TEXT, grating TEXT, field TEXT, ra DOUBLE PRECISION, "dec" DOUBLE PRECISION,
@@ -1860,6 +1906,8 @@ BEGIN
     WHERE t.program_slug = ANY(v_filtered_program_slugs)
       AND (o.id IS NULL OR o.is_active = true)
       AND (NOT v_grating_filter_active OR s.grating = ANY(p_gratings))
+      -- B1: hide unpublished spectra (fail-closed; admin opt-in only).
+      AND (p_include_unpublished OR s.deploy_status = 'published')
       AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR t.field = ANY(p_fields))
       AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR t.observation = ANY(p_observations))
       AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
@@ -1966,7 +2014,8 @@ CREATE OR REPLACE FUNCTION public.get_csv_export_objects(
   p_photo_z_min DOUBLE PRECISION DEFAULT NULL, p_photo_z_max DOUBLE PRECISION DEFAULT NULL,
   p_comment_search TEXT DEFAULT NULL, p_comment_search_scope TEXT DEFAULT NULL,
   p_comment_user_id UUID DEFAULT NULL,
-  p_sort_column TEXT DEFAULT 'object_id', p_sort_direction TEXT DEFAULT 'asc'
+  p_sort_column TEXT DEFAULT 'object_id', p_sort_direction TEXT DEFAULT 'asc',
+  p_include_unpublished BOOLEAN DEFAULT false
 )
 RETURNS TABLE(
   object_id TEXT, field TEXT, ra DOUBLE PRECISION, "dec" DOUBLE PRECISION,
@@ -2052,13 +2101,14 @@ BEGIN
     LEFT JOIN member_targets mt ON mt.object_id = o.id
     LEFT JOIN visible_lists vl ON vl.object_id = o.id
     LEFT JOIN user_profiles up ON up.user_id = o.last_inspected_by
-    LEFT JOIN LATERAL public.object_scoped_aggregates(o.id, v_filtered_program_slugs) sa ON true
+    LEFT JOIN LATERAL public.object_scoped_aggregates(o.id, v_filtered_program_slugs, p_include_unpublished) sa ON true
     LEFT JOIN LATERAL (
       SELECT op.photometry FROM object_photometry op
       WHERE op.object_id = o.id ORDER BY op.updated_at DESC LIMIT 1
     ) phot ON true
     WHERE o.programs && v_filtered_program_slugs
       AND o.is_active = true
+      AND (p_include_unpublished OR o.has_published_spectrum)
       AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
       AND (
         NOT v_grating_filter_active
@@ -2216,7 +2266,7 @@ GRANT EXECUTE ON FUNCTION public.refresh_programs_overview TO authenticated;
 -- masquerade as observation-level reductions.
 DROP FUNCTION IF EXISTS public.get_observation_stats(text[]);
 
-CREATE OR REPLACE FUNCTION public.get_observation_stats(p_program_slugs text[])
+CREATE OR REPLACE FUNCTION public.get_observation_stats(p_program_slugs text[], p_include_unpublished boolean DEFAULT false)
 RETURNS TABLE(
   observation text, program_slug text, program_name text, field text,
   target_count bigint, spectrum_count bigint, total_size_bytes bigint,
@@ -2234,6 +2284,8 @@ RETURNS TABLE(
     FROM targets t
     JOIN programs p ON p.slug = t.program_slug
     LEFT JOIN spectra s ON s.target_id = t.target_id
+      -- B1: unpublished spectra don't contribute to counts/size (targets still appear).
+      AND (p_include_unpublished OR s.deploy_status = 'published')
     WHERE t.program_slug = ANY(p_program_slugs)
     GROUP BY t.observation, t.program_slug, p.program_name, t.field
   )
@@ -2292,7 +2344,7 @@ GRANT EXECUTE ON FUNCTION public.get_observation_stats TO authenticated;
 DROP FUNCTION IF EXISTS public.get_observations_overview();
 DROP FUNCTION IF EXISTS public.get_observations_overview(text[]);
 
-CREATE OR REPLACE FUNCTION public.get_observations_overview(p_program_slugs text[])
+CREATE OR REPLACE FUNCTION public.get_observations_overview(p_program_slugs text[], p_include_unpublished boolean DEFAULT false)
 RETURNS TABLE(
   observation text, program_slug text, program_name text, field text,
   cycle integer, gratings text[], pointing_count integer, pointings jsonb,
@@ -2311,6 +2363,8 @@ RETURNS TABLE(
         FILTER (WHERE s.grating IS NOT NULL) AS gratings
     FROM public.targets t
     LEFT JOIN public.spectra s ON s.target_id = t.target_id
+      -- B1: unpublished spectra don't contribute to counts/size/gratings.
+      AND (p_include_unpublished OR s.deploy_status = 'published')
     WHERE t.program_slug = ANY(p_program_slugs)
     GROUP BY t.observation, t.program_slug
   )
@@ -2367,7 +2421,7 @@ GRANT EXECUTE ON FUNCTION public.get_observations_overview TO authenticated;
 -- get_database_overview
 -- =============================================================================
 -- Single-row scope summary for the metadata page header.
-CREATE OR REPLACE FUNCTION public.get_database_overview()
+CREATE OR REPLACE FUNCTION public.get_database_overview(p_include_unpublished boolean DEFAULT false)
 RETURNS TABLE(
   n_programs bigint, n_observations bigint, n_pointings bigint,
   n_targets bigint, n_spectra bigint, total_size_bytes bigint,
@@ -2387,8 +2441,11 @@ RETURNS TABLE(
        FROM public.observations
        WHERE pointings IS NOT NULL) AS n_pointings,
     (SELECT COUNT(*)::bigint FROM public.targets) AS n_targets,
-    (SELECT COUNT(*)::bigint FROM public.spectra) AS n_spectra,
-    (SELECT COALESCE(SUM(file_size), 0)::bigint FROM public.spectra) AS total_size_bytes,
+    -- B1: gate spectra count/size on publish status (no alias param available).
+    (SELECT COUNT(*)::bigint FROM public.spectra
+       WHERE p_include_unpublished OR deploy_status = 'published') AS n_spectra,
+    (SELECT COALESCE(SUM(file_size), 0)::bigint FROM public.spectra
+       WHERE p_include_unpublished OR deploy_status = 'published') AS total_size_bytes,
     (SELECT deployed_at FROM latest) AS latest_deployed_at,
     (SELECT cfpipe_version FROM latest) AS latest_cfpipe_version;
 $$;
@@ -2402,7 +2459,7 @@ GRANT EXECUTE ON FUNCTION public.get_database_overview TO authenticated;
 
 DROP FUNCTION IF EXISTS public.get_observation_manifest(TEXT, TEXT[]);
 
-CREATE OR REPLACE FUNCTION public.get_observation_manifest(p_obs_name text, p_program_slugs text[])
+CREATE OR REPLACE FUNCTION public.get_observation_manifest(p_obs_name text, p_program_slugs text[], p_include_unpublished boolean DEFAULT false)
 RETURNS TABLE(
   spectra_id integer, spectrum_id text, target_id text, grating text, fits_path text,
   file_hash text, file_size bigint, signal_to_noise double precision, cfpipe_version text
@@ -2414,6 +2471,8 @@ BEGIN
   FROM spectra s
   JOIN targets t ON t.target_id = s.target_id
   WHERE t.observation = p_obs_name AND t.program_slug = ANY(p_program_slugs)
+    -- B1: fail-closed; admin sync passes p_include_unpublished => true.
+    AND (p_include_unpublished OR s.deploy_status = 'published')
   ORDER BY s.spectrum_id;
 END;
 $$;
@@ -2428,7 +2487,8 @@ GRANT EXECUTE ON FUNCTION public.get_observation_manifest TO authenticated;
 CREATE OR REPLACE FUNCTION public.get_targets_in_viewport(
   p_ra_min double precision, p_ra_max double precision,
   p_dec_min double precision, p_dec_max double precision,
-  p_field text DEFAULT NULL, p_limit integer DEFAULT 5000
+  p_field text DEFAULT NULL, p_limit integer DEFAULT 5000,
+  p_include_unpublished boolean DEFAULT false
 )
 RETURNS TABLE(
   "target_id" text, "ra" double precision, "dec" double precision,
@@ -2440,6 +2500,8 @@ BEGIN
   FROM public.targets t
   WHERE t.ra BETWEEN p_ra_min AND p_ra_max AND t.dec BETWEEN p_dec_min AND p_dec_max
     AND (p_field IS NULL OR t.field = p_field)
+    -- B1: hide targets with no published spectrum (fail-closed).
+    AND (p_include_unpublished OR t.has_published_spectrum)
   ORDER BY t.ra LIMIT p_limit;
 END;
 $$;
@@ -2492,7 +2554,7 @@ $$;
 -- targets(target_id) for the slit-filter bridge — both very expensive on
 -- COSMOS-sized fields. RLS on objects still applies (SECURITY INVOKER).
 
-CREATE OR REPLACE FUNCTION public.get_field_object_markers(p_field TEXT)
+CREATE OR REPLACE FUNCTION public.get_field_object_markers(p_field TEXT, p_include_unpublished BOOLEAN DEFAULT false)
 RETURNS TABLE (
   object_id           TEXT,
   ra                  DOUBLE PRECISION,
@@ -2527,6 +2589,10 @@ AS $$
     CROSS JOIN acc
     WHERE t.field = p_field
       AND t.program_slug = ANY(acc.slugs)
+      -- B1: mirror object_scoped_aggregates -- only count targets that
+      -- contribute a published spectrum so draft-only members vanish (the
+      -- final JOIN mt is inner, so objects with zero published members drop out).
+      AND (p_include_unpublished OR t.has_published_spectrum)
     GROUP BY t.object_id
   ),
   sp AS (
@@ -2536,6 +2602,7 @@ AS $$
     CROSS JOIN acc
     WHERE t.field = p_field
       AND t.program_slug = ANY(acc.slugs)
+      AND (p_include_unpublished OR s.deploy_status = 'published')
     GROUP BY t.object_id
   )
   SELECT

--- a/supabase/schemas/indexes.sql
+++ b/supabase/schemas/indexes.sql
@@ -177,6 +177,15 @@ CREATE INDEX IF NOT EXISTS idx_spectra_grating
 CREATE INDEX IF NOT EXISTS idx_spectra_dq_flags
     ON public.spectra USING btree (dq_flags) WHERE (dq_flags != 0);
 
+-- B1 (#217): non-published spectra are the rare case (zero in B1, a minority in
+-- B2); a partial index on the exclusion keeps the admin "show in_prep/revoked"
+-- triage cheap, mirroring idx_objects_is_active / idx_spectra_dq_flags. The
+-- common published-only path is served as a residual filter while all rows are
+-- published; B2 should add an EXPLAIN-driven partial/covering index on the hot
+-- filter+sort key once real in_prep volume exists (do NOT guess it here).
+CREATE INDEX IF NOT EXISTS idx_spectra_deploy_status
+    ON public.spectra USING btree (deploy_status) WHERE (deploy_status <> 'published');
+
 -- Phase E: incremental spectra sync keys on updated_at.
 CREATE INDEX IF NOT EXISTS idx_spectra_updated_at
     ON public.spectra USING btree (updated_at);

--- a/supabase/schemas/policies.sql
+++ b/supabase/schemas/policies.sql
@@ -159,6 +159,10 @@ CREATE POLICY "select_targets_by_access"
   ON targets FOR SELECT
   USING (
     program_slug = ANY((SELECT public.accessible_program_slugs())::text[])
+    -- B1 (#217): hide targets whose only spectra are unpublished. Covers the
+    -- target-derived readers that never join spectra (map markers, sed-plot,
+    -- /api/targets/[id], tile-thumbnail). Admins see all.
+    AND (has_published_spectrum OR (SELECT public.is_admin()))
   );
 
 -- Users with can_inspect permission can update targets in accessible programs.
@@ -168,6 +172,9 @@ CREATE POLICY "update_targets_by_access"
   USING (
     program_slug = ANY((SELECT public.accessible_program_slugs())::text[])
     AND (SELECT public.can_inspect())
+    -- B1 (#217): a non-admin inspector cannot mutate a target with no published
+    -- spectrum (defense-in-depth; can't see it anyway via select policy).
+    AND (has_published_spectrum OR (SELECT public.is_admin()))
   );
 
 -- Admins can insert targets (deploy CLI).
@@ -204,6 +211,9 @@ CREATE POLICY "select_objects_by_access"
   ON objects FOR SELECT
   USING (
     programs && (SELECT public.accessible_program_slugs())
+    -- B1 (#217): hide objects whose only member spectra are unpublished. Admins
+    -- see all. has_published_spectrum is recomputed by reconcile from members.
+    AND (has_published_spectrum OR (SELECT public.is_admin()))
   );
 
 -- Admins can insert objects (deploy CLI: objects rebuild).
@@ -233,10 +243,14 @@ CREATE POLICY "update_objects_by_access"
   USING (
     programs && (SELECT public.accessible_program_slugs())
     AND (SELECT public.can_inspect())
+    -- B1 (#217): non-admin inspectors cannot mutate an object with no published
+    -- spectrum (defense-in-depth; not visible via select policy either).
+    AND (has_published_spectrum OR (SELECT public.is_admin()))
   )
   WITH CHECK (
     programs && (SELECT public.accessible_program_slugs())
     AND (SELECT public.can_inspect())
+    AND (has_published_spectrum OR (SELECT public.is_admin()))
   );
 
 -- Admins can delete objects (deploy CLI: objects rebuild wipes before re-insert).
@@ -260,6 +274,8 @@ CREATE POLICY "select_object_photometry_by_access"
     object_id IN (
       SELECT o.id FROM objects o
       WHERE o.programs && (SELECT public.accessible_program_slugs())
+        -- B1 (#217): no photometry for objects with no published spectrum.
+        AND (o.has_published_spectrum OR (SELECT public.is_admin()))
     )
   );
 
@@ -357,6 +373,9 @@ CREATE POLICY "select_list_members"
       OR object_id IN (
         SELECT o.id FROM objects o
         WHERE o.programs && (SELECT public.accessible_program_slugs())
+          -- B1 (#217): list members matched to an unpublished-only object are
+          -- hidden from non-admins (the object itself is invisible).
+          AND (o.has_published_spectrum OR (SELECT public.is_admin()))
       )
     )
   );
@@ -456,6 +475,11 @@ CREATE POLICY "select_spectra_by_access"
       SELECT t.target_id FROM targets t
       WHERE t.program_slug = ANY((SELECT public.accessible_program_slugs())::text[])
     )
+    -- B1 (#217): PRIMARY per-row gate. Only 'published' spectra reach non-admins;
+    -- 'in_prep' and 'revoked' are hidden. This is the sole gate for the user-client
+    -- web routes that read spectra directly and never call an RPC (/api/spectrum,
+    -- /api/download, /api/redshift-fit, /api/spectrum-thumbnail). Admins see all.
+    AND (deploy_status = 'published' OR (SELECT public.is_admin()))
   );
 
 -- Admins can insert spectra (deploy CLI).
@@ -491,6 +515,9 @@ CREATE POLICY "update_spectra_dq_by_access"
       SELECT t.target_id FROM targets t
       WHERE t.program_slug = ANY((SELECT public.accessible_program_slugs())::text[])
     )
+    -- B1 (#217): a non-admin inspector cannot set DQ flags on an unpublished
+    -- spectrum (can't see it via the select policy either).
+    AND (deploy_status = 'published' OR (SELECT public.is_admin()))
   )
   WITH CHECK (
     (SELECT public.can_inspect())
@@ -498,6 +525,7 @@ CREATE POLICY "update_spectra_dq_by_access"
       SELECT t.target_id FROM targets t
       WHERE t.program_slug = ANY((SELECT public.accessible_program_slugs())::text[])
     )
+    AND (deploy_status = 'published' OR (SELECT public.is_admin()))
   );
 
 
@@ -516,12 +544,14 @@ CREATE POLICY "select_comments_by_access"
     (target_id IS NOT NULL AND target_id IN (
       SELECT t.id FROM targets t
       WHERE t.program_slug = ANY((SELECT public.accessible_program_slugs())::text[])
+        AND (t.has_published_spectrum OR (SELECT public.is_admin()))  -- B1 (#217)
     ))
     OR
     -- Object-level comments
     (target_id IS NULL AND object_id IS NOT NULL AND object_id IN (
       SELECT o.id FROM objects o
       WHERE o.programs && (SELECT public.accessible_program_slugs())
+        AND (o.has_published_spectrum OR (SELECT public.is_admin()))  -- B1 (#217)
     ))
   );
 
@@ -563,15 +593,18 @@ CREATE POLICY "select_audit_by_access"
     (target_id IS NOT NULL AND target_id IN (
       SELECT t.id FROM targets t
       WHERE t.program_slug = ANY((SELECT public.accessible_program_slugs())::text[])
+        AND (t.has_published_spectrum OR (SELECT public.is_admin()))  -- B1 (#217)
     ))
     OR (object_id IS NOT NULL AND object_id IN (
       SELECT o.id FROM objects o
       WHERE o.programs && (SELECT public.accessible_program_slugs())
+        AND (o.has_published_spectrum OR (SELECT public.is_admin()))  -- B1 (#217)
     ))
     OR (spectrum_id IS NOT NULL AND spectrum_id IN (
       SELECT s.id FROM spectra s
       JOIN targets t ON t.target_id = s.target_id
       WHERE t.program_slug = ANY((SELECT public.accessible_program_slugs())::text[])
+        AND (s.deploy_status = 'published' OR (SELECT public.is_admin()))  -- B1 (#217)
     ))
   );
 
@@ -586,15 +619,18 @@ CREATE POLICY "insert_audit_by_access"
     (target_id IS NOT NULL AND target_id IN (
       SELECT t.id FROM targets t
       WHERE t.program_slug = ANY((SELECT public.accessible_program_slugs())::text[])
+        AND (t.has_published_spectrum OR (SELECT public.is_admin()))  -- B1 (#217)
     ))
     OR (object_id IS NOT NULL AND object_id IN (
       SELECT o.id FROM objects o
       WHERE o.programs && (SELECT public.accessible_program_slugs())
+        AND (o.has_published_spectrum OR (SELECT public.is_admin()))  -- B1 (#217)
     ))
     OR (spectrum_id IS NOT NULL AND spectrum_id IN (
       SELECT s.id FROM spectra s
       JOIN targets t ON t.target_id = s.target_id
       WHERE t.program_slug = ANY((SELECT public.accessible_program_slugs())::text[])
+        AND (s.deploy_status = 'published' OR (SELECT public.is_admin()))  -- B1 (#217)
     ))
   );
 
@@ -713,11 +749,21 @@ CREATE POLICY "Service role has full access to map layers"
 
 ALTER TABLE slit_regions ENABLE ROW LEVEL SECURITY;
 
--- All authenticated users can read slit regions.
+-- All authenticated users can read slit regions, EXCEPT those belonging to an
+-- object whose spectra are all unpublished (B1 #217). NOT EXISTS form: a slit is
+-- hidden only when a matching objects row exists AND is unpublished — orphan
+-- slits (no objects row) stay visible, so there is zero change while everything
+-- is published. Program-scoping of this table is tracked in #229.
 DROP POLICY IF EXISTS "Authenticated users can view slit regions" ON slit_regions;
 CREATE POLICY "Authenticated users can view slit regions"
   ON slit_regions FOR SELECT TO authenticated
-  USING (true);
+  USING (
+    (SELECT public.is_admin())
+    OR NOT EXISTS (
+      SELECT 1 FROM objects o
+      WHERE o.object_id = slit_regions.object_id AND o.has_published_spectrum = false
+    )
+  );
 
 -- Admins can insert slit regions (deploy CLI).
 DROP POLICY IF EXISTS "admin_slit_regions_insert" ON slit_regions;
@@ -738,11 +784,22 @@ CREATE POLICY "admin_slit_regions_delete"
 
 ALTER TABLE shutters ENABLE ROW LEVEL SECURITY;
 
--- All authenticated users can read shutters.
+-- All authenticated users can read shutters, EXCEPT those belonging to an object
+-- whose spectra are all unpublished (B1 #217). NOT EXISTS form: hidden only when a
+-- matching objects row exists AND is unpublished — orphan shutters stay visible,
+-- zero change while everything is published. NOTE: the /api/v1/shutters route and
+-- the get_*_shutters RPCs run under the service role (RLS bypassed) and gate
+-- separately. Program-scoping of this table is tracked in #229.
 DROP POLICY IF EXISTS "Authenticated users can view shutters" ON shutters;
 CREATE POLICY "Authenticated users can view shutters"
   ON shutters FOR SELECT TO authenticated
-  USING (true);
+  USING (
+    (SELECT public.is_admin())
+    OR NOT EXISTS (
+      SELECT 1 FROM objects o
+      WHERE o.object_id = shutters.object_id AND o.has_published_spectrum = false
+    )
+  );
 
 -- Admins can insert shutters (deploy CLI).
 DROP POLICY IF EXISTS "admin_shutters_insert" ON shutters;

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -300,6 +300,14 @@ CREATE TABLE IF NOT EXISTS "public"."spectra" (
     -- Phase A: per-spectrum auto-fit and DQ (populated in Phase B by deploy pipeline; backfilled in Phase D)
     "redshift_auto" double precision,
     "dq_flags" integer NOT NULL DEFAULT 0,
+    -- B1 (#217): deploy lifecycle. 'published' is the only status visible to
+    -- non-admins; 'in_prep' (admin-only draft, written by B2) and 'revoked'
+    -- (soft-deleted, recoverable) are hidden by the status predicate threaded
+    -- through every reader. Default 'published' so existing rows and any deploy
+    -- path that omits the column stay visible (fail-closed: forgetting to mark a
+    -- row keeps it published; forgetting to *filter* a reader is the hazard the
+    -- predicate guards). Mirrors storage_objects.status.
+    "deploy_status" "text" NOT NULL DEFAULT 'published' CONSTRAINT "spectra_deploy_status_check" CHECK (("deploy_status" = ANY (ARRAY['in_prep'::"text", 'published'::"text", 'revoked'::"text"]))),
     -- Stable per-spectrum identifier derived from fits_path: strips the leading
     -- directory and the trailing "_spec.fits" suffix (e.g. ember_cosmos_p1_prism_clear_12345).
     -- Generated/stored so it stays in sync with fits_path with no application code path.
@@ -379,7 +387,14 @@ END) STORED,
     "max_exposure_time" double precision,
     "program_slug" "text" NOT NULL,
     "observation" "text" NOT NULL,
-    "object_id" integer
+    "object_id" integer,
+    -- B1 (#217): true iff this target has >= 1 published member spectrum.
+    -- Object/target-derived readers (map markers, sed-plot, /api/targets/[id],
+    -- tile-thumbnail) gate on this rather than on per-spectrum deploy_status,
+    -- since they never join spectra. Recomputed from member spectra by
+    -- recompute_target_aggregates / deploy; always true in B1 (all published),
+    -- the wiring is what B2 needs. Default true = fail-closed visible.
+    "has_published_spectrum" boolean NOT NULL DEFAULT true
 );
 
 
@@ -457,6 +472,12 @@ CREATE TABLE IF NOT EXISTS "public"."objects" (
     "staleness_reason" "text",
     "version" integer NOT NULL DEFAULT 1,
     "is_active" boolean NOT NULL DEFAULT true,
+    -- B1 (#217): true iff this object has >= 1 published member spectrum.
+    -- Object-derived readers (filter/markers/lists/photometry) gate on this
+    -- rather than per-spectrum deploy_status. Recomputed by reconcile alongside
+    -- is_active; always true in B1, the wiring is what B2 needs. Default true =
+    -- fail-closed visible. Distinct from is_active (reconciliation soft-delete).
+    "has_published_spectrum" boolean NOT NULL DEFAULT true,
     -- Denormalized search blob: object_id + member target_ids + program_slugs +
     -- observations. Cross-table (member targets), so it cannot be a generated
     -- column; maintained by recompute_object_search_text() at the end of

--- a/supabase/schemas/views.sql
+++ b/supabase/schemas/views.sql
@@ -17,11 +17,16 @@
 --    Refresh after data deployments using refresh_filter_options().
 DROP MATERIALIZED VIEW IF EXISTS public.mv_filter_options;
 
+-- Published-only (B1): this is a GLOBAL matview with no per-viewer scope, so it
+-- is restricted to published data for everyone. fields/observations are derived
+-- from targets via has_published_spectrum; gratings from spectra via
+-- deploy_status. Admins get draft filter options through a live query elsewhere,
+-- not this matview. In B1 every predicate is a no-op (nothing is unpublished yet).
 CREATE MATERIALIZED VIEW public.mv_filter_options AS
 SELECT 1 AS id,
-    ARRAY(SELECT DISTINCT targets.field FROM public.targets ORDER BY targets.field) AS fields,
-    ARRAY(SELECT DISTINCT targets.observation FROM public.targets WHERE targets.observation IS NOT NULL ORDER BY targets.observation) AS observations,
-    ARRAY(SELECT DISTINCT spectra.grating FROM public.spectra ORDER BY spectra.grating) AS gratings
+    ARRAY(SELECT DISTINCT targets.field FROM public.targets WHERE targets.has_published_spectrum ORDER BY targets.field) AS fields,
+    ARRAY(SELECT DISTINCT targets.observation FROM public.targets WHERE targets.observation IS NOT NULL AND targets.has_published_spectrum ORDER BY targets.observation) AS observations,
+    ARRAY(SELECT DISTINCT spectra.grating FROM public.spectra WHERE spectra.deploy_status = 'published' ORDER BY spectra.grating) AS gratings
 WITH DATA;
 
 CREATE UNIQUE INDEX mv_filter_options_id ON public.mv_filter_options USING btree (id);
@@ -60,7 +65,11 @@ LEFT JOIN (
         ARRAY_AGG(DISTINCT t.field ORDER BY t.field) AS fields,
         ARRAY_AGG(DISTINCT t.observation ORDER BY t.observation) AS observations
     FROM targets t
-    LEFT JOIN spectra s ON s.target_id = t.target_id
+    -- Published-only (B1): restrict the grating aggregation to published
+    -- spectra. Predicate lives in the LEFT JOIN ON clause so targets with no
+    -- published spectrum are still counted (just contribute no gratings).
+    -- No-op in B1 (nothing is unpublished yet); guards B2 in_prep data.
+    LEFT JOIN spectra s ON s.target_id = t.target_id AND s.deploy_status = 'published'
     GROUP BY t.program_slug
 ) stats ON p.slug = stats.program_slug
 LEFT JOIN (
@@ -95,7 +104,12 @@ GRANT SELECT ON public.mv_programs_overview TO authenticated;
 --    (which also covered spectral_features — that flag category is dropped).
 DROP VIEW IF EXISTS public.spectrum_flag_summary;
 DROP VIEW IF EXISTS public.target_flag_summary;
-CREATE VIEW public.spectrum_flag_summary AS
+-- security_invoker (B1): this was a plain (definer) view that bypassed the
+-- spectra RLS policy. Flip to invoker semantics so the caller's RLS applies, and
+-- add a published predicate so draft spectra are hidden from non-admins. In B1
+-- every spectrum is published, so this is a no-op; it guards B2 in_prep data.
+CREATE VIEW public.spectrum_flag_summary
+WITH (security_invoker = true) AS
 SELECT
     s.id,
     s.target_id,
@@ -103,6 +117,7 @@ SELECT
     array_agg(DISTINCT fd.label) FILTER (WHERE fd.category = 'dq_flags' AND (s.dq_flags & fd.value) > 0) AS dq_flags_labels
 FROM public.spectra s
 CROSS JOIN public.flag_definitions fd
+WHERE (s.deploy_status = 'published' OR public.is_admin())
 GROUP BY s.id, s.target_id, s.grating;
 
 GRANT ALL ON TABLE public.spectrum_flag_summary TO anon;
@@ -122,7 +137,12 @@ DROP VIEW IF EXISTS public.targets_with_flags;
 --    chain). `uncal` means the raw exposure exists but no canonical file
 --    has been produced yet by `detector1`.
 DROP VIEW IF EXISTS public.nircam_reduction_progress;
-CREATE VIEW public.nircam_reduction_progress AS
+-- security_invoker (B1): this was a plain (definer) view that bypassed the
+-- admin-only RLS on nircam_exposures, leaking QA aggregates to all authenticated
+-- users. Flip to invoker semantics so the nircam_exposures RLS policy applies.
+-- (NIRCam deploy_status gating is deferred to B2; this is only the leak fix.)
+CREATE VIEW public.nircam_reduction_progress
+WITH (security_invoker = true) AS
 SELECT
     field,
     filter,

--- a/web/app/api/og-image/[id]/route.ts
+++ b/web/app/api/og-image/[id]/route.ts
@@ -26,10 +26,15 @@ export async function GET(
     // Look up coordinates — try targets first, fall back to objects
     let obj: { ra: number; dec: number; field: string } | null = null;
 
+    // This endpoint is PUBLIC (no auth) and uses the service-role client, so it
+    // must surface nothing about unpublished data: require >=1 published
+    // spectrum (has_published_spectrum) on the target/object, else 404 below.
+    // No-op in B1. (Program-level gating is out of scope — pre-existing #229.)
     const { data: target } = await supabase
       .from('targets')
       .select('ra, dec, field')
       .eq('target_id', targetId)
+      .eq('has_published_spectrum', true)
       .single();
 
     if (target) {
@@ -39,6 +44,7 @@ export async function GET(
         .from('objects')
         .select('ra, dec, field')
         .eq('object_id', targetId)
+        .eq('has_published_spectrum', true)
         .single();
       obj = object;
     }

--- a/web/app/api/v1/cutout/route.ts
+++ b/web/app/api/v1/cutout/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { validateAuth } from '@/lib/api-auth';
-import { getAccessiblePrograms } from '@/lib/api-helpers';
+import { getAccessiblePrograms, isAdminUser } from '@/lib/api-helpers';
 import {
   compositeTileThumbnail,
   type MapLayerInfo,
@@ -64,12 +64,17 @@ export async function GET(request: NextRequest) {
     }
     const fov = Math.min(30, Math.max(1, parsedFov));
 
-    // Look up object
-    const { data: obj, error: objErr } = await supabase
+    // Look up object. Service-role read bypasses RLS, so gate objects with no
+    // published spectrum behind admin. No-op in B1.
+    const isAdmin = await isAdminUser(userId);
+    let objQuery = supabase
       .from('objects')
       .select('ra, dec, field, programs')
-      .eq('object_id', objectId)
-      .single();
+      .eq('object_id', objectId);
+    if (!isAdmin) {
+      objQuery = objQuery.eq('has_published_spectrum', true);
+    }
+    const { data: obj, error: objErr } = await objQuery.single();
 
     if (objErr || !obj) {
       return NextResponse.json(

--- a/web/app/api/v1/objects/route.ts
+++ b/web/app/api/v1/objects/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAuth } from '@/lib/api-auth';
-import { getAccessiblePrograms, parseCSV, parseIntCSV, resolveListIds } from '@/lib/api-helpers';
+import { getAccessiblePrograms, isAdminUser, parseCSV, parseIntCSV, resolveListIds } from '@/lib/api-helpers';
 import { createServiceClient } from '@/lib/supabase/server';
 import { convertRadiusToDegrees } from '@/lib/utils/coordinate-parser';
 
@@ -33,6 +33,12 @@ export async function GET(request: NextRequest) {
 
     const searchParams = request.nextUrl.searchParams;
     const supabase = createServiceClient();
+
+    // Objects with no published spectrum are admin-only, gated behind an
+    // explicit opt-in (include_unpublished=true). Fail-closed otherwise
+    // (no-op in B1 since every object has a published spectrum).
+    const includeUnpublished =
+      searchParams.get('include_unpublished') === 'true' && (await isAdminUser(userId));
 
     // Programs filter (intersect with accessible)
     const programsParam = parseCSV(searchParams.get('programs'));
@@ -112,6 +118,7 @@ export async function GET(request: NextRequest) {
       p_sort_direction: sortDirection,
       p_page: page,
       p_page_size: limit,
+      p_include_unpublished: includeUnpublished,
     };
 
     const { data, error } = await supabase.rpc('get_filtered_objects_paginated', rpcParams);

--- a/web/app/api/v1/observations/[obs_name]/manifest/route.ts
+++ b/web/app/api/v1/observations/[obs_name]/manifest/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { validateAuth } from '@/lib/api-auth';
-import { getAccessiblePrograms } from '@/lib/api-helpers';
+import { getAccessiblePrograms, isAdminUser } from '@/lib/api-helpers';
 import { generateDownloadUrl } from '@/lib/r2';
 
 /**
@@ -41,10 +41,15 @@ export async function GET(
       process.env.SUPABASE_SERVICE_ROLE_KEY!
     );
 
+    // Admins syncing an observation need its full manifest, including
+    // in_prep spectra; non-admins only ever see published rows. No-op in B1.
+    const includeUnpublished = await isAdminUser(userId);
+
     // Get all spectra for this observation (the main payload)
     const { data: spectra, error: spectraError } = await supabase.rpc('get_observation_manifest', {
       p_obs_name: obs_name,
       p_program_slugs: accessibleProgramSlugs,
+      p_include_unpublished: includeUnpublished,
     });
 
     if (spectraError) {

--- a/web/app/api/v1/observations/route.ts
+++ b/web/app/api/v1/observations/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { validateAuth } from '@/lib/api-auth';
-import { getAccessiblePrograms } from '@/lib/api-helpers';
+import { getAccessiblePrograms, isAdminUser } from '@/lib/api-helpers';
 
 /**
  * GET /api/v1/observations
@@ -33,8 +33,14 @@ export async function GET(request: NextRequest) {
       process.env.SUPABASE_SERVICE_ROLE_KEY!
     );
 
+    // Unpublished spectra only count toward observation stats for admins who
+    // explicitly opt in. Fail-closed otherwise; no-op in B1.
+    const includeUnpublished =
+      request.nextUrl.searchParams.get('include_unpublished') === 'true' && (await isAdminUser(userId));
+
     const { data, error } = await supabase.rpc('get_observation_stats', {
       p_program_slugs: accessibleProgramSlugs,
+      p_include_unpublished: includeUnpublished,
     });
 
     if (error) {

--- a/web/app/api/v1/redshift-fit/route.ts
+++ b/web/app/api/v1/redshift-fit/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { validateAuth } from '@/lib/api-auth';
-import { getAccessiblePrograms } from '@/lib/api-helpers';
+import { getAccessiblePrograms, isAdminUser } from '@/lib/api-helpers';
 import { generateDownloadUrl } from '@/lib/r2';
 import { deriveSibling } from '@/lib/layout';
 
@@ -55,6 +55,11 @@ export async function GET(request: NextRequest) {
       );
     }
 
+    // Service-role read bypasses RLS, so gate unpublished spectra here: a
+    // non-admin must never receive zfit JSON for an in_prep/revoked spectrum,
+    // whether resolved by (target_id, grating) or by fits_path. No-op in B1.
+    const isAdmin = await isAdminUser(userId);
+
     // Parse query parameters
     const searchParams = request.nextUrl.searchParams;
     const targetId = searchParams.get('target_id');
@@ -85,12 +90,15 @@ export async function GET(request: NextRequest) {
       }
 
       // Look up the spectrum
-      const { data: spectrumData, error: spectrumError } = await supabase
+      let spectrumLookup = supabase
         .from('spectra')
         .select('fits_path')
         .eq('target_id', targetId)
-        .eq('grating', grating)
-        .single();
+        .eq('grating', grating);
+      if (!isAdmin) {
+        spectrumLookup = spectrumLookup.eq('deploy_status', 'published');
+      }
+      const { data: spectrumData, error: spectrumError } = await spectrumLookup.single();
 
       if (spectrumError || !spectrumData) {
         return NextResponse.json(
@@ -110,11 +118,14 @@ export async function GET(request: NextRequest) {
     }
 
     // Verify user has access to this file via the spectra table
-    const { data: spectrum, error: spectrumError } = await supabase
+    let spectrumQuery = supabase
       .from('spectra')
       .select('id, target_id')
-      .eq('fits_path', fitsPath)
-      .single();
+      .eq('fits_path', fitsPath);
+    if (!isAdmin) {
+      spectrumQuery = spectrumQuery.eq('deploy_status', 'published');
+    }
+    const { data: spectrum, error: spectrumError } = await spectrumQuery.single();
 
     if (spectrumError || !spectrum) {
       return NextResponse.json(

--- a/web/app/api/v1/shutters/route.ts
+++ b/web/app/api/v1/shutters/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { validateAuth } from '@/lib/api-auth';
-import { getAccessiblePrograms } from '@/lib/api-helpers';
+import { getAccessiblePrograms, isAdminUser } from '@/lib/api-helpers';
 import {
   SHUTTER_WIDTH_ARCSEC,
   SHUTTER_HEIGHT_ARCSEC,
@@ -60,12 +60,18 @@ export async function GET(request: NextRequest) {
     }
     const radiusArcsec = Math.min(30, Math.max(1, parsedFov));
 
-    // Look up object
-    const { data: obj, error: objErr } = await supabase
+    // Look up object. Service-role read bypasses RLS, so gate object existence
+    // on has_published_spectrum unless admin — an unpublished object must not be
+    // confirmable via its shutter geometry. No-op in B1.
+    const isAdmin = await isAdminUser(userId);
+    let objQuery = supabase
       .from('objects')
       .select('ra, dec, field, programs')
-      .eq('object_id', objectId)
-      .single();
+      .eq('object_id', objectId);
+    if (!isAdmin) {
+      objQuery = objQuery.eq('has_published_spectrum', true);
+    }
+    const { data: obj, error: objErr } = await objQuery.single();
 
     if (objErr || !obj) {
       return NextResponse.json(

--- a/web/app/api/v1/spectra/list/route.ts
+++ b/web/app/api/v1/spectra/list/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { validateAuth } from '@/lib/api-auth';
-import { getAccessiblePrograms, parseCSV, parseIntCSV, resolveListIds } from '@/lib/api-helpers';
+import { getAccessiblePrograms, isAdminUser, parseCSV, parseIntCSV, resolveListIds } from '@/lib/api-helpers';
 import { createServiceClient } from '@/lib/supabase/server';
 import { convertRadiusToDegrees } from '@/lib/utils/coordinate-parser';
 
@@ -45,6 +45,12 @@ export async function GET(request: NextRequest) {
 
     const searchParams = request.nextUrl.searchParams;
     const supabase = createServiceClient();
+
+    // Unpublished (in_prep/revoked) spectra are admin-only and gated behind an
+    // explicit opt-in: admins must pass include_unpublished=true to see drafts.
+    // Fail-closed for everyone else (no-op in B1 since all data is published).
+    const includeUnpublished =
+      searchParams.get('include_unpublished') === 'true' && (await isAdminUser(userId));
 
     const programsParam = parseCSV(searchParams.get('programs'));
     const filterPrograms = programsParam
@@ -128,6 +134,7 @@ export async function GET(request: NextRequest) {
       p_page: page,
       p_page_size: limit,
       p_include_thumbnails: false,
+      p_include_unpublished: includeUnpublished,
     };
 
     const { data, error } = await supabase.rpc('get_filtered_spectra_paginated', rpcParams);

--- a/web/app/api/v1/spectra/route.ts
+++ b/web/app/api/v1/spectra/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { validateAuth } from '@/lib/api-auth';
-import { getAccessiblePrograms } from '@/lib/api-helpers';
+import { getAccessiblePrograms, isAdminUser } from '@/lib/api-helpers';
 import { generateDownloadUrl } from '@/lib/r2';
 
 /**
@@ -55,7 +55,11 @@ export async function GET(request: NextRequest) {
     const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
     const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
-    const { data: spectrum, error: spectrumError } = await supabase
+    // Service-role read bypasses RLS, so gate unpublished spectra here: a
+    // non-admin must never resolve an in_prep/revoked FITS by path. No-op in B1.
+    const isAdmin = await isAdminUser(userId);
+
+    let spectrumQuery = supabase
       .from('spectra')
       .select(`
         id,
@@ -64,8 +68,11 @@ export async function GET(request: NextRequest) {
           program_slug
         )
       `)
-      .eq('fits_path', fitsPath)
-      .single();
+      .eq('fits_path', fitsPath);
+    if (!isAdmin) {
+      spectrumQuery = spectrumQuery.eq('deploy_status', 'published');
+    }
+    const { data: spectrum, error: spectrumError } = await spectrumQuery.single();
 
     if (spectrumError || !spectrum) {
       return NextResponse.json(

--- a/web/app/api/v1/spectrum/route.ts
+++ b/web/app/api/v1/spectrum/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { validateAuth } from '@/lib/api-auth';
-import { getAccessiblePrograms } from '@/lib/api-helpers';
+import { getAccessiblePrograms, isAdminUser } from '@/lib/api-helpers';
 import { generateDownloadUrl } from '@/lib/r2';
 import { deriveSibling } from '@/lib/layout';
 
@@ -56,6 +56,11 @@ export async function GET(request: NextRequest) {
       );
     }
 
+    // Service-role read bypasses RLS, so gate unpublished spectra here: a
+    // non-admin must never receive flux/wave/2D JSON for an in_prep/revoked
+    // spectrum, whether resolved by spectrum_id or by fits_path. No-op in B1.
+    const isAdmin = await isAdminUser(userId);
+
     // Parse query parameters
     const searchParams = request.nextUrl.searchParams;
     const spectrumId = searchParams.get('spectrum_id');
@@ -63,11 +68,14 @@ export async function GET(request: NextRequest) {
 
     // If spectrum_id provided, look up the fits_path
     if (spectrumId && !fitsPath) {
-      const { data: spectrumRow, error: spectrumRowError } = await supabase
+      let spectrumRowQuery = supabase
         .from('spectra')
         .select('fits_path, target_id, targets!inner(program_slug)')
-        .eq('spectrum_id', spectrumId)
-        .single();
+        .eq('spectrum_id', spectrumId);
+      if (!isAdmin) {
+        spectrumRowQuery = spectrumRowQuery.eq('deploy_status', 'published');
+      }
+      const { data: spectrumRow, error: spectrumRowError } = await spectrumRowQuery.single();
 
       if (spectrumRowError || !spectrumRow) {
         return NextResponse.json(
@@ -99,11 +107,14 @@ export async function GET(request: NextRequest) {
     }
 
     // Verify user has access to this file via the spectra table
-    const { data: spectrum, error: spectrumError } = await supabase
+    let spectrumQuery = supabase
       .from('spectra')
       .select('id, target_id')
-      .eq('fits_path', fitsPath)
-      .single();
+      .eq('fits_path', fitsPath);
+    if (!isAdmin) {
+      spectrumQuery = spectrumQuery.eq('deploy_status', 'published');
+    }
+    const { data: spectrum, error: spectrumError } = await spectrumQuery.single();
 
     if (spectrumError || !spectrum) {
       return NextResponse.json(

--- a/web/app/api/v1/sync/lists/route.ts
+++ b/web/app/api/v1/sync/lists/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { validateAuth } from '@/lib/api-auth';
+import { isAdminUser } from '@/lib/api-helpers';
 
 /**
  * GET /api/v1/sync/lists
@@ -24,8 +25,14 @@ export async function GET(request: NextRequest) {
     const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
     const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
+    // List member counts may reference unpublished-backed objects; admins can
+    // opt in to include them, everyone else is fail-closed. No-op in B1.
+    const includeUnpublished =
+      request.nextUrl.searchParams.get('include_unpublished') === 'true' && (await isAdminUser(userId));
+
     const { data, error } = await supabase.rpc('get_lists_for_sync', {
       p_user_id: userId,
+      p_include_unpublished: includeUnpublished,
     });
 
     if (error) {

--- a/web/app/api/v1/sync/objects/route.ts
+++ b/web/app/api/v1/sync/objects/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { validateAuth } from '@/lib/api-auth';
-import { getAccessiblePrograms } from '@/lib/api-helpers';
+import { getAccessiblePrograms, isAdminUser } from '@/lib/api-helpers';
 
 /**
  * GET /api/v1/sync/objects
@@ -47,6 +47,11 @@ export async function GET(request: NextRequest) {
     const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
     const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
+    // Admins can opt in to syncing objects with no published spectrum;
+    // everyone else is fail-closed to published-backed objects. No-op in B1.
+    const includeUnpublished =
+      searchParams.get('include_unpublished') === 'true' && (await isAdminUser(userId));
+
     const { data, error } = await supabase.rpc('get_objects_for_sync', {
       p_program_slugs: accessibleProgramSlugs,
       p_user_id: userId,
@@ -54,6 +59,7 @@ export async function GET(request: NextRequest) {
       p_limit: limit,
       p_offset: offset,
       p_include_counts: includeCounts,
+      p_include_unpublished: includeUnpublished,
     });
 
     if (error) {

--- a/web/app/api/v1/sync/photometry/route.ts
+++ b/web/app/api/v1/sync/photometry/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { validateAuth } from '@/lib/api-auth';
-import { getAccessiblePrograms } from '@/lib/api-helpers';
+import { getAccessiblePrograms, isAdminUser } from '@/lib/api-helpers';
 
 /**
  * GET /api/v1/sync/photometry
@@ -45,11 +45,17 @@ export async function GET(request: NextRequest) {
     const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
     const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
+    // Photometry for objects with no published spectrum is admin-only and
+    // gated behind explicit opt-in. Fail-closed otherwise; no-op in B1.
+    const includeUnpublished =
+      searchParams.get('include_unpublished') === 'true' && (await isAdminUser(userId));
+
     const { data, error } = await supabase.rpc('get_photometry_for_sync', {
       p_program_slugs: accessibleProgramSlugs,
       p_updated_since: updatedSince,
       p_limit: limit,
       p_offset: offset,
+      p_include_unpublished: includeUnpublished,
     });
 
     if (error) {

--- a/web/app/api/v1/sync/spectra/route.ts
+++ b/web/app/api/v1/sync/spectra/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { validateAuth } from '@/lib/api-auth';
-import { getAccessiblePrograms } from '@/lib/api-helpers';
+import { getAccessiblePrograms, isAdminUser } from '@/lib/api-helpers';
 
 /**
  * GET /api/v1/sync/spectra
@@ -46,6 +46,11 @@ export async function GET(request: NextRequest) {
     const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
     const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
+    // Admins can opt in to syncing unpublished spectra; everyone else is
+    // fail-closed to published rows only. No-op in B1.
+    const includeUnpublished =
+      searchParams.get('include_unpublished') === 'true' && (await isAdminUser(userId));
+
     const { data, error } = await supabase.rpc('get_spectra_for_sync', {
       p_program_slugs: accessibleProgramSlugs,
       p_user_id: userId,
@@ -53,6 +58,7 @@ export async function GET(request: NextRequest) {
       p_limit: limit,
       p_offset: offset,
       p_include_counts: includeCounts,
+      p_include_unpublished: includeUnpublished,
     });
 
     if (error) {

--- a/web/app/nirspec/targets/[id]/page.tsx
+++ b/web/app/nirspec/targets/[id]/page.tsx
@@ -51,10 +51,14 @@ export default async function TargetRedirectPage({ params, searchParams }: Targe
   // Look up the target's parent object using service role (no auth needed for redirect)
   const supabase = createServiceClient();
 
+  // Service-role read with no auth. Gate on has_published_spectrum so a target
+  // with no published spectrum is treated as nonexistent (notFound) rather than
+  // leaking its target_id → object_id mapping. No-op in B1.
   const { data, error } = await supabase
     .from('targets')
     .select('object_id, objects!inner(object_id)')
     .eq('target_id', targetId)
+    .eq('has_published_spectrum', true)
     .single();
 
   if (error || !data) {

--- a/web/lib/actions/spectra.ts
+++ b/web/lib/actions/spectra.ts
@@ -391,6 +391,8 @@ export async function getTargetMetadata(targetId: string): Promise<{
     // Use service role client to bypass RLS for social media crawlers
     const supabase = createServiceClient();
 
+    // Service-role read with no auth (serves OG/social metadata). Gate on
+    // has_published_spectrum so draft targets return null. No-op in B1.
     const { data, error } = await supabase
       .from('targets')
       .select(`
@@ -400,6 +402,7 @@ export async function getTargetMetadata(targetId: string): Promise<{
         programs:program_slug (program_name)
       `)
       .eq('target_id', targetId)
+      .eq('has_published_spectrum', true)
       .single();
 
     if (error || !data) {
@@ -601,10 +604,13 @@ export async function getObjectMetadata(objectId: string): Promise<{
   try {
     const supabase = createServiceClient();
 
+    // Service-role read with no auth (serves OG/social metadata). Gate on
+    // has_published_spectrum so draft objects return null. No-op in B1.
     const { data, error } = await supabase
       .from('objects')
       .select('object_id, redshift, field')
       .eq('object_id', objectId)
+      .eq('has_published_spectrum', true)
       .single();
 
     if (error || !data) {

--- a/web/lib/api-helpers.ts
+++ b/web/lib/api-helpers.ts
@@ -31,6 +31,29 @@ export async function resolveListIds(
 }
 
 /**
+ * Check whether a user is a CAMPFIRE admin.
+ *
+ * Admin-ness is derived ONLY from user_profiles.is_admin via the service-role
+ * client (mirrors the check in /api/v1/deploy/presign) — it is NEVER inferred
+ * from program slugs. Used to gate visibility of unpublished spectra
+ * (deploy_status != 'published') and their parent objects/targets
+ * (has_published_spectrum = false). Fail-closed: any lookup failure → false.
+ */
+export async function isAdminUser(userId: string): Promise<boolean> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+  const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+  const { data: profile } = await supabase
+    .from('user_profiles')
+    .select('is_admin')
+    .eq('user_id', userId)
+    .single();
+
+  return profile?.is_admin === true;
+}
+
+/**
  * Get all program slugs accessible to a user (public + explicit access)
  */
 export async function getAccessiblePrograms(userId: string): Promise<string[]> {


### PR DESCRIPTION
Closes #217. First implementation step of **Track B** in epic #210 (intermediate products & cloud-as-source-of-truth).

## What this does

Adds a `deploy_status` lifecycle and threads a **fail-closed published predicate through every reader**, so that when B2 (#218) starts deploying `in_prep` intermediate products, none of them reach non-admins. **B1 ships everything `published` → zero user-visible change.** It is the safety prerequisite that B2's `deploy --in-prep` capability-gates on.

**Readers only.** `has_published_spectrum` is always `true` in B1 (nothing is `in_prep`), so every predicate added here is a no-op until B2 — the point is that readers are status-aware *before* `in_prep` data exists. Population/recompute logic and the deploy write-path are B2. No `python/campfire` changes, no `pipeline/**` (so no CHANGELOG entry).

## Schema (`supabase/schemas/` + `20260629014642_add_deploy_status_lifecycle.sql`)

- `spectra.deploy_status` (`in_prep|published|revoked`, default `published`, CHECK) + `targets`/`objects.has_published_spectrum` (default `true`) — all fail-closed-visible. Partial index on the rare non-published case (the published-path covering index is deferred to B2, where real `in_prep` volume can drive an EXPLAIN).
- **RLS**: every science reader gated — `spectra` (primary), `targets`/`objects`/`object_photometry`/`object_list_members`, `comments` + `flag_audit_log` (all branches), the 3 inspector-UPDATE policies, and `shutters`/`slit_regions` via a zero-change `NOT EXISTS` form.
- **RPCs** (`functions.sql`): 17 readers threaded with `p_include_unpublished` (admin opt-in, `DEFAULT false`) + the predicate — including 3-CTE consistency on the `*_for_sync` RPCs (so totals match the row set) and `object_scoped_aggregates()` threaded into its 3 callers. Admin opt-in derives **only** from `is_admin()`, never from program slugs.
- **Views**: `mv_filter_options`/`mv_programs_overview` published-filtered; `spectrum_flag_summary` + `nircam_reduction_progress` flipped to `security_invoker` (the latter was leaking NIRCam QA aggregates to all authenticated users — a pre-existing leak).

## Web (17 files)

New `isAdminUser()` helper (explicit `user_profiles.is_admin` lookup via the service-role client, the presign-route pattern). RPC-calling `/api/v1` routes thread `p_include_unpublished`; the direct-read routes that bypass RLS filter `deploy_status='published'` unless admin — critically `/api/v1/spectra` (presign by path), `/spectrum`, and `/redshift-fit`. `og-image` 404s for entities with no published spectrum.

## Why both RLS *and* RPC predicates

The filter RPCs are `SECURITY INVOKER` (verified), so RLS covers user-client reads and the non-`/v1` web routes that never call an RPC. But the same RPCs are also invoked under the service-role key from `/api/v1/*` where RLS is bypassed — so the in-body predicate is also required. Neither layer alone is sufficient.

## Validation

- `supabase db reset` clean; **seed applies unchanged** (defaults cover the new NOT NULL columns).
- **Leak gate passes** (`python/tests/test_deploy_status_rls.py` + `sql/b1_deploy_status_leak.sql`): a non-admin with full program access sees **zero** in_prep/revoked spectra/objects/targets via RLS (published control still visible); admin sees them; the service-role RPC predicate hides with `false` / reveals with `true`.
- Full pytest **216 passed, 1 skipped**; `cd web && npm run build` green.

## Reviewer notes

- The generated migration was hand-patched over migra's known matview/view limitations: the two **matview unique indexes** were re-added (required for `REFRESH … CONCURRENTLY`; grants auto-restore via default privileges), and **`WITH (security_invoker = true)`** was re-added to both views (migra drops the option).
- A fresh `supabase db diff` still shows **matview/view noise** (migra can't diff materialized views — the repo's standing norm) plus the **pre-existing #195 `search_path` drift** on `can_inspect`/`handle_new_user`, which I deliberately **stripped** from this migration to keep it single-purpose. That drift is tracked in #228.
- Pre-existing **program-scoping** leaks surfaced during scoping (deployments readable cross-program, public og-image, shutters/slits `USING(true)`) are intentionally out of scope here and tracked in #229 — this PR handles only their `in_prep` dimension.

Generated with Claude Code

https://claude.ai/code/session_01QMm3DuLALxzNtLBUQqPfkR