### PR TITLE
feat(210): CFSCHEMA canonical format-version keyword (B-track prereq)

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -203,6 +203,17 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- **Canonical format-version keyword (`CFSCHEMA`, epic #210 B-track prereq).**
+  Every NIRSpec canonical spectrum-exposure now carries an integer `CFSCHEMA`
+  card (value `1`) stamped at birth in `_finalize_canonical`, self-identifying
+  the on-disk layout so a future format migrator can locate old-layout files. It
+  is deliberately *not* a `CFP_*` provenance card — it tags the file format, not a
+  processing step, so `cfpipe nirspec reset` never strips it, and it rides through
+  stage2b's `MultiSlitModel` re-save via the jwst `extra_fits` round-trip. A file
+  with no `CFSCHEMA` is byte-format identical to a `v1` file, so
+  `canonical.read_schema_version` reads "absent" back as `1`; the keyword only
+  discriminates once it increments. **No change to scientific output** (a header
+  keyword only). Bumped only when the canonical layout itself changes.
 - **Layout & key contract (`campfire_layout`, #213, PR-2 of epic #210).** The
   `$CAMPFIRE_ROOT/` directory tree — previously a three-way contract re-derived
   independently in the pipeline, the deploy/download client, and the web portal —

--- a/pipeline/campfire_pipeline/nirspec/canonical.py
+++ b/pipeline/campfire_pipeline/nirspec/canonical.py
@@ -43,6 +43,20 @@ PRE_BKGSUB_PREFIX = 'PRE_BKGSUB'
 S2D_PREFIX = 'S2D'
 S2D_BKGSUB_PREFIX = 'S2D_BKGSUB'
 
+# Canonical-file *format* version. Bumped only when the on-disk layout changes
+# (an HDU is added/removed/renamed, or the primary-header contract shifts) — NOT
+# when the science changes. Deliberately a standalone primary-header keyword
+# (``CFSCHEMA``), *not* a ``CFP_*`` provenance card: it identifies the file
+# format, so it must survive ``cfpipe nirspec reset`` (which clears the CFP_*
+# state chain) and a stage2b re-save. A future format migrator reads it to find
+# old-layout files. Absent ⇒ treated as version 1 (the format that shipped with
+# issue #212): adding the keyword is itself not a layout change, so "missing" and
+# "=1" denote the same physical format. The keyword only discriminates once it
+# increments — every v2 file carries ``CFSCHEMA = 2`` and everything else is v1.
+SCHEMA_VERSION_KEYWORD = 'CFSCHEMA'
+SCHEMA_VERSION_COMMENT = 'campfire: canonical file format version'
+CANONICAL_SCHEMA_VERSION = 1
+
 # EXTNAME prefixes for the non-schema HDUs this module manages. These are the
 # HDUs that must be preserved across a ``DataModel.save()`` (which drops them).
 CUSTOM_HDU_PREFIXES = (PRE_BKGSUB_PREFIX, S2D_PREFIX)
@@ -52,6 +66,31 @@ def is_custom_hdu(hdu):
     """True if ``hdu`` is one of the canonical file's managed non-schema HDUs."""
     name = (hdu.name or '').upper()
     return any(name.startswith(p) for p in CUSTOM_HDU_PREFIXES)
+
+
+def schema_version_card(version=CANONICAL_SCHEMA_VERSION):
+    """The ``(value, comment)`` tuple for the ``CFSCHEMA`` format keyword.
+
+    Stamped at canonical-file birth (``stage2._finalize_canonical``). Returned as
+    a dict so it composes with the other ``header_updates`` passed to the canonical
+    writers (``save_canonical`` / ``append_extras``).
+    """
+    return {SCHEMA_VERSION_KEYWORD: (int(version), SCHEMA_VERSION_COMMENT)}
+
+
+def read_schema_version(path_or_header):
+    """Return a canonical file's format version (int).
+
+    Accepts a path or an already-open ``fits.Header``. A file with no
+    ``CFSCHEMA`` keyword predates the keyword but is byte-format-identical to a
+    ``CFSCHEMA = 1`` file, so it reads back as :data:`CANONICAL_SCHEMA_VERSION`'s
+    baseline ``1`` (see the module constant for the rationale).
+    """
+    if isinstance(path_or_header, fits.Header):
+        header = path_or_header
+    else:
+        header = fits.getheader(path_or_header)
+    return int(header.get(SCHEMA_VERSION_KEYWORD, 1))
 
 
 def _tmp_path(path):

--- a/pipeline/campfire_pipeline/nirspec/stage2.py
+++ b/pipeline/campfire_pipeline/nirspec/stage2.py
@@ -850,16 +850,24 @@ def _finalize_canonical(prod_name, cards):
     workspace (relative paths). Returns the canonical path, or None if the cal
     product is absent (NoDataOnDetectorError)."""
     from campfire_pipeline.common import cfp
+    from campfire_pipeline.nirspec import canonical as C
     cal_out = f'{prod_name}_cal.fits'
     canonical = f'{prod_name}.fits'
     if not os.path.exists(cal_out):
         return None
     os.replace(cal_out, canonical)
     cfp_cards = cfp.format(keyset=cfp.NIRSPEC, CFP_CAL=None)
+    # Stamp the canonical format version at birth. It rides through stage2b's
+    # MultiSlitModel re-save via the jwst datamodel's extra_fits round-trip (same
+    # path the CFP_* / provenance cards rely on), and is intentionally not a CFP_*
+    # card so `nirspec reset` never strips it (a reset doesn't change the format).
+    schema_card = C.schema_version_card()
     with fits.open(canonical, mode='update') as hdul:
         for card in cards:
             hdul['PRIMARY'].header[card[0]] = card[1:3]
         for key, (val, comment) in cfp_cards.items():
+            hdul['PRIMARY'].header[key] = (val, comment)
+        for key, (val, comment) in schema_card.items():
             hdul['PRIMARY'].header[key] = (val, comment)
         hdul.flush()
     return canonical

--- a/pipeline/tests/test_nirspec_canonical.py
+++ b/pipeline/tests/test_nirspec_canonical.py
@@ -190,6 +190,51 @@ def test_restore_pre_bkgsub_raises_without_revert(tmp_path):
         C.restore_pre_bkgsub(p)
 
 
+# --- CFSCHEMA canonical format-version keyword ------------------------------
+
+def test_schema_version_card_shape():
+    card = C.schema_version_card()
+    assert set(card) == {C.SCHEMA_VERSION_KEYWORD}
+    val, comment = card[C.SCHEMA_VERSION_KEYWORD]
+    assert val == C.CANONICAL_SCHEMA_VERSION and isinstance(val, int)
+    assert isinstance(comment, str) and comment
+
+
+def test_read_schema_version_missing_is_one(tmp_path):
+    # A canonical with no CFSCHEMA predates the keyword but is byte-format
+    # identical to a v1 file, so it reads back as 1 (not 0/None).
+    p = _slit_fits(tmp_path / 'c.fits')
+    assert C.read_schema_version(p) == 1
+
+
+def test_read_schema_version_explicit(tmp_path):
+    p = _slit_fits(tmp_path / 'c.fits', CFSCHEMA=2)
+    assert C.read_schema_version(p) == 2
+    # also accepts an already-open header
+    with fits.open(p) as hdul:
+        assert C.read_schema_version(hdul[0].header) == 2
+
+
+def test_finalize_canonical_stamps_schema_version(tmp_path, monkeypatch):
+    # _finalize_canonical promotes Spec2's `_cal.fits` to the bare canonical and
+    # is the single birth chokepoint where CFSCHEMA must be stamped (alongside
+    # CFP_CAL + provenance cards). Operates on cwd-relative paths.
+    from campfire_pipeline.nirspec.stage2 import _finalize_canonical
+    monkeypatch.chdir(tmp_path)
+    _slit_fits(tmp_path / 'foo_1_123_cal.fits')          # the Spec2 cal product
+    cards = [('STKSHFIL', 'stuck.fits', 'Stuck shutter file name')]
+    out = _finalize_canonical('foo_1_123', cards)
+    assert out == 'foo_1_123.fits'
+    assert not (tmp_path / 'foo_1_123_cal.fits').exists()  # renamed in place
+    with fits.open(tmp_path / 'foo_1_123.fits') as hdul:
+        hdr = hdul[0].header
+        assert hdr['CFSCHEMA'] == C.CANONICAL_SCHEMA_VERSION   # birth stamp
+        assert hdr.comments['CFSCHEMA'] == C.SCHEMA_VERSION_COMMENT
+        assert 'CFP_CAL' in hdr                                # state anchor
+        assert hdr['STKSHFIL'] == 'stuck.fits'                 # provenance card
+    assert C.read_schema_version(tmp_path / 'foo_1_123.fits') == C.CANONICAL_SCHEMA_VERSION
+
+
 # --- stage2b skip-check is rectify-aware (#225 review regression guard) -------
 
 def test_bkgsub_group_done_rectify_aware(tmp_path):


### PR DESCRIPTION
## What

Stamp an integer `CFSCHEMA` card (value `1`) on every NIRSpec canonical spectrum-exposure at birth (`_finalize_canonical`), self-identifying the on-disk layout so a future format migrator can locate old-layout files. This is the cheap pipeline prerequisite for epic #210's B-track (intermediate-product deploy): once we start putting canonical intermediates in the cloud, the files need to self-identify their format version.

## Design

- **Standalone keyword, not a `CFP_*` provenance card.** The `CFP_*` cards form a provenance/state chain that `cfpipe nirspec reset --from <step>` clears. `CFSCHEMA` tags the file *format*, not a processing step — a reset doesn't change the format — so it lives outside that namespace and survives resets.
- **Survives stage2b's re-save.** Stamped via astropy in `_finalize_canonical`, it rides through the later `MultiSlitModel.save()` via the jwst `extra_fits` round-trip — the same mechanism the existing `CFP_CAL` / `STKSHFIL` / `CFEXTWAV` primary-header cards already rely on.
- **Absent ⇒ v1.** A canonical with no `CFSCHEMA` predates the keyword but is byte-format identical to a `CFSCHEMA = 1` file (adding the keyword is not a layout change). So `canonical.read_schema_version()` reads "absent" back as `1`; the keyword only discriminates once it increments (every v2 file carries `= 2`, everything else is v1). This means in-flight reductions on current `main` validate the B-track fine even though they won't carry the card.
- Bumped only when the canonical *layout* changes (HDU added/removed/renamed, or the primary-header contract shifts) — never for science changes.

## Changes
- `canonical.py`: `CANONICAL_SCHEMA_VERSION` / `SCHEMA_VERSION_KEYWORD` constants, `schema_version_card()`, `read_schema_version()`.
- `stage2.py` `_finalize_canonical`: stamp the card at the canonical birth chokepoint, alongside `CFP_CAL` + provenance cards.
- Tests: helper round-trips + an integration test asserting `_finalize_canonical` stamps `CFSCHEMA` on the promoted canonical.

## Impact
**No change to scientific output** — a header keyword only. Categorized **Infrastructure → PATCH** in `pipeline/CHANGELOG.md`.

Generated with Claude Code

https://claude.ai/code/session_01QMm3DuLALxzNtLBUQqPfkR