### PR TITLE
feat(218): B2 — intermediate-product lifecycle backbone (in_prep + publish/revoke)

### DIFF
--- a/python/campfire/deploy/cli.py
+++ b/python/campfire/deploy/cli.py
@@ -81,7 +81,11 @@ from campfire.deploy.deploy import (
     deploy_thumbnails,
     deploy_zfit,
 )
-from campfire.deploy.supabase import get_supabase_client, upsert_programs, refresh_filter_options, refresh_programs_overview
+from campfire.deploy.supabase import (
+    get_supabase_client, upsert_programs, refresh_filter_options,
+    refresh_programs_overview, get_latest_deployment_id, set_deployment_status,
+    get_user_id_from_token,
+)
 
 
 def _gate_admin(config: dict) -> None:
@@ -184,12 +188,16 @@ def source_ids_option(f):
               help='Skip photometry upsert after objects reconcile.')
 @click.option('--skip-astrometry', is_flag=True,
               help='Skip astrometric correction for shutters (deploy raw MSA positions).')
+@click.option('--in-prep', 'in_prep', is_flag=True,
+              help='Deploy as an admin-only draft: spectra land deploy_status=in_prep '
+                   '(invisible to users) until published via the admin UI. Requires the '
+                   'B1 lifecycle to be applied to the target DB (checked up front).')
 @click.option('--local', is_flag=True,
               help='Use local Supabase (127.0.0.1:54321).')
 @click.pass_context
 def deploy_group(ctx, config_path, obs, dry_run, source_ids, supabase_only,
                  force_overwrite, auto_approve, rgb, no_sed, no_shutters,
-                 no_photometry, skip_astrometry, local):
+                 no_photometry, skip_astrometry, in_prep, local):
     """Deploy CAMPFIRE pipeline products to Supabase + R2."""
     ctx.ensure_object(dict)
     ctx.obj['local'] = local
@@ -228,6 +236,7 @@ def deploy_group(ctx, config_path, obs, dry_run, source_ids, supabase_only,
                 source_ids=list(source_ids) if source_ids else None,
                 auto_approve=auto_approve,
                 defer_rebuild=multi,
+                in_prep=in_prep,
             )
             if result and result.get('needs_reconcile'):
                 fields_needing_rebuild.add(result['field'])
@@ -361,6 +370,51 @@ def slits(ctx, config_path, obs, dry_run, local):
     config = load_config(config_path, local=_resolve_local(ctx, local))
     for obs_name in obs:
         deploy_slits(obs_name, config, dry_run=dry_run)
+
+
+def _lifecycle_transition(ctx, config_path, obs, dry_run, local, *, to_status, verb):
+    """Shared body for the publish/revoke subcommands (epic #210, B2).
+
+    Resolves each observation's latest deployment and calls set_deployment_status,
+    which flips the deployment + its spectra + recomputes has_published_spectrum +
+    writes audit rows server-side.
+    """
+    config = load_config(config_path, local=_resolve_local(ctx, local))
+    sb = get_supabase_client(config)
+    actor = get_user_id_from_token(config)
+    for obs_name in obs:
+        dep_id = get_latest_deployment_id(sb, obs_name)
+        if dep_id is None:
+            print(f"  {obs_name}: no deployment found, skipping")
+            continue
+        if dry_run:
+            print(f"  [dry-run] {verb} {obs_name} (deployment #{dep_id})")
+            continue
+        result = set_deployment_status(sb, dep_id, to_status, actor=actor)
+        if result is None:
+            print(f"  {obs_name}: {verb.lower()} failed")
+            continue
+        spectra = (result.get('spectra') or {})
+        print(f"  {verb}ed {obs_name} (deployment #{dep_id}): "
+              f"{spectra.get('updated', 0)} spectra -> {to_status}")
+
+
+@deploy_group.command()
+@shared_options
+@click.pass_context
+def publish(ctx, config_path, obs, dry_run, local):
+    """Publish in_prep draft observation(s): make their spectra visible to users."""
+    _lifecycle_transition(ctx, config_path, obs, dry_run, local,
+                          to_status='published', verb='Publish')
+
+
+@deploy_group.command()
+@shared_options
+@click.pass_context
+def revoke(ctx, config_path, obs, dry_run, local):
+    """Revoke published observation(s): hide their spectra from users (bytes retained)."""
+    _lifecycle_transition(ctx, config_path, obs, dry_run, local,
+                          to_status='revoked', verb='Revoke')
 
 
 @deploy_group.command()

--- a/python/campfire/deploy/deploy.py
+++ b/python/campfire/deploy/deploy.py
@@ -11,6 +11,7 @@ Each public function follows the same pattern:
 
 import re
 import shutil
+import sys
 from pathlib import Path
 
 from tqdm import tqdm
@@ -42,9 +43,11 @@ from campfire.deploy.supabase import (
     deploy_shutters as db_deploy_shutters,
     deploy_slits as db_deploy_slits,
     fetch_deployment_config,
+    get_lifecycle_status,
     get_supabase_client,
     get_user_id_from_token,
     insert_deployment,
+    log_deploy_event,
     recompute_target_aggregates,
     refresh_filter_options,
     refresh_programs_overview,
@@ -140,6 +143,29 @@ def _collect_crds_contexts(spectra) -> list[str]:
     return sorted(contexts)
 
 
+def _count_published_spectra(sb, spectra: list[dict]) -> int:
+    """How many of these (target_id, grating) spectra are currently 'published'.
+
+    Used by the `--in-prep` guard so a re-draft never silently hides live data.
+    PostgREST can't filter on tuples, so over-fetch by target_id and filter the
+    (target_id, grating) pairs Python-side (gratings per target are few).
+    """
+    wanted = {(s['target_id'], s['grating']) for s in spectra}
+    target_ids = sorted({tid for (tid, _) in wanted})
+    published = 0
+    for i in range(0, len(target_ids), 200):
+        batch = target_ids[i:i + 200]
+        resp = (sb.table('spectra')
+                .select('target_id, grating, deploy_status')
+                .in_('target_id', batch)
+                .eq('deploy_status', 'published')
+                .execute())
+        for row in resp.data or []:
+            if (row['target_id'], row['grating']) in wanted:
+                published += 1
+    return published
+
+
 def deploy_observation(
     obs_name: str,
     config: dict,
@@ -155,12 +181,20 @@ def deploy_observation(
     source_ids: list[int] | None = None,
     auto_approve: bool = False,
     defer_rebuild: bool = False,
+    in_prep: bool = False,
 ) -> dict:
     """Full deployment: ECSV -> generate content -> R2 upload -> Supabase upsert.
 
     When *defer_rebuild* is True, the per-field objects reconciliation
     (and materialized-view refresh) is skipped so the caller can batch
     them after processing multiple observations of the same field.
+
+    When *in_prep* is True (epic #210, B2), the deployed spectra land
+    ``deploy_status='in_prep'`` (admin-only, invisible to users) and the
+    deployment record is marked ``in_prep`` — a draft an admin reviews and
+    publishes via the admin UI. Requires the B1 (#217) lifecycle to be applied
+    to the target database; checked up front via ``get_lifecycle_status`` so the
+    deploy aborts cleanly rather than silently shipping unguarded drafts.
 
     Returns a dict with ``field`` and ``needs_reconcile`` (always True
     for completed deploys; the no-op return at the dry-run / nothing-
@@ -323,6 +357,23 @@ def deploy_observation(
     # --- Live deployment ---
     sb = get_supabase_client(config)
 
+    # B2 capability gate: `--in-prep` requires the B1 (#217) lifecycle to be live
+    # on the TARGET database, or the drafts would not actually be hidden. Check the
+    # marker up front and abort cleanly if absent (or if the RPC itself is missing,
+    # i.e. this deploy code is newer than the DB).
+    if in_prep:
+        cap = get_lifecycle_status(sb)
+        if not cap.get('enabled'):
+            print("ERROR: --in-prep requires the B1 lifecycle enforcement (#217) on "
+                  "the target database, but it is not enabled.")
+            if cap.get('checks'):
+                print(f"  capability checks: {cap['checks']}")
+            if cap.get('error'):
+                print(f"  {cap['error']}")
+            print("  Deploy the B1 migration first, or omit --in-prep to publish directly.")
+            sys.exit(1)
+        print("Deploying as in_prep draft (admin-only until published).")
+
     # Check for existing targets and confirm
     target_ids = [o['object_id'] for o in objects]
     existing = check_existing_objects(sb, target_ids)
@@ -428,6 +479,27 @@ def deploy_observation(
         print("Upserting objects...")
         n_obj, new_object_ids, _n_quality_reset = batch_upsert_objects(sb, objects, field, force_overwrite, objects_with_sed)
         print(f"  {n_obj} objects")
+
+        # B2: an in_prep deploy forces deploy_status='in_prep' on every spectrum it
+        # writes — the whole observation lands as an admin-only draft. Guard first
+        # against silently hiding data that is already live: warn (and require
+        # confirmation) if any of these (target_id, grating) rows are currently
+        # 'published', since re-drafting them would pull them from users until an
+        # explicit publish. A single spectra row per (target,grating) can't hold a
+        # live + draft version at once, so this is "take the observation back to
+        # draft", not zero-downtime staging of a re-reduction.
+        if in_prep:
+            already_published = _count_published_spectra(sb, spectra)
+            if already_published and not auto_approve:
+                print()
+                print(f"WARNING: --in-prep will hide {already_published} currently-PUBLISHED "
+                      f"spectrum row(s) until you re-publish them.")
+                resp = input("  Take these back to draft (in_prep)? [y/N]: ")
+                if resp.lower() != 'y':
+                    print("Aborted.")
+                    return {'field': field, 'needs_reconcile': False}
+            for rec in spectra:
+                rec['deploy_status'] = 'in_prep'
 
         print("Upserting spectra...")
         n_spec, changed_hashes = batch_upsert_spectra(sb, spectra)
@@ -542,10 +614,22 @@ def deploy_observation(
             force_overwrite=force_overwrite,
             source_ids_filter=source_ids,
             supabase_only=supabase_only,
+            status='in_prep' if in_prep else 'published',
         )
         if deployment_id:
             update_latest_deployment(sb, obs_name, deployment_id)
-            print(f"\nDeployment #{deployment_id} recorded")
+            print(f"\nDeployment #{deployment_id} recorded"
+                  f"{' (in_prep draft)' if in_prep else ''}")
+            # B2: record the deploy in the lifecycle audit log.
+            log_deploy_event(
+                sb,
+                action='upload',
+                actor=user_id,
+                deployment_id=deployment_id,
+                observation=obs_name,
+                affected_count=len(spectra),
+                metadata={'in_prep': in_prep, 'n_objects': len(objects)},
+            )
 
         # Storage registry (#214): index the objects that actually landed in this
         # deploy. Shadow index — additive, nothing reads it as authoritative yet.

--- a/python/campfire/deploy/supabase.py
+++ b/python/campfire/deploy/supabase.py
@@ -151,9 +151,13 @@ def insert_deployment(
     force_overwrite: bool = False,
     source_ids_filter: list[int] | None = None,
     supabase_only: bool = False,
+    status: str = 'published',
 ) -> int | None:
     """
     Insert a deployment record and return its ID.
+
+    ``status`` is the deployment lifecycle (epic #210, B2): 'published' for a
+    normal deploy (stamps published_at=now), 'in_prep' for a `--in-prep` draft.
 
     Returns None if the insert fails (e.g. deployed_by is not set).
     """
@@ -166,7 +170,14 @@ def insert_deployment(
         'deployed_by': deployed_by,
         'force_overwrite': force_overwrite,
         'supabase_only': supabase_only,
+        'status': status,
     }
+    # A normal (published) deploy stamps published_at so the lifecycle timeline is
+    # complete without a separate publish step; in_prep drafts leave it NULL until
+    # an admin publishes via set_deployment_status.
+    if status == 'published':
+        from datetime import datetime, timezone
+        data['published_at'] = datetime.now(timezone.utc).isoformat()
     if cfpipe_version:
         data['cfpipe_version'] = cfpipe_version
     if jwst_version:
@@ -192,6 +203,95 @@ def insert_deployment(
     if resp.data and len(resp.data) > 0:
         return resp.data[0]['id']
     return None
+
+
+def get_lifecycle_status(client: Client) -> dict:
+    """Return the target DB's intermediate-lifecycle capability (epic #210, B2).
+
+    The marker the deploy CLI gates ``--in-prep`` on: it introspects the live
+    catalog and returns ``{'enabled': bool, 'checks': {...}, 'version': int}``,
+    enabled only when B1 (#217) is applied (deploy_status column + reader RPCs
+    threaded with p_include_unpublished). Returns ``{'enabled': False, ...}`` when
+    the RPC itself is missing (deploy code newer than the DB) so the caller can
+    abort cleanly instead of crashing.
+    """
+    try:
+        resp = client.rpc('get_lifecycle_status', {}).execute()
+    except Exception as e:
+        return {'enabled': False, 'error': f'get_lifecycle_status unavailable: {e}'}
+    data = resp.data if resp.data is not None else {}
+    if isinstance(data, dict):
+        return data
+    return {'enabled': False, 'error': 'unexpected get_lifecycle_status response'}
+
+
+def log_deploy_event(
+    client: Client,
+    *,
+    action: str,
+    actor: str | None = None,
+    deployment_id: int | None = None,
+    observation: str | None = None,
+    affected_count: int | None = None,
+    metadata: dict | None = None,
+    host: str | None = None,
+) -> str | None:
+    """Append one row to the deploy_events audit log via the SECURITY DEFINER RPC
+    (the only sanctioned write path — the table has no client INSERT policy).
+    Returns the event id, or None on failure (audit is best-effort; never blocks
+    the deploy)."""
+    try:
+        resp = client.rpc('log_deploy_event', {
+            'p_action': action,
+            'p_actor': actor,
+            'p_deployment_id': deployment_id,
+            'p_observation': observation,
+            'p_affected_count': affected_count,
+            'p_metadata': metadata,
+            'p_host': host,
+        }).execute()
+        return resp.data if resp.data else None
+    except Exception as e:
+        print(f"  Warning: could not write deploy_event ({action}): {e}")
+        return None
+
+
+def get_latest_deployment_id(client: Client, observation: str) -> int | None:
+    """The most recent deployment id for an observation (lifecycle anchor)."""
+    resp = (client.table('deployments')
+            .select('id')
+            .eq('observation', observation)
+            .order('id', desc=True)
+            .limit(1)
+            .execute())
+    if resp.data:
+        return resp.data[0]['id']
+    return None
+
+
+def set_deployment_status(
+    client: Client,
+    deployment_id: int,
+    to_status: str,
+    *,
+    actor: str | None = None,
+    host: str | None = None,
+) -> dict | None:
+    """Transition a deployment's lifecycle (publish/revoke/in_prep) via the
+    SECURITY DEFINER RPC: flips the deployment + its spectra + recomputes
+    has_published_spectrum + writes audit rows, all server-side. Returns the RPC
+    result json, or None on failure."""
+    try:
+        resp = client.rpc('set_deployment_status', {
+            'p_deployment_id': deployment_id,
+            'p_to': to_status,
+            'p_actor': actor,
+            'p_host': host,
+        }).execute()
+        return resp.data
+    except Exception as e:
+        print(f"  Warning: set_deployment_status({deployment_id} -> {to_status}) failed: {e}")
+        return None
 
 
 def update_latest_deployment(

--- a/python/tests/sql/b2_lifecycle.sql
+++ b/python/tests/sql/b2_lifecycle.sql
@@ -1,0 +1,193 @@
+-- =============================================================================
+-- B2 (#218) intermediate-product lifecycle harness.
+-- =============================================================================
+-- Builds on the B1 leak gate. Drives the seed's published control object (#3,
+-- public program castellano3073) through a full revoke -> recover cycle using
+-- the B2 lifecycle RPCs, and proves end to end that:
+--   A. get_lifecycle_status().enabled is true (the capability marker the deploy
+--      CLI gates `--in-prep` on — confirms B1 is applied to this DB).
+--   B. set_spectra_deploy_status('revoked') flips spectra.deploy_status AND
+--      recomputes targets/objects.has_published_spectrum to false AND writes a
+--      deploy_events audit row — all in one call.
+--   C. A NON-ADMIN then sees ZERO of the revoked object/spectra through RLS, and
+--      ZERO rows of the admin-only deploy_events / spectrum_exposures tables.
+--   D. set_spectra_deploy_status('published') recovers: has_published_spectrum
+--      back to true, an admin can read spectrum_exposures, a 'recover' audit row.
+--   E. The non-admin sees the recovered object again (regression guard).
+--   F. service_role can log_deploy_event (the deploy 'upload' path).
+--   G. A non-admin is DENIED the lifecycle RPC (the admin/service_role gate).
+--
+-- One transaction, ROLLBACK'd. A RAISE (any failed assertion) makes psql exit
+-- non-zero; success prints the PASS marker. Seed-anchored: admin@=1111…,
+-- user@=2222…, control object id=3 in castellano3073.
+-- =============================================================================
+\set ON_ERROR_STOP on
+\set ADMIN '11111111-1111-1111-1111-111111111111'
+\set USER  '22222222-2222-2222-2222-222222222222'
+BEGIN;
+
+-- ---- fixtures (bootstrap superuser, bypasses RLS) ---------------------------
+CREATE TEMP TABLE _o3tgt AS
+  SELECT t.id, t.target_id FROM public.targets t WHERE t.object_id = 3;
+CREATE TEMP TABLE _o3spec AS
+  SELECT s.id FROM public.spectra s JOIN _o3tgt t ON s.target_id = t.target_id;
+
+DO $$ BEGIN
+  IF (SELECT count(*) FROM _o3spec) = 0 THEN
+    RAISE EXCEPTION 'FIXTURE EMPTY: object 3 has no member spectra — seed shape changed';
+  END IF;
+  IF (SELECT count(*) FROM public.objects WHERE id = 3 AND has_published_spectrum) = 0 THEN
+    RAISE EXCEPTION 'FIXTURE: object 3 is not published at start — seed shape changed';
+  END IF;
+END $$;
+
+-- A spectrum_exposures row for an object-3 spectrum, so the admin-only RLS on
+-- that table is exercised against real data (it is otherwise empty here).
+INSERT INTO public.spectrum_exposures (spectrum_id, exposure_ref, stage)
+  SELECT (SELECT id FROM _o3spec ORDER BY id LIMIT 1), 'harness_root_1_nrs1_999', 'cal';
+
+GRANT SELECT ON _o3tgt, _o3spec TO authenticated, service_role;
+
+-- =========================================================================
+-- A. capability marker enabled (B1 applied), checked as ADMIN
+-- =========================================================================
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claims',
+  json_build_object('sub', :'ADMIN', 'role', 'authenticated')::text, true);
+
+DO $$
+DECLARE st json;
+BEGIN
+  st := public.get_lifecycle_status();
+  IF (st->>'enabled')::boolean IS NOT TRUE THEN
+    RAISE EXCEPTION 'CAPABILITY: get_lifecycle_status().enabled is not true: %', st::text;
+  END IF;
+END $$;
+
+-- =========================================================================
+-- B. revoke object 3 via the lifecycle RPC (admin) -> status + recompute + audit
+-- =========================================================================
+DO $$
+DECLARE ids int[]; flag boolean;
+BEGIN
+  SELECT array_agg(id) INTO ids FROM _o3spec;
+  PERFORM public.set_spectra_deploy_status(
+    p_spectrum_db_ids := ids, p_to := 'revoked', p_action := 'revoke',
+    p_actor := '11111111-1111-1111-1111-111111111111'::uuid);
+
+  IF EXISTS (SELECT 1 FROM public.spectra WHERE id = ANY(ids) AND deploy_status <> 'revoked') THEN
+    RAISE EXCEPTION 'STATUS: a member spectrum was not set revoked';
+  END IF;
+  SELECT has_published_spectrum INTO flag FROM public.objects WHERE id = 3;
+  IF flag IS NOT FALSE THEN
+    RAISE EXCEPTION 'RECOMPUTE: object 3 has_published_spectrum=% after revoke (expected false)', flag;
+  END IF;
+  IF EXISTS (SELECT 1 FROM public.targets WHERE object_id = 3 AND has_published_spectrum) THEN
+    RAISE EXCEPTION 'RECOMPUTE: a target of object 3 still has_published_spectrum after revoke';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.deploy_events WHERE action = 'revoke' AND status_to = 'revoked') THEN
+    RAISE EXCEPTION 'AUDIT: no deploy_events row for the revoke';
+  END IF;
+END $$;
+
+-- =========================================================================
+-- C. NON-ADMIN sees zero of the revoked object + zero admin-only-table rows
+-- =========================================================================
+SELECT set_config('request.jwt.claims',
+  json_build_object('sub', :'USER', 'role', 'authenticated')::text, true);
+
+DO $$
+DECLARE n int;
+BEGIN
+  SELECT count(*) INTO n FROM public.objects WHERE id = 3;
+  IF n <> 0 THEN RAISE EXCEPTION 'LEAK: non-admin sees revoked object 3 (got %, expected 0)', n; END IF;
+
+  SELECT count(*) INTO n FROM public.spectra WHERE id IN (SELECT id FROM _o3spec);
+  IF n <> 0 THEN RAISE EXCEPTION 'LEAK: non-admin sees % revoked spectra of object 3', n; END IF;
+
+  -- Admin-only audit log: rows exist (the revoke above), non-admin sees none.
+  SELECT count(*) INTO n FROM public.deploy_events;
+  IF n <> 0 THEN RAISE EXCEPTION 'LEAK: non-admin reads deploy_events (% rows)', n; END IF;
+
+  -- Admin-only intermediates: a row exists (fixture), non-admin sees none.
+  SELECT count(*) INTO n FROM public.spectrum_exposures;
+  IF n <> 0 THEN RAISE EXCEPTION 'LEAK: non-admin reads spectrum_exposures (% rows)', n; END IF;
+END $$;
+
+-- =========================================================================
+-- D. recover via the RPC (admin) -> visible again + admin reads intermediates
+-- =========================================================================
+SELECT set_config('request.jwt.claims',
+  json_build_object('sub', :'ADMIN', 'role', 'authenticated')::text, true);
+
+DO $$
+DECLARE ids int[]; flag boolean; n int;
+BEGIN
+  SELECT array_agg(id) INTO ids FROM _o3spec;
+  PERFORM public.set_spectra_deploy_status(
+    p_spectrum_db_ids := ids, p_to := 'published', p_action := 'recover',
+    p_actor := '11111111-1111-1111-1111-111111111111'::uuid);
+
+  SELECT has_published_spectrum INTO flag FROM public.objects WHERE id = 3;
+  IF flag IS NOT TRUE THEN
+    RAISE EXCEPTION 'RECOMPUTE: object 3 has_published_spectrum=% after recover (expected true)', flag;
+  END IF;
+  SELECT count(*) INTO n FROM public.spectrum_exposures;
+  IF n < 1 THEN RAISE EXCEPTION 'ADMIN BLOCKED: admin cannot read spectrum_exposures (got %)', n; END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.deploy_events WHERE action = 'recover' AND status_to = 'published') THEN
+    RAISE EXCEPTION 'AUDIT: no deploy_events row for the recover';
+  END IF;
+END $$;
+
+-- =========================================================================
+-- E. NON-ADMIN sees the recovered object again (regression guard)
+-- =========================================================================
+SELECT set_config('request.jwt.claims',
+  json_build_object('sub', :'USER', 'role', 'authenticated')::text, true);
+
+DO $$
+DECLARE n int;
+BEGIN
+  SELECT count(*) INTO n FROM public.objects WHERE id = 3;
+  IF n <> 1 THEN RAISE EXCEPTION 'REGRESSION: non-admin cannot see recovered object 3 (got %, expected 1)', n; END IF;
+END $$;
+
+-- =========================================================================
+-- F. service_role can write an 'upload' audit event (the deploy path)
+-- =========================================================================
+RESET ROLE;
+SET LOCAL ROLE service_role;
+SELECT set_config('request.jwt.claims', json_build_object('role', 'service_role')::text, true);
+
+DO $$
+DECLARE ev uuid;
+BEGIN
+  ev := public.log_deploy_event(p_action := 'upload', p_observation := 'harness_obs', p_affected_count := 3);
+  IF ev IS NULL THEN RAISE EXCEPTION 'service_role could not log_deploy_event'; END IF;
+END $$;
+
+-- =========================================================================
+-- G. a NON-ADMIN authenticated caller is DENIED the lifecycle RPC
+-- =========================================================================
+RESET ROLE;
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claims',
+  json_build_object('sub', :'USER', 'role', 'authenticated')::text, true);
+
+DO $$
+DECLARE denied boolean := false;
+BEGIN
+  BEGIN
+    PERFORM public.set_spectra_deploy_status(p_spectrum_db_ids := ARRAY[1], p_to := 'revoked');
+  EXCEPTION WHEN OTHERS THEN
+    denied := true;  -- expected: 'Access denied: Admin privileges required'
+  END;
+  IF NOT denied THEN
+    RAISE EXCEPTION 'GATE: non-admin was allowed to call set_spectra_deploy_status';
+  END IF;
+END $$;
+
+RESET ROLE;
+SELECT '✅ B2 LIFECYCLE HARNESS: ALL ASSERTIONS PASSED' AS result;
+
+ROLLBACK;

--- a/python/tests/sql/b2_lifecycle.sql
+++ b/python/tests/sql/b2_lifecycle.sql
@@ -46,7 +46,24 @@ END $$;
 INSERT INTO public.spectrum_exposures (spectrum_id, exposure_ref, stage)
   SELECT (SELECT id FROM _o3spec ORDER BY id LIMIT 1), 'harness_root_1_nrs1_999', 'cal';
 
-GRANT SELECT ON _o3tgt, _o3spec TO authenticated, service_role;
+-- A deployment for object 3's observation, to exercise the DEPLOYMENT-level
+-- lifecycle (set_deployment_status) — the path B3's admin UI uses (section H).
+CREATE TEMP TABLE _o3dep AS
+  SELECT (SELECT observation FROM public.targets
+          WHERE object_id = 3 AND observation IS NOT NULL LIMIT 1) AS obs,
+         NULL::integer AS dep_id;
+DO $$ BEGIN
+  IF (SELECT obs FROM _o3dep) IS NULL THEN
+    RAISE EXCEPTION 'FIXTURE: object 3 targets carry no observation — seed shape changed';
+  END IF;
+END $$;
+INSERT INTO public.deployments (observation, deployed_by, status)
+  SELECT obs, '11111111-1111-1111-1111-111111111111'::uuid, 'published' FROM _o3dep;
+UPDATE _o3dep SET dep_id = (
+  SELECT id FROM public.deployments
+  WHERE observation = (SELECT obs FROM _o3dep) ORDER BY id DESC LIMIT 1);
+
+GRANT SELECT ON _o3tgt, _o3spec, _o3dep TO authenticated, service_role;
 
 -- =========================================================================
 -- A. capability marker enabled (B1 applied), checked as ADMIN
@@ -184,6 +201,51 @@ BEGIN
   END;
   IF NOT denied THEN
     RAISE EXCEPTION 'GATE: non-admin was allowed to call set_spectra_deploy_status';
+  END IF;
+END $$;
+
+-- =========================================================================
+-- H. DEPLOYMENT-level revoke -> recover restores visibility (#233 regression)
+-- =========================================================================
+-- The path B3's admin UI uses. Recover (set_deployment_status -> 'published')
+-- MUST flip the deployment's *revoked* spectra back to published — the prior
+-- version only matched 'in_prep', silently leaving them hidden ("0 updated").
+RESET ROLE;
+SET LOCAL ROLE service_role;
+SELECT set_config('request.jwt.claims', json_build_object('role', 'service_role')::text, true);
+
+DO $$
+DECLARE v_dep int; v_obs text; r json; v_status text;
+BEGIN
+  SELECT dep_id, obs INTO v_dep, v_obs FROM _o3dep;
+
+  -- Revoke the whole deployment: every published spectrum of the obs -> revoked.
+  r := public.set_deployment_status(v_dep, 'revoked');
+  IF EXISTS (SELECT 1 FROM public.spectra s JOIN public.targets t ON s.target_id = t.target_id
+             WHERE t.observation = v_obs AND s.deploy_status = 'published') THEN
+    RAISE EXCEPTION 'DEPLOY REVOKE: a published spectrum survived the deployment revoke';
+  END IF;
+
+  -- Recover the whole deployment: the revoked spectra MUST become published again.
+  r := public.set_deployment_status(v_dep, 'published');
+  IF EXISTS (SELECT 1 FROM public.spectra s JOIN public.targets t ON s.target_id = t.target_id
+             WHERE t.observation = v_obs AND s.deploy_status = 'revoked') THEN
+    RAISE EXCEPTION 'DEPLOY RECOVER BUG (#233): spectra still revoked after deployment recover';
+  END IF;
+  IF (r->'spectra'->>'updated')::int = 0 THEN
+    RAISE EXCEPTION 'DEPLOY RECOVER BUG (#233): 0 spectra updated (the silent failure)';
+  END IF;
+
+  -- Recover is audited as 'recover' (not a first 'publish').
+  IF NOT EXISTS (SELECT 1 FROM public.deploy_events
+                 WHERE action = 'recover' AND deployment_id = v_dep) THEN
+    RAISE EXCEPTION 'AUDIT: deployment recover not labelled recover';
+  END IF;
+
+  -- Deployment row reflects published with a stamped published_at.
+  SELECT status INTO v_status FROM public.deployments WHERE id = v_dep;
+  IF v_status <> 'published' THEN
+    RAISE EXCEPTION 'DEPLOY: deployment row is % after recover, expected published', v_status;
   END IF;
 END $$;
 

--- a/python/tests/test_lifecycle_deploy.py
+++ b/python/tests/test_lifecycle_deploy.py
@@ -1,0 +1,112 @@
+"""Unit tests for the B2 (#218) deploy-side lifecycle plumbing.
+
+Pure-Python: a tiny fake Supabase client captures/serves the PostgREST chain so
+we can assert the deploy logic without a DB. The DB-backed behaviour (the RPCs,
+RLS, recompute) is covered by ``test_lifecycle_rls.py`` against a local instance.
+"""
+import types
+
+from campfire.deploy.deploy import _count_published_spectra
+from campfire.deploy.supabase import insert_deployment
+
+
+# ---------------------------------------------------------------------------
+# fake client: supports .table().select().in_().eq().execute() and .insert()
+# ---------------------------------------------------------------------------
+
+class _FakeQuery:
+    def __init__(self, rows, captured):
+        self._rows = rows
+        self._in = None
+        self._eq = []
+        self._captured = captured
+
+    def select(self, *a, **k):
+        return self
+
+    def in_(self, col, vals):
+        self._in = (col, set(vals))
+        return self
+
+    def eq(self, col, val):
+        self._eq.append((col, val))
+        return self
+
+    def insert(self, data):
+        self._captured.append(data)
+        return self
+
+    def execute(self):
+        rows = list(self._rows)
+        if self._in:
+            col, vals = self._in
+            rows = [r for r in rows if r.get(col) in vals]
+        for col, val in self._eq:
+            rows = [r for r in rows if r.get(col) == val]
+        # insert() returns a row with an id (mimic deployments insert)
+        if self._captured:
+            return types.SimpleNamespace(data=[{**self._captured[-1], "id": 42}])
+        return types.SimpleNamespace(data=rows)
+
+
+class _FakeClient:
+    def __init__(self, rows=None):
+        self._rows = rows or []
+        self.inserted = []
+
+    def table(self, name):
+        return _FakeQuery(self._rows, self.inserted)
+
+
+# ---------------------------------------------------------------------------
+# _count_published_spectra: the --in-prep "would hide live data" guard
+# ---------------------------------------------------------------------------
+
+def test_count_published_spectra_counts_only_matching_pairs():
+    existing = [
+        {"target_id": "t1", "grating": "prism", "deploy_status": "published"},
+        {"target_id": "t1", "grating": "g140m", "deploy_status": "published"},
+        {"target_id": "t2", "grating": "prism", "deploy_status": "in_prep"},  # not published
+    ]
+    client = _FakeClient(existing)
+    # Deploying t1/prism (live) + t2/prism (draft) + t3/prism (new) -> only t1/prism counts.
+    spectra = [
+        {"target_id": "t1", "grating": "prism"},
+        {"target_id": "t2", "grating": "prism"},
+        {"target_id": "t3", "grating": "prism"},
+    ]
+    assert _count_published_spectra(client, spectra) == 1
+
+
+def test_count_published_spectra_zero_for_all_new():
+    client = _FakeClient([])  # nothing exists yet
+    spectra = [{"target_id": "t9", "grating": "prism"}]
+    assert _count_published_spectra(client, spectra) == 0
+
+
+# ---------------------------------------------------------------------------
+# insert_deployment: status threading + published_at stamping
+# ---------------------------------------------------------------------------
+
+def test_insert_deployment_published_stamps_published_at():
+    client = _FakeClient()
+    dep_id = insert_deployment(client, observation="obs", deployed_by="u1",
+                               status="published")
+    assert dep_id == 42
+    rec = client.inserted[-1]
+    assert rec["status"] == "published"
+    assert rec.get("published_at")  # stamped on a published deploy
+
+
+def test_insert_deployment_in_prep_leaves_published_at_null():
+    client = _FakeClient()
+    insert_deployment(client, observation="obs", deployed_by="u1", status="in_prep")
+    rec = client.inserted[-1]
+    assert rec["status"] == "in_prep"
+    assert "published_at" not in rec  # draft: no publish stamp until an admin publishes
+
+
+def test_insert_deployment_defaults_to_published():
+    client = _FakeClient()
+    insert_deployment(client, observation="obs", deployed_by="u1")
+    assert client.inserted[-1]["status"] == "published"

--- a/python/tests/test_lifecycle_rls.py
+++ b/python/tests/test_lifecycle_rls.py
@@ -1,0 +1,67 @@
+"""B2 (#218) intermediate-product lifecycle gate.
+
+DB-backed integration test: runs ``sql/b2_lifecycle.sql`` against the local
+Supabase Postgres via ``docker exec ... psql`` and asserts the harness reaches
+its PASS marker. The SQL drives the seed's published control object through a
+full revoke -> recover cycle using the B2 lifecycle RPCs (inside a rolled-back
+transaction) and proves end to end that:
+
+  * ``get_lifecycle_status().enabled`` is true (the ``--in-prep`` capability gate),
+  * ``set_spectra_deploy_status`` flips deploy_status, recomputes
+    targets/objects.has_published_spectrum, and writes a deploy_events audit row,
+  * a non-admin sees ZERO revoked rows and ZERO admin-only-table rows through RLS,
+  * a non-admin is denied the lifecycle RPC, while service_role / admin are not.
+
+Skips automatically when the local Supabase DB container is not reachable (no-op
+without ``supabase start``). In CI it runs after ``supabase db reset``. Companion
+to ``test_deploy_status_rls.py`` (B1): B1 proves the readers hide unpublished
+data; this proves the RPCs that produce and reverse that state are correct.
+"""
+import subprocess
+from pathlib import Path
+
+import pytest
+
+CONTAINER = "supabase_db_campfire"
+SQL_FILE = Path(__file__).parent / "sql" / "b2_lifecycle.sql"
+PASS_MARKER = "B2 LIFECYCLE HARNESS: ALL ASSERTIONS PASSED"
+
+
+def _docker_psql_available() -> bool:
+    """True iff the local Supabase Postgres container answers a trivial query."""
+    try:
+        r = subprocess.run(
+            ["docker", "exec", "-i", CONTAINER,
+             "psql", "-U", "postgres", "-d", "postgres", "-tA", "-c", "SELECT 1"],
+            capture_output=True, text=True, timeout=15,
+        )
+        return r.returncode == 0 and r.stdout.strip().startswith("1")
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return False
+
+
+requires_local_db = pytest.mark.skipif(
+    not _docker_psql_available(),
+    reason=f"local Supabase container '{CONTAINER}' not reachable (run `supabase start` + `supabase db reset`)",
+)
+
+
+@requires_local_db
+def test_lifecycle_publish_revoke_no_leak():
+    """The full revoke/recover lifecycle keeps unpublished data hidden + audited."""
+    sql = SQL_FILE.read_text()
+    result = subprocess.run(
+        ["docker", "exec", "-i", CONTAINER,
+         "psql", "-U", "postgres", "-d", "postgres", "-v", "ON_ERROR_STOP=1", "-f", "-"],
+        input=sql, capture_output=True, text=True, timeout=120,
+    )
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, (
+        f"B2 lifecycle harness FAILED (psql exit {result.returncode}).\n"
+        f"A lifecycle RPC mis-transitioned status, skipped a has_published_spectrum "
+        f"recompute, missed an audit row, or leaked an admin-only row to a non-admin. "
+        f"Output:\n{combined}"
+    )
+    assert PASS_MARKER in result.stdout, (
+        f"B2 lifecycle harness did not reach its PASS marker.\nOutput:\n{combined}"
+    )

--- a/supabase/migrations/20260629025904_add_intermediate_lifecycle_b2.sql
+++ b/supabase/migrations/20260629025904_add_intermediate_lifecycle_b2.sql
@@ -1,0 +1,575 @@
+create sequence "public"."spectrum_exposures_id_seq";
+
+drop materialized view if exists "public"."mv_filter_options";
+
+drop materialized view if exists "public"."mv_programs_overview";
+
+drop view if exists "public"."nircam_reduction_progress";
+
+drop view if exists "public"."spectrum_flag_summary";
+
+
+  create table "public"."deploy_events" (
+    "id" uuid not null default gen_random_uuid(),
+    "actor" uuid,
+    "action" text not null,
+    "deployment_id" integer,
+    "observation" text,
+    "spectrum_id" text,
+    "object_id" integer,
+    "status_from" text,
+    "status_to" text,
+    "affected_count" integer,
+    "host" text,
+    "metadata" jsonb,
+    "occurred_at" timestamp with time zone not null default now()
+      );
+
+
+alter table "public"."deploy_events" enable row level security;
+
+
+  create table "public"."spectrum_exposures" (
+    "id" integer not null default nextval('public.spectrum_exposures_id_seq'::regclass),
+    "spectrum_id" integer not null,
+    "exposure_ref" text not null,
+    "root" text,
+    "nod" integer,
+    "detector" text,
+    "source_id" integer,
+    "grating" text,
+    "stage" text not null default 'cal'::text,
+    "review_status" text not null default 'pending'::text,
+    "masking" text not null default 'none'::text,
+    "notes" text,
+    "created_at" timestamp with time zone not null default now(),
+    "updated_at" timestamp with time zone not null default now()
+      );
+
+
+alter table "public"."spectrum_exposures" enable row level security;
+
+alter table "public"."deployments" add column "published_at" timestamp with time zone;
+
+alter table "public"."deployments" add column "revoked_at" timestamp with time zone;
+
+alter table "public"."deployments" add column "status" text not null default 'published'::text;
+
+alter sequence "public"."spectrum_exposures_id_seq" owned by "public"."spectrum_exposures"."id";
+
+CREATE UNIQUE INDEX deploy_events_pkey ON public.deploy_events USING btree (id);
+
+CREATE INDEX idx_deploy_events_deployment_id ON public.deploy_events USING btree (deployment_id) WHERE (deployment_id IS NOT NULL);
+
+CREATE INDEX idx_deploy_events_occurred_at ON public.deploy_events USING btree (occurred_at DESC);
+
+CREATE INDEX idx_spectrum_exposures_exposure_ref ON public.spectrum_exposures USING btree (exposure_ref);
+
+CREATE INDEX idx_spectrum_exposures_review ON public.spectrum_exposures USING btree (review_status) WHERE (review_status <> 'approved'::text);
+
+CREATE INDEX idx_spectrum_exposures_spectrum_id ON public.spectrum_exposures USING btree (spectrum_id);
+
+CREATE UNIQUE INDEX spectrum_exposures_pkey ON public.spectrum_exposures USING btree (id);
+
+CREATE UNIQUE INDEX spectrum_exposures_unique ON public.spectrum_exposures USING btree (spectrum_id, exposure_ref);
+
+alter table "public"."deploy_events" add constraint "deploy_events_pkey" PRIMARY KEY using index "deploy_events_pkey";
+
+alter table "public"."spectrum_exposures" add constraint "spectrum_exposures_pkey" PRIMARY KEY using index "spectrum_exposures_pkey";
+
+alter table "public"."deploy_events" add constraint "deploy_events_action_check" CHECK ((action = ANY (ARRAY['upload'::text, 'publish'::text, 'revoke'::text, 'recover'::text, 'supersede'::text, 'delete'::text]))) not valid;
+
+alter table "public"."deploy_events" validate constraint "deploy_events_action_check";
+
+alter table "public"."deploy_events" add constraint "deploy_events_deployment_id_fkey" FOREIGN KEY (deployment_id) REFERENCES public.deployments(id) ON DELETE SET NULL not valid;
+
+alter table "public"."deploy_events" validate constraint "deploy_events_deployment_id_fkey";
+
+alter table "public"."deployments" add constraint "deployments_status_check" CHECK ((status = ANY (ARRAY['in_prep'::text, 'published'::text, 'revoked'::text]))) not valid;
+
+alter table "public"."deployments" validate constraint "deployments_status_check";
+
+alter table "public"."spectrum_exposures" add constraint "spectrum_exposures_spectrum_id_fkey" FOREIGN KEY (spectrum_id) REFERENCES public.spectra(id) ON DELETE CASCADE not valid;
+
+alter table "public"."spectrum_exposures" validate constraint "spectrum_exposures_spectrum_id_fkey";
+
+alter table "public"."spectrum_exposures" add constraint "spectrum_exposures_unique" UNIQUE using index "spectrum_exposures_unique";
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_lifecycle_status()
+ RETURNS json
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_is_admin boolean;
+  v_has_status_col boolean;
+  v_has_target_flag boolean;
+  v_reader_threaded boolean;
+BEGIN
+  SELECT COALESCE(up.is_admin, false) INTO v_is_admin
+  FROM user_profiles up WHERE up.user_id = auth.uid();
+  IF NOT (COALESCE(v_is_admin, false) OR COALESCE(auth.role(), '') = 'service_role') THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'spectra' AND column_name = 'deploy_status'
+  ) INTO v_has_status_col;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'targets' AND column_name = 'has_published_spectrum'
+  ) INTO v_has_target_flag;
+
+  -- A representative reader RPC must carry the predicate parameter — proof that
+  -- B1's reader-threading (not just the column) is deployed.
+  SELECT EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'get_filtered_object_ids'
+      AND pg_get_function_arguments(p.oid) LIKE '%p_include_unpublished%'
+  ) INTO v_reader_threaded;
+
+  RETURN json_build_object(
+    'enabled', (v_has_status_col AND v_has_target_flag AND v_reader_threaded),
+    'version', 1,
+    'checks', json_build_object(
+      'spectra_deploy_status', v_has_status_col,
+      'targets_has_published_spectrum', v_has_target_flag,
+      'reader_p_include_unpublished', v_reader_threaded
+    )
+  );
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.log_deploy_event(p_action text, p_actor uuid DEFAULT NULL::uuid, p_deployment_id integer DEFAULT NULL::integer, p_observation text DEFAULT NULL::text, p_affected_count integer DEFAULT NULL::integer, p_metadata jsonb DEFAULT NULL::jsonb, p_host text DEFAULT NULL::text)
+ RETURNS uuid
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_is_admin boolean;
+  v_id uuid;
+BEGIN
+  SELECT COALESCE(up.is_admin, false) INTO v_is_admin
+  FROM user_profiles up WHERE up.user_id = auth.uid();
+  IF NOT (COALESCE(v_is_admin, false) OR COALESCE(auth.role(), '') = 'service_role') THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+
+  IF p_action NOT IN ('upload', 'publish', 'revoke', 'recover', 'supersede', 'delete') THEN
+    RAISE EXCEPTION 'Invalid deploy_event action: %', p_action;
+  END IF;
+
+  INSERT INTO deploy_events(actor, action, deployment_id, observation, affected_count, metadata, host)
+  VALUES (p_actor, p_action, p_deployment_id, p_observation, p_affected_count, p_metadata, p_host)
+  RETURNING id INTO v_id;
+  RETURN v_id;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.recompute_has_published_spectrum(p_target_ids text[] DEFAULT NULL::text[], p_field text DEFAULT NULL::text)
+ RETURNS json
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_is_admin boolean;
+  v_targets text[];
+  v_n_targets int := 0;
+  v_n_objects int := 0;
+BEGIN
+  SELECT COALESCE(up.is_admin, false) INTO v_is_admin
+  FROM user_profiles up WHERE up.user_id = auth.uid();
+  IF NOT (COALESCE(v_is_admin, false) OR COALESCE(auth.role(), '') = 'service_role') THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+
+  IF p_target_ids IS NOT NULL THEN
+    v_targets := p_target_ids;
+  ELSIF p_field IS NOT NULL THEN
+    SELECT array_agg(t.target_id) INTO v_targets FROM targets t WHERE t.field = p_field;
+  ELSE
+    RAISE EXCEPTION 'recompute_has_published_spectrum requires p_target_ids or p_field';
+  END IF;
+
+  IF v_targets IS NULL OR array_length(v_targets, 1) IS NULL THEN
+    RETURN json_build_object('targets_updated', 0, 'objects_updated', 0);
+  END IF;
+
+  UPDATE targets t
+  SET has_published_spectrum = EXISTS (
+        SELECT 1 FROM spectra s
+        WHERE s.target_id = t.target_id AND s.deploy_status = 'published'
+      )
+  WHERE t.target_id = ANY(v_targets);
+  GET DIAGNOSTICS v_n_targets = ROW_COUNT;
+
+  UPDATE objects o
+  SET has_published_spectrum = EXISTS (
+        SELECT 1 FROM targets t WHERE t.object_id = o.id AND t.has_published_spectrum
+      )
+  WHERE o.id IN (
+    SELECT DISTINCT t2.object_id FROM targets t2
+    WHERE t2.target_id = ANY(v_targets) AND t2.object_id IS NOT NULL
+  );
+  GET DIAGNOSTICS v_n_objects = ROW_COUNT;
+
+  RETURN json_build_object('targets_updated', v_n_targets, 'objects_updated', v_n_objects);
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.set_deployment_status(p_deployment_id integer, p_to text, p_actor uuid DEFAULT NULL::uuid, p_host text DEFAULT NULL::text)
+ RETURNS json
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_is_admin boolean;
+  v_obs text;
+  v_from text;
+  v_action text;
+  v_spectrum_ids integer[];
+  v_result json;
+BEGIN
+  SELECT COALESCE(up.is_admin, false) INTO v_is_admin
+  FROM user_profiles up WHERE up.user_id = auth.uid();
+  IF NOT (COALESCE(v_is_admin, false) OR COALESCE(auth.role(), '') = 'service_role') THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+
+  IF p_to NOT IN ('in_prep', 'published', 'revoked') THEN
+    RAISE EXCEPTION 'Invalid status: %', p_to;
+  END IF;
+
+  SELECT observation INTO v_obs FROM deployments WHERE id = p_deployment_id;
+  IF v_obs IS NULL THEN
+    RAISE EXCEPTION 'Deployment % not found', p_deployment_id;
+  END IF;
+
+  -- publish: in_prep->published; revoke: published->revoked; in_prep: published->in_prep.
+  v_from := CASE p_to WHEN 'published' THEN 'in_prep' WHEN 'revoked' THEN 'published' ELSE 'published' END;
+  v_action := CASE p_to WHEN 'published' THEN 'publish' WHEN 'revoked' THEN 'revoke' ELSE 'upload' END;
+
+  SELECT array_agg(s.id) INTO v_spectrum_ids
+  FROM spectra s JOIN targets t ON s.target_id = t.target_id
+  WHERE t.observation = v_obs AND s.deploy_status = v_from;
+
+  UPDATE deployments SET
+    status = p_to,
+    published_at = CASE WHEN p_to = 'published' THEN now() ELSE published_at END,
+    revoked_at = CASE WHEN p_to = 'revoked' THEN now() ELSE revoked_at END
+  WHERE id = p_deployment_id;
+
+  IF v_spectrum_ids IS NOT NULL THEN
+    v_result := public.set_spectra_deploy_status(
+      p_spectrum_db_ids := v_spectrum_ids, p_to := p_to, p_action := v_action,
+      p_actor := p_actor, p_deployment_id := p_deployment_id, p_host := p_host);
+  ELSE
+    v_result := json_build_object('updated', 0, 'action', v_action);
+  END IF;
+
+  RETURN json_build_object(
+    'deployment_id', p_deployment_id, 'observation', v_obs,
+    'status', p_to, 'spectra', v_result);
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.set_spectra_deploy_status(p_spectrum_db_ids integer[], p_to text, p_action text DEFAULT NULL::text, p_actor uuid DEFAULT NULL::uuid, p_deployment_id integer DEFAULT NULL::integer, p_host text DEFAULT NULL::text)
+ RETURNS json
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_is_admin boolean;
+  v_action text;
+  v_updated int := 0;
+  v_target_ids text[];
+  v_recompute json;
+BEGIN
+  SELECT COALESCE(up.is_admin, false) INTO v_is_admin
+  FROM user_profiles up WHERE up.user_id = auth.uid();
+  IF NOT (COALESCE(v_is_admin, false) OR COALESCE(auth.role(), '') = 'service_role') THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+
+  IF p_to NOT IN ('in_prep', 'published', 'revoked') THEN
+    RAISE EXCEPTION 'Invalid deploy_status: %', p_to;
+  END IF;
+
+  v_action := COALESCE(p_action,
+    CASE p_to WHEN 'published' THEN 'publish' WHEN 'revoked' THEN 'revoke' ELSE 'upload' END);
+  IF v_action NOT IN ('upload', 'publish', 'revoke', 'recover', 'supersede', 'delete') THEN
+    RAISE EXCEPTION 'Invalid action: %', v_action;
+  END IF;
+
+  IF p_spectrum_db_ids IS NULL OR array_length(p_spectrum_db_ids, 1) IS NULL THEN
+    RETURN json_build_object('updated', 0, 'action', v_action);
+  END IF;
+
+  SELECT array_agg(DISTINCT s.target_id) INTO v_target_ids
+  FROM spectra s WHERE s.id = ANY(p_spectrum_db_ids);
+
+  UPDATE spectra s SET deploy_status = p_to
+  WHERE s.id = ANY(p_spectrum_db_ids) AND s.deploy_status <> p_to;
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+
+  IF v_target_ids IS NOT NULL THEN
+    v_recompute := public.recompute_has_published_spectrum(p_target_ids := v_target_ids);
+  END IF;
+
+  INSERT INTO deploy_events(actor, action, deployment_id, status_to, affected_count, host, metadata)
+  VALUES (p_actor, v_action, p_deployment_id, p_to, v_updated, p_host,
+          jsonb_build_object('n_targets', COALESCE(array_length(v_target_ids, 1), 0)));
+
+  RETURN json_build_object('updated', v_updated, 'action', v_action, 'recompute', v_recompute);
+END;
+$function$
+;
+
+-- NOTE (#228): db diff re-emits can_inspect()/handle_new_user() because the
+-- declarative schema and the deployed migration differ on SET search_path
+-- (pre-existing drift tracked in #228). Stripped here to keep this B2 migration
+-- single-purpose; restore via the #228 fix, not this PR.
+
+create materialized view "public"."mv_filter_options" as  SELECT 1 AS id,
+    ARRAY( SELECT DISTINCT targets.field
+           FROM public.targets
+          WHERE targets.has_published_spectrum
+          ORDER BY targets.field) AS fields,
+    ARRAY( SELECT DISTINCT targets.observation
+           FROM public.targets
+          WHERE ((targets.observation IS NOT NULL) AND targets.has_published_spectrum)
+          ORDER BY targets.observation) AS observations,
+    ARRAY( SELECT DISTINCT spectra.grating
+           FROM public.spectra
+          WHERE (spectra.deploy_status = 'published'::text)
+          ORDER BY spectra.grating) AS gratings;
+
+
+create materialized view "public"."mv_programs_overview" as  SELECT p.slug,
+    p.program_name,
+    p.pi_name,
+    p.description,
+    p.is_public,
+    p.cycle,
+    COALESCE(stats.target_count, (0)::bigint) AS target_count,
+    COALESCE(stats.gratings, ARRAY[]::text[]) AS gratings,
+    COALESCE(stats.fields, ARRAY[]::text[]) AS fields,
+    COALESCE(stats.observations, ARRAY[]::text[]) AS observations,
+    COALESCE(pids.jwst_pids, ARRAY[]::integer[]) AS jwst_pids,
+    COALESCE(pids.n_observations, (0)::bigint) AS n_observations,
+    last_red.last_reduced_at
+   FROM (((public.programs p
+     LEFT JOIN ( SELECT t.program_slug,
+            count(DISTINCT t.target_id) AS target_count,
+            array_agg(DISTINCT s.grating ORDER BY s.grating) FILTER (WHERE (s.grating IS NOT NULL)) AS gratings,
+            array_agg(DISTINCT t.field ORDER BY t.field) AS fields,
+            array_agg(DISTINCT t.observation ORDER BY t.observation) AS observations
+           FROM (public.targets t
+             LEFT JOIN public.spectra s ON (((s.target_id = t.target_id) AND (s.deploy_status = 'published'::text))))
+          GROUP BY t.program_slug) stats ON ((p.slug = stats.program_slug)))
+     LEFT JOIN ( SELECT observations.program_slug,
+            array_agg(DISTINCT observations.jwst_program_id ORDER BY observations.jwst_program_id) AS jwst_pids,
+            count(*) AS n_observations
+           FROM public.observations
+          GROUP BY observations.program_slug) pids ON ((p.slug = pids.program_slug)))
+     LEFT JOIN ( SELECT o.program_slug,
+            max(d.reduced_at) AS last_reduced_at
+           FROM (public.observations o
+             JOIN public.deployments d ON ((d.observation = o.name)))
+          WHERE (d.source_ids_filter IS NULL)
+          GROUP BY o.program_slug) last_red ON ((p.slug = last_red.program_slug)));
+
+-- B2 (#218): migra recreates the matviews but does NOT track their unique indexes;
+-- restore them (REFRESH ... CONCURRENTLY requires a unique index). Validated by
+-- the check-mv-indexes CI job.
+CREATE UNIQUE INDEX mv_filter_options_id ON public.mv_filter_options USING btree (id);
+CREATE UNIQUE INDEX mv_programs_overview_slug ON public.mv_programs_overview USING btree (slug);
+
+-- B2 (#218): security_invoker restored (migra drops the view option on recreate).
+create or replace view "public"."nircam_reduction_progress" with (security_invoker = true) as  SELECT field,
+    filter,
+    count(*) AS total,
+    count(*) FILTER (WHERE (stage = 'uncal'::text)) AS at_uncal,
+    count(*) FILTER (WHERE (stage = 'detector1'::text)) AS at_detector1,
+    count(*) FILTER (WHERE (stage = 'persistence'::text)) AS at_persistence,
+    count(*) FILTER (WHERE (stage = 'wisp'::text)) AS at_wisp,
+    count(*) FILTER (WHERE (stage = 'striping'::text)) AS at_striping,
+    count(*) FILTER (WHERE (stage = 'image2'::text)) AS at_image2,
+    count(*) FILTER (WHERE (stage = 'edge'::text)) AS at_edge,
+    count(*) FILTER (WHERE (stage = 'sky'::text)) AS at_sky,
+    count(*) FILTER (WHERE (stage = 'diag_striping'::text)) AS at_diag_striping,
+    count(*) FILTER (WHERE (stage = 'variance'::text)) AS at_variance,
+    count(*) FILTER (WHERE (stage = 'wcs_shift'::text)) AS at_wcs_shift,
+    count(*) FILTER (WHERE (stage = 'preview'::text)) AS at_preview,
+    count(*) FILTER (WHERE (stage = 'jhat'::text)) AS at_jhat,
+    count(*) FILTER (WHERE (stage = 'apply_mask'::text)) AS at_apply_mask,
+    count(*) FILTER (WHERE (stage = 'bad_pixel'::text)) AS at_bad_pixel,
+    count(*) FILTER (WHERE (stage = 'outlier'::text)) AS at_outlier,
+    count(*) FILTER (WHERE (review_status = 'pending'::text)) AS pending_review,
+    count(*) FILTER (WHERE (review_status = 'approved'::text)) AS approved,
+    count(*) FILTER (WHERE (review_status = 'excluded'::text)) AS excluded,
+    count(*) FILTER (WHERE (masking = 'needed'::text)) AS needs_masking,
+    count(*) FILTER (WHERE (correction = 'needed'::text)) AS needs_correction
+   FROM public.nircam_exposures
+  GROUP BY field, filter;
+
+
+-- B2 (#218): security_invoker restored (migra drops the view option on recreate).
+create or replace view "public"."spectrum_flag_summary" with (security_invoker = true) as  SELECT s.id,
+    s.target_id,
+    s.grating,
+    array_agg(DISTINCT fd.label) FILTER (WHERE ((fd.category = 'dq_flags'::text) AND ((s.dq_flags & fd.value) > 0))) AS dq_flags_labels
+   FROM (public.spectra s
+     CROSS JOIN public.flag_definitions fd)
+  WHERE ((s.deploy_status = 'published'::text) OR public.is_admin())
+  GROUP BY s.id, s.target_id, s.grating;
+
+
+grant delete on table "public"."deploy_events" to "anon";
+
+grant insert on table "public"."deploy_events" to "anon";
+
+grant references on table "public"."deploy_events" to "anon";
+
+grant select on table "public"."deploy_events" to "anon";
+
+grant trigger on table "public"."deploy_events" to "anon";
+
+grant truncate on table "public"."deploy_events" to "anon";
+
+grant update on table "public"."deploy_events" to "anon";
+
+grant delete on table "public"."deploy_events" to "authenticated";
+
+grant insert on table "public"."deploy_events" to "authenticated";
+
+grant references on table "public"."deploy_events" to "authenticated";
+
+grant select on table "public"."deploy_events" to "authenticated";
+
+grant trigger on table "public"."deploy_events" to "authenticated";
+
+grant truncate on table "public"."deploy_events" to "authenticated";
+
+grant update on table "public"."deploy_events" to "authenticated";
+
+grant delete on table "public"."deploy_events" to "service_role";
+
+grant insert on table "public"."deploy_events" to "service_role";
+
+grant references on table "public"."deploy_events" to "service_role";
+
+grant select on table "public"."deploy_events" to "service_role";
+
+grant trigger on table "public"."deploy_events" to "service_role";
+
+grant truncate on table "public"."deploy_events" to "service_role";
+
+grant update on table "public"."deploy_events" to "service_role";
+
+grant delete on table "public"."spectrum_exposures" to "anon";
+
+grant insert on table "public"."spectrum_exposures" to "anon";
+
+grant references on table "public"."spectrum_exposures" to "anon";
+
+grant select on table "public"."spectrum_exposures" to "anon";
+
+grant trigger on table "public"."spectrum_exposures" to "anon";
+
+grant truncate on table "public"."spectrum_exposures" to "anon";
+
+grant update on table "public"."spectrum_exposures" to "anon";
+
+grant delete on table "public"."spectrum_exposures" to "authenticated";
+
+grant insert on table "public"."spectrum_exposures" to "authenticated";
+
+grant references on table "public"."spectrum_exposures" to "authenticated";
+
+grant select on table "public"."spectrum_exposures" to "authenticated";
+
+grant trigger on table "public"."spectrum_exposures" to "authenticated";
+
+grant truncate on table "public"."spectrum_exposures" to "authenticated";
+
+grant update on table "public"."spectrum_exposures" to "authenticated";
+
+grant delete on table "public"."spectrum_exposures" to "service_role";
+
+grant insert on table "public"."spectrum_exposures" to "service_role";
+
+grant references on table "public"."spectrum_exposures" to "service_role";
+
+grant select on table "public"."spectrum_exposures" to "service_role";
+
+grant trigger on table "public"."spectrum_exposures" to "service_role";
+
+grant truncate on table "public"."spectrum_exposures" to "service_role";
+
+grant update on table "public"."spectrum_exposures" to "service_role";
+
+
+  create policy "admin_select_deploy_events"
+  on "public"."deploy_events"
+  as permissive
+  for select
+  to authenticated
+using (( SELECT public.is_admin() AS is_admin));
+
+
+
+  create policy "admin_deployments_update"
+  on "public"."deployments"
+  as permissive
+  for update
+  to authenticated
+using (( SELECT public.is_admin() AS is_admin))
+with check (( SELECT public.is_admin() AS is_admin));
+
+
+
+  create policy "admin_insert_spectrum_exposures"
+  on "public"."spectrum_exposures"
+  as permissive
+  for insert
+  to authenticated
+with check (( SELECT public.is_admin() AS is_admin));
+
+
+
+  create policy "admin_select_spectrum_exposures"
+  on "public"."spectrum_exposures"
+  as permissive
+  for select
+  to authenticated
+using (( SELECT public.is_admin() AS is_admin));
+
+
+
+  create policy "admin_update_spectrum_exposures"
+  on "public"."spectrum_exposures"
+  as permissive
+  for update
+  to authenticated
+using (( SELECT public.is_admin() AS is_admin))
+with check (( SELECT public.is_admin() AS is_admin));
+
+
+
+
+-- B2 (#218): COMMENT ON statements (migra does not track comments; hand-appended
+-- so production, built from migrations, carries the same documentation as the
+-- declarative schema files).
+COMMENT ON TABLE "public"."spectrum_exposures" IS 'NIRSpec canonical spectrum-exposure intermediates (epic #210, B2). One logical row per (exposure,detector,source); child of spectra (FK to integer PK). Registered to storage_objects with product_type=''nirspec_spectrum_exposure''. Admin-only lifecycle (intermediates are never user-facing science).';
+COMMENT ON COLUMN "public"."spectrum_exposures"."spectrum_id" IS 'FK to spectra.id (the stable integer PK, NOT the GENERATED spectra.spectrum_id text column which is not uniquely constrained). ON DELETE CASCADE: intermediates die with their parent spectrum and are rebuilt on the next deploy.';
+COMMENT ON COLUMN "public"."spectrum_exposures"."exposure_ref" IS 'Stable (root,nod,detector,source) tuple identifying the input NIRSpec exposure. Matches storage_objects.exposure_ref for the registry join; backs the partial unique (product_type, exposure_ref) WHERE status=''active'' on storage_objects.';
+COMMENT ON TABLE "public"."deploy_events" IS 'Append-only audit log for the intermediate-product lifecycle (epic #210, B2/B3). One row per action (upload/publish/revoke/recover/supersede/delete), written only by the lifecycle RPCs (SECURITY DEFINER). deployment_id is nullable (some events are not tied to a deployment). Admin-readable; never client-inserted.';

--- a/supabase/migrations/20260629025904_add_intermediate_lifecycle_b2.sql
+++ b/supabase/migrations/20260629025904_add_intermediate_lifecycle_b2.sql
@@ -232,7 +232,6 @@ AS $function$
 DECLARE
   v_is_admin boolean;
   v_obs text;
-  v_from text;
   v_action text;
   v_spectrum_ids integer[];
   v_result json;
@@ -252,13 +251,31 @@ BEGIN
     RAISE EXCEPTION 'Deployment % not found', p_deployment_id;
   END IF;
 
-  -- publish: in_prep->published; revoke: published->revoked; in_prep: published->in_prep.
-  v_from := CASE p_to WHEN 'published' THEN 'in_prep' WHEN 'revoked' THEN 'published' ELSE 'published' END;
-  v_action := CASE p_to WHEN 'published' THEN 'publish' WHEN 'revoked' THEN 'revoke' ELSE 'upload' END;
-
+  -- Which current statuses transition to p_to:
+  --   p_to='published'  -> in_prep (first publish) OR revoked (recover) become visible
+  --   p_to='revoked'    -> published spectra are hidden
+  --   p_to='in_prep'    -> published spectra go back to draft
+  -- The prior version matched only 'in_prep' for the published case, so recovering
+  -- a REVOKED deployment flipped the deployment row but left its spectra revoked
+  -- and hidden ("0 updated", silently inconsistent) — #233 review.
   SELECT array_agg(s.id) INTO v_spectrum_ids
   FROM spectra s JOIN targets t ON s.target_id = t.target_id
-  WHERE t.observation = v_obs AND s.deploy_status = v_from;
+  WHERE t.observation = v_obs
+    AND s.deploy_status = ANY (
+      CASE p_to WHEN 'published' THEN ARRAY['in_prep', 'revoked']
+                WHEN 'revoked'   THEN ARRAY['published']
+                ELSE                  ARRAY['published'] END);
+
+  -- Audit label: publishing previously-revoked spectra is a 'recover', not a
+  -- first 'publish'. Computed before the transition (spectra still hold old status).
+  v_action := CASE
+    WHEN p_to = 'revoked' THEN 'revoke'
+    WHEN p_to = 'in_prep' THEN 'upload'
+    WHEN EXISTS (SELECT 1 FROM spectra s JOIN targets t ON s.target_id = t.target_id
+                 WHERE t.observation = v_obs AND s.deploy_status = 'revoked')
+      THEN 'recover'
+    ELSE 'publish'
+  END;
 
   UPDATE deployments SET
     status = p_to,

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -3207,7 +3207,6 @@ AS $$
 DECLARE
   v_is_admin boolean;
   v_obs text;
-  v_from text;
   v_action text;
   v_spectrum_ids integer[];
   v_result json;
@@ -3227,13 +3226,31 @@ BEGIN
     RAISE EXCEPTION 'Deployment % not found', p_deployment_id;
   END IF;
 
-  -- publish: in_prep->published; revoke: published->revoked; in_prep: published->in_prep.
-  v_from := CASE p_to WHEN 'published' THEN 'in_prep' WHEN 'revoked' THEN 'published' ELSE 'published' END;
-  v_action := CASE p_to WHEN 'published' THEN 'publish' WHEN 'revoked' THEN 'revoke' ELSE 'upload' END;
-
+  -- Which current statuses transition to p_to:
+  --   p_to='published'  -> in_prep (first publish) OR revoked (recover) become visible
+  --   p_to='revoked'    -> published spectra are hidden
+  --   p_to='in_prep'    -> published spectra go back to draft
+  -- The prior version matched only 'in_prep' for the published case, so recovering
+  -- a REVOKED deployment flipped the deployment row but left its spectra revoked
+  -- and hidden ("0 updated", silently inconsistent) — #233 review.
   SELECT array_agg(s.id) INTO v_spectrum_ids
   FROM spectra s JOIN targets t ON s.target_id = t.target_id
-  WHERE t.observation = v_obs AND s.deploy_status = v_from;
+  WHERE t.observation = v_obs
+    AND s.deploy_status = ANY (
+      CASE p_to WHEN 'published' THEN ARRAY['in_prep', 'revoked']
+                WHEN 'revoked'   THEN ARRAY['published']
+                ELSE                  ARRAY['published'] END);
+
+  -- Audit label: publishing previously-revoked spectra is a 'recover', not a
+  -- first 'publish'. Computed before the transition (spectra still hold old status).
+  v_action := CASE
+    WHEN p_to = 'revoked' THEN 'revoke'
+    WHEN p_to = 'in_prep' THEN 'upload'
+    WHEN EXISTS (SELECT 1 FROM spectra s JOIN targets t ON s.target_id = t.target_id
+                 WHERE t.observation = v_obs AND s.deploy_status = 'revoked')
+      THEN 'recover'
+    ELSE 'publish'
+  END;
 
   UPDATE deployments SET
     status = p_to,

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -2961,6 +2961,304 @@ GRANT EXECUTE ON FUNCTION public.get_storage_budget TO authenticated, service_ro
 
 
 -- =============================================================================
+-- Intermediate-product lifecycle (epic #210, B2/B3)
+-- =============================================================================
+-- The publish/revoke/recover flow for in_prep science. spectra.deploy_status is
+-- the user-facing visibility gate (B1); these RPCs are the only sanctioned way
+-- to transition it, and they keep targets/objects.has_published_spectrum and the
+-- deploy_events audit log in lockstep. All are SECURITY DEFINER + admin/service_role
+-- gated (the same gate as get_storage_budget): callers are the deploy CLI
+-- (service_role / admin token) and the B3 admin web actions (admin session).
+
+-- get_lifecycle_status: the capability marker the deploy CLI checks before any
+-- `--in-prep` upload. It introspects the LIVE catalog to confirm B1 (#217) is
+-- applied to *this* database: the deploy_status column exists AND the reader RPCs
+-- actually carry the p_include_unpublished predicate. Returns enabled=false (not
+-- an error) when B1 is absent, so `deploy --in-prep` can abort cleanly; if even
+-- this function is missing, the client catches the RPC-not-found and aborts too.
+CREATE OR REPLACE FUNCTION public.get_lifecycle_status()
+RETURNS json
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_is_admin boolean;
+  v_has_status_col boolean;
+  v_has_target_flag boolean;
+  v_reader_threaded boolean;
+BEGIN
+  SELECT COALESCE(up.is_admin, false) INTO v_is_admin
+  FROM user_profiles up WHERE up.user_id = auth.uid();
+  IF NOT (COALESCE(v_is_admin, false) OR COALESCE(auth.role(), '') = 'service_role') THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'spectra' AND column_name = 'deploy_status'
+  ) INTO v_has_status_col;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'targets' AND column_name = 'has_published_spectrum'
+  ) INTO v_has_target_flag;
+
+  -- A representative reader RPC must carry the predicate parameter — proof that
+  -- B1's reader-threading (not just the column) is deployed.
+  SELECT EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'get_filtered_object_ids'
+      AND pg_get_function_arguments(p.oid) LIKE '%p_include_unpublished%'
+  ) INTO v_reader_threaded;
+
+  RETURN json_build_object(
+    'enabled', (v_has_status_col AND v_has_target_flag AND v_reader_threaded),
+    'version', 1,
+    'checks', json_build_object(
+      'spectra_deploy_status', v_has_status_col,
+      'targets_has_published_spectrum', v_has_target_flag,
+      'reader_p_include_unpublished', v_reader_threaded
+    )
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_lifecycle_status() TO authenticated, service_role;
+
+
+-- recompute_has_published_spectrum: refresh targets/objects.has_published_spectrum
+-- (the B1 object/target visibility gate) from the current spectra.deploy_status.
+-- Scope by p_target_ids (publish/revoke) or p_field (reconcile, after membership
+-- changes). A target is published iff a member spectrum is; an object is published
+-- iff a member target is. Fail-closed default is TRUE, so this MUST run after any
+-- status change or membership relink — forgetting it leaves rows over-visible.
+CREATE OR REPLACE FUNCTION public.recompute_has_published_spectrum(
+  p_target_ids text[] DEFAULT NULL,
+  p_field text DEFAULT NULL
+)
+RETURNS json
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_is_admin boolean;
+  v_targets text[];
+  v_n_targets int := 0;
+  v_n_objects int := 0;
+BEGIN
+  SELECT COALESCE(up.is_admin, false) INTO v_is_admin
+  FROM user_profiles up WHERE up.user_id = auth.uid();
+  IF NOT (COALESCE(v_is_admin, false) OR COALESCE(auth.role(), '') = 'service_role') THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+
+  IF p_target_ids IS NOT NULL THEN
+    v_targets := p_target_ids;
+  ELSIF p_field IS NOT NULL THEN
+    SELECT array_agg(t.target_id) INTO v_targets FROM targets t WHERE t.field = p_field;
+  ELSE
+    RAISE EXCEPTION 'recompute_has_published_spectrum requires p_target_ids or p_field';
+  END IF;
+
+  IF v_targets IS NULL OR array_length(v_targets, 1) IS NULL THEN
+    RETURN json_build_object('targets_updated', 0, 'objects_updated', 0);
+  END IF;
+
+  UPDATE targets t
+  SET has_published_spectrum = EXISTS (
+        SELECT 1 FROM spectra s
+        WHERE s.target_id = t.target_id AND s.deploy_status = 'published'
+      )
+  WHERE t.target_id = ANY(v_targets);
+  GET DIAGNOSTICS v_n_targets = ROW_COUNT;
+
+  UPDATE objects o
+  SET has_published_spectrum = EXISTS (
+        SELECT 1 FROM targets t WHERE t.object_id = o.id AND t.has_published_spectrum
+      )
+  WHERE o.id IN (
+    SELECT DISTINCT t2.object_id FROM targets t2
+    WHERE t2.target_id = ANY(v_targets) AND t2.object_id IS NOT NULL
+  );
+  GET DIAGNOSTICS v_n_objects = ROW_COUNT;
+
+  RETURN json_build_object('targets_updated', v_n_targets, 'objects_updated', v_n_objects);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.recompute_has_published_spectrum(text[], text) TO authenticated, service_role;
+
+
+-- log_deploy_event: append one row to the deploy_events audit log. The only
+-- sanctioned write path (deploy_events has no INSERT policy, so direct client
+-- inserts are denied). Used by the deploy CLI for 'upload' events; the set_*
+-- RPCs write their own rows inline.
+CREATE OR REPLACE FUNCTION public.log_deploy_event(
+  p_action text,
+  p_actor uuid DEFAULT NULL,
+  p_deployment_id integer DEFAULT NULL,
+  p_observation text DEFAULT NULL,
+  p_affected_count integer DEFAULT NULL,
+  p_metadata jsonb DEFAULT NULL,
+  p_host text DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_is_admin boolean;
+  v_id uuid;
+BEGIN
+  SELECT COALESCE(up.is_admin, false) INTO v_is_admin
+  FROM user_profiles up WHERE up.user_id = auth.uid();
+  IF NOT (COALESCE(v_is_admin, false) OR COALESCE(auth.role(), '') = 'service_role') THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+
+  IF p_action NOT IN ('upload', 'publish', 'revoke', 'recover', 'supersede', 'delete') THEN
+    RAISE EXCEPTION 'Invalid deploy_event action: %', p_action;
+  END IF;
+
+  INSERT INTO deploy_events(actor, action, deployment_id, observation, affected_count, metadata, host)
+  VALUES (p_actor, p_action, p_deployment_id, p_observation, p_affected_count, p_metadata, p_host)
+  RETURNING id INTO v_id;
+  RETURN v_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.log_deploy_event(text, uuid, integer, text, integer, jsonb, text) TO authenticated, service_role;
+
+
+-- set_spectra_deploy_status: the publish/revoke/recover primitive. Transitions a
+-- set of spectra (by PK) to p_to, recomputes has_published_spectrum for their
+-- targets/objects, and writes one audit row. p_action labels intent (publish vs
+-- recover both land 'published'); defaulted from p_to when omitted.
+CREATE OR REPLACE FUNCTION public.set_spectra_deploy_status(
+  p_spectrum_db_ids integer[],
+  p_to text,
+  p_action text DEFAULT NULL,
+  p_actor uuid DEFAULT NULL,
+  p_deployment_id integer DEFAULT NULL,
+  p_host text DEFAULT NULL
+)
+RETURNS json
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_is_admin boolean;
+  v_action text;
+  v_updated int := 0;
+  v_target_ids text[];
+  v_recompute json;
+BEGIN
+  SELECT COALESCE(up.is_admin, false) INTO v_is_admin
+  FROM user_profiles up WHERE up.user_id = auth.uid();
+  IF NOT (COALESCE(v_is_admin, false) OR COALESCE(auth.role(), '') = 'service_role') THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+
+  IF p_to NOT IN ('in_prep', 'published', 'revoked') THEN
+    RAISE EXCEPTION 'Invalid deploy_status: %', p_to;
+  END IF;
+
+  v_action := COALESCE(p_action,
+    CASE p_to WHEN 'published' THEN 'publish' WHEN 'revoked' THEN 'revoke' ELSE 'upload' END);
+  IF v_action NOT IN ('upload', 'publish', 'revoke', 'recover', 'supersede', 'delete') THEN
+    RAISE EXCEPTION 'Invalid action: %', v_action;
+  END IF;
+
+  IF p_spectrum_db_ids IS NULL OR array_length(p_spectrum_db_ids, 1) IS NULL THEN
+    RETURN json_build_object('updated', 0, 'action', v_action);
+  END IF;
+
+  SELECT array_agg(DISTINCT s.target_id) INTO v_target_ids
+  FROM spectra s WHERE s.id = ANY(p_spectrum_db_ids);
+
+  UPDATE spectra s SET deploy_status = p_to
+  WHERE s.id = ANY(p_spectrum_db_ids) AND s.deploy_status <> p_to;
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+
+  IF v_target_ids IS NOT NULL THEN
+    v_recompute := public.recompute_has_published_spectrum(p_target_ids := v_target_ids);
+  END IF;
+
+  INSERT INTO deploy_events(actor, action, deployment_id, status_to, affected_count, host, metadata)
+  VALUES (p_actor, v_action, p_deployment_id, p_to, v_updated, p_host,
+          jsonb_build_object('n_targets', COALESCE(array_length(v_target_ids, 1), 0)));
+
+  RETURN json_build_object('updated', v_updated, 'action', v_action, 'recompute', v_recompute);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.set_spectra_deploy_status(integer[], text, text, uuid, integer, text) TO authenticated, service_role;
+
+
+-- set_deployment_status: deployment-scoped publish/revoke. Resolves the
+-- deployment's observation, transitions its spectra (in_prep->published on
+-- publish; published->revoked on revoke), stamps the deployment lifecycle, and
+-- delegates the per-spectrum work (+ audit + recompute) to set_spectra_deploy_status.
+CREATE OR REPLACE FUNCTION public.set_deployment_status(
+  p_deployment_id integer,
+  p_to text,
+  p_actor uuid DEFAULT NULL,
+  p_host text DEFAULT NULL
+)
+RETURNS json
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_is_admin boolean;
+  v_obs text;
+  v_from text;
+  v_action text;
+  v_spectrum_ids integer[];
+  v_result json;
+BEGIN
+  SELECT COALESCE(up.is_admin, false) INTO v_is_admin
+  FROM user_profiles up WHERE up.user_id = auth.uid();
+  IF NOT (COALESCE(v_is_admin, false) OR COALESCE(auth.role(), '') = 'service_role') THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+
+  IF p_to NOT IN ('in_prep', 'published', 'revoked') THEN
+    RAISE EXCEPTION 'Invalid status: %', p_to;
+  END IF;
+
+  SELECT observation INTO v_obs FROM deployments WHERE id = p_deployment_id;
+  IF v_obs IS NULL THEN
+    RAISE EXCEPTION 'Deployment % not found', p_deployment_id;
+  END IF;
+
+  -- publish: in_prep->published; revoke: published->revoked; in_prep: published->in_prep.
+  v_from := CASE p_to WHEN 'published' THEN 'in_prep' WHEN 'revoked' THEN 'published' ELSE 'published' END;
+  v_action := CASE p_to WHEN 'published' THEN 'publish' WHEN 'revoked' THEN 'revoke' ELSE 'upload' END;
+
+  SELECT array_agg(s.id) INTO v_spectrum_ids
+  FROM spectra s JOIN targets t ON s.target_id = t.target_id
+  WHERE t.observation = v_obs AND s.deploy_status = v_from;
+
+  UPDATE deployments SET
+    status = p_to,
+    published_at = CASE WHEN p_to = 'published' THEN now() ELSE published_at END,
+    revoked_at = CASE WHEN p_to = 'revoked' THEN now() ELSE revoked_at END
+  WHERE id = p_deployment_id;
+
+  IF v_spectrum_ids IS NOT NULL THEN
+    v_result := public.set_spectra_deploy_status(
+      p_spectrum_db_ids := v_spectrum_ids, p_to := p_to, p_action := v_action,
+      p_actor := p_actor, p_deployment_id := p_deployment_id, p_host := p_host);
+  ELSE
+    v_result := json_build_object('updated', 0, 'action', v_action);
+  END IF;
+
+  RETURN json_build_object(
+    'deployment_id', p_deployment_id, 'observation', v_obs,
+    'status', p_to, 'spectra', v_result);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.set_deployment_status(integer, text, uuid, text) TO authenticated, service_role;
+
+
+-- =============================================================================
 -- Device Auth, API Keys, and Refresh Tokens
 -- =============================================================================
 

--- a/supabase/schemas/indexes.sql
+++ b/supabase/schemas/indexes.sql
@@ -342,6 +342,33 @@ CREATE INDEX IF NOT EXISTS idx_nircam_exposures_review
 
 
 -- =============================================================================
+-- spectrum_exposures (epic #210, B2)
+-- =============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_spectrum_exposures_spectrum_id
+    ON public.spectrum_exposures USING btree (spectrum_id);
+
+CREATE INDEX IF NOT EXISTS idx_spectrum_exposures_exposure_ref
+    ON public.spectrum_exposures USING btree (exposure_ref);
+
+CREATE INDEX IF NOT EXISTS idx_spectrum_exposures_review
+    ON public.spectrum_exposures USING btree (review_status)
+    WHERE review_status != 'approved';
+
+
+-- =============================================================================
+-- deploy_events (epic #210, B2/B3)
+-- =============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_deploy_events_occurred_at
+    ON public.deploy_events USING btree (occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_deploy_events_deployment_id
+    ON public.deploy_events USING btree (deployment_id)
+    WHERE deployment_id IS NOT NULL;
+
+
+-- =============================================================================
 -- storage_objects (epic #210, F1)
 -- =============================================================================
 

--- a/supabase/schemas/policies.sql
+++ b/supabase/schemas/policies.sql
@@ -675,6 +675,46 @@ CREATE POLICY "admin_update_exposures"
 
 
 -- =============================================================================
+-- spectrum_exposures (admin-only — NIRSpec intermediates, epic #210 B2)
+-- =============================================================================
+-- Reduction intermediates, never user-facing science. Admin-only, mirroring
+-- nircam_exposures. Deploy writes them under service_role (RLS bypassed).
+
+ALTER TABLE spectrum_exposures ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "admin_select_spectrum_exposures" ON spectrum_exposures;
+CREATE POLICY "admin_select_spectrum_exposures"
+  ON spectrum_exposures FOR SELECT TO authenticated
+  USING ((SELECT public.is_admin()));
+
+DROP POLICY IF EXISTS "admin_insert_spectrum_exposures" ON spectrum_exposures;
+CREATE POLICY "admin_insert_spectrum_exposures"
+  ON spectrum_exposures FOR INSERT TO authenticated
+  WITH CHECK ((SELECT public.is_admin()));
+
+DROP POLICY IF EXISTS "admin_update_spectrum_exposures" ON spectrum_exposures;
+CREATE POLICY "admin_update_spectrum_exposures"
+  ON spectrum_exposures FOR UPDATE TO authenticated
+  USING ((SELECT public.is_admin()))
+  WITH CHECK ((SELECT public.is_admin()));
+
+
+-- =============================================================================
+-- deploy_events (admin-only — lifecycle audit log, epic #210 B2/B3)
+-- =============================================================================
+-- Append-only audit log, written only by the lifecycle RPCs (SECURITY DEFINER,
+-- service_role) — never a direct client INSERT. Admins read it; no INSERT/UPDATE
+-- policy for authenticated, so a non-RPC write attempt is denied (RLS fail-closed).
+
+ALTER TABLE deploy_events ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "admin_select_deploy_events" ON deploy_events;
+CREATE POLICY "admin_select_deploy_events"
+  ON deploy_events FOR SELECT TO authenticated
+  USING ((SELECT public.is_admin()));
+
+
+-- =============================================================================
 -- storage_objects (admin-only — internal storage registry, epic #210 F1)
 -- =============================================================================
 -- The registry is admin/internal: the web portal never reads it in F1, and
@@ -830,6 +870,16 @@ CREATE POLICY "authenticated_select_deployments"
 DROP POLICY IF EXISTS "admin_deployments_insert" ON deployments;
 CREATE POLICY "admin_deployments_insert"
   ON deployments FOR INSERT TO authenticated
+  WITH CHECK ((SELECT public.is_admin()));
+
+-- Admins can update a deployment's lifecycle (status/published_at/revoked_at).
+-- B2 (#218): the publish/revoke flow flips these via the set_deployment_status
+-- RPC (SECURITY DEFINER) under service_role, but the policy lets an admin web
+-- session do it too. Defense-in-depth — the RPC is the intended path.
+DROP POLICY IF EXISTS "admin_deployments_update" ON deployments;
+CREATE POLICY "admin_deployments_update"
+  ON deployments FOR UPDATE TO authenticated
+  USING ((SELECT public.is_admin()))
   WITH CHECK ((SELECT public.is_admin()));
 
 

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -636,7 +636,16 @@ CREATE TABLE IF NOT EXISTS "public"."deployments" (
     "source_ids_filter" integer[],
     "supabase_only" boolean DEFAULT false,
     "stuck_shutters" "jsonb",
-    "reduced_at" timestamp with time zone
+    "reduced_at" timestamp with time zone,
+    -- B2 (#218): deployment lifecycle. A deployment is the batch anchor for the
+    -- in_prep -> published -> revoked flow. 'published' is the default so existing
+    -- rows (and ordinary deploys) stay published; `deploy --in-prep` inserts with
+    -- 'in_prep'. published_at/revoked_at stamp the transitions (set by the
+    -- set_deployment_status RPC). The user-facing visibility gate lives on
+    -- spectra.deploy_status; this column is the provenance/audit record.
+    "status" "text" NOT NULL DEFAULT 'published' CONSTRAINT "deployments_status_check" CHECK (("status" = ANY (ARRAY['in_prep'::"text", 'published'::"text", 'revoked'::"text"]))),
+    "published_at" timestamp with time zone,
+    "revoked_at" timestamp with time zone
 );
 
 
@@ -747,6 +756,56 @@ ALTER SEQUENCE "public"."nircam_exposures_id_seq" OWNER TO "postgres";
 ALTER SEQUENCE "public"."nircam_exposures_id_seq" OWNED BY "public"."nircam_exposures"."id";
 
 
+-- spectrum_exposures: NIRSpec canonical spectrum-exposure intermediates (epic
+-- #210, B2). One logical row per (exposure, detector, source) that combines into
+-- a final spectrum — the NIRSpec analogue of nircam_exposures. Child of spectra
+-- (FK to the stable integer PK, not the GENERATED spectrum_id). Admin-only: these
+-- are reduction intermediates, never user-facing science. The physical object
+-- (key/hash/size/backend) lives in storage_objects (product_type
+-- 'nirspec_spectrum_exposure'); this table owns the reviewer-facing lifecycle
+-- state (stage, review_status, masking, notes) and the join key (exposure_ref).
+CREATE TABLE IF NOT EXISTS "public"."spectrum_exposures" (
+    "id" integer NOT NULL,
+    "spectrum_id" integer NOT NULL,
+    "exposure_ref" "text" NOT NULL,
+    "root" "text",
+    "nod" integer,
+    "detector" "text",
+    "source_id" integer,
+    "grating" "text",
+    "stage" "text" NOT NULL DEFAULT 'cal'::"text",
+    "review_status" "text" NOT NULL DEFAULT 'pending'::"text",
+    "masking" "text" NOT NULL DEFAULT 'none'::"text",
+    "notes" "text",
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL
+);
+
+
+ALTER TABLE "public"."spectrum_exposures" OWNER TO "postgres";
+
+
+CREATE SEQUENCE IF NOT EXISTS "public"."spectrum_exposures_id_seq"
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE "public"."spectrum_exposures_id_seq" OWNER TO "postgres";
+
+
+ALTER SEQUENCE "public"."spectrum_exposures_id_seq" OWNED BY "public"."spectrum_exposures"."id";
+
+
+COMMENT ON TABLE "public"."spectrum_exposures" IS 'NIRSpec canonical spectrum-exposure intermediates (epic #210, B2). One logical row per (exposure,detector,source); child of spectra (FK to integer PK). Registered to storage_objects with product_type=''nirspec_spectrum_exposure''. Admin-only lifecycle (intermediates are never user-facing science).';
+
+COMMENT ON COLUMN "public"."spectrum_exposures"."spectrum_id" IS 'FK to spectra.id (the stable integer PK, NOT the GENERATED spectra.spectrum_id text column which is not uniquely constrained). ON DELETE CASCADE: intermediates die with their parent spectrum and are rebuilt on the next deploy.';
+
+COMMENT ON COLUMN "public"."spectrum_exposures"."exposure_ref" IS 'Stable (root,nod,detector,source) tuple identifying the input NIRSpec exposure. Matches storage_objects.exposure_ref for the registry join; backs the partial unique (product_type, exposure_ref) WHERE status=''active'' on storage_objects.';
+
 
 -- storage_objects: the keystone shadow index of every object in cloud storage
 -- (epic #210, F1). Deploy writes one row per uploaded object using canonical keys
@@ -824,6 +883,35 @@ COMMENT ON COLUMN "public"."storage_objects"."spectrum_id" IS 'Typed, indexed sc
 COMMENT ON COLUMN "public"."storage_objects"."exposure_ref" IS 'Stable per-exposure reference for intermediate products (nircam rootname; nirspec (root,nod,detector,source) tuple). Backs the partial unique (product_type, exposure_ref) WHERE status=''active'' — one current object per product/exposure.';
 
 COMMENT ON COLUMN "public"."storage_objects"."status" IS 'active = current object; superseded = replaced by a newer hash (tombstone, GC-eligible later); revoked = un-published. Only active rows count toward the budget and the partial-unique constraint.';
+
+
+-- deploy_events: append-only audit log for the intermediate-product lifecycle
+-- (epic #210, B2/B3). One row per lifecycle action (upload/publish/revoke/
+-- recover/supersede/delete). Mirrors download_log's shape. Written only by the
+-- lifecycle RPCs (SECURITY DEFINER, service_role/admin) — never by a direct
+-- client insert — so the action record is trustworthy. Admin-readable.
+CREATE TABLE IF NOT EXISTS "public"."deploy_events" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "actor" "uuid",
+    "action" "text" NOT NULL,
+    "deployment_id" integer,
+    "observation" "text",
+    "spectrum_id" "text",
+    "object_id" integer,
+    "status_from" "text",
+    "status_to" "text",
+    "affected_count" integer,
+    "host" "text",
+    "metadata" "jsonb",
+    "occurred_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "deploy_events_action_check" CHECK (("action" = ANY (ARRAY['upload'::"text", 'publish'::"text", 'revoke'::"text", 'recover'::"text", 'supersede'::"text", 'delete'::"text"])))
+);
+
+
+ALTER TABLE "public"."deploy_events" OWNER TO "postgres";
+
+
+COMMENT ON TABLE "public"."deploy_events" IS 'Append-only audit log for the intermediate-product lifecycle (epic #210, B2/B3). One row per action (upload/publish/revoke/recover/supersede/delete), written only by the lifecycle RPCs (SECURITY DEFINER). deployment_id is nullable (some events are not tied to a deployment). Admin-readable; never client-inserted.';
 
 
 CREATE TABLE IF NOT EXISTS "public"."password_reset_log" (
@@ -1182,6 +1270,10 @@ ALTER TABLE ONLY "public"."nircam_exposures" ALTER COLUMN "id" SET DEFAULT "next
 
 
 
+ALTER TABLE ONLY "public"."spectrum_exposures" ALTER COLUMN "id" SET DEFAULT "nextval"('"public"."spectrum_exposures_id_seq"'::"regclass");
+
+
+
 ALTER TABLE ONLY "public"."storage_objects" ALTER COLUMN "id" SET DEFAULT "nextval"('"public"."storage_objects_id_seq"'::"regclass");
 
 
@@ -1327,6 +1419,17 @@ ALTER TABLE ONLY "public"."nircam_exposures"
 ALTER TABLE ONLY "public"."nircam_exposures"
     ADD CONSTRAINT "nircam_exposures_unique" UNIQUE ("field", "filter", "filename");
 
+ALTER TABLE ONLY "public"."spectrum_exposures"
+    ADD CONSTRAINT "spectrum_exposures_pkey" PRIMARY KEY ("id");
+
+ALTER TABLE ONLY "public"."spectrum_exposures"
+    ADD CONSTRAINT "spectrum_exposures_unique" UNIQUE ("spectrum_id", "exposure_ref");
+
+ALTER TABLE ONLY "public"."deploy_events"
+    ADD CONSTRAINT "deploy_events_pkey" PRIMARY KEY ("id");
+-- (FK constraints for spectrum_exposures/deploy_events are added below, after
+-- their referenced PKs (spectra_pkey, deployments_pkey) exist in the build order.)
+
 
 ALTER TABLE ONLY "public"."storage_objects"
     ADD CONSTRAINT "storage_objects_pkey" PRIMARY KEY ("id");
@@ -1395,6 +1498,18 @@ ALTER TABLE ONLY "public"."deployments"
 
 ALTER TABLE ONLY "public"."spectra"
     ADD CONSTRAINT "spectra_pkey" PRIMARY KEY ("id");
+
+-- B2 (#218) cross-table FKs, placed after the referenced PKs (spectra_pkey above,
+-- deployments_pkey earlier) so the declarative build order resolves them.
+-- spectrum_exposures -> spectra.id, CASCADE: intermediates die with their parent
+-- spectrum and are rebuilt on the next deploy.
+ALTER TABLE ONLY "public"."spectrum_exposures"
+    ADD CONSTRAINT "spectrum_exposures_spectrum_id_fkey" FOREIGN KEY ("spectrum_id") REFERENCES "public"."spectra"("id") ON DELETE CASCADE;
+
+-- deploy_events -> deployments.id, SET NULL: audit rows outlive the deployment
+-- they reference (don't cascade-delete history), matching storage_objects.deployment_id.
+ALTER TABLE ONLY "public"."deploy_events"
+    ADD CONSTRAINT "deploy_events_deployment_id_fkey" FOREIGN KEY ("deployment_id") REFERENCES "public"."deployments"("id") ON DELETE SET NULL;
 
 
 
@@ -1836,6 +1951,16 @@ GRANT ALL ON TABLE "public"."nircam_exposures" TO "authenticated";
 GRANT ALL ON TABLE "public"."nircam_exposures" TO "service_role";
 
 
+-- spectrum_exposures is admin-only (RLS); not granted to anon. Mirrors nircam_exposures.
+GRANT ALL ON TABLE "public"."spectrum_exposures" TO "authenticated";
+GRANT ALL ON TABLE "public"."spectrum_exposures" TO "service_role";
+
+
+-- deploy_events is an admin/internal audit log (RLS admin-only); not granted to anon.
+GRANT ALL ON TABLE "public"."deploy_events" TO "authenticated";
+GRANT ALL ON TABLE "public"."deploy_events" TO "service_role";
+
+
 -- storage_objects is an admin/internal registry (RLS admin-only); not granted to anon.
 GRANT ALL ON TABLE "public"."storage_objects" TO "authenticated";
 GRANT ALL ON TABLE "public"."storage_objects" TO "service_role";
@@ -1931,6 +2056,10 @@ GRANT ALL ON SEQUENCE "public"."nircam_images_id_seq" TO "service_role";
 
 GRANT ALL ON SEQUENCE "public"."nircam_exposures_id_seq" TO "authenticated";
 GRANT ALL ON SEQUENCE "public"."nircam_exposures_id_seq" TO "service_role";
+
+
+GRANT ALL ON SEQUENCE "public"."spectrum_exposures_id_seq" TO "authenticated";
+GRANT ALL ON SEQUENCE "public"."spectrum_exposures_id_seq" TO "service_role";
 
 
 GRANT ALL ON SEQUENCE "public"."storage_objects_id_seq" TO "authenticated";


### PR DESCRIPTION
Part of epic #210 (Track B / lifecycle). Closes #218. **Stacked on top of the B1 lifecycle (#217, merged as #230).**

## What

The publish/revoke/recover lifecycle for `in_prep` science, built on B1's `deploy_status` gate. An admin can deploy a freshly-reduced observation as an invisible **draft**, review it, and **publish** (or **revoke**) it — the science-workflow payoff of the epic.

`spectra.deploy_status` (B1) is the user-facing visibility gate; B2 is the only sanctioned way to transition it, keeping `targets/objects.has_published_spectrum` and the audit log in lockstep.

## Schema (`migration 20260629025904`)
- **`spectrum_exposures`** — NIRSpec canonical spectrum-exposure intermediates (child of `spectra`, admin-only RLS, mirrors `nircam_exposures`); the logical intermediate row B3's admin UI browses.
- **`deployments`** += `status` / `published_at` / `revoked_at` (the batch lifecycle anchor) + an admin `UPDATE` policy.
- **`deploy_events`** — append-only audit log (`upload`/`publish`/`revoke`/`recover`/`supersede`/`delete`), written **only** by the `SECURITY DEFINER` RPCs (no client `INSERT` policy, so direct writes are denied).
- **RPCs** (admin/`service_role` gated, same gate as `get_storage_budget`):
  - `get_lifecycle_status()` — the capability marker `deploy --in-prep` checks. It introspects the **live catalog** to confirm B1 is applied to *this* DB (the `deploy_status` column **and** reader RPCs carrying `p_include_unpublished`). Returns `enabled=false` (not an error) when B1 is absent, so deploy aborts cleanly; if the function itself is missing (deploy code newer than the DB), the client catches that too.
  - `recompute_has_published_spectrum()` — refresh the fail-closed object/target visibility flags from `spectra.deploy_status`.
  - `set_spectra_deploy_status()` / `set_deployment_status()` — the publish/revoke/recover primitive: flip status + recompute + audit, atomically server-side.
  - `log_deploy_event()` — the sanctioned audit-write path.

## Deploy (`python`)
- **`campfire deploy --in-prep`** — spectra land `deploy_status='in_prep'`, the deployment is marked `in_prep`, an `upload` audit event is written. **Capability-gated up front** (aborts cleanly if B1 is absent on the target DB — acceptance gate). Guards against silently hiding currently-*published* spectra (warns + confirms; `--in-prep` is "take the observation back to draft", not zero-downtime staging of a re-reduction).
- **`campfire deploy publish|revoke --obs <name>`** — drive the lifecycle from the CLI, completing the draft → review → publish loop without needing B3's UI.

## Tests
- `python/tests/sql/b2_lifecycle.sql` + `test_lifecycle_rls.py` — DB-backed harness (transaction-scoped, rolled back) drives the seed's published control object through a full **revoke → recover** cycle, asserting: status transitions, `has_published_spectrum` recompute, audit rows, **a non-admin sees ZERO unpublished rows and ZERO admin-only-table rows through RLS**, and the lifecycle RPC **denies** a non-admin. Companion to B1's leak gate.
- `test_lifecycle_deploy.py` — the `--in-prep` "would hide live data" guard + `insert_deployment` status/`published_at` logic.
- B1 leak harness still passes (no regression); matview unique indexes + view `security_invoker` preserved through the migra recreate (hand-patched, same as B1).

## Acceptance gates (#218)
- ✅ in_prep rows admin-visible, invisible to non-admins (re-run B1 leak test + new B2 harness).
- ✅ `deploy --in-prep` aborts cleanly when the B1 marker is absent (capability gate).
- ✅ Budget `SUM(size_bytes)` reflects the deploy's objects (existing F1 registry path; `get_storage_budget` already sums all `active` rows).

## Scoping notes (for review)
- **Single registry write path.** No HTTP `/register` PUT-verify indirection: the deployer is always an admin with service-role, so a second write path would *reduce* infra consistency. The proven direct registry write (F1) stays, with status threading.
- **Physical canonical-exposure FITS upload + `spectrum_exposures` row population** is a focused follow-up that rides the same registry plumbing. The deploy registers its products and marks the science `in_prep` via the existing F1 path, which satisfies all three acceptance gates above. The `spectrum_exposures` table, RLS, and lifecycle are fully in place for that follow-up (and for B3 to browse).
- Pre-existing #228 search_path drift (`can_inspect`/`handle_new_user`) was stripped from the migration to keep it single-purpose, same as B1.

Generated with Claude Code

https://claude.ai/code/session_01QMm3DuLALxzNtLBUQqPfkR