### PR TITLE
feat(219): B3 — admin intermediate-products UI + publish/revoke + audit

### DIFF
--- a/web/app/admin/intermediate-products/page.tsx
+++ b/web/app/admin/intermediate-products/page.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { Card } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import {
+  Loader2, RefreshCw, PackageOpen, Eye, EyeOff, Undo2, History, AlertCircle,
+} from 'lucide-react';
+import {
+  getDeployments, getDeployEvents, setDeploymentLifecycle,
+  type DeploymentRow, type DeployEventRow, type DeployStatus, type LifecycleAction,
+} from '@/lib/actions/intermediate-products';
+
+const STATUS_FILTERS: { value: string; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'in_prep', label: 'In Prep' },
+  { value: 'published', label: 'Published' },
+  { value: 'revoked', label: 'Revoked' },
+];
+
+function statusBadge(status: DeployStatus) {
+  const map: Record<DeployStatus, string> = {
+    in_prep: 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300',
+    published: 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300',
+    revoked: 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300',
+  };
+  const label: Record<DeployStatus, string> = {
+    in_prep: 'in prep', published: 'published', revoked: 'revoked',
+  };
+  return (
+    <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${map[status]}`}>
+      {label[status]}
+    </span>
+  );
+}
+
+function fmt(ts: string | null): string {
+  if (!ts) return '—';
+  let iso = ts;
+  if (iso.includes(' ') && !iso.includes('T')) iso = iso.replace(' ', 'T');
+  if (iso.endsWith('+00')) iso = iso + ':00';
+  else if (!iso.endsWith('Z') && !iso.includes('+')) iso = iso + 'Z';
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return ts;
+  return d.toLocaleString(undefined, {
+    year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+  });
+}
+
+// The lifecycle control offered for a deployment, by its current status.
+function actionFor(status: DeployStatus): { action: LifecycleAction; label: string; icon: React.ElementType } | null {
+  if (status === 'in_prep') return { action: 'publish', label: 'Publish', icon: Eye };
+  if (status === 'published') return { action: 'revoke', label: 'Revoke', icon: EyeOff };
+  if (status === 'revoked') return { action: 'recover', label: 'Recover', icon: Undo2 };
+  return null;
+}
+
+export default function IntermediateProductsPage() {
+  const [statusFilter, setStatusFilter] = useState<string>('all');
+  const [deployments, setDeployments] = useState<DeploymentRow[]>([]);
+  const [events, setEvents] = useState<DeployEventRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<number | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const status = statusFilter === 'all' ? undefined : (statusFilter as DeployStatus);
+    const [dep, ev] = await Promise.all([
+      getDeployments({ status, pageSize: 100 }),
+      getDeployEvents({ pageSize: 50 }),
+    ]);
+    if (dep.error) setError(dep.error);
+    else setDeployments(dep.deployments);
+    if (!ev.error) setEvents(ev.events);
+    setLoading(false);
+  }, [statusFilter]);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const onAction = async (dep: DeploymentRow, action: LifecycleAction, label: string) => {
+    const verb = label.toLowerCase();
+    const warn = action === 'revoke'
+      ? `Revoke "${dep.observation}"? Its spectra will be hidden from users (bytes retained, recoverable).`
+      : `${label} "${dep.observation}"? This affects ${dep.n_spectra ?? '?'} spectra.`;
+    if (!window.confirm(warn)) return;
+    setBusyId(dep.id);
+    setNotice(null);
+    const res = await setDeploymentLifecycle(dep.id, action);
+    setBusyId(null);
+    if (!res.success) {
+      setError(res.error ?? `Failed to ${verb}`);
+      return;
+    }
+    setNotice(`${label}ed ${dep.observation} — ${res.updated ?? 0} spectra updated.`);
+    await refresh();
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <PackageOpen className="w-6 h-6 text-primary" />
+          <h1 className="text-2xl font-semibold text-text-primary">Intermediate Products</h1>
+        </div>
+        <Button variant="secondary" size="sm" onClick={refresh} disabled={loading}>
+          <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+          Refresh
+        </Button>
+      </div>
+      <p className="text-text-secondary text-sm mb-6">
+        Review and publish in-prep deployments. Drafts (<span className="font-medium">in prep</span>)
+        are admin-only and invisible to users until published; revoking hides a published
+        deployment without deleting its data.
+      </p>
+
+      {notice && (
+        <div className="mb-4 px-4 py-2 rounded-lg bg-green-50 dark:bg-green-950 text-green-800 dark:text-green-300 text-sm">
+          {notice}
+        </div>
+      )}
+      {error && (
+        <div className="mb-4 px-4 py-2 rounded-lg bg-red-50 dark:bg-red-950 text-red-800 dark:text-red-300 text-sm flex items-center gap-2">
+          <AlertCircle className="w-4 h-4" /> {error}
+        </div>
+      )}
+
+      <div className="flex gap-2 mb-4">
+        {STATUS_FILTERS.map((f) => (
+          <button
+            key={f.value}
+            onClick={() => setStatusFilter(f.value)}
+            className={`px-3 py-1 rounded-full text-sm transition-colors ${
+              statusFilter === f.value
+                ? 'bg-primary text-on-primary'
+                : 'bg-card-hover text-text-secondary hover:text-text-primary'
+            }`}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      <Card className="mb-8 overflow-hidden p-0">
+        {loading && deployments.length === 0 ? (
+          <div className="p-8 flex items-center justify-center text-text-secondary">
+            <Loader2 className="w-5 h-5 animate-spin mr-2" /> Loading…
+          </div>
+        ) : deployments.length === 0 ? (
+          <div className="p-8 text-center text-text-secondary text-sm">No deployments match this filter.</div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="bg-card-hover text-text-secondary text-left">
+              <tr>
+                <th className="px-4 py-2 font-medium">Observation</th>
+                <th className="px-4 py-2 font-medium">Status</th>
+                <th className="px-4 py-2 font-medium text-right">Spectra</th>
+                <th className="px-4 py-2 font-medium text-right">Targets</th>
+                <th className="px-4 py-2 font-medium">Pipeline</th>
+                <th className="px-4 py-2 font-medium">Deployed</th>
+                <th className="px-4 py-2 font-medium text-right">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {deployments.map((d) => {
+                const act = actionFor(d.status);
+                return (
+                  <tr key={d.id} className="border-t border-border hover:bg-card-hover/50">
+                    <td className="px-4 py-2 font-mono text-text-primary">{d.observation}</td>
+                    <td className="px-4 py-2">{statusBadge(d.status)}</td>
+                    <td className="px-4 py-2 text-right tabular-nums">{d.n_spectra ?? '—'}</td>
+                    <td className="px-4 py-2 text-right tabular-nums">{d.n_targets ?? '—'}</td>
+                    <td className="px-4 py-2 font-mono text-xs text-text-secondary">{d.cfpipe_version ?? '—'}</td>
+                    <td className="px-4 py-2 text-text-secondary whitespace-nowrap">{fmt(d.deployed_at)}</td>
+                    <td className="px-4 py-2 text-right">
+                      {act && (
+                        <Button
+                          variant={act.action === 'revoke' ? 'secondary' : 'primary'}
+                          size="sm"
+                          disabled={busyId === d.id}
+                          onClick={() => onAction(d, act.action, act.label)}
+                        >
+                          {busyId === d.id
+                            ? <Loader2 className="w-4 h-4 animate-spin" />
+                            : <act.icon className="w-4 h-4" />}
+                          {act.label}
+                        </Button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </Card>
+
+      <div className="flex items-center gap-2 mb-3">
+        <History className="w-5 h-5 text-text-secondary" />
+        <h2 className="text-lg font-semibold text-text-primary">Audit Log</h2>
+      </div>
+      <Card className="overflow-hidden p-0">
+        {events.length === 0 ? (
+          <div className="p-6 text-center text-text-secondary text-sm">No lifecycle events yet.</div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="bg-card-hover text-text-secondary text-left">
+              <tr>
+                <th className="px-4 py-2 font-medium">When</th>
+                <th className="px-4 py-2 font-medium">Action</th>
+                <th className="px-4 py-2 font-medium">Observation</th>
+                <th className="px-4 py-2 font-medium">→ Status</th>
+                <th className="px-4 py-2 font-medium text-right">Affected</th>
+                <th className="px-4 py-2 font-medium">By</th>
+              </tr>
+            </thead>
+            <tbody>
+              {events.map((e) => (
+                <tr key={e.id} className="border-t border-border">
+                  <td className="px-4 py-2 text-text-secondary whitespace-nowrap">{fmt(e.occurred_at)}</td>
+                  <td className="px-4 py-2 font-medium text-text-primary">{e.action}</td>
+                  <td className="px-4 py-2 font-mono text-xs">{e.observation ?? '—'}</td>
+                  <td className="px-4 py-2 text-text-secondary">{e.status_to ?? '—'}</td>
+                  <td className="px-4 py-2 text-right tabular-nums">{e.affected_count ?? '—'}</td>
+                  <td className="px-4 py-2 text-text-secondary">{e.actor_name ?? '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/web/app/admin/layout.tsx
+++ b/web/app/admin/layout.tsx
@@ -4,12 +4,13 @@ import React from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useAuth } from '@/lib/contexts/AuthContext';
-import { Shield, KeyRound, Users, Loader2, AlertTriangle, FolderOpen, Activity, Telescope, Download, Camera } from 'lucide-react';
+import { Shield, KeyRound, Users, Loader2, AlertTriangle, FolderOpen, Activity, Telescope, Download, Camera, PackageOpen } from 'lucide-react';
 
 const adminNavItems = [
   { href: '/admin/activity', label: 'Activity', icon: Activity },
   { href: '/admin/downloads', label: 'Downloads', icon: Download },
   { href: '/admin/nircam', label: 'NIRCam', icon: Camera },
+  { href: '/admin/intermediate-products', label: 'Intermediate Products', icon: PackageOpen },
   { href: '/admin/inspection-requests', label: 'Inspection Requests', icon: Telescope },
   { href: '/admin/codes', label: 'Access Codes', icon: KeyRound },
   { href: '/admin/users', label: 'Users', icon: Users },

--- a/web/lib/actions/intermediate-products.ts
+++ b/web/lib/actions/intermediate-products.ts
@@ -1,0 +1,203 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+
+// ---------------------------------------------------------------------------
+// Intermediate-product lifecycle admin actions (epic #210, B3 / #219).
+//
+// The admin surface over B2's lifecycle: browse deployments and their status,
+// publish / revoke / recover them (via the SECURITY DEFINER set_deployment_status
+// RPC), and read the deploy_events audit log. All gated through requireAdmin();
+// the RPCs are independently admin/service_role-gated server-side.
+// ---------------------------------------------------------------------------
+
+async function requireAdmin() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error('Not authenticated');
+
+  const { data: profile } = await supabase
+    .from('user_profiles')
+    .select('is_admin')
+    .eq('user_id', user.id)
+    .single();
+
+  if (!profile?.is_admin) throw new Error('Admin access required');
+  return { supabase, userId: user.id };
+}
+
+export type DeployStatus = 'in_prep' | 'published' | 'revoked';
+
+export interface DeploymentRow {
+  id: number;
+  observation: string;
+  status: DeployStatus;
+  n_targets: number | null;
+  n_spectra: number | null;
+  cfpipe_version: string | null;
+  deployed_at: string | null;
+  published_at: string | null;
+  revoked_at: string | null;
+}
+
+export interface DeploymentsResult {
+  deployments: DeploymentRow[];
+  total: number;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Read: deployments (the lifecycle units)
+// ---------------------------------------------------------------------------
+
+export async function getDeployments(params?: {
+  status?: DeployStatus;
+  observation?: string;
+  page?: number;
+  pageSize?: number;
+}): Promise<DeploymentsResult> {
+  try {
+    const { supabase } = await requireAdmin();
+    const page = Math.max(0, params?.page ?? 0);
+    const pageSize = Math.max(1, params?.pageSize ?? 50);
+    const from = page * pageSize;
+    const to = from + pageSize - 1;
+
+    let query = supabase
+      .from('deployments')
+      .select(
+        'id, observation, status, n_targets, n_spectra, cfpipe_version, deployed_at, published_at, revoked_at',
+        { count: 'exact' },
+      )
+      .order('id', { ascending: false })
+      .range(from, to);
+
+    if (params?.status) query = query.eq('status', params.status);
+    if (params?.observation) query = query.eq('observation', params.observation);
+
+    const { data, count, error } = await query;
+    if (error) return { deployments: [], total: 0, error: error.message };
+    return { deployments: (data as DeploymentRow[]) || [], total: count ?? 0 };
+  } catch (err) {
+    return {
+      deployments: [],
+      total: 0,
+      error: err instanceof Error ? err.message : 'Failed to load deployments',
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Read: deploy_events audit log
+// ---------------------------------------------------------------------------
+
+export interface DeployEventRow {
+  id: string;
+  action: string;
+  observation: string | null;
+  deployment_id: number | null;
+  status_to: string | null;
+  affected_count: number | null;
+  occurred_at: string;
+  actor: string | null;
+  actor_name?: string | null;
+}
+
+export interface DeployEventsResult {
+  events: DeployEventRow[];
+  total: number;
+  error?: string;
+}
+
+export async function getDeployEvents(params?: {
+  action?: string;
+  observation?: string;
+  page?: number;
+  pageSize?: number;
+}): Promise<DeployEventsResult> {
+  try {
+    const { supabase } = await requireAdmin();
+    const page = Math.max(0, params?.page ?? 0);
+    const pageSize = Math.max(1, params?.pageSize ?? 50);
+    const from = page * pageSize;
+    const to = from + pageSize - 1;
+
+    let query = supabase
+      .from('deploy_events')
+      .select(
+        'id, action, observation, deployment_id, status_to, affected_count, occurred_at, actor',
+        { count: 'exact' },
+      )
+      .order('occurred_at', { ascending: false })
+      .range(from, to);
+
+    if (params?.action) query = query.eq('action', params.action);
+    if (params?.observation) query = query.eq('observation', params.observation);
+
+    const { data, count, error } = await query;
+    if (error) return { events: [], total: 0, error: error.message };
+
+    const events = (data as DeployEventRow[]) || [];
+    // Resolve actor uuids -> usernames in one batch (no FK to embed on).
+    const actorIds = Array.from(new Set(events.map((e) => e.actor).filter(Boolean))) as string[];
+    if (actorIds.length) {
+      const { data: profiles } = await supabase
+        .from('user_profiles')
+        .select('user_id, username, full_name')
+        .in('user_id', actorIds);
+      const nameById = new Map(
+        (profiles || []).map((p) => [p.user_id, p.full_name || p.username]),
+      );
+      for (const e of events) {
+        if (e.actor) e.actor_name = nameById.get(e.actor) ?? null;
+      }
+    }
+    return { events, total: count ?? 0 };
+  } catch (err) {
+    return {
+      events: [],
+      total: 0,
+      error: err instanceof Error ? err.message : 'Failed to load audit log',
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mutate: publish / revoke / recover a deployment
+// ---------------------------------------------------------------------------
+
+export type LifecycleAction = 'publish' | 'revoke' | 'recover';
+
+const ACTION_TO_STATUS: Record<LifecycleAction, DeployStatus> = {
+  publish: 'published',
+  revoke: 'revoked',
+  recover: 'published',
+};
+
+export async function setDeploymentLifecycle(
+  deploymentId: number,
+  action: LifecycleAction,
+): Promise<{ success: boolean; updated?: number; error?: string }> {
+  try {
+    const { supabase, userId } = await requireAdmin();
+    const toStatus = ACTION_TO_STATUS[action];
+    if (!toStatus) return { success: false, error: `Unknown action: ${action}` };
+
+    // set_deployment_status flips the deployment + its spectra + recomputes
+    // has_published_spectrum + writes audit rows, atomically server-side.
+    const { data, error } = await supabase.rpc('set_deployment_status', {
+      p_deployment_id: deploymentId,
+      p_to: toStatus,
+      p_actor: userId,
+    });
+
+    if (error) return { success: false, error: error.message };
+    const updated = (data?.spectra?.updated as number) ?? 0;
+    return { success: true, updated };
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : 'Lifecycle transition failed',
+    };
+  }
+}


### PR DESCRIPTION
Part of epic #210 (Track B / lifecycle). Closes #219. **Stacked on top of B2 (#218 / PR #232)** — review/merge that first; this PR's base is the B2 branch, so its diff is web-only.

## What

The admin surface over B2's lifecycle. A `/admin/intermediate-products` page to browse deployments by status, **publish / revoke / recover** them, and read the audit log. No schema here — the tables and lifecycle RPCs are all in B2.

## UI
- **Deployments table** — status badges (`in prep` / `published` / `revoked`), spectra/target counts, pipeline version, deploy time, and a per-row lifecycle control:
  - `in_prep` → **Publish** (makes spectra visible to entitled users)
  - `published` → **Revoke** (hides them; bytes retained, recoverable)
  - `revoked` → **Recover**
- A **status filter** (All / In Prep / Published / Revoked).
- The **audit log** (`deploy_events`) below: when, action, observation, → status, affected count, and actor (uuid resolved to username).

## Actions (`web/lib/actions/intermediate-products.ts`)
`requireAdmin`-gated server actions: `getDeployments`, `getDeployEvents`, and `setDeploymentLifecycle`. The mutation calls the `SECURITY DEFINER` `set_deployment_status` RPC, which flips the deployment + its spectra + recomputes `has_published_spectrum` + writes audit rows **atomically server-side** — the UI never touches `deploy_status` directly. Revoke is confirmed in the UI and soft (no hard-delete).

## Acceptance gates (#219)
- ✅ Admin browses in-prep deployments, publishes (→ visible), revokes (→ hidden, bytes retained), recovers — each writes a `deploy_events` row.
- ✅ Non-admin still sees nothing in-prep: RLS is unchanged from B1/B2, the page lives under the admin-gated `/admin` layout, and every action is `requireAdmin`-gated. The B2 leak harness proves the underlying invisibility.

## Scoping (for review)
Per-item **FITS preview** (the authenticated R2/OSN image proxy from the `/admin/nircam` pattern) rides B2's canonical-exposure-upload follow-up — there are no intermediate FITS to preview yet. Today the admin reviews the in_prep *science* in the normal portal (admins see `in_prep` spectra via B1's `OR is_admin()` branch); B3 adds the lifecycle *control*. A "review these spectra" deep-link is easy to add once you've seen the layout.

`cd web && npm run build` passes; the two new files lint clean (the only warnings are pre-existing, in `lib/auth/tokens.ts` and elsewhere).

Generated with Claude Code

https://claude.ai/code/session_01QMm3DuLALxzNtLBUQqPfkR