### PR TITLE
feat(220): B4 — multi-reducer safety + delete-local verified-in-cloud interlock

### DIFF
--- a/python/campfire/deploy/cli.py
+++ b/python/campfire/deploy/cli.py
@@ -417,6 +417,66 @@ def revoke(ctx, config_path, obs, dry_run, local):
                           to_status='revoked', verb='Revoke')
 
 
+@deploy_group.command('delete-local')
+@click.option('--config', 'config_path', default=None, help='Path to deploy config TOML.')
+@click.option('--obs', required=True, multiple=True, cls=_VariadicOption,
+              help='Observation name(s) whose local product files to delete.')
+@click.option('--verify', is_flag=True,
+              help='Hash each local file and require it to match the registry sha256 '
+                   'before deleting (default: trust the registry row exists + has a hash).')
+@click.option('--yes', is_flag=True, help='Actually delete (default is a dry-run preview).')
+@click.option('--local', is_flag=True, help='Use local Supabase (127.0.0.1:54321).')
+@click.pass_context
+def delete_local(ctx, config_path, obs, verify, yes, local):
+    """Delete local product files that are verified-present in cloud storage (B4).
+
+    The verified-in-cloud interlock: only files that have an *active registry row
+    carrying a sha256 hash* are candidates, so a local file is never deleted
+    unless a verified cloud copy exists. --verify additionally requires the local
+    file to hash-match the cloud copy. Files with no registry row are never
+    touched. Dry-run by default — pass --yes to unlink. The delete half of the
+    reduce -> deploy -> delete-local -> re-download restore loop (intermediate
+    resume-set fetch lands with the canonical-exposure upload follow-up).
+    """
+    from campfire.deploy import registry as reg
+    from campfire.config import products_dir
+
+    config = load_config(config_path, local=_resolve_local(ctx, local))
+    _gate_admin(config)
+    sb = get_supabase_client(config)
+    proot = products_dir()
+
+    grand_deleted = 0
+    grand_bytes = 0
+    for obs_name in obs:
+        plan = reg.plan_delete_local(sb, obs_name, proot, verify=verify)
+        print(f"\n{obs_name}: {len(plan.deletable)} deletable "
+              f"({_fmt_bytes(plan.total_bytes)}), {len(plan.skipped)} skipped, "
+              f"{len(plan.absent)} registered-but-absent")
+        for local_path, _key, reason in plan.skipped:
+            print(f"  skip {local_path.name}: {reason}")
+        if not yes:
+            for local_path, _key, _size in plan.deletable[:10]:
+                print(f"  [dry-run] would delete {local_path}")
+            if len(plan.deletable) > 10:
+                print(f"  ... and {len(plan.deletable) - 10} more")
+            continue
+        for local_path, _key, size in plan.deletable:
+            try:
+                local_path.unlink()
+                grand_deleted += 1
+                grand_bytes += size
+            except OSError as e:
+                print(f"  ! failed to delete {local_path}: {e}")
+
+    if yes:
+        print(f"\nDeleted {grand_deleted} files ({_fmt_bytes(grand_bytes)} freed). "
+              f"Restore with: campfire download --obs <name>")
+    else:
+        print(f"\nDry run — pass --yes to delete. Interlock: only registered, "
+              f"sha256-hashed{'+verified' if verify else ''} files are candidates.")
+
+
 @deploy_group.command()
 @shared_options
 @click.option('--skip-astrometry', is_flag=True,

--- a/python/campfire/deploy/deploy.py
+++ b/python/campfire/deploy/deploy.py
@@ -43,6 +43,8 @@ from campfire.deploy.supabase import (
     deploy_shutters as db_deploy_shutters,
     deploy_slits as db_deploy_slits,
     fetch_deployment_config,
+    claim_deploy_scope,
+    get_deploy_scope_version,
     get_lifecycle_status,
     get_supabase_client,
     get_user_id_from_token,
@@ -374,6 +376,11 @@ def deploy_observation(
             sys.exit(1)
         print("Deploying as in_prep draft (admin-only until published).")
 
+    # B4 multi-reducer safety: snapshot this observation's deploy-scope version
+    # now; we compare-and-set it at finalize to detect a concurrent deploy of the
+    # same observation (advisory — never blocks).
+    scope_version_at_start = get_deploy_scope_version(sb, 'observation', obs_name)
+
     # Check for existing targets and confirm
     target_ids = [o['object_id'] for o in objects]
     existing = check_existing_objects(sb, target_ids)
@@ -630,6 +637,20 @@ def deploy_observation(
                 affected_count=len(spectra),
                 metadata={'in_prep': in_prep, 'n_objects': len(objects)},
             )
+
+        # B4 multi-reducer safety: compare-and-set the scope version. A conflict
+        # means another reducer deployed this same observation while we were
+        # running — surface it so the operator can re-check (the writes are
+        # idempotent by key, but a concurrent re-reduction may have interleaved).
+        claim = claim_deploy_scope(sb, 'observation', obs_name,
+                                   scope_version_at_start, actor=user_id)
+        if claim.get('conflict'):
+            print()
+            print(f"⚠  CONCURRENT DEPLOY DETECTED for {obs_name}: another deploy "
+                  f"advanced this observation (version {scope_version_at_start} -> "
+                  f"{claim.get('current')}) while this one was running.")
+            print("   Both deploys' writes are present; re-check the result and "
+                  "re-deploy if a re-reduction was clobbered.")
 
         # Storage registry (#214): index the objects that actually landed in this
         # deploy. Shadow index — additive, nothing reads it as authoritative yet.

--- a/python/campfire/deploy/registry.py
+++ b/python/campfire/deploy/registry.py
@@ -307,6 +307,76 @@ def registry_keys(client, bucket: str = 'data') -> list[str]:
     ]
 
 
+# ---------------------------------------------------------------------------
+# delete-local interlock (epic #210, B4)
+# ---------------------------------------------------------------------------
+
+class DeleteLocalPlan:
+    """What ``delete-local`` would do, after the verified-in-cloud interlock.
+
+    Only files that have an *active registry row with a sha256 hash* are ever
+    candidates — so a file is never deleted unless a verified cloud copy exists.
+    ``--verify`` additionally hashes the local file and requires it to match the
+    registry hash (the cloud copy is byte-identical to what we're about to drop).
+    """
+
+    def __init__(self):
+        self.deletable: list[tuple] = []   # (local_path: Path, key, size_bytes)
+        self.skipped: list[tuple] = []     # (local_path: Path, key, reason)
+        self.absent: list[str] = []        # registered keys with no local file
+
+    @property
+    def total_bytes(self) -> int:
+        return sum(sz for _, _, sz in self.deletable)
+
+
+def plan_delete_local(
+    client, observation: str, products_root: Path, *,
+    verify: bool = False, bucket: str = 'data',
+) -> DeleteLocalPlan:
+    """Build a safe delete plan for an observation's local product files.
+
+    Enumerates the observation's *active registry rows* (objects known to be in
+    the cloud), maps each to its local path via the layout contract, and clears
+    only those that pass the interlock. Files with no registry row are never
+    touched — they are not in the candidate set.
+    """
+    from campfire.config import products_relpath
+
+    resp = (
+        client.table('storage_objects')
+        .select('storage_key, content_hash, size_bytes')
+        .eq('observation', observation)
+        .eq('bucket', bucket)
+        .eq('status', 'active')
+        .execute()
+    )
+    rows = resp.data or []
+    plan = DeleteLocalPlan()
+    for r in rows:
+        key = r.get('storage_key')
+        if not key:
+            continue
+        chash = r.get('content_hash') or ''
+        local = Path(products_root) / products_relpath(key)
+        if not local.exists():
+            plan.absent.append(key)
+            continue
+        # Interlock: the cloud copy must carry an authoritative sha256 (an etag is
+        # provisional — never delete a local file against an unverified cloud hash).
+        if not chash.startswith('sha256:'):
+            plan.skipped.append((local, key, 'registry hash is provisional (etag), not sha256'))
+            continue
+        if verify:
+            local_hash, _ = hash_file(local)
+            if local_hash != chash:
+                plan.skipped.append((local, key, 'local hash != cloud hash'))
+                continue
+        size = r.get('size_bytes') or local.stat().st_size
+        plan.deletable.append((local, key, int(size)))
+    return plan
+
+
 def _data_client_and_bucket(config: dict):
     """Resolve a boto3 client + bucket name for the data backend (LIST/HEAD).
 

--- a/python/campfire/deploy/supabase.py
+++ b/python/campfire/deploy/supabase.py
@@ -256,6 +256,42 @@ def log_deploy_event(
         return None
 
 
+def get_deploy_scope_version(client: Client, scope_type: str, scope_key: str) -> int:
+    """The current optimistic-concurrency version of a deploy scope (0 if new).
+
+    Read at the START of a deploy; passed back to claim_deploy_scope at finalize
+    to detect a concurrent deploy of the same scope (epic #210, B4).
+    """
+    try:
+        resp = client.rpc('get_deploy_scope_version', {
+            'p_scope_type': scope_type, 'p_scope_key': scope_key,
+        }).execute()
+        return int(resp.data) if resp.data is not None else 0
+    except Exception:
+        # Multi-reducer detection is advisory; never block a deploy on it.
+        return 0
+
+
+def claim_deploy_scope(
+    client: Client, scope_type: str, scope_key: str, expected_version: int,
+    *, actor: str | None = None,
+) -> dict:
+    """Compare-and-set a deploy scope's version at finalize (epic #210, B4).
+
+    Returns the RPC json: ``{'claimed': bool, 'conflict': bool, ...}``. A
+    conflict (claimed=False) means another reducer deployed the same scope
+    concurrently. Advisory — never raises into the deploy path.
+    """
+    try:
+        resp = client.rpc('claim_deploy_scope', {
+            'p_scope_type': scope_type, 'p_scope_key': scope_key,
+            'p_expected_version': expected_version, 'p_actor': actor,
+        }).execute()
+        return resp.data if isinstance(resp.data, dict) else {'claimed': True, 'conflict': False}
+    except Exception as e:
+        return {'claimed': True, 'conflict': False, 'error': str(e)}
+
+
 def get_latest_deployment_id(client: Client, observation: str) -> int | None:
     """The most recent deployment id for an observation (lifecycle anchor)."""
     resp = (client.table('deployments')

--- a/python/tests/sql/b4_multireducer.sql
+++ b/python/tests/sql/b4_multireducer.sql
@@ -1,0 +1,77 @@
+-- =============================================================================
+-- B4 (#220) multi-reducer concurrency harness.
+-- =============================================================================
+-- Proves the optimistic compare-and-set in claim_deploy_scope detects a
+-- concurrent deploy of the same scope (the "not silently clobbered" gate):
+--   1. First deploy of a new scope (expected version 0) -> claimed v1.
+--   2. Reducer A (read v1) commits -> v2.
+--   3. Reducer B (also read v1, stale) commits -> CONFLICT (current is now 2).
+--   4. B re-reads (v2) and retries -> claimed v3.
+--   5. A non-admin is DENIED the RPC (admin/service_role gate).
+--
+-- One transaction, ROLLBACK'd. A RAISE makes psql exit non-zero; success prints
+-- the PASS marker. Seed-anchored only for the non-admin uuid (user@=2222…).
+-- =============================================================================
+\set ON_ERROR_STOP on
+\set USER '22222222-2222-2222-2222-222222222222'
+BEGIN;
+
+SET LOCAL ROLE service_role;
+SELECT set_config('request.jwt.claims', json_build_object('role', 'service_role')::text, true);
+
+DO $$
+DECLARE r json;
+BEGIN
+  -- 1. new scope, expected 0 -> v1
+  r := public.claim_deploy_scope('observation', 'harness_obs', 0);
+  IF NOT (r->>'claimed')::boolean OR (r->>'version')::int <> 1 THEN
+    RAISE EXCEPTION 'CLAIM1: expected claimed v1, got %', r::text;
+  END IF;
+
+  -- 2. reducer A read v1, commits -> v2
+  r := public.claim_deploy_scope('observation', 'harness_obs', 1);
+  IF NOT (r->>'claimed')::boolean OR (r->>'version')::int <> 2 THEN
+    RAISE EXCEPTION 'CLAIM A: expected claimed v2, got %', r::text;
+  END IF;
+
+  -- 3. reducer B read v1 too (stale) -> CONFLICT (current is 2)
+  r := public.claim_deploy_scope('observation', 'harness_obs', 1);
+  IF (r->>'claimed')::boolean OR NOT (r->>'conflict')::boolean OR (r->>'current')::int <> 2 THEN
+    RAISE EXCEPTION 'CLAIM B: expected conflict (current 2), got %', r::text;
+  END IF;
+
+  -- 4. B re-reads (2) and retries -> v3
+  r := public.claim_deploy_scope('observation', 'harness_obs', 2);
+  IF NOT (r->>'claimed')::boolean OR (r->>'version')::int <> 3 THEN
+    RAISE EXCEPTION 'CLAIM B2: expected claimed v3, got %', r::text;
+  END IF;
+
+  -- get_deploy_scope_version reflects the latest
+  IF public.get_deploy_scope_version('observation', 'harness_obs') <> 3 THEN
+    RAISE EXCEPTION 'VERSION: get_deploy_scope_version should be 3';
+  END IF;
+END $$;
+
+-- 5. non-admin is denied
+RESET ROLE;
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claims',
+  json_build_object('sub', :'USER', 'role', 'authenticated')::text, true);
+
+DO $$
+DECLARE denied boolean := false;
+BEGIN
+  BEGIN
+    PERFORM public.claim_deploy_scope('observation', 'harness_obs', 3);
+  EXCEPTION WHEN OTHERS THEN
+    denied := true;
+  END;
+  IF NOT denied THEN
+    RAISE EXCEPTION 'GATE: non-admin was allowed to claim_deploy_scope';
+  END IF;
+END $$;
+
+RESET ROLE;
+SELECT '✅ B4 MULTI-REDUCER HARNESS: ALL ASSERTIONS PASSED' AS result;
+
+ROLLBACK;

--- a/python/tests/test_delete_local.py
+++ b/python/tests/test_delete_local.py
@@ -1,0 +1,123 @@
+"""Unit tests for the B4 (#220) delete-local verified-in-cloud interlock.
+
+Pure-Python with a fake Supabase client + tmp files: asserts plan_delete_local
+only marks for deletion local files that have an active registry row with a
+sha256 hash (and, with --verify, whose local bytes hash-match the cloud copy),
+and never touches files with no registry row. No DB.
+"""
+import hashlib
+from pathlib import Path
+
+import types
+
+from campfire.deploy import registry as reg
+from campfire.config import products_relpath
+
+
+class _FakeQuery:
+    def __init__(self, rows):
+        self._rows = rows
+        self._eq = []
+
+    def select(self, *a, **k):
+        return self
+
+    def eq(self, col, val):
+        self._eq.append((col, val))
+        return self
+
+    def execute(self):
+        rows = list(self._rows)
+        for col, val in self._eq:
+            rows = [r for r in rows if r.get(col) == val]
+        return types.SimpleNamespace(data=rows)
+
+
+class _FakeClient:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def table(self, name):
+        return _FakeQuery(self._rows if name == 'storage_objects' else [])
+
+
+OBS = "ember_egs_p1"
+SPEC_KEY = f"spectra/{OBS}/{OBS}_prism_clear_12345_spec.fits"
+JSON_KEY = f"spectra/{OBS}/{OBS}_prism_clear_12345_spec.json"
+
+
+def _sha256(b: bytes) -> str:
+    return "sha256:" + hashlib.sha256(b).hexdigest()
+
+
+def _make_local(products_root: Path, key: str, content: bytes) -> Path:
+    p = products_root / products_relpath(key)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(content)
+    return p
+
+
+def test_deletable_only_when_registered_with_sha256(tmp_path):
+    body = b"fits-bytes" * 100
+    local = _make_local(tmp_path, SPEC_KEY, body)
+    rows = [{
+        "storage_key": SPEC_KEY, "content_hash": _sha256(body),
+        "size_bytes": len(body), "observation": OBS, "bucket": "data", "status": "active",
+    }]
+    plan = reg.plan_delete_local(_FakeClient(rows), OBS, tmp_path)
+    keys = [k for _, k, _ in plan.deletable]
+    assert SPEC_KEY in keys
+    assert local.exists()  # planning never deletes
+
+
+def test_etag_only_hash_is_skipped(tmp_path):
+    body = b"x" * 50
+    _make_local(tmp_path, SPEC_KEY, body)
+    rows = [{
+        "storage_key": SPEC_KEY, "content_hash": "etag:deadbeef",
+        "size_bytes": len(body), "observation": OBS, "bucket": "data", "status": "active",
+    }]
+    plan = reg.plan_delete_local(_FakeClient(rows), OBS, tmp_path)
+    assert not plan.deletable
+    assert any("provisional" in reason for _, _, reason in plan.skipped)
+
+
+def test_verify_rejects_hash_mismatch(tmp_path):
+    body = b"local-bytes"
+    _make_local(tmp_path, SPEC_KEY, body)
+    rows = [{
+        "storage_key": SPEC_KEY, "content_hash": _sha256(b"different-cloud-bytes"),
+        "size_bytes": 99, "observation": OBS, "bucket": "data", "status": "active",
+    }]
+    plan = reg.plan_delete_local(_FakeClient(rows), OBS, tmp_path, verify=True)
+    assert not plan.deletable
+    assert any("hash" in reason for _, _, reason in plan.skipped)
+
+
+def test_verify_accepts_hash_match(tmp_path):
+    body = b"matching-bytes" * 10
+    _make_local(tmp_path, SPEC_KEY, body)
+    rows = [{
+        "storage_key": SPEC_KEY, "content_hash": _sha256(body),
+        "size_bytes": len(body), "observation": OBS, "bucket": "data", "status": "active",
+    }]
+    plan = reg.plan_delete_local(_FakeClient(rows), OBS, tmp_path, verify=True)
+    assert len(plan.deletable) == 1
+
+
+def test_registered_but_absent_local_file(tmp_path):
+    # registry row exists, but the local file does not -> 'absent', not deletable
+    rows = [{
+        "storage_key": JSON_KEY, "content_hash": _sha256(b"z"),
+        "size_bytes": 1, "observation": OBS, "bucket": "data", "status": "active",
+    }]
+    plan = reg.plan_delete_local(_FakeClient(rows), OBS, tmp_path)
+    assert not plan.deletable
+    assert JSON_KEY in plan.absent
+
+
+def test_unregistered_local_file_is_never_a_candidate(tmp_path):
+    # A local file exists but has NO registry row -> never touched (not in the set).
+    _make_local(tmp_path, SPEC_KEY, b"orphan-local")
+    plan = reg.plan_delete_local(_FakeClient([]), OBS, tmp_path)
+    assert not plan.deletable and not plan.skipped and not plan.absent

--- a/python/tests/test_multireducer_rls.py
+++ b/python/tests/test_multireducer_rls.py
@@ -1,0 +1,54 @@
+"""B4 (#220) multi-reducer concurrency gate.
+
+DB-backed integration test: runs ``sql/b4_multireducer.sql`` against the local
+Supabase Postgres via ``docker exec ... psql`` and asserts the harness reaches
+its PASS marker. The SQL proves claim_deploy_scope's optimistic compare-and-set
+detects a concurrent same-scope deploy (the "not silently clobbered" gate) and
+denies non-admins. Skips when the local DB container is unreachable.
+"""
+import subprocess
+from pathlib import Path
+
+import pytest
+
+CONTAINER = "supabase_db_campfire"
+SQL_FILE = Path(__file__).parent / "sql" / "b4_multireducer.sql"
+PASS_MARKER = "B4 MULTI-REDUCER HARNESS: ALL ASSERTIONS PASSED"
+
+
+def _docker_psql_available() -> bool:
+    try:
+        r = subprocess.run(
+            ["docker", "exec", "-i", CONTAINER,
+             "psql", "-U", "postgres", "-d", "postgres", "-tA", "-c", "SELECT 1"],
+            capture_output=True, text=True, timeout=15,
+        )
+        return r.returncode == 0 and r.stdout.strip().startswith("1")
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return False
+
+
+requires_local_db = pytest.mark.skipif(
+    not _docker_psql_available(),
+    reason=f"local Supabase container '{CONTAINER}' not reachable (run `supabase start` + `supabase db reset`)",
+)
+
+
+@requires_local_db
+def test_concurrent_deploy_detected():
+    """A stale compare-and-set is detected as a conflict, not silently applied."""
+    sql = SQL_FILE.read_text()
+    result = subprocess.run(
+        ["docker", "exec", "-i", CONTAINER,
+         "psql", "-U", "postgres", "-d", "postgres", "-v", "ON_ERROR_STOP=1", "-f", "-"],
+        input=sql, capture_output=True, text=True, timeout=60,
+    )
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, (
+        f"B4 multi-reducer harness FAILED (psql exit {result.returncode}).\n"
+        f"claim_deploy_scope did not detect a stale compare-and-set, or the admin "
+        f"gate failed. Output:\n{combined}"
+    )
+    assert PASS_MARKER in result.stdout, (
+        f"B4 multi-reducer harness did not reach its PASS marker.\nOutput:\n{combined}"
+    )

--- a/supabase/migrations/20260629032458_add_deploy_scope_state_b4.sql
+++ b/supabase/migrations/20260629032458_add_deploy_scope_state_b4.sql
@@ -1,0 +1,249 @@
+drop materialized view if exists "public"."mv_filter_options";
+
+drop materialized view if exists "public"."mv_programs_overview";
+
+drop view if exists "public"."nircam_reduction_progress";
+
+drop view if exists "public"."spectrum_flag_summary";
+
+
+  create table "public"."deploy_scope_state" (
+    "scope_type" text not null,
+    "scope_key" text not null,
+    "version" integer not null default 0,
+    "last_actor" uuid,
+    "last_deploy_at" timestamp with time zone,
+    "updated_at" timestamp with time zone not null default now()
+      );
+
+
+alter table "public"."deploy_scope_state" enable row level security;
+
+CREATE UNIQUE INDEX deploy_scope_state_pkey ON public.deploy_scope_state USING btree (scope_type, scope_key);
+
+alter table "public"."deploy_scope_state" add constraint "deploy_scope_state_pkey" PRIMARY KEY using index "deploy_scope_state_pkey";
+
+alter table "public"."deploy_scope_state" add constraint "deploy_scope_state_scope_type_check" CHECK ((scope_type = ANY (ARRAY['observation'::text, 'field'::text]))) not valid;
+
+alter table "public"."deploy_scope_state" validate constraint "deploy_scope_state_scope_type_check";
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.claim_deploy_scope(p_scope_type text, p_scope_key text, p_expected_version integer, p_actor uuid DEFAULT NULL::uuid)
+ RETURNS json
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_is_admin boolean;
+  v_new_version integer;
+  v_current integer;
+BEGIN
+  SELECT COALESCE(up.is_admin, false) INTO v_is_admin
+  FROM user_profiles up WHERE up.user_id = auth.uid();
+  IF NOT (COALESCE(v_is_admin, false) OR COALESCE(auth.role(), '') = 'service_role') THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+
+  IF p_scope_type NOT IN ('observation', 'field') THEN
+    RAISE EXCEPTION 'Invalid scope_type: %', p_scope_type;
+  END IF;
+
+  -- CAS: insert at version 1 if the scope is new (expected 0); otherwise bump
+  -- only when the stored version still matches what the caller read at start.
+  INSERT INTO deploy_scope_state AS d (scope_type, scope_key, version, last_actor, last_deploy_at, updated_at)
+  VALUES (p_scope_type, p_scope_key, 1, p_actor, now(), now())
+  ON CONFLICT (scope_type, scope_key) DO UPDATE
+    SET version = d.version + 1, last_actor = p_actor, last_deploy_at = now(), updated_at = now()
+    WHERE d.version = p_expected_version
+  RETURNING d.version INTO v_new_version;
+
+  IF v_new_version IS NOT NULL THEN
+    RETURN json_build_object('claimed', true, 'version', v_new_version, 'conflict', false);
+  END IF;
+
+  -- No row returned: an existing row's version != expected (concurrent deploy).
+  SELECT version INTO v_current FROM deploy_scope_state
+  WHERE scope_type = p_scope_type AND scope_key = p_scope_key;
+  RETURN json_build_object('claimed', false, 'conflict', true,
+                           'current', COALESCE(v_current, 0), 'expected', p_expected_version);
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_deploy_scope_version(p_scope_type text, p_scope_key text)
+ RETURNS integer
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_is_admin boolean;
+  v_version integer;
+BEGIN
+  SELECT COALESCE(up.is_admin, false) INTO v_is_admin
+  FROM user_profiles up WHERE up.user_id = auth.uid();
+  IF NOT (COALESCE(v_is_admin, false) OR COALESCE(auth.role(), '') = 'service_role') THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+
+  SELECT version INTO v_version FROM deploy_scope_state
+  WHERE scope_type = p_scope_type AND scope_key = p_scope_key;
+  RETURN COALESCE(v_version, 0);
+END;
+$function$
+;
+
+-- NOTE (#228): can_inspect()/handle_new_user() re-emitted by migra (pre-existing
+-- SET search_path drift, tracked in #228). Stripped to keep this B4 migration
+-- single-purpose.
+
+create materialized view "public"."mv_filter_options" as  SELECT 1 AS id,
+    ARRAY( SELECT DISTINCT targets.field
+           FROM public.targets
+          WHERE targets.has_published_spectrum
+          ORDER BY targets.field) AS fields,
+    ARRAY( SELECT DISTINCT targets.observation
+           FROM public.targets
+          WHERE ((targets.observation IS NOT NULL) AND targets.has_published_spectrum)
+          ORDER BY targets.observation) AS observations,
+    ARRAY( SELECT DISTINCT spectra.grating
+           FROM public.spectra
+          WHERE (spectra.deploy_status = 'published'::text)
+          ORDER BY spectra.grating) AS gratings;
+
+
+create materialized view "public"."mv_programs_overview" as  SELECT p.slug,
+    p.program_name,
+    p.pi_name,
+    p.description,
+    p.is_public,
+    p.cycle,
+    COALESCE(stats.target_count, (0)::bigint) AS target_count,
+    COALESCE(stats.gratings, ARRAY[]::text[]) AS gratings,
+    COALESCE(stats.fields, ARRAY[]::text[]) AS fields,
+    COALESCE(stats.observations, ARRAY[]::text[]) AS observations,
+    COALESCE(pids.jwst_pids, ARRAY[]::integer[]) AS jwst_pids,
+    COALESCE(pids.n_observations, (0)::bigint) AS n_observations,
+    last_red.last_reduced_at
+   FROM (((public.programs p
+     LEFT JOIN ( SELECT t.program_slug,
+            count(DISTINCT t.target_id) AS target_count,
+            array_agg(DISTINCT s.grating ORDER BY s.grating) FILTER (WHERE (s.grating IS NOT NULL)) AS gratings,
+            array_agg(DISTINCT t.field ORDER BY t.field) AS fields,
+            array_agg(DISTINCT t.observation ORDER BY t.observation) AS observations
+           FROM (public.targets t
+             LEFT JOIN public.spectra s ON (((s.target_id = t.target_id) AND (s.deploy_status = 'published'::text))))
+          GROUP BY t.program_slug) stats ON ((p.slug = stats.program_slug)))
+     LEFT JOIN ( SELECT observations.program_slug,
+            array_agg(DISTINCT observations.jwst_program_id ORDER BY observations.jwst_program_id) AS jwst_pids,
+            count(*) AS n_observations
+           FROM public.observations
+          GROUP BY observations.program_slug) pids ON ((p.slug = pids.program_slug)))
+     LEFT JOIN ( SELECT o.program_slug,
+            max(d.reduced_at) AS last_reduced_at
+           FROM (public.observations o
+             JOIN public.deployments d ON ((d.observation = o.name)))
+          WHERE (d.source_ids_filter IS NULL)
+          GROUP BY o.program_slug) last_red ON ((p.slug = last_red.program_slug)));
+
+
+-- B4 (#220): security_invoker restored (migra drops the view option on recreate).
+-- B4 (#220): migra recreates the matviews but drops their unique indexes; restore
+-- them (REFRESH CONCURRENTLY needs them). Validated by the check-mv-indexes CI.
+CREATE UNIQUE INDEX mv_filter_options_id ON public.mv_filter_options USING btree (id);
+CREATE UNIQUE INDEX mv_programs_overview_slug ON public.mv_programs_overview USING btree (slug);
+
+create or replace view "public"."nircam_reduction_progress" with (security_invoker = true) as  SELECT field,
+    filter,
+    count(*) AS total,
+    count(*) FILTER (WHERE (stage = 'uncal'::text)) AS at_uncal,
+    count(*) FILTER (WHERE (stage = 'detector1'::text)) AS at_detector1,
+    count(*) FILTER (WHERE (stage = 'persistence'::text)) AS at_persistence,
+    count(*) FILTER (WHERE (stage = 'wisp'::text)) AS at_wisp,
+    count(*) FILTER (WHERE (stage = 'striping'::text)) AS at_striping,
+    count(*) FILTER (WHERE (stage = 'image2'::text)) AS at_image2,
+    count(*) FILTER (WHERE (stage = 'edge'::text)) AS at_edge,
+    count(*) FILTER (WHERE (stage = 'sky'::text)) AS at_sky,
+    count(*) FILTER (WHERE (stage = 'diag_striping'::text)) AS at_diag_striping,
+    count(*) FILTER (WHERE (stage = 'variance'::text)) AS at_variance,
+    count(*) FILTER (WHERE (stage = 'wcs_shift'::text)) AS at_wcs_shift,
+    count(*) FILTER (WHERE (stage = 'preview'::text)) AS at_preview,
+    count(*) FILTER (WHERE (stage = 'jhat'::text)) AS at_jhat,
+    count(*) FILTER (WHERE (stage = 'apply_mask'::text)) AS at_apply_mask,
+    count(*) FILTER (WHERE (stage = 'bad_pixel'::text)) AS at_bad_pixel,
+    count(*) FILTER (WHERE (stage = 'outlier'::text)) AS at_outlier,
+    count(*) FILTER (WHERE (review_status = 'pending'::text)) AS pending_review,
+    count(*) FILTER (WHERE (review_status = 'approved'::text)) AS approved,
+    count(*) FILTER (WHERE (review_status = 'excluded'::text)) AS excluded,
+    count(*) FILTER (WHERE (masking = 'needed'::text)) AS needs_masking,
+    count(*) FILTER (WHERE (correction = 'needed'::text)) AS needs_correction
+   FROM public.nircam_exposures
+  GROUP BY field, filter;
+
+
+-- B4 (#220): security_invoker restored (migra drops the view option on recreate).
+create or replace view "public"."spectrum_flag_summary" with (security_invoker = true) as  SELECT s.id,
+    s.target_id,
+    s.grating,
+    array_agg(DISTINCT fd.label) FILTER (WHERE ((fd.category = 'dq_flags'::text) AND ((s.dq_flags & fd.value) > 0))) AS dq_flags_labels
+   FROM (public.spectra s
+     CROSS JOIN public.flag_definitions fd)
+  WHERE ((s.deploy_status = 'published'::text) OR public.is_admin())
+  GROUP BY s.id, s.target_id, s.grating;
+
+
+grant delete on table "public"."deploy_scope_state" to "anon";
+
+grant insert on table "public"."deploy_scope_state" to "anon";
+
+grant references on table "public"."deploy_scope_state" to "anon";
+
+grant select on table "public"."deploy_scope_state" to "anon";
+
+grant trigger on table "public"."deploy_scope_state" to "anon";
+
+grant truncate on table "public"."deploy_scope_state" to "anon";
+
+grant update on table "public"."deploy_scope_state" to "anon";
+
+grant delete on table "public"."deploy_scope_state" to "authenticated";
+
+grant insert on table "public"."deploy_scope_state" to "authenticated";
+
+grant references on table "public"."deploy_scope_state" to "authenticated";
+
+grant select on table "public"."deploy_scope_state" to "authenticated";
+
+grant trigger on table "public"."deploy_scope_state" to "authenticated";
+
+grant truncate on table "public"."deploy_scope_state" to "authenticated";
+
+grant update on table "public"."deploy_scope_state" to "authenticated";
+
+grant delete on table "public"."deploy_scope_state" to "service_role";
+
+grant insert on table "public"."deploy_scope_state" to "service_role";
+
+grant references on table "public"."deploy_scope_state" to "service_role";
+
+grant select on table "public"."deploy_scope_state" to "service_role";
+
+grant trigger on table "public"."deploy_scope_state" to "service_role";
+
+grant truncate on table "public"."deploy_scope_state" to "service_role";
+
+grant update on table "public"."deploy_scope_state" to "service_role";
+
+
+  create policy "admin_select_deploy_scope_state"
+  on "public"."deploy_scope_state"
+  as permissive
+  for select
+  to authenticated
+using (( SELECT public.is_admin() AS is_admin));
+
+
+
+
+-- B4 (#220): COMMENT ON (migra does not track comments).
+COMMENT ON TABLE "public"."deploy_scope_state" IS 'Optimistic-concurrency version per deploy scope (epic #210, B4). claim_deploy_scope does the compare-and-set so concurrent same-scope deploys are detected, not silently clobbered. Admin/internal.';

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -3259,6 +3259,94 @@ GRANT EXECUTE ON FUNCTION public.set_deployment_status(integer, text, uuid, text
 
 
 -- =============================================================================
+-- Multi-reducer safety (epic #210, B4)
+-- =============================================================================
+-- Optimistic concurrency over deploy scopes. A deploy reads the scope version
+-- when it starts (get_deploy_scope_version) and compare-and-sets at finalize
+-- (claim_deploy_scope). A version mismatch means another reducer deployed the
+-- same scope concurrently — the clobber is detected and surfaced, not silent.
+
+-- get_deploy_scope_version: the scope's current version (0 if it has never been
+-- deployed). SECURITY DEFINER so it reads uniformly under admin and service_role.
+CREATE OR REPLACE FUNCTION public.get_deploy_scope_version(
+  p_scope_type text,
+  p_scope_key text
+)
+RETURNS integer
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_is_admin boolean;
+  v_version integer;
+BEGIN
+  SELECT COALESCE(up.is_admin, false) INTO v_is_admin
+  FROM user_profiles up WHERE up.user_id = auth.uid();
+  IF NOT (COALESCE(v_is_admin, false) OR COALESCE(auth.role(), '') = 'service_role') THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+
+  SELECT version INTO v_version FROM deploy_scope_state
+  WHERE scope_type = p_scope_type AND scope_key = p_scope_key;
+  RETURN COALESCE(v_version, 0);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_deploy_scope_version(text, text) TO authenticated, service_role;
+
+
+-- claim_deploy_scope: atomic compare-and-set. Bumps the scope version iff it
+-- still equals p_expected_version (the value the deploy read at start). Returns
+-- {claimed, version, current, conflict}: claimed=false + conflict=true means a
+-- concurrent deploy advanced the scope (the caller should surface the clobber).
+CREATE OR REPLACE FUNCTION public.claim_deploy_scope(
+  p_scope_type text,
+  p_scope_key text,
+  p_expected_version integer,
+  p_actor uuid DEFAULT NULL
+)
+RETURNS json
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_is_admin boolean;
+  v_new_version integer;
+  v_current integer;
+BEGIN
+  SELECT COALESCE(up.is_admin, false) INTO v_is_admin
+  FROM user_profiles up WHERE up.user_id = auth.uid();
+  IF NOT (COALESCE(v_is_admin, false) OR COALESCE(auth.role(), '') = 'service_role') THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+
+  IF p_scope_type NOT IN ('observation', 'field') THEN
+    RAISE EXCEPTION 'Invalid scope_type: %', p_scope_type;
+  END IF;
+
+  -- CAS: insert at version 1 if the scope is new (expected 0); otherwise bump
+  -- only when the stored version still matches what the caller read at start.
+  INSERT INTO deploy_scope_state AS d (scope_type, scope_key, version, last_actor, last_deploy_at, updated_at)
+  VALUES (p_scope_type, p_scope_key, 1, p_actor, now(), now())
+  ON CONFLICT (scope_type, scope_key) DO UPDATE
+    SET version = d.version + 1, last_actor = p_actor, last_deploy_at = now(), updated_at = now()
+    WHERE d.version = p_expected_version
+  RETURNING d.version INTO v_new_version;
+
+  IF v_new_version IS NOT NULL THEN
+    RETURN json_build_object('claimed', true, 'version', v_new_version, 'conflict', false);
+  END IF;
+
+  -- No row returned: an existing row's version != expected (concurrent deploy).
+  SELECT version INTO v_current FROM deploy_scope_state
+  WHERE scope_type = p_scope_type AND scope_key = p_scope_key;
+  RETURN json_build_object('claimed', false, 'conflict', true,
+                           'current', COALESCE(v_current, 0), 'expected', p_expected_version);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.claim_deploy_scope(text, text, integer, uuid) TO authenticated, service_role;
+
+
+-- =============================================================================
 -- Device Auth, API Keys, and Refresh Tokens
 -- =============================================================================
 

--- a/supabase/schemas/policies.sql
+++ b/supabase/schemas/policies.sql
@@ -715,6 +715,20 @@ CREATE POLICY "admin_select_deploy_events"
 
 
 -- =============================================================================
+-- deploy_scope_state (admin-only — multi-reducer concurrency, epic #210 B4)
+-- =============================================================================
+-- Mutated only by the claim_deploy_scope RPC (SECURITY DEFINER, service_role/
+-- admin). Admin-readable for inspection; defense-in-depth RLS.
+
+ALTER TABLE deploy_scope_state ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "admin_select_deploy_scope_state" ON deploy_scope_state;
+CREATE POLICY "admin_select_deploy_scope_state"
+  ON deploy_scope_state FOR SELECT TO authenticated
+  USING ((SELECT public.is_admin()));
+
+
+-- =============================================================================
 -- storage_objects (admin-only — internal storage registry, epic #210 F1)
 -- =============================================================================
 -- The registry is admin/internal: the web portal never reads it in F1, and

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -914,6 +914,30 @@ ALTER TABLE "public"."deploy_events" OWNER TO "postgres";
 COMMENT ON TABLE "public"."deploy_events" IS 'Append-only audit log for the intermediate-product lifecycle (epic #210, B2/B3). One row per action (upload/publish/revoke/recover/supersede/delete), written only by the lifecycle RPCs (SECURITY DEFINER). deployment_id is nullable (some events are not tied to a deployment). Admin-readable; never client-inserted.';
 
 
+-- deploy_scope_state: optimistic concurrency for multi-reducer safety (epic #210,
+-- B4). One row per deploy scope ((observation|field), key). A deploy reads the
+-- scope version when it starts and compare-and-sets it at finalize via
+-- claim_deploy_scope; a mismatch means another reducer deployed the same scope
+-- concurrently, so the clobber is DETECTED (and surfaced) rather than silent.
+-- Deliberately the simplest mechanism that satisfies the gate: no leases, no
+-- heartbeats — concurrent same-scope deploys are rare.
+CREATE TABLE IF NOT EXISTS "public"."deploy_scope_state" (
+    "scope_type" "text" NOT NULL,
+    "scope_key" "text" NOT NULL,
+    "version" integer NOT NULL DEFAULT 0,
+    "last_actor" "uuid",
+    "last_deploy_at" timestamp with time zone,
+    "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    CONSTRAINT "deploy_scope_state_scope_type_check" CHECK (("scope_type" = ANY (ARRAY['observation'::"text", 'field'::"text"])))
+);
+
+
+ALTER TABLE "public"."deploy_scope_state" OWNER TO "postgres";
+
+
+COMMENT ON TABLE "public"."deploy_scope_state" IS 'Optimistic-concurrency version per deploy scope (epic #210, B4). claim_deploy_scope does the compare-and-set so concurrent same-scope deploys are detected, not silently clobbered. Admin/internal.';
+
+
 CREATE TABLE IF NOT EXISTS "public"."password_reset_log" (
     "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
     "user_id" "uuid" NOT NULL,
@@ -1427,6 +1451,9 @@ ALTER TABLE ONLY "public"."spectrum_exposures"
 
 ALTER TABLE ONLY "public"."deploy_events"
     ADD CONSTRAINT "deploy_events_pkey" PRIMARY KEY ("id");
+
+ALTER TABLE ONLY "public"."deploy_scope_state"
+    ADD CONSTRAINT "deploy_scope_state_pkey" PRIMARY KEY ("scope_type", "scope_key");
 -- (FK constraints for spectrum_exposures/deploy_events are added below, after
 -- their referenced PKs (spectra_pkey, deployments_pkey) exist in the build order.)
 
@@ -1959,6 +1986,11 @@ GRANT ALL ON TABLE "public"."spectrum_exposures" TO "service_role";
 -- deploy_events is an admin/internal audit log (RLS admin-only); not granted to anon.
 GRANT ALL ON TABLE "public"."deploy_events" TO "authenticated";
 GRANT ALL ON TABLE "public"."deploy_events" TO "service_role";
+
+
+-- deploy_scope_state is admin/internal concurrency state (RLS admin-only); not anon.
+GRANT ALL ON TABLE "public"."deploy_scope_state" TO "authenticated";
+GRANT ALL ON TABLE "public"."deploy_scope_state" TO "service_role";
 
 
 -- storage_objects is an admin/internal registry (RLS admin-only); not granted to anon.

--- a/web/app/admin/intermediate-products/page.tsx
+++ b/web/app/admin/intermediate-products/page.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { Card } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import {
+  Loader2, RefreshCw, PackageOpen, Eye, EyeOff, Undo2, History, AlertCircle,
+} from 'lucide-react';
+import {
+  getDeployments, getDeployEvents, setDeploymentLifecycle,
+  type DeploymentRow, type DeployEventRow, type DeployStatus, type LifecycleAction,
+} from '@/lib/actions/intermediate-products';
+
+const STATUS_FILTERS: { value: string; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'in_prep', label: 'In Prep' },
+  { value: 'published', label: 'Published' },
+  { value: 'revoked', label: 'Revoked' },
+];
+
+function statusBadge(status: DeployStatus) {
+  const map: Record<DeployStatus, string> = {
+    in_prep: 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300',
+    published: 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300',
+    revoked: 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300',
+  };
+  const label: Record<DeployStatus, string> = {
+    in_prep: 'in prep', published: 'published', revoked: 'revoked',
+  };
+  return (
+    <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${map[status]}`}>
+      {label[status]}
+    </span>
+  );
+}
+
+function fmt(ts: string | null): string {
+  if (!ts) return '—';
+  let iso = ts;
+  if (iso.includes(' ') && !iso.includes('T')) iso = iso.replace(' ', 'T');
+  if (iso.endsWith('+00')) iso = iso + ':00';
+  else if (!iso.endsWith('Z') && !iso.includes('+')) iso = iso + 'Z';
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return ts;
+  return d.toLocaleString(undefined, {
+    year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+  });
+}
+
+// The lifecycle control offered for a deployment, by its current status.
+function actionFor(status: DeployStatus): { action: LifecycleAction; label: string; icon: React.ElementType } | null {
+  if (status === 'in_prep') return { action: 'publish', label: 'Publish', icon: Eye };
+  if (status === 'published') return { action: 'revoke', label: 'Revoke', icon: EyeOff };
+  if (status === 'revoked') return { action: 'recover', label: 'Recover', icon: Undo2 };
+  return null;
+}
+
+export default function IntermediateProductsPage() {
+  const [statusFilter, setStatusFilter] = useState<string>('all');
+  const [deployments, setDeployments] = useState<DeploymentRow[]>([]);
+  const [events, setEvents] = useState<DeployEventRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<number | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const status = statusFilter === 'all' ? undefined : (statusFilter as DeployStatus);
+    const [dep, ev] = await Promise.all([
+      getDeployments({ status, pageSize: 100 }),
+      getDeployEvents({ pageSize: 50 }),
+    ]);
+    if (dep.error) setError(dep.error);
+    else setDeployments(dep.deployments);
+    if (!ev.error) setEvents(ev.events);
+    setLoading(false);
+  }, [statusFilter]);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const onAction = async (dep: DeploymentRow, action: LifecycleAction, label: string) => {
+    const verb = label.toLowerCase();
+    const warn = action === 'revoke'
+      ? `Revoke "${dep.observation}"? Its spectra will be hidden from users (bytes retained, recoverable).`
+      : `${label} "${dep.observation}"? This affects ${dep.n_spectra ?? '?'} spectra.`;
+    if (!window.confirm(warn)) return;
+    setBusyId(dep.id);
+    setNotice(null);
+    const res = await setDeploymentLifecycle(dep.id, action);
+    setBusyId(null);
+    if (!res.success) {
+      setError(res.error ?? `Failed to ${verb}`);
+      return;
+    }
+    setNotice(`${label}ed ${dep.observation} — ${res.updated ?? 0} spectra updated.`);
+    await refresh();
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <PackageOpen className="w-6 h-6 text-primary" />
+          <h1 className="text-2xl font-semibold text-text-primary">Intermediate Products</h1>
+        </div>
+        <Button variant="secondary" size="sm" onClick={refresh} disabled={loading}>
+          <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+          Refresh
+        </Button>
+      </div>
+      <p className="text-text-secondary text-sm mb-6">
+        Review and publish in-prep deployments. Drafts (<span className="font-medium">in prep</span>)
+        are admin-only and invisible to users until published; revoking hides a published
+        deployment without deleting its data.
+      </p>
+
+      {notice && (
+        <div className="mb-4 px-4 py-2 rounded-lg bg-green-50 dark:bg-green-950 text-green-800 dark:text-green-300 text-sm">
+          {notice}
+        </div>
+      )}
+      {error && (
+        <div className="mb-4 px-4 py-2 rounded-lg bg-red-50 dark:bg-red-950 text-red-800 dark:text-red-300 text-sm flex items-center gap-2">
+          <AlertCircle className="w-4 h-4" /> {error}
+        </div>
+      )}
+
+      <div className="flex gap-2 mb-4">
+        {STATUS_FILTERS.map((f) => (
+          <button
+            key={f.value}
+            onClick={() => setStatusFilter(f.value)}
+            className={`px-3 py-1 rounded-full text-sm transition-colors ${
+              statusFilter === f.value
+                ? 'bg-primary text-on-primary'
+                : 'bg-card-hover text-text-secondary hover:text-text-primary'
+            }`}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      <Card className="mb-8 overflow-hidden p-0">
+        {loading && deployments.length === 0 ? (
+          <div className="p-8 flex items-center justify-center text-text-secondary">
+            <Loader2 className="w-5 h-5 animate-spin mr-2" /> Loading…
+          </div>
+        ) : deployments.length === 0 ? (
+          <div className="p-8 text-center text-text-secondary text-sm">No deployments match this filter.</div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="bg-card-hover text-text-secondary text-left">
+              <tr>
+                <th className="px-4 py-2 font-medium">Observation</th>
+                <th className="px-4 py-2 font-medium">Status</th>
+                <th className="px-4 py-2 font-medium text-right">Spectra</th>
+                <th className="px-4 py-2 font-medium text-right">Targets</th>
+                <th className="px-4 py-2 font-medium">Pipeline</th>
+                <th className="px-4 py-2 font-medium">Deployed</th>
+                <th className="px-4 py-2 font-medium text-right">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {deployments.map((d) => {
+                const act = actionFor(d.status);
+                return (
+                  <tr key={d.id} className="border-t border-border hover:bg-card-hover/50">
+                    <td className="px-4 py-2 font-mono text-text-primary">{d.observation}</td>
+                    <td className="px-4 py-2">{statusBadge(d.status)}</td>
+                    <td className="px-4 py-2 text-right tabular-nums">{d.n_spectra ?? '—'}</td>
+                    <td className="px-4 py-2 text-right tabular-nums">{d.n_targets ?? '—'}</td>
+                    <td className="px-4 py-2 font-mono text-xs text-text-secondary">{d.cfpipe_version ?? '—'}</td>
+                    <td className="px-4 py-2 text-text-secondary whitespace-nowrap">{fmt(d.deployed_at)}</td>
+                    <td className="px-4 py-2 text-right">
+                      {act && (
+                        <Button
+                          variant={act.action === 'revoke' ? 'secondary' : 'primary'}
+                          size="sm"
+                          disabled={busyId === d.id}
+                          onClick={() => onAction(d, act.action, act.label)}
+                        >
+                          {busyId === d.id
+                            ? <Loader2 className="w-4 h-4 animate-spin" />
+                            : <act.icon className="w-4 h-4" />}
+                          {act.label}
+                        </Button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </Card>
+
+      <div className="flex items-center gap-2 mb-3">
+        <History className="w-5 h-5 text-text-secondary" />
+        <h2 className="text-lg font-semibold text-text-primary">Audit Log</h2>
+      </div>
+      <Card className="overflow-hidden p-0">
+        {events.length === 0 ? (
+          <div className="p-6 text-center text-text-secondary text-sm">No lifecycle events yet.</div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="bg-card-hover text-text-secondary text-left">
+              <tr>
+                <th className="px-4 py-2 font-medium">When</th>
+                <th className="px-4 py-2 font-medium">Action</th>
+                <th className="px-4 py-2 font-medium">Observation</th>
+                <th className="px-4 py-2 font-medium">→ Status</th>
+                <th className="px-4 py-2 font-medium text-right">Affected</th>
+                <th className="px-4 py-2 font-medium">By</th>
+              </tr>
+            </thead>
+            <tbody>
+              {events.map((e) => (
+                <tr key={e.id} className="border-t border-border">
+                  <td className="px-4 py-2 text-text-secondary whitespace-nowrap">{fmt(e.occurred_at)}</td>
+                  <td className="px-4 py-2 font-medium text-text-primary">{e.action}</td>
+                  <td className="px-4 py-2 font-mono text-xs">{e.observation ?? '—'}</td>
+                  <td className="px-4 py-2 text-text-secondary">{e.status_to ?? '—'}</td>
+                  <td className="px-4 py-2 text-right tabular-nums">{e.affected_count ?? '—'}</td>
+                  <td className="px-4 py-2 text-text-secondary">{e.actor_name ?? '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/web/app/admin/layout.tsx
+++ b/web/app/admin/layout.tsx
@@ -4,12 +4,13 @@ import React from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useAuth } from '@/lib/contexts/AuthContext';
-import { Shield, KeyRound, Users, Loader2, AlertTriangle, FolderOpen, Activity, Telescope, Download, Camera } from 'lucide-react';
+import { Shield, KeyRound, Users, Loader2, AlertTriangle, FolderOpen, Activity, Telescope, Download, Camera, PackageOpen } from 'lucide-react';
 
 const adminNavItems = [
   { href: '/admin/activity', label: 'Activity', icon: Activity },
   { href: '/admin/downloads', label: 'Downloads', icon: Download },
   { href: '/admin/nircam', label: 'NIRCam', icon: Camera },
+  { href: '/admin/intermediate-products', label: 'Intermediate Products', icon: PackageOpen },
   { href: '/admin/inspection-requests', label: 'Inspection Requests', icon: Telescope },
   { href: '/admin/codes', label: 'Access Codes', icon: KeyRound },
   { href: '/admin/users', label: 'Users', icon: Users },

--- a/web/lib/actions/intermediate-products.ts
+++ b/web/lib/actions/intermediate-products.ts
@@ -1,0 +1,203 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+
+// ---------------------------------------------------------------------------
+// Intermediate-product lifecycle admin actions (epic #210, B3 / #219).
+//
+// The admin surface over B2's lifecycle: browse deployments and their status,
+// publish / revoke / recover them (via the SECURITY DEFINER set_deployment_status
+// RPC), and read the deploy_events audit log. All gated through requireAdmin();
+// the RPCs are independently admin/service_role-gated server-side.
+// ---------------------------------------------------------------------------
+
+async function requireAdmin() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error('Not authenticated');
+
+  const { data: profile } = await supabase
+    .from('user_profiles')
+    .select('is_admin')
+    .eq('user_id', user.id)
+    .single();
+
+  if (!profile?.is_admin) throw new Error('Admin access required');
+  return { supabase, userId: user.id };
+}
+
+export type DeployStatus = 'in_prep' | 'published' | 'revoked';
+
+export interface DeploymentRow {
+  id: number;
+  observation: string;
+  status: DeployStatus;
+  n_targets: number | null;
+  n_spectra: number | null;
+  cfpipe_version: string | null;
+  deployed_at: string | null;
+  published_at: string | null;
+  revoked_at: string | null;
+}
+
+export interface DeploymentsResult {
+  deployments: DeploymentRow[];
+  total: number;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Read: deployments (the lifecycle units)
+// ---------------------------------------------------------------------------
+
+export async function getDeployments(params?: {
+  status?: DeployStatus;
+  observation?: string;
+  page?: number;
+  pageSize?: number;
+}): Promise<DeploymentsResult> {
+  try {
+    const { supabase } = await requireAdmin();
+    const page = Math.max(0, params?.page ?? 0);
+    const pageSize = Math.max(1, params?.pageSize ?? 50);
+    const from = page * pageSize;
+    const to = from + pageSize - 1;
+
+    let query = supabase
+      .from('deployments')
+      .select(
+        'id, observation, status, n_targets, n_spectra, cfpipe_version, deployed_at, published_at, revoked_at',
+        { count: 'exact' },
+      )
+      .order('id', { ascending: false })
+      .range(from, to);
+
+    if (params?.status) query = query.eq('status', params.status);
+    if (params?.observation) query = query.eq('observation', params.observation);
+
+    const { data, count, error } = await query;
+    if (error) return { deployments: [], total: 0, error: error.message };
+    return { deployments: (data as DeploymentRow[]) || [], total: count ?? 0 };
+  } catch (err) {
+    return {
+      deployments: [],
+      total: 0,
+      error: err instanceof Error ? err.message : 'Failed to load deployments',
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Read: deploy_events audit log
+// ---------------------------------------------------------------------------
+
+export interface DeployEventRow {
+  id: string;
+  action: string;
+  observation: string | null;
+  deployment_id: number | null;
+  status_to: string | null;
+  affected_count: number | null;
+  occurred_at: string;
+  actor: string | null;
+  actor_name?: string | null;
+}
+
+export interface DeployEventsResult {
+  events: DeployEventRow[];
+  total: number;
+  error?: string;
+}
+
+export async function getDeployEvents(params?: {
+  action?: string;
+  observation?: string;
+  page?: number;
+  pageSize?: number;
+}): Promise<DeployEventsResult> {
+  try {
+    const { supabase } = await requireAdmin();
+    const page = Math.max(0, params?.page ?? 0);
+    const pageSize = Math.max(1, params?.pageSize ?? 50);
+    const from = page * pageSize;
+    const to = from + pageSize - 1;
+
+    let query = supabase
+      .from('deploy_events')
+      .select(
+        'id, action, observation, deployment_id, status_to, affected_count, occurred_at, actor',
+        { count: 'exact' },
+      )
+      .order('occurred_at', { ascending: false })
+      .range(from, to);
+
+    if (params?.action) query = query.eq('action', params.action);
+    if (params?.observation) query = query.eq('observation', params.observation);
+
+    const { data, count, error } = await query;
+    if (error) return { events: [], total: 0, error: error.message };
+
+    const events = (data as DeployEventRow[]) || [];
+    // Resolve actor uuids -> usernames in one batch (no FK to embed on).
+    const actorIds = Array.from(new Set(events.map((e) => e.actor).filter(Boolean))) as string[];
+    if (actorIds.length) {
+      const { data: profiles } = await supabase
+        .from('user_profiles')
+        .select('user_id, username, full_name')
+        .in('user_id', actorIds);
+      const nameById = new Map(
+        (profiles || []).map((p) => [p.user_id, p.full_name || p.username]),
+      );
+      for (const e of events) {
+        if (e.actor) e.actor_name = nameById.get(e.actor) ?? null;
+      }
+    }
+    return { events, total: count ?? 0 };
+  } catch (err) {
+    return {
+      events: [],
+      total: 0,
+      error: err instanceof Error ? err.message : 'Failed to load audit log',
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mutate: publish / revoke / recover a deployment
+// ---------------------------------------------------------------------------
+
+export type LifecycleAction = 'publish' | 'revoke' | 'recover';
+
+const ACTION_TO_STATUS: Record<LifecycleAction, DeployStatus> = {
+  publish: 'published',
+  revoke: 'revoked',
+  recover: 'published',
+};
+
+export async function setDeploymentLifecycle(
+  deploymentId: number,
+  action: LifecycleAction,
+): Promise<{ success: boolean; updated?: number; error?: string }> {
+  try {
+    const { supabase, userId } = await requireAdmin();
+    const toStatus = ACTION_TO_STATUS[action];
+    if (!toStatus) return { success: false, error: `Unknown action: ${action}` };
+
+    // set_deployment_status flips the deployment + its spectra + recomputes
+    // has_published_spectrum + writes audit rows, atomically server-side.
+    const { data, error } = await supabase.rpc('set_deployment_status', {
+      p_deployment_id: deploymentId,
+      p_to: toStatus,
+      p_actor: userId,
+    });
+
+    if (error) return { success: false, error: error.message };
+    const updated = (data?.spectra?.updated as number) ?? 0;
+    return { success: true, updated };
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : 'Lifecycle transition failed',
+    };
+  }
+}


### PR DESCRIPTION
Part of epic #210 (Track B / lifecycle). Addresses #220. **Stacked on top of B3 (#219 / PR #233)** → B2 (#218 / PR #232). Review/merge bottom-up; this PR's diff is `supabase/` + `python/` only.

## What

The deploy/delete safety half of the `reduce → deploy → delete-local → restore` loop.

### Multi-reducer safety (`migration 20260629032458` + deploy integration)
- **`deploy_scope_state`** — one optimistic-version row per `((observation|field), key)`, admin-only RLS.
- **`claim_deploy_scope()` / `get_deploy_scope_version()`** RPCs (`SECURITY DEFINER`, admin/`service_role`): an atomic **compare-and-set**. A deploy snapshots the scope version at *start* and CAS-bumps it at *finalize*; a stale version means **another reducer deployed the same scope concurrently** → the clobber is *detected and surfaced*, not silent. The simplest mechanism that meets the gate — no leases, no heartbeats (concurrent same-scope deploys are rare).
- `deploy_observation` wires it in: reads the version up front, claims at finalize, prints a prominent **CONCURRENT DEPLOY** warning on conflict. Advisory — it never blocks the deploy (writes are idempotent by key); it makes the race *visible*.

### delete-local interlock (`python`)
- **`registry.plan_delete_local()`** — enumerates an observation's **active registry rows** (objects known to be in the cloud), maps each to its local path via the layout contract, and clears only those that pass the interlock: an active row with a **`sha256`** hash; with `--verify`, the local bytes must **hash-match** the cloud copy. **Files with no registry row are never candidates**, so a local file is never deleted unless a verified cloud copy exists.
- **`campfire deploy delete-local --obs <name> [--verify] [--yes]`** — dry-run by default, admin-gated, reuses the registry + layout (the same admin Supabase path as the `registry` commands — infra consistency).

## Tests
- `sql/b4_multireducer.sql` + `test_multireducer_rls.py` — DB-backed CAS harness: first claim → v1, reducer A → v2, reducer B's **stale** claim → **conflict** (current=2), B retries → v3, non-admin **denied**.
- `test_delete_local.py` — the interlock: deletable only when registered + `sha256`; `etag` provisional → skipped; `--verify` hash mismatch rejected / match accepted; registered-but-absent; **unregistered local file never a candidate**.
- Full python suite: **228 passed, 1 skipped** — the B1, B2, and B4 DB harnesses are all green on the B4-migrated DB.

## Acceptance gates (#220)
- ✅ Interlock refuses to delete an unverified file (only registered + `sha256`, optionally hash-verified, files are candidates).
- ✅ Concurrent deploys to the same scope are **detected, not silently clobbered** (CAS harness).
- ⏳ `delete-local` then re-download reconstructs a re-reducible workspace — true today for **deployed products** (`delete-local` + existing `campfire download`); the **intermediate resume-set** (`_rate` + canonical exposures) lands with the upload follow-up.

## Scoping (for review)
`download --intermediate` (the restore-*fetch* of the resume set) and the client-facing `campfire status` cloud view are the **restore half**, paired with B2's canonical-exposure **upload** follow-up — there are no cloud intermediates to *fetch* until those are uploaded, and `campfire deploy registry budget` already exposes the registry/budget view to admins. Building a hollow `--intermediate` flag that fetches nothing would be untested speculation; this PR delivers the two safety-critical, fully-tested halves (multi-reducer detection + the delete interlock) instead.

`delete-local` lives under `campfire deploy` (not the user `campfire` CLI) because it needs admin registry access — same identity/path as `registry reconcile`.

Generated with Claude Code

https://claude.ai/code/session_01QMm3DuLALxzNtLBUQqPfkR