### PR TITLE
feat(210): B5 — unconditional intermediates + admin split + draft rename

### DIFF
--- a/python/campfire/deploy/cli.py
+++ b/python/campfire/deploy/cli.py
@@ -188,8 +188,8 @@ def source_ids_option(f):
               help='Skip photometry upsert after objects reconcile.')
 @click.option('--skip-astrometry', is_flag=True,
               help='Skip astrometric correction for shutters (deploy raw MSA positions).')
-@click.option('--in-prep', 'in_prep', is_flag=True,
-              help='Deploy as an admin-only draft: spectra land deploy_status=in_prep '
+@click.option('--draft', 'draft', is_flag=True,
+              help='Deploy as an admin-only draft: spectra land deploy_status=draft '
                    '(invisible to users) until published via the admin UI. Requires the '
                    'B1 lifecycle to be applied to the target DB (checked up front).')
 @click.option('--local', is_flag=True,
@@ -197,7 +197,7 @@ def source_ids_option(f):
 @click.pass_context
 def deploy_group(ctx, config_path, obs, dry_run, source_ids, supabase_only,
                  force_overwrite, auto_approve, rgb, no_sed, no_shutters,
-                 no_photometry, skip_astrometry, in_prep, local):
+                 no_photometry, skip_astrometry, draft, local):
     """Deploy CAMPFIRE pipeline products to Supabase + R2."""
     ctx.ensure_object(dict)
     ctx.obj['local'] = local
@@ -236,7 +236,7 @@ def deploy_group(ctx, config_path, obs, dry_run, source_ids, supabase_only,
                 source_ids=list(source_ids) if source_ids else None,
                 auto_approve=auto_approve,
                 defer_rebuild=multi,
-                in_prep=in_prep,
+                draft=draft,
             )
             if result and result.get('needs_reconcile'):
                 fields_needing_rebuild.add(result['field'])
@@ -403,7 +403,7 @@ def _lifecycle_transition(ctx, config_path, obs, dry_run, local, *, to_status, v
 @shared_options
 @click.pass_context
 def publish(ctx, config_path, obs, dry_run, local):
-    """Publish in_prep draft observation(s): make their spectra visible to users."""
+    """Publish draft observation(s): make their spectra visible to users."""
     _lifecycle_transition(ctx, config_path, obs, dry_run, local,
                           to_status='published', verb='Publish')
 

--- a/python/campfire/deploy/deploy.py
+++ b/python/campfire/deploy/deploy.py
@@ -22,6 +22,7 @@ from campfire.deploy.discover import (
     discover_rgb_images,
     discover_sed_plots,
     discover_shutters_ecsv,
+    discover_spectrum_exposures,
     discover_slits_json,
     extract_object_ids_from_files,
     filter_files_by_source_ids,
@@ -168,6 +169,138 @@ def _count_published_spectra(sb, spectra: list[dict]) -> int:
     return published
 
 
+def _filter_exposures_by_source_ids(files: list, source_ids: list[int]) -> list:
+    """Keep only canonical exposures whose trailing ``_<source_id>.fits`` is selected."""
+    allowed = {str(s) for s in source_ids}
+    out = []
+    for p in files:
+        stem = p.name[:-len('.fits')] if p.name.endswith('.fits') else p.name
+        if stem.rsplit('_', 1)[-1] in allowed:
+            out.append(p)
+    return out
+
+
+def _jwst_pid_from_obs_cfg(obs_cfg: dict) -> int:
+    """Best-effort JWST program id for an intermediates-only deploy (no summary).
+
+    Prefer the numeric ``data_subdir``; else parse ``jw<5 digits>`` from the files
+    glob; else 0 (the observations upsert tolerates it; a later full deploy from the
+    summary corrects it)."""
+    ds = str(obs_cfg.get('data_subdir', '')).strip()
+    if ds.isdigit():
+        return int(ds)
+    files = obs_cfg.get('files', '')
+    files = files if isinstance(files, str) else (files[0] if files else '')
+    m = re.search(r'jw(\d{5})', str(files))
+    return int(m.group(1)) if m else 0
+
+
+def _deploy_intermediates_only(
+    obs_name: str, obs_dir, config: dict, *,
+    dry_run: bool = False, auto_approve: bool = False,
+) -> dict:
+    """Deploy canonical spectrum-exposure intermediates for an observation with no
+    stage3 finals yet (epic #210, B5) — the "reduced through stage2, review before
+    stage3" flow. Uploads + registers the intermediates and records an auto-DRAFT
+    deployment. There is no science to publish; finishing stage3 + a normal deploy
+    publishes it. Scope (field/program/pid) comes from observations.toml since there
+    is no summary to read it from.
+    """
+    exposure_files = discover_spectrum_exposures(obs_dir)
+    obs_cfg = load_observations().get(obs_name, {})
+    field = obs_cfg.get('field', '')
+    program_slug = obs_cfg.get('program', '')
+    programs_config = load_programs()
+    if program_slug:
+        validate_program_slug(program_slug, programs_config, obs_name)
+
+    print(f"Observation: {obs_name}  (intermediates-only — no stage3 finals yet)")
+    print(f"  Field: {field}")
+    print(f"  Program: {program_slug}")
+    print(f"  Canonical spectrum-exposures: {len(exposure_files)}")
+
+    if not exposure_files:
+        print("No canonical spectrum-exposures and no finals — nothing to deploy.")
+        return {'field': field, 'needs_reconcile': False}
+
+    if dry_run:
+        print("\n=== DRY RUN (intermediates-only → auto-draft) ===")
+        print(f"Would upload {len(exposure_files)} canonical spectrum-exposures "
+              f"and record a draft deployment for {obs_name}.")
+        return {'field': field, 'needs_reconcile': False}
+
+    sb = get_supabase_client(config)
+
+    # A draft deploy requires the B1 lifecycle on the target DB (same gate as --draft).
+    cap = get_lifecycle_status(sb)
+    if not cap.get('enabled'):
+        print("ERROR: deploying intermediates as a draft requires the B1 lifecycle "
+              "enforcement (#217) on the target database, but it is not enabled.")
+        if cap.get('error'):
+            print(f"  {cap['error']}")
+        sys.exit(1)
+
+    user_id = get_user_id_from_token(config)
+    jwst_program_id = _jwst_pid_from_obs_cfg(obs_cfg)
+
+    # The deployment row FKs observations(name); ensure program + observation exist.
+    if program_slug:
+        print("Upserting program + observation...")
+        upsert_programs(sb, [program_slug], programs_config)
+        file_globs_raw = obs_cfg.get('files', [])
+        file_globs = [file_globs_raw] if isinstance(file_globs_raw, str) else list(file_globs_raw)
+        upsert_observation(
+            sb, obs_name, program_slug, jwst_program_id, field,
+            file_globs=file_globs or None,
+            gratings=obs_cfg.get('gratings') or None,
+            data_subdir=obs_cfg.get('data_subdir'),
+        )
+
+    scope = Scope(obs=obs_name)
+    scope_version_at_start = get_deploy_scope_version(sb, 'observation', obs_name)
+    upload_tasks = [
+        UploadTask(p, storage_key('nirspec_spectrum_exposure', scope, p.name), 'application/fits')
+        for p in exposure_files
+    ]
+    uploaded_keys: set[str] = set()
+    print(f"Uploading {len(upload_tasks)} canonical spectrum-exposures...")
+    success, failed, failed_msgs = upload_files_parallel(
+        config, upload_tasks, desc="R2 uploads", succeeded_out=uploaded_keys)
+    print(f"Uploaded {success}/{len(upload_tasks)} files")
+
+    deployment_id = insert_deployment(
+        sb, observation=obs_name, deployed_by=user_id, status='draft',
+        cfpipe_version=None, n_targets=0, n_spectra=0,
+    )
+    if deployment_id:
+        update_latest_deployment(sb, obs_name, deployment_id)
+        print(f"\nDeployment #{deployment_id} recorded (draft — intermediates only)")
+        log_deploy_event(
+            sb, action='upload', actor=user_id, deployment_id=deployment_id,
+            observation=obs_name, affected_count=len(exposure_files),
+            metadata={'intermediates_only': True, 'draft': True})
+
+    if uploaded_keys:
+        from campfire.deploy.registry import (
+            build_registry_rows, resolve_backend_label, upsert_storage_objects,
+        )
+        reg_rows = build_registry_rows(
+            upload_tasks, backend=resolve_backend_label(config),
+            deployment_id=deployment_id, uploaded_by=user_id,
+            succeeded_keys=uploaded_keys)
+        n_reg = upsert_storage_objects(sb, reg_rows)
+        print(f"Registered {n_reg} storage objects")
+
+    claim = claim_deploy_scope(sb, 'observation', obs_name, scope_version_at_start, actor=user_id)
+    if claim.get('conflict'):
+        print(f"⚠  CONCURRENT DEPLOY DETECTED for {obs_name}: another deploy advanced "
+              f"this observation while this one was running.")
+
+    print(f"\nDeployed {len(exposure_files)} canonical spectrum-exposures "
+          f"(draft — no finals yet). Finish stage3 + re-deploy to publish.")
+    return {'field': field, 'needs_reconcile': False}
+
+
 def deploy_observation(
     obs_name: str,
     config: dict,
@@ -183,7 +316,7 @@ def deploy_observation(
     source_ids: list[int] | None = None,
     auto_approve: bool = False,
     defer_rebuild: bool = False,
-    in_prep: bool = False,
+    draft: bool = False,
 ) -> dict:
     """Full deployment: ECSV -> generate content -> R2 upload -> Supabase upsert.
 
@@ -191,9 +324,9 @@ def deploy_observation(
     (and materialized-view refresh) is skipped so the caller can batch
     them after processing multiple observations of the same field.
 
-    When *in_prep* is True (epic #210, B2), the deployed spectra land
-    ``deploy_status='in_prep'`` (admin-only, invisible to users) and the
-    deployment record is marked ``in_prep`` — a draft an admin reviews and
+    When *draft* is True (epic #210, B2), the deployed spectra land
+    ``deploy_status='draft'`` (admin-only, invisible to users) and the
+    deployment record is marked ``draft`` — a draft an admin reviews and
     publishes via the admin UI. Requires the B1 (#217) lifecycle to be applied
     to the target database; checked up front via ``get_lifecycle_status`` so the
     deploy aborts cleanly rather than silently shipping unguarded drafts.
@@ -203,7 +336,16 @@ def deploy_observation(
     to-do branch above sets it False).
     """
     obs_dir = resolve_obs_dir(obs_name)
-    summary = load_summary(obs_dir, obs_name)
+    summary = load_summary(obs_dir, obs_name, required=False)
+
+    # Intermediates-only deploy (epic #210, B5): reduced through stage2 (canonical
+    # spectrum-exposures exist) but no stage3 finals/summary yet. Upload + register
+    # the intermediates and record an auto-draft deployment for portal review, then
+    # return — the finals path below is summary-driven. An incomplete deployment is
+    # always a draft.
+    if summary is None or len(summary) == 0:
+        return _deploy_intermediates_only(
+            obs_name, obs_dir, config, dry_run=dry_run, auto_approve=auto_approve)
 
     if source_ids:
         total = len(summary)
@@ -363,18 +505,18 @@ def deploy_observation(
     # on the TARGET database, or the drafts would not actually be hidden. Check the
     # marker up front and abort cleanly if absent (or if the RPC itself is missing,
     # i.e. this deploy code is newer than the DB).
-    if in_prep:
+    if draft:
         cap = get_lifecycle_status(sb)
         if not cap.get('enabled'):
-            print("ERROR: --in-prep requires the B1 lifecycle enforcement (#217) on "
+            print("ERROR: --draft requires the B1 lifecycle enforcement (#217) on "
                   "the target database, but it is not enabled.")
             if cap.get('checks'):
                 print(f"  capability checks: {cap['checks']}")
             if cap.get('error'):
                 print(f"  {cap['error']}")
-            print("  Deploy the B1 migration first, or omit --in-prep to publish directly.")
+            print("  Deploy the B1 migration first, or omit --draft to publish directly.")
             sys.exit(1)
-        print("Deploying as in_prep draft (admin-only until published).")
+        print("Deploying as draft (admin-only until published).")
 
     # B4 multi-reducer safety: snapshot this observation's deploy-scope version
     # now; we compare-and-set it at finalize to detect a concurrent deploy of the
@@ -452,6 +594,20 @@ def deploy_observation(
             for sed_path in sed_files:
                 upload_tasks.append(UploadTask(sed_path, storage_key('sed', scope, sed_path.name), 'application/pdf'))
 
+            # Canonical spectrum-exposure intermediates (epic #210, B5): uploaded on
+            # EVERY deploy (cloud-as-source-of-truth + delete-local→restore), filtered
+            # to the deployed source_ids when --source-ids is set. Registered as
+            # product_type='nirspec_spectrum_exposure' with a per-exposure exposure_ref.
+            exposure_files = discover_spectrum_exposures(obs_dir)
+            if source_ids:
+                exposure_files = _filter_exposures_by_source_ids(exposure_files, source_ids)
+            for exp_path in exposure_files:
+                upload_tasks.append(UploadTask(
+                    exp_path, storage_key('nirspec_spectrum_exposure', scope, exp_path.name),
+                    'application/fits'))
+            if exposure_files:
+                print(f"  + {len(exposure_files)} canonical spectrum-exposure intermediates")
+
             print(f"Uploading {len(upload_tasks)} files...")
             success, failed, failed_msgs = upload_files_parallel(
                 config, upload_tasks, desc="R2 uploads", succeeded_out=uploaded_keys,
@@ -487,7 +643,7 @@ def deploy_observation(
         n_obj, new_object_ids, _n_quality_reset = batch_upsert_objects(sb, objects, field, force_overwrite, objects_with_sed)
         print(f"  {n_obj} objects")
 
-        # B2: an in_prep deploy forces deploy_status='in_prep' on every spectrum it
+        # B2: an draft deploy forces deploy_status='draft' on every spectrum it
         # writes — the whole observation lands as an admin-only draft. Guard first
         # against silently hiding data that is already live: warn (and require
         # confirmation) if any of these (target_id, grating) rows are currently
@@ -495,18 +651,18 @@ def deploy_observation(
         # explicit publish. A single spectra row per (target,grating) can't hold a
         # live + draft version at once, so this is "take the observation back to
         # draft", not zero-downtime staging of a re-reduction.
-        if in_prep:
+        if draft:
             already_published = _count_published_spectra(sb, spectra)
             if already_published and not auto_approve:
                 print()
                 print(f"WARNING: --in-prep will hide {already_published} currently-PUBLISHED "
                       f"spectrum row(s) until you re-publish them.")
-                resp = input("  Take these back to draft (in_prep)? [y/N]: ")
+                resp = input("  Take these back to draft (draft)? [y/N]: ")
                 if resp.lower() != 'y':
                     print("Aborted.")
                     return {'field': field, 'needs_reconcile': False}
             for rec in spectra:
-                rec['deploy_status'] = 'in_prep'
+                rec['deploy_status'] = 'draft'
 
         print("Upserting spectra...")
         n_spec, changed_hashes = batch_upsert_spectra(sb, spectra)
@@ -621,12 +777,12 @@ def deploy_observation(
             force_overwrite=force_overwrite,
             source_ids_filter=source_ids,
             supabase_only=supabase_only,
-            status='in_prep' if in_prep else 'published',
+            status='draft' if draft else 'published',
         )
         if deployment_id:
             update_latest_deployment(sb, obs_name, deployment_id)
             print(f"\nDeployment #{deployment_id} recorded"
-                  f"{' (in_prep draft)' if in_prep else ''}")
+                  f"{' (draft)' if draft else ''}")
             # B2: record the deploy in the lifecycle audit log.
             log_deploy_event(
                 sb,
@@ -635,7 +791,7 @@ def deploy_observation(
                 deployment_id=deployment_id,
                 observation=obs_name,
                 affected_count=len(spectra),
-                metadata={'in_prep': in_prep, 'n_objects': len(objects)},
+                metadata={'draft': draft, 'n_objects': len(objects)},
             )
 
         # B4 multi-reducer safety: compare-and-set the scope version. A conflict

--- a/python/campfire/deploy/discover.py
+++ b/python/campfire/deploy/discover.py
@@ -19,6 +19,22 @@ def discover_sed_plots(obs_dir: Path) -> list[Path]:
     return sorted(obs_dir.glob('*_sed.pdf'))
 
 
+def discover_spectrum_exposures(obs_dir: Path) -> list[Path]:
+    """Find the canonical NIRSpec spectrum-exposure intermediates (epic #210, B5).
+
+    These are the bare per-(exposure,detector,source) canonical files (issue #212),
+    named ``{root}_{nod}_nrs[12]_{source}.fits`` — e.g.
+    ``jw07076020001_04101_00001_nrs1_117757.fits``. They live in the same products
+    directory as the final ``*_spec.fits`` products; the ``_nrs[12]_`` segment is
+    what distinguishes a per-exposure intermediate from a final (whose name is
+    grating/filter-based and ends ``_spec.fits``). Excludes finals defensively.
+    """
+    return sorted(
+        p for p in obs_dir.glob('*_nrs[12]_*.fits')
+        if not p.name.endswith('_spec.fits')
+    )
+
+
 def discover_slits_json(obs_dir: Path, obs_name: str) -> Path | None:
     """Find the slit geometry JSON file, or None if absent."""
     slits_path = obs_dir / f'{obs_name}_slits.json'

--- a/python/campfire/deploy/registry.py
+++ b/python/campfire/deploy/registry.py
@@ -82,6 +82,21 @@ def normalize_etag(etag: str | None) -> str | None:
 # Key → row mapping
 # ---------------------------------------------------------------------------
 
+def _exposure_ref_for(product_type: str, filename: str) -> str | None:
+    """Stable per-exposure reference for exposure-level intermediates (epic #210).
+
+    For ``nirspec_spectrum_exposure`` the canonical filename
+    (``{root}_{nod}_nrs[12]_{source}.fits``) IS the natural unique exposure key, so
+    the ref is the filename stem (drop ``.fits``). Backs the partial-unique
+    ``(product_type, exposure_ref) WHERE status='active'`` registry contract
+    (one current object per product/exposure). None for non-exposure products
+    (their exposure_ref stays NULL; NULLs are distinct, so finals never collide).
+    """
+    if product_type == 'nirspec_spectrum_exposure' and filename.endswith('.fits'):
+        return filename[: -len('.fits')]
+    return None
+
+
 def _spectrum_id_for(filename: str) -> str | None:
     """Derive the owning spectrum_id from a spectrum-family filename.
 
@@ -145,10 +160,10 @@ def row_for_key(
         'observation': scope.obs,
         'field': scope.field,
         'spectrum_id': _spectrum_id_for(parsed.filename),
-        # exposure_ref is reserved for exposure-level intermediates (not deployed
-        # in F1). Left NULL so the partial UNIQUE (product_type, exposure_ref)
-        # WHERE active never collides for finals/previews (NULLs are distinct).
-        'exposure_ref': None,
+        # Exposure-level intermediates (nirspec_spectrum_exposure) carry a stable
+        # exposure_ref (filename stem) backing the partial-unique registry contract;
+        # finals/previews leave it NULL (NULLs are distinct, so they never collide).
+        'exposure_ref': _exposure_ref_for(product_type, parsed.filename),
         'deployment_id': deployment_id,
         'cfpipe_version': cfpipe_version,
         'uploaded_by': uploaded_by,

--- a/python/campfire/deploy/summary.py
+++ b/python/campfire/deploy/summary.py
@@ -50,14 +50,19 @@ def _clean_str(value) -> str | None:
     return s
 
 
-def load_summary(obs_dir: Path, obs_name: str) -> Table:
+def load_summary(obs_dir: Path, obs_name: str, required: bool = True) -> Table | None:
     """
-    Load the observation summary ECSV.
+    Load the observation summary ECSV (the stage3 finals manifest).
 
-    Raises SystemExit with a helpful message if the file is missing.
+    When ``required`` (default), a missing file is a hard error. When
+    ``required=False`` (epic #210, B5), a missing summary returns None instead —
+    the caller then treats the deploy as intermediates-only (no stage3 finals yet),
+    which is automatically a draft.
     """
     ecsv_path = obs_dir / f"{obs_name}_summary.ecsv"
     if not ecsv_path.exists():
+        if not required:
+            return None
         print(f"Error: Summary file not found: {ecsv_path}")
         print(f"Run `cfpipe nirspec summary --obs {obs_name}` first.")
         sys.exit(1)

--- a/python/campfire/deploy/supabase.py
+++ b/python/campfire/deploy/supabase.py
@@ -156,24 +156,23 @@ def insert_deployment(
     """
     Insert a deployment record and return its ID.
 
-    ``status`` is the deployment lifecycle (epic #210, B2): 'published' for a
-    normal deploy (stamps published_at=now), 'in_prep' for a `--in-prep` draft.
+    ``status`` is the deployment lifecycle (epic #210): 'published' for a normal
+    deploy (stamps published_at=now), 'draft' for a draft / incomplete deploy.
 
-    Returns None if the insert fails (e.g. deployed_by is not set).
+    The deployment record is ALWAYS written (it is the admin-review anchor for the
+    draft lifecycle). On a service-role / `--local` deploy there is no user JWT, so
+    ``deployed_by`` is NULL (the column is nullable as of B5); prod `login` deploys
+    still record the real user. Returns the new id, or None only on insert failure.
     """
-    if not deployed_by:
-        print("  Warning: No user_id available, skipping deployment record")
-        return None
-
     data = {
         'observation': observation,
-        'deployed_by': deployed_by,
+        'deployed_by': deployed_by,  # may be NULL on service-role / local deploys
         'force_overwrite': force_overwrite,
         'supabase_only': supabase_only,
         'status': status,
     }
     # A normal (published) deploy stamps published_at so the lifecycle timeline is
-    # complete without a separate publish step; in_prep drafts leave it NULL until
+    # complete without a separate publish step; drafts leave it NULL until
     # an admin publishes via set_deployment_status.
     if status == 'published':
         from datetime import datetime, timezone
@@ -313,7 +312,7 @@ def set_deployment_status(
     actor: str | None = None,
     host: str | None = None,
 ) -> dict | None:
-    """Transition a deployment's lifecycle (publish/revoke/in_prep) via the
+    """Transition a deployment's lifecycle (publish/revoke/draft) via the
     SECURITY DEFINER RPC: flips the deployment + its spectra + recomputes
     has_published_spectrum + writes audit rows, all server-side. Returns the RPC
     result json, or None on failure."""

--- a/python/tests/sql/b1_deploy_status_leak.sql
+++ b/python/tests/sql/b1_deploy_status_leak.sql
@@ -3,7 +3,7 @@
 -- =============================================================================
 -- Proves, against a freshly `supabase db reset` local DB, that:
 --   1. A NON-ADMIN authenticated user (with full program access) gets ZERO
---      in_prep/revoked spectra/objects/targets through RLS, while a published
+--      draft/revoked spectra/objects/targets through RLS, while a published
 --      control row stays visible.
 --   2. An ADMIN sees the unpublished rows (the `OR is_admin()` branch).
 --   3. The service-role RPC predicate `p_include_unpublished` gates: false hides
@@ -25,7 +25,7 @@ BEGIN;
 
 -- ---- fixtures (run as the bootstrap superuser, bypasses RLS) ----------------
 CREATE TEMP TABLE _vobj (oid int, st text);
-INSERT INTO _vobj VALUES (1, 'in_prep'), (2, 'revoked');
+INSERT INTO _vobj VALUES (1, 'draft'), (2, 'revoked');
 
 CREATE TEMP TABLE _vtgt AS
   SELECT t.id, t.target_id, v.st
@@ -67,7 +67,7 @@ DO $$
 DECLARE n int;
 BEGIN
   SELECT count(*) INTO n FROM public.spectra WHERE id IN (SELECT id FROM _vspec);
-  IF n <> 0 THEN RAISE EXCEPTION 'RLS LEAK: non-admin sees % in_prep/revoked spectra (expected 0)', n; END IF;
+  IF n <> 0 THEN RAISE EXCEPTION 'RLS LEAK: non-admin sees % draft/revoked spectra (expected 0)', n; END IF;
 
   SELECT count(*) INTO n FROM public.objects WHERE id IN (SELECT oid FROM _vobj);
   IF n <> 0 THEN RAISE EXCEPTION 'RLS LEAK: non-admin sees % unpublished objects (expected 0)', n; END IF;

--- a/python/tests/sql/b2_lifecycle.sql
+++ b/python/tests/sql/b2_lifecycle.sql
@@ -209,7 +209,7 @@ END $$;
 -- =========================================================================
 -- The path B3's admin UI uses. Recover (set_deployment_status -> 'published')
 -- MUST flip the deployment's *revoked* spectra back to published — the prior
--- version only matched 'in_prep', silently leaving them hidden ("0 updated").
+-- version only matched 'draft', silently leaving them hidden ("0 updated").
 RESET ROLE;
 SET LOCAL ROLE service_role;
 SELECT set_config('request.jwt.claims', json_build_object('role', 'service_role')::text, true);

--- a/python/tests/test_deploy_status_rls.py
+++ b/python/tests/test_deploy_status_rls.py
@@ -2,7 +2,7 @@
 
 DB-backed integration test: runs ``sql/b1_deploy_status_leak.sql`` against the
 local Supabase Postgres via ``docker exec ... psql`` and asserts the harness
-reaches its PASS marker. The SQL marks seed rows in_prep/revoked inside a
+reaches its PASS marker. The SQL marks seed rows draft/revoked inside a
 transaction (rolled back) and asserts a non-admin sees ZERO of them through RLS
 and the service-role RPC predicate, while an admin does — the B1 exit criterion.
 
@@ -43,7 +43,7 @@ requires_local_db = pytest.mark.skipif(
 
 @requires_local_db
 def test_deploy_status_no_leak_to_non_admin():
-    """Non-admin gets zero in_prep/revoked rows (RLS + RPC); admin sees them."""
+    """Non-admin gets zero draft/revoked rows (RLS + RPC); admin sees them."""
     sql = SQL_FILE.read_text()
     result = subprocess.run(
         ["docker", "exec", "-i", CONTAINER,
@@ -54,7 +54,7 @@ def test_deploy_status_no_leak_to_non_admin():
     # A leak/regression RAISEs inside a DO block -> ON_ERROR_STOP -> non-zero exit.
     assert result.returncode == 0, (
         f"B1 leak harness FAILED (psql exit {result.returncode}).\n"
-        f"This means a reader exposed an in_prep/revoked row to a non-admin, or a "
+        f"This means a reader exposed an draft/revoked row to a non-admin, or a "
         f"published control row regressed. Output:\n{combined}"
     )
     assert PASS_MARKER in result.stdout, (

--- a/python/tests/test_intermediate_upload.py
+++ b/python/tests/test_intermediate_upload.py
@@ -1,0 +1,66 @@
+"""Unit tests for B5 (epic #210) unconditional intermediate-exposure upload.
+
+Pure functions, no DB/cloud: canonical-exposure discovery, source-id filtering,
+exposure_ref derivation, and the no-summary JWST-PID fallback. The end-to-end
+upload + registration + auto-draft is exercised live against local Supabase in CI
+(`campfire deploy --obs … --local`).
+"""
+from campfire.deploy.discover import discover_spectrum_exposures
+from campfire.deploy.deploy import _filter_exposures_by_source_ids, _jwst_pid_from_obs_cfg
+from campfire.deploy.registry import _exposure_ref_for
+
+
+def _touch(d, name):
+    p = d / name
+    p.write_bytes(b"\x00")
+    return p
+
+
+def test_discover_spectrum_exposures_excludes_finals(tmp_path):
+    # canonical per-exposure intermediates
+    _touch(tmp_path, "jw07076020001_04101_00001_nrs1_117757.fits")
+    _touch(tmp_path, "jw07076020001_04101_00001_nrs2_117757.fits")
+    _touch(tmp_path, "jw07076020001_04101_00002_nrs1_120383.fits")
+    # finals + other products that must NOT be picked up
+    _touch(tmp_path, "ember_egs_p1_prism_clear_117757_spec.fits")
+    _touch(tmp_path, "ember_egs_p1_summary.ecsv")
+    _touch(tmp_path, "117757_rgb.png")
+
+    found = discover_spectrum_exposures(tmp_path)
+    names = sorted(p.name for p in found)
+    assert names == [
+        "jw07076020001_04101_00001_nrs1_117757.fits",
+        "jw07076020001_04101_00001_nrs2_117757.fits",
+        "jw07076020001_04101_00002_nrs1_120383.fits",
+    ]
+    assert all("_spec.fits" not in n for n in names)
+
+
+def test_filter_exposures_by_source_ids(tmp_path):
+    files = [
+        _touch(tmp_path, "jw07076020001_04101_00001_nrs1_117757.fits"),
+        _touch(tmp_path, "jw07076020001_04101_00001_nrs2_117757.fits"),
+        _touch(tmp_path, "jw07076020001_04101_00002_nrs1_120383.fits"),
+    ]
+    kept = _filter_exposures_by_source_ids(files, [117757])
+    assert sorted(p.name for p in kept) == [
+        "jw07076020001_04101_00001_nrs1_117757.fits",
+        "jw07076020001_04101_00001_nrs2_117757.fits",
+    ]
+
+
+def test_exposure_ref_is_stem_for_intermediates_else_none():
+    assert _exposure_ref_for(
+        "nirspec_spectrum_exposure", "jw07076020001_04101_00001_nrs1_117757.fits"
+    ) == "jw07076020001_04101_00001_nrs1_117757"
+    # finals / other products carry no exposure_ref (NULL; never collide on the
+    # partial-unique (product_type, exposure_ref) registry index)
+    assert _exposure_ref_for("nirspec_spec", "x_spec.fits") is None
+    assert _exposure_ref_for("rgb", "12345_rgb.png") is None
+
+
+def test_jwst_pid_from_obs_cfg():
+    assert _jwst_pid_from_obs_cfg({"data_subdir": "7076"}) == 7076
+    assert _jwst_pid_from_obs_cfg({"files": "jw07076020001*"}) == 7076
+    assert _jwst_pid_from_obs_cfg({"files": ["jw07076020001*"]}) == 7076
+    assert _jwst_pid_from_obs_cfg({}) == 0

--- a/python/tests/test_lifecycle_deploy.py
+++ b/python/tests/test_lifecycle_deploy.py
@@ -66,7 +66,7 @@ def test_count_published_spectra_counts_only_matching_pairs():
     existing = [
         {"target_id": "t1", "grating": "prism", "deploy_status": "published"},
         {"target_id": "t1", "grating": "g140m", "deploy_status": "published"},
-        {"target_id": "t2", "grating": "prism", "deploy_status": "in_prep"},  # not published
+        {"target_id": "t2", "grating": "prism", "deploy_status": "draft"},  # not published
     ]
     client = _FakeClient(existing)
     # Deploying t1/prism (live) + t2/prism (draft) + t3/prism (new) -> only t1/prism counts.
@@ -98,11 +98,11 @@ def test_insert_deployment_published_stamps_published_at():
     assert rec.get("published_at")  # stamped on a published deploy
 
 
-def test_insert_deployment_in_prep_leaves_published_at_null():
+def test_insert_deployment_draft_leaves_published_at_null():
     client = _FakeClient()
-    insert_deployment(client, observation="obs", deployed_by="u1", status="in_prep")
+    insert_deployment(client, observation="obs", deployed_by="u1", status="draft")
     rec = client.inserted[-1]
-    assert rec["status"] == "in_prep"
+    assert rec["status"] == "draft"
     assert "published_at" not in rec  # draft: no publish stamp until an admin publishes
 
 

--- a/supabase/migrations/20260629131409_b5_rename_draft_and_nullable_deployed_by.sql
+++ b/supabase/migrations/20260629131409_b5_rename_draft_and_nullable_deployed_by.sql
@@ -1,0 +1,253 @@
+alter table "public"."deployments" drop constraint "deployments_status_check";
+
+alter table "public"."spectra" drop constraint "spectra_deploy_status_check";
+
+-- B5: migrate existing rows to the renamed value BEFORE the new CHECK validates
+-- (none in prod yet; idempotent).
+UPDATE public.spectra SET deploy_status = 'draft' WHERE deploy_status = 'in_prep';
+UPDATE public.deployments SET status = 'draft' WHERE status = 'in_prep';
+
+drop materialized view if exists "public"."mv_filter_options";
+
+drop materialized view if exists "public"."mv_programs_overview";
+
+drop view if exists "public"."nircam_reduction_progress";
+
+drop view if exists "public"."spectrum_flag_summary";
+
+alter table "public"."deployments" alter column "deployed_by" drop not null;
+
+alter table "public"."deployments" add constraint "deployments_status_check" CHECK ((status = ANY (ARRAY['draft'::text, 'published'::text, 'revoked'::text]))) not valid;
+
+alter table "public"."deployments" validate constraint "deployments_status_check";
+
+alter table "public"."spectra" add constraint "spectra_deploy_status_check" CHECK ((deploy_status = ANY (ARRAY['draft'::text, 'published'::text, 'revoked'::text]))) not valid;
+
+alter table "public"."spectra" validate constraint "spectra_deploy_status_check";
+
+set check_function_bodies = off;
+
+-- NOTE (#228): can_inspect()/handle_new_user() re-emitted by migra (pre-existing
+-- SET search_path drift, tracked in #228). Stripped to keep this migration single-purpose.
+
+create materialized view "public"."mv_filter_options" as  SELECT 1 AS id,
+    ARRAY( SELECT DISTINCT targets.field
+           FROM public.targets
+          WHERE targets.has_published_spectrum
+          ORDER BY targets.field) AS fields,
+    ARRAY( SELECT DISTINCT targets.observation
+           FROM public.targets
+          WHERE ((targets.observation IS NOT NULL) AND targets.has_published_spectrum)
+          ORDER BY targets.observation) AS observations,
+    ARRAY( SELECT DISTINCT spectra.grating
+           FROM public.spectra
+          WHERE (spectra.deploy_status = 'published'::text)
+          ORDER BY spectra.grating) AS gratings;
+
+
+create materialized view "public"."mv_programs_overview" as  SELECT p.slug,
+    p.program_name,
+    p.pi_name,
+    p.description,
+    p.is_public,
+    p.cycle,
+    COALESCE(stats.target_count, (0)::bigint) AS target_count,
+    COALESCE(stats.gratings, ARRAY[]::text[]) AS gratings,
+    COALESCE(stats.fields, ARRAY[]::text[]) AS fields,
+    COALESCE(stats.observations, ARRAY[]::text[]) AS observations,
+    COALESCE(pids.jwst_pids, ARRAY[]::integer[]) AS jwst_pids,
+    COALESCE(pids.n_observations, (0)::bigint) AS n_observations,
+    last_red.last_reduced_at
+   FROM (((public.programs p
+     LEFT JOIN ( SELECT t.program_slug,
+            count(DISTINCT t.target_id) AS target_count,
+            array_agg(DISTINCT s.grating ORDER BY s.grating) FILTER (WHERE (s.grating IS NOT NULL)) AS gratings,
+            array_agg(DISTINCT t.field ORDER BY t.field) AS fields,
+            array_agg(DISTINCT t.observation ORDER BY t.observation) AS observations
+           FROM (public.targets t
+             LEFT JOIN public.spectra s ON (((s.target_id = t.target_id) AND (s.deploy_status = 'published'::text))))
+          GROUP BY t.program_slug) stats ON ((p.slug = stats.program_slug)))
+     LEFT JOIN ( SELECT observations.program_slug,
+            array_agg(DISTINCT observations.jwst_program_id ORDER BY observations.jwst_program_id) AS jwst_pids,
+            count(*) AS n_observations
+           FROM public.observations
+          GROUP BY observations.program_slug) pids ON ((p.slug = pids.program_slug)))
+     LEFT JOIN ( SELECT o.program_slug,
+            max(d.reduced_at) AS last_reduced_at
+           FROM (public.observations o
+             JOIN public.deployments d ON ((d.observation = o.name)))
+          WHERE (d.source_ids_filter IS NULL)
+          GROUP BY o.program_slug) last_red ON ((p.slug = last_red.program_slug)));
+
+
+-- B5: security_invoker restored (migra drops it on recreate).
+-- B5: restore matview unique indexes migra drops (REFRESH CONCURRENTLY needs them).
+CREATE UNIQUE INDEX mv_filter_options_id ON public.mv_filter_options USING btree (id);
+CREATE UNIQUE INDEX mv_programs_overview_slug ON public.mv_programs_overview USING btree (slug);
+
+create or replace view "public"."nircam_reduction_progress" with (security_invoker = true) as  SELECT field,
+    filter,
+    count(*) AS total,
+    count(*) FILTER (WHERE (stage = 'uncal'::text)) AS at_uncal,
+    count(*) FILTER (WHERE (stage = 'detector1'::text)) AS at_detector1,
+    count(*) FILTER (WHERE (stage = 'persistence'::text)) AS at_persistence,
+    count(*) FILTER (WHERE (stage = 'wisp'::text)) AS at_wisp,
+    count(*) FILTER (WHERE (stage = 'striping'::text)) AS at_striping,
+    count(*) FILTER (WHERE (stage = 'image2'::text)) AS at_image2,
+    count(*) FILTER (WHERE (stage = 'edge'::text)) AS at_edge,
+    count(*) FILTER (WHERE (stage = 'sky'::text)) AS at_sky,
+    count(*) FILTER (WHERE (stage = 'diag_striping'::text)) AS at_diag_striping,
+    count(*) FILTER (WHERE (stage = 'variance'::text)) AS at_variance,
+    count(*) FILTER (WHERE (stage = 'wcs_shift'::text)) AS at_wcs_shift,
+    count(*) FILTER (WHERE (stage = 'preview'::text)) AS at_preview,
+    count(*) FILTER (WHERE (stage = 'jhat'::text)) AS at_jhat,
+    count(*) FILTER (WHERE (stage = 'apply_mask'::text)) AS at_apply_mask,
+    count(*) FILTER (WHERE (stage = 'bad_pixel'::text)) AS at_bad_pixel,
+    count(*) FILTER (WHERE (stage = 'outlier'::text)) AS at_outlier,
+    count(*) FILTER (WHERE (review_status = 'pending'::text)) AS pending_review,
+    count(*) FILTER (WHERE (review_status = 'approved'::text)) AS approved,
+    count(*) FILTER (WHERE (review_status = 'excluded'::text)) AS excluded,
+    count(*) FILTER (WHERE (masking = 'needed'::text)) AS needs_masking,
+    count(*) FILTER (WHERE (correction = 'needed'::text)) AS needs_correction
+   FROM public.nircam_exposures
+  GROUP BY field, filter;
+
+
+CREATE OR REPLACE FUNCTION public.set_deployment_status(p_deployment_id integer, p_to text, p_actor uuid DEFAULT NULL::uuid, p_host text DEFAULT NULL::text)
+ RETURNS json
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_is_admin boolean;
+  v_obs text;
+  v_action text;
+  v_spectrum_ids integer[];
+  v_result json;
+BEGIN
+  SELECT COALESCE(up.is_admin, false) INTO v_is_admin
+  FROM user_profiles up WHERE up.user_id = auth.uid();
+  IF NOT (COALESCE(v_is_admin, false) OR COALESCE(auth.role(), '') = 'service_role') THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+
+  IF p_to NOT IN ('draft', 'published', 'revoked') THEN
+    RAISE EXCEPTION 'Invalid status: %', p_to;
+  END IF;
+
+  SELECT observation INTO v_obs FROM deployments WHERE id = p_deployment_id;
+  IF v_obs IS NULL THEN
+    RAISE EXCEPTION 'Deployment % not found', p_deployment_id;
+  END IF;
+
+  -- Which current statuses transition to p_to:
+  --   p_to='published'  -> draft (first publish) OR revoked (recover) become visible
+  --   p_to='revoked'    -> published spectra are hidden
+  --   p_to='draft'    -> published spectra go back to draft
+  -- The prior version matched only 'draft' for the published case, so recovering
+  -- a REVOKED deployment flipped the deployment row but left its spectra revoked
+  -- and hidden ("0 updated", silently inconsistent) — #233 review.
+  SELECT array_agg(s.id) INTO v_spectrum_ids
+  FROM spectra s JOIN targets t ON s.target_id = t.target_id
+  WHERE t.observation = v_obs
+    AND s.deploy_status = ANY (
+      CASE p_to WHEN 'published' THEN ARRAY['draft', 'revoked']
+                WHEN 'revoked'   THEN ARRAY['published']
+                ELSE                  ARRAY['published'] END);
+
+  -- Audit label: publishing previously-revoked spectra is a 'recover', not a
+  -- first 'publish'. Computed before the transition (spectra still hold old status).
+  v_action := CASE
+    WHEN p_to = 'revoked' THEN 'revoke'
+    WHEN p_to = 'draft' THEN 'upload'
+    WHEN EXISTS (SELECT 1 FROM spectra s JOIN targets t ON s.target_id = t.target_id
+                 WHERE t.observation = v_obs AND s.deploy_status = 'revoked')
+      THEN 'recover'
+    ELSE 'publish'
+  END;
+
+  UPDATE deployments SET
+    status = p_to,
+    published_at = CASE WHEN p_to = 'published' THEN now() ELSE published_at END,
+    revoked_at = CASE WHEN p_to = 'revoked' THEN now() ELSE revoked_at END
+  WHERE id = p_deployment_id;
+
+  IF v_spectrum_ids IS NOT NULL THEN
+    v_result := public.set_spectra_deploy_status(
+      p_spectrum_db_ids := v_spectrum_ids, p_to := p_to, p_action := v_action,
+      p_actor := p_actor, p_deployment_id := p_deployment_id, p_host := p_host);
+  ELSE
+    v_result := json_build_object('updated', 0, 'action', v_action);
+  END IF;
+
+  RETURN json_build_object(
+    'deployment_id', p_deployment_id, 'observation', v_obs,
+    'status', p_to, 'spectra', v_result);
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.set_spectra_deploy_status(p_spectrum_db_ids integer[], p_to text, p_action text DEFAULT NULL::text, p_actor uuid DEFAULT NULL::uuid, p_deployment_id integer DEFAULT NULL::integer, p_host text DEFAULT NULL::text)
+ RETURNS json
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_is_admin boolean;
+  v_action text;
+  v_updated int := 0;
+  v_target_ids text[];
+  v_recompute json;
+BEGIN
+  SELECT COALESCE(up.is_admin, false) INTO v_is_admin
+  FROM user_profiles up WHERE up.user_id = auth.uid();
+  IF NOT (COALESCE(v_is_admin, false) OR COALESCE(auth.role(), '') = 'service_role') THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+
+  IF p_to NOT IN ('draft', 'published', 'revoked') THEN
+    RAISE EXCEPTION 'Invalid deploy_status: %', p_to;
+  END IF;
+
+  v_action := COALESCE(p_action,
+    CASE p_to WHEN 'published' THEN 'publish' WHEN 'revoked' THEN 'revoke' ELSE 'upload' END);
+  IF v_action NOT IN ('upload', 'publish', 'revoke', 'recover', 'supersede', 'delete') THEN
+    RAISE EXCEPTION 'Invalid action: %', v_action;
+  END IF;
+
+  IF p_spectrum_db_ids IS NULL OR array_length(p_spectrum_db_ids, 1) IS NULL THEN
+    RETURN json_build_object('updated', 0, 'action', v_action);
+  END IF;
+
+  SELECT array_agg(DISTINCT s.target_id) INTO v_target_ids
+  FROM spectra s WHERE s.id = ANY(p_spectrum_db_ids);
+
+  UPDATE spectra s SET deploy_status = p_to
+  WHERE s.id = ANY(p_spectrum_db_ids) AND s.deploy_status <> p_to;
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+
+  IF v_target_ids IS NOT NULL THEN
+    v_recompute := public.recompute_has_published_spectrum(p_target_ids := v_target_ids);
+  END IF;
+
+  INSERT INTO deploy_events(actor, action, deployment_id, status_to, affected_count, host, metadata)
+  VALUES (p_actor, v_action, p_deployment_id, p_to, v_updated, p_host,
+          jsonb_build_object('n_targets', COALESCE(array_length(v_target_ids, 1), 0)));
+
+  RETURN json_build_object('updated', v_updated, 'action', v_action, 'recompute', v_recompute);
+END;
+$function$
+;
+
+-- B5: security_invoker restored (migra drops it on recreate).
+create or replace view "public"."spectrum_flag_summary" with (security_invoker = true) as  SELECT s.id,
+    s.target_id,
+    s.grating,
+    array_agg(DISTINCT fd.label) FILTER (WHERE ((fd.category = 'dq_flags'::text) AND ((s.dq_flags & fd.value) > 0))) AS dq_flags_labels
+   FROM (public.spectra s
+     CROSS JOIN public.flag_definitions fd)
+  WHERE ((s.deploy_status = 'published'::text) OR public.is_admin())
+  GROUP BY s.id, s.target_id, s.grating;
+
+
+

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -2963,7 +2963,7 @@ GRANT EXECUTE ON FUNCTION public.get_storage_budget TO authenticated, service_ro
 -- =============================================================================
 -- Intermediate-product lifecycle (epic #210, B2/B3)
 -- =============================================================================
--- The publish/revoke/recover flow for in_prep science. spectra.deploy_status is
+-- The publish/revoke/recover flow for draft science. spectra.deploy_status is
 -- the user-facing visibility gate (B1); these RPCs are the only sanctioned way
 -- to transition it, and they keep targets/objects.has_published_spectrum and the
 -- deploy_events audit log in lockstep. All are SECURITY DEFINER + admin/service_role
@@ -3155,7 +3155,7 @@ BEGIN
     RAISE EXCEPTION 'Access denied: Admin privileges required';
   END IF;
 
-  IF p_to NOT IN ('in_prep', 'published', 'revoked') THEN
+  IF p_to NOT IN ('draft', 'published', 'revoked') THEN
     RAISE EXCEPTION 'Invalid deploy_status: %', p_to;
   END IF;
 
@@ -3192,7 +3192,7 @@ GRANT EXECUTE ON FUNCTION public.set_spectra_deploy_status(integer[], text, text
 
 
 -- set_deployment_status: deployment-scoped publish/revoke. Resolves the
--- deployment's observation, transitions its spectra (in_prep->published on
+-- deployment's observation, transitions its spectra (draft->published on
 -- publish; published->revoked on revoke), stamps the deployment lifecycle, and
 -- delegates the per-spectrum work (+ audit + recompute) to set_spectra_deploy_status.
 CREATE OR REPLACE FUNCTION public.set_deployment_status(
@@ -3217,7 +3217,7 @@ BEGIN
     RAISE EXCEPTION 'Access denied: Admin privileges required';
   END IF;
 
-  IF p_to NOT IN ('in_prep', 'published', 'revoked') THEN
+  IF p_to NOT IN ('draft', 'published', 'revoked') THEN
     RAISE EXCEPTION 'Invalid status: %', p_to;
   END IF;
 
@@ -3227,17 +3227,17 @@ BEGIN
   END IF;
 
   -- Which current statuses transition to p_to:
-  --   p_to='published'  -> in_prep (first publish) OR revoked (recover) become visible
+  --   p_to='published'  -> draft (first publish) OR revoked (recover) become visible
   --   p_to='revoked'    -> published spectra are hidden
-  --   p_to='in_prep'    -> published spectra go back to draft
-  -- The prior version matched only 'in_prep' for the published case, so recovering
+  --   p_to='draft'    -> published spectra go back to draft
+  -- The prior version matched only 'draft' for the published case, so recovering
   -- a REVOKED deployment flipped the deployment row but left its spectra revoked
   -- and hidden ("0 updated", silently inconsistent) — #233 review.
   SELECT array_agg(s.id) INTO v_spectrum_ids
   FROM spectra s JOIN targets t ON s.target_id = t.target_id
   WHERE t.observation = v_obs
     AND s.deploy_status = ANY (
-      CASE p_to WHEN 'published' THEN ARRAY['in_prep', 'revoked']
+      CASE p_to WHEN 'published' THEN ARRAY['draft', 'revoked']
                 WHEN 'revoked'   THEN ARRAY['published']
                 ELSE                  ARRAY['published'] END);
 
@@ -3245,7 +3245,7 @@ BEGIN
   -- first 'publish'. Computed before the transition (spectra still hold old status).
   v_action := CASE
     WHEN p_to = 'revoked' THEN 'revoke'
-    WHEN p_to = 'in_prep' THEN 'upload'
+    WHEN p_to = 'draft' THEN 'upload'
     WHEN EXISTS (SELECT 1 FROM spectra s JOIN targets t ON s.target_id = t.target_id
                  WHERE t.observation = v_obs AND s.deploy_status = 'revoked')
       THEN 'recover'

--- a/supabase/schemas/indexes.sql
+++ b/supabase/schemas/indexes.sql
@@ -178,11 +178,11 @@ CREATE INDEX IF NOT EXISTS idx_spectra_dq_flags
     ON public.spectra USING btree (dq_flags) WHERE (dq_flags != 0);
 
 -- B1 (#217): non-published spectra are the rare case (zero in B1, a minority in
--- B2); a partial index on the exclusion keeps the admin "show in_prep/revoked"
+-- B2); a partial index on the exclusion keeps the admin "show draft/revoked"
 -- triage cheap, mirroring idx_objects_is_active / idx_spectra_dq_flags. The
 -- common published-only path is served as a residual filter while all rows are
 -- published; B2 should add an EXPLAIN-driven partial/covering index on the hot
--- filter+sort key once real in_prep volume exists (do NOT guess it here).
+-- filter+sort key once real draft volume exists (do NOT guess it here).
 CREATE INDEX IF NOT EXISTS idx_spectra_deploy_status
     ON public.spectra USING btree (deploy_status) WHERE (deploy_status <> 'published');
 

--- a/supabase/schemas/policies.sql
+++ b/supabase/schemas/policies.sql
@@ -476,7 +476,7 @@ CREATE POLICY "select_spectra_by_access"
       WHERE t.program_slug = ANY((SELECT public.accessible_program_slugs())::text[])
     )
     -- B1 (#217): PRIMARY per-row gate. Only 'published' spectra reach non-admins;
-    -- 'in_prep' and 'revoked' are hidden. This is the sole gate for the user-client
+    -- 'draft' and 'revoked' are hidden. This is the sole gate for the user-client
     -- web routes that read spectra directly and never call an RPC (/api/spectrum,
     -- /api/download, /api/redshift-fit, /api/spectrum-thumbnail). Admins see all.
     AND (deploy_status = 'published' OR (SELECT public.is_admin()))

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -301,13 +301,13 @@ CREATE TABLE IF NOT EXISTS "public"."spectra" (
     "redshift_auto" double precision,
     "dq_flags" integer NOT NULL DEFAULT 0,
     -- B1 (#217): deploy lifecycle. 'published' is the only status visible to
-    -- non-admins; 'in_prep' (admin-only draft, written by B2) and 'revoked'
+    -- non-admins; 'draft' (admin-only draft, written by B2) and 'revoked'
     -- (soft-deleted, recoverable) are hidden by the status predicate threaded
     -- through every reader. Default 'published' so existing rows and any deploy
     -- path that omits the column stay visible (fail-closed: forgetting to mark a
     -- row keeps it published; forgetting to *filter* a reader is the hazard the
     -- predicate guards). Mirrors storage_objects.status.
-    "deploy_status" "text" NOT NULL DEFAULT 'published' CONSTRAINT "spectra_deploy_status_check" CHECK (("deploy_status" = ANY (ARRAY['in_prep'::"text", 'published'::"text", 'revoked'::"text"]))),
+    "deploy_status" "text" NOT NULL DEFAULT 'published' CONSTRAINT "spectra_deploy_status_check" CHECK (("deploy_status" = ANY (ARRAY['draft'::"text", 'published'::"text", 'revoked'::"text"]))),
     -- Stable per-spectrum identifier derived from fits_path: strips the leading
     -- directory and the trailing "_spec.fits" suffix (e.g. ember_cosmos_p1_prism_clear_12345).
     -- Generated/stored so it stays in sync with fits_path with no application code path.
@@ -623,7 +623,7 @@ ALTER TABLE "public"."observations" OWNER TO "postgres";
 CREATE TABLE IF NOT EXISTS "public"."deployments" (
     "id" integer NOT NULL,
     "observation" "text" NOT NULL,
-    "deployed_by" "uuid" NOT NULL,
+    "deployed_by" "uuid",
     "deployed_at" timestamp with time zone DEFAULT "now"(),
     "cfpipe_version" "text",
     "jwst_version" "text",
@@ -638,12 +638,12 @@ CREATE TABLE IF NOT EXISTS "public"."deployments" (
     "stuck_shutters" "jsonb",
     "reduced_at" timestamp with time zone,
     -- B2 (#218): deployment lifecycle. A deployment is the batch anchor for the
-    -- in_prep -> published -> revoked flow. 'published' is the default so existing
+    -- draft -> published -> revoked flow. 'published' is the default so existing
     -- rows (and ordinary deploys) stay published; `deploy --in-prep` inserts with
-    -- 'in_prep'. published_at/revoked_at stamp the transitions (set by the
+    -- 'draft'. published_at/revoked_at stamp the transitions (set by the
     -- set_deployment_status RPC). The user-facing visibility gate lives on
     -- spectra.deploy_status; this column is the provenance/audit record.
-    "status" "text" NOT NULL DEFAULT 'published' CONSTRAINT "deployments_status_check" CHECK (("status" = ANY (ARRAY['in_prep'::"text", 'published'::"text", 'revoked'::"text"]))),
+    "status" "text" NOT NULL DEFAULT 'published' CONSTRAINT "deployments_status_check" CHECK (("status" = ANY (ARRAY['draft'::"text", 'published'::"text", 'revoked'::"text"]))),
     "published_at" timestamp with time zone,
     "revoked_at" timestamp with time zone
 );

--- a/supabase/schemas/views.sql
+++ b/supabase/schemas/views.sql
@@ -68,7 +68,7 @@ LEFT JOIN (
     -- Published-only (B1): restrict the grating aggregation to published
     -- spectra. Predicate lives in the LEFT JOIN ON clause so targets with no
     -- published spectrum are still counted (just contribute no gratings).
-    -- No-op in B1 (nothing is unpublished yet); guards B2 in_prep data.
+    -- No-op in B1 (nothing is unpublished yet); guards B2 draft data.
     LEFT JOIN spectra s ON s.target_id = t.target_id AND s.deploy_status = 'published'
     GROUP BY t.program_slug
 ) stats ON p.slug = stats.program_slug
@@ -107,7 +107,7 @@ DROP VIEW IF EXISTS public.target_flag_summary;
 -- security_invoker (B1): this was a plain (definer) view that bypassed the
 -- spectra RLS policy. Flip to invoker semantics so the caller's RLS applies, and
 -- add a published predicate so draft spectra are hidden from non-admins. In B1
--- every spectrum is published, so this is a no-op; it guards B2 in_prep data.
+-- every spectrum is published, so this is a no-op; it guards B2 draft data.
 CREATE VIEW public.spectrum_flag_summary
 WITH (security_invoker = true) AS
 SELECT

--- a/web/app/admin/deployments/page.tsx
+++ b/web/app/admin/deployments/page.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { Card } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import {
+  Loader2, RefreshCw, GitBranch, Eye, EyeOff, Undo2, History, AlertCircle,
+} from 'lucide-react';
+import {
+  getDeployments, getDeployEvents, setDeploymentLifecycle,
+  type DeploymentRow, type DeployEventRow, type DeployStatus, type LifecycleAction,
+} from '@/lib/actions/deployments';
+
+const STATUS_FILTERS: { value: string; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'draft', label: 'Draft' },
+  { value: 'published', label: 'Published' },
+  { value: 'revoked', label: 'Revoked' },
+];
+
+function statusBadge(status: DeployStatus) {
+  const map: Record<DeployStatus, string> = {
+    draft: 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300',
+    published: 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300',
+    revoked: 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300',
+  };
+  const label: Record<DeployStatus, string> = {
+    draft: 'draft', published: 'published', revoked: 'revoked',
+  };
+  return (
+    <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${map[status]}`}>
+      {label[status]}
+    </span>
+  );
+}
+
+function fmt(ts: string | null): string {
+  if (!ts) return '—';
+  let iso = ts;
+  if (iso.includes(' ') && !iso.includes('T')) iso = iso.replace(' ', 'T');
+  if (iso.endsWith('+00')) iso = iso + ':00';
+  else if (!iso.endsWith('Z') && !iso.includes('+')) iso = iso + 'Z';
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return ts;
+  return d.toLocaleString(undefined, {
+    year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+  });
+}
+
+// The lifecycle control offered for a deployment, by its current status.
+function actionFor(status: DeployStatus): { action: LifecycleAction; label: string; icon: React.ElementType } | null {
+  if (status === 'draft') return { action: 'publish', label: 'Publish', icon: Eye };
+  if (status === 'published') return { action: 'revoke', label: 'Revoke', icon: EyeOff };
+  if (status === 'revoked') return { action: 'recover', label: 'Recover', icon: Undo2 };
+  return null;
+}
+
+export default function DeploymentsPage() {
+  const [statusFilter, setStatusFilter] = useState<string>('all');
+  const [deployments, setDeployments] = useState<DeploymentRow[]>([]);
+  const [events, setEvents] = useState<DeployEventRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<number | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const status = statusFilter === 'all' ? undefined : (statusFilter as DeployStatus);
+    const [dep, ev] = await Promise.all([
+      getDeployments({ status, pageSize: 100 }),
+      getDeployEvents({ pageSize: 50 }),
+    ]);
+    if (dep.error) setError(dep.error);
+    else setDeployments(dep.deployments);
+    if (!ev.error) setEvents(ev.events);
+    setLoading(false);
+  }, [statusFilter]);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const onAction = async (dep: DeploymentRow, action: LifecycleAction, label: string) => {
+    const verb = label.toLowerCase();
+    const warn = action === 'revoke'
+      ? `Revoke "${dep.observation}"? Its spectra will be hidden from users (bytes retained, recoverable).`
+      : `${label} "${dep.observation}"? This affects ${dep.n_spectra ?? '?'} spectra.`;
+    if (!window.confirm(warn)) return;
+    setBusyId(dep.id);
+    setNotice(null);
+    const res = await setDeploymentLifecycle(dep.id, action);
+    setBusyId(null);
+    if (!res.success) {
+      setError(res.error ?? `Failed to ${verb}`);
+      return;
+    }
+    setNotice(`${label}ed ${dep.observation} — ${res.updated ?? 0} spectra updated.`);
+    await refresh();
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <GitBranch className="w-6 h-6 text-primary" />
+          <h1 className="text-2xl font-semibold text-text-primary">Deployments</h1>
+        </div>
+        <Button variant="secondary" size="sm" onClick={refresh} disabled={loading}>
+          <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+          Refresh
+        </Button>
+      </div>
+      <p className="text-text-secondary text-sm mb-6">
+        Review and publish deployments. <span className="font-medium">Drafts</span> — explicit
+        <code className="px-1">--draft</code> deploys and incomplete reductions (intermediates
+        uploaded, no stage3 finals yet) — are admin-only and invisible to users until published;
+        revoking hides a published deployment without deleting its data. The files each deployment
+        uploaded are browsable under <span className="font-medium">Intermediate Products</span>.
+      </p>
+
+      {notice && (
+        <div className="mb-4 px-4 py-2 rounded-lg bg-green-50 dark:bg-green-950 text-green-800 dark:text-green-300 text-sm">
+          {notice}
+        </div>
+      )}
+      {error && (
+        <div className="mb-4 px-4 py-2 rounded-lg bg-red-50 dark:bg-red-950 text-red-800 dark:text-red-300 text-sm flex items-center gap-2">
+          <AlertCircle className="w-4 h-4" /> {error}
+        </div>
+      )}
+
+      <div className="flex gap-2 mb-4">
+        {STATUS_FILTERS.map((f) => (
+          <button
+            key={f.value}
+            onClick={() => setStatusFilter(f.value)}
+            className={`px-3 py-1 rounded-full text-sm transition-colors ${
+              statusFilter === f.value
+                ? 'bg-primary text-on-primary'
+                : 'bg-card-hover text-text-secondary hover:text-text-primary'
+            }`}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      <Card className="mb-8 overflow-hidden p-0">
+        {loading && deployments.length === 0 ? (
+          <div className="p-8 flex items-center justify-center text-text-secondary">
+            <Loader2 className="w-5 h-5 animate-spin mr-2" /> Loading…
+          </div>
+        ) : deployments.length === 0 ? (
+          <div className="p-8 text-center text-text-secondary text-sm">No deployments match this filter.</div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="bg-card-hover text-text-secondary text-left">
+              <tr>
+                <th className="px-4 py-2 font-medium">Observation</th>
+                <th className="px-4 py-2 font-medium">Status</th>
+                <th className="px-4 py-2 font-medium text-right">Spectra</th>
+                <th className="px-4 py-2 font-medium text-right">Targets</th>
+                <th className="px-4 py-2 font-medium">Pipeline</th>
+                <th className="px-4 py-2 font-medium">Deployed</th>
+                <th className="px-4 py-2 font-medium text-right">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {deployments.map((d) => {
+                const act = actionFor(d.status);
+                return (
+                  <tr key={d.id} className="border-t border-border hover:bg-card-hover/50">
+                    <td className="px-4 py-2 font-mono text-text-primary">{d.observation}</td>
+                    <td className="px-4 py-2">{statusBadge(d.status)}</td>
+                    <td className="px-4 py-2 text-right tabular-nums">{d.n_spectra ?? '—'}</td>
+                    <td className="px-4 py-2 text-right tabular-nums">{d.n_targets ?? '—'}</td>
+                    <td className="px-4 py-2 font-mono text-xs text-text-secondary">{d.cfpipe_version ?? '—'}</td>
+                    <td className="px-4 py-2 text-text-secondary whitespace-nowrap">{fmt(d.deployed_at)}</td>
+                    <td className="px-4 py-2 text-right">
+                      {act && (
+                        <Button
+                          variant={act.action === 'revoke' ? 'secondary' : 'primary'}
+                          size="sm"
+                          disabled={busyId === d.id}
+                          onClick={() => onAction(d, act.action, act.label)}
+                        >
+                          {busyId === d.id
+                            ? <Loader2 className="w-4 h-4 animate-spin" />
+                            : <act.icon className="w-4 h-4" />}
+                          {act.label}
+                        </Button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </Card>
+
+      <div className="flex items-center gap-2 mb-3">
+        <History className="w-5 h-5 text-text-secondary" />
+        <h2 className="text-lg font-semibold text-text-primary">Audit Log</h2>
+      </div>
+      <Card className="overflow-hidden p-0">
+        {events.length === 0 ? (
+          <div className="p-6 text-center text-text-secondary text-sm">No lifecycle events yet.</div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="bg-card-hover text-text-secondary text-left">
+              <tr>
+                <th className="px-4 py-2 font-medium">When</th>
+                <th className="px-4 py-2 font-medium">Action</th>
+                <th className="px-4 py-2 font-medium">Observation</th>
+                <th className="px-4 py-2 font-medium">→ Status</th>
+                <th className="px-4 py-2 font-medium text-right">Affected</th>
+                <th className="px-4 py-2 font-medium">By</th>
+              </tr>
+            </thead>
+            <tbody>
+              {events.map((e) => (
+                <tr key={e.id} className="border-t border-border">
+                  <td className="px-4 py-2 text-text-secondary whitespace-nowrap">{fmt(e.occurred_at)}</td>
+                  <td className="px-4 py-2 font-medium text-text-primary">{e.action}</td>
+                  <td className="px-4 py-2 font-mono text-xs">{e.observation ?? '—'}</td>
+                  <td className="px-4 py-2 text-text-secondary">{e.status_to ?? '—'}</td>
+                  <td className="px-4 py-2 text-right tabular-nums">{e.affected_count ?? '—'}</td>
+                  <td className="px-4 py-2 text-text-secondary">{e.actor_name ?? '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/web/app/admin/intermediate-products/page.tsx
+++ b/web/app/admin/intermediate-products/page.tsx
@@ -3,106 +3,95 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
+import { Loader2, RefreshCw, Database, AlertCircle, HardDrive } from 'lucide-react';
 import {
-  Loader2, RefreshCw, PackageOpen, Eye, EyeOff, Undo2, History, AlertCircle,
-} from 'lucide-react';
-import {
-  getDeployments, getDeployEvents, setDeploymentLifecycle,
-  type DeploymentRow, type DeployEventRow, type DeployStatus, type LifecycleAction,
-} from '@/lib/actions/intermediate-products';
+  getStorageObjects, getStorageBudget,
+  type StorageObjectRow, type StorageBudget,
+} from '@/lib/actions/storage-registry';
+
+// Intermediate/data product types worth filtering by (the registry holds more,
+// but these are the ones an admin browses here). 'all' clears the filter.
+const PRODUCT_FILTERS: { value: string; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'nirspec_spectrum_exposure', label: 'Spectrum exposures' },
+  { value: 'nirspec_spec', label: 'Spectra (final)' },
+  { value: 'nircam_exposure', label: 'NIRCam exposures' },
+  { value: 'zfit', label: 'Zfit' },
+];
 
 const STATUS_FILTERS: { value: string; label: string }[] = [
   { value: 'all', label: 'All' },
-  { value: 'in_prep', label: 'In Prep' },
-  { value: 'published', label: 'Published' },
+  { value: 'active', label: 'Active' },
+  { value: 'superseded', label: 'Superseded' },
   { value: 'revoked', label: 'Revoked' },
 ];
 
-function statusBadge(status: DeployStatus) {
-  const map: Record<DeployStatus, string> = {
-    in_prep: 'bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300',
-    published: 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300',
-    revoked: 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300',
-  };
-  const label: Record<DeployStatus, string> = {
-    in_prep: 'in prep', published: 'published', revoked: 'revoked',
-  };
-  return (
-    <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${map[status]}`}>
-      {label[status]}
-    </span>
-  );
+function fmtBytes(n: number): string {
+  let v = Number(n);
+  for (const u of ['B', 'KB', 'MB', 'GB', 'TB', 'PB']) {
+    if (Math.abs(v) < 1024 || u === 'PB') return u === 'B' ? `${v} B` : `${v.toFixed(1)} ${u}`;
+    v /= 1024;
+  }
+  return `${v} B`;
 }
 
-function fmt(ts: string | null): string {
-  if (!ts) return '—';
+function fmtDate(ts: string): string {
   let iso = ts;
   if (iso.includes(' ') && !iso.includes('T')) iso = iso.replace(' ', 'T');
   if (iso.endsWith('+00')) iso = iso + ':00';
   else if (!iso.endsWith('Z') && !iso.includes('+')) iso = iso + 'Z';
   const d = new Date(iso);
-  if (isNaN(d.getTime())) return ts;
-  return d.toLocaleString(undefined, {
+  return isNaN(d.getTime()) ? ts : d.toLocaleString(undefined, {
     year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
   });
 }
 
-// The lifecycle control offered for a deployment, by its current status.
-function actionFor(status: DeployStatus): { action: LifecycleAction; label: string; icon: React.ElementType } | null {
-  if (status === 'in_prep') return { action: 'publish', label: 'Publish', icon: Eye };
-  if (status === 'published') return { action: 'revoke', label: 'Revoke', icon: EyeOff };
-  if (status === 'revoked') return { action: 'recover', label: 'Recover', icon: Undo2 };
-  return null;
+function statusBadge(status: string) {
+  const map: Record<string, string> = {
+    active: 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300',
+    superseded: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+    revoked: 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300',
+  };
+  return (
+    <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${map[status] ?? ''}`}>
+      {status}
+    </span>
+  );
 }
 
 export default function IntermediateProductsPage() {
-  const [statusFilter, setStatusFilter] = useState<string>('all');
-  const [deployments, setDeployments] = useState<DeploymentRow[]>([]);
-  const [events, setEvents] = useState<DeployEventRow[]>([]);
+  const [productFilter, setProductFilter] = useState('all');
+  const [statusFilter, setStatusFilter] = useState('active');
+  const [objects, setObjects] = useState<StorageObjectRow[]>([]);
+  const [total, setTotal] = useState(0);
+  const [budget, setBudget] = useState<StorageBudget | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [busyId, setBusyId] = useState<number | null>(null);
-  const [notice, setNotice] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     setLoading(true);
     setError(null);
-    const status = statusFilter === 'all' ? undefined : (statusFilter as DeployStatus);
-    const [dep, ev] = await Promise.all([
-      getDeployments({ status, pageSize: 100 }),
-      getDeployEvents({ pageSize: 50 }),
+    const [res, bud] = await Promise.all([
+      getStorageObjects({
+        productType: productFilter === 'all' ? undefined : productFilter,
+        status: statusFilter === 'all' ? undefined : statusFilter,
+        pageSize: 200,
+      }),
+      getStorageBudget(),
     ]);
-    if (dep.error) setError(dep.error);
-    else setDeployments(dep.deployments);
-    if (!ev.error) setEvents(ev.events);
+    if (res.error) setError(res.error);
+    else { setObjects(res.objects); setTotal(res.total); }
+    if (bud && !('error' in bud)) setBudget(bud as StorageBudget);
     setLoading(false);
-  }, [statusFilter]);
+  }, [productFilter, statusFilter]);
 
   useEffect(() => { refresh(); }, [refresh]);
-
-  const onAction = async (dep: DeploymentRow, action: LifecycleAction, label: string) => {
-    const verb = label.toLowerCase();
-    const warn = action === 'revoke'
-      ? `Revoke "${dep.observation}"? Its spectra will be hidden from users (bytes retained, recoverable).`
-      : `${label} "${dep.observation}"? This affects ${dep.n_spectra ?? '?'} spectra.`;
-    if (!window.confirm(warn)) return;
-    setBusyId(dep.id);
-    setNotice(null);
-    const res = await setDeploymentLifecycle(dep.id, action);
-    setBusyId(null);
-    if (!res.success) {
-      setError(res.error ?? `Failed to ${verb}`);
-      return;
-    }
-    setNotice(`${label}ed ${dep.observation} — ${res.updated ?? 0} spectra updated.`);
-    await refresh();
-  };
 
   return (
     <div>
       <div className="flex items-center justify-between mb-2">
         <div className="flex items-center gap-2">
-          <PackageOpen className="w-6 h-6 text-primary" />
+          <Database className="w-6 h-6 text-primary" />
           <h1 className="text-2xl font-semibold text-text-primary">Intermediate Products</h1>
         </div>
         <Button variant="secondary" size="sm" onClick={refresh} disabled={loading}>
@@ -111,124 +100,89 @@ export default function IntermediateProductsPage() {
         </Button>
       </div>
       <p className="text-text-secondary text-sm mb-6">
-        Review and publish in-prep deployments. Drafts (<span className="font-medium">in prep</span>)
-        are admin-only and invisible to users until published; revoking hides a published
-        deployment without deleting its data.
+        Every object in cloud storage — the canonical spectrum-exposure intermediates and final
+        products each deploy uploads. This is the storage/registry view; the draft → published
+        lifecycle lives on the <span className="font-medium">Deployments</span> page.
       </p>
 
-      {notice && (
-        <div className="mb-4 px-4 py-2 rounded-lg bg-green-50 dark:bg-green-950 text-green-800 dark:text-green-300 text-sm">
-          {notice}
-        </div>
+      {budget && (
+        <Card className="mb-6 p-4">
+          <div className="flex items-center gap-3 text-sm">
+            <HardDrive className="w-5 h-5 text-text-secondary" />
+            <span className="text-text-primary font-medium">{fmtBytes(budget.total_bytes)}</span>
+            <span className="text-text-secondary">of {fmtBytes(budget.cap_bytes)} ({budget.pct_used}%)</span>
+          </div>
+        </Card>
       )}
+
       {error && (
         <div className="mb-4 px-4 py-2 rounded-lg bg-red-50 dark:bg-red-950 text-red-800 dark:text-red-300 text-sm flex items-center gap-2">
           <AlertCircle className="w-4 h-4" /> {error}
         </div>
       )}
 
-      <div className="flex gap-2 mb-4">
-        {STATUS_FILTERS.map((f) => (
-          <button
-            key={f.value}
-            onClick={() => setStatusFilter(f.value)}
+      <div className="flex flex-wrap gap-2 mb-2">
+        {PRODUCT_FILTERS.map((f) => (
+          <button key={f.value} onClick={() => setProductFilter(f.value)}
             className={`px-3 py-1 rounded-full text-sm transition-colors ${
-              statusFilter === f.value
-                ? 'bg-primary text-on-primary'
-                : 'bg-card-hover text-text-secondary hover:text-text-primary'
-            }`}
-          >
+              productFilter === f.value ? 'bg-primary text-on-primary'
+                : 'bg-card-hover text-text-secondary hover:text-text-primary'}`}>
+            {f.label}
+          </button>
+        ))}
+      </div>
+      <div className="flex flex-wrap gap-2 mb-4">
+        {STATUS_FILTERS.map((f) => (
+          <button key={f.value} onClick={() => setStatusFilter(f.value)}
+            className={`px-3 py-1 rounded-full text-xs transition-colors ${
+              statusFilter === f.value ? 'bg-primary text-on-primary'
+                : 'bg-card-hover text-text-secondary hover:text-text-primary'}`}>
             {f.label}
           </button>
         ))}
       </div>
 
-      <Card className="mb-8 overflow-hidden p-0">
-        {loading && deployments.length === 0 ? (
+      <Card className="overflow-hidden p-0">
+        {loading && objects.length === 0 ? (
           <div className="p-8 flex items-center justify-center text-text-secondary">
             <Loader2 className="w-5 h-5 animate-spin mr-2" /> Loading…
           </div>
-        ) : deployments.length === 0 ? (
-          <div className="p-8 text-center text-text-secondary text-sm">No deployments match this filter.</div>
+        ) : objects.length === 0 ? (
+          <div className="p-8 text-center text-text-secondary text-sm">No storage objects match this filter.</div>
         ) : (
-          <table className="w-full text-sm">
-            <thead className="bg-card-hover text-text-secondary text-left">
-              <tr>
-                <th className="px-4 py-2 font-medium">Observation</th>
-                <th className="px-4 py-2 font-medium">Status</th>
-                <th className="px-4 py-2 font-medium text-right">Spectra</th>
-                <th className="px-4 py-2 font-medium text-right">Targets</th>
-                <th className="px-4 py-2 font-medium">Pipeline</th>
-                <th className="px-4 py-2 font-medium">Deployed</th>
-                <th className="px-4 py-2 font-medium text-right">Action</th>
-              </tr>
-            </thead>
-            <tbody>
-              {deployments.map((d) => {
-                const act = actionFor(d.status);
-                return (
-                  <tr key={d.id} className="border-t border-border hover:bg-card-hover/50">
-                    <td className="px-4 py-2 font-mono text-text-primary">{d.observation}</td>
-                    <td className="px-4 py-2">{statusBadge(d.status)}</td>
-                    <td className="px-4 py-2 text-right tabular-nums">{d.n_spectra ?? '—'}</td>
-                    <td className="px-4 py-2 text-right tabular-nums">{d.n_targets ?? '—'}</td>
-                    <td className="px-4 py-2 font-mono text-xs text-text-secondary">{d.cfpipe_version ?? '—'}</td>
-                    <td className="px-4 py-2 text-text-secondary whitespace-nowrap">{fmt(d.deployed_at)}</td>
-                    <td className="px-4 py-2 text-right">
-                      {act && (
-                        <Button
-                          variant={act.action === 'revoke' ? 'secondary' : 'primary'}
-                          size="sm"
-                          disabled={busyId === d.id}
-                          onClick={() => onAction(d, act.action, act.label)}
-                        >
-                          {busyId === d.id
-                            ? <Loader2 className="w-4 h-4 animate-spin" />
-                            : <act.icon className="w-4 h-4" />}
-                          {act.label}
-                        </Button>
-                      )}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        )}
-      </Card>
-
-      <div className="flex items-center gap-2 mb-3">
-        <History className="w-5 h-5 text-text-secondary" />
-        <h2 className="text-lg font-semibold text-text-primary">Audit Log</h2>
-      </div>
-      <Card className="overflow-hidden p-0">
-        {events.length === 0 ? (
-          <div className="p-6 text-center text-text-secondary text-sm">No lifecycle events yet.</div>
-        ) : (
-          <table className="w-full text-sm">
-            <thead className="bg-card-hover text-text-secondary text-left">
-              <tr>
-                <th className="px-4 py-2 font-medium">When</th>
-                <th className="px-4 py-2 font-medium">Action</th>
-                <th className="px-4 py-2 font-medium">Observation</th>
-                <th className="px-4 py-2 font-medium">→ Status</th>
-                <th className="px-4 py-2 font-medium text-right">Affected</th>
-                <th className="px-4 py-2 font-medium">By</th>
-              </tr>
-            </thead>
-            <tbody>
-              {events.map((e) => (
-                <tr key={e.id} className="border-t border-border">
-                  <td className="px-4 py-2 text-text-secondary whitespace-nowrap">{fmt(e.occurred_at)}</td>
-                  <td className="px-4 py-2 font-medium text-text-primary">{e.action}</td>
-                  <td className="px-4 py-2 font-mono text-xs">{e.observation ?? '—'}</td>
-                  <td className="px-4 py-2 text-text-secondary">{e.status_to ?? '—'}</td>
-                  <td className="px-4 py-2 text-right tabular-nums">{e.affected_count ?? '—'}</td>
-                  <td className="px-4 py-2 text-text-secondary">{e.actor_name ?? '—'}</td>
+          <>
+            <div className="px-4 py-2 text-xs text-text-secondary border-b border-border">
+              Showing {objects.length} of {total}
+            </div>
+            <table className="w-full text-sm">
+              <thead className="bg-card-hover text-text-secondary text-left">
+                <tr>
+                  <th className="px-4 py-2 font-medium">Key</th>
+                  <th className="px-4 py-2 font-medium">Product</th>
+                  <th className="px-4 py-2 font-medium">Observation</th>
+                  <th className="px-4 py-2 font-medium text-right">Size</th>
+                  <th className="px-4 py-2 font-medium">Backend</th>
+                  <th className="px-4 py-2 font-medium">Status</th>
+                  <th className="px-4 py-2 font-medium">Created</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {objects.map((o) => (
+                  <tr key={o.id} className="border-t border-border hover:bg-card-hover/50">
+                    <td className="px-4 py-2 font-mono text-xs text-text-primary truncate max-w-[28rem]" title={o.storage_key}>
+                      {o.storage_key.split('/').pop()}
+                    </td>
+                    <td className="px-4 py-2 text-text-secondary">{o.product_type}</td>
+                    <td className="px-4 py-2 font-mono text-xs">{o.observation ?? '—'}</td>
+                    <td className="px-4 py-2 text-right tabular-nums">{fmtBytes(o.size_bytes)}</td>
+                    <td className="px-4 py-2 uppercase text-xs text-text-secondary">{o.backend}</td>
+                    <td className="px-4 py-2">{statusBadge(o.status)}</td>
+                    <td className="px-4 py-2 text-text-secondary whitespace-nowrap">{fmtDate(o.created_at)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </>
         )}
       </Card>
     </div>

--- a/web/app/admin/layout.tsx
+++ b/web/app/admin/layout.tsx
@@ -4,13 +4,14 @@ import React from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useAuth } from '@/lib/contexts/AuthContext';
-import { Shield, KeyRound, Users, Loader2, AlertTriangle, FolderOpen, Activity, Telescope, Download, Camera, PackageOpen } from 'lucide-react';
+import { Shield, KeyRound, Users, Loader2, AlertTriangle, FolderOpen, Activity, Telescope, Download, Camera, Database, GitBranch } from 'lucide-react';
 
 const adminNavItems = [
   { href: '/admin/activity', label: 'Activity', icon: Activity },
   { href: '/admin/downloads', label: 'Downloads', icon: Download },
   { href: '/admin/nircam', label: 'NIRCam', icon: Camera },
-  { href: '/admin/intermediate-products', label: 'Intermediate Products', icon: PackageOpen },
+  { href: '/admin/deployments', label: 'Deployments', icon: GitBranch },
+  { href: '/admin/intermediate-products', label: 'Intermediate Products', icon: Database },
   { href: '/admin/inspection-requests', label: 'Inspection Requests', icon: Telescope },
   { href: '/admin/codes', label: 'Access Codes', icon: KeyRound },
   { href: '/admin/users', label: 'Users', icon: Users },

--- a/web/app/api/v1/observations/[obs_name]/manifest/route.ts
+++ b/web/app/api/v1/observations/[obs_name]/manifest/route.ts
@@ -42,7 +42,7 @@ export async function GET(
     );
 
     // Admins syncing an observation need its full manifest, including
-    // in_prep spectra; non-admins only ever see published rows. No-op in B1.
+    // draft spectra; non-admins only ever see published rows. No-op in B1.
     const includeUnpublished = await isAdminUser(userId);
 
     // Get all spectra for this observation (the main payload)

--- a/web/app/api/v1/redshift-fit/route.ts
+++ b/web/app/api/v1/redshift-fit/route.ts
@@ -56,7 +56,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Service-role read bypasses RLS, so gate unpublished spectra here: a
-    // non-admin must never receive zfit JSON for an in_prep/revoked spectrum,
+    // non-admin must never receive zfit JSON for an draft/revoked spectrum,
     // whether resolved by (target_id, grating) or by fits_path. No-op in B1.
     const isAdmin = await isAdminUser(userId);
 

--- a/web/app/api/v1/spectra/list/route.ts
+++ b/web/app/api/v1/spectra/list/route.ts
@@ -46,7 +46,7 @@ export async function GET(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams;
     const supabase = createServiceClient();
 
-    // Unpublished (in_prep/revoked) spectra are admin-only and gated behind an
+    // Unpublished (draft/revoked) spectra are admin-only and gated behind an
     // explicit opt-in: admins must pass include_unpublished=true to see drafts.
     // Fail-closed for everyone else (no-op in B1 since all data is published).
     const includeUnpublished =

--- a/web/app/api/v1/spectra/route.ts
+++ b/web/app/api/v1/spectra/route.ts
@@ -56,7 +56,7 @@ export async function GET(request: NextRequest) {
     const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
     // Service-role read bypasses RLS, so gate unpublished spectra here: a
-    // non-admin must never resolve an in_prep/revoked FITS by path. No-op in B1.
+    // non-admin must never resolve an draft/revoked FITS by path. No-op in B1.
     const isAdmin = await isAdminUser(userId);
 
     let spectrumQuery = supabase

--- a/web/app/api/v1/spectrum/route.ts
+++ b/web/app/api/v1/spectrum/route.ts
@@ -57,7 +57,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Service-role read bypasses RLS, so gate unpublished spectra here: a
-    // non-admin must never receive flux/wave/2D JSON for an in_prep/revoked
+    // non-admin must never receive flux/wave/2D JSON for an draft/revoked
     // spectrum, whether resolved by spectrum_id or by fits_path. No-op in B1.
     const isAdmin = await isAdminUser(userId);
 

--- a/web/lib/actions/deployments.ts
+++ b/web/lib/actions/deployments.ts
@@ -26,7 +26,7 @@ async function requireAdmin() {
   return { supabase, userId: user.id };
 }
 
-export type DeployStatus = 'in_prep' | 'published' | 'revoked';
+export type DeployStatus = 'draft' | 'published' | 'revoked';
 
 export interface DeploymentRow {
   id: number;

--- a/web/lib/actions/storage-registry.ts
+++ b/web/lib/actions/storage-registry.ts
@@ -1,0 +1,110 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+
+// ---------------------------------------------------------------------------
+// Storage-registry (Axis A) admin actions — epic #210, B5.
+//
+// Read-only browser over `storage_objects`, the shadow index of every object in
+// cloud storage. This is the "what's in the cloud" view (orthogonal to the
+// draft/publish lifecycle, which lives on the Deployments page). Populated by
+// every deploy — including the canonical spectrum-exposure intermediates.
+// `storage_objects` RLS is admin-only; requireAdmin is defense-in-depth.
+// ---------------------------------------------------------------------------
+
+async function requireAdmin() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error('Not authenticated');
+
+  const { data: profile } = await supabase
+    .from('user_profiles')
+    .select('is_admin')
+    .eq('user_id', user.id)
+    .single();
+
+  if (!profile?.is_admin) throw new Error('Admin access required');
+  return supabase;
+}
+
+export interface StorageObjectRow {
+  id: number;
+  storage_key: string;
+  product_type: string;
+  instrument: string | null;
+  observation: string | null;
+  field: string | null;
+  exposure_ref: string | null;
+  size_bytes: number;
+  content_hash: string;
+  backend: string;
+  status: string;
+  cfpipe_version: string | null;
+  created_at: string;
+}
+
+export interface StorageObjectsResult {
+  objects: StorageObjectRow[];
+  total: number;
+  error?: string;
+}
+
+export async function getStorageObjects(params?: {
+  observation?: string;
+  productType?: string;
+  status?: string;
+  page?: number;
+  pageSize?: number;
+}): Promise<StorageObjectsResult> {
+  try {
+    const supabase = await requireAdmin();
+    const page = Math.max(0, params?.page ?? 0);
+    const pageSize = Math.max(1, params?.pageSize ?? 100);
+    const from = page * pageSize;
+    const to = from + pageSize - 1;
+
+    let query = supabase
+      .from('storage_objects')
+      .select(
+        'id, storage_key, product_type, instrument, observation, field, exposure_ref, ' +
+        'size_bytes, content_hash, backend, status, cfpipe_version, created_at',
+        { count: 'exact' },
+      )
+      .order('created_at', { ascending: false })
+      .range(from, to);
+
+    if (params?.observation) query = query.eq('observation', params.observation);
+    if (params?.productType) query = query.eq('product_type', params.productType);
+    if (params?.status) query = query.eq('status', params.status);
+
+    const { data, count, error } = await query;
+    if (error) return { objects: [], total: 0, error: error.message };
+    return { objects: (data as unknown as StorageObjectRow[]) || [], total: count ?? 0 };
+  } catch (err) {
+    return {
+      objects: [],
+      total: 0,
+      error: err instanceof Error ? err.message : 'Failed to load storage objects',
+    };
+  }
+}
+
+export interface StorageBudget {
+  total_bytes: number;
+  cap_bytes: number;
+  pct_used: number;
+  by_product_type: Record<string, number> | null;
+  by_backend: Record<string, number> | null;
+  error?: string;
+}
+
+export async function getStorageBudget(): Promise<StorageBudget | { error: string }> {
+  try {
+    const supabase = await requireAdmin();
+    const { data, error } = await supabase.rpc('get_storage_budget');
+    if (error) return { error: error.message };
+    return data as unknown as StorageBudget;
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : 'Failed to load budget' };
+  }
+}


### PR DESCRIPTION
Part of epic #210 (Track B). **Stacked on B4 (#234)** → B3 → B2. Corrects a conceptual error in B2/B3 that surfaced while testing on local Supabase.

## Why
B2/B3 collapsed two **orthogonal axes** into one feature and mislabeled the UI:
- **Axis A — what's in the cloud (storage/intermediates):** every deploy should upload *all* products including the canonical spectrum-exposure intermediates (cloud-as-source-of-truth + `delete-local`→restore). It wasn't uploading them at all.
- **Axis B — is the science visible (draft → published → revoked):** about user visibility, not which files exist.

The `/admin/intermediate-products` page actually showed Axis B under an Axis-A name, and was empty because the `deployments` record was skipped under service-role. New requirement: **`draft` is a reduction-completeness state** — an incomplete deployment (intermediates exist, no stage3 finals) is *automatically* a draft, enabling "reduce through stage2 → review in the portal → finish stage3".

## What

### Axis A — intermediates upload unconditionally
- `discover_spectrum_exposures` (glob `*_nrs[12]_*.fits` minus `*_spec.fits`); `row_for_key` derives `exposure_ref` (filename stem) for `nirspec_spectrum_exposure` so the partial-unique `(product_type, exposure_ref)` registry contract holds. Every deploy appends the canonical exposures to its uploads.

### Axis B — draft as completeness
- `load_summary` optional; an obs with **no finals** deploys via `_deploy_intermediates_only` → uploads intermediates + records an **auto-draft** deployment (scope from `observations.toml`). Explicit `--draft` still forces draft on a complete deploy.

### `in_prep` → `draft` rename (the value B1 shipped to prod)
- Forward migration ALTERs both CHECK constraints + recreates the lifecycle RPCs + migrates existing rows **before** validating; `--in-prep`→`--draft`; ~80 refs across schema/python/web/tests. (The `action` vocabulary `upload/publish/...` is unchanged.)

### Deploy-record fix (why the admin page was empty)
- `deployments.deployed_by` made nullable + `insert_deployment` no longer early-returns without a user JWT → service-role/local deploys always record the deployment (the draft-review anchor).

### Admin UI split
- **`/admin/deployments`** (new) — the draft→published→revoke lifecycle (moved here; actions → `deployments.ts`).
- **`/admin/intermediate-products`** (repurposed) — read-only `storage_objects` registry browser (Axis A) via new `storage-registry.ts`, with a budget header + product_type/status filters.

## Validated on local Supabase (`ember_egs_p1`)
- **Published deploy** registers the intermediates *with* `exposure_ref` and records a deployment **under service-role** (`deployed_by` NULL); finals carry NULL ref.
- **`--draft`** → spectra `draft`, **invisible to non-admins** (RLS), capability-gated.
- **Intermediates-only** (summary moved aside) → all **720** canonical exposures registered as an **auto-draft** deployment, no crash.
- Full suite **232 passed, 1 skipped**; `npm run build` green (`/admin/deployments` + `/admin/intermediate-products` both build); B1/B2/B4 DB harnesses pass on the renamed schema.

## Migration hand-patches (recurring)
matview unique indexes + view `security_invoker` restored; #228 `can_inspect`/`handle_new_user` re-emit stripped; the `in_prep`→`draft` data update runs **before** the new CHECK validates (existing rows would otherwise violate it).

## Follow-ups (unchanged from plan)
`spectrum_exposures` standalone-model + per-exposure review UI; `download --intermediate` restore-fetch + client `campfire status` cloud view (now fetchable since intermediates upload).

Generated with Claude Code

https://claude.ai/code/session_01QMm3DuLALxzNtLBUQqPfkR