### PR TITLE
feat(210): unify client download layer onto storage_objects (download --intermediate + status)

### DIFF
--- a/python/campfire/api/client.py
+++ b/python/campfire/api/client.py
@@ -224,6 +224,43 @@ class APIClient:
         _handle_response_error(response)
         return response.json()
 
+    # ------------------------------------------------------------------
+    # Storage registry (the client download/availability layer)
+    # ------------------------------------------------------------------
+    def fetch_all_storage(
+        self,
+        updated_since: Optional[str] = None,
+        on_page_complete: Optional[Callable[[int, int], None]] = None,
+    ) -> Tuple[List[dict], int]:
+        """Fetch the storage_objects mirror via /sync/storage (program-scoped)."""
+        return self._paginate_sync_endpoint(
+            "/sync/storage", updated_since, on_page_complete,
+        )
+
+    def presign_keys(self, keys: List[str]) -> Dict[str, str]:
+        """Get signed download URLs for storage keys the caller may access.
+
+        Returns ``{key: url}``; keys the server declines to authorize are simply
+        absent from the result. Batches of up to 200 keys per request.
+        """
+        urls: Dict[str, str] = {}
+        for start in range(0, len(keys), 200):
+            batch = keys[start:start + 200]
+            response = self._session.post(
+                "/storage/presign", json={"keys": batch}, timeout=60
+            )
+            _handle_response_error(response, "presigning storage keys")
+            urls.update(response.json().get("urls", {}))
+        return urls
+
+    def get_storage_budget(self) -> Optional[dict]:
+        """Fetch the global storage budget (admin-only). Returns None if forbidden."""
+        response = self._session.get("/storage/budget", timeout=30)
+        if response.status_code == 403:
+            return None
+        _handle_response_error(response, "fetching storage budget")
+        return response.json()
+
     def _paginate_sync_endpoint(
         self,
         path: str,

--- a/python/campfire/cli.py
+++ b/python/campfire/cli.py
@@ -391,27 +391,40 @@ def status(base_url: Optional[str]):
     else:
         click.echo(f"Catalog: {len(obs_list)} observations")
 
-    # Download stats per observation
-    if obs_list:
+    # Per-observation cloud-vs-local view, from the storage_objects mirror. Each
+    # cell is local/available; intermediates only appear where the cloud has them
+    # (admins reviewing a draft, or after --intermediate). No network call.
+    summary = store.get_object_summary()
+    materialized = [r for r in summary if r["finals_local"] or r["intermediates_local"]]
+    if materialized:
         click.echo()
-        click.echo(f"  {'OBSERVATION':<25} {'DOWNLOADED':<14} {'SIZE':<12}")
+        click.echo(f"  {'OBSERVATION':<25} {'FINALS':<12} {'INTERMEDIATES':<15} {'SIZE':<12}")
+        for r in materialized:
+            finals = f"{r['finals_local']}/{r['finals_available']}"
+            if r["intermediates_available"]:
+                inter = f"{r['intermediates_local']}/{r['intermediates_available']}"
+            else:
+                inter = "—"
+            size = format_size(r["local_bytes"])
+            click.echo(f"  {r['observation']:<25} {finals:<12} {inter:<15} {size:<12}")
+    else:
+        click.echo()
+        click.echo("  No files downloaded yet. Run: campfire download --obs <name>")
 
-        total_downloaded = 0
-        total_bytes = 0
-        for obs in obs_list:
-            stats = store.get_observation_stats(obs)
-            downloaded = stats["synced_count"]
-            size = format_size(stats["total_bytes"])
-            total_downloaded += downloaded
-            total_bytes += stats["total_bytes"]
-            if downloaded > 0:
-                click.echo(f"  {obs:<25} {downloaded:<14} {size:<12}")
+    # Global cloud storage budget (admin-only; best-effort, skipped otherwise).
+    try:
+        api = APIClient(APISession(base_url=base_url))
+        budget = api.get_storage_budget()
+        if budget:
+            used = format_size(int(budget.get("total_bytes", 0)))
+            cap = format_size(int(budget.get("cap_bytes", 0)))
+            pct = budget.get("pct_used", 0)
+            click.echo(f"\nCloud storage: {used} of {cap} ({pct}%)")
+    except Exception:
+        pass
 
-        if total_downloaded == 0:
-            click.echo("  No FITS files downloaded yet. Run: campfire download --obs <name>")
-
-    # Stale files
-    stale = store.get_stale_files()
+    # Stale files (server hash != local hash, via the mirror)
+    stale = store.get_stale_objects()
     if stale:
         click.echo(f"\n⚠ {len(stale)} local file(s) updated on server. Run: campfire download --stale")
 
@@ -485,7 +498,7 @@ def sync_cmd(full: bool, base_url: Optional[str]):
         # Verify local files so status reports correct counts immediately
         pd = _products_dir()
         if pd.exists():
-            verify = store.verify_local_files(pd, show_progress=True)
+            verify = store.verify_local_objects(pd, show_progress=True)
             if verify["cleared"]:
                 click.echo(f"  Detected {verify['cleared']} missing local file(s).")
             if verify["rehashed"]:
@@ -540,34 +553,45 @@ class _VariadicOption(click.Option):
 @click.option("--field", "field_filter", multiple=True, cls=_VariadicOption, help="Download by field name")
 @click.option("--grating", "grating_filter", multiple=True, cls=_VariadicOption, help="Filter by grating type")
 @click.option("--stale", is_flag=True, help="Re-download files updated on the server")
+@click.option("--intermediate", "include_intermediate", is_flag=True,
+              help="Also fetch canonical spectrum-exposure intermediates (the resume set)")
 @click.option("--all", "download_all", is_flag=True, help="Download everything accessible")
 @click.option("--workers", default=4, help="Parallel download workers")
 @click.option("--yes", is_flag=True, help="Skip confirmation")
 @click.option("--dry-run", is_flag=True, help="Show plan without downloading")
 @click.option("--base-url", default=None, help="API base URL")
 def download(obs_filter, program_filter, field_filter, grating_filter,
-             stale, download_all, workers, yes, dry_run, base_url):
-    """Download FITS spectrum files.
+             stale, include_intermediate, download_all, workers, yes, dry_run, base_url):
+    """Download data products.
 
-    Requires a prior 'campfire sync' to populate the local catalog.
-    Use filters to select which observations to download.
+    Requires a prior 'campfire sync' to populate the local catalog. Use filters
+    to select which observations to download. By default only final spectra are
+    fetched; --intermediate also pulls the canonical spectrum-exposures (so you
+    can restore a deleted-local observation or inspect a stage-1/2 draft).
+    --grating narrows finals only.
 
     \b
     Examples:
       campfire download --obs ember_uds_p4
       campfire download --obs ember_uds_p4 ember_uds_p5
       campfire download --program EMBER-UDS --grating PRISM
+      campfire download --obs ember_egs_p1 --intermediate
       campfire download --field COSMOS
       campfire download --stale
       campfire download --all
     """
     from .config import products_dir as _products_dir, meta_dir as _meta_dir
     from .sync import (
-        download_observation,
+        download_objects,
         sync_metadata,
         format_size,
     )
+    from .db.store import FINAL_PRODUCT_TYPES, INTERMEDIATE_PRODUCT_TYPES
     from .api.session import create_download_session
+
+    product_types = list(FINAL_PRODUCT_TYPES)
+    if include_intermediate:
+        product_types += list(INTERMEDIATE_PRODUCT_TYPES)
 
     base_url = base_url or resolve_base_url()
 
@@ -656,13 +680,13 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
 
     # Determine which observations to download
     if stale:
-        stale_files = store.get_stale_files()
+        stale_files = store.get_stale_objects()
         if not stale_files:
             click.echo("All local files are up to date.")
             store.close()
             return
         # Group stale files by observation
-        stale_obs = set(f["observation"] for f in stale_files)
+        stale_obs = set(f["observation"] for f in stale_files if f.get("observation"))
         target_obs = sorted(stale_obs)
         click.echo(f"Found {len(stale_files)} stale file(s) across {len(target_obs)} observation(s)")
     else:
@@ -707,7 +731,9 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
         return
 
     # Reconcile DB with filesystem before planning
-    verify = store.verify_local_files(_products_dir(), show_progress=True)
+    verify = store.verify_local_objects(
+        _products_dir(), product_types=product_types, show_progress=True
+    )
     if verify["cleared"]:
         click.echo(f"  Detected {verify['cleared']} missing local file(s), will re-download.")
     if verify.get("rehashed"):
@@ -719,8 +745,9 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
     grating_list = list(grating_filter) if grating_filter else None
     click.echo("Checking files...")
 
-    pending = store.get_pending_downloads(
+    pending = store.get_pending_objects(
         observations=list(target_obs),
+        product_types=product_types,
         gratings=grating_list,
     )
 
@@ -737,7 +764,7 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
 
         new_count = sum(1 for s in obs_pending if s["status"] == "new")
         updated_count = sum(1 for s in obs_pending if s["status"] == "updated")
-        download_bytes = sum(s.get("file_size") or 0 for s in obs_pending)
+        download_bytes = sum(s.get("size_bytes") or 0 for s in obs_pending)
 
         parts = []
         if new_count:
@@ -766,33 +793,30 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
             store.close()
             return
 
-    # Execute downloads — only fetch manifests for observations that need them
+    # Execute downloads — one product-type-agnostic pass over the planned set.
+    # Plan + URLs are computed locally then presigned; the generic engine fetches,
+    # verifies content_hash, and records local state in the storage_objects mirror.
     click.echo()
     dl_session = create_download_session(max_workers=workers)
-    all_stats = []
+    api_session._ensure_valid_token()
 
-    for obs in obs_with_downloads:
-        api_session._ensure_valid_token()
+    stats = download_objects(
+        api,
+        obs_with_downloads,
+        product_types,
+        store,
+        _products_dir(),
+        max_workers=workers,
+        download_session=dl_session,
+        gratings=grating_list,
+    )
 
-        try:
-            stats = download_observation(
-                api, obs,
-                _products_dir(), store,
-                max_workers=workers,
-                download_session=dl_session,
-                grating_filter=grating_list,
-            )
-            all_stats.append(stats)
-        except Exception as e:
-            click.echo(f"✗ Failed to download {obs}: {e}")
-
-    # Summary
-    total_downloaded = sum(s.get("downloaded", 0) for s in all_stats)
-    total_failed = sum(s.get("failed", 0) for s in all_stats)
     click.echo(f"\n✓ Download complete")
-    click.echo(f"  Files downloaded: {total_downloaded}")
-    if total_failed:
-        click.echo(f"  Files failed: {total_failed}")
+    click.echo(f"  Files downloaded: {stats.get('downloaded', 0)}")
+    if stats.get("failed"):
+        click.echo(f"  Files failed: {stats['failed']}")
+    if stats.get("unauthorized"):
+        click.echo(f"  Files skipped (no access): {stats['unauthorized']}")
     click.echo(f"  Total size: {format_size(total_download)}")
 
     store.close()

--- a/python/campfire/client.py
+++ b/python/campfire/client.py
@@ -218,9 +218,10 @@ class Campfire:
         max_workers: int = 4,
         show_progress: bool = True,
     ) -> dict:
-        """Download FITS files for matching spectra."""
+        """Download FITS files for matching spectra (final products)."""
         from .api.session import create_download_session
-        from .sync import download_observation
+        from .sync import download_objects
+        from .db.store import FINAL_PRODUCT_TYPES
 
         if self._local is None:
             raise ValidationError("No local catalog. Run cf.sync() first.")
@@ -228,8 +229,8 @@ class Campfire:
         target_obs = set()
 
         if stale_only:
-            stale_files = self._local.get_stale_files()
-            target_obs = set(f["observation"] for f in stale_files)
+            stale_files = self._local.get_stale_objects()
+            target_obs = set(f["observation"] for f in stale_files if f.get("observation"))
             if not target_obs:
                 return {"downloaded": 0, "failed": 0, "bytes": 0, "message": "All files up to date"}
         else:
@@ -250,26 +251,21 @@ class Campfire:
                 )
 
         dl_session = create_download_session(max_workers)
-        total_downloaded = 0
-        total_failed = 0
-        total_bytes = 0
-
-        for obs in sorted(target_obs):
-            self._api_session._ensure_valid_token()
-            stats = download_observation(
-                self._api, obs, self._products_dir, self._local,
-                max_workers=max_workers,
-                download_session=dl_session,
-                grating_filter=gratings,
-            )
-            total_downloaded += stats.get("downloaded", 0)
-            total_failed += stats.get("failed", 0)
-            total_bytes += stats.get("download_bytes", 0)
-
+        self._api_session._ensure_valid_token()
+        stats = download_objects(
+            self._api,
+            sorted(target_obs),
+            list(FINAL_PRODUCT_TYPES),
+            self._local,
+            self._products_dir,
+            max_workers=max_workers,
+            download_session=dl_session,
+            gratings=gratings,
+        )
         return {
-            "downloaded": total_downloaded,
-            "failed": total_failed,
-            "bytes": total_bytes,
+            "downloaded": stats.get("downloaded", 0),
+            "failed": stats.get("failed", 0),
+            "bytes": stats.get("download_bytes", 0),
         }
 
     # -------------------------------------------------------------------------
@@ -711,13 +707,14 @@ class Campfire:
             from .config import products_relpath
             local_rel_path = products_relpath(fits_path)
             st = dest.stat()
-            self._local.mark_synced(
-                spectrum_id=spectrum_id,
+            # fits_path is the storage key for the final product, so record local
+            # state directly on its storage_objects mirror row.
+            self._local.mark_object_synced(
+                storage_key=fits_path,
                 local_path=local_rel_path,
-                file_hash=f"sha256:{sha256.hexdigest()}",
-                file_size=file_size,
-                local_file_mtime=st.st_mtime,
+                local_file_hash=f"sha256:{sha256.hexdigest()}",
                 local_file_size=st.st_size,
+                local_file_mtime=st.st_mtime,
             )
 
         return SpectrumData.from_fits(

--- a/python/campfire/db/store.py
+++ b/python/campfire/db/store.py
@@ -15,7 +15,19 @@ from typing import Dict, List, Optional, Tuple
 
 # Schema version — bump when tables change. Existing DBs at a lower version
 # will raise SchemaMismatchError and must be deleted + re-synced.
-SCHEMA_VERSION = 5
+#   v6 (epic #210): storage_objects is now the single download/availability
+#   layer. The spectra table holds science metadata only; file keys, hashes, and
+#   local-download bookkeeping moved to the storage_objects mirror.
+SCHEMA_VERSION = 6
+
+
+# Product-type classes the client download engine understands. Finals are the
+# default download set; --intermediate adds the canonical spectrum-exposures.
+# Both are layout-mirrored (have a local relpath), so the same engine places
+# them. Widen these tuples as more product types become client-fetchable.
+FINAL_PRODUCT_TYPES = ("nirspec_spec",)
+INTERMEDIATE_PRODUCT_TYPES = ("nirspec_spectrum_exposure",)
+DOWNLOADABLE_PRODUCT_TYPES = FINAL_PRODUCT_TYPES + INTERMEDIATE_PRODUCT_TYPES
 
 
 # Columns exposed on `objects` from `/sync/objects`.
@@ -125,15 +137,16 @@ CREATE INDEX IF NOT EXISTS idx_objects_redshift ON objects(redshift);
 CREATE INDEX IF NOT EXISTS idx_objects_redshift_quality ON objects(redshift_quality);
 CREATE INDEX IF NOT EXISTS idx_objects_is_active ON objects(is_active);
 
+-- spectra: science metadata only. File keys, hashes, sizes, and local-download
+-- bookkeeping live in storage_objects (the single download/availability layer),
+-- joined on spectrum_id. query_spectra/get_spectrum surface fits_path/local_path/
+-- file_hash via that join for backward compatibility.
 CREATE TABLE IF NOT EXISTS spectra (
     id INTEGER PRIMARY KEY,
     spectrum_id TEXT UNIQUE NOT NULL,
     target_id TEXT,
     object_id TEXT,
     grating TEXT NOT NULL,
-    fits_path TEXT,
-    file_hash TEXT,
-    file_size INTEGER,
     signal_to_noise REAL,
     exposure_time REAL,
     cfpipe_version TEXT,
@@ -146,11 +159,6 @@ CREATE TABLE IF NOT EXISTS spectra (
     program_slug TEXT,
     observation TEXT,
     field TEXT,
-    local_path TEXT,
-    local_file_hash TEXT,
-    local_file_mtime REAL,
-    local_file_size INTEGER,
-    synced_at TEXT,
     created_at TEXT,
     updated_at TEXT,
     _synced_at TEXT
@@ -164,6 +172,43 @@ CREATE INDEX IF NOT EXISTS idx_spectra_grating ON spectra(grating);
 CREATE INDEX IF NOT EXISTS idx_spectra_dq_flags ON spectra(dq_flags) WHERE dq_flags != 0;
 CREATE INDEX IF NOT EXISTS idx_spectra_crds_context ON spectra(crds_context);
 CREATE INDEX IF NOT EXISTS idx_spectra_cfpipe_version ON spectra(cfpipe_version);
+
+-- storage_objects: local mirror of the server registry (epic #210). The single
+-- download/availability layer for every product type — finals, intermediates,
+-- and future NIRCam share one engine. Server columns mirror /api/v1/sync/storage
+-- (content_hash is the server's authoritative hash); the local_* columns track
+-- what's materialized on disk and are preserved across metadata refreshes.
+CREATE TABLE IF NOT EXISTS storage_objects (
+    storage_key TEXT PRIMARY KEY,
+    id INTEGER,
+    backend TEXT,
+    bucket TEXT,
+    content_hash TEXT,
+    size_bytes INTEGER,
+    content_type TEXT,
+    product_type TEXT,
+    instrument TEXT,
+    status TEXT,
+    observation TEXT,
+    field TEXT,
+    spectrum_id TEXT,
+    exposure_ref TEXT,
+    deployment_id INTEGER,
+    cfpipe_version TEXT,
+    created_at TEXT,
+    updated_at TEXT,
+    local_path TEXT,
+    local_file_hash TEXT,
+    local_file_mtime REAL,
+    local_file_size INTEGER,
+    synced_at TEXT,
+    _synced_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_so_observation ON storage_objects(observation);
+CREATE INDEX IF NOT EXISTS idx_so_product_type ON storage_objects(product_type);
+CREATE INDEX IF NOT EXISTS idx_so_spectrum_id ON storage_objects(spectrum_id);
+CREATE INDEX IF NOT EXISTS idx_so_obs_product ON storage_objects(observation, product_type);
 
 CREATE TABLE IF NOT EXISTS object_photometry (
     id INTEGER PRIMARY KEY,
@@ -632,11 +677,10 @@ class LocalStore:
     # Spectra
     # -------------------------------------------------------------------------
     def upsert_spectra(self, spectra_data: List[dict]) -> int:
-        """Insert or update spectra from the /sync/spectra endpoint.
+        """Insert or update spectra (science metadata) from /sync/spectra.
 
-        Preserves ``local_path``, ``local_file_hash``, ``local_file_mtime``,
-        ``local_file_size``, and ``synced_at`` on conflict — those are local
-        download bookkeeping and must not be clobbered by metadata refresh.
+        File keys, hashes, and local-download state live in storage_objects
+        (synced separately); any fits_path/file_hash in the payload is ignored.
         """
         now = datetime.now(timezone.utc).isoformat()
         count = 0
@@ -645,20 +689,17 @@ class LocalStore:
             self._conn.execute(
                 """
                 INSERT INTO spectra
-                    (id, spectrum_id, target_id, object_id, grating, fits_path,
-                     file_hash, file_size, signal_to_noise, exposure_time,
+                    (id, spectrum_id, target_id, object_id, grating,
+                     signal_to_noise, exposure_time,
                      cfpipe_version, crds_context, jwst_version, date_obs, reduced_at,
                      redshift_auto, dq_flags,
                      program_slug, observation, field,
                      created_at, updated_at, _synced_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(spectrum_id) DO UPDATE SET
                     target_id=excluded.target_id,
                     object_id=excluded.object_id,
                     grating=excluded.grating,
-                    fits_path=excluded.fits_path,
-                    file_hash=excluded.file_hash,
-                    file_size=COALESCE(excluded.file_size, spectra.file_size),
                     signal_to_noise=excluded.signal_to_noise,
                     exposure_time=excluded.exposure_time,
                     cfpipe_version=excluded.cfpipe_version,
@@ -680,9 +721,6 @@ class LocalStore:
                     spec.get("target_id"),
                     spec.get("object_id"),
                     spec.get("grating"),
-                    spec.get("fits_path"),
-                    spec.get("file_hash"),
-                    spec.get("file_size"),
                     spec.get("signal_to_noise"),
                     spec.get("exposure_time"),
                     spec.get("cfpipe_version"),
@@ -880,15 +918,26 @@ class LocalStore:
         else:
             distance_expr = "NULL AS distance"
 
+        # File info (key, hash, size, local availability) lives in storage_objects
+        # now; surface it on read via the spectrum's active nirspec_spec row so
+        # callers (export, open_spectrum) keep seeing fits_path/local_path/file_hash.
         sql = f"""
             SELECT s.*,
                    o.redshift AS redshift,
                    o.redshift_quality AS redshift_quality,
                    o.ra AS ra,
                    o.dec AS dec,
+                   so.storage_key AS fits_path,
+                   so.content_hash AS file_hash,
+                   so.size_bytes AS file_size,
+                   so.local_path AS local_path,
                    {distance_expr}
             FROM spectra s
             LEFT JOIN objects o ON o.object_id = s.object_id
+            LEFT JOIN storage_objects so
+                   ON so.spectrum_id = s.spectrum_id
+                  AND so.product_type = 'nirspec_spec'
+                  AND so.status = 'active'
             WHERE {where_sql}
             ORDER BY {order_clause}
         """
@@ -918,9 +967,22 @@ class LocalStore:
         return len(self.query_spectra(**filters))
 
     def get_spectrum(self, spectrum_id: str) -> Optional[dict]:
-        """Single spectrum lookup by spectrum_id."""
+        """Single spectrum lookup by spectrum_id (with file info joined in)."""
         row = self._conn.execute(
-            "SELECT * FROM spectra WHERE spectrum_id = ?", (spectrum_id,)
+            """
+            SELECT s.*,
+                   so.storage_key AS fits_path,
+                   so.content_hash AS file_hash,
+                   so.size_bytes AS file_size,
+                   so.local_path AS local_path
+            FROM spectra s
+            LEFT JOIN storage_objects so
+                   ON so.spectrum_id = s.spectrum_id
+                  AND so.product_type = 'nirspec_spec'
+                  AND so.status = 'active'
+            WHERE s.spectrum_id = ?
+            """,
+            (spectrum_id,),
         ).fetchone()
         if not row:
             return None
@@ -935,24 +997,18 @@ class LocalStore:
         return row[0] if row and row[0] else None
 
     def purge_stale_spectra(self, sync_timestamp: str) -> dict:
-        """Delete spectra not seen in the latest full sync.
+        """Delete spectra (science rows) not seen in the latest full sync.
 
-        Returns orphaned local files so the caller can clean them up.
+        Orphaned local files are reported by purge_stale_storage_objects now
+        (file/download state lives in storage_objects).
         """
-        orphaned = self._conn.execute(
-            """SELECT local_path FROM spectra
-               WHERE _synced_at < ? AND local_path IS NOT NULL""",
-            (sync_timestamp,),
-        ).fetchall()
-        orphaned_files = [r["local_path"] for r in orphaned]
-
         cursor = self._conn.execute(
             "DELETE FROM spectra WHERE _synced_at < ?",
             (sync_timestamp,),
         )
         purged = cursor.rowcount
         self._conn.commit()
-        return {"purged_spectra": purged, "orphaned_files": orphaned_files}
+        return {"purged_spectra": purged, "orphaned_files": []}
 
     # -------------------------------------------------------------------------
     # Distinct values / observation summaries (read from spectra)
@@ -974,7 +1030,12 @@ class LocalStore:
         return [r[0] for r in rows if r[0]]
 
     def get_observation_summary(self) -> List[dict]:
-        """Per-observation summary with program, field, and download status."""
+        """Per-observation summary with program, field, and finals download status.
+
+        spectrum_count is the science catalog count; downloaded_count is how many
+        of those finals are materialized locally, read from the storage_objects
+        mirror (product_type='nirspec_spec').
+        """
         rows = self._conn.execute(
             """
             SELECT
@@ -983,8 +1044,12 @@ class LocalStore:
                 s.field,
                 COUNT(DISTINCT s.object_id) AS object_count,
                 COUNT(*) AS spectrum_count,
-                COUNT(CASE WHEN s.local_path IS NOT NULL THEN 1 END) AS downloaded_count
+                COUNT(CASE WHEN so.local_path IS NOT NULL THEN 1 END) AS downloaded_count
             FROM spectra s
+            LEFT JOIN storage_objects so
+                   ON so.spectrum_id = s.spectrum_id
+                  AND so.product_type = 'nirspec_spec'
+                  AND so.status = 'active'
             GROUP BY s.observation, s.program_slug, s.field
             ORDER BY s.observation
             """
@@ -998,225 +1063,146 @@ class LocalStore:
         return row[0] if row and row[0] else None
 
     # -------------------------------------------------------------------------
-    # Local-file bookkeeping
+    # storage_objects mirror — the single download/availability layer
     # -------------------------------------------------------------------------
-    def get_synced_files(self, observation: str) -> Dict[int, dict]:
-        """Return {spectrum_id_pk: row_dict} for downloaded files in an observation."""
-        rows = self._conn.execute(
-            """
-            SELECT s.id, s.spectrum_id, s.target_id, s.object_id, s.grating,
-                   s.fits_path, s.local_path, s.local_file_hash, s.file_hash,
-                   s.file_size, s.synced_at
-            FROM spectra s
-            WHERE s.observation = ? AND s.local_path IS NOT NULL
-            """,
-            (observation,),
-        ).fetchall()
+    def upsert_storage_objects(self, rows: List[dict]) -> int:
+        """Insert/update the local storage_objects mirror from /sync/storage.
 
-        result: Dict[int, dict] = {}
-        for row in rows:
-            d = dict(row)
-            d["file_hash"] = d.get("local_file_hash")
-            result[row["id"]] = d
-
-        legacy_rows = self._conn.execute(
-            """SELECT id, spectrum_id, target_id, object_id, grating, fits_path,
-                      local_path, local_file_hash, file_hash, file_size, synced_at
-               FROM spectra
-               WHERE local_path IS NOT NULL AND local_path LIKE ?""",
-            (f"{observation}/%",),
-        ).fetchall()
-        for row in legacy_rows:
-            if row["id"] not in result:
-                d = dict(row)
-                d["file_hash"] = d.get("local_file_hash")
-                result[row["id"]] = d
-
-        return result
-
-    def verify_local_files(
-        self,
-        products_dir: Path,
-        observation: Optional[str] = None,
-        show_progress: bool = False,
-    ) -> dict:
-        """Reconcile DB sync state with the local filesystem."""
-        from ..config import products_relpath
-        from ..sync import compute_file_hash
-
-        now = datetime.now(timezone.utc).isoformat()
-        obs_filter = "AND s.observation = ?" if observation else ""
-        obs_params: tuple = (observation,) if observation else ()
-
-        tracked_rows = self._conn.execute(
-            f"""
-            SELECT s.id, s.local_path, s.local_file_mtime,
-                   s.local_file_size, s.local_file_hash
-            FROM spectra s
-            WHERE s.local_path IS NOT NULL {obs_filter}
-            """,
-            obs_params,
-        ).fetchall()
-
-        cleared = 0
-        rehashed = 0
-
-        untracked_rows = self._conn.execute(
-            f"""
-            SELECT s.id, s.fits_path, s.file_hash, s.observation
-            FROM spectra s
-            WHERE s.local_path IS NULL AND s.fits_path IS NOT NULL {obs_filter}
-            """,
-            obs_params,
-        ).fetchall()
-
-        total = len(tracked_rows) + len(untracked_rows)
-        pbar = None
-        if show_progress and total > 0:
-            from tqdm import tqdm
-            pbar = tqdm(total=total, desc="Verifying local files", unit="file")
-
-        for row in tracked_rows:
-            full_path = products_dir / row["local_path"]
-            if not full_path.exists():
-                self._conn.execute(
-                    """UPDATE spectra SET local_path = NULL, local_file_hash = NULL,
-                       local_file_mtime = NULL, local_file_size = NULL, synced_at = NULL
-                       WHERE id = ?""",
-                    (row["id"],),
-                )
-                cleared += 1
-            else:
-                st = full_path.stat()
-                stored_mtime = row["local_file_mtime"]
-                stored_size = row["local_file_size"]
-                if (
-                    stored_mtime is not None
-                    and stored_size is not None
-                    and abs(st.st_mtime - stored_mtime) < 0.001
-                    and st.st_size == stored_size
-                ):
-                    if pbar:
-                        pbar.update(1)
-                    continue
-                new_hash = compute_file_hash(full_path)
-                self._conn.execute(
-                    """UPDATE spectra SET local_file_hash = ?,
-                       local_file_mtime = ?, local_file_size = ?
-                       WHERE id = ?""",
-                    (new_hash, st.st_mtime, st.st_size, row["id"]),
-                )
-                rehashed += 1
-            if pbar:
-                pbar.update(1)
-
-        discovered = 0
-        for row in untracked_rows:
-            # Resolve the local destination via the layout contract (the same
-            # mapping the downloader uses), so rediscovery looks where files are
-            # actually written: products/nirspec/<obs>/… (PR-4), not products/<obs>/.
-            rel_path = products_relpath(row["fits_path"])
-            local_path = products_dir / rel_path
-            if local_path.exists():
-                st = local_path.stat()
-                actual_hash = compute_file_hash(local_path)
-                self._conn.execute(
-                    """UPDATE spectra SET local_path = ?, local_file_hash = ?,
-                       local_file_mtime = ?, local_file_size = ?, synced_at = ?
-                       WHERE id = ?""",
-                    (rel_path, actual_hash, st.st_mtime, st.st_size, now, row["id"]),
-                )
-                discovered += 1
-            if pbar:
-                pbar.update(1)
-
-        if pbar:
-            pbar.close()
-
-        if cleared or discovered or rehashed:
-            self._conn.commit()
-        return {"cleared": cleared, "rehashed": rehashed, "discovered": discovered}
-
-    def mark_synced(
-        self,
-        spectrum_id: str,
-        local_path: str,
-        file_hash: Optional[str],
-        file_size: Optional[int],
-        local_file_mtime: Optional[float] = None,
-        local_file_size: Optional[int] = None,
-    ) -> None:
-        """Record that a file has been downloaded locally, keyed by spectrum_id.
-
-        The ``file_hash`` parameter is stored as ``local_file_hash``.
-        Assumes the spectrum row already exists (inserted during sync).
+        Preserves the local_* download bookkeeping on conflict — those track
+        on-disk state and must survive a metadata refresh. ``content_hash`` is
+        the server's authoritative hash (the staleness reference).
         """
         now = datetime.now(timezone.utc).isoformat()
-        self._conn.execute(
-            """UPDATE spectra SET local_path = ?, local_file_hash = ?,
-               file_size = COALESCE(?, file_size),
-               local_file_mtime = ?, local_file_size = ?, synced_at = ?
-               WHERE spectrum_id = ?""",
-            (
-                local_path,
-                file_hash,
-                file_size,
-                local_file_mtime,
-                local_file_size,
-                now,
-                spectrum_id,
-            ),
-        )
+        count = 0
+        for r in rows:
+            self._conn.execute(
+                """
+                INSERT INTO storage_objects
+                    (storage_key, id, backend, bucket, content_hash, size_bytes,
+                     content_type, product_type, instrument, status, observation,
+                     field, spectrum_id, exposure_ref, deployment_id, cfpipe_version,
+                     created_at, updated_at, _synced_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(storage_key) DO UPDATE SET
+                    id=excluded.id,
+                    backend=excluded.backend,
+                    bucket=excluded.bucket,
+                    content_hash=excluded.content_hash,
+                    size_bytes=excluded.size_bytes,
+                    content_type=excluded.content_type,
+                    product_type=excluded.product_type,
+                    instrument=excluded.instrument,
+                    status=excluded.status,
+                    observation=excluded.observation,
+                    field=excluded.field,
+                    spectrum_id=excluded.spectrum_id,
+                    exposure_ref=excluded.exposure_ref,
+                    deployment_id=excluded.deployment_id,
+                    cfpipe_version=excluded.cfpipe_version,
+                    created_at=excluded.created_at,
+                    updated_at=excluded.updated_at,
+                    _synced_at=excluded._synced_at
+                """,
+                (
+                    r.get("storage_key"),
+                    r.get("id"),
+                    r.get("backend"),
+                    r.get("bucket"),
+                    r.get("content_hash"),
+                    r.get("size_bytes"),
+                    r.get("content_type"),
+                    r.get("product_type"),
+                    r.get("instrument"),
+                    r.get("status"),
+                    r.get("observation"),
+                    r.get("field"),
+                    r.get("spectrum_id"),
+                    r.get("exposure_ref"),
+                    r.get("deployment_id"),
+                    r.get("cfpipe_version"),
+                    r.get("created_at"),
+                    r.get("updated_at"),
+                    now,
+                ),
+            )
+            count += 1
         self._conn.commit()
+        return count
 
-    def get_stale_files(self) -> List[dict]:
-        """Return locally downloaded files whose server hash differs from local."""
-        rows = self._conn.execute(
-            """
-            SELECT s.id, s.spectrum_id, s.target_id, s.object_id, s.grating,
-                   s.fits_path, s.local_path, s.file_hash AS server_hash,
-                   s.local_file_hash, s.observation
-            FROM spectra s
-            WHERE s.local_path IS NOT NULL
-              AND s.file_hash IS NOT NULL
-              AND s.local_file_hash IS NOT NULL
-              AND s.file_hash != s.local_file_hash
-            """
+    def get_max_storage_updated_at(self) -> Optional[str]:
+        row = self._conn.execute(
+            "SELECT MAX(updated_at) FROM storage_objects"
+        ).fetchone()
+        return row[0] if row and row[0] else None
+
+    def purge_stale_storage_objects(self, sync_timestamp: str) -> dict:
+        """Delete mirror rows not seen in the latest full sync.
+
+        Returns local files that are now orphaned (their registry row went away)
+        so the caller can optionally clean them up.
+        """
+        orphaned = self._conn.execute(
+            """SELECT local_path FROM storage_objects
+               WHERE _synced_at < ? AND local_path IS NOT NULL""",
+            (sync_timestamp,),
         ).fetchall()
-        return [dict(r) for r in rows]
+        orphaned_files = [r["local_path"] for r in orphaned]
 
-    def get_pending_downloads(
+        cursor = self._conn.execute(
+            "DELETE FROM storage_objects WHERE _synced_at < ?",
+            (sync_timestamp,),
+        )
+        purged = cursor.rowcount
+        self._conn.commit()
+        return {"purged": purged, "orphaned_files": orphaned_files}
+
+    def get_pending_objects(
         self,
         observations: Optional[List[str]] = None,
+        product_types: Optional[List[str]] = None,
         gratings: Optional[List[str]] = None,
     ) -> Dict[str, List[dict]]:
-        """Find spectra that need downloading, grouped by observation."""
-        where = ["s.fits_path IS NOT NULL"]
+        """Find storage objects that need downloading, grouped by observation.
+
+        A row is pending if it isn't materialized locally, or its local hash no
+        longer matches the server's content_hash. ``--grating`` narrows finals
+        (joined to the science spectrum); the registry has no grating column, so
+        exposure-level intermediates are always included.
+        """
+        where = ["so.status = 'active'"]
         params: list = []
 
+        if product_types:
+            ph = ",".join("?" * len(product_types))
+            where.append(f"so.product_type IN ({ph})")
+            params.extend(product_types)
+
         if observations:
-            placeholders = ",".join("?" * len(observations))
-            where.append(f"s.observation IN ({placeholders})")
+            ph = ",".join("?" * len(observations))
+            where.append(f"so.observation IN ({ph})")
             params.extend(observations)
 
+        join = ""
         if gratings:
-            placeholders = ",".join("?" * len(gratings))
-            where.append(f"UPPER(s.grating) IN ({placeholders})")
+            join = "LEFT JOIN spectra sp ON sp.spectrum_id = so.spectrum_id"
+            ph = ",".join("?" * len(gratings))
+            where.append(f"(so.spectrum_id IS NULL OR UPPER(sp.grating) IN ({ph}))")
             params.extend(g.upper() for g in gratings)
 
         where.append(
-            "(s.local_file_hash IS NULL OR (s.file_hash IS NOT NULL AND s.local_file_hash != s.file_hash))"
+            "(so.local_file_hash IS NULL OR "
+            "(so.content_hash IS NOT NULL AND so.local_file_hash != so.content_hash))"
         )
         where_sql = " AND ".join(where)
 
         rows = self._conn.execute(
             f"""
-            SELECT s.id, s.spectrum_id, s.target_id, s.object_id, s.grating,
-                   s.fits_path, s.file_hash, s.file_size, s.local_file_hash,
-                   s.observation
-            FROM spectra s
+            SELECT so.storage_key, so.content_hash, so.size_bytes, so.product_type,
+                   so.observation, so.spectrum_id, so.exposure_ref, so.local_file_hash
+            FROM storage_objects so
+            {join}
             WHERE {where_sql}
-            ORDER BY s.observation, s.id
+            ORDER BY so.observation, so.storage_key
             """,
             params,
         ).fetchall()
@@ -1225,38 +1211,202 @@ class LocalStore:
         for row in rows:
             d = dict(row)
             d["status"] = "new" if d["local_file_hash"] is None else "updated"
-            obs = d["observation"]
-            result.setdefault(obs, []).append(d)
-
+            result.setdefault(d["observation"], []).append(d)
         return result
 
-    def remove_observation(self, observation: str) -> int:
-        """Clear local-download state for all spectra in an observation."""
+    def mark_object_synced(
+        self,
+        storage_key: str,
+        local_path: str,
+        local_file_hash: Optional[str],
+        local_file_size: Optional[int] = None,
+        local_file_mtime: Optional[float] = None,
+    ) -> None:
+        """Record that a storage object has been materialized locally."""
+        now = datetime.now(timezone.utc).isoformat()
+        self._conn.execute(
+            """UPDATE storage_objects SET local_path = ?, local_file_hash = ?,
+               local_file_mtime = ?, local_file_size = ?, synced_at = ?
+               WHERE storage_key = ?""",
+            (local_path, local_file_hash, local_file_mtime, local_file_size, now, storage_key),
+        )
+        self._conn.commit()
+
+    def get_stale_objects(self) -> List[dict]:
+        """Locally materialized objects whose server hash differs from local."""
+        rows = self._conn.execute(
+            """
+            SELECT storage_key, observation, product_type, spectrum_id,
+                   local_path, content_hash AS server_hash, local_file_hash
+            FROM storage_objects
+            WHERE local_path IS NOT NULL
+              AND content_hash IS NOT NULL
+              AND local_file_hash IS NOT NULL
+              AND content_hash != local_file_hash
+            """
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def verify_local_objects(
+        self,
+        products_dir: Path,
+        observation: Optional[str] = None,
+        product_types: Optional[List[str]] = None,
+        show_progress: bool = False,
+    ) -> dict:
+        """Reconcile the storage_objects mirror's local state with the filesystem.
+
+        Clears rows whose file vanished, re-hashes modified files, and re-discovers
+        already-present files (so a fresh mirror after a schema bump finds existing
+        downloads). Scoped to mirrored, downloadable product types.
+        """
+        from ..config import products_relpath
+        from ..sync import compute_file_hash
+        from campfire_layout import LayoutError
+
+        now = datetime.now(timezone.utc).isoformat()
+        types = list(product_types or DOWNLOADABLE_PRODUCT_TYPES)
+        type_ph = ",".join("?" * len(types))
+        clauses = [f"product_type IN ({type_ph})", "status = 'active'"]
+        params: list = list(types)
+        if observation:
+            clauses.append("observation = ?")
+            params.append(observation)
+        where = " AND ".join(clauses)
+
+        tracked = self._conn.execute(
+            f"""SELECT storage_key, local_path, local_file_mtime, local_file_size
+                FROM storage_objects
+                WHERE local_path IS NOT NULL AND {where}""",
+            params,
+        ).fetchall()
+        untracked = self._conn.execute(
+            f"""SELECT storage_key FROM storage_objects
+                WHERE local_path IS NULL AND {where}""",
+            params,
+        ).fetchall()
+
+        total = len(tracked) + len(untracked)
+        pbar = None
+        if show_progress and total > 0:
+            from tqdm import tqdm
+            pbar = tqdm(total=total, desc="Verifying local files", unit="file")
+
+        cleared = rehashed = discovered = 0
+
+        for row in tracked:
+            full_path = products_dir / row["local_path"]
+            if not full_path.exists():
+                self._conn.execute(
+                    """UPDATE storage_objects SET local_path = NULL, local_file_hash = NULL,
+                       local_file_mtime = NULL, local_file_size = NULL, synced_at = NULL
+                       WHERE storage_key = ?""",
+                    (row["storage_key"],),
+                )
+                cleared += 1
+            else:
+                st = full_path.stat()
+                if (
+                    row["local_file_mtime"] is not None
+                    and row["local_file_size"] is not None
+                    and abs(st.st_mtime - row["local_file_mtime"]) < 0.001
+                    and st.st_size == row["local_file_size"]
+                ):
+                    if pbar:
+                        pbar.update(1)
+                    continue
+                new_hash = compute_file_hash(full_path)
+                self._conn.execute(
+                    """UPDATE storage_objects SET local_file_hash = ?,
+                       local_file_mtime = ?, local_file_size = ? WHERE storage_key = ?""",
+                    (new_hash, st.st_mtime, st.st_size, row["storage_key"]),
+                )
+                rehashed += 1
+            if pbar:
+                pbar.update(1)
+
+        for row in untracked:
+            try:
+                rel_path = products_relpath(row["storage_key"])
+            except (LayoutError, ValueError):
+                if pbar:
+                    pbar.update(1)
+                continue
+            local_path = products_dir / rel_path
+            if local_path.exists():
+                st = local_path.stat()
+                actual_hash = compute_file_hash(local_path)
+                self._conn.execute(
+                    """UPDATE storage_objects SET local_path = ?, local_file_hash = ?,
+                       local_file_mtime = ?, local_file_size = ?, synced_at = ?
+                       WHERE storage_key = ?""",
+                    (rel_path, actual_hash, st.st_mtime, st.st_size, now, row["storage_key"]),
+                )
+                discovered += 1
+            if pbar:
+                pbar.update(1)
+
+        if pbar:
+            pbar.close()
+        if cleared or discovered or rehashed:
+            self._conn.commit()
+        return {"cleared": cleared, "rehashed": rehashed, "discovered": discovered}
+
+    def remove_observation_objects(self, observation: str) -> int:
+        """Clear local-download state for all storage objects in an observation."""
         cursor = self._conn.execute(
-            """UPDATE spectra
+            """UPDATE storage_objects
                SET local_path = NULL, local_file_hash = NULL,
-                   local_file_mtime = NULL, local_file_size = NULL,
-                   synced_at = NULL
-               WHERE observation = ? OR local_path LIKE ?""",
-            (observation, f"{observation}/%"),
+                   local_file_mtime = NULL, local_file_size = NULL, synced_at = NULL
+               WHERE observation = ?""",
+            (observation,),
         )
         count = cursor.rowcount
         self._conn.commit()
         return count
 
-    def get_observation_stats(self, observation: str) -> dict:
+    def get_object_stats(
+        self, observation: str, product_types: Optional[List[str]] = None
+    ) -> dict:
+        """Downloaded count + bytes for an observation's objects (optionally by type)."""
+        clauses = ["local_path IS NOT NULL", "observation = ?", "status = 'active'"]
+        params: list = [observation]
+        if product_types:
+            ph = ",".join("?" * len(product_types))
+            clauses.append(f"product_type IN ({ph})")
+            params.extend(product_types)
         row = self._conn.execute(
-            """
-            SELECT
-                COUNT(*) AS synced_count,
-                COALESCE(SUM(s.file_size), 0) AS total_bytes
-            FROM spectra s
-            WHERE s.local_path IS NOT NULL
-              AND (s.observation = ? OR s.local_path LIKE ?)
-            """,
-            (observation, f"{observation}/%"),
+            f"""SELECT COUNT(*) AS synced_count, COALESCE(SUM(size_bytes), 0) AS total_bytes
+                FROM storage_objects WHERE {' AND '.join(clauses)}""",
+            params,
         ).fetchone()
         return dict(row) if row else {"synced_count": 0, "total_bytes": 0}
+
+    def get_object_summary(self) -> List[dict]:
+        """Per-observation finals/intermediates availability + local materialization.
+
+        Drives `campfire status`. Counts active mirror rows by product class and
+        how many are present on disk. Includes obs that have only intermediates
+        (e.g. an admin's draft with no published finals).
+        """
+        rows = self._conn.execute(
+            """
+            SELECT
+                observation,
+                field,
+                COUNT(CASE WHEN product_type IN ('nirspec_spec') THEN 1 END) AS finals_available,
+                COUNT(CASE WHEN product_type IN ('nirspec_spec') AND local_path IS NOT NULL THEN 1 END) AS finals_local,
+                COUNT(CASE WHEN product_type IN ('nirspec_spectrum_exposure') THEN 1 END) AS intermediates_available,
+                COUNT(CASE WHEN product_type IN ('nirspec_spectrum_exposure') AND local_path IS NOT NULL THEN 1 END) AS intermediates_local,
+                COALESCE(SUM(CASE WHEN local_path IS NOT NULL THEN size_bytes END), 0) AS local_bytes,
+                COALESCE(SUM(size_bytes), 0) AS available_bytes
+            FROM storage_objects
+            WHERE status = 'active'
+            GROUP BY observation, field
+            ORDER BY observation
+            """
+        ).fetchall()
+        return [dict(r) for r in rows]
 
     def get_last_sync(self, observation: str) -> Optional[str]:
         row = self._conn.execute(
@@ -1293,9 +1443,11 @@ class LocalStore:
         self._conn.commit()
 
     def find_local_path(self, spectrum_id: str) -> Optional[str]:
-        """Return the relative local_path for a spectrum if downloaded, else None."""
+        """Return the relative local_path for a spectrum's final FITS if downloaded."""
         row = self._conn.execute(
-            "SELECT local_path FROM spectra WHERE spectrum_id = ? AND local_path IS NOT NULL",
+            """SELECT local_path FROM storage_objects
+               WHERE spectrum_id = ? AND product_type = 'nirspec_spec'
+                 AND status = 'active' AND local_path IS NOT NULL""",
             (spectrum_id,),
         ).fetchone()
         return row["local_path"] if row else None

--- a/python/campfire/sync.py
+++ b/python/campfire/sync.py
@@ -13,8 +13,6 @@ from typing import Dict, List, Optional, Tuple
 import requests
 from tqdm import tqdm
 
-from campfire_layout import parse_key
-
 from .api.session import create_download_session
 from .exceptions import DownloadError
 
@@ -147,6 +145,36 @@ def _sync_tags(api, store, show_progress):
         return 0
 
 
+def _sync_storage_objects(api, store, full, show_progress):
+    """Sync the storage_objects mirror (the download/availability layer).
+
+    Program-scoped server-side: admins mirror everything, others get published
+    rows in their accessible programs. Returns (row_count, purged, orphaned).
+    """
+    updated_since = None if full else store.get_max_storage_updated_at()
+    incremental = updated_since is not None
+    sync_timestamp = datetime.now(timezone.utc).isoformat()
+
+    pbar, callback = _make_progress(show_progress, "obj", "Storage")
+    all_rows, _server_total = api.fetch_all_storage(
+        updated_since=updated_since,
+        on_page_complete=callback,
+    )
+    if pbar:
+        pbar.close()
+
+    n = store.upsert_storage_objects(all_rows)
+
+    purged = 0
+    orphaned: List[str] = []
+    if not incremental:
+        res = store.purge_stale_storage_objects(sync_timestamp)
+        purged = res["purged"]
+        orphaned = res["orphaned_files"]
+
+    return n, purged, orphaned
+
+
 def sync_metadata(
     api, store, meta_dir: Path,
     show_progress: bool = False,
@@ -175,17 +203,22 @@ def sync_metadata(
         api, store, full, show_progress
     )
 
-    # 3. Sync photometry
+    # 3. Sync the storage_objects mirror (download/availability layer)
+    storage_count, storage_purged, storage_orphaned = _sync_storage_objects(
+        api, store, full, show_progress
+    )
+
+    # 4. Sync photometry
     phot_count, phot_purged = _sync_photometry(api, store, full, show_progress)
 
-    # 4. Sync tag metadata
+    # 5. Sync tag metadata
     tags_count = _sync_tags(api, store, show_progress)
 
-    # 5. Export CSVs
+    # 6. Export CSVs
     export_catalogs(store, meta_dir)
 
-    # 6. Detect stale local files
-    stale = store.get_stale_files()
+    # 7. Detect stale local files (server hash != local hash, via the mirror)
+    stale = store.get_stale_objects()
 
     obs_set = set(store.get_synced_observations())
 
@@ -194,6 +227,8 @@ def sync_metadata(
         "objects": obj_count,
         "objects_purged": obj_purged,
         "spectra": spec_count,
+        "storage_objects": storage_count,
+        "storage_purged": storage_purged,
         "photometry": phot_count,
         "photometry_purged": phot_purged,
         "tags": tags_count,
@@ -204,63 +239,38 @@ def sync_metadata(
     }
     if spec_purge:
         result["purged_spectra"] = spec_purge["purged_spectra"]
-        result["orphaned_files"] = spec_purge["orphaned_files"]
+    if storage_orphaned:
+        result["orphaned_files"] = storage_orphaned
 
     return result
 
 
-def compute_download_plan(
-    manifest: dict,
-    synced_files: Dict[int, dict],
-) -> Tuple[List[dict], List[dict], List[dict]]:
-    """Compare manifest against local state to determine what needs downloading.
-
-    The ``synced_files`` dict is keyed by the integer PK (``spectra_id``);
-    ``synced_files[id]["file_hash"]`` is the locally hashed value (the server
-    hash lives in the manifest entry).
-    """
-    new_files = []
-    updated_files = []
-    up_to_date = []
-
-    for spec in manifest.get("spectra", []):
-        spectra_id = spec["spectra_id"]
-        local = synced_files.get(spectra_id)
-
-        if local is None:
-            new_files.append(spec)
-        elif spec.get("file_hash") and local.get("file_hash") != spec["file_hash"]:
-            updated_files.append(spec)
-        else:
-            up_to_date.append(spec)
-
-    return new_files, updated_files, up_to_date
-
-
-def download_and_verify(
-    spec: dict,
+def _download_and_verify_key(
+    obj: dict,
+    download_url: str,
     products_dir: Path,
     download_session: requests.Session,
 ) -> dict:
-    """Download a single file, verify checksum, return result dict.
+    """Download one storage object, verify its hash, return local-state dict.
 
-    The local destination is derived from the object's storage key via the shared
-    layout contract (``products_relpath``), so it always lands in the same tree
-    the pipeline writes and deploy reads (``products/nirspec/<obs>/…``).
+    The destination is derived from the object's storage key via the shared
+    layout contract (``products_relpath``), so every product type lands in the
+    same tree the pipeline writes and deploy reads (``products/nirspec/<obs>/…``).
     """
     from .config import products_relpath
 
-    rel = products_relpath(spec["fits_path"])
+    key = obj["storage_key"]
+    rel = products_relpath(key)
     local_path = products_dir / rel
     local_path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = local_path.with_suffix(".tmp")
+    tmp_path = local_path.with_name(local_path.name + ".tmp")
 
+    expected = obj.get("content_hash")
     try:
-        response = download_session.get(spec["download_url"], stream=True, timeout=300)
+        response = download_session.get(download_url, stream=True, timeout=300)
         response.raise_for_status()
 
         hasher = hashlib.sha256()
-
         with open(tmp_path, "wb") as f:
             for chunk in response.iter_content(chunk_size=65536):
                 f.write(chunk)
@@ -268,118 +278,101 @@ def download_and_verify(
 
         computed_hash = f"sha256:{hasher.hexdigest()}"
 
-        if spec.get("file_hash") and computed_hash != spec["file_hash"]:
+        # Only verify against authoritative sha256: hashes (etag: rows are
+        # provisional bucket metadata, not a content digest).
+        if expected and expected.startswith("sha256:") and computed_hash != expected:
             tmp_path.unlink()
             raise DownloadError(
-                f"Hash mismatch for {spec['fits_path']}: "
-                f"expected {spec['file_hash']}, got {computed_hash}"
+                f"Hash mismatch for {key}: expected {expected}, got {computed_hash}"
             )
 
         tmp_path.rename(local_path)
-
         st = local_path.stat()
         return {
-            "id": spec.get("spectra_id"),
-            "spectrum_id": spec.get("spectrum_id"),
-            "target_id": spec.get("target_id"),
-            "observation": spec.get("observation") or parse_key(spec["fits_path"]).scope.obs,
-            "grating": spec["grating"],
-            "fits_path": spec["fits_path"],
+            "storage_key": key,
             "local_path": str(local_path.relative_to(products_dir)),
-            "file_hash": computed_hash,
-            "file_size": st.st_size,
-            "local_file_mtime": st.st_mtime,
+            "local_file_hash": computed_hash,
             "local_file_size": st.st_size,
+            "local_file_mtime": st.st_mtime,
         }
-
     except DownloadError:
         raise
     except requests.RequestException as e:
         if tmp_path.exists():
             tmp_path.unlink()
-        raise DownloadError(f"Failed to download {spec['fits_path']}: {e}")
+        raise DownloadError(f"Failed to download {key}: {e}")
 
 
-def download_observation(
+def download_objects(
     api_client,
-    obs_name: str,
-    products_dir: Path,
+    observations: List[str],
+    product_types: List[str],
     store,
+    products_dir: Path,
     max_workers: int = 4,
     dry_run: bool = False,
     download_session: Optional[requests.Session] = None,
-    manifest: Optional[dict] = None,
-    grating_filter: Optional[List[str]] = None,
+    gratings: Optional[List[str]] = None,
 ) -> dict:
-    """Download FITS files for a single observation."""
-    if manifest is None:
-        manifest = api_client.fetch_manifest(obs_name)
+    """Download storage objects for the given observations + product types.
 
-    if grating_filter:
-        grating_set = set(g.upper() for g in grating_filter)
-        manifest = dict(manifest)
-        manifest["spectra"] = [
-            s for s in manifest.get("spectra", [])
-            if s.get("grating", "").upper() in grating_set
-        ]
-
-    synced = store.get_synced_files(obs_name)
-    new_files, updated_files, up_to_date = compute_download_plan(manifest, synced)
-
-    to_download = new_files + updated_files
-    total_bytes = sum(s.get("file_size") or 0 for s in to_download)
+    The single, product-type-agnostic download engine: plan locally from the
+    storage_objects mirror, presign the to-download set, fetch in parallel,
+    verify ``content_hash``, and record local state. Used for finals,
+    intermediates, and (later) NIRCam alike.
+    """
+    pending = store.get_pending_objects(
+        observations=list(observations),
+        product_types=list(product_types),
+        gratings=gratings,
+    )
+    to_download = [row for rows in pending.values() for row in rows]
 
     stats = {
-        "observation": obs_name,
-        "new_count": len(new_files),
-        "updated_count": len(updated_files),
-        "up_to_date_count": len(up_to_date),
-        "download_bytes": total_bytes,
+        "to_download": len(to_download),
+        "download_bytes": sum(r.get("size_bytes") or 0 for r in to_download),
         "downloaded": 0,
         "failed": 0,
-        "skipped": len(up_to_date),
+        "unauthorized": 0,
+        "by_observation": {obs: len(rows) for obs, rows in pending.items()},
     }
 
     if dry_run or not to_download:
         return stats
 
-    # Destinations are resolved per-file from each object's storage key (via the
-    # layout contract), so no obs_dir is precomputed here — download_and_verify
-    # creates parents under products/nirspec/<obs>/ as needed.
     products_dir.mkdir(parents=True, exist_ok=True)
+
+    urls = api_client.presign_keys([r["storage_key"] for r in to_download])
+    fetchable = [r for r in to_download if r["storage_key"] in urls]
+    stats["unauthorized"] = len(to_download) - len(fetchable)
 
     dl_session = download_session or create_download_session(max_workers)
 
-    log_id = store.log_sync_start(obs_name)
-    bytes_downloaded = 0
-
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        future_to_spec = {
-            executor.submit(download_and_verify, spec, products_dir, dl_session): spec
-            for spec in to_download
+        future_to_obj = {
+            executor.submit(
+                _download_and_verify_key, r, urls[r["storage_key"]], products_dir, dl_session
+            ): r
+            for r in fetchable
         }
-
-        with tqdm(total=len(to_download), desc=obs_name, unit="file") as pbar:
-            for future in as_completed(future_to_spec):
-                spec = future_to_spec[future]
+        with tqdm(total=len(fetchable), desc="Downloading", unit="file") as pbar:
+            for future in as_completed(future_to_obj):
+                obj = future_to_obj[future]
                 try:
                     result = future.result()
-                    store.mark_synced(
-                        spectrum_id=result["spectrum_id"],
+                    store.mark_object_synced(
+                        storage_key=result["storage_key"],
                         local_path=result["local_path"],
-                        file_hash=result["file_hash"],
-                        file_size=result["file_size"],
-                        local_file_mtime=result.get("local_file_mtime"),
-                        local_file_size=result.get("local_file_size"),
+                        local_file_hash=result["local_file_hash"],
+                        local_file_size=result["local_file_size"],
+                        local_file_mtime=result["local_file_mtime"],
                     )
                     stats["downloaded"] += 1
-                    bytes_downloaded += result.get("file_size") or 0
                 except Exception as e:
                     stats["failed"] += 1
-                    tqdm.write(f"  Failed: {spec['fits_path']}: {e}")
+                    tqdm.write(f"  Failed: {obj['storage_key']}: {e}")
                 pbar.update(1)
 
-    store.log_sync_complete(log_id, stats["downloaded"], stats["skipped"], bytes_downloaded)
     return stats
 
 

--- a/python/tests/sql/storage_objects_scope_leak.sql
+++ b/python/tests/sql/storage_objects_scope_leak.sql
@@ -1,0 +1,167 @@
+-- =============================================================================
+-- storage_objects scope leak harness (epic #210) — the exit gate for opening the
+-- registry from admin-only to program-scoped reads.
+-- =============================================================================
+-- Proves, against a freshly `supabase db reset` local DB, that a NON-ADMIN
+-- authenticated user (full public-program access) gets through RLS:
+--   1. ZERO storage_objects whose parent spectrum is draft/revoked (publish gate).
+--   2. ZERO storage_objects in a program they cannot access (program gate).
+--   3. The still-published control row stays visible (no over-blocking).
+-- And that an ADMIN sees the unpublished rows, and the service-role RPCs
+-- (get_storage_objects_for_sync / filter_accessible_storage_keys) gate the same
+-- way via p_include_unpublished — the predicate the /api/v1 routes rely on.
+--
+-- Runs in one ROLLBACK'd transaction. Seed-anchored: user@=2222…, admin@=1111…,
+-- all seed finals are published nirspec_spec rows in public programs.
+--
+-- Run:  docker exec -i supabase_db_campfire psql -U postgres -d postgres \
+--          -v ON_ERROR_STOP=1 -f python/tests/sql/storage_objects_scope_leak.sql
+-- =============================================================================
+\set ON_ERROR_STOP on
+BEGIN;
+
+-- ---- fixtures (run as the bootstrap superuser, bypasses RLS) ----------------
+-- Three published finals: a control (stays published) and two victims we flip to
+-- draft/revoked. A fourth control gets re-pointed into a private program.
+-- One published final per DISTINCT target (so flipping one victim's target/
+-- spectrum can never disturb another pick — control and victims are independent).
+CREATE TEMP TABLE _pick AS
+  SELECT storage_key, spectrum_id, target_id,
+         row_number() OVER (ORDER BY storage_key) AS rn
+  FROM (
+    SELECT DISTINCT ON (s.target_id) so.storage_key, so.spectrum_id, s.target_id
+    FROM storage_objects so
+    JOIN spectra s ON s.spectrum_id = so.spectrum_id
+    JOIN targets t ON t.target_id = s.target_id
+    JOIN programs p ON p.slug = t.program_slug
+    WHERE so.product_type = 'nirspec_spec'
+      AND so.status = 'active'
+      AND s.deploy_status = 'published'
+      AND p.is_public
+    ORDER BY s.target_id, so.storage_key
+  ) d
+  ORDER BY storage_key
+  LIMIT 4;
+
+DO $$ BEGIN
+  IF (SELECT count(*) FROM _pick) < 4 THEN
+    RAISE EXCEPTION 'FIXTURE: need >=4 published public-program finals in seed (got %)',
+      (SELECT count(*) FROM _pick);
+  END IF;
+END $$;
+
+CREATE TEMP TABLE _ctrl AS SELECT storage_key, spectrum_id FROM _pick WHERE rn = 1;
+CREATE TEMP TABLE _vic_draft AS SELECT storage_key, spectrum_id, target_id FROM _pick WHERE rn = 2;
+CREATE TEMP TABLE _vic_revoked AS SELECT storage_key, spectrum_id, target_id FROM _pick WHERE rn = 3;
+CREATE TEMP TABLE _vic_xprog AS SELECT storage_key, spectrum_id, target_id FROM _pick WHERE rn = 4;
+
+-- Publish-gate victims: flip their spectra (B1 status).
+UPDATE spectra SET deploy_status = 'draft'   WHERE spectrum_id IN (SELECT spectrum_id FROM _vic_draft);
+UPDATE spectra SET deploy_status = 'revoked' WHERE spectrum_id IN (SELECT spectrum_id FROM _vic_revoked);
+
+-- Program-gate victim: move its target into a private program the user can't access.
+INSERT INTO programs (slug, program_name, is_public)
+  VALUES ('leak_priv_prog', 'Leak Private Program', false)
+  ON CONFLICT (slug) DO UPDATE SET is_public = false;
+UPDATE targets SET program_slug = 'leak_priv_prog'
+  WHERE target_id IN (SELECT target_id FROM _vic_xprog);
+
+GRANT SELECT ON _ctrl, _vic_draft, _vic_revoked, _vic_xprog TO authenticated, service_role;
+
+-- =========================================================================
+-- 1. RLS as NON-ADMIN (user@, public-program access) -> zero leak
+-- =========================================================================
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claims',
+  json_build_object('sub', '22222222-2222-2222-2222-222222222222', 'role', 'authenticated')::text, true);
+
+DO $$
+DECLARE n int;
+BEGIN
+  SELECT count(*) INTO n FROM storage_objects WHERE storage_key IN (SELECT storage_key FROM _vic_draft);
+  IF n <> 0 THEN RAISE EXCEPTION 'RLS LEAK: non-admin sees a DRAFT-spectrum storage object (expected 0)'; END IF;
+
+  SELECT count(*) INTO n FROM storage_objects WHERE storage_key IN (SELECT storage_key FROM _vic_revoked);
+  IF n <> 0 THEN RAISE EXCEPTION 'RLS LEAK: non-admin sees a REVOKED-spectrum storage object (expected 0)'; END IF;
+
+  SELECT count(*) INTO n FROM storage_objects WHERE storage_key IN (SELECT storage_key FROM _vic_xprog);
+  IF n <> 0 THEN RAISE EXCEPTION 'RLS LEAK: non-admin sees an OUT-OF-PROGRAM storage object (expected 0)'; END IF;
+
+  -- No over-blocking: the published, in-program control stays visible.
+  SELECT count(*) INTO n FROM storage_objects WHERE storage_key IN (SELECT storage_key FROM _ctrl);
+  IF n <> 1 THEN RAISE EXCEPTION 'REGRESSION: non-admin cannot see published control storage object (got %)', n; END IF;
+END $$;
+
+-- =========================================================================
+-- 2. RLS as ADMIN (admin@) -> unpublished rows ARE visible
+-- =========================================================================
+SELECT set_config('request.jwt.claims',
+  json_build_object('sub', '11111111-1111-1111-1111-111111111111', 'role', 'authenticated')::text, true);
+
+DO $$
+DECLARE n int;
+BEGIN
+  SELECT count(*) INTO n FROM storage_objects
+    WHERE storage_key IN (SELECT storage_key FROM _vic_draft
+                          UNION ALL SELECT storage_key FROM _vic_revoked
+                          UNION ALL SELECT storage_key FROM _vic_xprog);
+  IF n <> 3 THEN RAISE EXCEPTION 'ADMIN BLOCKED: admin sees %/3 unpublished/out-of-program storage objects', n; END IF;
+END $$;
+
+-- =========================================================================
+-- 3. RPC predicates as SERVICE_ROLE (RLS bypassed) -> p_include_unpublished gates
+-- =========================================================================
+RESET ROLE;
+SET LOCAL ROLE service_role;
+SELECT set_config('request.jwt.claims', '', true);
+
+DO $$
+DECLARE pubs text[];
+        leaked int; shown int;
+        keys text[];
+BEGIN
+  pubs := ARRAY(SELECT slug FROM programs WHERE is_public);
+  keys := ARRAY(SELECT storage_key FROM _ctrl
+                UNION ALL SELECT storage_key FROM _vic_draft
+                UNION ALL SELECT storage_key FROM _vic_revoked
+                UNION ALL SELECT storage_key FROM _vic_xprog);
+
+  -- filter_accessible_storage_keys: only the control is authorized for a member.
+  SELECT count(*) INTO shown
+    FROM public.filter_accessible_storage_keys(keys, pubs, false)
+    WHERE storage_key IN (SELECT storage_key FROM _ctrl);
+  IF shown <> 1 THEN RAISE EXCEPTION 'PRESIGN GATE: control key not authorized for member (got %)', shown; END IF;
+
+  SELECT count(*) INTO leaked
+    FROM public.filter_accessible_storage_keys(keys, pubs, false)
+    WHERE storage_key IN (SELECT storage_key FROM _vic_draft
+                          UNION ALL SELECT storage_key FROM _vic_revoked
+                          UNION ALL SELECT storage_key FROM _vic_xprog);
+  IF leaked <> 0 THEN RAISE EXCEPTION 'PRESIGN LEAK: % unpublished/out-of-program keys authorized (expected 0)', leaked; END IF;
+
+  -- Admin override authorizes everything.
+  SELECT count(*) INTO shown FROM public.filter_accessible_storage_keys(keys, pubs, true);
+  IF shown <> 4 THEN RAISE EXCEPTION 'PRESIGN ADMIN: include_unpublished=true authorized %/4 keys', shown; END IF;
+
+  -- get_storage_objects_for_sync: victim keys absent for a member, present for admin.
+  SELECT count(*) INTO leaked FROM (
+    SELECT jsonb_array_elements(objects)->>'storage_key' AS k
+    FROM public.get_storage_objects_for_sync(pubs, NULL, 100000, 0, false, false)
+  ) q WHERE k IN (SELECT storage_key FROM _vic_draft
+                  UNION ALL SELECT storage_key FROM _vic_revoked
+                  UNION ALL SELECT storage_key FROM _vic_xprog);
+  IF leaked <> 0 THEN RAISE EXCEPTION 'SYNC LEAK: % unpublished/out-of-program rows in member sync (expected 0)', leaked; END IF;
+
+  SELECT count(*) INTO shown FROM (
+    SELECT jsonb_array_elements(objects)->>'storage_key' AS k
+    FROM public.get_storage_objects_for_sync(pubs, NULL, 100000, 0, false, true)
+  ) q WHERE k IN (SELECT storage_key FROM _vic_draft
+                  UNION ALL SELECT storage_key FROM _vic_revoked
+                  UNION ALL SELECT storage_key FROM _vic_xprog);
+  IF shown <> 3 THEN RAISE EXCEPTION 'SYNC ADMIN: admin sync returns %/3 unpublished rows', shown; END IF;
+END $$;
+
+RESET ROLE;
+SELECT '✅ STORAGE_OBJECTS SCOPE LEAK HARNESS: ALL ASSERTIONS PASSED' AS result;
+
+ROLLBACK;

--- a/python/tests/test_download_objects.py
+++ b/python/tests/test_download_objects.py
@@ -1,0 +1,159 @@
+"""Tests for the generic, product-type-agnostic download engine (epic #210).
+
+The engine plans locally from the storage_objects mirror, presigns the
+to-download set, fetches + verifies, and records local state — the one path for
+finals, intermediates, and (later) NIRCam.
+"""
+
+import hashlib
+from pathlib import Path
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from campfire.db.store import (
+    LocalStore,
+    FINAL_PRODUCT_TYPES,
+    INTERMEDIATE_PRODUCT_TYPES,
+)
+from campfire.sync import download_objects
+
+FINAL_KEY = "spectra/test_obs/test_obs_prism_100_spec.fits"
+EXP_KEY = "data/products/nirspec/test_obs/jw01_00001_nrs1_100.fits"
+CONTENT = b"FAKE-FITS-BYTES" * 64
+CONTENT_SHA = "sha256:" + hashlib.sha256(CONTENT).hexdigest()
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = LocalStore(tmp_path / "campfire.db")
+    yield s
+    s.close()
+
+
+def _so(key, product_type, content_hash, spectrum_id=None, exposure_ref=None):
+    return {
+        "storage_key": key, "backend": "r2", "bucket": "data",
+        "content_hash": content_hash, "size_bytes": len(CONTENT),
+        "content_type": "application/fits", "product_type": product_type,
+        "instrument": "nirspec", "status": "active", "observation": "test_obs",
+        "field": "cosmos", "spectrum_id": spectrum_id, "exposure_ref": exposure_ref,
+        "deployment_id": 1,
+    }
+
+
+class _FakeAPI:
+    """Presigns only authorized keys (the rest are silently denied)."""
+    def __init__(self, authorized):
+        self._authorized = set(authorized)
+
+    def presign_keys(self, keys):
+        return {k: f"https://signed.example/{k}" for k in keys if k in self._authorized}
+
+
+def _fake_session(content=CONTENT):
+    resp = MagicMock()
+    resp.raise_for_status = Mock()
+    resp.iter_content = Mock(return_value=[content])
+    sess = MagicMock()
+    sess.get = Mock(return_value=resp)
+    return sess
+
+
+def test_downloads_final(store, tmp_path):
+    store.upsert_storage_objects([_so(FINAL_KEY, "nirspec_spec", CONTENT_SHA, "test_obs_prism_100")])
+    products = tmp_path / "products"
+
+    stats = download_objects(
+        _FakeAPI([FINAL_KEY]), ["test_obs"], list(FINAL_PRODUCT_TYPES),
+        store, products, download_session=_fake_session(),
+    )
+
+    assert stats["downloaded"] == 1
+    assert stats["failed"] == 0
+    placed = products / "nirspec" / "test_obs" / "test_obs_prism_100_spec.fits"
+    assert placed.exists()
+    assert store.find_local_path("test_obs_prism_100") == "nirspec/test_obs/test_obs_prism_100_spec.fits"
+
+
+def test_intermediate_only_skips_finals(store, tmp_path):
+    store.upsert_storage_objects([
+        _so(FINAL_KEY, "nirspec_spec", CONTENT_SHA, "test_obs_prism_100"),
+        _so(EXP_KEY, "nirspec_spectrum_exposure", CONTENT_SHA, exposure_ref="jw01_00001_nrs1_100"),
+    ])
+    products = tmp_path / "products"
+
+    stats = download_objects(
+        _FakeAPI([FINAL_KEY, EXP_KEY]), ["test_obs"], list(INTERMEDIATE_PRODUCT_TYPES),
+        store, products, download_session=_fake_session(),
+    )
+
+    # Only the exposure was in the requested product-type set.
+    assert stats["downloaded"] == 1
+    assert (products / "nirspec" / "test_obs" / "jw01_00001_nrs1_100.fits").exists()
+    assert not (products / "nirspec" / "test_obs" / "test_obs_prism_100_spec.fits").exists()
+
+
+def test_unauthorized_keys_are_skipped(store, tmp_path):
+    store.upsert_storage_objects([_so(FINAL_KEY, "nirspec_spec", CONTENT_SHA, "test_obs_prism_100")])
+    products = tmp_path / "products"
+
+    # API authorizes nothing -> presign returns {} -> nothing fetched.
+    stats = download_objects(
+        _FakeAPI([]), ["test_obs"], list(FINAL_PRODUCT_TYPES),
+        store, products, download_session=_fake_session(),
+    )
+
+    assert stats["downloaded"] == 0
+    assert stats["unauthorized"] == 1
+    assert not (products / "nirspec" / "test_obs" / "test_obs_prism_100_spec.fits").exists()
+
+
+def test_hash_mismatch_fails(store, tmp_path):
+    # content_hash claims a different sha256 than the bytes we serve.
+    store.upsert_storage_objects([_so(FINAL_KEY, "nirspec_spec", "sha256:deadbeef", "test_obs_prism_100")])
+    products = tmp_path / "products"
+
+    stats = download_objects(
+        _FakeAPI([FINAL_KEY]), ["test_obs"], list(FINAL_PRODUCT_TYPES),
+        store, products, download_session=_fake_session(),
+    )
+
+    assert stats["downloaded"] == 0
+    assert stats["failed"] == 1
+    assert store.find_local_path("test_obs_prism_100") is None
+
+
+def test_dry_run_plans_without_fetching(store, tmp_path):
+    store.upsert_storage_objects([_so(FINAL_KEY, "nirspec_spec", CONTENT_SHA, "test_obs_prism_100")])
+    products = tmp_path / "products"
+    sess = _fake_session()
+
+    stats = download_objects(
+        _FakeAPI([FINAL_KEY]), ["test_obs"], list(FINAL_PRODUCT_TYPES),
+        store, products, dry_run=True, download_session=sess,
+    )
+
+    assert stats["to_download"] == 1
+    assert stats["downloaded"] == 0
+    sess.get.assert_not_called()
+
+
+def test_skips_already_local(store, tmp_path):
+    store.upsert_storage_objects([_so(FINAL_KEY, "nirspec_spec", CONTENT_SHA, "test_obs_prism_100")])
+    # Mark it already present with a matching hash -> not pending.
+    store.mark_object_synced(
+        storage_key=FINAL_KEY,
+        local_path="nirspec/test_obs/test_obs_prism_100_spec.fits",
+        local_file_hash=CONTENT_SHA,
+        local_file_size=len(CONTENT),
+    )
+    products = tmp_path / "products"
+
+    stats = download_objects(
+        _FakeAPI([FINAL_KEY]), ["test_obs"], list(FINAL_PRODUCT_TYPES),
+        store, products, download_session=_fake_session(),
+    )
+
+    assert stats["to_download"] == 0
+    assert stats["downloaded"] == 0

--- a/python/tests/test_local_first.py
+++ b/python/tests/test_local_first.py
@@ -96,6 +96,27 @@ def local_store(tmp_path):
         },
     ])
 
+    # File/availability layer: the spectra above resolve their fits_path via the
+    # storage_objects mirror join, so seed matching rows.
+    store.upsert_storage_objects([
+        {
+            "storage_key": "spectra/test_obs/test_obs_prism_100_spec.fits",
+            "content_hash": "sha256:abc", "size_bytes": 1024,
+            "content_type": "application/fits", "product_type": "nirspec_spec",
+            "instrument": "nirspec", "status": "active", "observation": "test_obs",
+            "field": "cosmos", "spectrum_id": "test_obs_prism_100", "backend": "r2",
+            "bucket": "data", "deployment_id": 1,
+        },
+        {
+            "storage_key": "spectra/test_obs/test_obs_prism_200_spec.fits",
+            "content_hash": "sha256:def", "size_bytes": 1024,
+            "content_type": "application/fits", "product_type": "nirspec_spec",
+            "instrument": "nirspec", "status": "active", "observation": "test_obs",
+            "field": "cosmos", "spectrum_id": "test_obs_prism_200", "backend": "r2",
+            "bucket": "data", "deployment_id": 1,
+        },
+    ])
+
     yield store, tmp_path
     store.close()
 
@@ -229,11 +250,11 @@ class TestOpenSpectrum:
         fits_file = obs_dir / "test_obs_prism_100_spec.fits"
         fits_file.write_bytes(self._make_fits_bytes(50))
 
-        store.mark_synced(
-            spectrum_id="test_obs_prism_100",
+        store.mark_object_synced(
+            storage_key="spectra/test_obs/test_obs_prism_100_spec.fits",
             local_path="nirspec/test_obs/test_obs_prism_100_spec.fits",
-            file_hash="sha256:abc",
-            file_size=fits_file.stat().st_size,
+            local_file_hash="sha256:abc",
+            local_file_size=fits_file.stat().st_size,
         )
 
         spec = client.open_spectrum("test_obs_prism_100")

--- a/python/tests/test_storage_scope_rls.py
+++ b/python/tests/test_storage_scope_rls.py
@@ -1,0 +1,58 @@
+"""storage_objects program-scope leak gate (epic #210).
+
+DB-backed integration test: runs ``sql/storage_objects_scope_leak.sql`` against
+the local Supabase Postgres via ``docker exec ... psql`` and asserts the harness
+reaches its PASS marker. The SQL flips seed rows to draft/revoked and moves one
+into a private program (inside a rolled-back transaction), then asserts a
+non-admin sees ZERO of those storage objects through RLS and the service-role
+RPCs (get_storage_objects_for_sync / filter_accessible_storage_keys), while an
+admin does — the exit criterion for opening the registry to program-scoped reads.
+
+Skips automatically when the local Supabase DB container is not reachable.
+"""
+import subprocess
+from pathlib import Path
+
+import pytest
+
+CONTAINER = "supabase_db_campfire"
+SQL_FILE = Path(__file__).parent / "sql" / "storage_objects_scope_leak.sql"
+PASS_MARKER = "ALL ASSERTIONS PASSED"
+
+
+def _docker_psql_available() -> bool:
+    try:
+        r = subprocess.run(
+            ["docker", "exec", "-i", CONTAINER,
+             "psql", "-U", "postgres", "-d", "postgres", "-tA", "-c", "SELECT 1"],
+            capture_output=True, text=True, timeout=15,
+        )
+        return r.returncode == 0 and r.stdout.strip().startswith("1")
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return False
+
+
+requires_local_db = pytest.mark.skipif(
+    not _docker_psql_available(),
+    reason=f"local Supabase container '{CONTAINER}' not reachable (run `supabase start` + `supabase db reset`)",
+)
+
+
+@requires_local_db
+def test_storage_objects_scope_no_leak_to_non_admin():
+    """Non-admin gets zero draft/revoked/out-of-program storage objects; admin sees them."""
+    sql = SQL_FILE.read_text()
+    result = subprocess.run(
+        ["docker", "exec", "-i", CONTAINER,
+         "psql", "-U", "postgres", "-d", "postgres", "-v", "ON_ERROR_STOP=1", "-f", "-"],
+        input=sql, capture_output=True, text=True, timeout=120,
+    )
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, (
+        f"storage_objects scope leak harness FAILED (psql exit {result.returncode}).\n"
+        f"A non-admin saw a draft/revoked/out-of-program storage object, or a "
+        f"published control row regressed. Output:\n{combined}"
+    )
+    assert PASS_MARKER in result.stdout, (
+        f"storage_objects scope leak harness did not reach its PASS marker.\nOutput:\n{combined}"
+    )

--- a/python/tests/test_store.py
+++ b/python/tests/test_store.py
@@ -136,6 +136,28 @@ def sample_spectra():
     ]
 
 
+@pytest.fixture
+def sample_storage_objects():
+    """Mirror rows for the three sample finals (the file/availability layer)."""
+    def _row(key, h, size, spectrum_id, obs, field):
+        return {
+            "storage_key": key, "id": None, "backend": "r2", "bucket": "data",
+            "content_hash": h, "size_bytes": size, "content_type": "application/fits",
+            "product_type": "nirspec_spec", "instrument": "nirspec", "status": "active",
+            "observation": obs, "field": field, "spectrum_id": spectrum_id,
+            "exposure_ref": None, "deployment_id": 1, "cfpipe_version": "v1.0",
+            "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+        }
+    return [
+        _row("spectra/ember_uds_p4/ember_uds_p4_PRISM_CLEAR_100_spec.fits",
+             "sha256:aaa", 1024, "ember_uds_p4_prism_clear_100", "ember_uds_p4", "uds"),
+        _row("spectra/ember_uds_p4/ember_uds_p4_G395M_F290LP_100_spec.fits",
+             "sha256:bbb", 2048, "ember_uds_p4_g395m_f290lp_100", "ember_uds_p4", "uds"),
+        _row("spectra/ember_cosmos_p1/ember_cosmos_p1_PRISM_CLEAR_200_spec.fits",
+             "sha256:ccc", 512, "ember_cosmos_p1_prism_clear_200", "ember_cosmos_p1", "cosmos"),
+    ]
+
+
 class TestSchema:
     def test_schema_version(self, store):
         assert store._get_schema_version() == SCHEMA_VERSION
@@ -272,20 +294,25 @@ class TestUpsertSpectra:
         count = store.upsert_spectra(sample_spectra)
         assert count == 3
 
-    def test_preserves_local_fields(self, store, sample_objects, sample_spectra):
+    def test_preserves_local_fields(self, store, sample_objects, sample_spectra, sample_storage_objects):
+        # Local download state lives on the storage_objects mirror now and must
+        # survive a metadata refresh of both spectra and the mirror.
         store.upsert_objects(sample_objects)
         store.upsert_spectra(sample_spectra)
-        store.mark_synced(
-            spectrum_id="ember_uds_p4_prism_clear_100",
-            local_path="ember_uds_p4/test.fits",
-            file_hash="sha256:local",
-            file_size=1024,
+        store.upsert_storage_objects(sample_storage_objects)
+        key = "spectra/ember_uds_p4/ember_uds_p4_PRISM_CLEAR_100_spec.fits"
+        store.mark_object_synced(
+            storage_key=key,
+            local_path="nirspec/ember_uds_p4/test.fits",
+            local_file_hash="sha256:local",
+            local_file_size=1024,
         )
-        # Re-upsert should not clobber local_path
+        # Re-upsert (metadata refresh) must not clobber local state.
         store.upsert_spectra(sample_spectra)
+        store.upsert_storage_objects(sample_storage_objects)
         row = store.get_spectrum("ember_uds_p4_prism_clear_100")
-        assert row["local_path"] == "ember_uds_p4/test.fits"
-        assert row["local_file_hash"] == "sha256:local"
+        assert row["local_path"] == "nirspec/ember_uds_p4/test.fits"
+        assert row["file_hash"] == "sha256:aaa"  # server hash, surfaced via the join
 
 
 class TestQuerySpectra:
@@ -369,63 +396,112 @@ class TestProvenance:
 
 
 class TestDownloadTracking:
-    def test_mark_synced(self, store, sample_objects, sample_spectra):
-        store.upsert_objects(sample_objects)
-        store.upsert_spectra(sample_spectra)
-        store.mark_synced(
-            spectrum_id="ember_uds_p4_prism_clear_100",
-            local_path="ember_uds_p4/test.fits",
-            file_hash="sha256:local",
-            file_size=1024,
-        )
-        row = store.get_spectrum("ember_uds_p4_prism_clear_100")
-        assert row["local_path"] == "ember_uds_p4/test.fits"
+    """Download/availability bookkeeping lives on the storage_objects mirror."""
 
-    def test_find_local_path(self, store, sample_objects, sample_spectra):
-        store.upsert_objects(sample_objects)
-        store.upsert_spectra(sample_spectra)
-        store.mark_synced(
-            spectrum_id="ember_uds_p4_prism_clear_100",
-            local_path="ember_uds_p4/test.fits",
-            file_hash="sha256:local",
-            file_size=1024,
+    KEY_100 = "spectra/ember_uds_p4/ember_uds_p4_PRISM_CLEAR_100_spec.fits"
+
+    def test_mark_object_synced(self, store, sample_storage_objects):
+        store.upsert_storage_objects(sample_storage_objects)
+        store.mark_object_synced(
+            storage_key=self.KEY_100,
+            local_path="nirspec/ember_uds_p4/test.fits",
+            local_file_hash="sha256:local",
+            local_file_size=1024,
         )
         path = store.find_local_path("ember_uds_p4_prism_clear_100")
-        assert path == "ember_uds_p4/test.fits"
+        assert path == "nirspec/ember_uds_p4/test.fits"
+
+    def test_find_local_path(self, store, sample_storage_objects):
+        store.upsert_storage_objects(sample_storage_objects)
+        store.mark_object_synced(
+            storage_key=self.KEY_100,
+            local_path="nirspec/ember_uds_p4/test.fits",
+            local_file_hash="sha256:local",
+            local_file_size=1024,
+        )
+        assert store.find_local_path("ember_uds_p4_prism_clear_100") == "nirspec/ember_uds_p4/test.fits"
         assert store.find_local_path("ember_uds_p4_g395m_f290lp_100") is None
 
-    def test_get_stale_files(self, store, sample_objects, sample_spectra):
-        store.upsert_objects(sample_objects)
-        store.upsert_spectra(sample_spectra)
-        store.mark_synced(
-            spectrum_id="ember_uds_p4_prism_clear_100",
-            local_path="ember_uds_p4/test.fits",
-            file_hash="sha256:OUTDATED",
-            file_size=1024,
+    def test_get_stale_objects(self, store, sample_storage_objects):
+        store.upsert_storage_objects(sample_storage_objects)
+        store.mark_object_synced(
+            storage_key=self.KEY_100,
+            local_path="nirspec/ember_uds_p4/test.fits",
+            local_file_hash="sha256:OUTDATED",  # differs from server sha256:aaa
+            local_file_size=1024,
         )
-        stale = store.get_stale_files()
+        stale = store.get_stale_objects()
         assert len(stale) == 1
         assert stale[0]["spectrum_id"] == "ember_uds_p4_prism_clear_100"
 
-    def test_get_pending_downloads(self, store, sample_objects, sample_spectra):
-        store.upsert_objects(sample_objects)
-        store.upsert_spectra(sample_spectra)
-        pending = store.get_pending_downloads()
+    def test_get_pending_objects(self, store, sample_storage_objects):
+        store.upsert_storage_objects(sample_storage_objects)
+        pending = store.get_pending_objects()
         total = sum(len(v) for v in pending.values())
         assert total == 3
 
-    def test_get_pending_after_sync(self, store, sample_objects, sample_spectra):
-        store.upsert_objects(sample_objects)
-        store.upsert_spectra(sample_spectra)
-        store.mark_synced(
-            spectrum_id="ember_uds_p4_prism_clear_100",
-            local_path="ember_uds_p4/test.fits",
-            file_hash="sha256:aaa",  # matches server
-            file_size=1024,
+    def test_get_pending_after_sync(self, store, sample_storage_objects):
+        store.upsert_storage_objects(sample_storage_objects)
+        store.mark_object_synced(
+            storage_key=self.KEY_100,
+            local_path="nirspec/ember_uds_p4/test.fits",
+            local_file_hash="sha256:aaa",  # matches server
+            local_file_size=1024,
         )
-        pending = store.get_pending_downloads()
+        pending = store.get_pending_objects()
         total = sum(len(v) for v in pending.values())
         assert total == 2
+
+    def test_get_pending_by_product_type(self, store, sample_storage_objects):
+        store.upsert_storage_objects(sample_storage_objects)
+        # All sample rows are finals; intermediates-only filter yields nothing.
+        pending = store.get_pending_objects(product_types=["nirspec_spectrum_exposure"])
+        assert sum(len(v) for v in pending.values()) == 0
+        pending = store.get_pending_objects(product_types=["nirspec_spec"])
+        assert sum(len(v) for v in pending.values()) == 3
+
+
+class TestStatusView:
+    """get_object_summary / get_object_stats drive `campfire status`."""
+
+    def test_object_summary_counts(self, store, sample_storage_objects):
+        store.upsert_storage_objects(sample_storage_objects)
+        # Add a draft-only obs with just an intermediate (no finals).
+        store.upsert_storage_objects([{
+            "storage_key": "data/products/nirspec/ember_draft/jw_00001_nrs1_9.fits",
+            "content_hash": "sha256:exp", "size_bytes": 4096,
+            "content_type": "application/fits", "product_type": "nirspec_spectrum_exposure",
+            "instrument": "nirspec", "status": "active", "observation": "ember_draft",
+            "field": "egs", "spectrum_id": None, "exposure_ref": "jw_00001_nrs1_9",
+            "backend": "r2", "bucket": "data", "deployment_id": 2,
+        }])
+        store.mark_object_synced(
+            storage_key="spectra/ember_uds_p4/ember_uds_p4_PRISM_CLEAR_100_spec.fits",
+            local_path="nirspec/ember_uds_p4/x.fits", local_file_hash="sha256:aaa",
+            local_file_size=1024,
+        )
+        summary = {r["observation"]: r for r in store.get_object_summary()}
+
+        uds = summary["ember_uds_p4"]
+        assert uds["finals_available"] == 2
+        assert uds["finals_local"] == 1
+        assert uds["intermediates_available"] == 0
+
+        draft = summary["ember_draft"]
+        assert draft["finals_available"] == 0
+        assert draft["intermediates_available"] == 1
+        assert draft["intermediates_local"] == 0
+
+    def test_object_stats(self, store, sample_storage_objects):
+        store.upsert_storage_objects(sample_storage_objects)
+        store.mark_object_synced(
+            storage_key="spectra/ember_uds_p4/ember_uds_p4_PRISM_CLEAR_100_spec.fits",
+            local_path="nirspec/ember_uds_p4/x.fits", local_file_hash="sha256:aaa",
+            local_file_size=1024,
+        )
+        stats = store.get_object_stats("ember_uds_p4")
+        assert stats["synced_count"] == 1
+        assert stats["total_bytes"] == 1024
 
 
 class TestPurge:

--- a/supabase/migrations/20260629153142_unified_storage_download_layer.sql
+++ b/supabase/migrations/20260629153142_unified_storage_download_layer.sql
@@ -1,0 +1,224 @@
+drop materialized view if exists "public"."mv_filter_options";
+
+drop materialized view if exists "public"."mv_programs_overview";
+
+drop view if exists "public"."nircam_reduction_progress";
+
+drop view if exists "public"."spectrum_flag_summary";
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.filter_accessible_storage_keys(p_keys text[], p_program_slugs text[], p_include_unpublished boolean DEFAULT false)
+ RETURNS TABLE(storage_key text)
+ LANGUAGE sql
+ STABLE
+AS $function$
+  SELECT so.storage_key
+  FROM storage_objects so
+  WHERE so.storage_key = ANY(p_keys)
+    AND so.status = 'active'
+    AND (
+      p_include_unpublished
+      OR (so.spectrum_id IS NOT NULL AND EXISTS (
+            SELECT 1 FROM spectra s
+            JOIN targets t ON t.target_id = s.target_id
+            WHERE s.spectrum_id = so.spectrum_id
+              AND s.deploy_status = 'published'
+              AND t.program_slug = ANY(p_program_slugs)))
+      OR (so.spectrum_id IS NULL AND so.deployment_id IS NOT NULL AND EXISTS (
+            SELECT 1 FROM deployments d
+            JOIN observations o ON o.name = d.observation
+            WHERE d.id = so.deployment_id
+              AND d.status = 'published'
+              AND o.program_slug = ANY(p_program_slugs)))
+    );
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_storage_objects_for_sync(p_program_slugs text[], p_updated_since timestamp with time zone DEFAULT NULL::timestamp with time zone, p_limit integer DEFAULT 1000, p_offset integer DEFAULT 0, p_include_counts boolean DEFAULT true, p_include_unpublished boolean DEFAULT false)
+ RETURNS TABLE(objects jsonb, total_count bigint, total_accessible_count bigint)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+ SET statement_timeout TO '120s'
+AS $function$
+BEGIN
+  RETURN QUERY
+  WITH scoped AS (
+    SELECT so.*
+    FROM storage_objects so
+    WHERE so.status = 'active'
+      AND (
+        p_include_unpublished
+        OR (so.spectrum_id IS NOT NULL AND EXISTS (
+              SELECT 1 FROM spectra s
+              JOIN targets t ON t.target_id = s.target_id
+              WHERE s.spectrum_id = so.spectrum_id
+                AND s.deploy_status = 'published'
+                AND t.program_slug = ANY(p_program_slugs)))
+        OR (so.spectrum_id IS NULL AND so.deployment_id IS NOT NULL AND EXISTS (
+              SELECT 1 FROM deployments d
+              JOIN observations o ON o.name = d.observation
+              WHERE d.id = so.deployment_id
+                AND d.status = 'published'
+                AND o.program_slug = ANY(p_program_slugs)))
+      )
+  ),
+  matched AS MATERIALIZED (
+    SELECT * FROM scoped
+    WHERE (p_updated_since IS NULL OR scoped.updated_at > p_updated_since)
+    ORDER BY scoped.storage_key
+    LIMIT p_limit OFFSET p_offset
+  ),
+  total AS (
+    SELECT COUNT(*) AS cnt FROM scoped
+    WHERE p_include_counts
+      AND (p_updated_since IS NULL OR scoped.updated_at > p_updated_since)
+  ),
+  accessible AS (
+    SELECT COUNT(*) AS cnt FROM scoped
+    WHERE p_include_counts
+  )
+  SELECT
+    COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'id', m.id,
+        'backend', m.backend,
+        'bucket', m.bucket,
+        'storage_key', m.storage_key,
+        'content_hash', m.content_hash,
+        'size_bytes', m.size_bytes,
+        'content_type', m.content_type,
+        'product_type', m.product_type,
+        'instrument', m.instrument,
+        'status', m.status,
+        'observation', m.observation,
+        'field', m.field,
+        'spectrum_id', m.spectrum_id,
+        'exposure_ref', m.exposure_ref,
+        'deployment_id', m.deployment_id,
+        'cfpipe_version', m.cfpipe_version,
+        'created_at', m.created_at,
+        'updated_at', m.updated_at
+      )
+    ), '[]'::jsonb),
+    COALESCE((SELECT cnt FROM total), 0)::BIGINT,
+    COALESCE((SELECT cnt FROM accessible), 0)::BIGINT
+  FROM matched m;
+END;
+$function$
+;
+
+-- NOTE (#228): can_inspect()/handle_new_user() re-emitted by migra (pre-existing
+-- SET search_path drift, tracked in #228). Stripped to keep this migration single-purpose.
+
+create materialized view "public"."mv_filter_options" as  SELECT 1 AS id,
+    ARRAY( SELECT DISTINCT targets.field
+           FROM public.targets
+          WHERE targets.has_published_spectrum
+          ORDER BY targets.field) AS fields,
+    ARRAY( SELECT DISTINCT targets.observation
+           FROM public.targets
+          WHERE ((targets.observation IS NOT NULL) AND targets.has_published_spectrum)
+          ORDER BY targets.observation) AS observations,
+    ARRAY( SELECT DISTINCT spectra.grating
+           FROM public.spectra
+          WHERE (spectra.deploy_status = 'published'::text)
+          ORDER BY spectra.grating) AS gratings;
+
+
+create materialized view "public"."mv_programs_overview" as  SELECT p.slug,
+    p.program_name,
+    p.pi_name,
+    p.description,
+    p.is_public,
+    p.cycle,
+    COALESCE(stats.target_count, (0)::bigint) AS target_count,
+    COALESCE(stats.gratings, ARRAY[]::text[]) AS gratings,
+    COALESCE(stats.fields, ARRAY[]::text[]) AS fields,
+    COALESCE(stats.observations, ARRAY[]::text[]) AS observations,
+    COALESCE(pids.jwst_pids, ARRAY[]::integer[]) AS jwst_pids,
+    COALESCE(pids.n_observations, (0)::bigint) AS n_observations,
+    last_red.last_reduced_at
+   FROM (((public.programs p
+     LEFT JOIN ( SELECT t.program_slug,
+            count(DISTINCT t.target_id) AS target_count,
+            array_agg(DISTINCT s.grating ORDER BY s.grating) FILTER (WHERE (s.grating IS NOT NULL)) AS gratings,
+            array_agg(DISTINCT t.field ORDER BY t.field) AS fields,
+            array_agg(DISTINCT t.observation ORDER BY t.observation) AS observations
+           FROM (public.targets t
+             LEFT JOIN public.spectra s ON (((s.target_id = t.target_id) AND (s.deploy_status = 'published'::text))))
+          GROUP BY t.program_slug) stats ON ((p.slug = stats.program_slug)))
+     LEFT JOIN ( SELECT observations.program_slug,
+            array_agg(DISTINCT observations.jwst_program_id ORDER BY observations.jwst_program_id) AS jwst_pids,
+            count(*) AS n_observations
+           FROM public.observations
+          GROUP BY observations.program_slug) pids ON ((p.slug = pids.program_slug)))
+     LEFT JOIN ( SELECT o.program_slug,
+            max(d.reduced_at) AS last_reduced_at
+           FROM (public.observations o
+             JOIN public.deployments d ON ((d.observation = o.name)))
+          WHERE (d.source_ids_filter IS NULL)
+          GROUP BY o.program_slug) last_red ON ((p.slug = last_red.program_slug)));
+
+
+-- Restore matview unique indexes migra drops (REFRESH CONCURRENTLY needs them).
+CREATE UNIQUE INDEX mv_filter_options_id ON public.mv_filter_options USING btree (id);
+CREATE UNIQUE INDEX mv_programs_overview_slug ON public.mv_programs_overview USING btree (slug);
+
+-- security_invoker restored (migra drops it on recreate).
+create or replace view "public"."nircam_reduction_progress" with (security_invoker = true) as  SELECT field,
+    filter,
+    count(*) AS total,
+    count(*) FILTER (WHERE (stage = 'uncal'::text)) AS at_uncal,
+    count(*) FILTER (WHERE (stage = 'detector1'::text)) AS at_detector1,
+    count(*) FILTER (WHERE (stage = 'persistence'::text)) AS at_persistence,
+    count(*) FILTER (WHERE (stage = 'wisp'::text)) AS at_wisp,
+    count(*) FILTER (WHERE (stage = 'striping'::text)) AS at_striping,
+    count(*) FILTER (WHERE (stage = 'image2'::text)) AS at_image2,
+    count(*) FILTER (WHERE (stage = 'edge'::text)) AS at_edge,
+    count(*) FILTER (WHERE (stage = 'sky'::text)) AS at_sky,
+    count(*) FILTER (WHERE (stage = 'diag_striping'::text)) AS at_diag_striping,
+    count(*) FILTER (WHERE (stage = 'variance'::text)) AS at_variance,
+    count(*) FILTER (WHERE (stage = 'wcs_shift'::text)) AS at_wcs_shift,
+    count(*) FILTER (WHERE (stage = 'preview'::text)) AS at_preview,
+    count(*) FILTER (WHERE (stage = 'jhat'::text)) AS at_jhat,
+    count(*) FILTER (WHERE (stage = 'apply_mask'::text)) AS at_apply_mask,
+    count(*) FILTER (WHERE (stage = 'bad_pixel'::text)) AS at_bad_pixel,
+    count(*) FILTER (WHERE (stage = 'outlier'::text)) AS at_outlier,
+    count(*) FILTER (WHERE (review_status = 'pending'::text)) AS pending_review,
+    count(*) FILTER (WHERE (review_status = 'approved'::text)) AS approved,
+    count(*) FILTER (WHERE (review_status = 'excluded'::text)) AS excluded,
+    count(*) FILTER (WHERE (masking = 'needed'::text)) AS needs_masking,
+    count(*) FILTER (WHERE (correction = 'needed'::text)) AS needs_correction
+   FROM public.nircam_exposures
+  GROUP BY field, filter;
+
+
+-- security_invoker restored (migra drops it on recreate).
+create or replace view "public"."spectrum_flag_summary" with (security_invoker = true) as  SELECT s.id,
+    s.target_id,
+    s.grating,
+    array_agg(DISTINCT fd.label) FILTER (WHERE ((fd.category = 'dq_flags'::text) AND ((s.dq_flags & fd.value) > 0))) AS dq_flags_labels
+   FROM (public.spectra s
+     CROSS JOIN public.flag_definitions fd)
+  WHERE ((s.deploy_status = 'published'::text) OR public.is_admin())
+  GROUP BY s.id, s.target_id, s.grating;
+
+
+
+  create policy "select_storage_objects_by_access"
+  on "public"."storage_objects"
+  as permissive
+  for select
+  to authenticated
+using (((status = 'active'::text) AND (((spectrum_id IS NOT NULL) AND (EXISTS ( SELECT 1
+   FROM (public.spectra s
+     JOIN public.targets t ON ((t.target_id = s.target_id)))
+  WHERE ((s.spectrum_id = storage_objects.spectrum_id) AND (s.deploy_status = 'published'::text) AND (t.program_slug = ANY (( SELECT public.accessible_program_slugs() AS accessible_program_slugs)::text[])))))) OR ((spectrum_id IS NULL) AND (deployment_id IS NOT NULL) AND (EXISTS ( SELECT 1
+   FROM (public.deployments d
+     JOIN public.observations o ON ((o.name = d.observation)))
+  WHERE ((d.id = storage_objects.deployment_id) AND (d.status = 'published'::text) AND (o.program_slug = ANY (( SELECT public.accessible_program_slugs() AS accessible_program_slugs)::text[])))))))));
+
+
+

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -2481,6 +2481,148 @@ GRANT EXECUTE ON FUNCTION public.get_observation_manifest TO authenticated;
 
 
 -- =============================================================================
+-- get_storage_objects_for_sync (epic #210)
+-- =============================================================================
+-- Catalog-sync endpoint for the Python client's local `storage_objects` mirror,
+-- which is the single download/availability layer (finals + intermediates +
+-- future NIRCam share one engine). Mirrors get_spectra_for_sync: returns a JSONB
+-- page + counts in one row, paginated, incremental via p_updated_since.
+--
+-- Scope (matches the storage_objects RLS SELECT policy, restated here because the
+-- route calls this under service_role with RLS bypassed):
+--   * status = 'active' (current rows only — superseded/revoked are GC state).
+--   * Admins (p_include_unpublished, set only when isAdminUser) get every active
+--     row — a faithful full mirror, including drafts and field-only products.
+--   * Non-admins get rows whose observation is in an accessible program AND that
+--     are published: spectrum-family rows follow their spectrum's deploy_status;
+--     exposure/object-level rows follow their deployment's status. Drafts/revoked
+--     and out-of-program rows are excluded. Field-only products (NULL observation,
+--     e.g. NIRCam) are admin-only here until NIRCam client download lands.
+CREATE OR REPLACE FUNCTION public.get_storage_objects_for_sync(
+  p_program_slugs TEXT[],
+  p_updated_since TIMESTAMPTZ DEFAULT NULL,
+  p_limit INTEGER DEFAULT 1000,
+  p_offset INTEGER DEFAULT 0,
+  p_include_counts BOOLEAN DEFAULT TRUE,
+  p_include_unpublished BOOLEAN DEFAULT FALSE
+)
+RETURNS TABLE(objects JSONB, total_count BIGINT, total_accessible_count BIGINT)
+LANGUAGE plpgsql STABLE
+SET plan_cache_mode = 'force_custom_plan'
+SET statement_timeout = '120s'
+AS $$
+BEGIN
+  RETURN QUERY
+  WITH scoped AS (
+    SELECT so.*
+    FROM storage_objects so
+    WHERE so.status = 'active'
+      AND (
+        p_include_unpublished
+        OR (so.spectrum_id IS NOT NULL AND EXISTS (
+              SELECT 1 FROM spectra s
+              JOIN targets t ON t.target_id = s.target_id
+              WHERE s.spectrum_id = so.spectrum_id
+                AND s.deploy_status = 'published'
+                AND t.program_slug = ANY(p_program_slugs)))
+        OR (so.spectrum_id IS NULL AND so.deployment_id IS NOT NULL AND EXISTS (
+              SELECT 1 FROM deployments d
+              JOIN observations o ON o.name = d.observation
+              WHERE d.id = so.deployment_id
+                AND d.status = 'published'
+                AND o.program_slug = ANY(p_program_slugs)))
+      )
+  ),
+  matched AS MATERIALIZED (
+    SELECT * FROM scoped
+    WHERE (p_updated_since IS NULL OR scoped.updated_at > p_updated_since)
+    ORDER BY scoped.storage_key
+    LIMIT p_limit OFFSET p_offset
+  ),
+  total AS (
+    SELECT COUNT(*) AS cnt FROM scoped
+    WHERE p_include_counts
+      AND (p_updated_since IS NULL OR scoped.updated_at > p_updated_since)
+  ),
+  accessible AS (
+    SELECT COUNT(*) AS cnt FROM scoped
+    WHERE p_include_counts
+  )
+  SELECT
+    COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'id', m.id,
+        'backend', m.backend,
+        'bucket', m.bucket,
+        'storage_key', m.storage_key,
+        'content_hash', m.content_hash,
+        'size_bytes', m.size_bytes,
+        'content_type', m.content_type,
+        'product_type', m.product_type,
+        'instrument', m.instrument,
+        'status', m.status,
+        'observation', m.observation,
+        'field', m.field,
+        'spectrum_id', m.spectrum_id,
+        'exposure_ref', m.exposure_ref,
+        'deployment_id', m.deployment_id,
+        'cfpipe_version', m.cfpipe_version,
+        'created_at', m.created_at,
+        'updated_at', m.updated_at
+      )
+    ), '[]'::jsonb),
+    COALESCE((SELECT cnt FROM total), 0)::BIGINT,
+    COALESCE((SELECT cnt FROM accessible), 0)::BIGINT
+  FROM matched m;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_storage_objects_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_storage_objects_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN) TO service_role;
+
+
+-- =============================================================================
+-- filter_accessible_storage_keys (epic #210)
+-- =============================================================================
+-- Per-key authorization for the /api/v1/storage/presign endpoint. Returns the
+-- subset of p_keys the caller may download, applying the same scope as
+-- get_storage_objects_for_sync (active + admin-all OR program-accessible &
+-- published). The route presigns only the returned keys; anything omitted is
+-- silently denied. Called under service_role (RLS bypassed), so scope is in SQL.
+CREATE OR REPLACE FUNCTION public.filter_accessible_storage_keys(
+  p_keys TEXT[],
+  p_program_slugs TEXT[],
+  p_include_unpublished BOOLEAN DEFAULT FALSE
+)
+RETURNS TABLE(storage_key TEXT)
+LANGUAGE sql STABLE
+AS $$
+  SELECT so.storage_key
+  FROM storage_objects so
+  WHERE so.storage_key = ANY(p_keys)
+    AND so.status = 'active'
+    AND (
+      p_include_unpublished
+      OR (so.spectrum_id IS NOT NULL AND EXISTS (
+            SELECT 1 FROM spectra s
+            JOIN targets t ON t.target_id = s.target_id
+            WHERE s.spectrum_id = so.spectrum_id
+              AND s.deploy_status = 'published'
+              AND t.program_slug = ANY(p_program_slugs)))
+      OR (so.spectrum_id IS NULL AND so.deployment_id IS NOT NULL AND EXISTS (
+            SELECT 1 FROM deployments d
+            JOIN observations o ON o.name = d.observation
+            WHERE d.id = so.deployment_id
+              AND d.status = 'published'
+              AND o.program_slug = ANY(p_program_slugs)))
+    );
+$$;
+
+GRANT EXECUTE ON FUNCTION public.filter_accessible_storage_keys(TEXT[], TEXT[], BOOLEAN) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.filter_accessible_storage_keys(TEXT[], TEXT[], BOOLEAN) TO service_role;
+
+
+-- =============================================================================
 -- get_targets_in_viewport
 -- =============================================================================
 

--- a/supabase/schemas/policies.sql
+++ b/supabase/schemas/policies.sql
@@ -729,11 +729,14 @@ CREATE POLICY "admin_select_deploy_scope_state"
 
 
 -- =============================================================================
--- storage_objects (admin-only — internal storage registry, epic #210 F1)
+-- storage_objects (program-scoped reads, epic #210 — the client download layer)
 -- =============================================================================
--- The registry is admin/internal: the web portal never reads it in F1, and
--- deploy backfill/reconcile run under the service role (RLS bypassed). RLS here
--- is defense-in-depth so no non-admin session can read or mutate it.
+-- The registry is the single file-availability authority. Reads are program-
+-- scoped (like targets/observations) so the Python client can mirror it as its
+-- one download/availability layer. Writes stay admin-only; deploy backfill/
+-- reconcile run under the service role (RLS bypassed). RLS is also the
+-- belt-and-suspenders companion to get_storage_objects_for_sync /
+-- filter_accessible_storage_keys, which restate this scope for the API path.
 
 ALTER TABLE storage_objects ENABLE ROW LEVEL SECURITY;
 
@@ -742,6 +745,36 @@ DROP POLICY IF EXISTS "admin_select_storage_objects" ON storage_objects;
 CREATE POLICY "admin_select_storage_objects"
   ON storage_objects FOR SELECT TO authenticated
   USING ((SELECT public.is_admin()));
+
+-- Program members can read PUBLISHED, active storage objects in programs they can
+-- access. Mirrors the spectra/targets B1 (#217) publish gate without depending on
+-- the (often-NULL) observation column: spectrum-family rows simply inherit their
+-- parent spectrum's visibility (program access + published); exposure/object-level
+-- rows are gated by their deployment (program via its observation + published
+-- status). Drafts/revoked and out-of-program rows stay hidden (admins see them via
+-- admin_select_storage_objects above). Rows with neither a spectrum_id nor a
+-- deployment_id (e.g. backfilled NIRCam) are admin-only until those land.
+DROP POLICY IF EXISTS "select_storage_objects_by_access" ON storage_objects;
+CREATE POLICY "select_storage_objects_by_access"
+  ON storage_objects FOR SELECT TO authenticated
+  USING (
+    status = 'active'
+    AND (
+      (storage_objects.spectrum_id IS NOT NULL AND EXISTS (
+         SELECT 1 FROM spectra s
+         JOIN targets t ON t.target_id = s.target_id
+         WHERE s.spectrum_id = storage_objects.spectrum_id
+           AND s.deploy_status = 'published'
+           AND t.program_slug = ANY((SELECT public.accessible_program_slugs())::text[])))
+      OR
+      (storage_objects.spectrum_id IS NULL AND storage_objects.deployment_id IS NOT NULL AND EXISTS (
+         SELECT 1 FROM deployments d
+         JOIN observations o ON o.name = d.observation
+         WHERE d.id = storage_objects.deployment_id
+           AND d.status = 'published'
+           AND o.program_slug = ANY((SELECT public.accessible_program_slugs())::text[])))
+    )
+  );
 
 -- Admins can insert storage objects.
 DROP POLICY IF EXISTS "admin_insert_storage_objects" ON storage_objects;

--- a/web/app/api/v1/storage/budget/route.ts
+++ b/web/app/api/v1/storage/budget/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { validateAuth } from '@/lib/api-auth';
+import { isAdminUser } from '@/lib/api-helpers';
+
+/**
+ * GET /api/v1/storage/budget
+ *
+ * Admin-only wrapper over the get_storage_budget() RPC, so `campfire status`
+ * can show the global cap line (bytes-at-rest vs cap, by product type/backend).
+ * The cap is an operator concern, so this stays admin-gated even though the
+ * registry rows themselves are program-scoped.
+ */
+export async function GET(request: NextRequest) {
+  const userId = await validateAuth(request);
+
+  if (!userId) {
+    return NextResponse.json(
+      { error: 'Invalid or missing authentication' },
+      { status: 401 }
+    );
+  }
+
+  if (!(await isAdminUser(userId))) {
+    return NextResponse.json(
+      { error: 'Admin privileges required' },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!
+    );
+
+    const { data, error } = await supabase.rpc('get_storage_budget');
+    if (error) {
+      console.error('Error fetching storage budget:', error);
+      return NextResponse.json(
+        { error: 'Failed to fetch storage budget', details: error.message },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Error in API /v1/storage/budget:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/web/app/api/v1/storage/presign/route.ts
+++ b/web/app/api/v1/storage/presign/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { validateAuth } from '@/lib/api-auth';
+import { getAccessiblePrograms, isAdminUser } from '@/lib/api-helpers';
+import { generateDownloadUrl } from '@/lib/r2';
+import { isKnownKey } from '@/lib/layout';
+
+const MAX_KEYS = 200;
+const URL_TTL_SECONDS = 21600; // 6 hours, matches the observation manifest
+
+/**
+ * POST /api/v1/storage/presign
+ *
+ * The single presign primitive for the client's storage_objects download
+ * engine. The client computes its download plan locally against the mirror,
+ * then asks for signed URLs for the exact keys it intends to fetch.
+ *
+ * Body: { keys: string[] }  (max 200/batch)
+ * Returns: { urls: { [key]: signedUrl } }  — only for keys the caller may
+ * download. Each key is first allowlisted via the layout contract (is_known_key)
+ * and then authorized by filter_accessible_storage_keys (same program/publish
+ * scope as the sync RPC). Unauthorized or unknown keys are omitted, never erroring
+ * the whole batch.
+ */
+export async function POST(request: NextRequest) {
+  const userId = await validateAuth(request);
+
+  if (!userId) {
+    return NextResponse.json(
+      { error: 'Invalid or missing authentication' },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const body = await request.json().catch(() => null);
+    const rawKeys: unknown = body?.keys;
+    if (!Array.isArray(rawKeys) || rawKeys.length === 0) {
+      return NextResponse.json(
+        { error: 'Body must include a non-empty "keys" array' },
+        { status: 400 }
+      );
+    }
+    if (rawKeys.length > MAX_KEYS) {
+      return NextResponse.json(
+        { error: `Too many keys (max ${MAX_KEYS} per request)` },
+        { status: 400 }
+      );
+    }
+
+    // De-dupe + drop keys that don't parse to a known cloud product (defense in
+    // depth: presign only ever mints URLs for layout-recognized keys).
+    const requested = Array.from(
+      new Set(rawKeys.filter((k): k is string => typeof k === 'string' && isKnownKey(k)))
+    );
+    if (requested.length === 0) {
+      return NextResponse.json({ urls: {} });
+    }
+
+    const accessibleProgramSlugs = await getAccessiblePrograms(userId);
+    const admin = await isAdminUser(userId);
+
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!
+    );
+
+    // Authorize each key against the caller's scope (admins → all active rows).
+    const { data: allowedRows, error } = await supabase.rpc('filter_accessible_storage_keys', {
+      p_keys: requested,
+      p_program_slugs: accessibleProgramSlugs,
+      p_include_unpublished: admin,
+    });
+
+    if (error) {
+      console.error('Error authorizing presign keys:', error);
+      return NextResponse.json(
+        { error: 'Failed to authorize keys', details: error.message },
+        { status: 500 }
+      );
+    }
+
+    const allowed: string[] = (allowedRows || []).map(
+      (r: { storage_key: string }) => r.storage_key
+    );
+
+    const urls: Record<string, string> = {};
+    await Promise.all(
+      allowed.map(async (key) => {
+        urls[key] = await generateDownloadUrl(key, URL_TTL_SECONDS);
+      })
+    );
+
+    return NextResponse.json({ urls });
+  } catch (error) {
+    console.error('Error in API /v1/storage/presign:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/web/app/api/v1/sync/storage/route.ts
+++ b/web/app/api/v1/sync/storage/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { validateAuth } from '@/lib/api-auth';
+import { getAccessiblePrograms, isAdminUser } from '@/lib/api-helpers';
+
+/**
+ * GET /api/v1/sync/storage
+ *
+ * Catalog sync for the Python client's local `storage_objects` mirror — the
+ * single download/availability layer (finals + intermediates + future NIRCam
+ * share one engine). Mirrors /api/v1/sync/spectra: paginated, optional
+ * incremental filtering via updated_since, counts on the first page only.
+ *
+ * Scope is program-based (epic #210): admins get a faithful full mirror;
+ * non-admins get published, active rows in accessible programs. Enforced in the
+ * get_storage_objects_for_sync RPC (this route runs under the service role).
+ *
+ * Query parameters:
+ * - updated_since: ISO 8601 timestamp (only rows updated after this)
+ * - limit: page size (default 1000)
+ * - offset: pagination offset (default 0)
+ * - include_counts: 'false' to skip total/accessible counts (default true)
+ */
+export async function GET(request: NextRequest) {
+  const userId = await validateAuth(request);
+
+  if (!userId) {
+    return NextResponse.json(
+      { error: 'Invalid or missing authentication' },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const accessibleProgramSlugs = await getAccessiblePrograms(userId);
+    const admin = await isAdminUser(userId);
+
+    // Non-admins with no program access have nothing to mirror. Admins fall
+    // through (the RPC returns the full mirror regardless of program list).
+    if (accessibleProgramSlugs.length === 0 && !admin) {
+      return NextResponse.json({
+        data: [],
+        pagination: { total: 0, limit: 0, offset: 0 },
+        total_accessible_count: 0,
+      });
+    }
+
+    const searchParams = request.nextUrl.searchParams;
+    const limit = parseInt(searchParams.get('limit') || '1000', 10);
+    const offset = parseInt(searchParams.get('offset') || '0', 10);
+    const updatedSince = searchParams.get('updated_since') || null;
+    const includeCounts = searchParams.get('include_counts') !== 'false';
+
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!
+    );
+
+    const { data, error } = await supabase.rpc('get_storage_objects_for_sync', {
+      p_program_slugs: accessibleProgramSlugs,
+      p_updated_since: updatedSince,
+      p_limit: limit,
+      p_offset: offset,
+      p_include_counts: includeCounts,
+      // Admins mirror everything (drafts + field-only products); everyone else
+      // is fail-closed to published, in-program rows.
+      p_include_unpublished: admin,
+    });
+
+    if (error) {
+      console.error('Error in sync storage:', error);
+      return NextResponse.json(
+        { error: 'Failed to fetch storage objects', details: error.message },
+        { status: 500 }
+      );
+    }
+
+    const result = data?.[0] || { objects: [], total_count: 0, total_accessible_count: 0 };
+
+    return NextResponse.json({
+      data: result.objects || [],
+      pagination: {
+        total: result.total_count || 0,
+        limit,
+        offset,
+      },
+      total_accessible_count: result.total_accessible_count || 0,
+    });
+  } catch (error) {
+    console.error('Error in API /v1/sync/storage:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Completes the deferred restore half of #220 (epic #210) — `campfire download --intermediate` and a storage-mirror-backed `campfire status` — and, per design discussion, **unifies the client's file-handling onto `storage_objects` as the single download/availability layer**. One generic, product-type-agnostic engine now serves finals, intermediates, and (later) NIRCam, instead of reinventing the wheel per product type.

## Architecture

- **`storage_objects` is the client's single download/availability layer.** The local SQLite store gained a `storage_objects` mirror (`SCHEMA_VERSION` 5→6, a one-time cache rebuild); the local `spectra` table is now **science-only**, with `fits_path`/`local_path`/`file_hash` surfaced on read via a join.
- **Registry RLS opened from admin-only to program-scoped + published.** Finals are gated by their parent spectrum (program via `spectra→targets` + `deploy_status='published'` — deliberately *not* the often-NULL `observation` column); intermediates by their deployment (`status='published'`). Drafts/revoked and out-of-program rows stay hidden; admins see all. Enforced in **both** RLS and the scoped RPCs (belt-and-suspenders, like B1).
- **`--intermediate` is just a product-type filter** on the generic engine — no longer an admin-only feature; access is enforced uniformly by program+published scope.

## Changes

**Server (`supabase/`)** — migration `20260629153142_unified_storage_download_layer.sql`: program-scoped SELECT policy on `storage_objects`; RPCs `get_storage_objects_for_sync` + `filter_accessible_storage_keys`. Recurring migra hand-patches applied (matview unique indexes, view `security_invoker`, #228 re-emit strip).

**Web (`web/app/api/v1/`)** — `sync/storage` (paginated mirror sync), `storage/presign` (per-key authorized batch presign via `is_known_key` + the filter RPC), `storage/budget` (admin).

**Client (`python/`)** — local mirror table + generic store methods; `fetch_all_storage`/`presign_keys`/`get_storage_budget`; the `download_objects` engine (plan→presign→fetch+verify→record); `download --intermediate` + mirror-backed `status` (FINALS + INTERMEDIATES local/available columns + admin budget line).

## Testing

- `supabase db reset` applies the migration + seed cleanly.
- **Leak gate** `python/tests/sql/storage_objects_scope_leak.sql` (+ `test_storage_scope_rls.py`) against real seed data: a non-admin sees zero draft/revoked/out-of-program storage objects via RLS **and** both RPCs; an admin sees them; the published control stays visible.
- `pytest python/tests/` → **242 passed** (new `test_download_objects.py` engine tests with mocked HTTP, store mirror tests, status-view tests).
- `cd web && npm run build` → green.

Touches only `supabase/` + `web/` + `python/` → **no pipeline CHANGELOG entry** required.

## Not in this PR

- **Live real-R2 deploy→download loop** — validated at the unit/integration/RLS/build level; the full loop (writes ~935 objects to production R2, needs a running dev server) is left for manual verification. To exercise the fetch path, `campfire deploy delete-local --obs <obs> --yes` then `download --obs <obs> --intermediate`.
- **Per-exposure review** (decouple `spectrum_exposures` from the `spectra` FK, deploy population, admin review UI) — designed in the plan, intentionally a follow-up PR.

Generated with Claude Code

https://claude.ai/code/session_01QMm3DuLALxzNtLBUQqPfkR
