### PR TITLE
feat(215): OSN copy + re-key + verify + inert dual-read (epic #210, A1)

### DIFF
--- a/python/campfire/deploy/backend.py
+++ b/python/campfire/deploy/backend.py
@@ -40,6 +40,16 @@ from typing import Optional
 PURPOSE_SECTIONS = {
     'data': 'r2',
     'tiles': 'r2_tiles',
+    # OSN data-bucket destination for the R2->OSN migration (epic #210 / #215).
+    # Resolved alongside 'data' so the copy tool can hold both clients at once.
+    'osn': 'r2_osn',
+}
+
+# Per-purpose env-var prefix used only to build a helpful "missing section" hint.
+_PURPOSE_ENV_HINT = {
+    'data': 'CAMPFIRE_S3',
+    'tiles': 'CAMPFIRE_S3_TILES',
+    'osn': 'CAMPFIRE_S3_OSN',
 }
 
 # Default endpoint host for Cloudflare R2 when only an account id is supplied.
@@ -119,10 +129,10 @@ def resolve_backend(config: dict, purpose: str = 'data') -> BackendConfig:
 
     section = config.get(section_key)
     if not section:
+        env_hint = _PURPOSE_ENV_HINT.get(purpose, 'CAMPFIRE_S3')
         raise ValueError(
             f"No [{section_key}] storage config found for '{purpose}'. "
-            f"Set CAMPFIRE_{'S3' if purpose == 'data' else 'S3_TILES'}_* env "
-            f"vars or add a [{section_key}] block to deploy.toml."
+            f"Set {env_hint}_* env vars or add a [{section_key}] block to deploy.toml."
         )
 
     endpoint = _resolve_endpoint(section, purpose)

--- a/python/campfire/deploy/cli.py
+++ b/python/campfire/deploy/cli.py
@@ -928,6 +928,110 @@ def registry_budget(ctx, config_path, local):
             print(f"    {pt:28} {_fmt_bytes(n)}")
 
 
+@registry.command('copy')
+@click.option('--config', 'config_path', default=None,
+              help='Path to deploy config TOML.')
+@click.option('--obs', 'observations', default=None, multiple=True, type=str,
+              cls=_VariadicOption, help='Limit to these observation(s).')
+@click.option('--field', 'fields', default=None, multiple=True, type=str,
+              cls=_VariadicOption, help='Limit to these field(s).')
+@click.option('--product-type', 'product_types', default=None, multiple=True, type=str,
+              cls=_VariadicOption,
+              help='Override the migrated product types (default excludes dead rgb/sed).')
+@click.option('--limit', type=int, default=None,
+              help='Migrate at most N objects (piloting).')
+@click.option('--execute', is_flag=True,
+              help='Actually copy + relocate. Without this, only a dry-run plan is printed.')
+@click.option('--verify-readback/--no-verify-readback', default=True,
+              help='Re-download from OSN and re-hash to verify (default on). '
+                   '--no-verify-readback only checks the uploaded size.')
+@click.option('--tmp-dir', default=None,
+              help='Scratch dir for streamed copies (default: system temp).')
+@click.option('--local', is_flag=True,
+              help='Use local Supabase (127.0.0.1:54321).')
+@click.pass_context
+def registry_copy(ctx, config_path, observations, fields, product_types, limit,
+                  execute, verify_readback, tmp_dir, local):
+    """Copy data objects R2->OSN, re-key legacy->canonical, verify, relocate (#215).
+
+    Reads each active backend='r2' registry row, GETs it from R2, PUTs it to OSN
+    under its canonical key, verifies by sha256 (upgrading provisional 'etag:'
+    hashes), then flips the registry row in place to osn+canonical+sha256. R2 bytes
+    are retained (rollback = read R2). Idempotent/resumable: already-migrated rows
+    are skipped. Dry-run by default; pass --execute to transfer.
+    """
+    from campfire.deploy import registry as reg
+
+    config = load_config(config_path, local=_resolve_local(ctx, local))
+    _gate_admin(config)
+    sb = get_supabase_client(config)
+
+    obs = list(observations) or None
+    flds = list(fields) or None
+    types = list(product_types) or None
+
+    # Resolve the OSN destination client up front so a missing [r2_osn] section
+    # fails fast with a clear message (not mid-transfer).
+    try:
+        dst_client, dst_bucket, dst_backend = reg._osn_client_and_bucket(config)
+    except Exception as e:
+        raise click.UsageError(
+            f"OSN destination not configured: {e}\n"
+            f"Set CAMPFIRE_S3_OSN_* env vars (or a [r2_osn] block in deploy.toml)."
+        )
+    src_client, src_bucket, _ = reg._data_client_and_bucket(config)
+
+    # G1 freeze guard: warn if any selected obs already has osn-canonical rows that
+    # collide with fresh r2-legacy rows (a re-deploy during the shadow window).
+    conflicts = reg.find_migration_conflicts(sb, observations=obs)
+    if conflicts:
+        print(f"  WARNING: {len(conflicts)} object(s) already have an active OSN copy "
+              f"but a fresh R2-legacy row exists (re-deploy during shadow?).")
+        for k in conflicts[:5]:
+            print(f"    conflict: {k}")
+        print("    These would create duplicate active rows — resolve before --execute.\n")
+
+    if not execute:
+        report = reg.copy_objects(
+            sb, src_client=src_client, src_bucket=src_bucket,
+            dst_client=dst_client, dst_bucket=dst_bucket, dst_backend=dst_backend,
+            observations=obs, fields=flds, product_types=types, limit=limit,
+            dry_run=True,
+        )
+        print(f"DRY RUN — {report.summary()}")
+        for legacy, canonical, _sz in report.planned[:10]:
+            print(f"    {legacy}  ->  {canonical}")
+        if len(report.planned) > 10:
+            print(f"    ... and {len(report.planned) - 10} more")
+        if report.skipped:
+            print(f"  {len(report.skipped)} unmappable key(s) would be skipped:")
+            for legacy, reason in report.skipped[:5]:
+                print(f"    skip: {legacy} ({reason})")
+        print(f"\n  Plan: {len(report.planned)} object(s), {_fmt_bytes(report.bytes_planned)}. "
+              f"Re-run with --execute to copy.")
+        return
+
+    print(f"Copying R2 -> OSN ({dst_backend}, bucket {dst_bucket})"
+          + (f", readback verify" if verify_readback else ", size-check only") + " ...")
+    report = reg.copy_objects(
+        sb, src_client=src_client, src_bucket=src_bucket,
+        dst_client=dst_client, dst_bucket=dst_bucket, dst_backend=dst_backend,
+        observations=obs, fields=flds, product_types=types, limit=limit,
+        dry_run=False, verify_readback=verify_readback, tmp_dir=tmp_dir, progress=True,
+    )
+    print(f"\n{report.summary()}  ({_fmt_bytes(report.bytes_copied)} copied)")
+    if report.skipped:
+        print(f"  {len(report.skipped)} skipped (unmappable key):")
+        for legacy, reason in report.skipped[:5]:
+            print(f"    skip: {legacy} ({reason})")
+    if report.failed:
+        print(f"  {len(report.failed)} FAILED (left on R2, not relocated):")
+        for legacy, reason in report.failed[:10]:
+            print(f"    fail: {legacy} ({reason})")
+        ctx.exit(1)
+    print("Copy complete.")
+
+
 # ---------------------------------------------------------------------------
 # photometry subcommand
 # ---------------------------------------------------------------------------

--- a/python/campfire/deploy/cli.py
+++ b/python/campfire/deploy/cli.py
@@ -947,11 +947,13 @@ def registry_budget(ctx, config_path, local):
                    '--no-verify-readback only checks the uploaded size.')
 @click.option('--tmp-dir', default=None,
               help='Scratch dir for streamed copies (default: system temp).')
+@click.option('--max-workers', type=int, default=8,
+              help='Parallel copy workers (default 8). Each does GET+PUT+readback.')
 @click.option('--local', is_flag=True,
               help='Use local Supabase (127.0.0.1:54321).')
 @click.pass_context
 def registry_copy(ctx, config_path, observations, fields, product_types, limit,
-                  execute, verify_readback, tmp_dir, local):
+                  execute, verify_readback, tmp_dir, max_workers, local):
     """Copy data objects R2->OSN, re-key legacy->canonical, verify, relocate (#215).
 
     Reads each active backend='r2' registry row, GETs it from R2, PUTs it to OSN
@@ -970,16 +972,22 @@ def registry_copy(ctx, config_path, observations, fields, product_types, limit,
     flds = list(fields) or None
     types = list(product_types) or None
 
+    # Size the S3 connection pools for the worker fan-out (each worker does a GET
+    # from R2 + a PUT and a readback GET to OSN concurrently).
+    pool = max(max_workers * 2, 8)
+
     # Resolve the OSN destination client up front so a missing [r2_osn] section
     # fails fast with a clear message (not mid-transfer).
     try:
-        dst_client, dst_bucket, dst_backend = reg._osn_client_and_bucket(config)
+        dst_client, dst_bucket, dst_backend = reg._osn_client_and_bucket(
+            config, max_pool_connections=pool)
     except Exception as e:
         raise click.UsageError(
             f"OSN destination not configured: {e}\n"
             f"Set CAMPFIRE_S3_OSN_* env vars (or a [r2_osn] block in deploy.toml)."
         )
-    src_client, src_bucket, _ = reg._data_client_and_bucket(config)
+    src_client, src_bucket, _ = reg._data_client_and_bucket(
+        config, max_pool_connections=pool)
 
     # G1 freeze guard: warn if any selected obs already has osn-canonical rows that
     # collide with fresh r2-legacy rows (a re-deploy during the shadow window).
@@ -1012,12 +1020,14 @@ def registry_copy(ctx, config_path, observations, fields, product_types, limit,
         return
 
     print(f"Copying R2 -> OSN ({dst_backend}, bucket {dst_bucket})"
-          + (f", readback verify" if verify_readback else ", size-check only") + " ...")
+          + (f", readback verify" if verify_readback else ", size-check only")
+          + f", {max_workers} workers ...")
     report = reg.copy_objects(
         sb, src_client=src_client, src_bucket=src_bucket,
         dst_client=dst_client, dst_bucket=dst_bucket, dst_backend=dst_backend,
         observations=obs, fields=flds, product_types=types, limit=limit,
-        dry_run=False, verify_readback=verify_readback, tmp_dir=tmp_dir, progress=True,
+        dry_run=False, verify_readback=verify_readback, tmp_dir=tmp_dir,
+        progress=True, max_workers=max_workers,
     )
     print(f"\n{report.summary()}  ({_fmt_bytes(report.bytes_copied)} copied)")
     if report.skipped:

--- a/python/campfire/deploy/config.py
+++ b/python/campfire/deploy/config.py
@@ -10,10 +10,12 @@ Credential resolution (env vars take priority over TOML):
   2. Explicit --config flag -> TOML file
   3. $CAMPFIRE_ROOT/config/deploy.toml
 
-Storage backend tuning (optional, per purpose — data / tiles): CAMPFIRE_S3_*
-and CAMPFIRE_S3_TILES_* accept ENDPOINT, REGION, FORCE_PATH_STYLE, BACKEND,
-and PUBLIC_URL_BASE so OSN (or any S3-compatible store) is a config change.
-See ``backend.py`` for how these resolve into an S3 client.
+Storage backend tuning (optional, per purpose — data / tiles / osn): CAMPFIRE_S3_*,
+CAMPFIRE_S3_TILES_*, and CAMPFIRE_S3_OSN_* accept ENDPOINT, REGION,
+FORCE_PATH_STYLE, BACKEND, and PUBLIC_URL_BASE so OSN (or any S3-compatible store)
+is a config change. The ``osn`` section (-> config['r2_osn']) is the data-bucket
+migration destination for epic #210 / #215. See ``backend.py`` for how these
+resolve into an S3 client.
 
 Programs resolution:
   $CAMPFIRE_ROOT/config/programs.toml
@@ -78,6 +80,23 @@ _TILES_ENV = {
     ],
 }
 
+# OSN (Open Storage Network) data backend -> config['r2_osn'] section. This is
+# the migration *destination* for the data bucket (epic #210 Track A / #215):
+# the copy tool holds the R2 'data' client (source) and this 'osn' client (dest)
+# simultaneously. OSN is S3-compatible Ceph — endpoint-driven, dummy region,
+# path-style — so it reuses the same backend factory. Only CAMPFIRE_S3_OSN_*
+# names (no legacy alias; this backend is new).
+_OSN_ENV = {
+    'access_key_id': ['CAMPFIRE_S3_OSN_ACCESS_KEY_ID'],
+    'secret_access_key': ['CAMPFIRE_S3_OSN_SECRET_ACCESS_KEY'],
+    'bucket_name': ['CAMPFIRE_S3_OSN_BUCKET_NAME'],
+    'endpoint': ['CAMPFIRE_S3_OSN_ENDPOINT'],
+    'region': ['CAMPFIRE_S3_OSN_REGION'],
+    'force_path_style': ['CAMPFIRE_S3_OSN_FORCE_PATH_STYLE'],
+    'backend': ['CAMPFIRE_S3_OSN_BACKEND'],
+    'public_url_base': ['CAMPFIRE_S3_OSN_PUBLIC_URL_BASE'],
+}
+
 # A storage section is "usable" with credentials + a bucket + a way to resolve
 # its endpoint (an explicit endpoint, or an account_id to derive the R2 host).
 _STORAGE_REQUIRED = ('access_key_id', 'secret_access_key', 'bucket_name')
@@ -114,7 +133,8 @@ def _config_from_env() -> dict | None:
 
     Returns a config dict when Supabase service-role creds **and** a usable
     ``data`` storage section are present, or None otherwise. The optional
-    ``tiles`` section is included when usable, but never blocks loading.
+    ``tiles`` and ``osn`` sections are included when usable, but never block
+    loading.
     """
     supabase = _read_env_section(_SUPABASE_ENV)
     if not all(supabase.get(k) for k in _SUPABASE_ENV):
@@ -129,6 +149,10 @@ def _config_from_env() -> dict | None:
     tiles = _read_env_section(_TILES_ENV)
     if _storage_section_complete(tiles):
         config['r2_tiles'] = tiles
+
+    osn = _read_env_section(_OSN_ENV)
+    if _storage_section_complete(osn):
+        config['r2_osn'] = osn
 
     return config
 

--- a/python/campfire/deploy/r2.py
+++ b/python/campfire/deploy/r2.py
@@ -206,6 +206,17 @@ def get_r2_client(config: dict):
     return make_client_for(config, 'data')
 
 
+def download_to_path(client, bucket: str, key: str, dest_path: Path) -> None:
+    """Download a single object to a local path via boto3 (managed, multipart).
+
+    The backend-agnostic GET counterpart to :func:`upload_to_r2` — used by the
+    R2->OSN copy (epic #210 / #215) to stream a source object to a temp file
+    before hashing and re-uploading. ``client``/``bucket`` are whatever the
+    caller resolved (R2 'data' source for the copy).
+    """
+    client.download_file(bucket, key, str(dest_path))
+
+
 def upload_to_r2(
     client,
     bucket: str,

--- a/python/campfire/deploy/registry.py
+++ b/python/campfire/deploy/registry.py
@@ -468,7 +468,7 @@ def plan_delete_local(
     return plan
 
 
-def _data_client_and_bucket(config: dict):
+def _data_client_and_bucket(config: dict, *, max_pool_connections: Optional[int] = None):
     """Resolve a boto3 client + bucket name for the data backend (LIST/HEAD).
 
     Backfill/reconcile need to read object metadata, which the presigned-URL
@@ -476,10 +476,11 @@ def _data_client_and_bucket(config: dict):
     """
     from campfire.deploy.backend import make_s3_client, resolve_backend
     bcfg = resolve_backend(config, 'data')
-    return make_s3_client(bcfg), bcfg.bucket, bcfg.backend
+    return (make_s3_client(bcfg, max_pool_connections=max_pool_connections),
+            bcfg.bucket, bcfg.backend)
 
 
-def _osn_client_and_bucket(config: dict):
+def _osn_client_and_bucket(config: dict, *, max_pool_connections: Optional[int] = None):
     """Resolve a boto3 client + bucket + label for the OSN data destination.
 
     The R2->OSN copy (#215) holds this dest client alongside the R2 'data' source
@@ -489,7 +490,8 @@ def _osn_client_and_bucket(config: dict):
     """
     from campfire.deploy.backend import make_s3_client, resolve_backend
     bcfg = resolve_backend(config, 'osn')
-    return make_s3_client(bcfg), bcfg.bucket, bcfg.backend
+    return (make_s3_client(bcfg, max_pool_connections=max_pool_connections),
+            bcfg.bucket, bcfg.backend)
 
 
 def list_bucket_keys(config: dict, prefix: str = '') -> Iterator[str]:
@@ -801,6 +803,7 @@ def copy_objects(
     verify_readback: bool = True,
     tmp_dir: Optional[str] = None,
     progress: bool = False,
+    max_workers: int = 8,
 ) -> CopyReport:
     """Migrate active data objects R2->OSN, re-key to canonical, verify, relocate.
 
@@ -812,12 +815,14 @@ def copy_objects(
     unverified/missing OSN object; until the flip, dual-read serves the retained R2
     bytes. Per-object failures are recorded and skipped — the run continues.
 
+    Each object is independent (its own temp files, its own one-row relocate), so the
+    GET/PUT/verify/relocate pipeline runs across a thread pool of ``max_workers``;
+    results are aggregated on the calling thread as they complete. The boto3 clients
+    must be built with a connection pool >= ``max_workers`` (the CLI sizes them).
+    Per-object flip stays resume-safe: a crash leaves already-migrated rows
+    ``backend='osn'`` and the candidate query only re-selects ``backend='r2'`` rows.
+
     ``dry_run`` (the default) only derives + plans (no transfer, no DB write).
-    The flip is **per-object** — each row is relocated immediately after its bytes
-    are verified on OSN. (Relocation is a per-row UPDATE regardless, so there is no
-    round-trip win from batching; flipping per object keeps a crash resume-safe with
-    minimal redo, since already-migrated rows are ``backend='osn'`` and the candidate
-    query only selects ``backend='r2'`` rows.)
     """
     candidates = copy_candidates(
         client, observations=observations, fields=fields,
@@ -825,25 +830,35 @@ def copy_objects(
     )
     report = CopyReport()
 
-    iterator = candidates
-    if progress and not dry_run:
-        from tqdm import tqdm
-        iterator = tqdm(candidates, desc='Copying R2->OSN', unit='obj')
+    if dry_run:
+        for row in candidates:
+            legacy = row.get('storage_key')
+            if not legacy:
+                continue
+            try:
+                canonical = canonical_key_for(legacy)
+            except LayoutError as e:
+                report.skipped.append((legacy, f'unknown/unsafe key: {e}'))
+                continue
+            report.planned.append((legacy, canonical, int(row.get('size_bytes') or 0)))
+        return report
 
-    for row in iterator:
+    # Pre-filter unmappable keys (cheap, no I/O) so the pool only does real work.
+    work: list[dict] = []
+    for row in candidates:
         legacy = row.get('storage_key')
         if not legacy:
             continue
         try:
-            canonical = canonical_key_for(legacy)
+            canonical_key_for(legacy)
         except LayoutError as e:
             report.skipped.append((legacy, f'unknown/unsafe key: {e}'))
             continue
+        work.append(row)
 
-        if dry_run:
-            report.planned.append((legacy, canonical, int(row.get('size_bytes') or 0)))
-            continue
-
+    def _copy_one(row: dict) -> tuple:
+        """Worker: migrate + relocate one object. Returns ('copied'|'failed', ...)."""
+        legacy = row['storage_key']
         try:
             canonical, sha, size = _migrate_one(
                 row, src_client=src_client, src_bucket=src_bucket,
@@ -851,11 +866,9 @@ def copy_objects(
                 verify_readback=verify_readback, tmp_dir=tmp_dir,
             )
         except Exception as e:  # CopyError or any boto3/IO error — skip this object
-            report.failed.append((legacy, str(e)))
-            continue
-
-        # Flip the registry row in place — backend, storage_key and content_hash
-        # switch together in one UPDATE, ONLY now that the bytes are verified on OSN.
+            return ('failed', legacy, str(e))
+        # Flip the registry row in place — backend/storage_key/content_hash switch
+        # together in one UPDATE, ONLY now that the bytes are verified on OSN.
         relocate_objects(client, [{
             'id': row['id'],
             'backend': dst_backend,
@@ -864,7 +877,27 @@ def copy_objects(
             'size_bytes': int(size),
             'updated_at': datetime.now(timezone.utc).isoformat(),
         }])
-        report.copied.append((legacy, canonical, int(size)))
+        return ('copied', legacy, canonical, int(size))
+
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    bar = None
+    if progress:
+        from tqdm import tqdm
+        bar = tqdm(total=len(work), desc='Copying R2->OSN', unit='obj')
+
+    with ThreadPoolExecutor(max_workers=max_workers) as ex:
+        futures = [ex.submit(_copy_one, row) for row in work]
+        for fut in as_completed(futures):
+            result = fut.result()
+            if result[0] == 'failed':
+                report.failed.append((result[1], result[2]))
+            else:
+                report.copied.append((result[1], result[2], result[3]))
+            if bar is not None:
+                bar.update(1)
+    if bar is not None:
+        bar.close()
 
     return report
 

--- a/python/campfire/deploy/registry.py
+++ b/python/campfire/deploy/registry.py
@@ -775,25 +775,22 @@ def copy_objects(
     bytes. Per-object failures are recorded and skipped — the run continues.
 
     ``dry_run`` (the default) only derives + plans (no transfer, no DB write).
-    Relocation is batched (``UPSERT_BATCH``); a crash mid-run is resume-safe because
-    the candidate query only selects ``backend='r2'`` rows.
+    The flip is **per-object** — each row is relocated immediately after its bytes
+    are verified on OSN. (Relocation is a per-row UPDATE regardless, so there is no
+    round-trip win from batching; flipping per object keeps a crash resume-safe with
+    minimal redo, since already-migrated rows are ``backend='osn'`` and the candidate
+    query only selects ``backend='r2'`` rows.)
     """
     candidates = copy_candidates(
         client, observations=observations, fields=fields,
         product_types=product_types, limit=limit,
     )
     report = CopyReport()
-    relocate_batch: list[dict] = []
 
     iterator = candidates
     if progress and not dry_run:
         from tqdm import tqdm
         iterator = tqdm(candidates, desc='Copying R2->OSN', unit='obj')
-
-    def _flush():
-        if relocate_batch:
-            relocate_objects(client, relocate_batch)
-            relocate_batch.clear()
 
     for row in iterator:
         legacy = row.get('storage_key')
@@ -819,19 +816,18 @@ def copy_objects(
             report.failed.append((legacy, str(e)))
             continue
 
-        relocate_batch.append({
+        # Flip the registry row in place — backend, storage_key and content_hash
+        # switch together in one UPDATE, ONLY now that the bytes are verified on OSN.
+        relocate_objects(client, [{
             'id': row['id'],
             'backend': dst_backend,
             'storage_key': canonical,
             'content_hash': sha,
             'size_bytes': int(size),
             'updated_at': datetime.now(timezone.utc).isoformat(),
-        })
+        }])
         report.copied.append((legacy, canonical, int(size)))
-        if len(relocate_batch) >= UPSERT_BATCH:
-            _flush()
 
-    _flush()
     return report
 
 

--- a/python/campfire/deploy/registry.py
+++ b/python/campfire/deploy/registry.py
@@ -29,14 +29,24 @@ byte-aggregated in ``map_layers.total_size_bytes`` (the budget RPC unions both).
 from __future__ import annotations
 
 import hashlib
+import os
+import tempfile
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable, Iterator, Optional
 
-from campfire_layout import bucket_for, is_known_key, parse_key
+from campfire_layout import (
+    KeyScheme,
+    LayoutError,
+    bucket_for,
+    is_known_key,
+    parse_key,
+    storage_key,
+)
 from campfire_layout.products import get as get_product
 
-from campfire.deploy.r2 import UploadTask
+from campfire.deploy.r2 import UploadTask, download_to_path, upload_to_r2
 
 # Streamed-hash chunk size (1 MiB).
 _HASH_CHUNK = 1 << 20
@@ -225,6 +235,38 @@ def upsert_storage_objects(client, rows: list[dict], batch_size: int = UPSERT_BA
     return len(rows)
 
 
+def relocate_objects(client, rows: list[dict]) -> int:
+    """Re-home registry rows in place by primary key ``id`` (epic #210 / #215).
+
+    The R2->OSN copy changes a row's ``backend``, ``storage_key`` (legacy->canonical)
+    and ``content_hash`` (etag->sha256) all at once.
+
+    This must be a real per-row **UPDATE keyed on ``id``** — NOT an upsert.
+    ``upsert_storage_objects``' conflict target is ``(backend, bucket, storage_key)``;
+    since all three change, an upsert there would INSERT a second row (and for
+    exposure products violate the partial-unique). Upserting on the PK ``id`` does
+    NOT help either: PostgreSQL evaluates NOT NULL on the candidate INSERT tuple
+    *before* the ``ON CONFLICT`` arbiter, so a partial payload (omitting the other
+    NOT NULL columns ``bucket``/``content_type``/``product_type``) raises a not-null
+    violation before it can route to DO UPDATE. A bare UPDATE only touches the named
+    columns and never validates the omitted ones — the only correct in-place mutation.
+    ``product_type``/``exposure_ref``/``status`` are untouched, so the partial-unique
+    ``(product_type, exposure_ref) WHERE status='active'`` always holds and exactly
+    one active row per logical object survives.
+
+    Each row carries its existing ``id`` plus the changed columns. Updates are
+    independent and idempotent; a crash mid-loop is resume-safe because already-
+    migrated rows are ``backend='osn'`` and the copy's candidate query only selects
+    ``backend='r2'`` rows. Returns rows written.
+    """
+    if not rows:
+        return 0
+    for row in rows:
+        payload = {k: v for k, v in row.items() if k != 'id'}
+        client.table('storage_objects').update(payload).eq('id', row['id']).execute()
+    return len(rows)
+
+
 # ---------------------------------------------------------------------------
 # Reconciliation (the coverage gate) — pure set logic, unit-testable
 # ---------------------------------------------------------------------------
@@ -403,6 +445,19 @@ def _data_client_and_bucket(config: dict):
     return make_s3_client(bcfg), bcfg.bucket, bcfg.backend
 
 
+def _osn_client_and_bucket(config: dict):
+    """Resolve a boto3 client + bucket + label for the OSN data destination.
+
+    The R2->OSN copy (#215) holds this dest client alongside the R2 'data' source
+    (``_data_client_and_bucket``). Requires the ``[r2_osn]`` config section
+    (CAMPFIRE_S3_OSN_* env). The returned label is normally ``'osn'`` and is what
+    the relocated rows record in ``storage_objects.backend``.
+    """
+    from campfire.deploy.backend import make_s3_client, resolve_backend
+    bcfg = resolve_backend(config, 'osn')
+    return make_s3_client(bcfg), bcfg.bucket, bcfg.backend
+
+
 def list_bucket_keys(config: dict, prefix: str = '') -> Iterator[str]:
     """Yield every object key under ``prefix`` in the data bucket (paginated)."""
     client, bucket, _ = _data_client_and_bucket(config)
@@ -518,3 +573,296 @@ def backfill_via_head(
     if not dry_run:
         upsert_storage_objects(client, rows)
     return len(rows), failed
+
+
+# ---------------------------------------------------------------------------
+# R2 -> OSN copy + re-key + verify (epic #210, Track A / #215)
+# ---------------------------------------------------------------------------
+
+# Live products migrated by default. RGB/SED are dead (no web call sites, superseded
+# by the on-the-fly cutout API) and deliberately excluded; dual-read serves any
+# non-migrated object from R2 by fallback, so omission is self-correcting.
+DEFAULT_COPY_PRODUCT_TYPES = (
+    'nirspec_spec',
+    'spectrum_json',
+    'zfit',
+    'photometry_pz',
+    'nirspec_spectrum_exposure',
+)
+
+
+class CopyError(Exception):
+    """A single object failed to copy/verify (skip it; never abort the run)."""
+
+
+@dataclass
+class CopyReport:
+    """Outcome of an R2->OSN copy pass."""
+    planned: list[tuple] = field(default_factory=list)    # (legacy, canonical, size) — dry-run
+    copied: list[tuple] = field(default_factory=list)     # (legacy, canonical, size)
+    skipped: list[tuple] = field(default_factory=list)    # (legacy, reason) — unparseable/underivable
+    failed: list[tuple] = field(default_factory=list)     # (legacy, reason) — transfer/verify error
+
+    @property
+    def bytes_copied(self) -> int:
+        return sum(sz for _, _, sz in self.copied)
+
+    @property
+    def bytes_planned(self) -> int:
+        return sum(sz for _, _, sz in self.planned)
+
+    @property
+    def ok(self) -> bool:
+        """True when nothing failed (skips are reported but not fatal on their own)."""
+        return not self.failed
+
+    def summary(self) -> str:
+        if self.planned:
+            return (f"plan: {len(self.planned)} object(s), {self.bytes_planned} bytes; "
+                    f"skipped={len(self.skipped)}")
+        return (f"copied={len(self.copied)} ({self.bytes_copied} bytes), "
+                f"skipped={len(self.skipped)}, failed={len(self.failed)}")
+
+
+def canonical_key_for(legacy_key: str) -> str:
+    """Derive the CANONICAL storage key for an existing (legacy) key.
+
+    ``parse_key`` resolves product_type/scope/filename for either scheme, then
+    ``storage_key(..., scheme=CANONICAL)`` rebuilds the canonical (``data/`` +
+    relpath) form. Raises ``LayoutError`` for unknown/unsafe keys.
+    """
+    pk = parse_key(legacy_key)
+    return storage_key(pk.product_type, pk.scope, pk.filename, scheme=KeyScheme.CANONICAL)
+
+
+def copy_candidates(
+    client,
+    *,
+    observations: Optional[Iterable[str]] = None,
+    fields: Optional[Iterable[str]] = None,
+    product_types: Optional[Iterable[str]] = None,
+    limit: Optional[int] = None,
+    bucket: str = 'data',
+) -> list[dict]:
+    """Active ``backend='r2'`` registry rows eligible for migration to OSN.
+
+    Filtering ``backend='r2'`` means already-migrated (``osn``) rows are invisible,
+    so re-running the copy is idempotent/resumable for free. Optional scope filters
+    narrow to specific observations/fields/product types. ``product_types`` defaults
+    to :data:`DEFAULT_COPY_PRODUCT_TYPES` (excludes dead rgb/sed).
+    """
+    types = list(product_types) if product_types is not None else list(DEFAULT_COPY_PRODUCT_TYPES)
+    q = (
+        client.table('storage_objects')
+        .select('id, storage_key, content_hash, content_type, product_type, '
+                'size_bytes, observation, field, exposure_ref, backend, status')
+        .eq('backend', 'r2')
+        .eq('bucket', bucket)
+        .eq('status', 'active')
+    )
+    if types:
+        q = q.in_('product_type', types)
+    if observations:
+        q = q.in_('observation', list(observations))
+    if fields:
+        q = q.in_('field', list(fields))
+    if limit:
+        q = q.limit(limit)
+    resp = q.execute()
+    return resp.data or []
+
+
+def _migrate_one(
+    row: dict,
+    *,
+    src_client, src_bucket: str,
+    dst_client, dst_bucket: str,
+    verify_readback: bool,
+    tmp_dir: Optional[str] = None,
+) -> tuple[str, str, int]:
+    """Copy one object R2->OSN and verify. Returns ``(canonical_key, sha256, size)``.
+
+    GET (R2) -> temp -> hash -> [drift guard / etag->sha256 upgrade] -> PUT (OSN
+    canonical) -> verify. Raises :class:`CopyError` on any integrity failure; the
+    caller records it and moves on WITHOUT relocating the row (so the object stays
+    ``r2``-legacy and dual-read keeps serving R2 — safe).
+    """
+    legacy = row['storage_key']
+    canonical = canonical_key_for(legacy)
+    content_type = row.get('content_type') or 'application/octet-stream'
+
+    # mkstemp opens an fd we don't use (download_file opens its own handle); close
+    # it immediately or a bulk run leaks two fds per object and hits RLIMIT_NOFILE.
+    _fd, _name = tempfile.mkstemp(dir=tmp_dir, prefix='cfcopy_')
+    os.close(_fd)
+    tmp = Path(_name)
+    rb_tmp: Optional[Path] = None
+    try:
+        download_to_path(src_client, src_bucket, legacy, tmp)
+        sha, size = hash_file(tmp)
+
+        existing = row.get('content_hash') or ''
+        if existing.startswith('sha256:') and existing != sha:
+            raise CopyError(
+                f"sha256 drift: registry has {existing} but downloaded bytes hash to {sha}"
+            )
+
+        upload_to_r2(dst_client, dst_bucket, tmp, canonical, content_type)
+
+        if verify_readback:
+            _rb_fd, _rb_name = tempfile.mkstemp(dir=tmp_dir, prefix='cfcopyrb_')
+            os.close(_rb_fd)
+            rb_tmp = Path(_rb_name)
+            download_to_path(dst_client, dst_bucket, canonical, rb_tmp)
+            rb_sha, rb_size = hash_file(rb_tmp)
+            if rb_sha != sha:
+                raise CopyError(
+                    f"readback hash mismatch on OSN: expected {sha}, got {rb_sha}"
+                )
+        else:
+            head = dst_client.head_object(Bucket=dst_bucket, Key=canonical)
+            if head.get('ContentLength') != size:
+                raise CopyError(
+                    f"readback size mismatch on OSN: expected {size}, "
+                    f"got {head.get('ContentLength')}"
+                )
+        return canonical, sha, size
+    finally:
+        tmp.unlink(missing_ok=True)
+        if rb_tmp is not None:
+            rb_tmp.unlink(missing_ok=True)
+
+
+def copy_objects(
+    client,
+    *,
+    src_client, src_bucket: str,
+    dst_client, dst_bucket: str,
+    dst_backend: str = 'osn',
+    observations: Optional[Iterable[str]] = None,
+    fields: Optional[Iterable[str]] = None,
+    product_types: Optional[Iterable[str]] = None,
+    limit: Optional[int] = None,
+    dry_run: bool = True,
+    verify_readback: bool = True,
+    tmp_dir: Optional[str] = None,
+    progress: bool = False,
+) -> CopyReport:
+    """Migrate active data objects R2->OSN, re-key to canonical, verify, relocate.
+
+    Per object: derive the canonical key (skip + report ``LayoutError``); when not
+    ``dry_run``, GET from ``src``, hash, PUT to ``dst`` (canonical), verify
+    (readback hash by default; size-match if ``verify_readback`` is False), then
+    relocate the registry row **in place by id** to ``osn``+canonical+``sha256:``.
+    The DB flip happens strictly AFTER verify, so dual-read never points at an
+    unverified/missing OSN object; until the flip, dual-read serves the retained R2
+    bytes. Per-object failures are recorded and skipped — the run continues.
+
+    ``dry_run`` (the default) only derives + plans (no transfer, no DB write).
+    Relocation is batched (``UPSERT_BATCH``); a crash mid-run is resume-safe because
+    the candidate query only selects ``backend='r2'`` rows.
+    """
+    candidates = copy_candidates(
+        client, observations=observations, fields=fields,
+        product_types=product_types, limit=limit,
+    )
+    report = CopyReport()
+    relocate_batch: list[dict] = []
+
+    iterator = candidates
+    if progress and not dry_run:
+        from tqdm import tqdm
+        iterator = tqdm(candidates, desc='Copying R2->OSN', unit='obj')
+
+    def _flush():
+        if relocate_batch:
+            relocate_objects(client, relocate_batch)
+            relocate_batch.clear()
+
+    for row in iterator:
+        legacy = row.get('storage_key')
+        if not legacy:
+            continue
+        try:
+            canonical = canonical_key_for(legacy)
+        except LayoutError as e:
+            report.skipped.append((legacy, f'unknown/unsafe key: {e}'))
+            continue
+
+        if dry_run:
+            report.planned.append((legacy, canonical, int(row.get('size_bytes') or 0)))
+            continue
+
+        try:
+            canonical, sha, size = _migrate_one(
+                row, src_client=src_client, src_bucket=src_bucket,
+                dst_client=dst_client, dst_bucket=dst_bucket,
+                verify_readback=verify_readback, tmp_dir=tmp_dir,
+            )
+        except Exception as e:  # CopyError or any boto3/IO error — skip this object
+            report.failed.append((legacy, str(e)))
+            continue
+
+        relocate_batch.append({
+            'id': row['id'],
+            'backend': dst_backend,
+            'storage_key': canonical,
+            'content_hash': sha,
+            'size_bytes': int(size),
+            'updated_at': datetime.now(timezone.utc).isoformat(),
+        })
+        report.copied.append((legacy, canonical, int(size)))
+        if len(relocate_batch) >= UPSERT_BATCH:
+            _flush()
+
+    _flush()
+    return report
+
+
+def find_migration_conflicts(
+    client,
+    *,
+    observations: Optional[Iterable[str]] = None,
+    bucket: str = 'data',
+) -> list[str]:
+    """Detect freeze-violation duplicates (epic #210 / #215 gap G1).
+
+    During the shadow window a re-deploy of an already-migrated observation writes a
+    fresh ``r2``-legacy row whose canonical form collides with an existing
+    ``osn``-canonical row → two active rows for one logical object (dual-read would
+    serve stale OSN bytes). Returns the legacy keys whose canonical form already has
+    an active ``osn`` row, so the copy command can warn before running.
+    """
+    candidates = copy_candidates(client, observations=observations, bucket=bucket)
+    if not candidates:
+        return []
+    # Map each candidate (r2-legacy) to its canonical form, then check whether that
+    # canonical key already exists as an active osn row.
+    canon_by_legacy: dict[str, str] = {}
+    for row in candidates:
+        legacy = row.get('storage_key')
+        if not legacy:
+            continue
+        try:
+            canon_by_legacy[legacy] = canonical_key_for(legacy)
+        except LayoutError:
+            continue
+    canon_keys = list(set(canon_by_legacy.values()))
+    if not canon_keys:
+        return []
+    existing_osn: set[str] = set()
+    for i in range(0, len(canon_keys), UPSERT_BATCH):
+        chunk = canon_keys[i:i + UPSERT_BATCH]
+        resp = (
+            client.table('storage_objects')
+            .select('storage_key')
+            .eq('backend', 'osn')
+            .eq('bucket', bucket)
+            .eq('status', 'active')
+            .in_('storage_key', chunk)
+            .execute()
+        )
+        for r in (resp.data or []):
+            if r.get('storage_key'):
+                existing_osn.add(r['storage_key'])
+    return [legacy for legacy, canon in canon_by_legacy.items() if canon in existing_osn]

--- a/python/campfire/deploy/registry.py
+++ b/python/campfire/deploy/registry.py
@@ -73,6 +73,22 @@ def hash_file(path: Path) -> tuple[str, int]:
     return f"sha256:{h.hexdigest()}", size
 
 
+def normalize_sha256(file_hash: str | None) -> str | None:
+    """Coerce a stored file hash to a single ``'sha256:<hex>'`` content_hash token.
+
+    Deploy stores ``spectra.file_hash`` **already scheme-prefixed** (``sha256:<hex>``,
+    from :func:`hash_file`), so a naive ``f"sha256:{file_hash}"`` would DOUBLE the
+    prefix (``sha256:sha256:<hex>``) — which slips past the ``^(sha256|etag):``
+    CHECK but then never matches a freshly-computed hash, breaking copy-verify and
+    download-verify. Idempotent: returns the value unchanged if already prefixed,
+    prepends ``sha256:`` to a bare hex digest, and returns None for an empty value.
+    """
+    if not file_hash:
+        return None
+    h = file_hash.strip()
+    return h if h.startswith('sha256:') else f"sha256:{h}"
+
+
 def normalize_etag(etag: str | None) -> str | None:
     """Coerce an S3 ETag to a ``'etag:<hex>'`` content_hash token.
 
@@ -511,8 +527,8 @@ def backfill_spectra(client, *, backend: str, dry_run: bool = False) -> tuple[in
         key = r.get('fits_path')
         if not key:
             continue
-        file_hash = r.get('file_hash')
-        if not file_hash:
+        content_hash = normalize_sha256(r.get('file_hash'))
+        if not content_hash:
             skipped += 1
             continue
         size = r.get('file_size')
@@ -522,7 +538,7 @@ def backfill_spectra(client, *, backend: str, dry_run: bool = False) -> tuple[in
         row = row_for_key(
             key,
             backend=backend,
-            content_hash=f"sha256:{file_hash}",
+            content_hash=content_hash,
             size_bytes=int(size),
             content_type='application/fits',
         )

--- a/python/campfire/deploy/registry.py
+++ b/python/campfire/deploy/registry.py
@@ -80,13 +80,17 @@ def normalize_sha256(file_hash: str | None) -> str | None:
     from :func:`hash_file`), so a naive ``f"sha256:{file_hash}"`` would DOUBLE the
     prefix (``sha256:sha256:<hex>``) — which slips past the ``^(sha256|etag):``
     CHECK but then never matches a freshly-computed hash, breaking copy-verify and
-    download-verify. Idempotent: returns the value unchanged if already prefixed,
-    prepends ``sha256:`` to a bare hex digest, and returns None for an empty value.
+    download-verify. Idempotent and defensive: collapses any number of leading
+    ``sha256:`` prefixes to exactly one (so a pre-doubled value is repaired rather
+    than propagated), prepends ``sha256:`` to a bare hex digest, and returns None
+    for an empty value.
     """
     if not file_hash:
         return None
     h = file_hash.strip()
-    return h if h.startswith('sha256:') else f"sha256:{h}"
+    while h.startswith('sha256:'):
+        h = h[len('sha256:'):]
+    return f"sha256:{h}" if h else None
 
 
 def normalize_etag(etag: str | None) -> str | None:
@@ -341,11 +345,25 @@ def compute_reconcile(
 # DB / bucket helpers for the CLI commands
 # ---------------------------------------------------------------------------
 
-def _iter_rows(client, table: str, columns: str, page: int = 1000) -> Iterator[dict]:
-    """Page through a Supabase table, yielding row dicts."""
+def _iter_rows(client, table: str, columns: str, *, order_by: str = 'id',
+               page: int = 1000) -> Iterator[dict]:
+    """Page through a Supabase table in a STABLE order, yielding row dicts.
+
+    Range/offset pagination WITHOUT an ``ORDER BY`` is non-deterministic in
+    Postgres: across pages rows silently repeat and others are skipped, so a full
+    scan under-covers a large table (and the gap varies run-to-run). That under-
+    coverage is why a backfill over ~50k spectra registered only a partial, shifting
+    subset. Ordering by a unique key (the PK ``id`` on every table this is used on:
+    spectra / nircam_images / nircam_exposures / storage_objects) makes the scan
+    complete and repeatable.
+    """
     start = 0
     while True:
-        resp = client.table(table).select(columns).range(start, start + page - 1).execute()
+        resp = (
+            client.table(table).select(columns)
+            .order(order_by)
+            .range(start, start + page - 1).execute()
+        )
         data = resp.data or []
         for row in data:
             yield row

--- a/python/campfire/deploy/registry.py
+++ b/python/campfire/deploy/registry.py
@@ -886,8 +886,7 @@ def find_migration_conflicts(
     candidates = copy_candidates(client, observations=observations, bucket=bucket)
     if not candidates:
         return []
-    # Map each candidate (r2-legacy) to its canonical form, then check whether that
-    # canonical key already exists as an active osn row.
+    # Map each candidate (r2-legacy) to its canonical form.
     canon_by_legacy: dict[str, str] = {}
     for row in candidates:
         legacy = row.get('storage_key')
@@ -897,22 +896,36 @@ def find_migration_conflicts(
             canon_by_legacy[legacy] = canonical_key_for(legacy)
         except LayoutError:
             continue
-    canon_keys = list(set(canon_by_legacy.values()))
-    if not canon_keys:
+    if not canon_by_legacy:
         return []
-    existing_osn: set[str] = set()
-    for i in range(0, len(canon_keys), UPSERT_BATCH):
-        chunk = canon_keys[i:i + UPSERT_BATCH]
-        resp = (
+    wanted = set(canon_by_legacy.values())
+
+    # Collect the active osn storage_keys and intersect LOCALLY. We deliberately do
+    # NOT filter by `storage_key IN (...)`: that list is hundreds of ~70-char keys
+    # and overflows the PostgREST request URI (Kong returns a bare 400 'Bad Request').
+    # Scope by observation when given (a short list) so the scan stays small; an osn
+    # row's observation is preserved by relocate, so a collision shares the obs.
+    present: set[str] = set()
+    start = 0
+    page = 1000
+    while True:
+        q = (
             client.table('storage_objects')
             .select('storage_key')
             .eq('backend', 'osn')
             .eq('bucket', bucket)
             .eq('status', 'active')
-            .in_('storage_key', chunk)
-            .execute()
+            .order('id')
+            .range(start, start + page - 1)
         )
-        for r in (resp.data or []):
-            if r.get('storage_key'):
-                existing_osn.add(r['storage_key'])
-    return [legacy for legacy, canon in canon_by_legacy.items() if canon in existing_osn]
+        if observations:
+            q = q.in_('observation', list(observations))
+        rows = q.execute().data or []
+        for r in rows:
+            k = r.get('storage_key')
+            if k and k in wanted:
+                present.add(k)
+        if len(rows) < page:
+            break
+        start += page
+    return [legacy for legacy, canon in canon_by_legacy.items() if canon in present]

--- a/python/campfire/deploy/registry.py
+++ b/python/campfire/deploy/registry.py
@@ -575,34 +575,54 @@ def backfill_via_head(
     backend: str,
     content_type: str = 'application/octet-stream',
     dry_run: bool = False,
+    max_workers: int = 16,
 ) -> tuple[int, int]:
     """Backfill rows for keys with no stored hash (nircam, orphans) via S3 HEAD.
 
     HEAD yields size + ETag (no GET), recorded as a provisional ``etag:`` hash.
     Returns ``(n_rows, n_failed)`` where failed = HEAD error or unparseable key.
+
+    The HEADs run in a thread pool against a **single reused** S3 client. The old
+    serial path rebuilt a boto3 client per key and blocked on each round-trip — for
+    a few thousand nircam pointers that was ~15 min, and the orphan pass (tens of
+    thousands of objects) was effectively unusable. Pooling cuts it to minutes.
     """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+    from campfire.deploy.backend import make_s3_client, resolve_backend
+
+    keys = [k for k in pointers if k]
+    if not keys:
+        return 0, 0
+
+    bcfg = resolve_backend(config, 'data')
+    s3 = make_s3_client(bcfg, max_pool_connections=max_workers)
+    bucket = bcfg.bucket
+
+    def _head_row(key: str) -> dict | None:
+        """HEAD one key and build its row, or raise/return None on failure."""
+        resp = s3.head_object(Bucket=bucket, Key=key)
+        content_hash = normalize_etag(resp.get('ETag'))
+        size = resp.get('ContentLength')
+        if not content_hash or size is None:
+            return None
+        return row_for_key(
+            key, backend=backend, content_hash=content_hash,
+            size_bytes=int(size), content_type=content_type,
+        )
+
     rows: list[dict] = []
     failed = 0
-    for key in pointers:
-        if not key:
-            continue
-        try:
-            content_hash, size = head_object(config, key)
-        except Exception:
-            failed += 1
-            continue
-        if not content_hash or size is None:
-            failed += 1
-            continue
-        try:
-            row = row_for_key(
-                key, backend=backend, content_hash=content_hash,
-                size_bytes=int(size), content_type=content_type,
-            )
-        except Exception:
-            failed += 1
-            continue
-        if row is not None:
+    with ThreadPoolExecutor(max_workers=max_workers) as ex:
+        futures = {ex.submit(_head_row, key): key for key in keys}
+        for fut in as_completed(futures):
+            try:
+                row = fut.result()
+            except Exception:
+                failed += 1          # HEAD error (missing object, etc.)
+                continue
+            if row is None:
+                failed += 1          # no ETag/size, or unparseable/unknown key
+                continue
             rows.append(row)
     if not dry_run:
         upsert_storage_objects(client, rows)

--- a/python/tests/test_registry.py
+++ b/python/tests/test_registry.py
@@ -33,6 +33,17 @@ def test_normalize_etag_strips_quotes_and_prefixes():
     assert reg.normalize_etag('""') is None
 
 
+def test_normalize_sha256_does_not_double_prefix():
+    hexd = "a" * 64
+    # spectra.file_hash is stored already-prefixed -> must NOT be doubled.
+    assert reg.normalize_sha256(f"sha256:{hexd}") == f"sha256:{hexd}"
+    # bare hex -> prefixed once.
+    assert reg.normalize_sha256(hexd) == f"sha256:{hexd}"
+    assert reg.normalize_sha256("  sha256:" + hexd + "  ") == f"sha256:{hexd}"
+    assert reg.normalize_sha256(None) is None
+    assert reg.normalize_sha256("") is None
+
+
 # ---------------------------------------------------------------------------
 # row_for_key — key → row mapping via the campfire_layout contract
 # ---------------------------------------------------------------------------

--- a/python/tests/test_registry.py
+++ b/python/tests/test_registry.py
@@ -33,15 +33,18 @@ def test_normalize_etag_strips_quotes_and_prefixes():
     assert reg.normalize_etag('""') is None
 
 
-def test_normalize_sha256_does_not_double_prefix():
+def test_normalize_sha256_collapses_to_single_prefix():
     hexd = "a" * 64
-    # spectra.file_hash is stored already-prefixed -> must NOT be doubled.
+    # already-prefixed (the common case) -> unchanged.
     assert reg.normalize_sha256(f"sha256:{hexd}") == f"sha256:{hexd}"
     # bare hex -> prefixed once.
     assert reg.normalize_sha256(hexd) == f"sha256:{hexd}"
     assert reg.normalize_sha256("  sha256:" + hexd + "  ") == f"sha256:{hexd}"
+    # pre-doubled value -> repaired to a single prefix, not propagated.
+    assert reg.normalize_sha256(f"sha256:sha256:{hexd}") == f"sha256:{hexd}"
     assert reg.normalize_sha256(None) is None
     assert reg.normalize_sha256("") is None
+    assert reg.normalize_sha256("sha256:") is None
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_registry_copy.py
+++ b/python/tests/test_registry_copy.py
@@ -68,8 +68,18 @@ class _FakeQuery:
         self._limit = None
         self._mode = "select"
         self._update_payload = None
+        self._order = None
+        self._range = None
 
     def select(self, _cols):
+        return self
+
+    def order(self, col, desc=False):
+        self._order = (col, desc)
+        return self
+
+    def range(self, start, end):
+        self._range = (start, end)
         return self
 
     def update(self, payload):
@@ -124,7 +134,13 @@ class _FakeQuery:
                     n += 1
             return SimpleNamespace(data=[], count=n)
         out = [dict(r) for r in rows if self._matches(r)]
-        if self._limit is not None:
+        if self._order is not None:
+            col, desc = self._order
+            out.sort(key=lambda r: r.get(col), reverse=desc)
+        if self._range is not None:
+            s, e = self._range
+            out = out[s:e + 1]
+        elif self._limit is not None:
             out = out[: self._limit]
         return SimpleNamespace(data=out)
 

--- a/python/tests/test_registry_copy.py
+++ b/python/tests/test_registry_copy.py
@@ -1,0 +1,344 @@
+"""Tests for the R2->OSN copy + re-key + verify engine (epic #210, Track A / #215).
+
+Exercises the engine with in-memory fakes (no boto3, no Supabase): a dict-backed
+S3 client for the R2 source + OSN destination, and a list-backed Supabase client
+whose ``upsert(on_conflict='id')`` mutates rows in place (so relocation and
+resume/idempotency are observable).
+"""
+
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from campfire.deploy import registry as reg
+
+SRC_BUCKET = "campfire"        # R2 data bucket
+DST_BUCKET = "campfire-jwst"   # OSN bucket
+
+CONTENT = b"FAKE-FITS-BYTES" * 64
+CONTENT_SHA = "sha256:" + hashlib.sha256(CONTENT).hexdigest()
+
+LEGACY_SPEC = "spectra/test_obs/test_obs_prism_100_spec.fits"
+CANON_SPEC = "data/products/nirspec/test_obs/test_obs_prism_100_spec.fits"
+LEGACY_RGB = "rgb/test_obs/test_obs_100_rgb.png"
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+# NOT NULL, no-default columns on storage_objects. The fake enforces these on
+# the INSERT/upsert path to mirror Postgres — so a regression that re-homes rows
+# via a partial-payload upsert (which raises a not-null violation on the candidate
+# tuple BEFORE the ON CONFLICT arbiter) is caught instead of silently passing.
+_REQUIRED_NOT_NULL = (
+    "backend", "bucket", "storage_key", "content_hash",
+    "size_bytes", "content_type", "product_type",
+)
+
+
+class _FakeS3:
+    """In-memory S3: objects keyed by (bucket, key) -> bytes."""
+
+    def __init__(self, objects=None, corrupt_download=False, head_size_delta=0):
+        self.objects = dict(objects or {})
+        self.corrupt_download = corrupt_download
+        self.head_size_delta = head_size_delta  # report a wrong ContentLength
+
+    def download_file(self, bucket, key, filename):
+        data = self.objects[(bucket, key)]  # KeyError == missing object
+        if self.corrupt_download:
+            data = data + b"X"
+        Path(filename).write_bytes(data)
+
+    def upload_file(self, filename, bucket, key, ExtraArgs=None):
+        self.objects[(bucket, key)] = Path(filename).read_bytes()
+
+    def head_object(self, Bucket, Key):
+        return {"ContentLength": len(self.objects[(Bucket, Key)]) + self.head_size_delta}
+
+
+class _FakeQuery:
+    def __init__(self, store, table):
+        self._store = store
+        self._table = table
+        self._filters = []
+        self._limit = None
+        self._mode = "select"
+        self._update_payload = None
+
+    def select(self, _cols):
+        return self
+
+    def update(self, payload):
+        self._mode = "update"
+        self._update_payload = dict(payload)
+        return self
+
+    def eq(self, col, val):
+        self._filters.append((col, "eq", val))
+        return self
+
+    def in_(self, col, vals):
+        self._filters.append((col, "in", set(vals)))
+        return self
+
+    def limit(self, n):
+        self._limit = n
+        return self
+
+    def _matches(self, row):
+        for col, op, val in self._filters:
+            if op == "eq" and row.get(col) != val:
+                return False
+            if op == "in" and row.get(col) not in val:
+                return False
+        return True
+
+    def upsert(self, batch, on_conflict=None):
+        rows = self._store.tables[self._table]
+        by_id = {r["id"]: r for r in rows if "id" in r}
+        for item in batch:
+            # Postgres validates NOT NULL on the candidate INSERT tuple before the
+            # ON CONFLICT arbiter — a partial payload raises regardless of conflict.
+            missing = [c for c in _REQUIRED_NOT_NULL if item.get(c) is None]
+            if missing:
+                raise ValueError(
+                    f"null value in column {missing[0]!r} violates not-null constraint"
+                )
+            if on_conflict == "id" and item.get("id") in by_id:
+                by_id[item["id"]].update(item)
+            else:
+                rows.append(dict(item))
+        return SimpleNamespace(execute=lambda: SimpleNamespace(data=batch))
+
+    def execute(self):
+        rows = self._store.tables[self._table]
+        if self._mode == "update":
+            n = 0
+            for r in rows:
+                if self._matches(r):
+                    r.update(self._update_payload)
+                    n += 1
+            return SimpleNamespace(data=[], count=n)
+        out = [dict(r) for r in rows if self._matches(r)]
+        if self._limit is not None:
+            out = out[: self._limit]
+        return SimpleNamespace(data=out)
+
+
+class _FakeSupabase:
+    def __init__(self, storage_objects):
+        # Assign stable ids if not present.
+        rows = []
+        for i, r in enumerate(storage_objects, start=1):
+            row = dict(r)
+            row.setdefault("id", i)
+            rows.append(row)
+        self.tables = {"storage_objects": rows}
+
+    def table(self, name):
+        return _FakeQuery(self, name)
+
+
+def _row(key, product_type, content_hash, *, backend="r2", bucket="data",
+         status="active", spectrum_id=None, exposure_ref=None, rid=None):
+    r = {
+        "storage_key": key, "backend": backend, "bucket": bucket,
+        "content_hash": content_hash, "size_bytes": len(CONTENT),
+        "content_type": "application/fits", "product_type": product_type,
+        "status": status, "observation": "test_obs", "field": "cosmos",
+        "spectrum_id": spectrum_id, "exposure_ref": exposure_ref,
+    }
+    if rid is not None:
+        r["id"] = rid
+    return r
+
+
+def _run(sb, src, dst, **kw):
+    return reg.copy_objects(
+        sb, src_client=src, src_bucket=SRC_BUCKET,
+        dst_client=dst, dst_bucket=DST_BUCKET, dst_backend="osn", **kw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_copies_final_rekeys_and_relocates():
+    sb = _FakeSupabase([_row(LEGACY_SPEC, "nirspec_spec", CONTENT_SHA, spectrum_id="test_obs_prism_100")])
+    src = _FakeS3({(SRC_BUCKET, LEGACY_SPEC): CONTENT})
+    dst = _FakeS3()
+
+    report = _run(sb, src, dst, dry_run=False)
+
+    assert report.ok and len(report.copied) == 1
+    # OSN got the bytes under the canonical key.
+    assert dst.objects[(DST_BUCKET, CANON_SPEC)] == CONTENT
+    # Registry row relocated in place: osn + canonical + sha256, still one row.
+    rows = sb.tables["storage_objects"]
+    assert len(rows) == 1
+    assert rows[0]["backend"] == "osn"
+    assert rows[0]["storage_key"] == CANON_SPEC
+    assert rows[0]["content_hash"] == CONTENT_SHA
+
+
+def test_etag_upgraded_to_sha256():
+    sb = _FakeSupabase([_row(LEGACY_SPEC, "nirspec_spec", "etag:abc123", spectrum_id="test_obs_prism_100")])
+    src = _FakeS3({(SRC_BUCKET, LEGACY_SPEC): CONTENT})
+    dst = _FakeS3()
+
+    report = _run(sb, src, dst, dry_run=False)
+
+    assert report.ok and len(report.copied) == 1
+    assert sb.tables["storage_objects"][0]["content_hash"] == CONTENT_SHA
+
+
+def test_sha256_drift_skips_without_relocate_or_upload():
+    sb = _FakeSupabase([_row(LEGACY_SPEC, "nirspec_spec", "sha256:deadbeef", spectrum_id="test_obs_prism_100")])
+    src = _FakeS3({(SRC_BUCKET, LEGACY_SPEC): CONTENT})
+    dst = _FakeS3()
+
+    report = _run(sb, src, dst, dry_run=False)
+
+    assert not report.ok and len(report.failed) == 1
+    # Drift is caught before the PUT: nothing landed on OSN, row untouched.
+    assert (DST_BUCKET, CANON_SPEC) not in dst.objects
+    assert sb.tables["storage_objects"][0]["backend"] == "r2"
+
+
+def test_readback_mismatch_fails_and_does_not_relocate():
+    sb = _FakeSupabase([_row(LEGACY_SPEC, "nirspec_spec", CONTENT_SHA, spectrum_id="test_obs_prism_100")])
+    src = _FakeS3({(SRC_BUCKET, LEGACY_SPEC): CONTENT})
+    dst = _FakeS3(corrupt_download=True)  # readback returns altered bytes
+
+    report = _run(sb, src, dst, dry_run=False, verify_readback=True)
+
+    assert not report.ok and len(report.failed) == 1
+    assert sb.tables["storage_objects"][0]["backend"] == "r2"
+
+
+def test_size_check_path_when_readback_disabled():
+    sb = _FakeSupabase([_row(LEGACY_SPEC, "nirspec_spec", CONTENT_SHA, spectrum_id="test_obs_prism_100")])
+    src = _FakeS3({(SRC_BUCKET, LEGACY_SPEC): CONTENT})
+    dst = _FakeS3()
+
+    report = _run(sb, src, dst, dry_run=False, verify_readback=False)
+
+    assert report.ok and len(report.copied) == 1
+    assert sb.tables["storage_objects"][0]["backend"] == "osn"
+
+
+def test_dry_run_plans_without_transfer_or_write():
+    sb = _FakeSupabase([_row(LEGACY_SPEC, "nirspec_spec", CONTENT_SHA, spectrum_id="test_obs_prism_100")])
+    src = _FakeS3({(SRC_BUCKET, LEGACY_SPEC): CONTENT})
+    dst = _FakeS3()
+
+    report = _run(sb, src, dst, dry_run=True)
+
+    assert len(report.planned) == 1 and not report.copied
+    assert report.planned[0][:2] == (LEGACY_SPEC, CANON_SPEC)
+    assert dst.objects == {}  # nothing uploaded
+    assert sb.tables["storage_objects"][0]["backend"] == "r2"  # nothing relocated
+
+
+def test_default_product_types_exclude_rgb():
+    sb = _FakeSupabase([
+        _row(LEGACY_SPEC, "nirspec_spec", CONTENT_SHA, spectrum_id="test_obs_prism_100"),
+        _row(LEGACY_RGB, "rgb", CONTENT_SHA),
+    ])
+    src = _FakeS3({(SRC_BUCKET, LEGACY_SPEC): CONTENT, (SRC_BUCKET, LEGACY_RGB): CONTENT})
+    dst = _FakeS3()
+
+    report = _run(sb, src, dst, dry_run=False)
+
+    # Only the spectrum migrated; the dead rgb product was never selected.
+    assert len(report.copied) == 1
+    assert report.copied[0][0] == LEGACY_SPEC
+    assert (DST_BUCKET, CANON_SPEC) in dst.objects
+    rgb_row = next(r for r in sb.tables["storage_objects"] if r["product_type"] == "rgb")
+    assert rgb_row["backend"] == "r2"  # untouched
+
+
+def test_unmappable_key_skipped_not_failed():
+    sb = _FakeSupabase([_row("garbage/not/a/known/key", "nirspec_spec", CONTENT_SHA)])
+    src = _FakeS3()
+    dst = _FakeS3()
+
+    report = _run(sb, src, dst, dry_run=False)
+
+    assert len(report.skipped) == 1 and not report.failed and not report.copied
+
+
+def test_idempotent_already_osn_not_reselected():
+    # An already-migrated (osn) row is invisible to the backend='r2' candidate query.
+    sb = _FakeSupabase([_row(CANON_SPEC, "nirspec_spec", CONTENT_SHA, backend="osn",
+                             spectrum_id="test_obs_prism_100")])
+    src = _FakeS3()
+    dst = _FakeS3()
+
+    report = _run(sb, src, dst, dry_run=False)
+
+    assert not report.copied and not report.failed and not report.planned
+
+
+def test_resume_second_run_is_noop():
+    sb = _FakeSupabase([_row(LEGACY_SPEC, "nirspec_spec", CONTENT_SHA, spectrum_id="test_obs_prism_100")])
+    src = _FakeS3({(SRC_BUCKET, LEGACY_SPEC): CONTENT})
+    dst = _FakeS3()
+
+    first = _run(sb, src, dst, dry_run=False)
+    second = _run(sb, src, dst, dry_run=False)
+
+    assert len(first.copied) == 1
+    assert not second.copied  # row is now osn -> not a candidate
+    assert len(sb.tables["storage_objects"]) == 1  # still exactly one active row
+
+
+def test_size_check_mismatch_fails_without_relocate():
+    # verify_readback=False path: a wrong uploaded size must fail (not relocate).
+    sb = _FakeSupabase([_row(LEGACY_SPEC, "nirspec_spec", CONTENT_SHA, spectrum_id="test_obs_prism_100")])
+    src = _FakeS3({(SRC_BUCKET, LEGACY_SPEC): CONTENT})
+    dst = _FakeS3(head_size_delta=7)  # HEAD reports a size that disagrees with the upload
+
+    report = _run(sb, src, dst, dry_run=False, verify_readback=False)
+
+    assert not report.ok and len(report.failed) == 1
+    assert sb.tables["storage_objects"][0]["backend"] == "r2"
+
+
+def test_continues_past_failure_to_later_object():
+    # First candidate drifts (fails); a later candidate must still migrate.
+    LEGACY2 = "spectra/test_obs/test_obs_prism_200_spec.fits"
+    CANON2 = "data/products/nirspec/test_obs/test_obs_prism_200_spec.fits"
+    sb = _FakeSupabase([
+        _row(LEGACY_SPEC, "nirspec_spec", "sha256:deadbeef", spectrum_id="test_obs_prism_100"),
+        _row(LEGACY2, "nirspec_spec", CONTENT_SHA, spectrum_id="test_obs_prism_200"),
+    ])
+    src = _FakeS3({(SRC_BUCKET, LEGACY_SPEC): CONTENT, (SRC_BUCKET, LEGACY2): CONTENT})
+    dst = _FakeS3()
+
+    report = _run(sb, src, dst, dry_run=False)
+
+    assert len(report.failed) == 1 and len(report.copied) == 1
+    rows = {r["storage_key"]: r for r in sb.tables["storage_objects"]}
+    # Failed object untouched (still r2-legacy); good object relocated to osn.
+    assert rows[LEGACY_SPEC]["backend"] == "r2"
+    assert rows[CANON2]["backend"] == "osn"
+    assert (DST_BUCKET, CANON2) in dst.objects
+    assert (DST_BUCKET, CANON_SPEC) not in dst.objects
+
+
+def test_find_migration_conflicts_detects_duplicate():
+    # An osn-canonical row AND a fresh r2-legacy row whose canonical form collides.
+    sb = _FakeSupabase([
+        _row(CANON_SPEC, "nirspec_spec", CONTENT_SHA, backend="osn", spectrum_id="test_obs_prism_100"),
+        _row(LEGACY_SPEC, "nirspec_spec", CONTENT_SHA, spectrum_id="test_obs_prism_100"),
+    ])
+
+    conflicts = reg.find_migration_conflicts(sb)
+
+    assert conflicts == [LEGACY_SPEC]

--- a/python/tests/test_storage_backend.py
+++ b/python/tests/test_storage_backend.py
@@ -156,6 +156,11 @@ _ALL_STORAGE_ENV = [
     'CAMPFIRE_S3_TILES_PUBLIC_URL_BASE',
     'CAMPFIRE_R2_TILES_ACCOUNT_ID', 'CAMPFIRE_R2_TILES_ACCESS_KEY_ID',
     'CAMPFIRE_R2_TILES_SECRET_ACCESS_KEY', 'CAMPFIRE_R2_TILES_BUCKET_NAME',
+    # osn (data-bucket migration destination, #215)
+    'CAMPFIRE_S3_OSN_ACCESS_KEY_ID', 'CAMPFIRE_S3_OSN_SECRET_ACCESS_KEY',
+    'CAMPFIRE_S3_OSN_BUCKET_NAME', 'CAMPFIRE_S3_OSN_ENDPOINT',
+    'CAMPFIRE_S3_OSN_REGION', 'CAMPFIRE_S3_OSN_FORCE_PATH_STYLE',
+    'CAMPFIRE_S3_OSN_BACKEND',
 ]
 
 
@@ -251,3 +256,55 @@ def test_tiles_section_omitted_when_incomplete(clean_env):
 
     config = load_config()
     assert 'r2_tiles' not in config
+
+
+# ---------------------------------------------------------------------------
+# OSN purpose (data-bucket migration destination, epic #210 / #215)
+# ---------------------------------------------------------------------------
+
+def test_osn_section_included_and_resolves(clean_env):
+    mp = clean_env
+    _set_supabase(mp)
+    mp.setenv('CAMPFIRE_S3_ACCOUNT_ID', 'acct')
+    mp.setenv('CAMPFIRE_S3_ACCESS_KEY_ID', 'ak')
+    mp.setenv('CAMPFIRE_S3_SECRET_ACCESS_KEY', 'sk')
+    mp.setenv('CAMPFIRE_S3_BUCKET_NAME', 'data')
+    # OSN destination
+    mp.setenv('CAMPFIRE_S3_OSN_ACCESS_KEY_ID', 'oak')
+    mp.setenv('CAMPFIRE_S3_OSN_SECRET_ACCESS_KEY', 'osk')
+    mp.setenv('CAMPFIRE_S3_OSN_BUCKET_NAME', 'campfire-jwst')
+    mp.setenv('CAMPFIRE_S3_OSN_ENDPOINT', 'https://uaz1.osn.mghpcc.org')
+    mp.setenv('CAMPFIRE_S3_OSN_REGION', 'us-east-1')
+    mp.setenv('CAMPFIRE_S3_OSN_FORCE_PATH_STYLE', 'true')
+
+    config = load_config()
+    assert 'r2_osn' in config
+
+    # data (R2) and osn (OSN) resolve independently and simultaneously.
+    data = backend.resolve_backend(config, 'data')
+    assert data.endpoint == 'https://acct.r2.cloudflarestorage.com'
+    osn = backend.resolve_backend(config, 'osn')
+    assert osn.endpoint == 'https://uaz1.osn.mghpcc.org'
+    assert osn.region == 'us-east-1'
+    assert osn.force_path_style is True
+    assert osn.backend == 'osn'           # inferred from non-R2 host
+    assert osn.bucket == 'campfire-jwst'
+
+
+def test_osn_section_omitted_when_incomplete(clean_env):
+    mp = clean_env
+    _set_supabase(mp)
+    mp.setenv('CAMPFIRE_S3_ACCESS_KEY_ID', 'ak')
+    mp.setenv('CAMPFIRE_S3_SECRET_ACCESS_KEY', 'sk')
+    mp.setenv('CAMPFIRE_S3_BUCKET_NAME', 'data')
+    mp.setenv('CAMPFIRE_S3_ENDPOINT', 'https://acct.r2.cloudflarestorage.com')
+    # partial OSN (no bucket / endpoint) -> dropped, never blocks loading
+    mp.setenv('CAMPFIRE_S3_OSN_ACCESS_KEY_ID', 'oak')
+
+    config = load_config()
+    assert 'r2_osn' not in config
+
+
+def test_osn_missing_section_raises_with_hint():
+    with pytest.raises(ValueError, match='CAMPFIRE_S3_OSN'):
+        backend.resolve_backend(_data(account_id='a'), 'osn')

--- a/web/app/api/download/route.ts
+++ b/web/app/api/download/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import { generateDownloadUrl } from '@/lib/r2';
+import { generateDownloadUrl, generateDownloadUrls } from '@/lib/r2';
 import { trackDownload, extractTargetIdFromFitsPath } from '@/lib/actions/download-tracking';
 
 /**
@@ -140,12 +140,13 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Generate signed URLs for all files
+    // Generate signed URLs for all files. Batched so dual-read resolves every
+    // backend in a single registry query (not one per file).
     const urls: Record<string, string> = {};
-    for (const path of paths) {
-      const signedUrl = await generateDownloadUrl(path, 3600);
-      urls[path] = signedUrl;
-    }
+    const signedUrls = await generateDownloadUrls(paths, 3600);
+    paths.forEach((path: string, i: number) => {
+      urls[path] = signedUrls[i];
+    });
 
     // Track batch download (fire-and-forget)
     const targetIdPromises = paths.map(extractTargetIdFromFitsPath);

--- a/web/app/api/v1/observations/[obs_name]/manifest/route.ts
+++ b/web/app/api/v1/observations/[obs_name]/manifest/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { validateAuth } from '@/lib/api-auth';
 import { getAccessiblePrograms, isAdminUser } from '@/lib/api-helpers';
-import { generateDownloadUrl } from '@/lib/r2';
+import { generateDownloadUrls } from '@/lib/r2';
 
 /**
  * GET /api/v1/observations/{obs_name}/manifest
@@ -82,10 +82,12 @@ export async function GET(
       .limit(1)
       .single();
 
-    // Generate signed URLs (6-hour expiry = 21600 seconds)
+    // Generate signed URLs (6-hour expiry = 21600 seconds). Batched so dual-read
+    // resolves every backend in a single registry query (not one per spectrum).
     const urlExpiresAt = new Date(Date.now() + 21600 * 1000).toISOString();
-    const signedUrls = await Promise.all(
-      spectraList.map((s: { fits_path: string }) => generateDownloadUrl(s.fits_path, 21600))
+    const signedUrls = await generateDownloadUrls(
+      spectraList.map((s: { fits_path: string }) => s.fits_path),
+      21600
     );
 
     // Build response with download URLs

--- a/web/app/api/v1/storage/presign/route.ts
+++ b/web/app/api/v1/storage/presign/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { validateAuth } from '@/lib/api-auth';
 import { getAccessiblePrograms, isAdminUser } from '@/lib/api-helpers';
-import { generateDownloadUrl } from '@/lib/r2';
+import { generateDownloadUrls } from '@/lib/r2';
 import { isKnownKey } from '@/lib/layout';
 
 const MAX_KEYS = 200;
@@ -84,12 +84,12 @@ export async function POST(request: NextRequest) {
       (r: { storage_key: string }) => r.storage_key
     );
 
+    // Batched dual-read presign: one registry lookup resolves every key's backend.
     const urls: Record<string, string> = {};
-    await Promise.all(
-      allowed.map(async (key) => {
-        urls[key] = await generateDownloadUrl(key, URL_TTL_SECONDS);
-      })
-    );
+    const signedUrls = await generateDownloadUrls(allowed, URL_TTL_SECONDS);
+    allowed.forEach((key, i) => {
+      urls[key] = signedUrls[i];
+    });
 
     return NextResponse.json({ urls });
   } catch (error) {

--- a/web/lib/layout.ts
+++ b/web/lib/layout.ts
@@ -318,6 +318,24 @@ export function deriveSibling(key: string, targetProductType: string, opts?: { b
   return `${prefix}/${base}${tgt.suffix}`;
 }
 
+/** Rewrite *key* into the CANONICAL scheme (`data/` + relpath), regardless of the
+ * input scheme. Used by dual-read (#215) to look an object up in the registry,
+ * whose rows hold canonical keys after the R2->OSN re-key. `parseKey` accepts
+ * either scheme, so passing an already-canonical key is idempotent. Throws
+ * `LayoutError` for unknown/unsafe keys. */
+export function toCanonicalKey(key: string, opts?: { bucket?: Bucket }): string {
+  const pk = parseKey(key, opts);
+  return storageKey(pk.productType, pk.scope, pk.filename, 'canonical');
+}
+
+/** Rewrite *key* into the LEGACY scheme (today's bare key on R2). The dual-read
+ * R2 fallback signs against this. Idempotent on an already-legacy key. Throws
+ * `LayoutError` for unknown/unsafe keys. */
+export function toLegacyKey(key: string, opts?: { bucket?: Bucket }): string {
+  const pk = parseKey(key, opts);
+  return storageKey(pk.productType, pk.scope, pk.filename, 'legacy');
+}
+
 /** True iff *key* parses to a cloud-backed product — the presign/proxy allowlist.
  * Rejects traversal/unsafe keys and keys resolving to non-cloud products. */
 export function isKnownKey(key: string, opts?: { bucket?: Bucket }): boolean {

--- a/web/lib/r2.dualread.test.ts
+++ b/web/lib/r2.dualread.test.ts
@@ -1,0 +1,156 @@
+// Dual-read backend resolution (epic #210 / #215). Exercises resolveObjectBackends
+// (the brain) and generateDownloadUrls (presign wiring) with the registry, the
+// storage clients, and the presigner all mocked. Uses the REAL ./layout so the
+// legacy<->canonical derivation is the production one.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// --- registry (service-role client) -----------------------------------------
+let dbRows: Array<{ storage_key: string; backend: string }> = [];
+let dbError: unknown = null;
+let dbCalls = 0;
+
+vi.mock('./supabase/server', () => ({
+  createServiceClient: () => {
+    const b: Record<string, unknown> = {
+      from: () => {
+        dbCalls += 1;
+        return b;
+      },
+      select: () => b,
+      in: () => b,
+      eq: () => b,
+      then: (resolve: (v: { data: unknown; error: unknown }) => unknown) =>
+        resolve({ data: dbRows, error: dbError }),
+    };
+    return b;
+  },
+}));
+
+// --- storage clients ---------------------------------------------------------
+vi.mock('./storage', () => ({
+  getS3Client: () => ({}),
+  getBucketName: () => 'campfire',
+  getS3ClientForBackend: (b: string) => ({ backend: b }),
+  getBucketNameForBackend: (b: string) => (b === 'osn' ? 'campfire-jwst' : 'campfire'),
+}));
+
+// --- AWS SDK -----------------------------------------------------------------
+vi.mock('@aws-sdk/client-s3', () => ({
+  GetObjectCommand: class {
+    input: { Bucket: string; Key: string };
+    constructor(input: { Bucket: string; Key: string }) {
+      this.input = input;
+    }
+  },
+}));
+vi.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: (_client: unknown, command: { input: { Bucket: string; Key: string } }) =>
+    Promise.resolve(`signed://${command.input.Bucket}/${command.input.Key}`),
+}));
+
+import { resolveObjectBackends, generateDownloadUrls } from './r2';
+
+const LEGACY = 'spectra/ember_egs_p1/ember_egs_p1_101_spec.fits';
+const CANON = 'data/products/nirspec/ember_egs_p1/ember_egs_p1_101_spec.fits';
+
+beforeEach(() => {
+  dbRows = [];
+  dbError = null;
+  dbCalls = 0;
+  vi.unstubAllEnvs();
+});
+
+describe('resolveObjectBackends — kill switch', () => {
+  it('OSN_READ_ENABLED off => R2 + input key, no DB query', async () => {
+    vi.stubEnv('OSN_READ_ENABLED', '');
+    const out = await resolveObjectBackends([LEGACY]);
+    expect(out).toEqual([{ backend: 'r2', key: LEGACY }]);
+    expect(dbCalls).toBe(0);
+  });
+
+  it('OSN_READ_ENABLED off + canonical input => R2 under the LEGACY key (rollback)', async () => {
+    vi.stubEnv('OSN_READ_ENABLED', '');
+    const out = await resolveObjectBackends([CANON]);
+    expect(out).toEqual([{ backend: 'r2', key: LEGACY }]);
+    expect(dbCalls).toBe(0);
+  });
+});
+
+describe('resolveObjectBackends — flag on', () => {
+  beforeEach(() => vi.stubEnv('OSN_READ_ENABLED', 'true'));
+
+  it('migrated osn row => OSN + canonical key', async () => {
+    dbRows = [{ storage_key: CANON, backend: 'osn' }];
+    const out = await resolveObjectBackends([LEGACY]);
+    expect(out).toEqual([{ backend: 'osn', key: CANON }]);
+    expect(dbCalls).toBe(1);
+  });
+
+  it('no registry row => R2 + input (legacy) key', async () => {
+    dbRows = [];
+    const out = await resolveObjectBackends([LEGACY]);
+    expect(out).toEqual([{ backend: 'r2', key: LEGACY }]);
+  });
+
+  it('row present but backend r2 => R2 + input key (never sign R2 with a canonical key)', async () => {
+    dbRows = [{ storage_key: CANON, backend: 'r2' }];
+    const out = await resolveObjectBackends([LEGACY]);
+    expect(out).toEqual([{ backend: 'r2', key: LEGACY }]);
+  });
+
+  it('already-canonical input + migrated row => OSN + canonical (idempotent)', async () => {
+    dbRows = [{ storage_key: CANON, backend: 'osn' }];
+    const out = await resolveObjectBackends([CANON]);
+    expect(out).toEqual([{ backend: 'osn', key: CANON }]);
+  });
+
+  it('DB error => fail open to R2 for all keys', async () => {
+    dbError = new Error('supabase down');
+    const out = await resolveObjectBackends([LEGACY]);
+    expect(out).toEqual([{ backend: 'r2', key: LEGACY }]);
+  });
+
+  it('canonical input + DB error => fail open to R2 under the LEGACY key', async () => {
+    // The client mirror sends canonical keys post-migration; R2 only has them
+    // under the legacy key, so fail-open must re-key canonical -> legacy.
+    dbError = new Error('supabase down');
+    const out = await resolveObjectBackends([CANON]);
+    expect(out).toEqual([{ backend: 'r2', key: LEGACY }]);
+  });
+
+  it('chunks the registry lookup for large key sets and still diverts', async () => {
+    const N = 250; // > LOOKUP_CHUNK (100) => multiple queries
+    const keys = Array.from(
+      { length: N },
+      (_, i) => `spectra/ember_egs_p1/ember_egs_p1_${i}_spec.fits`
+    );
+    const migratedCanon = 'data/products/nirspec/ember_egs_p1/ember_egs_p1_123_spec.fits';
+    dbRows = [{ storage_key: migratedCanon, backend: 'osn' }];
+
+    const out = await resolveObjectBackends(keys);
+
+    expect(out[123]).toEqual({ backend: 'osn', key: migratedCanon });
+    expect(out[0]).toEqual({ backend: 'r2', key: keys[0] });
+    expect(dbCalls).toBeGreaterThan(1); // not one URL-overflowing .in()
+  });
+
+  it('unparseable key => R2 fallback, still resolves the others', async () => {
+    dbRows = [{ storage_key: CANON, backend: 'osn' }];
+    const out = await resolveObjectBackends(['garbage/not/a/key', LEGACY]);
+    expect(out[0]).toEqual({ backend: 'r2', key: 'garbage/not/a/key' });
+    expect(out[1]).toEqual({ backend: 'osn', key: CANON });
+  });
+});
+
+describe('generateDownloadUrls — presign wiring', () => {
+  beforeEach(() => vi.stubEnv('OSN_READ_ENABLED', 'true'));
+
+  it('signs OSN bucket for a migrated object, R2 for an unmigrated one', async () => {
+    const OTHER = 'spectra/ember_egs_p1/ember_egs_p1_999_spec.fits';
+    dbRows = [{ storage_key: CANON, backend: 'osn' }]; // only LEGACY migrated
+    const urls = await generateDownloadUrls([LEGACY, OTHER]);
+    expect(urls[0]).toBe(`signed://campfire-jwst/${CANON}`);
+    expect(urls[1]).toBe(`signed://campfire/${OTHER}`);
+  });
+});

--- a/web/lib/r2.ts
+++ b/web/lib/r2.ts
@@ -1,53 +1,185 @@
 // Storage client helpers for the `data` bucket (FITS, RGB, SED, …).
 //
 // Endpoint/region/addressing-style are resolved per-purpose by the storage
-// backend factory (`./storage`), so this layer is backend-agnostic
-// (R2 today, OSN later). The `data` client is built lazily on first use.
+// backend factory (`./storage`), so this layer is backend-agnostic.
+//
+// DUAL-READ (epic #210 / #215): an object's home (R2 or OSN) is recorded in
+// storage_objects.backend. `generateDownloadUrl` resolves each key's backend
+// from the registry and presigns there, falling back to R2. This is gated by
+// the OSN_READ_ENABLED env flag — when unset/false it short-circuits to today's
+// behavior (presign R2 with the input key, no DB query), so the change is inert
+// until creds + flag are set. Resolution fails OPEN to R2 on any error.
 
 import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import { getS3Client, getBucketName } from './storage';
-import { storageKey } from './layout';
+import {
+  getS3Client,
+  getBucketName,
+  getS3ClientForBackend,
+  getBucketNameForBackend,
+  type DataBackend,
+} from './storage';
+import { storageKey, toCanonicalKey, toLegacyKey } from './layout';
+import { createServiceClient } from './supabase/server';
+
+// Max keys per storage_objects lookup. Chunked so a large observation manifest
+// (hundreds–thousands of spectra) can't overflow the PostgREST/Kong URL length
+// (the `.in()` list rides in the query string) — mirrors the chunked lookup in
+// the Python registry.find_migration_conflicts.
+const LOOKUP_CHUNK = 100;
+
+/** Legacy form of a key for R2 reads; identity on unrecognized keys (fail-safe).
+ * R2 retains objects under their LEGACY key, so every R2-bound presign must sign
+ * the legacy form — including canonical keys arriving from the client's
+ * storage_objects mirror during a rollback or a fail-open. */
+function toLegacyKeySafe(key: string): string {
+  try {
+    return toLegacyKey(key);
+  } catch {
+    return key;
+  }
+}
 
 /** S3 client for the `data` storage backend (lazy, cached). */
 export function getDataClient() {
   return getS3Client('data');
 }
 
+/** Where a requested key should be read from: a backend label + the key to sign. */
+interface ResolvedObject {
+  backend: DataBackend;
+  key: string;
+}
+
+/** Dual-read master switch. Off (default) => behave exactly like pre-migration. */
+function osnReadEnabled(): boolean {
+  return (process.env.OSN_READ_ENABLED || '').trim().toLowerCase() === 'true';
+}
+
 /**
- * Generate a signed URL for downloading a file from the data store.
+ * Resolve, for each input key, which backend holds the object and the key to
+ * sign there. Canonical-only lookup: each input is mapped to its canonical form
+ * and looked up in storage_objects; a matching `osn` row => read OSN with the
+ * canonical key; anything else (no row, or an r2 row) => read R2 with the input
+ * key (R2 bytes are retained, so this is always a safe answer).
+ *
+ * Fails OPEN: with OSN reads disabled, or on any derivation/DB error, returns
+ * R2 + the input key for every entry — never converts a today-working download
+ * into an error.
+ */
+export async function resolveObjectBackends(keys: string[]): Promise<ResolvedObject[]> {
+  // R2 reads always use the LEGACY key (where R2 retains the bytes), even if the
+  // caller passed a canonical key (the client mirror holds canonical keys after
+  // migration). This is the rollback / fail-open answer for every key.
+  const r2Only = (): ResolvedObject[] =>
+    keys.map((key) => ({ backend: 'r2' as const, key: toLegacyKeySafe(key) }));
+
+  if (!osnReadEnabled()) return r2Only();
+
+  try {
+    // Canonical form per input (LayoutError on an unrecognized key => R2 fallback).
+    const canonicalByInput = new Map<string, string | null>();
+    for (const k of keys) {
+      try {
+        canonicalByInput.set(k, toCanonicalKey(k));
+      } catch {
+        canonicalByInput.set(k, null);
+      }
+    }
+
+    const canonicalForms = Array.from(
+      new Set(
+        Array.from(canonicalByInput.values()).filter((v): v is string => v !== null)
+      )
+    );
+
+    const backendByCanonical = new Map<string, DataBackend>();
+    if (canonicalForms.length > 0) {
+      const supabase = createServiceClient();
+      // Chunked so the `.in()` list never overflows the request URL.
+      for (let i = 0; i < canonicalForms.length; i += LOOKUP_CHUNK) {
+        const chunk = canonicalForms.slice(i, i + LOOKUP_CHUNK);
+        const { data, error } = await supabase
+          .from('storage_objects')
+          .select('storage_key, backend')
+          .in('storage_key', chunk)
+          .eq('status', 'active');
+        if (error) throw error;
+        for (const row of data ?? []) {
+          backendByCanonical.set(row.storage_key as string, row.backend as DataBackend);
+        }
+      }
+    }
+
+    return keys.map((key) => {
+      const canonical = canonicalByInput.get(key);
+      // Only divert to OSN when the registry explicitly homes the canonical key
+      // there; every other case reads R2 under the legacy key.
+      if (canonical && backendByCanonical.get(canonical) === 'osn') {
+        return { backend: 'osn' as const, key: canonical };
+      }
+      return { backend: 'r2' as const, key: toLegacyKeySafe(key) };
+    });
+  } catch (err) {
+    console.error('[dual-read] backend resolution failed; falling back to R2:', err);
+    return r2Only();
+  }
+}
+
+/** Presign a GET against a resolved object's backend. */
+async function presignResolved(o: ResolvedObject, expiresIn: number): Promise<string> {
+  const command = new GetObjectCommand({
+    Bucket: getBucketNameForBackend(o.backend),
+    Key: o.key,
+  });
+  try {
+    return await getSignedUrl(getS3ClientForBackend(o.backend), command, { expiresIn });
+  } catch (error) {
+    console.error(`Failed to sign download URL for "${o.key}" (${o.backend}):`, error);
+    throw new Error(`Failed to generate download URL for ${o.key}`);
+  }
+}
+
+/**
+ * Generate a signed URL for downloading a file from the data store, reading from
+ * whichever backend currently homes the object (R2 fallback). See
+ * {@link resolveObjectBackends}.
  * @param fitsPath - Object key (e.g., "spectra/obs_name/file.fits")
  * @param expiresIn - URL expiration time in seconds (default: 1 hour)
- * @returns Signed URL for downloading the file
- * @throws if storage is misconfigured or signing fails — surfaced loudly so a
- *   cutover misconfig is diagnosable rather than silently masked.
+ * @throws if signing fails — surfaced loudly so a cutover misconfig is
+ *   diagnosable rather than silently masked.
  */
 export async function generateDownloadUrl(
   fitsPath: string,
   expiresIn: number = 3600
 ): Promise<string> {
-  const command = new GetObjectCommand({
-    Bucket: getBucketName('data'),
-    Key: fitsPath,
-  });
-
-  try {
-    return await getSignedUrl(getDataClient(), command, { expiresIn });
-  } catch (error) {
-    console.error(`Failed to sign download URL for "${fitsPath}":`, error);
-    throw new Error(`Failed to generate download URL for ${fitsPath}`);
-  }
+  const [resolved] = await resolveObjectBackends([fitsPath]);
+  return presignResolved(resolved, expiresIn);
 }
 
 /**
- * Generate multiple download URLs for an object's spectra
+ * Batched dual-read presign: resolves all backends in a single registry query,
+ * then signs in parallel. Use this for routes that presign many keys at once
+ * (manifest, batch download, the client's storage presign) to avoid one DB
+ * round-trip per key.
+ */
+export async function generateDownloadUrls(
+  keys: string[],
+  expiresIn: number = 3600
+): Promise<string[]> {
+  const resolved = await resolveObjectBackends(keys);
+  return Promise.all(resolved.map((o) => presignResolved(o, expiresIn)));
+}
+
+/**
+ * Generate multiple download URLs for an object's spectra.
  * @param fitsPaths - Array of FITS file paths
  * @returns Array of signed URLs
  */
 export async function generateMultipleDownloadUrls(
   fitsPaths: string[]
 ): Promise<string[]> {
-  return Promise.all(fitsPaths.map(path => generateDownloadUrl(path)));
+  return generateDownloadUrls(fitsPaths);
 }
 
 /**

--- a/web/lib/r2.ts
+++ b/web/lib/r2.ts
@@ -22,11 +22,11 @@ import {
 import { storageKey, toCanonicalKey, toLegacyKey } from './layout';
 import { createServiceClient } from './supabase/server';
 
-// Max keys per storage_objects lookup. Chunked so a large observation manifest
-// (hundreds–thousands of spectra) can't overflow the PostgREST/Kong URL length
-// (the `.in()` list rides in the query string) — mirrors the chunked lookup in
-// the Python registry.find_migration_conflicts.
-const LOOKUP_CHUNK = 100;
+// Max keys per storage_objects lookup. The `.in()` list rides in the request URL,
+// and canonical keys are ~70+ chars (URL-encoded ~110), so this is kept small to
+// stay well under the PostgREST/Kong URI limit — overflowing it yields a bare
+// 400 'Bad Request'. A large observation manifest is split across several queries.
+const LOOKUP_CHUNK = 50;
 
 /** Legacy form of a key for R2 reads; identity on unrecognized keys (fail-safe).
  * R2 retains objects under their LEGACY key, so every R2-bound presign must sign

--- a/web/lib/storage.test.ts
+++ b/web/lib/storage.test.ts
@@ -1,0 +1,56 @@
+// Real-execution coverage for the dual-read storage resolution (epic #210 / #215)
+// — exercises the actual S3_OSN_* env resolution, client cache, and r2-vs-osn
+// bucket selection in storage.ts (the TS twin of test_storage_backend.py's OSN
+// cases), which r2.dualread.test.ts mocks out. Modules are reset per test so the
+// internal client caches don't leak across cases.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+function setOsnEnv() {
+  vi.stubEnv('S3_OSN_ACCESS_KEY_ID', 'oak');
+  vi.stubEnv('S3_OSN_SECRET_ACCESS_KEY', 'osk');
+  vi.stubEnv('S3_OSN_BUCKET_NAME', 'campfire-jwst');
+  vi.stubEnv('S3_OSN_ENDPOINT', 'https://uaz1.osn.mghpcc.org/');
+  vi.stubEnv('S3_OSN_REGION', 'us-east-1');
+  vi.stubEnv('S3_OSN_FORCE_PATH_STYLE', 'true');
+}
+
+function setR2Env() {
+  vi.stubEnv('S3_ACCESS_KEY_ID', 'ak');
+  vi.stubEnv('S3_SECRET_ACCESS_KEY', 'sk');
+  vi.stubEnv('S3_BUCKET_NAME', 'campfire');
+  vi.stubEnv('S3_ENDPOINT', 'https://acct.r2.cloudflarestorage.com');
+}
+
+beforeEach(() => vi.resetModules());
+afterEach(() => vi.unstubAllEnvs());
+
+describe('dual-read storage resolution (storage.ts)', () => {
+  it('resolves the OSN bucket from S3_OSN_*', async () => {
+    setOsnEnv();
+    const { getBucketNameForBackend } = await import('./storage');
+    expect(getBucketNameForBackend('osn')).toBe('campfire-jwst');
+  });
+
+  it('throws when OSN creds are incomplete', async () => {
+    vi.stubEnv('S3_OSN_ACCESS_KEY_ID', 'oak'); // missing secret / bucket / endpoint
+    const { getBucketNameForBackend } = await import('./storage');
+    expect(() => getBucketNameForBackend('osn')).toThrow(/osn/i);
+  });
+
+  it('caches the OSN client and keeps it distinct from the R2 client', async () => {
+    setOsnEnv();
+    setR2Env();
+    const { getS3ClientForBackend } = await import('./storage');
+    const osn1 = getS3ClientForBackend('osn');
+    const osn2 = getS3ClientForBackend('osn');
+    expect(osn1).toBe(osn2); // cached
+    expect(getS3ClientForBackend('r2')).not.toBe(osn1);
+  });
+
+  it("'r2' backend resolves the existing data bucket", async () => {
+    setR2Env();
+    const { getBucketNameForBackend } = await import('./storage');
+    expect(getBucketNameForBackend('r2')).toBe('campfire');
+  });
+});

--- a/web/lib/storage.ts
+++ b/web/lib/storage.ts
@@ -128,3 +128,68 @@ export function getBucketName(purpose: StoragePurpose = 'data'): string {
 export function getPublicUrlBase(purpose: StoragePurpose = 'data'): string | undefined {
   return resolveBackend(purpose).publicUrlBase;
 }
+
+// ---------------------------------------------------------------------------
+// By-backend resolution for the data bucket (dual-read, epic #210 / #215).
+//
+// During the R2->OSN migration both backends are live: each object's home is
+// recorded in storage_objects.backend, and the web reads from whichever the
+// registry says (R2 fallback). `'r2'` reuses the existing `data` purpose (R2
+// today); `'osn'` reads the parallel S3_OSN_* env block (region us-east-1,
+// path-style). Inert until S3_OSN_* is set + OSN_READ_ENABLED is flipped on.
+// ---------------------------------------------------------------------------
+
+export type DataBackend = 'r2' | 'osn';
+
+/** Resolve the OSN data backend from S3_OSN_* env (no R2 alias; this is new). */
+function resolveOsnBackend(): BackendConfig {
+  const accessKeyId = env('S3_OSN_ACCESS_KEY_ID');
+  const secretAccessKey = env('S3_OSN_SECRET_ACCESS_KEY');
+  const bucket = env('S3_OSN_BUCKET_NAME');
+  const endpointRaw = env('S3_OSN_ENDPOINT');
+  const region = env('S3_OSN_REGION') || 'auto';
+  const forcePathStyle = coerceBool(env('S3_OSN_FORCE_PATH_STYLE'));
+
+  if (!accessKeyId || !secretAccessKey || !bucket || !endpointRaw) {
+    throw new Error('Storage "osn" credentials not configured (set S3_OSN_*)');
+  }
+
+  const endpoint = endpointRaw.replace(/\/+$/, '');
+  const backend =
+    (env('S3_OSN_BACKEND') as 'r2' | 'osn' | undefined) ||
+    (endpoint.includes('r2.cloudflarestorage.com') ? 'r2' : 'osn');
+
+  return {
+    purpose: 'data',
+    backend,
+    endpoint,
+    region,
+    bucket,
+    accessKeyId,
+    secretAccessKey,
+    forcePathStyle,
+  };
+}
+
+const _osnClient = new Map<'osn', S3Client>();
+
+/** S3 client for a data-bucket backend label ('r2' => the `data` purpose). */
+export function getS3ClientForBackend(b: DataBackend): S3Client {
+  if (b === 'r2') return getS3Client('data');
+  const cached = _osnClient.get('osn');
+  if (cached) return cached;
+  const cfg = resolveOsnBackend();
+  const client = new S3Client({
+    region: cfg.region,
+    endpoint: cfg.endpoint,
+    forcePathStyle: cfg.forcePathStyle,
+    credentials: { accessKeyId: cfg.accessKeyId, secretAccessKey: cfg.secretAccessKey },
+  });
+  _osnClient.set('osn', client);
+  return client;
+}
+
+/** Bucket name for a data-bucket backend label. */
+export function getBucketNameForBackend(b: DataBackend): string {
+  return b === 'r2' ? getBucketName('data') : resolveOsnBackend().bucket;
+}


### PR DESCRIPTION
## A1 (#215) — OSN copy + re-key + verify + dual-read

First step of **Track A** of epic #210: move the data bucket off Cloudflare R2 onto **OSN** (Open Storage Network, academically-free-egress S3-compatible Ceph). A1 adds the registry-driven migration tool and the portal's dual-read path. A2 (#216) later flips the default backend and rewrites the R2-binding zip Worker.

Couples three things into one byte-copy pass (avoids copying every object twice):
1. **Copy** R2 → OSN.
2. **Re-key** legacy (`spectra/<obs>/X.fits`) → canonical (`data/products/nirspec/<obs>/X.fits`) — the layout contract's CANONICAL scheme, inert until now.
3. **Hash upgrade** — compute sha256 while streaming, upgrading the registry's provisional `etag:` hashes.

### Safety / inertness
- **No Postgres migration** — the schema already permits `backend='osn'`, `sha256:`, and canonical keys. No seed regen, no schema-PR contention.
- **R2 bytes retained** through A1 + a bake period after A2. Rollback at every layer = read R2.
- **Merges inert**: the copy is a manually-run CLI (not a merge hook); the web dual-read is gated off by `OSN_READ_ENABLED` and behaves exactly as today (no DB query) until creds + flag are set on Vercel. Resolution **fails open to R2** on any error.

### Python (`campfire/deploy`)
- **`campfire deploy registry copy`** — copies active `backend='r2'` data objects to OSN, re-keys, verifies by sha256 (readback by default; `--no-verify-readback` = size check), then relocates each `storage_objects` row in place. **Dry-run by default**; `--execute` to transfer. Idempotent/resumable (skips `backend='osn'`); per-object failures skip + report + non-zero exit, **never abort or relocate** (the object stays r2-legacy so dual-read serves R2). Default product set **excludes dead rgb/sed**. Filters: `--obs`/`--field`/`--product-type`/`--limit`; `--tmp-dir`.
- OSN backend wiring (`CAMPFIRE_S3_OSN_*` → `r2_osn` section + an `osn` purpose), `download_to_path` GET helper, and `relocate_objects` (**per-row UPDATE by id**, not upsert — a partial-payload id-upsert hits a NOT NULL violation because Postgres validates the candidate INSERT tuple before the ON CONFLICT arbiter; verified against live PG).

### Web (inert until `OSN_READ_ENABLED=true` + `S3_OSN_*` on Vercel)
- `generateDownloadUrl` is backend-aware: `resolveObjectBackends` maps each key to its canonical form and looks it up in `storage_objects` (canonical-only, **chunked** to avoid PostgREST URL overflow); a `backend='osn'` row presigns OSN with the canonical key, everything else presigns **R2 under the legacy key**. Zero DB query when the flag is off; fails open to R2 on any error.
- By-backend storage resolution (`S3_OSN_*`), `toCanonicalKey`/`toLegacyKey`, and the 3 batch routes (manifest, download POST, `storage/presign`) refactored to a single lookup.

### Reviewed
4-dimension adversarial review (Python engine / web dual-read / tests / security) with each finding independently verified against the code. 7 confirmed findings fixed — including a **critical**: the original `relocate_objects` used `upsert(on_conflict='id')`, which fails the NOT NULL check, so the DB flip would never complete (masked by a too-lenient test fake). Fixed to a per-row UPDATE, the fake now enforces NOT NULL, and the fix is verified end-to-end against live Postgres.

### Tests
- **258** python pass (`test_registry_copy.py` + OSN cases in `test_storage_backend.py`).
- **105** web vitest pass (`r2.dualread` + `storage` suites); `npm run build` + types clean.
- No `pipeline/**` change → no CHANGELOG entry.

### Not run here (manual, after merge — needs OSN RW creds on the M2 Ultra)
The live R2→OSN copy and the Vercel-preview dual-read shadow are operator steps (see the PR discussion / runbook). **Shadow-window constraint (G1):** do not re-deploy an already-migrated observation until A2 — a re-deploy writes a fresh r2-legacy row that can shadow stale OSN bytes; the `copy` command warns when it detects this.

Generated with Claude Code

https://claude.ai/code/session_01QMm3DuLALxzNtLBUQqPfkR
