### PR TITLE
feat(deploy): route NIRSpec deploys to OSN canonical keys

### DIFF
--- a/python/campfire/deploy/deploy.py
+++ b/python/campfire/deploy/deploy.py
@@ -35,7 +35,7 @@ from campfire.deploy.generate import (
     generate_thumbnails_from_fits,
     generate_zfit_json,
 )
-from campfire_layout import Scope, storage_key
+from campfire_layout import KeyScheme, Scope, storage_key
 from campfire.deploy.r2 import UploadTask, upload_files_parallel
 from campfire.deploy.supabase import (
     batch_upsert_objects,
@@ -277,13 +277,15 @@ def _deploy_intermediates_only(
     scope = Scope(obs=obs_name)
     scope_version_at_start = get_deploy_scope_version(sb, 'observation', obs_name)
     upload_tasks = [
-        UploadTask(p, storage_key('nirspec_spectrum_exposure', scope, p.name), 'application/fits')
+        UploadTask(p, storage_key('nirspec_spectrum_exposure', scope, p.name,
+                                  scheme=KeyScheme.CANONICAL), 'application/fits')
         for p in exposure_files
     ]
     uploaded_keys: set[str] = set()
-    print(f"Uploading {len(upload_tasks)} canonical spectrum-exposures...")
+    print(f"Uploading {len(upload_tasks)} canonical spectrum-exposures to OSN...")
     success, failed, failed_msgs = upload_files_parallel(
-        config, upload_tasks, desc="R2 uploads", succeeded_out=uploaded_keys)
+        config, upload_tasks, desc="OSN uploads", succeeded_out=uploaded_keys,
+        backend='osn')
     print(f"Uploaded {success}/{len(upload_tasks)} files")
 
     deployment_id = insert_deployment(
@@ -300,10 +302,11 @@ def _deploy_intermediates_only(
 
     if uploaded_keys:
         from campfire.deploy.registry import (
-            build_registry_rows, resolve_backend_label, upsert_storage_objects,
+            build_registry_rows, upsert_storage_objects,
         )
+        # NIRSpec products are homed on OSN under canonical keys (epic #210 / #216).
         reg_rows = build_registry_rows(
-            upload_tasks, backend=resolve_backend_label(config),
+            upload_tasks, backend='osn',
             deployment_id=deployment_id, uploaded_by=user_id,
             succeeded_keys=uploaded_keys)
         n_reg = upsert_storage_objects(sb, reg_rows)
@@ -590,28 +593,30 @@ def deploy_observation(
         uploaded_keys: set[str] = set()  # r2_keys that actually landed (for the registry)
         scope = Scope(obs=obs_name)
 
+        # NIRSpec science products are homed on OSN under CANONICAL keys (epic #210 /
+        # #216 — deploy → OSN); rgb/sed are dead products that stay on R2 under legacy
+        # keys (unregistered, 404, not migrated). They upload in separate batches.
+        legacy_tasks: list[UploadTask] = []
         if not supabase_only:
             print("Generating content...")
             for spec_path in tqdm(spec_paths, desc="Processing", unit="file"):
                 # FITS file
-                upload_tasks.append(UploadTask(spec_path, storage_key('nirspec_spec', scope, spec_path.name), 'application/fits'))
+                upload_tasks.append(UploadTask(spec_path, storage_key('nirspec_spec', scope, spec_path.name, scheme=KeyScheme.CANONICAL), 'application/fits'))
 
                 # Spectrum JSON
                 json_path = generate_spectrum_json(spec_path, temp_dir)
-                upload_tasks.append(UploadTask(json_path, storage_key('spectrum_json', scope, json_path.name), 'application/json'))
+                upload_tasks.append(UploadTask(json_path, storage_key('spectrum_json', scope, json_path.name, scheme=KeyScheme.CANONICAL), 'application/json'))
 
             # Zfit JSONs
             for zfit_path in zfit_paths:
                 zfit_json = generate_zfit_json(zfit_path, temp_dir)
-                upload_tasks.append(UploadTask(zfit_json, storage_key('zfit', scope, zfit_json.name), 'application/json'))
+                upload_tasks.append(UploadTask(zfit_json, storage_key('zfit', scope, zfit_json.name, scheme=KeyScheme.CANONICAL), 'application/json'))
 
-            # RGB images
+            # RGB images / SED plots — dead products (kept on R2/legacy, unchanged).
             for rgb_path in rgb_files:
-                upload_tasks.append(UploadTask(rgb_path, storage_key('rgb', scope, rgb_path.name), 'image/png'))
-
-            # SED plots
+                legacy_tasks.append(UploadTask(rgb_path, storage_key('rgb', scope, rgb_path.name), 'image/png'))
             for sed_path in sed_files:
-                upload_tasks.append(UploadTask(sed_path, storage_key('sed', scope, sed_path.name), 'application/pdf'))
+                legacy_tasks.append(UploadTask(sed_path, storage_key('sed', scope, sed_path.name), 'application/pdf'))
 
             # Canonical spectrum-exposure intermediates (epic #210, B5): uploaded on
             # EVERY deploy (cloud-as-source-of-truth + delete-local→restore), filtered
@@ -622,15 +627,25 @@ def deploy_observation(
                 exposure_files = _filter_exposures_by_source_ids(exposure_files, source_ids)
             for exp_path in exposure_files:
                 upload_tasks.append(UploadTask(
-                    exp_path, storage_key('nirspec_spectrum_exposure', scope, exp_path.name),
+                    exp_path, storage_key('nirspec_spectrum_exposure', scope, exp_path.name, scheme=KeyScheme.CANONICAL),
                     'application/fits'))
             if exposure_files:
                 print(f"  + {len(exposure_files)} canonical spectrum-exposure intermediates")
 
-            print(f"Uploading {len(upload_tasks)} files...")
+            total_tasks = len(upload_tasks) + len(legacy_tasks)
+            print(f"Uploading {total_tasks} files ({len(upload_tasks)} NIRSpec → OSN)...")
             success, failed, failed_msgs = upload_files_parallel(
-                config, upload_tasks, desc="R2 uploads", succeeded_out=uploaded_keys,
+                config, upload_tasks, desc="OSN uploads", succeeded_out=uploaded_keys,
+                backend='osn',
             )
+            if legacy_tasks:
+                s2, f2, m2 = upload_files_parallel(
+                    config, legacy_tasks, desc="R2 uploads (rgb/sed)",
+                    succeeded_out=uploaded_keys, backend='r2',
+                )
+                success += s2
+                failed += f2
+                failed_msgs = failed_msgs + m2
 
             if failed_msgs:
                 print(f"\n  {failed} uploads failed:")
@@ -638,7 +653,7 @@ def deploy_observation(
                     print(f"    - {msg}")
                 if len(failed_msgs) > 10:
                     print(f"    ... and {len(failed_msgs) - 10} more")
-            print(f"Uploaded {success}/{len(upload_tasks)} files")
+            print(f"Uploaded {success}/{total_tasks} files")
             print()
 
         # Generate thumbnails and enrich spectra records
@@ -831,11 +846,13 @@ def deploy_observation(
         # deploy. Shadow index — additive, nothing reads it as authoritative yet.
         if uploaded_keys:
             from campfire.deploy.registry import (
-                build_registry_rows, resolve_backend_label, upsert_storage_objects,
+                build_registry_rows, upsert_storage_objects,
             )
+            # upload_tasks are the NIRSpec products, homed on OSN under canonical
+            # keys (rgb/sed are in legacy_tasks and never register). backend='osn'.
             reg_rows = build_registry_rows(
                 upload_tasks,
-                backend=resolve_backend_label(config),
+                backend='osn',
                 deployment_id=deployment_id,
                 uploaded_by=user_id,
                 cfpipe_version=summary.meta.get('cfpipe_version'),
@@ -1003,7 +1020,7 @@ def deploy_json(
     if dry_run:
         print("=== DRY RUN ===")
         for path in spec_paths[:5]:
-            print(f"  {path.name} -> {storage_key('spectrum_json', Scope(obs=obs_name), f'{path.stem}.json')}")
+            print(f"  {path.name} -> {storage_key('spectrum_json', Scope(obs=obs_name), f'{path.stem}.json', scheme=KeyScheme.CANONICAL)}")
         if len(spec_paths) > 5:
             print(f"  ... and {len(spec_paths) - 5} more")
         return
@@ -1013,13 +1030,16 @@ def deploy_json(
 
     try:
         print("Generating JSON files...")
+        scope = Scope(obs=obs_name)
         tasks = []
         for path in tqdm(spec_paths, desc="Generating", unit="file"):
             json_path = generate_spectrum_json(path, temp_dir)
-            tasks.append(UploadTask(json_path, storage_key('spectrum_json', Scope(obs=obs_name), json_path.name), 'application/json'))
+            tasks.append(UploadTask(json_path, storage_key('spectrum_json', scope, json_path.name, scheme=KeyScheme.CANONICAL), 'application/json'))
 
-        print("Uploading...")
-        success, failed, failed_msgs = upload_files_parallel(config, tasks, desc="JSON files")
+        print("Uploading to OSN...")
+        uploaded_keys: set[str] = set()
+        success, failed, failed_msgs = upload_files_parallel(
+            config, tasks, desc="JSON files", succeeded_out=uploaded_keys, backend='osn')
 
         if failed_msgs:
             print(f"\n  {failed} failed:")
@@ -1027,6 +1047,17 @@ def deploy_json(
                 print(f"    - {msg}")
 
         print(f"Uploaded {success}/{len(spec_paths)} JSON files")
+
+        # Refresh registry rows for the re-uploaded canonical objects so the served
+        # OSN bytes and the recorded sha256 stay consistent (epic #210 / #216).
+        # deployment_id stays NULL — a content-only refresh records no deployment;
+        # the next full `deploy --obs` re-links provenance.
+        if uploaded_keys:
+            from campfire.deploy.registry import build_registry_rows, upsert_storage_objects
+            sb = get_supabase_client(config)
+            reg_rows = build_registry_rows(tasks, backend='osn', succeeded_keys=uploaded_keys)
+            n_reg = upsert_storage_objects(sb, reg_rows)
+            print(f"Registered {n_reg} storage objects")
     finally:
         if temp_dir.exists():
             shutil.rmtree(temp_dir)
@@ -1072,13 +1103,16 @@ def deploy_zfit(
 
     try:
         print("Generating zfit JSON files...")
+        scope = Scope(obs=obs_name)
         tasks = []
         for path in zfit_paths:
             json_path = generate_zfit_json(path, temp_dir)
-            tasks.append(UploadTask(json_path, storage_key('zfit', Scope(obs=obs_name), json_path.name), 'application/json'))
+            tasks.append(UploadTask(json_path, storage_key('zfit', scope, json_path.name, scheme=KeyScheme.CANONICAL), 'application/json'))
 
-        print("Uploading...")
-        success, failed, failed_msgs = upload_files_parallel(config, tasks, desc="Zfit JSON")
+        print("Uploading to OSN...")
+        uploaded_keys: set[str] = set()
+        success, failed, failed_msgs = upload_files_parallel(
+            config, tasks, desc="Zfit JSON", succeeded_out=uploaded_keys, backend='osn')
 
         if failed_msgs:
             print(f"\n  {failed} failed:")
@@ -1086,6 +1120,16 @@ def deploy_zfit(
                 print(f"    - {msg}")
 
         print(f"Uploaded {success}/{len(zfit_paths)} zfit JSON files")
+
+        # Refresh registry rows for the re-uploaded canonical objects so the served
+        # OSN bytes and the recorded sha256 stay consistent (epic #210 / #216).
+        # Must run before `finally` removes temp_dir (build_registry_rows hashes the
+        # local files). deployment_id stays NULL (content-only refresh).
+        if uploaded_keys:
+            from campfire.deploy.registry import build_registry_rows, upsert_storage_objects
+            reg_rows = build_registry_rows(tasks, backend='osn', succeeded_keys=uploaded_keys)
+            n_reg = upsert_storage_objects(get_supabase_client(config), reg_rows)
+            print(f"Registered {n_reg} storage objects")
     finally:
         if temp_dir.exists():
             shutil.rmtree(temp_dir)

--- a/python/campfire/deploy/r2.py
+++ b/python/campfire/deploy/r2.py
@@ -14,9 +14,13 @@ Supports two upload modes:
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import NamedTuple, Optional
+from urllib.parse import urlparse
 
 import requests as http_requests
 from tqdm import tqdm
+
+# A returned presigned URL on this host means the web route signed R2, not OSN.
+_R2_PRESIGN_HOST_FRAGMENT = 'r2.cloudflarestorage.com'
 
 
 class UploadTask(NamedTuple):
@@ -62,6 +66,7 @@ def request_presigned_urls(
     tasks: list[UploadTask],
     bucket: str = 'data',
     cache_control: Optional[str] = None,
+    backend: str = 'r2',
 ) -> Optional[dict[str, str]]:
     """
     Request presigned PutObject URLs from the web API in batches.
@@ -76,6 +81,11 @@ def request_presigned_urls(
         Bucket identifier: 'data' or 'tiles'.
     cache_control : str, optional
         Cache-Control header to set on uploaded objects.
+    backend : str
+        Storage backend to sign against: 'r2' (default) or 'osn'. 'osn' signs
+        canonical data keys against the OSN bucket (epic #210 / #216 — deploy →
+        OSN); the web route requires ``backend='osn'`` to be implemented for this
+        to land in OSN rather than R2 (see the host guard in upload_files_parallel).
 
     Returns
     -------
@@ -97,6 +107,7 @@ def request_presigned_urls(
         batch = tasks[i:i + PRESIGN_BATCH_SIZE]
         payload = {
             'bucket': bucket,
+            'backend': backend,
             'uploads': [
                 {'key': t.r2_key, 'content_type': t.content_type}
                 for t in batch
@@ -115,6 +126,28 @@ def request_presigned_urls(
             return None
 
     return all_urls
+
+
+def _assert_presigned_backend_osn(urls: dict[str, str]) -> None:
+    """Fail loudly if OSN was requested but the web route returned R2-host URLs.
+
+    A web deployment that predates OSN upload support ignores the ``backend``
+    field and signs the R2 'data' bucket. Uploading there would land bytes in R2
+    under canonical keys while the deploy registers ``backend='osn'`` — a silent
+    divergence between what the registry points at (OSN) and where bytes live
+    (R2). Refuse before any upload so the operator updates/redeploys the web app.
+    """
+    r2_signed = [
+        key for key, url in urls.items()
+        if _R2_PRESIGN_HOST_FRAGMENT in urlparse(url).netloc
+    ]
+    if r2_signed:
+        raise RuntimeError(
+            "Requested OSN presigned uploads but the deploy API returned R2 URLs "
+            f"(e.g. {r2_signed[0]}). The web deployment predates OSN upload support "
+            "(the /api/v1/deploy/presign route must accept backend='osn'). Update and "
+            "redeploy the web app before deploying NIRSpec products to OSN."
+        )
 
 
 def _upload_to_presigned_url(url: str, local_path: Path, content_type: str) -> None:
@@ -301,12 +334,13 @@ def upload_files_parallel(
     desc: str = 'Uploading',
     cache_control: Optional[str] = None,
     succeeded_out: Optional[set[str]] = None,
+    backend: str = 'r2',
 ) -> tuple[int, int, list[str]]:
     """
-    Upload files to R2, using presigned URLs if available, else direct boto3.
+    Upload files to the data store, using presigned URLs if available, else boto3.
 
-    This is the main entry point for all R2 uploads. It tries presigned URLs
-    first (no R2 credentials needed), falling back to direct boto3 upload.
+    This is the main entry point for all uploads. It tries presigned URLs first
+    (no local object-store credentials needed), falling back to direct boto3.
 
     Parameters
     ----------
@@ -325,6 +359,11 @@ def upload_files_parallel(
     succeeded_out : set[str], optional
         If given, collects the ``r2_key`` of each successfully-uploaded object so
         the caller can register exactly what landed (used for storage_objects).
+    backend : str
+        Destination backend: 'r2' (default) or 'osn'. 'osn' routes NIRSpec
+        canonical products to OSN (epic #210 / #216). The presigned path signs
+        against OSN via the web route; the direct-boto3 fallback resolves the
+        'osn' purpose (CAMPFIRE_S3_OSN_*).
 
     Returns
     -------
@@ -335,8 +374,16 @@ def upload_files_parallel(
         return 0, 0, []
 
     # Try presigned URL mode first
-    urls = request_presigned_urls(config, tasks, bucket=bucket_id, cache_control=cache_control)
+    urls = request_presigned_urls(
+        config, tasks, bucket=bucket_id, cache_control=cache_control, backend=backend,
+    )
     if urls:
+        # Guard against a web deployment that predates OSN upload support: an old
+        # /deploy/presign ignores `backend` and signs R2, which would land bytes in
+        # R2 under canonical keys while the registry records backend='osn' — silent
+        # divergence. Refuse if we asked for OSN but got R2-host URLs.
+        if backend == 'osn':
+            _assert_presigned_backend_osn(urls)
         return upload_files_presigned(
             urls, tasks, max_workers=max_workers, desc=desc, succeeded_out=succeeded_out,
         )
@@ -346,10 +393,13 @@ def upload_files_parallel(
         PURPOSE_SECTIONS, make_s3_client, resolve_backend,
     )
 
-    purpose = 'tiles' if bucket_id == 'tiles' else 'data'
+    if backend == 'osn':
+        purpose = 'osn'
+    else:
+        purpose = 'tiles' if bucket_id == 'tiles' else 'data'
     if PURPOSE_SECTIONS[purpose] not in config:
         raise ValueError(
-            f"No storage credentials available for the '{bucket_id}' bucket. "
+            f"No storage credentials available for the '{purpose}' backend. "
             "Run 'campfire login' to use presigned URLs, or provide storage "
             "credentials in deploy config."
         )

--- a/python/tests/test_deploy_osn_routing.py
+++ b/python/tests/test_deploy_osn_routing.py
@@ -1,0 +1,126 @@
+"""Unit tests for deploy → OSN routing (epic #210 / #216).
+
+Pure/mocked: the presign request carries the ``backend`` field, the OSN-host
+guard rejects R2 URLs (a web deployment that predates OSN upload support), and
+canonical NIRSpec keys map to ``backend='osn'`` registry rows with the right
+identity. The full upload + registry round-trip is exercised live against local
+Supabase in CI (``campfire deploy --obs … --local``).
+"""
+import types
+
+import pytest
+
+from campfire.deploy import r2 as r2mod
+from campfire.deploy.r2 import UploadTask, _assert_presigned_backend_osn
+from campfire.deploy.registry import row_for_key
+from campfire_layout import KeyScheme, Scope, storage_key
+
+OSN_URL = (
+    "https://uaz1.osn.mghpcc.org/campfire-jwst/"
+    "data/products/nirspec/o/x_spec.fits?X-Amz-Signature=abc"
+)
+R2_URL = (
+    "https://acct.r2.cloudflarestorage.com/campfire/"
+    "data/products/nirspec/o/x_spec.fits?X-Amz-Signature=abc"
+)
+
+
+# --- OSN-host guard ---------------------------------------------------------
+
+def test_assert_presigned_backend_osn_passes_for_osn_hosts():
+    _assert_presigned_backend_osn({"k1": OSN_URL, "k2": OSN_URL})  # no raise
+
+
+def test_assert_presigned_backend_osn_raises_on_any_r2_host():
+    with pytest.raises(RuntimeError, match="predates OSN upload support"):
+        _assert_presigned_backend_osn({"k1": OSN_URL, "k2": R2_URL})
+
+
+# --- presign request carries the backend ------------------------------------
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._p = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return {"urls": {u["key"]: OSN_URL for u in self._p["uploads"]}}
+
+
+def test_request_presigned_urls_sends_backend(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        captured.update(json)
+        return _FakeResp(json)
+
+    monkeypatch.setattr(r2mod, "http_requests", types.SimpleNamespace(post=fake_post))
+    monkeypatch.setattr(r2mod, "_get_presign_headers", lambda cfg: {"Authorization": "Bearer x"})
+    monkeypatch.setattr(r2mod, "_get_presign_base_url", lambda: "https://example.com/api/v1")
+
+    task = UploadTask(tmp_path / "x.fits", "data/products/nirspec/o/x_spec.fits", "application/fits")
+    urls = r2mod.request_presigned_urls({}, [task], backend="osn")
+    assert captured["backend"] == "osn"
+    assert urls == {task.r2_key: OSN_URL}
+
+
+def test_upload_files_parallel_threads_backend_and_guards(monkeypatch, tmp_path):
+    f = tmp_path / "x.fits"
+    f.write_bytes(b"\x00")
+    task = UploadTask(f, "data/products/nirspec/o/x_spec.fits", "application/fits")
+
+    # A web deployment without OSN support signs R2 → the guard must abort.
+    monkeypatch.setattr(r2mod, "request_presigned_urls", lambda *a, **k: {task.r2_key: R2_URL})
+    with pytest.raises(RuntimeError, match="predates OSN upload support"):
+        r2mod.upload_files_parallel({}, [task], backend="osn")
+
+    # With OSN URLs the backend is threaded through and the upload proceeds.
+    seen = {}
+
+    def fake_presign(config, tasks, **kw):
+        seen.update(kw)
+        return {t.r2_key: OSN_URL for t in tasks}
+
+    monkeypatch.setattr(r2mod, "request_presigned_urls", fake_presign)
+    monkeypatch.setattr(r2mod, "upload_files_presigned", lambda urls, tasks, **kw: (len(tasks), 0, []))
+    success, failed, msgs = r2mod.upload_files_parallel({}, [task], backend="osn")
+    assert seen["backend"] == "osn"
+    assert (success, failed, msgs) == (1, 0, [])
+
+
+# --- canonical/osn row shape (what makes the upsert idempotent) -------------
+
+SHA = "sha256:" + "a" * 64
+
+
+def test_canonical_final_registers_as_osn_with_canonical_key():
+    canon = storage_key(
+        "nirspec_spec", Scope(obs="ember_egs_p1"),
+        "ember_egs_p1_prism_clear_123_spec.fits", scheme=KeyScheme.CANONICAL,
+    )
+    row = row_for_key(canon, backend="osn", content_hash=SHA, size_bytes=1,
+                      content_type="application/fits")
+    assert row["backend"] == "osn"
+    assert row["bucket"] == "data"
+    assert row["storage_key"] == canon == "data/products/nirspec/ember_egs_p1/ember_egs_p1_prism_clear_123_spec.fits"
+    assert row["product_type"] == "nirspec_spec"
+    assert row["observation"] == "ember_egs_p1"
+    assert row["exposure_ref"] is None  # finals never collide on the partial-unique
+
+
+def test_canonical_exposure_row_carries_osn_key_and_exposure_ref():
+    # The A1 migration wrote (osn, data, <canonical key>) for this exposure. A
+    # re-deploy now writes the SAME conflict tuple, so upsert_storage_objects
+    # UPDATEs in place instead of inserting a colliding legacy/r2 row — the fix
+    # for the partial-unique (product_type, exposure_ref) WHERE status='active'.
+    fname = "jw07076020001_04101_00001_nrs1_117757.fits"
+    canon = storage_key("nirspec_spectrum_exposure", Scope(obs="ember_egs_p1"),
+                        fname, scheme=KeyScheme.CANONICAL)
+    row = row_for_key(canon, backend="osn", content_hash=SHA, size_bytes=1,
+                      content_type="application/fits")
+    assert row["backend"] == "osn"
+    assert row["storage_key"].startswith("data/products/nirspec/")
+    assert row["product_type"] == "nirspec_spectrum_exposure"
+    assert row["exposure_ref"] == "jw07076020001_04101_00001_nrs1_117757"

--- a/web/app/api/v1/deploy/presign/route.ts
+++ b/web/app/api/v1/deploy/presign/route.ts
@@ -3,7 +3,13 @@ import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { validateAuth } from '@/lib/api-auth';
 import { createClient } from '@supabase/supabase-js';
-import { getS3Client, getBucketName, type StoragePurpose } from '@/lib/storage';
+import {
+  getS3Client,
+  getBucketName,
+  getOsnWriteClient,
+  getOsnWriteBucket,
+  type StoragePurpose,
+} from '@/lib/storage';
 import { isKnownKey } from '@/lib/layout';
 
 const MAX_BATCH_SIZE = 500;
@@ -18,6 +24,9 @@ const PRESIGN_EXPIRY_SECONDS = 3600; // 1 hour
  * Request body:
  * {
  *   bucket: "data" | "tiles",
+ *   backend?: "r2" | "osn",   // default "r2"; "osn" signs against the OSN data
+ *                             // bucket (epic #210 / #216 — deploy → OSN). Only
+ *                             // valid with bucket="data".
  *   uploads: [
  *     { key: "spectra/obs_name/file.fits", content_type: "application/fits" },
  *     ...
@@ -64,7 +73,7 @@ export async function POST(request: NextRequest) {
 
     // Parse request
     const body = await request.json();
-    const { bucket: bucketId = 'data', uploads, cache_control } = body;
+    const { bucket: bucketId = 'data', backend = 'r2', uploads, cache_control } = body;
 
     if (!uploads || !Array.isArray(uploads) || uploads.length === 0) {
       return NextResponse.json(
@@ -87,6 +96,21 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    if (backend !== 'r2' && backend !== 'osn') {
+      return NextResponse.json(
+        { error: 'invalid_request', error_description: 'backend must be "r2" or "osn"' },
+        { status: 400 }
+      );
+    }
+
+    // OSN holds only data-bucket products (tiles stay on R2 permanently).
+    if (backend === 'osn' && bucketId !== 'data') {
+      return NextResponse.json(
+        { error: 'invalid_request', error_description: 'backend "osn" is only valid with bucket "data"' },
+        { status: 400 }
+      );
+    }
+
     // Allowlist: every key must be a contract-valid key for the requested bucket.
     // Rejects traversal/unsafe keys and anything outside the layout contract, so
     // a presign can never sign an arbitrary or out-of-tree object.
@@ -100,10 +124,12 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Resolve the storage client + bucket for the requested purpose.
-    const purpose = bucketId as StoragePurpose;
-    const client = getS3Client(purpose);
-    const bucket = getBucketName(purpose);
+    // Resolve the storage client + bucket. The key allowlist above is keyed on the
+    // logical bucket ('data'/'tiles'); the signing target is chosen by `backend`:
+    // 'osn' signs canonical data keys against the OSN bucket with write creds,
+    // 'r2' keeps today's behavior (R2 'data'/'tiles' purpose).
+    const client = backend === 'osn' ? getOsnWriteClient() : getS3Client(bucketId as StoragePurpose);
+    const bucket = backend === 'osn' ? getOsnWriteBucket() : getBucketName(bucketId as StoragePurpose);
 
     // Generate presigned URLs in parallel
     const urlEntries = await Promise.all(

--- a/web/lib/storage.test.ts
+++ b/web/lib/storage.test.ts
@@ -22,6 +22,17 @@ function setR2Env() {
   vi.stubEnv('S3_ENDPOINT', 'https://acct.r2.cloudflarestorage.com');
 }
 
+// OSN *write* creds (deploy presign) reuse the shared S3_OSN_* endpoint/bucket
+// but carry their own RW keys (S3_OSN_RW_*), distinct from the RO read creds.
+function setOsnWriteEnv() {
+  vi.stubEnv('S3_OSN_RW_ACCESS_KEY_ID', 'rwak');
+  vi.stubEnv('S3_OSN_RW_SECRET_ACCESS_KEY', 'rwsk');
+  vi.stubEnv('S3_OSN_BUCKET_NAME', 'campfire-jwst');
+  vi.stubEnv('S3_OSN_ENDPOINT', 'https://uaz1.osn.mghpcc.org/');
+  vi.stubEnv('S3_OSN_REGION', 'us-east-1');
+  vi.stubEnv('S3_OSN_FORCE_PATH_STYLE', 'true');
+}
+
 beforeEach(() => vi.resetModules());
 afterEach(() => vi.unstubAllEnvs());
 
@@ -52,5 +63,29 @@ describe('dual-read storage resolution (storage.ts)', () => {
     setR2Env();
     const { getBucketNameForBackend } = await import('./storage');
     expect(getBucketNameForBackend('r2')).toBe('campfire');
+  });
+});
+
+describe('OSN write client for deploy presign (storage.ts)', () => {
+  it('resolves the OSN write bucket from S3_OSN_RW_* + shared S3_OSN_*', async () => {
+    setOsnWriteEnv();
+    const { getOsnWriteBucket } = await import('./storage');
+    expect(getOsnWriteBucket()).toBe('campfire-jwst');
+  });
+
+  it('throws when write creds are missing even if read creds are present', async () => {
+    setOsnEnv(); // RO creds only (S3_OSN_ACCESS_KEY_ID, no S3_OSN_RW_*)
+    const { getOsnWriteClient } = await import('./storage');
+    expect(() => getOsnWriteClient()).toThrow(/write credentials/i);
+  });
+
+  it('caches the OSN write client and keeps it distinct from the RO client', async () => {
+    setOsnEnv();
+    setOsnWriteEnv();
+    const { getOsnWriteClient, getS3ClientForBackend } = await import('./storage');
+    const w1 = getOsnWriteClient();
+    const w2 = getOsnWriteClient();
+    expect(w1).toBe(w2); // cached
+    expect(getS3ClientForBackend('osn')).not.toBe(w1); // RO read client is separate
   });
 });

--- a/web/lib/storage.ts
+++ b/web/lib/storage.ts
@@ -193,3 +193,63 @@ export function getS3ClientForBackend(b: DataBackend): S3Client {
 export function getBucketNameForBackend(b: DataBackend): string {
   return b === 'r2' ? getBucketName('data') : resolveOsnBackend().bucket;
 }
+
+// ---------------------------------------------------------------------------
+// OSN *write* client (deploy upload presigning, epic #210 / #216).
+//
+// The dual-read above uses read-only OSN creds (S3_OSN_*). Minting presigned
+// PutObject URLs for the deploy path requires write creds, kept distinct and
+// least-privilege: S3_OSN_RW_* (endpoint/bucket/region/path-style reuse the
+// shared S3_OSN_* block). Used ONLY by the admin-gated /api/v1/deploy/presign
+// route handler — never shipped to the browser, never used for reads.
+// ---------------------------------------------------------------------------
+
+/** Resolve the OSN write backend from S3_OSN_RW_* (+ shared S3_OSN_* config). */
+function resolveOsnWriteBackend(): BackendConfig {
+  const accessKeyId = env('S3_OSN_RW_ACCESS_KEY_ID');
+  const secretAccessKey = env('S3_OSN_RW_SECRET_ACCESS_KEY');
+  const bucket = env('S3_OSN_BUCKET_NAME');
+  const endpointRaw = env('S3_OSN_ENDPOINT');
+  const region = env('S3_OSN_REGION') || 'auto';
+  const forcePathStyle = coerceBool(env('S3_OSN_FORCE_PATH_STYLE'));
+
+  if (!accessKeyId || !secretAccessKey || !bucket || !endpointRaw) {
+    throw new Error(
+      'OSN write credentials not configured (set S3_OSN_RW_ACCESS_KEY_ID / ' +
+        'S3_OSN_RW_SECRET_ACCESS_KEY plus the shared S3_OSN_ENDPOINT / S3_OSN_BUCKET_NAME)',
+    );
+  }
+
+  return {
+    purpose: 'data',
+    backend: 'osn',
+    endpoint: endpointRaw.replace(/\/+$/, ''),
+    region,
+    bucket,
+    accessKeyId,
+    secretAccessKey,
+    forcePathStyle,
+  };
+}
+
+const _osnWriteClient = new Map<'osn', S3Client>();
+
+/** S3 client with OSN *write* creds, for presigning deploy PutObject URLs. */
+export function getOsnWriteClient(): S3Client {
+  const cached = _osnWriteClient.get('osn');
+  if (cached) return cached;
+  const cfg = resolveOsnWriteBackend();
+  const client = new S3Client({
+    region: cfg.region,
+    endpoint: cfg.endpoint,
+    forcePathStyle: cfg.forcePathStyle,
+    credentials: { accessKeyId: cfg.accessKeyId, secretAccessKey: cfg.secretAccessKey },
+  });
+  _osnWriteClient.set('osn', client);
+  return client;
+}
+
+/** OSN bucket name for deploy writes. */
+export function getOsnWriteBucket(): string {
+  return resolveOsnWriteBackend().bucket;
+}


### PR DESCRIPTION
Closes #247. Part of epic #210 / A2 (#216).

## Why

A1 (#215) migrated ~162k NIRSpec products to **OSN** under canonical keys, and the portal now reads them from OSN (dual-read, `OSN_READ_ENABLED=true` in prod). But `campfire deploy` still wrote **R2/legacy** + `backend='r2'`, so re-deploying a migrated obs was unsafe:

- **Finals**: a 2nd active `r2`/legacy row appears; dual-read keeps serving the **old OSN bytes** (silent stale).
- **Intermediates**: the fresh `r2`/legacy row collides with the migrated `osn`/canonical row on the partial-unique `(product_type, exposure_ref) WHERE status='active'` → the registry upsert **crashes the deploy**.

## What

Route **all** NIRSpec deploys (new obs + re-deploys) to write canonical keys to OSN, reusing the presigned-upload model (no write keys on admin machines):

- **web** `app/api/v1/deploy/presign/route.ts`: accepts `backend: 'r2'|'osn'` (default r2); `'osn'` signs `PutObject` with a new **server-only** OSN write client. `lib/storage.ts`: `getOsnWriteClient()`/`getOsnWriteBucket()` read `S3_OSN_RW_*` (+ shared `S3_OSN_*`), distinct from the RO read creds. Admin check + `isKnownKey` allowlist unchanged (canonical `data/` keys already pass).
- **python** `deploy/r2.py`: `request_presigned_urls`/`upload_files_parallel` thread a `backend` param; an **OSN-host guard** aborts if a web deployment that predates OSN support signs R2 (prevents silent R2/registry divergence). `deploy/deploy.py`: `deploy_observation`, `_deploy_intermediates_only`, `deploy_json`, `deploy_zfit` build `scheme=CANONICAL` keys, upload `backend='osn'`, register `backend='osn'`. rgb/sed (dead) stay R2/legacy in a separate batch.

Same code path, two outcomes: **new** obs INSERT a fresh `osn` row; **re-deploys** hit the same `(backend,bucket,storage_key)` conflict tuple as the migrated row → **UPDATE in place** (fixes both failure modes). `spectra.fits_path` stays legacy (dual-read canonicalizes).

## Deploy ordering (important)

Requires `S3_OSN_RW_ACCESS_KEY_ID` / `S3_OSN_RW_SECRET_ACCESS_KEY` on Vercel (server-side) **and** this web change deployed **before** running a NIRSpec deploy. The python OSN-host guard fails loudly if the web route hasn't been updated yet, so there's no silent mis-route.

## Tests

- python: `tests/test_deploy_osn_routing.py` (6) — presign `backend` payload, OSN-host guard, canonical/osn row shape (incl. the exposure idempotency identity). 71 python pass.
- web: 3 new in `lib/storage.test.ts` (OSN write client/bucket, RO≠RW). 108 web pass; `npm run build` green.
- Live validation pending (post-merge, after Vercel env + redeploy): re-deploy `ember_egs_p1` (UPDATE path / crash case) + a fresh obs (INSERT path).

## Out of scope (tracked separately)

Worker rewrite, NIRCam rework, default-backend flip + R2 retirement, and the pre-existing `compute_reconcile` legacy↔canonical mismatch (affects the deferred R2-retirement coverage gate, not the deploy path).

Generated with Claude Code

https://claude.ai/code/session_01QMm3DuLALxzNtLBUQqPfkR
