### PR TITLE
fix(#228): reconcile can_inspect/handle_new_user schema drift

### DIFF
--- a/supabase/migrations/20260701000000_reconcile_can_inspect_handle_new_user_body_drift.sql
+++ b/supabase/migrations/20260701000000_reconcile_can_inspect_handle_new_user_body_drift.sql
@@ -1,0 +1,81 @@
+-- Reconcile can_inspect() and handle_new_user() with the declarative schema
+-- files (fixes #228).
+--
+-- Root cause: the applied definitions from
+-- 20260625000000_open_registration_and_can_inspect.sql are functionally
+-- identical to supabase/schemas/functions.sql (can_inspect) and
+-- supabase/schemas/triggers.sql (handle_new_user), but differ in keyword case
+-- and inline comments. migra (under `supabase db diff`) compares function
+-- bodies (pg_proc.prosrc) verbatim, so those cosmetic differences made every
+-- unrelated migration re-emit both functions.
+--
+-- This is NOT a search_path issue: both the applied migration and the schema
+-- files already pin `SET search_path = public`. This migration only aligns the
+-- stored body text with the schema files so future `db diff` runs are clean.
+-- No behavioral change; CREATE OR REPLACE keeps the on_auth_user_created
+-- trigger's dependency on handle_new_user() intact (no DROP ... CASCADE).
+
+CREATE OR REPLACE FUNCTION public.can_inspect()
+RETURNS boolean
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT COALESCE(
+    (SELECT can_inspect FROM user_profiles WHERE user_id = auth.uid()),
+    false
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.handle_new_user() RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_base text;
+    v_username text;
+    v_full_name text;
+    v_suffix integer := 0;
+BEGIN
+    -- Only handle genuine self-service signups.
+    IF NEW.raw_user_meta_data->>'self_signup' IS DISTINCT FROM 'true' THEN
+        RETURN NEW;
+    END IF;
+
+    -- Derive a username candidate from metadata or the email local-part, then
+    -- coerce it to satisfy user_profiles_username_check
+    -- (^[a-z0-9][a-z0-9._-]{0,38}[a-z0-9]$).
+    v_base := lower(coalesce(
+        nullif(NEW.raw_user_meta_data->>'username', ''),
+        split_part(NEW.email, '@', 1)
+    ));
+    v_base := regexp_replace(v_base, '[^a-z0-9._-]', '', 'g');
+    v_base := regexp_replace(v_base, '^[._-]+', '');
+    v_base := regexp_replace(v_base, '[._-]+$', '');
+    IF length(v_base) < 2 THEN
+        v_base := 'user' || v_base;
+    END IF;
+    v_base := left(v_base, 38);
+    v_base := regexp_replace(v_base, '[._-]+$', '');
+
+    v_full_name := coalesce(nullif(NEW.raw_user_meta_data->>'full_name', ''), v_base);
+
+    -- De-duplicate with a numeric suffix if needed.
+    v_username := v_base;
+    WHILE EXISTS (SELECT 1 FROM public.user_profiles WHERE username = v_username) LOOP
+        v_suffix := v_suffix + 1;
+        v_username := left(v_base, 39 - length(v_suffix::text)) || v_suffix::text;
+    END LOOP;
+
+    INSERT INTO public.user_profiles (
+        user_id, username, full_name,
+        is_group_account, can_comment, can_inspect, is_admin
+    )
+    VALUES (
+        NEW.id, v_username, v_full_name,
+        false, true, false, false
+    )
+    ON CONFLICT (user_id) DO NOTHING;
+
+    RETURN NEW;
+END;
+$$;


### PR DESCRIPTION
Closes #228.

## What & why

`supabase db diff` on a clean `main` re-emitted `public.can_inspect()` and `public.handle_new_user()` on top of every unrelated migration. Five migrations since #195 had to hand-strip the spurious churn:

- `20260629014642_add_deploy_status_lifecycle.sql` (B1)
- `20260629025904_add_intermediate_lifecycle_b2.sql` (B2)
- `20260629032458_add_deploy_scope_state_b4.sql` (B4)
- `20260629131409_b5_rename_draft_and_nullable_deployed_by.sql` (B5)
- `20260629153142_unified_storage_download_layer.sql`

## Root cause (corrected from the issue)

The issue attributes the drift to a missing `SET search_path`, but that's not the cause. **Both** the applied migration (`20260625000000_open_registration_and_can_inspect.sql:33,91`) and the declarative schema files already pin `SET search_path = public`. `SET search_path = public` and `SET search_path TO 'public'` normalize to the same stored `proconfig`, so search_path is identical on both sides of the diff — there is **no `SECURITY DEFINER` hardening gap**, and the "applied DB carries `SET search_path`" acceptance criterion was already satisfied.

The real cause is that migra compares function bodies (`pg_proc.prosrc`) **verbatim**, and the applied bodies differ from the declarative schema files only in **keyword case** (`select`/`begin`/`if` lowercase in the migration vs uppercase in the schema files) and, for `handle_new_user`, **inline comments** present in the schema file but absent from the migration. Those cosmetic differences alone were enough to make `db diff` re-emit both functions. The `SET search_path TO 'public'` line appearing in the diff output is just `pg_get_functiondef` rendering the complete definition, not evidence of a missing attribute.

## Fix

A new migration `CREATE OR REPLACE`s both functions with bodies copied **byte-for-byte** from `supabase/schemas/functions.sql` (`can_inspect`) and `supabase/schemas/triggers.sql` (`handle_new_user`), so the migrations-built DB's `prosrc` becomes identical to the schema-files DB's `prosrc` and future diffs stay clean. `CREATE OR REPLACE` (no `DROP ... CASCADE`) preserves the `on_auth_user_created` trigger's dependency on `handle_new_user()`.

This is a pure reconciliation — SQL is case-insensitive at execution and comments are ignored, so there is **no behavioral change**.

## Verification

- Diffed the migration's two `CREATE OR REPLACE FUNCTION` statements against the schema-file regions: **byte-identical** for both functions.
- Confirmed both functions already carry `SET search_path = public` in the applied migration and schema files, and that all attributes (`STABLE`/`SECURITY DEFINER`/language) match — so `prosrc` was the only differing dimension.

`supabase db diff` was not run in CI-less form here (it needs a local Docker/Postgres stack, unavailable in this environment) — the same constraint under which the five prior migrations were hand-authored. The byte-identity check is the definitive equivalent since migra's function comparison is a verbatim `prosrc` comparison.

## Acceptance criteria

- [x] `supabase db diff` on `main` no longer re-emits `can_inspect()` / `handle_new_user()` (migration `prosrc` now byte-identical to schema files)
- [x] Both functions carry `SET search_path TO 'public'` in the applied DB — note: this was **already** true before this PR; retained, not newly added

## Scope

Touches only `supabase/` (one new migration), so no `pipeline/CHANGELOG.md` entry is required per CLAUDE.md.

Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHg3uQoqf77RZxZ7zrRRST)_