### PR TITLE
fix(deploy): route photometry_pz sidecars to OSN canonical

### DIFF
--- a/python/campfire/deploy/deploy.py
+++ b/python/campfire/deploy/deploy.py
@@ -473,15 +473,17 @@ def deploy_observation(
         if force_overwrite:
             print("!! FORCE OVERWRITE: inspection data will be reset")
         if not supabase_only:
-            print(f"Would upload to R2:")
+            print(f"Would upload to OSN (NIRSpec, canonical keys):")
             print(f"  {len(spec_paths)} FITS files")
             print(f"  {len(spec_paths)} spectrum JSON files")
             if zfit_paths:
                 print(f"  {len(zfit_paths)} zfit JSON files")
-            if rgb_files:
-                print(f"  {len(rgb_files)} RGB images")
-            if sed_files:
-                print(f"  {len(sed_files)} SED plots")
+            if rgb_files or sed_files:
+                print(f"Would upload to R2 (dead rgb/sed, legacy keys):")
+                if rgb_files:
+                    print(f"  {len(rgb_files)} RGB images")
+                if sed_files:
+                    print(f"  {len(sed_files)} SED plots")
         print(f"Would upsert to Supabase:")
         print(f"  Program: {program_slug}")
         print(f"  {len(objects)} object(s)")

--- a/python/campfire/deploy/photometry.py
+++ b/python/campfire/deploy/photometry.py
@@ -26,7 +26,7 @@ from astropy.table import Table
 import astropy.units as u
 from supabase import Client
 
-from campfire_layout import Scope, storage_key
+from campfire_layout import KeyScheme, Scope, storage_key
 from campfire.deploy.r2 import UploadTask, upload_files_parallel
 
 
@@ -690,7 +690,7 @@ def deploy_field_photometry(
                 if sidecar is not None:
                     has_pz = True
                     n_pz += 1
-                    r2_key = storage_key('photometry_pz', Scope(field=field, object_id=obj['object_id']))
+                    r2_key = storage_key('photometry_pz', Scope(field=field, object_id=obj['object_id']), scheme=KeyScheme.CANONICAL)
                     local_path = Path(tmpdir) / f"{obj['object_id']}_pz.json"
                     local_path.write_text(
                         json.dumps(sidecar, separators=(',', ':')),
@@ -714,13 +714,16 @@ def deploy_field_photometry(
         }
         records.append(record)
 
-    # Upload P(z) sidecars to R2
+    # Upload P(z) sidecars to OSN (epic #210 / #216 — deploy → OSN). photometry_pz
+    # is a migrated data-bucket product, so it writes CANONICAL keys to OSN with
+    # backend='osn', matching the migrated registry row in place (see the NIRSpec
+    # paths in deploy.py).
     if upload_tasks:
-        print(f"  Uploading {len(upload_tasks)} P(z) sidecars to R2...")
+        print(f"  Uploading {len(upload_tasks)} P(z) sidecars to OSN...")
         uploaded_keys: set[str] = set()
         success, failed, errors = upload_files_parallel(
             deploy_config, upload_tasks, desc="P(z) sidecars",
-            succeeded_out=uploaded_keys,
+            succeeded_out=uploaded_keys, backend='osn',
         )
         if failed:
             print(f"    WARNING: {failed} sidecar uploads failed")
@@ -730,12 +733,12 @@ def deploy_field_photometry(
         # Storage registry (#214): index the P(z) sidecars that landed.
         if uploaded_keys:
             from campfire.deploy.registry import (
-                build_registry_rows, resolve_backend_label, upsert_storage_objects,
+                build_registry_rows, upsert_storage_objects,
             )
             from campfire.deploy.supabase import get_user_id_from_token
             reg_rows = build_registry_rows(
                 upload_tasks,
-                backend=resolve_backend_label(deploy_config),
+                backend='osn',
                 uploaded_by=get_user_id_from_token(deploy_config),
                 succeeded_keys=uploaded_keys,
             )

--- a/python/tests/test_deploy_osn_routing.py
+++ b/python/tests/test_deploy_osn_routing.py
@@ -124,3 +124,19 @@ def test_canonical_exposure_row_carries_osn_key_and_exposure_ref():
     assert row["storage_key"].startswith("data/products/nirspec/")
     assert row["product_type"] == "nirspec_spectrum_exposure"
     assert row["exposure_ref"] == "jw07076020001_04101_00001_nrs1_117757"
+
+
+def test_canonical_photometry_pz_registers_as_osn_field_scoped():
+    # photometry_pz is a migrated (DEFAULT_COPY_PRODUCT_TYPES) data-bucket product;
+    # deploy_field_photometry must write it canonical+osn like the NIRSpec paths,
+    # else `campfire deploy [photometry]` silently re-creates a stale r2/legacy row.
+    canon = storage_key("photometry_pz", Scope(field="egs", object_id="egs_12345"),
+                        scheme=KeyScheme.CANONICAL)
+    row = row_for_key(canon, backend="osn", content_hash=SHA, size_bytes=1,
+                      content_type="application/json")
+    assert row["backend"] == "osn"
+    assert row["storage_key"] == canon == "data/photometry/egs/egs_12345_pz.json"
+    assert row["product_type"] == "photometry_pz"
+    assert row["field"] == "egs"
+    assert row["observation"] is None
+    assert row["exposure_ref"] is None


### PR DESCRIPTION
Part of epic #210 / A2 (#216). Follow-up to #248 (deploy → OSN).

## Why

`deploy_field_photometry` was the **last** deploy write path still sending a *migrated* data-bucket product to R2/legacy. `photometry_pz` is in `DEFAULT_COPY_PRODUCT_TYPES` (A1 migrated it to OSN), but every deploy re-wrote a **LEGACY key + R2 upload + r2-labeled registry row** — so the dual-read (which matches `storage_objects` by canonical key) kept serving the **stale OSN copy** over the freshly-deployed R2 bytes. It fires on `campfire deploy photometry` *and inline in every `campfire deploy --obs`* (photometry runs after reconcile), so it was active on normal deploys.

## What

The same three-leg fix as #248, in `photometry.py::deploy_field_photometry`:
- `storage_key('photometry_pz', …, scheme=KeyScheme.CANONICAL)`
- `upload_files_parallel(…, backend='osn')`
- `build_registry_rows(…, backend='osn')` (drop `resolve_backend_label`)

Plus a cosmetic fix to the deploy dry-run label (`"Would upload to R2"` → `OSN (NIRSpec, canonical)` / `R2 (dead rgb/sed, legacy)`).

## Comprehensive gap audit

Ran a 5-scout + completeness-critic audit of **every** object-store write path (all `upload_*`/`put_object`/`PutObjectCommand`/`storage_key` write sites across `python/campfire`, `web/app`, `scripts`, cross-checked against the layout product table). Verdict: **`photometry_pz` was the only remaining gap.** Everything else is correctly classified:

- **OSN (correct):** all NIRSpec paths (#248) + the `registry copy` tool.
- **Intentional R2 (must stay):** `tiles` (separate bucket, permanent); `rgb`/`sed` (dead, unregistered, superseded by `/api/v1/cutout`); NIRCam previews (known temporary exception, reworked separately); `scripts/archive/deploy_old.py` (dead archived code).
- **Not gaps (no writer exists today):** reserved `nirspec_manual_mask`/`stuck_shutters`/`bkg_override` + future NIRCam products — flagged to use OSN+CANONICAL if a writer is ever added.

**Invariant now holds: every deploy writes OSN except the tiles bucket.**

## Tests

`tests/test_deploy_osn_routing.py` — added `photometry_pz` canonical/osn field-scoped row assertion. 27 deploy/registry tests pass. Python-only change (no web build).

Generated with Claude Code

https://claude.ai/code/session_01QMm3DuLALxzNtLBUQqPfkR
