### PR TITLE
refactor(deploy): make login/presigned the only implicit auth path (#250)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,13 @@ campfire deploy tiles --field cosmos --filter f444w      # map tiles
 campfire deploy sync-programs                            # upsert from programs.toml
 ```
 
-Credentials via env vars (`CAMPFIRE_SUPABASE_URL`, `CAMPFIRE_S3_*`; legacy `CAMPFIRE_R2_*` accepted as aliases) or gitignored `$CAMPFIRE_ROOT/config/deploy.toml`. Storage endpoint/region/path-style are configurable per purpose (`CAMPFIRE_S3_*` for data, `CAMPFIRE_S3_TILES_*` for tiles); see `python/campfire/deploy/backend.py`.
+**Deploy auth (issue #250).** Two decisions, kept independent:
+
+- **Supabase auth mode** is chosen *explicitly*, never inferred from which creds are present:
+  - `login` (**default**): `campfire login` (device-flow OAuth). Operates through RLS; uploads go via **presigned URLs** so admin machines hold no object-store write keys. This is the only path the normal `campfire deploy` uses — presigning is required, with **no silent boto3 fallback**.
+  - `service-role` (**explicit opt-in** — `--service-role` or `CAMPFIRE_DEPLOY_MODE=service-role`): bypasses RLS for unattended / CI deploys. Needs `CAMPFIRE_SUPABASE_URL` + `CAMPFIRE_SUPABASE_SERVICE_ROLE_KEY` (or a TOML `[supabase]` block). A service-role key merely *present* in the env no longer wins by precedence.
+  - `local` (`--local` / `CAMPFIRE_DEPLOY_MODE=local`): local Supabase (127.0.0.1:54321) with the standard CLI service-role key.
+- **Object-store credentials** (`CAMPFIRE_S3_*`; legacy `CAMPFIRE_R2_*` aliases; or a gitignored `$CAMPFIRE_ROOT/config/deploy.toml`) resolve the same way in every mode and are decoupled from the Supabase decision. In `login` mode they're only needed by the direct-boto3 maintenance commands (`deploy remove`, `objects reconcile`, `registry backfill`/`copy`, tile deletion) — the LIST/HEAD/DELETE/cross-bucket-COPY ops presigned PutObject URLs can't express. Storage endpoint/region/path-style are configurable per purpose (`CAMPFIRE_S3_*` data, `CAMPFIRE_S3_TILES_*` tiles, `CAMPFIRE_S3_OSN_*` OSN); see `python/campfire/deploy/backend.py`.
 
 ## General Notes
 

--- a/python/campfire/deploy/cli.py
+++ b/python/campfire/deploy/cli.py
@@ -30,6 +30,7 @@ Multiple observations are processed serially:
     campfire deploy rgb --obs ember_uds_p4 ember_uds_p5
 """
 
+import os
 import sys
 
 import click
@@ -158,6 +159,41 @@ def _resolve_local(ctx, local: bool) -> bool:
     return bool(local) or bool((ctx.obj or {}).get('local', False))
 
 
+def _resolve_service_role(ctx) -> bool:
+    """Whether the explicit service-role escape hatch is engaged.
+
+    True when the top-level ``--service-role`` flag was passed (stored in ctx.obj)
+    or ``CAMPFIRE_DEPLOY_MODE=service-role`` is set. The env var is the universal
+    switch (works for every subcommand); the flag is convenience sugar for the
+    main deploy command. Either way it is an explicit opt-in — a service-role key
+    merely present in the environment does NOT engage it (issue #250).
+    """
+    if (ctx.obj or {}).get('service_role', False):
+        return True
+    raw = (os.environ.get('CAMPFIRE_DEPLOY_MODE') or '').strip().lower().replace('-', '_')
+    return raw in ('service_role', 'servicerole')
+
+
+def _announce_auth_mode(config: dict) -> None:
+    """Print the resolved deploy auth mode + where uploads land (issue #250 #4).
+
+    Makes the login/presigned vs service-role/direct choice obvious and
+    non-surprising up front, instead of silently inferring it from ambient creds.
+    """
+    sb = config.get('supabase', {})
+    mode = sb.get('_auth_mode')
+    if mode == 'login':
+        tm = sb.get('_token_manager')
+        email = tm.get_user_email() if tm else None
+        who = f" as {email}" if email else ""
+        print(f"Deploy auth: login{who} → presigned uploads (no local write keys).")
+    elif mode == 'service_role':
+        print("Deploy auth: service-role → direct uploads via local S3 creds "
+              "(RLS bypassed).")
+    elif mode == 'local':
+        print("Deploy auth: local Supabase → direct uploads via local S3 creds.")
+
+
 def source_ids_option(f):
     """Decorator: --source-ids."""
     f = click.option('--source-ids', multiple=True, type=str, default=None,
@@ -194,17 +230,29 @@ def source_ids_option(f):
                    'B1 lifecycle to be applied to the target DB (checked up front).')
 @click.option('--local', is_flag=True,
               help='Use local Supabase (127.0.0.1:54321).')
+@click.option('--service-role', 'service_role', is_flag=True,
+              help='Explicit escape hatch: authenticate to Supabase with a '
+                   'service-role key and upload directly with local S3 creds '
+                   '(bypasses RLS + presigned URLs). For unattended / CI deploys. '
+                   'Equivalent to CAMPFIRE_DEPLOY_MODE=service-role.')
 @click.pass_context
 def deploy_group(ctx, config_path, obs, dry_run, source_ids, supabase_only,
                  force_overwrite, auto_approve, rgb, no_sed, no_shutters,
-                 no_photometry, skip_astrometry, draft, local):
-    """Deploy CAMPFIRE pipeline products to Supabase + R2."""
+                 no_photometry, skip_astrometry, draft, local, service_role):
+    """Deploy CAMPFIRE pipeline products to Supabase + object storage."""
     ctx.ensure_object(dict)
     ctx.obj['local'] = local
+    # Propagate the flag to subcommands via the env switch load_config reads, so
+    # ``campfire deploy --service-role <sub>`` behaves like the env var everywhere.
+    if service_role:
+        os.environ['CAMPFIRE_DEPLOY_MODE'] = 'service-role'
+    ctx.obj['service_role'] = _resolve_service_role(ctx)
     if not local:
         # Gate once here (the group callback runs before every subcommand and
-        # subgroup), through the actual write client.
-        _gate_admin(load_config(config_path, local=local))
+        # subgroup), through the actual write client. Skipped for service-role
+        # (it bypasses RLS; the gate no-ops for that mode anyway).
+        _gate_admin(load_config(config_path, local=local,
+                                service_role=ctx.obj['service_role']))
 
     # When invoked without a subcommand, --obs is required
     if ctx.invoked_subcommand is None:
@@ -213,12 +261,14 @@ def deploy_group(ctx, config_path, obs, dry_run, source_ids, supabase_only,
             print("Usage: campfire deploy --obs <observation_name>")
             sys.exit(1)
 
-        config = load_config(config_path, local=local)
+        config = load_config(config_path, local=local,
+                             service_role=ctx.obj['service_role'])
+        _announce_auth_mode(config)
         multi = len(obs) > 1
         if multi and config.get('supabase', {}).get('_auth_mode') == 'login':
             print(f"  Note: deploying {len(obs)} observations on a user login "
-                  f"(token auto-refreshes). For large unattended batches, prefer "
-                  f"a service-role key (CAMPFIRE_SUPABASE_SERVICE_ROLE_KEY).")
+                  f"(the token auto-refreshes, so long batches are fine). For "
+                  f"unattended batches, --service-role is available.")
         fields_needing_rebuild: set[str] = set()
 
         for obs_name in obs:

--- a/python/campfire/deploy/config.py
+++ b/python/campfire/deploy/config.py
@@ -1,8 +1,31 @@
 """
 Configuration loading, credential resolution, and path helpers.
 
-Credential resolution (env vars take priority over TOML):
-  1. CAMPFIRE_SUPABASE_URL, CAMPFIRE_SUPABASE_SERVICE_ROLE_KEY,
+Deploy auth has ONE default — ``campfire login`` — and one explicit escape hatch.
+The two decisions that used to be tangled are now independent:
+
+  * **Supabase auth mode** — resolved from an *explicit* signal only (issue #250):
+      - ``login`` (default): the logged-in user's credentials (device-flow OAuth
+        via ``CredentialManager``). Operates through RLS; uploads go presigned.
+      - ``service_role``: opt-in via ``CAMPFIRE_DEPLOY_MODE=service-role`` (or the
+        top-level ``--service-role`` flag). Bypasses RLS; for unattended / CI runs.
+        Requires ``CAMPFIRE_SUPABASE_URL`` + ``CAMPFIRE_SUPABASE_SERVICE_ROLE_KEY``
+        (or a TOML ``[supabase]`` block). A service-role key that merely *exists*
+        in the environment no longer wins by precedence — it is ignored unless the
+        mode is explicitly requested.
+      - ``local``: ``--local`` (or ``CAMPFIRE_DEPLOY_MODE=local``) — the local
+        Supabase instance with the standard CLI service-role key.
+
+  * **Object-store credentials** — the ``data`` / ``tiles`` / ``osn`` storage
+    sections are resolved from env vars / TOML *independently of the Supabase
+    mode*. Presence of storage creds never changes the auth mode. The normal
+    deploy uploads via presigned URLs (no local write keys needed); the storage
+    sections are only consumed by the direct-boto3 maintenance paths
+    (``remove`` / ``reconcile`` / ``registry backfill`` / ``registry copy``) and
+    by ``service_role`` / ``local`` uploads.
+
+Credential source precedence (env vars take priority over TOML), per section:
+  1. CAMPFIRE_SUPABASE_URL, CAMPFIRE_SUPABASE_SERVICE_ROLE_KEY (service-role mode);
      CAMPFIRE_S3_ACCESS_KEY_ID, CAMPFIRE_S3_SECRET_ACCESS_KEY,
      CAMPFIRE_S3_BUCKET_NAME, and either CAMPFIRE_S3_ENDPOINT or
      CAMPFIRE_S3_ACCOUNT_ID (R2 host derived from the account id).
@@ -101,6 +124,19 @@ _OSN_ENV = {
 # its endpoint (an explicit endpoint, or an account_id to derive the R2 host).
 _STORAGE_REQUIRED = ('access_key_id', 'secret_access_key', 'bucket_name')
 
+# Storage config-dict section -> its env-var spec. Each is resolved independently
+# of the Supabase auth mode (issue #250): storage creds never decide who you are.
+_STORAGE_ENV = {
+    'r2': _DATA_ENV,
+    'r2_tiles': _TILES_ENV,
+    'r2_osn': _OSN_ENV,
+}
+
+# The explicit deploy-mode switch. Values (case/dash-insensitive): 'login'
+# (default), 'service-role', 'local'. The top-level --service-role / --local
+# flags override it.
+_DEPLOY_MODE_ENV = 'CAMPFIRE_DEPLOY_MODE'
+
 
 def _load_toml(path: Path) -> dict:
     """Load a TOML file and return as dict."""
@@ -127,34 +163,56 @@ def _storage_section_complete(section: dict) -> bool:
     return bool(section.get('endpoint') or section.get('account_id'))
 
 
-def _config_from_env() -> dict | None:
+def _resolve_storage_sections(toml_config: dict | None) -> dict:
+    """Resolve every storage section (data / tiles / osn) from TOML + env vars.
+
+    Storage is resolved the SAME way in every auth mode — presence of these creds
+    no longer influences who you authenticate as (issue #250). TOML seeds each
+    section; env vars override per-key (env wins, TOML fills gaps).
+
+    A section is included when it is actually usable (complete creds + resolvable
+    endpoint) or when a TOML block explicitly declared it — an intentional config
+    is honored even if partial, and ``backend.resolve_backend`` surfaces any gap
+    precisely at the point of use. A stray partial *env* section (e.g. a lone
+    ``CAMPFIRE_R2_TILES_ACCOUNT_ID``) is dropped rather than half-created.
     """
-    Build a config dict from environment variables.
-
-    Returns a config dict when Supabase service-role creds **and** a usable
-    ``data`` storage section are present, or None otherwise. The optional
-    ``tiles`` and ``osn`` sections are included when usable, but never block
-    loading.
-    """
-    supabase = _read_env_section(_SUPABASE_ENV)
-    if not all(supabase.get(k) for k in _SUPABASE_ENV):
-        return None
-
-    data = _read_env_section(_DATA_ENV)
-    if not _storage_section_complete(data):
-        return None
-
-    config: dict = {'supabase': supabase, 'r2': data}
-
-    tiles = _read_env_section(_TILES_ENV)
-    if _storage_section_complete(tiles):
-        config['r2_tiles'] = tiles
-
-    osn = _read_env_section(_OSN_ENV)
-    if _storage_section_complete(osn):
-        config['r2_osn'] = osn
-
+    config: dict = {}
+    for section_key, spec in _STORAGE_ENV.items():
+        toml_section = (toml_config or {}).get(section_key)
+        has_toml = isinstance(toml_section, dict) and bool(toml_section)
+        merged: dict = dict(toml_section) if has_toml else {}
+        merged.update(_read_env_section(spec))  # env overrides TOML per key
+        if merged and (has_toml or _storage_section_complete(merged)):
+            config[section_key] = merged
     return config
+
+
+def _resolve_deploy_mode(*, local: bool, service_role: bool) -> str:
+    """Resolve the explicit Supabase auth mode: 'login' | 'service_role' | 'local'.
+
+    Flags win over the env var; the env var wins over the 'login' default. A
+    service-role key that merely exists in the environment does NOT flip the mode
+    (that silent precedence was the issue #250 footgun) — it is used only when the
+    mode is explicitly ``service_role``.
+    """
+    if local:
+        return 'local'
+    if service_role:
+        return 'service_role'
+
+    raw = (os.environ.get(_DEPLOY_MODE_ENV) or '').strip().lower().replace('-', '_')
+    if raw in ('', 'login'):
+        return 'login'
+    if raw == 'local':
+        return 'local'
+    if raw in ('service_role', 'servicerole'):
+        return 'service_role'
+
+    print(
+        f"Error: {_DEPLOY_MODE_ENV}={os.environ.get(_DEPLOY_MODE_ENV)!r} is not a "
+        f"valid deploy mode. Use one of: login (default), service-role, local."
+    )
+    sys.exit(1)
 
 
 def _find_toml(config_path: str | None = None) -> dict | None:
@@ -184,73 +242,76 @@ _LOCAL_SUPABASE_SERVICE_ROLE_KEY = (
 )
 
 
-def load_config(config_path: str | None = None, *, local: bool = False) -> dict:
+def load_config(
+    config_path: str | None = None,
+    *,
+    local: bool = False,
+    service_role: bool = False,
+) -> dict:
     """
-    Load deployment credentials (Supabase + R2).
+    Load deployment credentials (Supabase + object storage).
 
-    Resolves Supabase auth into exactly ONE coherent mode, tagged on
-    ``config['supabase']['_auth_mode']``:
+    Object-storage sections (``r2`` / ``r2_tiles`` / ``r2_osn``) are resolved from
+    env vars + TOML in **every** mode, independently of the Supabase auth decision.
+    The Supabase auth mode — tagged on ``config['supabase']['_auth_mode']`` — is
+    chosen *explicitly*, never by which credentials happen to be lying around
+    (issue #250):
 
-      - ``local`` (``--local``): local instance (127.0.0.1:54321) with the
-        standard Supabase CLI service-role key.
-      - ``service_role``: env vars (``CAMPFIRE_SUPABASE_URL`` +
-        ``CAMPFIRE_SUPABASE_SERVICE_ROLE_KEY``) or a TOML ``[supabase]`` block
-        with ``service_role_key`` + ``url``. Bypasses RLS — the preferred path
-        for unattended / batch / CI deploys (no JWT expiry).
-      - ``login``: the logged-in user's Supabase credentials from
-        ``campfire login`` (url + anon_key + token + TokenManager, taken as a
-        matched set). Operates through RLS.
+      - ``login`` (default): the logged-in user's Supabase credentials from
+        ``campfire login`` (url + anon_key + token + TokenManager, a matched set).
+        Operates through RLS; uploads go via presigned URLs (no local write keys).
+      - ``service_role`` (``--service-role`` / ``CAMPFIRE_DEPLOY_MODE=service-role``):
+        ``CAMPFIRE_SUPABASE_URL`` + ``CAMPFIRE_SUPABASE_SERVICE_ROLE_KEY`` (or a TOML
+        ``[supabase]`` block). Bypasses RLS — for unattended / CI deploys. A
+        service-role key present in the env is used ONLY when this mode is
+        explicitly requested; it never silently wins.
+      - ``local`` (``--local`` / ``CAMPFIRE_DEPLOY_MODE=local``): the local instance
+        (127.0.0.1:54321) with the standard Supabase CLI service-role key.
 
-    Precedence: ``--local`` > env service-role > TOML service-role > login.
-    When env or TOML supplies a service-role key, login credentials are NOT
-    injected. R2 / r2_tiles sections are always resolved from env vars / TOML.
+    ``local`` and ``service_role`` args are the flag overrides; absent them the
+    mode comes from ``CAMPFIRE_DEPLOY_MODE`` (default ``login``).
     """
-    if local:
-        base = _config_from_env() or _find_toml(config_path) or {}
-        base.setdefault('supabase', {})
-        base['supabase']['url'] = _LOCAL_SUPABASE_URL
-        base['supabase']['service_role_key'] = _LOCAL_SUPABASE_SERVICE_ROLE_KEY
-        base['supabase'].pop('supabase_token', None)
-        base['supabase'].pop('anon_key', None)
-        base['supabase'].pop('_token_manager', None)
-        base['supabase']['_auth_mode'] = 'local'
+    mode = _resolve_deploy_mode(local=local, service_role=service_role)
+    toml_config = _find_toml(config_path)
+
+    # Storage first — same in every mode, decoupled from auth.
+    base = _resolve_storage_sections(toml_config)
+
+    if mode == 'local':
+        base['supabase'] = {
+            'url': _LOCAL_SUPABASE_URL,
+            'service_role_key': _LOCAL_SUPABASE_SERVICE_ROLE_KEY,
+            '_auth_mode': 'local',
+        }
         print(f"  Using local Supabase at {_LOCAL_SUPABASE_URL}")
         return base
 
-    # 1. Environment service-role credentials. `_config_from_env` only returns a
-    #    config when both url and service_role_key are present, so this is always
-    #    service-role mode (used as-is, no login injection).
-    env_config = _config_from_env()
-    if env_config:
-        toml_config = _find_toml(config_path)
-        if toml_config:
-            for key, val in toml_config.items():
-                if key not in env_config:
-                    env_config[key] = val
-                elif isinstance(val, dict) and isinstance(env_config[key], dict):
-                    # env takes priority per-key; TOML fills any gaps (e.g. a
-                    # public_url_base configured in TOML alongside env creds).
-                    for subkey, subval in val.items():
-                        env_config[key].setdefault(subkey, subval)
-        env_config.setdefault('supabase', {})['_auth_mode'] = 'service_role'
-        return env_config
+    if mode == 'service_role':
+        # url + service_role_key from env (canonical) then TOML [supabase] gaps.
+        sb = _read_env_section(_SUPABASE_ENV)
+        toml_sb = (toml_config or {}).get('supabase', {})
+        if isinstance(toml_sb, dict):
+            for key in ('url', 'service_role_key'):
+                if not sb.get(key) and toml_sb.get(key):
+                    sb[key] = toml_sb[key]
+        if not (sb.get('url') and sb.get('service_role_key')):
+            _service_role_missing_error(config_path)
+        sb['_auth_mode'] = 'service_role'
+        base['supabase'] = sb
+        return base
 
-    # 2. TOML service-role credentials short-circuit (no login injection).
-    toml_config = _find_toml(config_path)
-    if toml_config:
-        sb = toml_config.setdefault('supabase', {})
-        if sb.get('service_role_key') and sb.get('url'):
-            sb['_auth_mode'] = 'service_role'
-            return toml_config
-
-    # 3. Logged-in user credentials (matched set), merged onto any TOML (R2 etc.).
-    base = toml_config or {}
+    # mode == 'login': inject the logged-in user's matched credential set.
     base = _inject_user_credentials(base)
     if base.get('supabase', {}).get('_auth_mode') == 'login':
         return base
 
-    # Nothing found — show helpful error
-    candidates = []
+    # Login was requested (default) but no usable session exists.
+    _no_login_error()
+
+
+def _service_role_missing_error(config_path: str | None) -> None:
+    """Explicit service-role mode was requested but creds are absent."""
+    candidates: list[str] = []
     if config_path:
         candidates.append(config_path)
     else:
@@ -258,33 +319,36 @@ def load_config(config_path: str | None = None, *, local: bool = False) -> dict:
         if root:
             candidates.append(str(Path(root) / 'config' / 'deploy.toml'))
 
-    searched = ', '.join(candidates) if candidates else '(none)'
-    # Show the canonical (neutral) env var names for the required sections.
-    env_names = (
-        [names[0] for names in _SUPABASE_ENV.values()]
-        + [_DATA_ENV[k][0] for k in _STORAGE_REQUIRED]
-    )
-
-    print("Error: No deploy credentials found.")
+    print("Error: service-role deploy mode requested, but no service-role "
+          "credentials were found.")
     print()
-    print("Option 1 — Log in with your CAMPFIRE account:")
+    print("Provide both, via environment:")
+    print(f"  export {_SUPABASE_ENV['url'][0]}=...")
+    print(f"  export {_SUPABASE_ENV['service_role_key'][0]}=...")
+    print("Or a TOML [supabase] block with url + service_role_key.")
+    if candidates:
+        print(f"  Searched: {', '.join(candidates)}")
+    print()
+    print("To deploy as yourself instead, drop the service-role mode and run:")
+    print("  campfire login")
+    sys.exit(1)
+
+
+def _no_login_error() -> None:
+    """Default (login) mode but the user isn't logged in."""
+    print("Error: Not logged in — no deploy credentials available.")
+    print()
+    print("Deploys authenticate as you by default (uploads go via presigned URLs,")
+    print("so your machine needs no object-store write keys):")
     print("  campfire login")
     print()
-    print("Option 2 — Set environment variables (service role):")
-    for name in env_names:
-        print(f"  export {name}=...")
-    # The endpoint can be given directly (OSN/MinIO/any S3) or derived from an
-    # R2 account id — one of the two is required, not both.
-    print(f"  export {_DATA_ENV['endpoint'][0]}=...        "
-          f"# e.g. https://<host>  (OSN / MinIO / S3)")
-    print(f"  # or, for Cloudflare R2:  export {_DATA_ENV['account_id'][0]}=...")
+    print("For an unattended / CI deploy, opt into service-role mode explicitly:")
+    print(f"  export {_DEPLOY_MODE_ENV}=service-role")
+    print(f"  export {_SUPABASE_ENV['url'][0]}=...")
+    print(f"  export {_SUPABASE_ENV['service_role_key'][0]}=...")
+    print("  # plus CAMPFIRE_S3_* object-store credentials for direct uploads")
     print()
-    print("Option 3 — Create a TOML config file:")
-    if candidates:
-        print(f"  Searched: {searched}")
-    else:
-        print("  Set $CAMPFIRE_ROOT and create $CAMPFIRE_ROOT/config/deploy.toml")
-        print("  Or use --config <path>")
+    print("Or target a local Supabase instance with --local.")
     sys.exit(1)
 
 

--- a/python/campfire/deploy/r2.py
+++ b/python/campfire/deploy/r2.py
@@ -1,14 +1,20 @@
 """
-Cloudflare R2 upload helpers.
+Object-store upload helpers.
 
-Supports two upload modes:
+Two upload modes, selected by the resolved deploy auth mode — NOT by a silent
+fallback (issue #250):
 
-1. **Presigned URLs** (preferred): Requests batch presigned PutObject URLs from
-   the CAMPFIRE web API and uploads directly to R2. No R2 credentials needed
-   on the client — just ``campfire login``.
+1. **Presigned URLs** (``login`` mode, the default): request batch presigned
+   PutObject URLs from the CAMPFIRE web API and upload straight to the store. No
+   object-store write credentials on the client — just ``campfire login``. If the
+   presign endpoint is unavailable the upload FAILS loudly; it never silently
+   drops to direct-boto3 (that silent switch was the footgun #250 removed).
 
-2. **Direct boto3** (legacy fallback): Uses R2 credentials from deploy config.
-   Used when presigned URL generation is not available.
+2. **Direct boto3** (``service_role`` / ``local`` mode): an explicit opt-in that
+   uses object-store credentials from the deploy config. Also the mechanism the
+   maintenance paths (``remove`` / ``reconcile`` / ``registry copy``) use for the
+   LIST / HEAD / DELETE / cross-bucket-COPY operations that presigned PutObject
+   URLs structurally cannot express.
 """
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -38,21 +44,27 @@ PRESIGN_BATCH_SIZE = 500  # Max URLs per presign request
 
 
 def _get_presign_headers(config: dict) -> Optional[dict]:
-    """Get auth headers for presign endpoint, or None if not available."""
-    sb = config.get('supabase', {})
-    token = sb.get('supabase_token')
-    if not token:
-        return None
+    """Bearer auth headers for the presign endpoint, straight from the login
+    ``TokenManager``; ``None`` when there is no usable login session.
 
-    # Try to get the access token from stored credentials for API auth
+    Authenticates directly against the stored OAuth session rather than gating on
+    ``config['supabase']['supabase_token']`` (issue #250): the presign route wants
+    the API access token, and coupling it to the Supabase token's presence is what
+    let an ambient service-role key silently disable presigned uploads.
+    """
     try:
         from campfire.api.session import resolve_base_url
         from campfire.auth.tokens import TokenManager
         tm = TokenManager(base_url=resolve_base_url())
+        if not tm.is_oauth():
+            return None
         access_token = tm.get_valid_token()
-        return {'Authorization': f'Bearer {access_token}'}
     except Exception:
         return None
+
+    if not access_token:
+        return None
+    return {'Authorization': f'Bearer {access_token}'}
 
 
 def _get_presign_base_url() -> str:
@@ -337,10 +349,13 @@ def upload_files_parallel(
     backend: str = 'r2',
 ) -> tuple[int, int, list[str]]:
     """
-    Upload files to the data store, using presigned URLs if available, else boto3.
+    Upload files to the data store, dispatching on the resolved deploy auth mode.
 
-    This is the main entry point for all uploads. It tries presigned URLs first
-    (no local object-store credentials needed), falling back to direct boto3.
+    This is the main entry point for all uploads. In ``login`` mode (the default)
+    it uploads via presigned URLs ONLY — if presigning is unavailable it raises,
+    rather than silently falling back to direct boto3 (the footgun #250 removed).
+    In the explicit ``service_role`` / ``local`` modes it uploads directly with
+    boto3 using local object-store credentials.
 
     Parameters
     ----------
@@ -373,11 +388,22 @@ def upload_files_parallel(
     if not tasks:
         return 0, 0, []
 
-    # Try presigned URL mode first
-    urls = request_presigned_urls(
-        config, tasks, bucket=bucket_id, cache_control=cache_control, backend=backend,
-    )
-    if urls:
+    # Direct boto3 is an EXPLICIT opt-in (service-role / --local), never a silent
+    # fallback. In login mode (default) uploads go only via presigned URLs.
+    mode = config.get('supabase', {}).get('_auth_mode')
+    if mode not in ('service_role', 'local'):
+        urls = request_presigned_urls(
+            config, tasks, bucket=bucket_id, cache_control=cache_control, backend=backend,
+        )
+        if not urls:
+            raise RuntimeError(
+                "Presigned upload URLs are unavailable, and login-mode deploys "
+                "upload only via presigned URLs (no direct-S3 fallback — issue #250). "
+                "This usually means the login session expired or the deploy API is "
+                "unreachable. Re-run `campfire login`; or, for an unattended run, set "
+                "CAMPFIRE_DEPLOY_MODE=service-role with CAMPFIRE_S3_* credentials to "
+                "upload directly."
+            )
         # Guard against a web deployment that predates OSN upload support: an old
         # /deploy/presign ignores `backend` and signs R2, which would land bytes in
         # R2 under canonical keys while the registry records backend='osn' — silent
@@ -388,7 +414,7 @@ def upload_files_parallel(
             urls, tasks, max_workers=max_workers, desc=desc, succeeded_out=succeeded_out,
         )
 
-    # Fall back to direct boto3 upload via the per-purpose backend factory.
+    # Explicit direct-boto3 upload via the per-purpose backend factory.
     from campfire.deploy.backend import (
         PURPOSE_SECTIONS, make_s3_client, resolve_backend,
     )

--- a/python/tests/test_deploy_auth_mode.py
+++ b/python/tests/test_deploy_auth_mode.py
@@ -25,6 +25,7 @@ _SUPABASE_ENV = (
 
 def _clear_env(monkeypatch):
     monkeypatch.delenv("CAMPFIRE_ROOT", raising=False)
+    monkeypatch.delenv("CAMPFIRE_DEPLOY_MODE", raising=False)
     for var in _SUPABASE_ENV:
         monkeypatch.delenv(var, raising=False)
 
@@ -93,7 +94,10 @@ class _LoginTM:
         return "e@x"
 
 
-def test_env_service_role_skips_login(monkeypatch):
+def test_env_service_role_key_ignored_without_optin(monkeypatch):
+    # Issue #250: a service-role key merely present in the env must NOT flip the
+    # mode. With a login session available, the default resolves to login and the
+    # ambient service-role key is ignored.
     _clear_env(monkeypatch)
     for var in _SUPABASE_ENV:
         monkeypatch.setenv(var, "x")
@@ -101,11 +105,63 @@ def test_env_service_role_skips_login(monkeypatch):
     monkeypatch.setenv("CAMPFIRE_SUPABASE_SERVICE_ROLE_KEY", "svc-key")
     monkeypatch.setattr("campfire.auth.tokens.TokenManager", _LoginTM)
 
+    config = load_config()
+    sb = config["supabase"]
+    assert sb["_auth_mode"] == "login"
+    assert sb["supabase_token"] == "login.jwt"
+    assert "service_role_key" not in sb
+    # Storage is still resolved from env, independently of the auth mode.
+    assert config["r2"]["access_key_id"] == "x"
+
+
+def test_explicit_service_role_via_env(monkeypatch):
+    _clear_env(monkeypatch)
+    for var in _SUPABASE_ENV:
+        monkeypatch.setenv(var, "x")
+    monkeypatch.setenv("CAMPFIRE_SUPABASE_URL", "https://prod.supabase.co")
+    monkeypatch.setenv("CAMPFIRE_SUPABASE_SERVICE_ROLE_KEY", "svc-key")
+    monkeypatch.setenv("CAMPFIRE_DEPLOY_MODE", "service-role")
+    monkeypatch.setattr("campfire.auth.tokens.TokenManager", _LoginTM)
+
     sb = load_config()["supabase"]
     assert sb["_auth_mode"] == "service_role"
     assert sb["service_role_key"] == "svc-key"
     assert "supabase_token" not in sb
     assert "_token_manager" not in sb
+
+
+def test_explicit_service_role_via_kwarg(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("CAMPFIRE_SUPABASE_URL", "https://prod.supabase.co")
+    monkeypatch.setenv("CAMPFIRE_SUPABASE_SERVICE_ROLE_KEY", "svc-key")
+    monkeypatch.setattr("campfire.auth.tokens.TokenManager", _LoginTM)
+
+    sb = load_config(service_role=True)["supabase"]
+    assert sb["_auth_mode"] == "service_role"
+    assert sb["service_role_key"] == "svc-key"
+
+
+def test_service_role_optin_without_creds_errors(monkeypatch):
+    # Explicit service-role but no key present -> hard error, never a silent
+    # downgrade to anon/login.
+    _clear_env(monkeypatch)
+    monkeypatch.setattr("campfire.auth.tokens.TokenManager", _LoginTM)
+    with pytest.raises(SystemExit):
+        load_config(service_role=True)
+
+
+def test_login_is_default_and_resolves_storage(monkeypatch):
+    # Logged in, storage creds present, no explicit mode -> login, and storage is
+    # still available for the maintenance/direct paths.
+    _clear_env(monkeypatch)
+    for var in ("CAMPFIRE_R2_ACCOUNT_ID", "CAMPFIRE_R2_ACCESS_KEY_ID",
+                "CAMPFIRE_R2_SECRET_ACCESS_KEY", "CAMPFIRE_R2_BUCKET_NAME"):
+        monkeypatch.setenv(var, "x")
+    monkeypatch.setattr("campfire.auth.tokens.TokenManager", _LoginTM)
+
+    config = load_config()
+    assert config["supabase"]["_auth_mode"] == "login"
+    assert config["r2"]["bucket_name"] == "x"
 
 
 def test_local_mode(monkeypatch):
@@ -131,7 +187,9 @@ def test_login_overwrites_foreign_toml_url(tmp_path, monkeypatch):
     assert sb["_token_manager"].__class__ is _LoginTM
 
 
-def test_toml_service_role_skips_login(tmp_path, monkeypatch):
+def test_toml_service_role_ignored_without_optin(tmp_path, monkeypatch):
+    # A TOML service_role_key no longer silently wins either (issue #250): with a
+    # login session the default mode is login.
     _clear_env(monkeypatch)
     monkeypatch.setattr("campfire.auth.tokens.TokenManager", _LoginTM)
     toml = tmp_path / "deploy.toml"
@@ -141,9 +199,24 @@ def test_toml_service_role_skips_login(tmp_path, monkeypatch):
     )
 
     sb = load_config(str(toml))["supabase"]
+    assert sb["_auth_mode"] == "login"
+    assert "service_role_key" not in sb
+
+
+def test_toml_service_role_used_with_optin(tmp_path, monkeypatch):
+    # The TOML [supabase] block supplies the creds when service-role is explicit.
+    _clear_env(monkeypatch)
+    monkeypatch.setattr("campfire.auth.tokens.TokenManager", _LoginTM)
+    toml = tmp_path / "deploy.toml"
+    toml.write_text(
+        '[supabase]\nurl = "https://prod.supabase.co"\n'
+        'service_role_key = "svc-key"\n'
+    )
+
+    sb = load_config(str(toml), service_role=True)["supabase"]
     assert sb["_auth_mode"] == "service_role"
+    assert sb["service_role_key"] == "svc-key"
     assert "supabase_token" not in sb
-    assert "_token_manager" not in sb
 
 
 # --------------------------------------------------------------------------

--- a/python/tests/test_deploy_upload_mode.py
+++ b/python/tests/test_deploy_upload_mode.py
@@ -1,0 +1,59 @@
+"""Tests for upload-path dispatch in ``upload_files_parallel`` (issue #250).
+
+Login mode uploads ONLY via presigned URLs and fails loudly when they are
+unavailable — it must never silently fall back to direct boto3. The explicit
+``service_role`` / ``local`` modes take the direct-boto3 path.
+"""
+from pathlib import Path
+
+import pytest
+
+from campfire.deploy import r2
+from campfire.deploy.r2 import UploadTask, upload_files_parallel
+
+
+def _task():
+    return UploadTask(Path("/nonexistent/file.fits"), "spectra/x/file.fits",
+                      "application/fits")
+
+
+def test_login_mode_no_presign_raises_not_fallback(monkeypatch):
+    # Presign unavailable + login mode -> hard error, never a boto3 fallback.
+    monkeypatch.setattr(r2, "request_presigned_urls", lambda *a, **k: None)
+    # A boto3 fallback would import the backend factory; make that explode so a
+    # silent fallback would surface as the wrong error.
+    def _boom(*a, **k):
+        raise AssertionError("login mode must not fall back to direct boto3")
+    monkeypatch.setattr("campfire.deploy.backend.resolve_backend", _boom)
+
+    config = {"supabase": {"_auth_mode": "login"}}
+    with pytest.raises(RuntimeError, match="presigned"):
+        upload_files_parallel(config, [_task()])
+
+
+def test_untagged_mode_treated_as_presigned_only(monkeypatch):
+    # A config with no explicit direct mode is treated like login: presigned only.
+    monkeypatch.setattr(r2, "request_presigned_urls", lambda *a, **k: None)
+    with pytest.raises(RuntimeError, match="presigned"):
+        upload_files_parallel({"supabase": {}}, [_task()])
+
+
+def test_service_role_mode_skips_presign_goes_direct(monkeypatch):
+    # Direct mode must NOT consult the presign endpoint at all; it goes straight
+    # to the boto3 backend (which here errors on the missing storage section).
+    called = {"presign": False}
+
+    def _presign(*a, **k):
+        called["presign"] = True
+        return {}
+    monkeypatch.setattr(r2, "request_presigned_urls", _presign)
+
+    config = {"supabase": {"_auth_mode": "service_role"}}  # no 'r2' section
+    with pytest.raises(ValueError, match="No storage credentials"):
+        upload_files_parallel(config, [_task()])
+    assert called["presign"] is False
+
+
+def test_no_tasks_short_circuits():
+    # Empty task list returns cleanly regardless of mode (no presign, no boto3).
+    assert upload_files_parallel({"supabase": {"_auth_mode": "login"}}, []) == (0, 0, [])

--- a/python/tests/test_storage_backend.py
+++ b/python/tests/test_storage_backend.py
@@ -167,14 +167,19 @@ _ALL_STORAGE_ENV = [
 @pytest.fixture
 def clean_env(monkeypatch):
     monkeypatch.delenv('CAMPFIRE_ROOT', raising=False)
+    monkeypatch.delenv('CAMPFIRE_DEPLOY_MODE', raising=False)
     for var in _ALL_STORAGE_ENV:
         monkeypatch.delenv(var, raising=False)
     return monkeypatch
 
 
 def _set_supabase(mp):
+    # These tests exercise the direct-storage path, which lives behind the
+    # explicit service-role opt-in (issue #250) — a service-role key alone no
+    # longer selects that mode.
     mp.setenv('CAMPFIRE_SUPABASE_URL', 'https://prod.supabase.co')
     mp.setenv('CAMPFIRE_SUPABASE_SERVICE_ROLE_KEY', 'svc-key')
+    mp.setenv('CAMPFIRE_DEPLOY_MODE', 'service-role')
 
 
 def test_neutral_s3_env_resolves_to_backend(clean_env):


### PR DESCRIPTION
Closes #250.

## Problem

Deploy auth tangled two decisions together — **Supabase auth** (`service_role` RLS-bypass vs `login`) and **object storage** (direct boto3 vs presigned URLs) — and let credential *presence* silently pick both. A Supabase service-role key in **either** env or TOML would (a) select service-role mode and (b) suppress `campfire login` token injection, which disabled presigned uploads and forced direct boto3. So a logged-in admin with `CAMPFIRE_*` exported in their shell deployed via direct R2 writes instead of the intended presigned path — the #247/#248 incident.

## Approach (issue #250, "login-only deploy + scoped escape hatch")

The normal `campfire deploy` needs nothing but login + presigned: RLS has full `is_admin()` policies on every table the deploy writes, and `/api/v1/deploy/presign` covers every upload. Service-role there is pure redundancy and the footgun. But a few admin/migration commands (`remove`, `reconcile`, `registry backfill`/`copy`, tile deletion) structurally need direct boto3 for LIST/HEAD/DELETE/cross-bucket-COPY — operations presigned PutObject URLs can't express. So direct/service-role survives as an **explicit, scoped escape hatch**, never a silent precedence winner.

## Changes

- **`config.py`** — object-store sections (`r2` / `r2_tiles` / `r2_osn`) now resolve identically in every mode, decoupled from the Supabase auth decision. Auth mode is chosen **explicitly**: `login` (default) | `service-role` (`--service-role` / `CAMPFIRE_DEPLOY_MODE=service-role`) | `local` (`--local`). A service-role key merely present in the env no longer flips the mode. Actionable errors for "service-role requested but no creds" and "not logged in".
- **`r2.py`** — login-mode uploads go presigned-**only** and raise loudly when presigning is unavailable, instead of silently dropping to boto3. `_get_presign_headers` authenticates straight from `TokenManager` rather than gating on `config['supabase']['supabase_token']` presence (#250 item 3).
- **`cli.py`** — top-level `--service-role` flag + a startup banner announcing the resolved auth mode and upload target (#250 item 4).
- **`CLAUDE.md`** — documents the login-first model and the decoupling.
- **Tests** — rewrote the auth-mode contract (env/TOML service-role no longer flips mode without opt-in; explicit opt-in via kwarg/env/flag; login is the default and still resolves storage); new `test_deploy_upload_mode.py` covering presigned-only dispatch with no silent fallback. 62 targeted tests green; full `python/tests` suite passes (one unrelated `matplotlib`-missing failure in the sandbox only).

## Behavior change to flag

Unattended/CI jobs that previously relied on a bare `CAMPFIRE_SUPABASE_SERVICE_ROLE_KEY` in the env must now set `CAMPFIRE_DEPLOY_MODE=service-role` (or pass `--service-role`). This is the intended "explicit, never silent" behavior; the not-logged-in error message spells it out.

Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZj42o3NAQPmjgtKAFVhbN)_