### PR TITLE
fix(reconcile): match live pointers to registry by canonical identity

### DIFF
--- a/python/campfire/deploy/registry.py
+++ b/python/campfire/deploy/registry.py
@@ -347,29 +347,56 @@ class ReconcileReport:
         )
 
 
+def _canonical_identity(key: str) -> str:
+    """Scheme-invariant identity for a storage key: its CANONICAL form, or the key
+    verbatim if it does not parse. A1 (#215) re-keyed migrated objects
+    legacy→canonical while the denormalized DB pointers (spectra.fits_path,
+    nircam_*) stayed legacy, so the vocabularies only line up under
+    canonicalization. Non-layout / unsafe keys raise and are compared as-is."""
+    try:
+        return canonical_key_for(key)
+    except Exception:
+        return key
+
+
 def compute_reconcile(
     live_pointers: Iterable[str],
     registry_keys: Iterable[str],
     bucket_keys: Optional[Iterable[str]] = None,
 ) -> ReconcileReport:
-    """Classify the three storage vocabularies against each other.
+    """Classify the three storage vocabularies against each other **by canonical
+    identity**, reporting the original keys.
 
     ``live_pointers`` = the union of denormalized DB storage keys
-    (spectra.fits_path, nircam_images.file_path, nircam_exposures png paths).
-    ``registry_keys`` = storage_objects.storage_key for the data bucket.
-    ``bucket_keys`` = actual object keys from a bucket LIST (optional; when None,
-    dangling/orphan detection is skipped — coverage is still computed).
+    (spectra.fits_path, nircam_images.file_path, nircam_exposures png paths) — all
+    LEGACY. ``registry_keys`` = storage_objects.storage_key (CANONICAL for objects
+    A1 migrated to OSN; LEGACY for the rest). ``bucket_keys`` = actual object keys
+    from a bucket LIST (optional; when None, dangling/orphan detection is skipped —
+    coverage is still computed).
+
+    #249: because A1 re-keyed migrated objects legacy→canonical while fits_path
+    stayed legacy, a naïve set difference reports every migrated final as
+    ``missing``. We collapse each key to its canonical identity for the set math
+    (legacy + canonical duplicates of the same object coincide), then report the
+    original keys so the operator sees the real fits_path / bucket key.
+
+    NOTE: ``bucket_keys`` today comes from a single data-bucket (R2) LIST; migrated
+    objects live on OSN but R2 retains their legacy copies, so canonicalizing keeps
+    dangling/orphan correct. When R2 *data* is retired (deferred A2 work), the LIST
+    must union OSN so dangling detection stays honest.
     """
-    live = {k for k in live_pointers if k}
-    registry = {k for k in registry_keys if k}
-    missing = live - registry
+    # canonical identity -> original key, per vocabulary (last-writer-wins on a
+    # legacy+canonical collision is fine: same logical object).
+    live = {_canonical_identity(k): k for k in live_pointers if k}
+    registry = {_canonical_identity(k): k for k in registry_keys if k}
+    missing = {live[c] for c in (live.keys() - registry.keys())}
 
     if bucket_keys is None:
         return ReconcileReport(missing, set(), set(), set())
 
-    bucket = {k for k in bucket_keys if k}
-    dangling = registry - bucket
-    orphans = bucket - registry
+    bucket = {_canonical_identity(k): k for k in bucket_keys if k}
+    dangling = {registry[c] for c in (registry.keys() - bucket.keys())}
+    orphans = {bucket[c] for c in (bucket.keys() - registry.keys())}
     adoptable = {k for k in orphans if is_known_key(k)}
     return ReconcileReport(missing, dangling, orphans, adoptable)
 

--- a/python/tests/test_registry.py
+++ b/python/tests/test_registry.py
@@ -204,3 +204,34 @@ def test_reconcile_no_bucket_skips_dangling_orphan():
     assert rep.dangling == set()
     assert rep.orphans == set()
     assert rep.covered
+
+
+def test_reconcile_matches_legacy_pointer_to_canonical_registry_key():
+    # #249: A1 re-keyed migrated objects legacy->canonical, but the live pointer
+    # (spectra.fits_path) stays legacy. Reconcile must match them by canonical
+    # identity, else the coverage gate falsely flags every migrated final 'missing'.
+    from campfire_layout import KeyScheme, Scope, storage_key
+    legacy = storage_key('nirspec_spec', Scope(obs='ember_egs_p1'),
+                         'ember_egs_p1_prism_clear_1_spec.fits', scheme=KeyScheme.LEGACY)
+    canonical = storage_key('nirspec_spec', Scope(obs='ember_egs_p1'),
+                            'ember_egs_p1_prism_clear_1_spec.fits', scheme=KeyScheme.CANONICAL)
+    assert legacy != canonical  # the two schemes really differ
+
+    # live pointer legacy, registry row canonical (osn) -> covered, not missing.
+    rep = reg.compute_reconcile([legacy], [canonical])
+    assert rep.missing == set()
+    assert rep.covered
+
+    # R2 retains the legacy copy in the bucket LIST -> no dangling/orphan.
+    rep2 = reg.compute_reconcile([legacy], [canonical], [legacy])
+    assert rep2.covered
+    assert rep2.dangling == set()
+    assert rep2.orphans == set()
+
+    # a genuinely unregistered pointer is still missing, reported as its ORIGINAL
+    # legacy key (not the canonical form).
+    other = storage_key('nirspec_spec', Scope(obs='ember_egs_p1'),
+                        'ember_egs_p1_prism_clear_2_spec.fits', scheme=KeyScheme.LEGACY)
+    rep3 = reg.compute_reconcile([legacy, other], [canonical])
+    assert rep3.missing == {other}
+    assert not rep3.covered


### PR DESCRIPTION
Closes #249. Part of epic #210 / A2 (#216).

## Why

A1 (#215) re-keyed migrated objects legacy→canonical, but the denormalized DB pointers (`spectra.fits_path`, `nircam_*`) stayed legacy. `compute_reconcile` compared them with a plain set difference (`live − registry`), so **every migrated NIRSpec final showed up as `missing`** and the F1 coverage gate — which the deferred R2-*data*-retirement step depends on — could never pass.

## What

`compute_reconcile` now collapses each key to its **canonical identity** (`canonical_key_for`, falling back to the verbatim key for non-layout/unsafe keys) for the `missing`/`dangling`/`orphan` set math, then **reports the original keys** so the operator still sees the real `fits_path` / bucket key. Legacy and canonical duplicates of the same object now coincide.

## Verified against prod (read-only `registry reconcile --no-bucket`)

```
spectra          : 49612 pointers |     0 missing   (all covered)   ← was ~49612 false-missings
nircam_images    :  1067 pointers |  1067 missing   (CANDIDE-CDN mosaics, no registry row)
nircam_exposures :  4320 pointers |     3 missing
```

Every migrated NIRSpec final is now covered. The residual ~1070 `missing` are **entirely NIRCam** — mosaic FITS served from the CANDIDE CDN (out of the R2/OSN data-bucket model) plus 3 unregistered previews — a separate NIRCam-registry matter (NIRCam is the known exception), not this bug.

## Scope note

`bucket_keys` still comes from an R2-only LIST. Migrated objects live on OSN, but R2 retains their legacy copies, so canonicalizing keeps `dangling`/`orphan` correct **today**. When R2 *data* is retired (deferred A2 work), the LIST must union OSN — documented in the `compute_reconcile` docstring so it isn't forgotten.

## Tests

`test_registry.py` — new `test_reconcile_matches_legacy_pointer_to_canonical_registry_key` (legacy pointer ↔ canonical row = covered; a genuinely unregistered pointer still reported missing, as its legacy key). Existing reconcile tests unchanged (they report original keys). 17 registry tests pass; Python-only, no web/DB change.

Generated with Claude Code

https://claude.ai/code/session_01QMm3DuLALxzNtLBUQqPfkR
