### PR TITLE
feat(download): storage-agnostic FITS download via credential-free proxy Worker

### DIFF
--- a/web/components/spectra/DownloadTableButtons.tsx
+++ b/web/components/spectra/DownloadTableButtons.tsx
@@ -91,12 +91,12 @@ export const DownloadDropdown: React.FC<DownloadDropdownProps> = ({
     try {
       const result = await generateFitsDownloadUrl(filters, sortColumn, sortDirection, viewMode);
 
-      if (result.error || !result.files || !result.token || !result.workerUrl) {
+      if (result.error || !result.files) {
         setError(result.error || 'Failed to generate download URL');
         return;
       }
 
-      const { files, token, workerUrl, zipFilename } = result;
+      const { files, zipFilename } = result;
       setFitsProgress({ done: 0, total: files.length });
 
       // Fetch files in parallel with concurrency limit
@@ -110,10 +110,9 @@ export const DownloadDropdown: React.FC<DownloadDropdownProps> = ({
         while (queue.length > 0) {
           const file = queue.shift()!;
           try {
-            const resp = await fetch(
-              `${workerUrl}/file?key=${encodeURIComponent(file.key)}`,
-              { headers: { Authorization: `Bearer ${token}` } }
-            );
+            // proxyUrl is a ready-to-fetch Worker link (?url=<presigned>&sig=<hmac>);
+            // the Worker supplies CORS so the browser can read the bytes to zip them.
+            const resp = await fetch(file.proxyUrl);
             if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
             const buf = await resp.arrayBuffer();
             fileData.push({ filename: file.filename, data: new Uint8Array(buf) });

--- a/web/lib/actions/download.ts
+++ b/web/lib/actions/download.ts
@@ -10,20 +10,19 @@ import { paginateRpc } from '@/lib/supabase/paginate';
 import { buildFilterParams } from './filter-params';
 import { DQ_FLAGS } from '@/lib/flags';
 import type { FlagDef } from '@/lib/flags';
+import { generateDownloadUrls } from '@/lib/r2';
 
-// JWT signing using Web Crypto API
 const WORKER_URL = process.env.NEXT_PUBLIC_WORKER_DOWNLOAD_URL || 'http://localhost:8787';
 const JWT_SECRET = process.env.WORKER_JWT_SECRET;
 
-interface DownloadFile {
-  key: string;
-  filename: string;
-}
+// Presigned-URL lifetime. Must outlive the WHOLE client-side download (the browser
+// fetches every file through the proxy, then zips), so keep it generous — 6h, the
+// same value the observation manifest / storage-presign routes use.
+const PRESIGN_TTL_SECONDS = 21600;
 
-interface DownloadPayload {
-  files: DownloadFile[];
-  exp: number;
-  zipFilename: string;
+interface DownloadFile {
+  proxyUrl: string; // ready-to-fetch Worker proxy URL (?url=<presigned>&sig=<hmac>)
+  filename: string;
 }
 
 interface PhotometryBands {
@@ -380,8 +379,13 @@ export async function generateCsvFilename(viewMode: string = 'objects'): Promise
 }
 
 /**
- * Generate download URL for FITS files
- * Creates a JWT token with file list and returns Worker URL
+ * Authorize a bulk FITS download and return ready-to-fetch Worker proxy URLs.
+ *
+ * The key set is derived server-side under the user's RLS session, each key is
+ * presigned against whichever backend homes it (dual-read: R2 or OSN), and each
+ * presigned URL is HMAC-signed so the credential-free proxy Worker will fetch
+ * only URLs we authorized. The browser fetches each proxy URL (which supplies
+ * CORS) and zips the results client-side.
  */
 export async function generateFitsDownloadUrl(
   filters: FilterOptions,
@@ -390,14 +394,12 @@ export async function generateFitsDownloadUrl(
   viewMode: ViewMode = 'objects'
 ): Promise<{
   files: DownloadFile[] | null;
-  token: string | null;
-  workerUrl: string | null;
   zipFilename: string | null;
   error: string | null;
 }> {
   try {
     if (!JWT_SECRET) {
-      return { files: null, token: null, workerUrl: null, zipFilename: null, error: 'Server configuration error: JWT secret not set' };
+      return { files: null, zipFilename: null, error: 'Server configuration error: JWT secret not set' };
     }
 
     // Get user for tracking
@@ -417,7 +419,7 @@ export async function generateFitsDownloadUrl(
     );
 
     if (result.error) {
-      return { files: null, token: null, workerUrl: null, zipFilename: null, error: result.error };
+      return { files: null, zipFilename: null, error: result.error };
     }
 
     // Guard against silent truncation. The UI gate is computed from the current
@@ -429,40 +431,40 @@ export async function generateFitsDownloadUrl(
     // biased first-N-of-M ZIP that looks complete (a reproducibility hazard).
     if (result.total > result.spectra.length) {
       return {
-        files: null, token: null, workerUrl: null, zipFilename: null,
+        files: null, zipFilename: null,
         error: `This filter set has ${result.total.toLocaleString()} spectra, which exceeds the ${FITS_DOWNLOAD_FILE_LIMIT.toLocaleString()}-file ZIP limit. Refine your filters, or use the CSV export (which includes every fits_path) to fetch the full set.`,
       };
     }
 
     // Extract all FITS file paths from spectra on each target
-    const files: DownloadFile[] = [];
+    const keys: string[] = [];
+    const filenames: string[] = [];
     for (const obj of result.spectra) {
       for (const spec of obj.spectra) {
-        files.push({
-          key: spec.fits_path, // R2 object key
-          filename: spec.fits_path.split('/').pop() || spec.fits_path, // Just the filename
-        });
+        keys.push(spec.fits_path);
+        filenames.push(spec.fits_path.split('/').pop() || spec.fits_path);
       }
     }
 
-    if (files.length === 0) {
-      return { files: null, token: null, workerUrl: null, zipFilename: null, error: 'No FITS files found for selected objects' };
+    if (keys.length === 0) {
+      return { files: null, zipFilename: null, error: 'No FITS files found for selected objects' };
     }
+
+    // Presign each key against its home backend (dual-read), then HMAC-sign the
+    // presigned URL so the proxy only fetches URLs we authorized.
+    const urls = await generateDownloadUrls(keys, PRESIGN_TTL_SECONDS);
+    const files: DownloadFile[] = await Promise.all(
+      urls.map(async (signedUrl, i) => {
+        const sig = await signUrlSignature(signedUrl, JWT_SECRET);
+        const proxyUrl = `${WORKER_URL}/proxy?url=${encodeURIComponent(signedUrl)}&sig=${sig}`;
+        return { proxyUrl, filename: filenames[i] };
+      })
+    );
 
     // Generate ZIP filename with date
     const now = new Date();
     const dateStr = now.toISOString().split('T')[0].replace(/-/g, ''); // YYYYMMDD
     const zipFilename = `campfire_download_${dateStr}.zip`;
-
-    // Create JWT payload
-    const payload: DownloadPayload = {
-      files,
-      exp: Date.now() + 10 * 60 * 1000, // Expire in 10 minutes
-      zipFilename,
-    };
-
-    // Sign JWT
-    const token = await signJWT(payload, JWT_SECRET);
 
     // Track ZIP download (fire-and-forget)
     if (user) {
@@ -477,64 +479,33 @@ export async function generateFitsDownloadUrl(
       });
     }
 
-    return { files, token, workerUrl: WORKER_URL, zipFilename, error: null };
+    return { files, zipFilename, error: null };
   } catch (error) {
     console.error('Error generating FITS download URL:', error);
-    return { files: null, token: null, workerUrl: null, zipFilename: null, error: 'Failed to generate download URL' };
+    return { files: null, zipFilename: null, error: 'Failed to generate download URL' };
   }
 }
 
 /**
- * Sign JWT using HMAC SHA-256 (Web Crypto API)
+ * HMAC-SHA256(secret, url), base64url-encoded — the per-URL signature the proxy
+ * Worker verifies. Web Crypto API (same primitive both ends).
  */
-async function signJWT(payload: DownloadPayload, secret: string): Promise<string> {
-  // Create header
-  const header = {
-    alg: 'HS256',
-    typ: 'JWT',
-  };
-
-  // Encode header and payload
-  const headerB64 = base64UrlEncode(JSON.stringify(header));
-  const payloadB64 = base64UrlEncode(JSON.stringify(payload));
-
-  // Create signature
-  const data = `${headerB64}.${payloadB64}`;
+async function signUrlSignature(url: string, secret: string): Promise<string> {
   const encoder = new TextEncoder();
-  const keyData = encoder.encode(secret);
-  const messageData = encoder.encode(data);
-
-  // Import key
   const key = await crypto.subtle.importKey(
     'raw',
-    keyData,
+    encoder.encode(secret),
     { name: 'HMAC', hash: 'SHA-256' },
     false,
     ['sign']
   );
-
-  // Sign
-  const signature = await crypto.subtle.sign('HMAC', key, messageData);
-  const signatureB64 = base64UrlEncode(signature);
-
-  // Return JWT
-  return `${data}.${signatureB64}`;
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(url));
+  return base64UrlEncode(signature);
 }
 
 /**
- * Base64URL encode (for JWT)
+ * Base64URL-encode the HMAC signature (ArrayBuffer).
  */
-function base64UrlEncode(data: string | ArrayBuffer): string {
-  let base64: string;
-
-  if (typeof data === 'string') {
-    // String to base64
-    base64 = Buffer.from(data).toString('base64');
-  } else {
-    // ArrayBuffer to base64
-    base64 = Buffer.from(data).toString('base64');
-  }
-
-  // Convert to base64url
-  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+function base64UrlEncode(data: ArrayBuffer): string {
+  return Buffer.from(data).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
 }

--- a/web/workers/download-worker/DEPLOYMENT_GUIDE.md
+++ b/web/workers/download-worker/DEPLOYMENT_GUIDE.md
@@ -5,9 +5,11 @@ This guide will walk you through deploying the CAMPFIRE download worker to Cloud
 ## Prerequisites
 
 - Cloudflare account (you have account ID: `2d136e3d61aca8a4ae08a2ea760f6d23`)
-- Wrangler CLI installed (you have version 4.28.0)
-- R2 bucket named `campfire` with FITS files
+- Wrangler CLI installed
+- FITS objects on R2 (`campfire`) and/or OSN — the Worker fetches presigned URLs,
+  so it needs **no** bucket binding and holds no object-store credentials
 - Domain: `download.campfire.hollisakins.com`
+- Free Workers plan is sufficient (one subrequest, ~0 CPU per request)
 
 ## Step 1: Install Worker Dependencies
 
@@ -19,9 +21,11 @@ npm install
 ```
 
 This will install:
-- `fflate` - For ZIP streaming
 - `@cloudflare/workers-types` - TypeScript types
 - `wrangler` - Cloudflare deployment tool
+
+The Worker has no runtime dependencies — it holds no credentials and does not
+zip; the browser zips client-side with `fflate`, which lives in the web app.
 
 ## Step 2: Generate JWT Secret
 
@@ -113,21 +117,19 @@ Published campfire-download (X.XX sec)
 Current Deployment ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
 
-## Step 8: Verify R2 Bucket Binding
+## Step 8: Smoke-Test the Proxy
 
-Check that the worker can access your R2 bucket:
+The Worker has no R2 binding — it proxies presigned URLs. Confirm it's up and
+rejecting unsigned requests:
 
 ```bash
-cd workers/download-worker
-wrangler whoami
+curl -i 'https://download.campfire.hollisakins.com/proxy'
+# expect: HTTP/1.1 400  Missing url or sig parameter
 ```
 
-Then verify the bucket is bound:
-```bash
-wrangler r2 bucket list
-```
-
-You should see `campfire` in the list.
+Also confirm `ALLOWED_FETCH_HOSTS` in `wrangler.toml` lists both the OSN host and
+your R2 account host, so both backends are fetchable. A real download is exercised
+end-to-end from the web app in Step 9.
 
 ## Step 9: Test from Next.js
 
@@ -171,14 +173,21 @@ Press `Ctrl+C` to stop tailing logs.
 1. Verify secrets match in both places
 2. Regenerate and update both if needed
 
-### Error: "File not found in R2"
+### A file fails with 403 "Target not allowed"
 
-**Cause:** FITS file path in database doesn't match R2 object key
+**Cause:** The presigned URL's host is not in `ALLOWED_FETCH_HOSTS` (e.g. an object
+still on R2 while the var lists only OSN, or a mismatched R2 account host).
 
 **Fix:**
-1. Check a sample FITS path in your database
-2. Verify it exists in R2: `wrangler r2 object get campfire <path>`
-3. Ensure paths match exactly (case-sensitive!)
+1. Confirm the presign host is `uaz1.osn.mghpcc.org` (OSN) or
+   `<accountid>.r2.cloudflarestorage.com` (R2).
+2. Add the missing host to `ALLOWED_FETCH_HOSTS` in `wrangler.toml` and redeploy.
+
+### A file fails with 403 "Invalid signature"
+
+**Cause:** `JWT_SECRET` (Worker) and `WORKER_JWT_SECRET` (Next.js) differ.
+
+**Fix:** Set both to the same value and redeploy.
 
 ### Error: "CORS error" in browser
 
@@ -227,7 +236,7 @@ Before going to production:
 - [ ] JWT secret generated and set in both Next.js and Worker
 - [ ] DNS record created for `download.campfire.hollisakins.com`
 - [ ] Worker deployed successfully
-- [ ] R2 bucket binding working
+- [ ] Proxy smoke test passes (`GET /proxy` → 400) and `ALLOWED_FETCH_HOSTS` lists OSN + R2
 - [ ] Test download with small dataset (1-5 objects)
 - [ ] Test download with larger dataset (50-100 objects)
 - [ ] Test download with max limit (200 objects)

--- a/web/workers/download-worker/README.md
+++ b/web/workers/download-worker/README.md
@@ -1,134 +1,88 @@
 # CAMPFIRE Download Worker
 
-Cloudflare Worker for streaming FITS file downloads from R2 storage.
+Cloudflare Worker: a credential-free CORS proxy for presigned download URLs. It
+lets the browser read FITS bytes from R2 **or** OSN so they can be zipped
+client-side.
 
-## Overview
+## Why it exists
 
-This worker handles bulk downloads of FITS spectroscopic data files from the CAMPFIRE catalog. It:
+Object bytes live in a private bucket on R2 or, after the epic #210 migration, on
+OSN (Open Storage Network). The browser can't `fetch()` those bytes directly:
+neither bucket sends CORS headers (and OSN's are not ours to set). This Worker
+sits on an origin we control, fetches the presigned URL server-to-server, and
+re-serves the bytes with `Access-Control-Allow-Origin` so the browser can read
+and zip them.
 
-1. Receives JWT-signed requests from the Next.js frontend
-2. Verifies token authenticity and expiration
-3. Fetches FITS files from R2 storage
-4. Streams them as a ZIP archive to the user
-5. Handles up to 200 objects (~600 FITS files, ~180MB)
+It holds **no** object-store credentials and **no** R2 binding. All authorization
+and presigning happen in the Next.js app; the Worker only proxies URLs the app
+signed. That also keeps it on the **free** Workers plan: one subrequest and ~0
+CPU per request (a plain passthrough), versus the 1000-subrequest / high-CPU
+profile that server-side zipping would need.
 
 ## Architecture
 
 ```
-Next.js Frontend
-    ↓ (generates JWT token)
-Cloudflare Worker
-    ↓ (fetches files)
-R2 Bucket (campfire)
-    ↓ (streams ZIP)
-User Download
+Next.js server action (RLS authorizes the key set)
+    |  presigns each key via dual-read (R2 or OSN) + HMAC-signs the URL
+Browser  ->  GET /proxy?url=<presigned>&sig=<hmac>   (one request per file)
+    |  Worker verifies the HMAC, host-allowlists the URL, fetches it
+R2 / OSN
+    |  Worker streams the bytes back with CORS headers
+Browser zips the results client-side (fflate) -> single .zip download
 ```
 
-## Features
+## Request
 
-- **JWT Authentication:** Secure token-based access
-- **Streaming ZIP:** No memory buffering, handles large datasets
-- **CORS Support:** Works with multiple origins
-- **Error Handling:** Graceful degradation for missing files
-- **Performance:** <30s for 200 objects
+`GET /proxy?url=<url-encoded presigned URL>&sig=<base64url HMAC-SHA256>`
 
-## Files
-
-- `src/index.ts` - Main worker handler
-- `src/auth.ts` - JWT verification
-- `src/zip.ts` - ZIP streaming logic
-- `wrangler.toml` - Configuration
-- `DEPLOYMENT_GUIDE.md` - Step-by-step deployment instructions
-
-## Quick Start
-
-```bash
-# Install dependencies
-npm install
-
-# Test locally
-wrangler dev
-
-# Deploy to production
-wrangler deploy
-
-# Monitor logs
-wrangler tail
-```
+The Worker:
+1. verifies `sig == HMAC-SHA256(JWT_SECRET, url)` — so it only fetches URLs the
+   app signed (not an open relay);
+2. checks the URL is `https`, has no embedded credentials, and its host is in
+   `ALLOWED_FETCH_HOSTS` (SSRF defense-in-depth);
+3. `fetch(url, { redirect: 'error' })` and streams the body back with CORS.
 
 ## Configuration
 
-### Environment Variables
+`wrangler.toml`:
+- `ALLOWED_ORIGINS` — browser origins allowed to read responses (CORS).
+- `ALLOWED_FETCH_HOSTS` — object-store hosts the proxy may fetch (SSRF guard).
+  Includes both the OSN host (migrated FITS) and the R2 account host (un-migrated
+  / NIRCam), so the proxy is storage-agnostic. Subdomains match, so R2
+  virtual-hosted URLs are covered. A host not in the list fails loudly (403).
 
-Set in `wrangler.toml`:
-- `ALLOWED_ORIGINS` - Comma-separated list of allowed origins
+Secret (via `wrangler secret put`):
+- `JWT_SECRET` — shared with the Next.js app (`WORKER_JWT_SECRET`); used to
+  HMAC-sign (app) and verify (Worker) each presigned URL.
 
-### Secrets
+## Files
 
-Set via Wrangler CLI:
-- `JWT_SECRET` - Shared secret for JWT verification
+- `src/index.ts` — request handler + `isAllowedFetchUrl` host guard
+- `src/auth.ts` — `verifyUrlSignature` (HMAC-SHA256, Web Crypto)
+- `src/proxy.test.ts` — unit tests for the host guard and signature verify
+- `wrangler.toml` — configuration
 
-### Bindings
-
-- `R2_BUCKET` - Bound to `campfire` R2 bucket
-
-## Development
-
-### Local Testing
-
-```bash
-wrangler dev
-```
-
-Worker runs on `http://localhost:8787`
-
-### Deploy
+## Develop / deploy
 
 ```bash
-wrangler deploy
+npm install
+wrangler dev        # local, http://localhost:8787
+wrangler deploy     # production, download.campfire.hollisakins.com
+wrangler tail       # logs
+npm test            # runs the unit tests via the web app's vitest
 ```
 
-Deploys to `download.campfire.hollisakins.com`
+Tests live in `src/proxy.test.ts` and run under the web app's vitest (they are
+also picked up by `npm test` in `web/`, so CI covers them).
 
-### Monitoring
-
-```bash
-wrangler tail
-```
-
-View real-time logs from production.
-
-## Limits
-
-- **Max Objects:** 200 (configurable in Next.js)
-- **Token TTL:** 10 minutes
-- **Worker CPU Time:** 30 seconds (soft limit)
-- **Max ZIP Size:** ~180MB (with current 300KB/file average)
+Runs on the free Workers plan; no paid features are used.
 
 ## Security
 
-- JWT tokens expire after 10 minutes
-- Tokens are single-use (time-limited)
-- R2 bucket is not publicly accessible
-- CORS restricted to allowed origins
-- No sensitive data in tokens (only file paths)
-
-## Future Enhancements
-
-- **Durable Objects:** For downloads >200 objects
-- **Progress Tracking:** WebSocket updates during generation
-- **Resume Support:** Allow interrupted downloads to resume
-- **Caching:** Cache popular download sets
-
-## Troubleshooting
-
-See `DEPLOYMENT_GUIDE.md` for detailed troubleshooting steps.
-
-Common issues:
-- Token expiration → Regenerate token
-- Missing files → Check R2 paths
-- CORS errors → Update ALLOWED_ORIGINS
-
-## License
-
-MIT - CAMPFIRE Project
+- The Worker holds no object-store credentials; presigned URLs (SigV4-scoped to a
+  single object with a TTL) are the only capability, and it fetches one only if
+  the app's HMAC over that exact URL verifies.
+- `ALLOWED_FETCH_HOSTS` + https-only + no-embedded-credentials + `redirect: error`
+  bound the fetch target to our object stores even if the secret leaks.
+- CORS reflection is limited to `ALLOWED_ORIGINS`, so only our portal's JS can
+  read proxied responses.

--- a/web/workers/download-worker/package.json
+++ b/web/workers/download-worker/package.json
@@ -1,12 +1,13 @@
 {
   "name": "campfire-download-worker",
   "version": "1.0.0",
-  "description": "Cloudflare Worker for authenticated R2 file proxy",
+  "description": "Cloudflare Worker: credential-free CORS proxy for presigned R2/OSN download URLs",
   "main": "src/index.ts",
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "tail": "wrangler tail"
+    "tail": "wrangler tail",
+    "test": "cd ../.. && npx vitest run workers/download-worker/src"
   },
   "keywords": [
     "cloudflare",

--- a/web/workers/download-worker/src/auth.ts
+++ b/web/workers/download-worker/src/auth.ts
@@ -1,54 +1,37 @@
 /**
- * JWT verification for download tokens
- * Uses Web Crypto API (built into Cloudflare Workers)
+ * Per-URL HMAC-SHA256 verification for the download proxy.
+ *
+ * The Worker no longer holds object-store credentials or an R2 binding — it
+ * proxies presigned URLs that Vercel minted (dual-read: R2 or OSN) and signed
+ * with the shared secret. Verifying the signature over the exact URL means the
+ * proxy will only fetch URLs our own server authorized, so it can't be turned
+ * into an open relay. Uses the Web Crypto API (built into Cloudflare Workers).
  */
-
-export interface DownloadFile {
-  key: string; // R2 object key
-  filename: string; // Original filename
-}
-
-export interface DownloadPayload {
-  files: DownloadFile[];
-  exp: number; // Expiration timestamp (milliseconds)
-  zipFilename: string; // Name for the ZIP file
-}
 
 /**
- * Verify JWT token using HMAC SHA-256
+ * Verify that `signature` is HMAC-SHA256(secret, url), base64url-encoded.
+ * Constant-time via crypto.subtle.verify.
  */
-export async function verifyToken(token: string, secret: string): Promise<DownloadPayload> {
-  const parts = token.split('.');
-
-  if (parts.length !== 3) {
-    throw new Error('Invalid token format');
-  }
-
-  const [headerB64, payloadB64, signatureB64] = parts;
-
-  // Verify signature
+export async function verifyUrlSignature(
+  url: string,
+  signature: string,
+  secret: string
+): Promise<boolean> {
   const encoder = new TextEncoder();
-  const data = encoder.encode(`${headerB64}.${payloadB64}`);
-  const secretKey = await crypto.subtle.importKey(
+  const key = await crypto.subtle.importKey(
     'raw',
     encoder.encode(secret),
     { name: 'HMAC', hash: 'SHA-256' },
     false,
     ['verify']
   );
-
-  const signature = base64UrlDecode(signatureB64);
-  const isValid = await crypto.subtle.verify('HMAC', secretKey, signature, data);
-
-  if (!isValid) {
-    throw new Error('Invalid token signature');
+  let sigBytes: ArrayBuffer;
+  try {
+    sigBytes = base64UrlDecode(signature);
+  } catch {
+    return false;
   }
-
-  // Decode payload
-  const payloadJson = atob(payloadB64.replace(/-/g, '+').replace(/_/g, '/'));
-  const payload = JSON.parse(payloadJson);
-
-  return payload as DownloadPayload;
+  return crypto.subtle.verify('HMAC', key, sigBytes, encoder.encode(url));
 }
 
 /**

--- a/web/workers/download-worker/src/index.ts
+++ b/web/workers/download-worker/src/index.ts
@@ -1,84 +1,114 @@
 /**
- * Cloudflare Worker for CAMPFIRE FITS file downloads
- * Authenticated file proxy — serves individual files from R2
+ * Cloudflare Worker for CAMPFIRE FITS file downloads.
+ *
+ * A credential-free, per-file CORS proxy. Vercel authorizes a download (RLS),
+ * presigns each file against whichever backend homes it (dual-read: R2 or OSN),
+ * signs the presigned URL with the shared secret, and hands the browser ready
+ * `/proxy?url=…&sig=…` links. This Worker verifies the signature, checks the
+ * target host against an allowlist, then streams the object back with CORS
+ * headers so the browser can read the bytes and zip them client-side.
+ *
+ * It holds NO object-store credentials and NO R2 binding — that's what keeps it
+ * on the free Workers plan (1 subrequest, ~0 CPU per request) and lets it serve
+ * OSN, which the old R2-binding proxy could not.
  */
 
-import { verifyToken } from './auth';
+import { verifyUrlSignature } from './auth';
 
 export interface Env {
-  R2_BUCKET: R2Bucket;
-  JWT_SECRET: string;
-  ALLOWED_ORIGINS: string;
+  JWT_SECRET: string; // shared HMAC secret with the Next.js server action
+  ALLOWED_ORIGINS: string; // comma-separated browser origins allowed to read responses
+  ALLOWED_FETCH_HOSTS: string; // comma-separated object-store hosts the proxy may fetch
 }
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
 
-    // Handle CORS preflight
     if (request.method === 'OPTIONS') {
       return handleCORS(request, env);
     }
 
-    // Only GET /file is supported
-    if (request.method !== 'GET' || url.pathname !== '/file') {
+    if (request.method !== 'GET' || url.pathname !== '/proxy') {
       return new Response('Not found', { status: 404 });
     }
 
     try {
-      // Extract parameters
-      const key = url.searchParams.get('key');
-      if (!key) {
-        return new Response('Missing key parameter', { status: 400 });
+      const target = url.searchParams.get('url');
+      const sig = url.searchParams.get('sig');
+      if (!target || !sig) {
+        return corsError('Missing url or sig parameter', 400, request, env);
       }
 
-      const authHeader = request.headers.get('Authorization');
-      const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
-      if (!token) {
-        return new Response('Missing Authorization header', { status: 401 });
+      // Only fetch URLs our own server signed — the proxy is not an open relay.
+      const valid = await verifyUrlSignature(target, sig, env.JWT_SECRET);
+      if (!valid) {
+        return corsError('Invalid signature', 403, request, env);
       }
 
-      // Verify JWT
-      const payload = await verifyToken(token, env.JWT_SECRET);
-
-      if (payload.exp && payload.exp < Date.now()) {
-        return new Response('Token expired', { status: 401 });
+      // Defense-in-depth: even a validly-signed URL must point at an allowlisted
+      // object-store host over https (guards SSRF if the secret ever leaks).
+      const check = isAllowedFetchUrl(target, env.ALLOWED_FETCH_HOSTS);
+      if (!check.ok) {
+        return corsError(`Target not allowed: ${check.reason}`, 403, request, env);
       }
 
-      // Check that requested key is in the token's allowlist
-      const allowed = payload.files?.some((f) => f.key === key);
-      if (!allowed) {
-        return new Response('File not authorized', { status: 403 });
+      // redirect: 'error' — an allowlisted host must not be able to bounce us
+      // to an arbitrary host after the allowlist check.
+      const upstream = await fetch(target, { redirect: 'error' });
+      if (!upstream.ok || !upstream.body) {
+        return corsError(`Upstream fetch failed (${upstream.status})`, 502, request, env);
       }
 
-      // Fetch from R2
-      const object = await env.R2_BUCKET.get(key);
-      if (!object) {
-        return new Response('File not found', { status: 404 });
-      }
+      const headers = new Headers();
+      headers.set('Content-Type', upstream.headers.get('Content-Type') || 'application/octet-stream');
+      const len = upstream.headers.get('Content-Length');
+      if (len) headers.set('Content-Length', len);
+      headers.set('Access-Control-Allow-Origin', getAllowedOrigin(request, env));
+      headers.set('Access-Control-Allow-Methods', 'GET, OPTIONS');
+      headers.set('Vary', 'Origin');
+      headers.set('Cache-Control', 'no-store');
 
-      return new Response(object.body, {
-        headers: {
-          'Content-Type': 'application/octet-stream',
-          'Content-Length': object.size.toString(),
-          'Access-Control-Allow-Origin': getAllowedOrigin(request, env),
-          'Access-Control-Allow-Methods': 'GET, OPTIONS',
-          'Access-Control-Allow-Headers': 'Authorization',
-        },
-      });
+      return new Response(upstream.body, { status: 200, headers });
     } catch (error) {
       console.error('Worker error:', error);
-
-      if (error instanceof Error) {
-        if (error.message.includes('Invalid token') || error.message.includes('verification')) {
-          return new Response('Invalid or expired token', { status: 401 });
-        }
-      }
-
-      return new Response('Internal server error', { status: 500 });
+      return corsError('Internal server error', 500, request, env);
     }
   },
 };
+
+/**
+ * Validate that a signed target URL is safe to fetch: https, no embedded
+ * credentials, and a hostname that exactly matches (or is a subdomain of) one
+ * of the allowlisted object-store hosts. Exported for unit testing.
+ */
+export function isAllowedFetchUrl(
+  rawUrl: string,
+  allowedHostsCsv: string
+): { ok: true } | { ok: false; reason: string } {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return { ok: false, reason: 'unparseable url' };
+  }
+  if (parsed.protocol !== 'https:') {
+    return { ok: false, reason: 'non-https scheme' };
+  }
+  if (parsed.username || parsed.password) {
+    return { ok: false, reason: 'embedded credentials' };
+  }
+  const allowed = allowedHostsCsv
+    .split(',')
+    .map((h) => h.trim().toLowerCase())
+    .filter(Boolean);
+  const host = parsed.hostname.toLowerCase();
+  const hostOk = allowed.some((h) => host === h || host.endsWith('.' + h));
+  if (!hostOk) {
+    return { ok: false, reason: 'host not in allowlist' };
+  }
+  return { ok: true };
+}
 
 function handleCORS(request: Request, env: Env): Response {
   return new Response(null, {
@@ -86,19 +116,33 @@ function handleCORS(request: Request, env: Env): Response {
     headers: {
       'Access-Control-Allow-Origin': getAllowedOrigin(request, env),
       'Access-Control-Allow-Methods': 'GET, OPTIONS',
-      'Access-Control-Allow-Headers': 'Authorization',
       'Access-Control-Max-Age': '86400',
+      'Vary': 'Origin',
     },
   });
 }
 
 function getAllowedOrigin(request: Request, env: Env): string {
   const origin = request.headers.get('Origin');
-  const allowedOrigins = env.ALLOWED_ORIGINS.split(',');
+  const allowedOrigins = (env.ALLOWED_ORIGINS || '').split(',').map((o) => o.trim()).filter(Boolean);
 
   if (origin && allowedOrigins.includes(origin)) {
     return origin;
   }
 
-  return allowedOrigins[0] || '*';
+  // Never fall back to '*': a misconfigured (empty) allowlist must DENY, not
+  // open the proxy to every origin. 'null' is a valid Origin value no browser matches.
+  return allowedOrigins[0] ?? 'null';
+}
+
+/** Error response that still carries CORS headers, so the browser can read the
+ * status/message instead of collapsing every failure into an opaque network error. */
+function corsError(message: string, status: number, request: Request, env: Env): Response {
+  return new Response(message, {
+    status,
+    headers: {
+      'Access-Control-Allow-Origin': getAllowedOrigin(request, env),
+      'Vary': 'Origin',
+    },
+  });
 }

--- a/web/workers/download-worker/src/proxy.test.ts
+++ b/web/workers/download-worker/src/proxy.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { isAllowedFetchUrl } from './index';
+import { verifyUrlSignature } from './auth';
+
+const ALLOWED = 'uaz1.osn.mghpcc.org,abc123.r2.cloudflarestorage.com';
+
+describe('isAllowedFetchUrl', () => {
+  it('allows the exact OSN host over https', () => {
+    expect(isAllowedFetchUrl('https://uaz1.osn.mghpcc.org/campfire-jwst/data/x_spec.fits?X-Amz-Signature=a', ALLOWED).ok).toBe(true);
+  });
+
+  it('allows a subdomain of an allowlisted host (R2 virtual-hosted style)', () => {
+    expect(isAllowedFetchUrl('https://bucket.abc123.r2.cloudflarestorage.com/key?sig=1', ALLOWED).ok).toBe(true);
+  });
+
+  it('rejects a non-https scheme', () => {
+    expect(isAllowedFetchUrl('http://uaz1.osn.mghpcc.org/x', ALLOWED)).toMatchObject({ ok: false });
+  });
+
+  it('rejects embedded credentials in the authority', () => {
+    // classic allowlist bypass: user@evil, or the allowed host as userinfo
+    expect(isAllowedFetchUrl('https://uaz1.osn.mghpcc.org@evil.com/x', ALLOWED)).toMatchObject({ ok: false });
+  });
+
+  it('rejects a host that merely contains an allowlisted host as a substring', () => {
+    expect(isAllowedFetchUrl('https://uaz1.osn.mghpcc.org.evil.com/x', ALLOWED)).toMatchObject({ ok: false });
+  });
+
+  it('rejects a host not in the allowlist', () => {
+    expect(isAllowedFetchUrl('https://example.com/x', ALLOWED)).toMatchObject({ ok: false });
+  });
+
+  it('rejects an unparseable url', () => {
+    expect(isAllowedFetchUrl('not a url', ALLOWED)).toMatchObject({ ok: false });
+  });
+});
+
+// Mirror of the server's signUrlSignature (download.ts) — proves sign/verify agree.
+async function sign(url: string, secret: string): Promise<string> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey('raw', enc.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(url));
+  const b64 = btoa(String.fromCharCode(...new Uint8Array(sig)));
+  return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+describe('verifyUrlSignature', () => {
+  const SECRET = 'test-shared-secret';
+  const URL_ = 'https://uaz1.osn.mghpcc.org/campfire-jwst/data/products/nirspec/obs/x_spec.fits?X-Amz-Signature=deadbeef';
+
+  it('accepts a signature the server would produce', async () => {
+    const sig = await sign(URL_, SECRET);
+    expect(await verifyUrlSignature(URL_, sig, SECRET)).toBe(true);
+  });
+
+  it('rejects a tampered url (key substitution)', async () => {
+    const sig = await sign(URL_, SECRET);
+    const tampered = URL_.replace('x_spec.fits', 'other_spec.fits');
+    expect(await verifyUrlSignature(tampered, sig, SECRET)).toBe(false);
+  });
+
+  it('rejects a signature made with a different secret', async () => {
+    const sig = await sign(URL_, 'wrong-secret');
+    expect(await verifyUrlSignature(URL_, sig, SECRET)).toBe(false);
+  });
+
+  it('rejects a malformed signature', async () => {
+    expect(await verifyUrlSignature(URL_, 'not-base64!!', SECRET)).toBe(false);
+  });
+});

--- a/web/workers/download-worker/wrangler.toml
+++ b/web/workers/download-worker/wrangler.toml
@@ -1,15 +1,19 @@
 name = "campfire-download"
 main = "src/index.ts"
-compatibility_date = "2024-01-01"
+compatibility_date = "2025-06-01"
 
-# R2 bucket binding
-[[r2_buckets]]
-binding = "R2_BUCKET"
-bucket_name = "campfire"
+# No R2 binding: the Worker fetches presigned URLs (R2 or OSN) that Vercel mints,
+# so it holds no object-store credentials and works for either backend. This is
+# also what keeps it on the free Workers plan — one subrequest, ~0 CPU per request.
 
 # Environment variables (non-secret)
 [vars]
 ALLOWED_ORIGINS = "https://campfire.hollisakins.com,https://dev.campfire.hollisakins.com,http://localhost:3000"
+# Object-store hosts the proxy is allowed to fetch (SSRF guard). Both backends
+# are included so the proxy is storage-agnostic: OSN holds migrated FITS, the R2
+# account host serves un-migrated / NIRCam objects. Subdomains match too, so R2
+# virtual-hosted URLs (<bucket>.<account>.r2.cloudflarestorage.com) are covered.
+ALLOWED_FETCH_HOSTS = "uaz1.osn.mghpcc.org,2d136e3d61aca8a4ae08a2ea760f6d23.r2.cloudflarestorage.com"
 
 # Secrets (set via: wrangler secret put SECRET_NAME)
-# JWT_SECRET - shared with Next.js for token signing/verification
+# JWT_SECRET - shared with Next.js; used to HMAC-sign/verify the presigned URLs.


### PR DESCRIPTION
Part of epic #210 / A2 (#216).

## Why

The bulk **FITS ZIP** download was an R2-only Cloudflare Worker: `GET /file?key=`, an R2 bucket binding, and a JWT allow-list of keys. After the R2→OSN migration, FITS objects live on OSN, which **emits no CORS headers and whose CORS we cannot set** (our key is object-scoped; `PutBucketCORS` → `AccessDenied`, verified empirically). So the browser can't `fetch()` OSN bytes to zip them, and the old Worker (R2 binding, hardcoded `campfire` bucket) can't serve OSN at all.

A server-side *streaming zip* Worker would need the **paid** Cloudflare plan (the 500-file fan-out blows the free plan's 50-subrequest + 10 ms-CPU limits). We don't want a monthly bill for handing out data we moved off R2 to *stop* paying.

## What

Turn the Worker into a **credential-free per-file CORS proxy of presigned URLs**, and keep zipping client-side (moderate counts on the web; the CLI handles true bulk). This is the current architecture with the byte source swapped R2-binding → presigned-URL, so it stays on the **free** plan (1 subrequest, ~0 CPU per request).

- **Server** (`lib/actions/download.ts`): `generateFitsDownloadUrl` keeps the RLS query + anti-truncation guard + `trackDownload`, presigns every key via the existing dual-read `generateDownloadUrls` (R2 or OSN), HMAC-signs each presigned URL, and returns ready-to-fetch `proxyUrl`s. JWT/`signJWT` removed.
- **Worker** (`workers/download-worker/`): `GET /proxy?url=&sig=` → verify the HMAC over the exact URL (so it only fetches URLs we signed — not an open relay) → host-allowlist (`https`, no embedded creds, exact-or-subdomain match, `redirect:'error'`) → stream the bytes back with CORS. No R2 binding, no credentials.
- **Client** (`DownloadTableButtons.tsx`): `fetch(file.proxyUrl)` instead of `/file?key=` + `Bearer`. `fflate` client-side zip unchanged.
- `ALLOWED_FETCH_HOSTS` ships with both the OSN host and the R2 account host, so the proxy is storage-agnostic (R2 objects still download).

## Security

Adversarially reviewed. Primary gate is the per-URL HMAC (constant-time verify, bound to the exact SigV4 URL — no key substitution). Defense-in-depth: `https`-only, embedded-credential rejection, exact-or-subdomain host allowlist, `redirect:'error'`. RLS is preserved (keys are server-derived under the user session, never client-supplied). CORS reflection is limited to the portal origins and **never** falls back to `*`. Error responses carry CORS headers so failures surface a real status instead of an opaque network error.

## Tests / build

- New `src/proxy.test.ts` — host-allowlist bypass attempts (`user@host`, `host.evil.com`, non-https, IP tricks) + HMAC sign/verify round-trip (11 tests).
- Full web suite **119/119**, `npm run build` green.

## Deploy notes (post-merge)

1. `cd web/workers/download-worker && wrangler deploy` — **free plan is sufficient**.
2. **No secret change**: reuses `JWT_SECRET` (Worker) / `WORKER_JWT_SECRET` (Vercel).
3. **Matched-pair cutover**: the Worker dropped `/file` + the R2 binding, so deploy it close to the merge (brief window where bulk download errors — low-traffic manual feature).
4. **Live gate**: one real download exercises a CF-edge → OSN SigV4 GET (only testable post-deploy).

## Follow-up

If OSN sets bucket CORS (their support can), the browser can read OSN directly and this Worker can be **deleted** in favor of direct presigned fetch — the simpler end-state. Until then, this Worker is the backend-agnostic bridge that unblocks R2 retirement without an external dependency.

Generated with Claude Code

https://claude.ai/code/session_01QMm3DuLALxzNtLBUQqPfkR
