### PR TITLE
Extract #212 layout migration to shared zero-dependency core

### DIFF
--- a/layout/campfire_layout/__init__.py
+++ b/layout/campfire_layout/__init__.py
@@ -25,6 +25,7 @@ from .bijection import (
 )
 from .keys import bucket_for, key_prefix, storage_key
 from .lifecycle import tree_class
+from .migrate import LayoutMigrator, apply_migration, plan_migration
 from .paths import (
     Roots,
     cache_path,
@@ -64,6 +65,8 @@ __all__ = [
     "derive_sibling", "is_known_key",
     # lifecycle
     "tree_class",
+    # migration (#212 one-time layout re-org)
+    "LayoutMigrator", "plan_migration", "apply_migration",
 ]
 
 __version__ = "0.1.0"

--- a/layout/campfire_layout/migrate.py
+++ b/layout/campfire_layout/migrate.py
@@ -1,0 +1,426 @@
+"""One-time #212 ``$CAMPFIRE_ROOT`` layout migration (shared core).
+
+Relocates an existing data root into the issue #212 instrument-parity layout.
+This is the single, dependency-free implementation shared by:
+
+  * ``pipeline/scripts/migrate_layout_212.py`` — the operator CLI (adds root
+    resolution + ``observations.toml`` loading on top of this core), and
+  * ``campfire sync`` — auto-detects the old layout and offers to run it.
+
+Moves (all within one ``$CAMPFIRE_ROOT``; symlinks are moved, never
+dereferenced; existing targets are never clobbered):
+
+  NIRSpec products   products/<obs>/                  -> products/nirspec/<obs>/
+  NIRSpec raw        raw/<data_subdir>/               -> raw/nirspec/<data_subdir>/
+  NIRSpec reducer    products/<obs>/_<obs>_stuck_closed_shutters.toml
+                                                      -> reference/nirspec/<obs>/stuck_closed_shutters.toml
+                     products/<obs>/_<obs>_nodded_background_overrides.toml
+                                                      -> reference/nirspec/<obs>/nodded_background_overrides.toml
+  NIRCam shared      reference/nircam/<field>/flats/  -> reference/nircam/shared/flats/   (de-fielded merge)
+                     reference/nircam/<field>/wisps/  -> reference/nircam/shared/wisps/
+
+The raw migration needs the observations table (to classify referenced raw
+dirs); it is skipped entirely when ``obs_cfg is None`` — so a download-only
+client (which has only ``products/`` and no ``observations.toml``) migrates the
+products tree and nothing else. The products + NIRCam-shared migrations run
+regardless.
+
+The core is **zero-dependency (stdlib only)**: the observations table and any
+config parsing are the caller's job and are passed in as plain dicts.
+"""
+
+from __future__ import annotations
+
+import filecmp
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Optional
+
+# Reducer-decision TOMLs that move out of the products workspace into reference/.
+# (expected source basename built from the obs name, destination basename)
+REDUCER_TOMLS = [
+    ('_{obs}_stuck_closed_shutters.toml', 'stuck_closed_shutters.toml'),
+    ('_{obs}_nodded_background_overrides.toml', 'nodded_background_overrides.toml'),
+]
+# Any file matching these suffixes that is NOT the expected per-obs name is a
+# stray (e.g. the program-named macs0647 duplicate) — flagged, never moved.
+TOML_SUFFIXES = ('_stuck_closed_shutters.toml', '_nodded_background_overrides.toml')
+
+# A directory "looks like" a NIRSpec obs workspace if it holds any of these.
+# Deliberately NIRSpec-specific (jw*_nrs[12]_* / *_msa*), NOT bare jw*.fits, so a
+# stray flat NIRCam dir can never be misfiled into products/nirspec/.
+NIRSPEC_MARKERS = ('*_spec.fits', '*_rate.fits', 'jw*_nrs[12]_*.fits', '*_msa*.fits',
+                   '*_summary.ecsv', '_*_stuck_closed_shutters.toml',
+                   '_*_nodded_background_overrides.toml')
+NIRCAM_MARKERS = ('jw*_nrc[ab]*.fits', 'jw*_nrcalong*.fits', 'jw*_nrcblong*.fits')
+
+# Stale per-exposure intermediate suffixes (loose quartet), cleaned only with
+# clean_intermediates, and only when the basename starts jw...­_nrs[12]_.
+QUARTET_SUFFIXES = ('_cal.fits', '_cal_bkgsub.fits', '_s2d.fits', '_s2d_bkgsub.fits')
+INTERMEDIATE_TARBALLS = ('cal.tar.gz', 'cal_bkgsub.tar.gz', 's2d.tar.gz',
+                         's2d_bkgsub.tar.gz', 'bkgsub.tar.gz')
+
+# Action tags that represent a real change to on-disk data (as opposed to
+# scaffolding like mkdir/rmdir). Used to decide whether a migration is pending.
+MATERIAL_ACTIONS = ('MOVE', 'DEDUP', 'CLEAN', 'FIX', 'REMOVE')
+
+
+def _noop(*_args, **_kwargs) -> None:
+    pass
+
+
+def _has_any(d: Path, patterns) -> bool:
+    """True if directory d (following symlinks) contains a file matching any glob."""
+    return any(next(d.glob(p), None) is not None for p in patterns)
+
+
+class LayoutMigrator:
+    """Crash-safe, idempotent, dry-run-by-default #212 layout migrator.
+
+    Parameters
+    ----------
+    root : Path
+        The ``$CAMPFIRE_ROOT`` to migrate.
+    apply : bool
+        When False (default) nothing is written — the plan is only recorded in
+        ``counts``/``warnings`` (and printed via ``echo``). Pass True to execute.
+    clean_intermediates : bool
+        Also delete the stale per-exposure NIRSpec quartet from migrated dirs.
+    obs_cfg : dict | None
+        The ``observations.toml`` mapping ``{obs: {data_subdir, ...}}``. When
+        None, the ``raw/`` migration is skipped (products + NIRCam-shared still
+        run). Callers without an observations table (download-only clients)
+        pass None.
+    echo : callable
+        Sink for human-readable progress lines (default ``print``). Pass a no-op
+        to plan silently.
+    """
+
+    def __init__(self, root, apply=False, clean_intermediates=False,
+                 obs_cfg: Optional[dict] = None, echo: Callable = print):
+        self.root = Path(root)
+        self.apply = apply
+        self.clean_intermediates = clean_intermediates
+        self.obs_cfg = obs_cfg
+        self.echo = echo
+        self.counts: dict = {}
+        self.warnings: list = []
+        self._removed: set = set()   # paths removed (real in apply, virtual in dry-run)
+        self._created: set = set()   # move destinations created this run (accurate dry-run)
+        self._mf = None              # JSONL manifest file handle (apply only)
+        self._manifest_path = None
+
+    # --- manifest / logging -------------------------------------------------
+
+    def open_manifest(self):
+        if not self.apply:
+            return
+        ts = datetime.now().strftime('%Y%m%dT%H%M%S')
+        self._manifest_path = self.root / f'migration_212_manifest_{ts}.jsonl'
+        self._mf = open(self._manifest_path, 'w')
+
+    def _record(self, action, src, dst):
+        if self._mf is not None:
+            self._mf.write(json.dumps({'action': action, 'src': src, 'dst': dst}) + '\n')
+            self._mf.flush()
+            os.fsync(self._mf.fileno())
+
+    def _tag(self, action):
+        self.counts[action] = self.counts.get(action, 0) + 1
+
+    def _rel(self, p):
+        try:
+            return str(Path(p).relative_to(self.root))
+        except ValueError:
+            return str(p)
+
+    def log(self, action, msg):
+        self.echo(f"  [{'' if self.apply else 'DRY '}{action}] {msg}")
+        self._tag(action)
+
+    def warn(self, msg):
+        self.warnings.append(msg)
+        self.echo(f"  [WARN] {msg}")
+        self._tag('WARN')
+
+    # --- mutation primitives (all crash-safe via _record-before-effect) ------
+
+    def _occupied(self, dst):
+        """A destination is occupied if it physically exists OR was created
+        earlier this run, unless it has since been removed."""
+        s = str(dst)
+        return (os.path.lexists(dst) or s in self._created) and s not in self._removed
+
+    def mkdir(self, d):
+        d = Path(d)
+        if d.exists() or str(d) in self._created:
+            return
+        self._record('mkdir', None, str(d))
+        if self.apply:
+            d.mkdir(parents=True, exist_ok=True)
+        self._created.add(str(d))
+
+    def move(self, src, dst):
+        """Rename src -> dst (preserves symlinks; intra-root, never cross-device).
+        Refuses to clobber an occupied destination."""
+        src, dst = Path(src), Path(dst)
+        if self._occupied(dst):
+            self.warn(f"target exists, NOT overwriting: {self._rel(dst)} (left {self._rel(src)})")
+            return False
+        self.mkdir(dst.parent)
+        self._record('move', str(src), str(dst))   # record BEFORE the effect
+        if self.apply:
+            os.rename(src, dst)
+        self.log('MOVE', f"{self._rel(src)} -> {self._rel(dst)}"
+                          + ('  (symlink)' if os.path.islink(src) else ''))
+        self._created.add(str(dst))
+        self._removed.discard(str(src))
+        return True
+
+    def remove_file(self, p, action='REMOVE', why=''):
+        p = Path(p)
+        self._record(action.lower(), str(p), None)   # record BEFORE the effect
+        if self.apply:
+            if p.is_symlink() or p.is_file():
+                p.unlink()
+            else:
+                p.rmdir()
+        self.log(action, f"{self._rel(p)}{('  (' + why + ')') if why else ''}")
+        self._removed.add(str(p))
+        self._created.discard(str(p))
+
+    def rmdir_if_empty(self, d):
+        d = Path(d)
+        if d.is_dir() and not any(d.iterdir()):
+            self._record('rmdir', str(d), None)
+            if self.apply:
+                d.rmdir()
+            self.log('RMDIR', self._rel(d))
+
+    # --- reducer TOML relocation -------------------------------------------
+
+    def relocate_reducer_tomls(self, src_dir, obs):
+        """Move the per-obs reducer TOMLs out of src_dir into reference/nirspec/<obs>/.
+        Dedups byte-identical leftovers; never clobbers a differing target; flags
+        stray (non-per-obs-named) reducer TOMLs without touching them."""
+        ref = self.root / 'reference' / 'nirspec' / obs
+        for src_tmpl, dst_name in REDUCER_TOMLS:
+            src = src_dir / src_tmpl.format(obs=obs)
+            if not src.exists():
+                continue
+            dst = ref / dst_name
+            if os.path.lexists(dst):
+                if dst.is_file() and src.is_file() and filecmp.cmp(src, dst, shallow=False):
+                    self.remove_file(src, action='DEDUP',
+                                     why='identical copy already at reference')
+                else:
+                    self.warn(f"reference TOML differs, kept both: {self._rel(dst)} "
+                              f"vs stale {self._rel(src)}")
+                continue
+            self.move(src, dst)
+        expected = {t.format(obs=obs) for t, _ in REDUCER_TOMLS}
+        for f in sorted(src_dir.glob('_*')):
+            if f.name not in expected and f.name.endswith(TOML_SUFFIXES):
+                self.warn(f"stray reducer TOML left in place (name != _{obs}_*): "
+                          f"{self._rel(f)} — review manually")
+
+    # --- sections -----------------------------------------------------------
+
+    def migrate_products(self):
+        self.echo("\n=== NIRSpec products: products/<obs>/ -> products/nirspec/<obs>/ ===")
+        products = self.root / 'products'
+        if not products.is_dir():
+            self.echo(f"  [info] no products/ dir at {self._rel(products)} — nothing to migrate")
+            return
+        self.mkdir(products / 'nirspec')
+        for entry in sorted(products.iterdir()):
+            name = entry.name
+            if not entry.is_dir() or name in ('nirspec', 'nircam'):
+                continue
+            if name.startswith('_') or name.startswith('.'):
+                continue  # backups (_*_baseline), .DS_Store, etc.
+            old_dir = products / name          # always exists (iterated entry)
+            new_dir = products / 'nirspec' / name
+            if not _has_any(old_dir, NIRSPEC_MARKERS):
+                self.warn(f"products/{name}/ has no NIRSpec markers — skipped (review manually)")
+                continue
+            if new_dir.exists():
+                # Already-migrated copy exists alongside the old one: new is
+                # authoritative. Fix any stray TOML in new; never clobber old.
+                self.relocate_reducer_tomls(new_dir, name)
+                self.warn(f"BOTH products/{name} and products/nirspec/{name} exist — "
+                          f"left old in place (new authoritative); resolve manually")
+                continue
+            # Only old exists: extract reducer TOMLs first, then move the dir.
+            self.relocate_reducer_tomls(old_dir, name)
+            moved = self.move(old_dir, new_dir)
+            if self.clean_intermediates:
+                self._clean_intermediates(new_dir if (moved and self.apply) else old_dir, name)
+
+    def _clean_intermediates(self, obs_dir, obs):
+        n = 0
+        for suf in QUARTET_SUFFIXES:
+            for f in obs_dir.glob(f'jw*_nrs[12]_*{suf}'):
+                self.remove_file(f, action='CLEAN', why='stale per-exposure intermediate')
+                n += 1
+        tarballs = [t for t in INTERMEDIATE_TARBALLS if (obs_dir / t).exists()]
+        if tarballs:
+            self.warn(f"{obs}: intermediate tarball(s) present (NOT auto-removed): "
+                      + ', '.join(tarballs))
+        if n == 0 and not tarballs:
+            self.echo(f"  [info] {obs}: no stale loose intermediates found")
+
+    def migrate_raw(self, obs_cfg):
+        self.echo("\n=== NIRSpec raw: raw/<data_subdir>/ -> raw/nirspec/<data_subdir>/ ===")
+        raw = self.root / 'raw'
+        if not raw.is_dir():
+            self.echo(f"  [info] no raw/ dir at {self._rel(raw)} — nothing to migrate")
+            return
+        self.mkdir(raw / 'nirspec')
+        referenced = {str(v['data_subdir']) for v in obs_cfg.values()
+                      if v.get('data_subdir') is not None}
+        seen = set()
+        # Iterate the flat raw dirs themselves (each unique subdir appears once, so
+        # shared data_subdirs never double-move). Move EVERY NIRSpec raw dir —
+        # referenced by an obs OR not (unreduced programs migrate too) — classified
+        # by content; leave genuine NIRCam / unclassified dirs in place.
+        for entry in sorted(raw.iterdir()):
+            name = entry.name
+            if name in ('nirspec', 'nircam') or name.startswith('.'):
+                continue
+            if not (entry.is_dir() or entry.is_symlink()):
+                continue
+            seen.add(name)
+            new = raw / 'nirspec' / name
+            has_nrs = _has_any(entry, ('*_nrs[12]_*.fits', '*_msa*.fits'))
+            has_nrc = _has_any(entry, NIRCAM_MARKERS)
+            is_ref = name in referenced
+            if has_nrc and not has_nrs:
+                self.warn(f"raw/{name} looks like NIRCam raw — left in place "
+                          f"(NIRCam raw lives under raw/nircam/<PID>/).")
+                continue
+            if not (has_nrs or is_ref):
+                link = '  (symlink, target unreadable?)' if entry.is_symlink() else ''
+                self.warn(f"raw/{name}{link} unclassified — no NIRSpec markers and not in "
+                          f"observations.toml; left in place, review manually.")
+                continue
+            # NIRSpec raw (referenced or unreduced) -> raw/nirspec/<name>.
+            if os.path.lexists(new):
+                if os.path.islink(new) and os.path.realpath(new) == os.path.realpath(entry):
+                    self.remove_file(new, action='FIX', why='self-referential test symlink')
+                else:
+                    self.warn(f"BOTH raw/{name} and raw/nirspec/{name} exist — left old in "
+                              f"place; resolve manually")
+                    continue
+            if self.move(entry, new) and not is_ref:
+                self.echo(f"  [info] raw/{name}: NIRSpec program not yet in observations.toml — migrated")
+        # Sanity: referenced data_subdirs with no raw in the old OR new location.
+        for sub in sorted(referenced):
+            if sub in seen or os.path.lexists(raw / 'nirspec' / sub):
+                continue
+            self.warn(f"observations.toml references data_subdir '{sub}' but no raw found at "
+                      f"raw/{sub} or raw/nirspec/{sub}")
+
+    def migrate_nircam_shared(self):
+        self.echo("\n=== NIRCam: reference/nircam/<field>/{flats,wisps} -> reference/nircam/shared/ ===")
+        nircam = self.root / 'reference' / 'nircam'
+        if not nircam.is_dir():
+            self.echo("  [info] no reference/nircam/ — nothing to hoist")
+            return
+        shared = nircam / 'shared'
+        for sub in ('flats', 'wisps'):
+            self.mkdir(shared / sub)
+        for field_dir in sorted(nircam.iterdir()):
+            if not field_dir.is_dir() or field_dir.name == 'shared':
+                continue
+            for sub in ('flats', 'wisps'):
+                fdir = field_dir / sub
+                if not fdir.is_dir():
+                    continue
+                for f in sorted(fdir.iterdir()):
+                    if f.is_dir():
+                        self.warn(f"unexpected subdir in {self._rel(fdir)}: {f.name} — skipped")
+                        continue
+                    dst = shared / sub / f.name
+                    if self._occupied(dst):
+                        if f.is_file() and dst.is_file() and filecmp.cmp(f, dst, shallow=False):
+                            self.remove_file(f, action='DEDUP', why='identical, already in shared')
+                        elif os.path.lexists(dst):
+                            self.warn(f"flat/wisp collision (differing content), kept both: "
+                                      f"{self._rel(f)} vs {self._rel(dst)}")
+                        else:  # only virtually created this run (dry-run sibling)
+                            self.warn(f"flat/wisp same name from multiple fields: {f.name} — "
+                                      f"apply will dedup-if-identical or keep-both")
+                        continue
+                    self.move(f, dst)
+                self.rmdir_if_empty(fdir)
+
+    # --- driver -------------------------------------------------------------
+
+    def run(self):
+        """Execute all in-scope sections. ``raw/`` is skipped when obs_cfg is None."""
+        self.open_manifest()
+        self.migrate_products()
+        if self.obs_cfg is not None:
+            self.migrate_raw(self.obs_cfg)
+        self.migrate_nircam_shared()
+
+    @property
+    def pending(self) -> bool:
+        """True if the run performed (or, in dry-run, would perform) a material
+        change to on-disk data — as opposed to pure scaffolding (mkdir/rmdir)."""
+        return sum(self.counts.get(a, 0) for a in MATERIAL_ACTIONS) > 0
+
+    def finalize(self, interrupted=False):
+        if self._mf is not None:
+            self._mf.close()
+        self.echo("\n=== SUMMARY ===")
+        for action in sorted(self.counts):
+            self.echo(f"  {action}: {self.counts[action]}")
+        if not self.apply:
+            self.echo("\nDRY RUN — no changes made. Re-run with apply=True to execute.")
+            return
+        note = " (INTERRUPTED — partial)" if interrupted else ""
+        self.echo(f"\nAPPLIED{note}. Manifest (every committed action, for audit/undo): "
+                  f"{self._manifest_path}")
+        if self.warnings:
+            self.echo(f"{len(self.warnings)} warning(s) above need manual review.")
+
+
+def plan_migration(root, obs_cfg: Optional[dict] = None,
+                   clean_intermediates: bool = False) -> dict:
+    """Dry-run the migration and return a structured summary (no output, no writes).
+
+    Returns a dict with keys: ``pending`` (bool — is there material work?),
+    ``counts`` (action → count), ``warnings`` (list of str).
+    """
+    m = LayoutMigrator(root, apply=False, clean_intermediates=clean_intermediates,
+                       obs_cfg=obs_cfg, echo=_noop)
+    m.run()
+    return {"pending": m.pending, "counts": dict(m.counts), "warnings": list(m.warnings)}
+
+
+def apply_migration(root, obs_cfg: Optional[dict] = None,
+                    clean_intermediates: bool = False, echo: Callable = print) -> dict:
+    """Execute the migration. Returns a dict with ``counts``, ``warnings``,
+    ``manifest_path`` (str | None), and ``interrupted`` (bool).
+
+    On any exception the manifest is finalized (so an interrupted run still
+    leaves an accurate audit record) and the exception is re-raised.
+    """
+    m = LayoutMigrator(root, apply=True, clean_intermediates=clean_intermediates,
+                       obs_cfg=obs_cfg, echo=echo)
+    try:
+        m.run()
+    except BaseException:
+        m.finalize(interrupted=True)
+        raise
+    m.finalize(interrupted=False)
+    return {
+        "counts": dict(m.counts),
+        "warnings": list(m.warnings),
+        "manifest_path": str(m._manifest_path) if m._manifest_path else None,
+        "interrupted": False,
+    }

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -203,6 +203,16 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- **`migrate_layout_212.py` now delegates to a shared migrator (#244).** The
+  one-time `$CAMPFIRE_ROOT` re-org logic moved verbatim into the zero-dependency
+  `campfire_layout.migrate` core, so the operator script and `campfire sync` run
+  the exact same code (no drift between the two migration paths). The script is
+  now a thin wrapper that keeps its pipeline-specific parts — root resolution,
+  `observations.toml` loading, and the stale-`[paths]` warning — and its CLI
+  (`--apply` / `--clean-intermediates` / `--root`), dry-run default, crash-safe
+  JSONL manifest, and idempotent no-clobber behavior are unchanged. Enables
+  `campfire sync` to detect the old layout and offer to migrate it in place.
+  **No change to scientific output** (a filesystem/CLI refactor only).
 - **Canonical format-version keyword (`CFSCHEMA`, epic #210 B-track prereq).**
   Every NIRSpec canonical spectrum-exposure now carries an integer `CFSCHEMA`
   card (value `1`) stamped at birth in `_finalize_canonical`, self-identifying

--- a/pipeline/scripts/migrate_layout_212.py
+++ b/pipeline/scripts/migrate_layout_212.py
@@ -7,6 +7,11 @@ DRY-RUN by default — it only prints the plan. Pass ``--apply`` to make changes
 Idempotent and re-runnable: it skips anything already at its destination and
 never overwrites existing data.
 
+The migration logic lives in ``campfire_layout.migrate`` (the shared, zero-dep
+layout-contract package) so this operator CLI and ``campfire sync`` run the exact
+same code. This wrapper only adds the pipeline-specific bits: resolving the root,
+loading ``observations.toml``, and warning about stale ``[paths]`` overrides.
+
 Moves (all within a single ``$CAMPFIRE_ROOT``; symlinks are moved, never
 dereferenced; existing targets are never clobbered):
 
@@ -45,38 +50,13 @@ Usage:
 """
 
 import argparse
-import filecmp
-import json
 import os
 import sys
-from datetime import datetime
 from pathlib import Path
 
 import toml
 
-# Reducer-decision TOMLs that move out of the products workspace into reference/.
-# (expected source basename built from the obs name, destination basename)
-REDUCER_TOMLS = [
-    ('_{obs}_stuck_closed_shutters.toml', 'stuck_closed_shutters.toml'),
-    ('_{obs}_nodded_background_overrides.toml', 'nodded_background_overrides.toml'),
-]
-# Any file matching these suffixes that is NOT the expected per-obs name is a
-# stray (e.g. the program-named macs0647 duplicate) — flagged, never moved.
-TOML_SUFFIXES = ('_stuck_closed_shutters.toml', '_nodded_background_overrides.toml')
-
-# A directory "looks like" a NIRSpec obs workspace if it holds any of these.
-# Deliberately NIRSpec-specific (jw*_nrs[12]_* / *_msa*), NOT bare jw*.fits, so a
-# stray flat NIRCam dir can never be misfiled into products/nirspec/.
-NIRSPEC_MARKERS = ('*_spec.fits', '*_rate.fits', 'jw*_nrs[12]_*.fits', '*_msa*.fits',
-                   '*_summary.ecsv', '_*_stuck_closed_shutters.toml',
-                   '_*_nodded_background_overrides.toml')
-NIRCAM_MARKERS = ('jw*_nrc[ab]*.fits', 'jw*_nrcalong*.fits', 'jw*_nrcblong*.fits')
-
-# Stale per-exposure intermediate suffixes (loose quartet), cleaned only with
-# --clean-intermediates, and only when the basename starts jw...­_nrs[12]_.
-QUARTET_SUFFIXES = ('_cal.fits', '_cal_bkgsub.fits', '_s2d.fits', '_s2d_bkgsub.fits')
-INTERMEDIATE_TARBALLS = ('cal.tar.gz', 'cal_bkgsub.tar.gz', 's2d.tar.gz',
-                         's2d_bkgsub.tar.gz', 'bkgsub.tar.gz')
+from campfire_layout.migrate import LayoutMigrator
 
 
 def _resolve_root(cli_root):
@@ -101,306 +81,25 @@ def _load_observations(root):
     return toml.load(path)
 
 
-def _has_any(d, patterns):
-    """True if directory d (following symlinks) contains a file matching any glob."""
-    return any(next(d.glob(p), None) is not None for p in patterns)
-
-
-class Migrator:
-    def __init__(self, root, apply, clean_intermediates):
-        self.root = root
-        self.apply = apply
-        self.clean_intermediates = clean_intermediates
-        self.counts = {}
-        self.warnings = []
-        self._removed = set()       # paths removed (real in --apply, virtual in dry-run)
-        self._created = set()       # move destinations created this run (for accurate dry-run)
-        self._mf = None             # JSONL manifest file handle (apply only)
-        self._manifest_path = None
-
-    # --- manifest / logging -------------------------------------------------
-
-    def open_manifest(self):
-        if not self.apply:
-            return
-        ts = datetime.now().strftime('%Y%m%dT%H%M%S')
-        self._manifest_path = self.root / f'migration_212_manifest_{ts}.jsonl'
-        self._mf = open(self._manifest_path, 'w')
-
-    def _record(self, action, src, dst):
-        if self._mf is not None:
-            self._mf.write(json.dumps({'action': action, 'src': src, 'dst': dst}) + '\n')
-            self._mf.flush()
-            os.fsync(self._mf.fileno())
-
-    def _tag(self, action):
-        self.counts[action] = self.counts.get(action, 0) + 1
-
-    def _rel(self, p):
+def _check_paths_config(root):
+    """Warn if config.toml still sets [paths] overrides that #212 removed."""
+    cfg = root / 'config' / 'config.toml'
+    if not cfg.exists():
+        return
+    try:
+        paths = toml.load(cfg).get('paths', {})
+    except Exception:
+        return
+    stale = {k: paths[k] for k in ('data_dir', 'products_dir') if k in paths}
+    if stale:
         try:
-            return str(Path(p).relative_to(self.root))
-        except ValueError:
-            return str(p)
-
-    def log(self, action, msg):
-        print(f"  [{'' if self.apply else 'DRY '}{action}] {msg}")
-        self._tag(action)
-
-    def warn(self, msg):
-        self.warnings.append(msg)
-        print(f"  [WARN] {msg}")
-        self._tag('WARN')
-
-    # --- mutation primitives (all crash-safe via _record-before-effect) ------
-
-    def _occupied(self, dst):
-        """A destination is occupied if it physically exists OR was created
-        earlier this run, unless it has since been removed."""
-        s = str(dst)
-        return (os.path.lexists(dst) or s in self._created) and s not in self._removed
-
-    def mkdir(self, d):
-        d = Path(d)
-        if d.exists() or str(d) in self._created:
-            return
-        self._record('mkdir', None, str(d))
-        if self.apply:
-            d.mkdir(parents=True, exist_ok=True)
-        self._created.add(str(d))
-
-    def move(self, src, dst):
-        """Rename src -> dst (preserves symlinks; intra-root, never cross-device).
-        Refuses to clobber an occupied destination."""
-        src, dst = Path(src), Path(dst)
-        if self._occupied(dst):
-            self.warn(f"target exists, NOT overwriting: {self._rel(dst)} (left {self._rel(src)})")
-            return False
-        self.mkdir(dst.parent)
-        self._record('move', str(src), str(dst))   # record BEFORE the effect
-        if self.apply:
-            os.rename(src, dst)
-        self.log('MOVE', f"{self._rel(src)} -> {self._rel(dst)}"
-                          + ('  (symlink)' if os.path.islink(src) else ''))
-        self._created.add(str(dst))
-        self._removed.discard(str(src))
-        return True
-
-    def remove_file(self, p, action='REMOVE', why=''):
-        p = Path(p)
-        self._record(action.lower(), str(p), None)   # record BEFORE the effect
-        if self.apply:
-            if p.is_symlink() or p.is_file():
-                p.unlink()
-            else:
-                p.rmdir()
-        self.log(action, f"{self._rel(p)}{('  (' + why + ')') if why else ''}")
-        self._removed.add(str(p))
-        self._created.discard(str(p))
-
-    def rmdir_if_empty(self, d):
-        d = Path(d)
-        if d.is_dir() and not any(d.iterdir()):
-            self._record('rmdir', str(d), None)
-            if self.apply:
-                d.rmdir()
-            self.log('RMDIR', self._rel(d))
-
-    # --- reducer TOML relocation -------------------------------------------
-
-    def relocate_reducer_tomls(self, src_dir, obs):
-        """Move the per-obs reducer TOMLs out of src_dir into reference/nirspec/<obs>/.
-        Dedups byte-identical leftovers; never clobbers a differing target; flags
-        stray (non-per-obs-named) reducer TOMLs without touching them."""
-        ref = self.root / 'reference' / 'nirspec' / obs
-        for src_tmpl, dst_name in REDUCER_TOMLS:
-            src = src_dir / src_tmpl.format(obs=obs)
-            if not src.exists():
-                continue
-            dst = ref / dst_name
-            if os.path.lexists(dst):
-                if dst.is_file() and src.is_file() and filecmp.cmp(src, dst, shallow=False):
-                    self.remove_file(src, action='DEDUP',
-                                     why='identical copy already at reference')
-                else:
-                    self.warn(f"reference TOML differs, kept both: {self._rel(dst)} "
-                              f"vs stale {self._rel(src)}")
-                continue
-            self.move(src, dst)
-        expected = {t.format(obs=obs) for t, _ in REDUCER_TOMLS}
-        for f in sorted(src_dir.glob('_*')):
-            if f.name not in expected and f.name.endswith(TOML_SUFFIXES):
-                self.warn(f"stray reducer TOML left in place (name != _{obs}_*): "
-                          f"{self._rel(f)} — review manually")
-
-    # --- sections -----------------------------------------------------------
-
-    def migrate_products(self):
-        print("\n=== NIRSpec products: products/<obs>/ -> products/nirspec/<obs>/ ===")
-        products = self.root / 'products'
-        if not products.is_dir():
-            self.warn(f"no products/ dir at {self._rel(products)}")
-            return
-        self.mkdir(products / 'nirspec')
-        for entry in sorted(products.iterdir()):
-            name = entry.name
-            if not entry.is_dir() or name in ('nirspec', 'nircam'):
-                continue
-            if name.startswith('_') or name.startswith('.'):
-                continue  # backups (_*_baseline), .DS_Store, etc.
-            old_dir = products / name          # always exists (iterated entry)
-            new_dir = products / 'nirspec' / name
-            if not _has_any(old_dir, NIRSPEC_MARKERS):
-                self.warn(f"products/{name}/ has no NIRSpec markers — skipped (review manually)")
-                continue
-            if new_dir.exists():
-                # Already-migrated copy exists alongside the old one: new is
-                # authoritative. Fix any stray TOML in new; never clobber old.
-                self.relocate_reducer_tomls(new_dir, name)
-                self.warn(f"BOTH products/{name} and products/nirspec/{name} exist — "
-                          f"left old in place (new authoritative); resolve manually")
-                continue
-            # Only old exists: extract reducer TOMLs first, then move the dir.
-            self.relocate_reducer_tomls(old_dir, name)
-            moved = self.move(old_dir, new_dir)
-            if self.clean_intermediates:
-                self._clean_intermediates(new_dir if (moved and self.apply) else old_dir, name)
-
-    def _clean_intermediates(self, obs_dir, obs):
-        n = 0
-        for suf in QUARTET_SUFFIXES:
-            for f in obs_dir.glob(f'jw*_nrs[12]_*{suf}'):
-                self.remove_file(f, action='CLEAN', why='stale per-exposure intermediate')
-                n += 1
-        tarballs = [t for t in INTERMEDIATE_TARBALLS if (obs_dir / t).exists()]
-        if tarballs:
-            self.warn(f"{obs}: intermediate tarball(s) present (NOT auto-removed): "
-                      + ', '.join(tarballs))
-        if n == 0 and not tarballs:
-            print(f"  [info] {obs}: no stale loose intermediates found")
-
-    def migrate_raw(self, obs_cfg):
-        print("\n=== NIRSpec raw: raw/<data_subdir>/ -> raw/nirspec/<data_subdir>/ ===")
-        raw = self.root / 'raw'
-        if not raw.is_dir():
-            self.warn(f"no raw/ dir at {self._rel(raw)}")
-            return
-        self.mkdir(raw / 'nirspec')
-        referenced = {str(v['data_subdir']) for v in obs_cfg.values()
-                      if v.get('data_subdir') is not None}
-        seen = set()
-        # Iterate the flat raw dirs themselves (each unique subdir appears once, so
-        # shared data_subdirs never double-move). Move EVERY NIRSpec raw dir —
-        # referenced by an obs OR not (unreduced programs migrate too) — classified
-        # by content; leave genuine NIRCam / unclassified dirs in place.
-        for entry in sorted(raw.iterdir()):
-            name = entry.name
-            if name in ('nirspec', 'nircam') or name.startswith('.'):
-                continue
-            if not (entry.is_dir() or entry.is_symlink()):
-                continue
-            seen.add(name)
-            new = raw / 'nirspec' / name
-            has_nrs = _has_any(entry, ('*_nrs[12]_*.fits', '*_msa*.fits'))
-            has_nrc = _has_any(entry, NIRCAM_MARKERS)
-            is_ref = name in referenced
-            if has_nrc and not has_nrs:
-                self.warn(f"raw/{name} looks like NIRCam raw — left in place "
-                          f"(NIRCam raw lives under raw/nircam/<PID>/).")
-                continue
-            if not (has_nrs or is_ref):
-                link = '  (symlink, target unreadable?)' if entry.is_symlink() else ''
-                self.warn(f"raw/{name}{link} unclassified — no NIRSpec markers and not in "
-                          f"observations.toml; left in place, review manually.")
-                continue
-            # NIRSpec raw (referenced or unreduced) -> raw/nirspec/<name>.
-            if os.path.lexists(new):
-                if os.path.islink(new) and os.path.realpath(new) == os.path.realpath(entry):
-                    self.remove_file(new, action='FIX', why='self-referential test symlink')
-                else:
-                    self.warn(f"BOTH raw/{name} and raw/nirspec/{name} exist — left old in "
-                              f"place; resolve manually")
-                    continue
-            if self.move(entry, new) and not is_ref:
-                print(f"  [info] raw/{name}: NIRSpec program not yet in observations.toml — migrated")
-        # Sanity: referenced data_subdirs with no raw in the old OR new location.
-        for sub in sorted(referenced):
-            if sub in seen or os.path.lexists(raw / 'nirspec' / sub):
-                continue
-            self.warn(f"observations.toml references data_subdir '{sub}' but no raw found at "
-                      f"raw/{sub} or raw/nirspec/{sub}")
-
-    def migrate_nircam_shared(self):
-        print("\n=== NIRCam: reference/nircam/<field>/{flats,wisps} -> reference/nircam/shared/ ===")
-        nircam = self.root / 'reference' / 'nircam'
-        if not nircam.is_dir():
-            print("  [info] no reference/nircam/ — nothing to hoist")
-            return
-        shared = nircam / 'shared'
-        for sub in ('flats', 'wisps'):
-            self.mkdir(shared / sub)
-        for field_dir in sorted(nircam.iterdir()):
-            if not field_dir.is_dir() or field_dir.name == 'shared':
-                continue
-            for sub in ('flats', 'wisps'):
-                fdir = field_dir / sub
-                if not fdir.is_dir():
-                    continue
-                for f in sorted(fdir.iterdir()):
-                    if f.is_dir():
-                        self.warn(f"unexpected subdir in {self._rel(fdir)}: {f.name} — skipped")
-                        continue
-                    dst = shared / sub / f.name
-                    if self._occupied(dst):
-                        if f.is_file() and dst.is_file() and filecmp.cmp(f, dst, shallow=False):
-                            self.remove_file(f, action='DEDUP', why='identical, already in shared')
-                        elif os.path.lexists(dst):
-                            self.warn(f"flat/wisp collision (differing content), kept both: "
-                                      f"{self._rel(f)} vs {self._rel(dst)}")
-                        else:  # only virtually created this run (dry-run sibling)
-                            self.warn(f"flat/wisp same name from multiple fields: {f.name} — "
-                                      f"apply will dedup-if-identical or keep-both")
-                        continue
-                    self.move(f, dst)
-                self.rmdir_if_empty(fdir)
-
-    # --- driver -------------------------------------------------------------
-
-    def check_paths_config(self):
-        cfg = self.root / 'config' / 'config.toml'
-        if not cfg.exists():
-            return
-        try:
-            paths = toml.load(cfg).get('paths', {})
+            rel = root.name
         except Exception:
-            return
-        stale = {k: paths[k] for k in ('data_dir', 'products_dir') if k in paths}
-        if stale:
-            self.warn(f"config.toml still sets [paths] {stale} — issue #212 removed those "
-                      f"overrides (everything now derives from $CAMPFIRE_ROOT). If they point "
-                      f"OUTSIDE {self._rel(self.root)}, that data is NOT migrated by this script. "
-                      f"Remove the [paths] block after confirming.")
-
-    def run(self, obs_cfg):
-        self.open_manifest()
-        self.check_paths_config()
-        self.migrate_products()
-        self.migrate_raw(obs_cfg)
-        self.migrate_nircam_shared()
-
-    def finalize(self, interrupted=False):
-        if self._mf is not None:
-            self._mf.close()
-        print("\n=== SUMMARY ===")
-        for action in sorted(self.counts):
-            print(f"  {action}: {self.counts[action]}")
-        if not self.apply:
-            print("\nDRY RUN — no changes made. Re-run with --apply to execute.")
-            return
-        note = " (INTERRUPTED — partial)" if interrupted else ""
-        print(f"\nAPPLIED{note}. Manifest (every committed action, for audit/undo): "
-              f"{self._manifest_path}")
-        if self.warnings:
-            print(f"{len(self.warnings)} warning(s) above need manual review.")
+            rel = str(root)
+        print(f"  [WARN] config.toml still sets [paths] {stale} — issue #212 removed those "
+              f"overrides (everything now derives from $CAMPFIRE_ROOT). If they point "
+              f"OUTSIDE {rel}, that data is NOT migrated by this script. "
+              f"Remove the [paths] block after confirming.")
 
 
 def main():
@@ -427,10 +126,13 @@ def main():
     if args.clean_intermediates:
         print("  --clean-intermediates: stale loose quartet WILL be removed from migrated dirs")
 
-    m = Migrator(root, apply=args.apply, clean_intermediates=args.clean_intermediates)
+    _check_paths_config(root)
+
+    m = LayoutMigrator(root, apply=args.apply,
+                       clean_intermediates=args.clean_intermediates, obs_cfg=obs_cfg)
     interrupted = False
     try:
-        m.run(obs_cfg)
+        m.run()
     except (KeyboardInterrupt, Exception) as e:   # always leave an accurate manifest
         interrupted = True
         print(f"\n!! ABORTED mid-migration: {type(e).__name__}: {e}")

--- a/python/campfire/cli.py
+++ b/python/campfire/cli.py
@@ -65,6 +65,61 @@ def _open_store():
             sys.exit(1)
 
 
+def _maybe_migrate_layout(store, migrate_layout: Optional[bool]) -> None:
+    """Detect a pre-#212 local layout and (optionally) migrate it in place.
+
+    Runs before the metadata sync so the relocated files are at their canonical
+    ``products/nirspec/<obs>/`` paths when ``verify_local_objects`` discovers
+    them — turning "nothing downloaded" back into recognized local files without
+    re-downloading. A ``_meta`` marker short-circuits the scan once migrated.
+    """
+    from .config import resolve_data_dir
+    from . import migrate as _mig
+
+    if store.get_meta(_mig.LAYOUT_MARKER_KEY) == _mig.LAYOUT_MARKER_VALUE:
+        return  # already migrated, or born on the new layout
+
+    root = resolve_data_dir()
+    plan_result = _mig.plan(root)
+    if not plan_result["pending"]:
+        # Fresh or already-migrated tree — stamp so we never scan again.
+        store.set_meta(_mig.LAYOUT_MARKER_KEY, _mig.LAYOUT_MARKER_VALUE)
+        return
+
+    counts = plan_result["counts"]
+    click.echo("\n⚠  Local data uses the old layout (products/<obs>/ instead of "
+               "products/nirspec/<obs>/).")
+    click.echo("   Files there won't be recognized as downloaded until the tree is migrated.")
+    summary = ", ".join(f"{k}:{v}" for k, v in sorted(counts.items()))
+    click.echo(f"   Planned actions (dry-run): {summary}")
+    if plan_result["warnings"]:
+        click.echo(f"   ({len(plan_result['warnings'])} item(s) will need manual review.)")
+
+    if migrate_layout is False:
+        click.echo("   Skipping (--no-migrate-layout). Run it yourself with:")
+        click.echo("     python pipeline/scripts/migrate_layout_212.py --apply")
+        return
+    if migrate_layout is None:
+        if not sys.stdin.isatty():
+            click.echo("   Non-interactive session — not migrating automatically. Re-run with "
+                       "--migrate-layout, or use pipeline/scripts/migrate_layout_212.py --apply.")
+            return
+        if not click.confirm("   Migrate the local layout now?", default=False):
+            click.echo("   Skipped — will be offered again on the next sync.")
+            return
+
+    click.echo("   Migrating…")
+    _mig.apply(root, echo=click.echo)
+    # Only stamp the marker if nothing material remains (an unresolved
+    # "BOTH exist" case needs a human; re-offering next sync is safe + idempotent).
+    if not _mig.plan(root)["pending"]:
+        store.set_meta(_mig.LAYOUT_MARKER_KEY, _mig.LAYOUT_MARKER_VALUE)
+        click.echo("   ✓ Local layout migrated.")
+    else:
+        click.echo("   ⚠ Migration applied; some items still need manual review "
+                   "(see warnings/manifest above).")
+
+
 def _check_client_version(base_url: str) -> None:
     """Check if a newer client version is available. Never raises."""
     from . import __version__
@@ -449,12 +504,19 @@ def status(base_url: Optional[str]):
 @cli.command(name="sync")
 @click.option("--full", is_flag=True, help="Force full sync (skip incremental)")
 @click.option("--base-url", default=None, help="API base URL")
-def sync_cmd(full: bool, base_url: Optional[str]):
+@click.option("--migrate-layout/--no-migrate-layout", "migrate_layout", default=None,
+              help="Migrate a pre-#212 local layout without prompting (or skip it). "
+                   "Default: prompt when an old layout is detected on a TTY.")
+def sync_cmd(full: bool, base_url: Optional[str], migrate_layout: Optional[bool]):
     """Sync the object catalog from the server (metadata only).
 
     On first run, pulls the full catalog. On subsequent runs, only
     fetches objects modified since the last sync (incremental).
     Use --full to force a complete re-sync.
+
+    If the local data directory still uses the pre-#212 layout, sync detects it
+    and offers to migrate it in place (products/<obs>/ -> products/nirspec/<obs>/,
+    plus raw/ and reference/ when observations.toml is present).
     """
     base_url = base_url or resolve_base_url()
 
@@ -471,6 +533,10 @@ def sync_cmd(full: bool, base_url: Optional[str]):
     store = _open_store()
 
     try:
+        # Migrate a pre-#212 local layout before anything reads the tree, so the
+        # verify step below discovers the relocated files instead of missing them.
+        _maybe_migrate_layout(store, migrate_layout)
+
         is_incremental = not full and store.get_max_objects_updated_at() is not None
         if is_incremental:
             click.echo("Syncing catalog (updating existing)...")

--- a/python/campfire/db/store.py
+++ b/python/campfire/db/store.py
@@ -321,6 +321,20 @@ class LocalStore:
         except Exception:
             return 0
 
+    def get_meta(self, key: str) -> Optional[str]:
+        """Read a value from the ``_meta`` key/value table (None if absent)."""
+        row = self._conn.execute(
+            "SELECT value FROM _meta WHERE key = ?", (key,)
+        ).fetchone()
+        return row[0] if row else None
+
+    def set_meta(self, key: str, value: str) -> None:
+        """Upsert a value into the ``_meta`` key/value table."""
+        self._conn.execute(
+            "INSERT OR REPLACE INTO _meta (key, value) VALUES (?, ?)", (key, str(value))
+        )
+        self._conn.commit()
+
     # -------------------------------------------------------------------------
     # Objects
     # -------------------------------------------------------------------------

--- a/python/campfire/migrate.py
+++ b/python/campfire/migrate.py
@@ -1,0 +1,56 @@
+"""Client-side hook for the one-time #212 layout migration.
+
+Detects when the local ``$CAMPFIRE_ROOT`` still uses the pre-#212 flat layout
+(``products/<obs>/`` instead of ``products/nirspec/<obs>/``) and, on ``campfire
+sync``, offers to migrate it in place. The heavy lifting is the shared,
+zero-dependency ``campfire_layout.migrate`` core — the same code the operator
+CLI (``pipeline/scripts/migrate_layout_212.py``) runs.
+
+"Full tree when possible": the products (and NIRCam-shared) migration always
+runs; the ``raw/`` + reference relocations additionally run when an
+``observations.toml`` is present under the root (reducers), and are skipped for
+download-only clients that have neither the file nor a ``raw/`` tree.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Optional
+
+# ``_meta`` marker recording that this client already migrated (or was born on)
+# the #212 layout. Purely an optimization: detection is filesystem-authoritative
+# and idempotent, so a lost marker (e.g. after a schema-bump DB rebuild) just
+# costs one cheap re-scan.
+LAYOUT_MARKER_KEY = "layout_migration"
+LAYOUT_MARKER_VALUE = "212"
+
+
+def load_obs_cfg(root: Path) -> Optional[dict]:
+    """Load ``<root>/config/observations.toml`` if present, else None.
+
+    None signals the shared core to skip the ``raw/`` migration entirely (a
+    download-only client has no observations table and no raw tree).
+    """
+    path = Path(root) / "config" / "observations.toml"
+    if not path.exists():
+        return None
+    try:
+        import toml
+        return toml.load(path)
+    except Exception:
+        # A malformed/unreadable observations.toml shouldn't block a sync; fall
+        # back to products-only migration rather than erroring out.
+        return None
+
+
+def plan(root: Path) -> dict:
+    """Dry-run the migration for ``root``; return the shared-core plan dict
+    ({pending, counts, warnings})."""
+    from campfire_layout.migrate import plan_migration
+    return plan_migration(root, obs_cfg=load_obs_cfg(root))
+
+
+def apply(root: Path, echo: Callable = print) -> dict:
+    """Execute the migration for ``root``; return the shared-core result dict."""
+    from campfire_layout.migrate import apply_migration
+    return apply_migration(root, obs_cfg=load_obs_cfg(root), echo=echo)

--- a/python/tests/test_migrate_layout.py
+++ b/python/tests/test_migrate_layout.py
@@ -1,0 +1,167 @@
+"""Tests for the one-time #212 layout migration (issue #244).
+
+Covers the shared, zero-dependency core in ``campfire_layout.migrate`` (the same
+code the operator CLI and ``campfire sync`` run) and the client hook in
+``campfire.migrate``:
+
+  * detection is dry-run by default and never touches disk;
+  * ``apply`` relocates products + raw + reference + NIRCam-shared and is
+    idempotent (a second plan is not pending);
+  * a download-only client (``obs_cfg=None``) migrates the products tree only
+    and leaves ``raw/`` untouched;
+  * the no-clobber invariant: an existing destination is never overwritten;
+  * the ``_meta`` layout marker round-trips through the LocalStore.
+"""
+
+import pytest
+
+from campfire_layout.migrate import LayoutMigrator, apply_migration, plan_migration
+
+
+OBS_CFG = {"ember_egs_p1": {"data_subdir": "7076"}}
+
+
+def _build_old_layout(root):
+    """Materialize a representative pre-#212 tree under ``root``."""
+    obs = root / "products" / "ember_egs_p1"
+    obs.mkdir(parents=True)
+    (obs / "ember_egs_p1_prism_clear_15182_spec.fits").write_text("spec")
+    (obs / "ember_egs_p1_summary.ecsv").write_text("summary")
+    (obs / "_ember_egs_p1_stuck_closed_shutters.toml").write_text("reducer")
+    # a non-NIRSpec stray dir: must be left in place + warned, never misfiled
+    (root / "products" / "junk").mkdir()
+    (root / "products" / "junk" / "notes.txt").write_text("n")
+    # OLD-layout NIRSpec raw dir (referenced by observations.toml)
+    raw = root / "raw" / "7076"
+    raw.mkdir(parents=True)
+    (raw / "jw07076020001_04101_00003_nrs1_uncal.fits").write_text("raw")
+    # NIRCam per-field shared flats -> hoisted to reference/nircam/shared
+    fl = root / "reference" / "nircam" / "cosmos" / "flats"
+    fl.mkdir(parents=True)
+    (fl / "flat_f444w.fits").write_text("flat")
+
+
+# --- detection / dry-run ----------------------------------------------------
+
+def test_plan_detects_old_layout_without_touching_disk(tmp_path):
+    _build_old_layout(tmp_path)
+    plan = plan_migration(tmp_path, obs_cfg=OBS_CFG)
+    assert plan["pending"] is True
+    assert plan["counts"].get("MOVE", 0) >= 3
+    # dry-run must not have moved anything
+    assert (tmp_path / "products" / "ember_egs_p1"
+            / "ember_egs_p1_prism_clear_15182_spec.fits").exists()
+    assert not (tmp_path / "products" / "nirspec").exists()
+
+
+def test_fresh_new_layout_is_not_pending(tmp_path):
+    obs = tmp_path / "products" / "nirspec" / "ember_egs_p1"
+    obs.mkdir(parents=True)
+    (obs / "ember_egs_p1_prism_clear_15182_spec.fits").write_text("spec")
+    assert plan_migration(tmp_path, obs_cfg=OBS_CFG)["pending"] is False
+
+
+# --- full-tree apply (reducer: observations.toml present) -------------------
+
+def test_apply_full_tree_and_idempotent(tmp_path):
+    _build_old_layout(tmp_path)
+    result = apply_migration(tmp_path, obs_cfg=OBS_CFG, echo=lambda *a, **k: None)
+
+    # products -> products/nirspec/<obs>/
+    assert (tmp_path / "products" / "nirspec" / "ember_egs_p1"
+            / "ember_egs_p1_prism_clear_15182_spec.fits").exists()
+    assert not (tmp_path / "products" / "ember_egs_p1").exists()
+    # raw -> raw/nirspec/<subdir>/
+    assert (tmp_path / "raw" / "nirspec" / "7076"
+            / "jw07076020001_04101_00003_nrs1_uncal.fits").exists()
+    # reducer TOML -> reference/nirspec/<obs>/
+    assert (tmp_path / "reference" / "nirspec" / "ember_egs_p1"
+            / "stuck_closed_shutters.toml").exists()
+    # NIRCam flat -> reference/nircam/shared/flats/
+    assert (tmp_path / "reference" / "nircam" / "shared" / "flats"
+            / "flat_f444w.fits").exists()
+    # stray dir untouched
+    assert (tmp_path / "products" / "junk" / "notes.txt").exists()
+    # audit manifest written
+    assert result["manifest_path"] is not None
+
+    # idempotent: nothing left to do
+    assert plan_migration(tmp_path, obs_cfg=OBS_CFG)["pending"] is False
+
+
+# --- download-only client (obs_cfg=None): products only, raw untouched ------
+
+def test_client_obs_cfg_none_skips_raw(tmp_path):
+    _build_old_layout(tmp_path)
+    apply_migration(tmp_path, obs_cfg=None, echo=lambda *a, **k: None)
+    # products migrated
+    assert (tmp_path / "products" / "nirspec" / "ember_egs_p1").exists()
+    # raw left flat (raw migration skipped entirely without an observations table)
+    assert (tmp_path / "raw" / "7076").exists()
+    assert not (tmp_path / "raw" / "nirspec" / "7076").exists()
+
+
+# --- safety: never clobber an existing destination -------------------------
+
+def test_no_clobber_when_both_old_and_new_exist(tmp_path):
+    _build_old_layout(tmp_path)
+    # simulate a partially-migrated tree: the new dir already holds a file
+    new = tmp_path / "products" / "nirspec" / "ember_egs_p1"
+    new.mkdir(parents=True)
+    (new / "keep.fits").write_text("authoritative")
+
+    plan = plan_migration(tmp_path, obs_cfg=OBS_CFG)
+    # a "BOTH exist" situation is a warning, not a material move of the obs dir
+    assert any("BOTH" in w for w in plan["warnings"])
+
+    apply_migration(tmp_path, obs_cfg=OBS_CFG, echo=lambda *a, **k: None)
+    # old dir left in place, new file preserved (not overwritten)
+    assert (tmp_path / "products" / "ember_egs_p1").exists()
+    assert (new / "keep.fits").read_text() == "authoritative"
+
+
+def test_dir_without_nirspec_markers_is_left_alone(tmp_path):
+    d = tmp_path / "products" / "mystery"
+    d.mkdir(parents=True)
+    (d / "random.dat").write_text("x")
+    plan = plan_migration(tmp_path, obs_cfg=OBS_CFG)
+    assert plan["pending"] is False
+    assert any("no NIRSpec markers" in w for w in plan["warnings"])
+    assert (tmp_path / "products" / "mystery").exists()
+    assert not (tmp_path / "products" / "nirspec" / "mystery").exists()
+
+
+# --- client helper: observations.toml discovery ----------------------------
+
+def test_client_load_obs_cfg(tmp_path):
+    from campfire import migrate as cmig
+
+    assert cmig.load_obs_cfg(tmp_path) is None  # no config/observations.toml
+    cfg = tmp_path / "config"
+    cfg.mkdir()
+    (cfg / "observations.toml").write_text('[ember_egs_p1]\ndata_subdir = "7076"\n')
+    assert cmig.load_obs_cfg(tmp_path) == {"ember_egs_p1": {"data_subdir": "7076"}}
+
+
+def test_client_plan_and_apply(tmp_path):
+    from campfire import migrate as cmig
+
+    _build_old_layout(tmp_path)
+    assert cmig.plan(tmp_path)["pending"] is True  # obs_cfg=None -> products still pending
+    cmig.apply(tmp_path, echo=lambda *a, **k: None)
+    assert (tmp_path / "products" / "nirspec" / "ember_egs_p1").exists()
+
+
+# --- store marker round-trip ------------------------------------------------
+
+def test_layout_marker_roundtrips_through_store(tmp_path):
+    from campfire.db.store import LocalStore
+    from campfire.migrate import LAYOUT_MARKER_KEY, LAYOUT_MARKER_VALUE
+
+    s = LocalStore(tmp_path / "meta" / "campfire.db")
+    try:
+        assert s.get_meta(LAYOUT_MARKER_KEY) is None
+        s.set_meta(LAYOUT_MARKER_KEY, LAYOUT_MARKER_VALUE)
+        assert s.get_meta(LAYOUT_MARKER_KEY) == LAYOUT_MARKER_VALUE
+    finally:
+        s.close()


### PR DESCRIPTION
## Summary

Refactors the one-time issue #212 `$CAMPFIRE_ROOT` layout migration logic into a shared, zero-dependency core (`campfire_layout.migrate`) so that both the operator CLI (`pipeline/scripts/migrate_layout_212.py`) and `campfire sync` run the exact same code. This eliminates drift between the two implementations and makes the migration available to any client that depends on `campfire-layout`.

## Key Changes

- **New `layout/campfire_layout/migrate.py`**: Extracted the complete migration logic into a reusable `LayoutMigrator` class and helper functions (`plan_migration`, `apply_migration`). The module is **stdlib-only** (zero external dependencies) and handles:
  - Products relocation (`products/<obs>/` → `products/nirspec/<obs>/`)
  - Raw data relocation (`raw/<subdir>/` → `raw/nirspec/<subdir>/`)
  - Reducer TOML extraction to `reference/nirspec/<obs>/`
  - NIRCam shared flats/wisps hoisting to `reference/nircam/shared/`
  - Crash-safe manifest logging (JSONL audit trail)
  - Dry-run mode (default) and idempotent apply

- **Updated `pipeline/scripts/migrate_layout_212.py`**: Now delegates to the shared core; retains only pipeline-specific concerns (root resolution, `observations.toml` loading, `config.toml` validation warnings)

- **New `python/campfire/migrate.py`**: Client-side hook that detects pre-#212 layouts and integrates with `campfire sync`. Loads `observations.toml` if present (full tree migration for reducers) or skips raw migration for download-only clients

- **Updated `python/campfire/cli.py`**: Adds `_maybe_migrate_layout()` to detect old layouts on sync, offer interactive migration, and stamp a `_meta` marker to avoid re-scanning

- **Updated `python/campfire/db/store.py`**: Adds `get_meta()` and `set_meta()` methods for the `_meta` key/value table (used to track migration status)

- **New `python/tests/test_migrate_layout.py`**: Comprehensive test suite covering detection, dry-run, full-tree apply, idempotency, download-only clients, no-clobber safety, and marker round-tripping

- **Updated `layout/campfire_layout/__init__.py`**: Exports the migration API (`LayoutMigrator`, `plan_migration`, `apply_migration`)

- **Updated `pipeline/CHANGELOG.md`**: Documents the refactoring under Infrastructure

## Notable Implementation Details

- **Zero dependencies**: The core uses only stdlib (`pathlib`, `json`, `filecmp`, `os`, `datetime`). Callers pass in `observations.toml` as a plain dict; no TOML parsing in the core.
- **Crash-safe**: Every mutation is recorded to a JSONL manifest *before* the effect, enabling audit trails and potential undo.
- **Idempotent**: Dry-run detection is filesystem-authoritative; a second plan after apply shows `pending=False`.
- **No clobber**: Existing destinations are never overwritten; conflicts are warned and left for manual review.
- **Symlink-aware**: Symlinks are moved (not dereferenced); self-referential test symlinks are detected and cleaned.
- **Download-only support**: When `obs_cfg=None`, raw migration is skipped entirely; products + NIRCam-shared still run.
- **Marker optimization**: A `_meta` entry (`layout_migration=212`) short-circuits re-scans after migration, though detection remains filesystem-authoritative.

https://claude.ai/code/session_01TMVBE3LXghEgCkPAwWGksw