### PR TITLE
fix(nirspec): disable optimal-extraction aperture bounding for fixed slits

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -71,6 +71,17 @@ Release procedure: edit the `## Unreleased` section below, then run
   feature failed for fixed-slit sources.
 
 ### Algorithm
+- NIRSpec optimal extraction no longer bounds the cross-dispersion profile to
+  the nominal aperture for fixed-slit sources. The aperture bounding in
+  `optext_profile` exists to keep the profile from picking up flux from
+  neighbouring shutters across the bars in MSA slitlets; NIRSpec fixed slits
+  have no such bars, so the full cross-dispersion cut is a valid spatial
+  profile. Fixed-slit sources (detected from the `fixed_slit` column of the
+  s2d `EXPOSURES` table / `CFFXSLT` header, covering both standalone
+  `NRS_FIXEDSLIT` and fixed-slit-in-MSA sources) now extract with
+  `bounded=False`, changing the optimally-extracted `fnu`/`flam` for those
+  sources. MSA sources are unchanged (still bounded), and the boxcar
+  extractions are unaffected.
 - **NIRSpec canonical spectrum-exposure + instrument-parity layout (issue #212).
   BREAKING file-naming/structure change — a pipeline MAJOR.** The four NIRSpec
   intermediate files per `(exposure, detector, source)` (`_cal` / `_cal_bkgsub` /

--- a/pipeline/campfire_pipeline/nirspec/extraction.py
+++ b/pipeline/campfire_pipeline/nirspec/extraction.py
@@ -63,14 +63,28 @@ def boxcar_profile(start, end, n_pixels):
     return profile
 
 
-def optext_profile(collapsed, start, end):
+def optext_profile(collapsed, start, end, bounded=True):
+    """Build a normalized cross-dispersion profile for optimal extraction.
 
+    When ``bounded`` is True (the default) the profile is restricted to the
+    nominal extraction aperture ``[start, end]``. This is appropriate for MSA
+    slitlets, where bars separate adjacent shutters and flux outside the
+    aperture belongs to neighbouring sources rather than the target.
+
+    NIRSpec fixed-slit exposures have no such bars, so the full cross-dispersion
+    cut is a valid spatial profile; pass ``bounded=False`` to use every pixel
+    (``start``/``end`` are then ignored for the profile itself).
+    """
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', category=RuntimeWarning)
 
-        x = np.arange(len(collapsed)+1)
         profile = np.zeros_like(collapsed)
-        profile[(x[:-1] > start)&(x[1:] <= end)] = collapsed[(x[:-1] > start)&(x[1:] <= end)]
+        if bounded:
+            x = np.arange(len(collapsed)+1)
+            in_ap = (x[:-1] > start) & (x[1:] <= end)
+            profile[in_ap] = collapsed[in_ap]
+        else:
+            profile[:] = collapsed
         profile[profile < 0] = 0
         profile /= np.nansum(profile)
 

--- a/pipeline/campfire_pipeline/nirspec/stage3.py
+++ b/pipeline/campfire_pipeline/nirspec/stage3.py
@@ -398,6 +398,11 @@ def opt_ext_single_source(
     except (KeyError, IndexError):
         pass
 
+    # Fixed-slit exposures have no MSA bars, so the optimal-extraction profile
+    # need not be bounded to the nominal aperture (the bounding exists to avoid
+    # picking up neighbouring shutters across bars in MSA data).
+    is_fixed_slit = bool(ph.get('CFFXSLT', False))
+
     primary = fits.PrimaryHDU(header=ph)
 
     # Optimal extraction
@@ -407,7 +412,7 @@ def opt_ext_single_source(
     x1d_start = x1d['EXTRACT1D'].header['EXTRYSTR']-1
     x1d_stop = x1d['EXTRACT1D'].header['EXTRYSTP']
     cen = (x1d_start+x1d_stop)/2
-    profile_opt = optext_profile(collapsed, x1d_start, x1d_stop)
+    profile_opt = optext_profile(collapsed, x1d_start, x1d_stop, bounded=not is_fixed_slit)
     corrupted, n_pos, pos_frac = optext_profile_is_corrupted(collapsed, x1d_start, x1d_stop)
     if corrupted or all(np.isnan(profile_opt)):
         log(f"Optimal-extraction profile is corrupted for {product_name} "
@@ -614,7 +619,15 @@ def combine_per_eg_spectra(
     x1d_start = x1d['EXTRACT1D'].header['EXTRYSTR'] - 1
     x1d_stop = x1d['EXTRACT1D'].header['EXTRYSTP']
     cen = (x1d_start + x1d_stop) / 2
-    profile_opt = optext_profile(collapsed, x1d_start, x1d_stop)
+    # Fixed-slit exposures have no MSA bars, so skip the aperture bounding on the
+    # optimal-extraction profile (see opt_ext_single_source).
+    try:
+        _exp = s2d['EXPOSURES'].data
+        is_fixed_slit = ('fixed_slit' in _exp.columns.names
+                         and bool(np.any(_exp['fixed_slit'])))
+    except (KeyError, IndexError):
+        is_fixed_slit = False
+    profile_opt = optext_profile(collapsed, x1d_start, x1d_stop, bounded=not is_fixed_slit)
     corrupted, n_pos, pos_frac = optext_profile_is_corrupted(collapsed, x1d_start, x1d_stop)
     if corrupted or all(np.isnan(profile_opt)):
         log(f"Stacked optimal-extraction profile is corrupted for {product_name} "


### PR DESCRIPTION
## Summary

The optimal-extraction cross-dispersion profile in `optext_profile` is restricted to the nominal extraction aperture `[start, end]`. That bounding exists to keep the profile from picking up flux across the **bars between MSA shutters** — flux outside the aperture belongs to a neighbouring source, not the target.

NIRSpec **fixed slits have no such bars**, so bounding needlessly clips the source's spatial profile. This PR disables the bounding for fixed-slit sources so their optimal extraction uses the full cross-dispersion cut.

## Changes

- **`extraction.py`** — `optext_profile` gains a `bounded` flag. `bounded=True` (default) is byte-identical to the previous code (verified: `np.allclose` against the old path); `bounded=False` builds the profile from every cross-dispersion pixel, ignoring `[start, end]`. Negative-pixel zeroing and normalization are unchanged in both modes, so nod residuals are still rejected.
- **`stage3.py`** — both optimal-extraction paths (`opt_ext_single_source` and `combine_per_eg_spectra`) detect fixed-slit sources and call `optext_profile(..., bounded=not is_fixed_slit)`. Detection reads the `fixed_slit` column of the s2d `EXPOSURES` table / `CFFXSLT` header, which covers both standalone `NRS_FIXEDSLIT` exposures and fixed-slit-in-MSA sources.

## Impact

- Only the **optimal** `fnu`/`flam` for **fixed-slit sources** change.
- MSA sources are unchanged (still bounded — default path is bit-identical).
- The 3px/4px/5px boxcar extractions are unaffected in all cases.
- Changelog entry added under `## Unreleased → ### Algorithm` (flux values change for the same input → pipeline MINOR).

## Verification

- `optext_profile` sanity check: default output equals the old bounded output; `bounded=False` includes previously-clipped in-slit pixels and still zeroes negative (nod-residual) pixels and normalizes to unit sum.
- Both edited modules byte-compile cleanly.

Generated with Claude Code


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbszs4aYdbVy94kWsWfsXN)_