### PR TITLE
fix(deploy): sanitize non-finite profile weights in spectrum JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ Thumbs.db
 # CAMPFIRE Secrets - DO NOT COMMIT
 campfire/config.toml
 scripts/config.toml
+.env
+.env.*
+!.env.example
 
 # Data directories (large files)
 data/raw/

--- a/python/campfire/deploy/generate.py
+++ b/python/campfire/deploy/generate.py
@@ -177,6 +177,11 @@ def read_spectrum_data(fits_path: Path) -> dict:
             collapsed_norm = collapsed / np.nanmax(np.abs(collapsed[valid_opt])) if np.any(valid_opt) else collapsed
             collapsed_norm = np.where(np.isfinite(collapsed_norm), collapsed_norm, 0)
             opt_norm = opt_weight / np.nanmax(opt_weight) if np.nanmax(opt_weight) > 0 else opt_weight
+            # opt weights can be non-finite at masked/edge pixels; a NaN here would
+            # be serialized as the bare token `NaN` (invalid JSON) and make the
+            # browser's JSON.parse reject the whole spectrum payload. Guard it the
+            # same way as snr_2d / collapsed_norm above.
+            opt_norm = np.where(np.isfinite(opt_norm), opt_norm, 0)
 
         return {
             'wave': wave,
@@ -196,7 +201,13 @@ def generate_spectrum_json(fits_path: Path, output_dir: Path) -> Path:
     data = read_spectrum_data(fits_path)
     json_path = output_dir / (fits_path.stem + '.json')
     with open(json_path, 'w') as f:
-        json.dump(data, f)
+        # allow_nan=False: a non-finite value would otherwise be written as the
+        # bare token `NaN`/`Infinity`, which is invalid JSON. The web render path
+        # (/api/spectrum -> response.json(); browser JSON.parse) rejects such a
+        # payload and the spectrum silently fails to render. Fail loudly here at
+        # deploy time instead; arrays that can legitimately be non-finite are
+        # sanitized in read_spectrum_data().
+        json.dump(data, f, allow_nan=False)
     return json_path
 
 

--- a/python/tests/test_generate.py
+++ b/python/tests/test_generate.py
@@ -1,0 +1,85 @@
+"""Regression tests for deploy-side spectrum JSON generation.
+
+Guards against the failure that hid `snake_ls1_ddt` on the web portal: a
+non-finite optimal-extraction weight leaked into `profile_fit` and was written
+by ``json.dump`` as the bare token ``NaN``. That is invalid JSON, so the browser
+(and the Next.js ``/api/spectrum`` route via ``response.json()``) rejected the
+whole payload and the spectrum silently failed to render.
+"""
+
+import json
+
+import numpy as np
+import pytest
+from astropy.io import fits
+
+from campfire.deploy.generate import generate_spectrum_json, read_spectrum_data
+
+
+def _strict_constant(x):
+    """parse_constant hook that mirrors JS ``JSON.parse`` — reject NaN/Infinity."""
+    raise ValueError(f"invalid JSON constant: {x}")
+
+
+def _write_spec_fits(path, *, opt, fnu=None, sci=None):
+    """Build a minimal spectrum FITS with the HDUs read_spectrum_data expects."""
+    n_spatial = len(opt)
+    n_wave = 4
+    wave = np.linspace(1.0, 5.0, n_wave)
+    fnu = np.ones(n_wave) if fnu is None else np.asarray(fnu, dtype=float)
+    fnu_err = np.full(n_wave, 0.1)
+    sci = np.ones((n_spatial, n_wave)) if sci is None else np.asarray(sci, dtype=float)
+    err = np.full((n_spatial, n_wave), 0.1)
+    ypos = np.arange(n_spatial, dtype=float)
+
+    hdu0 = fits.PrimaryHDU()
+    spec1d = fits.BinTableHDU.from_columns([
+        fits.Column(name="wave", format="D", array=wave),
+        fits.Column(name="fnu", format="D", array=fnu),
+        fits.Column(name="fnu_err", format="D", array=fnu_err),
+    ], name="SPEC1D")
+    prof1d = fits.BinTableHDU.from_columns([
+        fits.Column(name="ypos", format="D", array=ypos),
+        fits.Column(name="opt", format="D", array=np.asarray(opt, dtype=float)),
+    ], name="PROF1D")
+    fits.HDUList([
+        hdu0,
+        spec1d,
+        fits.ImageHDU(data=sci, name="SCI"),
+        fits.ImageHDU(data=err, name="ERR"),
+        prof1d,
+    ]).writeto(path)
+
+
+def test_nonfinite_profile_weight_yields_valid_json(tmp_path):
+    """A NaN optimal-extraction weight must not corrupt the JSON payload."""
+    fits_path = tmp_path / "obj_prism_clear_1_spec.fits"
+    # opt[0] non-finite (masked/edge pixel) — this is exactly what broke snake.
+    _write_spec_fits(fits_path, opt=[np.nan, 1.0, 2.0, 1.0, 0.5])
+
+    json_path = generate_spectrum_json(fits_path, tmp_path)
+    text = json_path.read_text()
+
+    # Must be valid *strict* JSON (browser JSON.parse equivalent).
+    data = json.loads(text, parse_constant=_strict_constant)
+    assert "NaN" not in text
+    # The offending weight is coerced to 0, mirroring snr_2d / profile handling.
+    assert data["profile_fit"][0] == 0.0
+    assert all(np.isfinite(v) for v in data["profile_fit"])
+
+
+def test_json_dump_rejects_unsanitized_nonfinite(tmp_path):
+    """allow_nan=False is a backstop: a leak in any *future* field fails loudly."""
+    with pytest.raises(ValueError):
+        json.dump({"x": float("nan")}, open(tmp_path / "x.json", "w"), allow_nan=False)
+
+
+def test_nonfinite_flux_becomes_null(tmp_path):
+    """Existing contract: non-finite fnu is emitted as JSON null, not NaN."""
+    fits_path = tmp_path / "obj_prism_clear_2_spec.fits"
+    _write_spec_fits(fits_path, opt=[1.0, 1.0, 1.0, 1.0, 0.5],
+                     fnu=[1.0, np.nan, 3.0, 4.0])
+
+    json_path = generate_spectrum_json(fits_path, tmp_path)
+    data = json.loads(json_path.read_text(), parse_constant=_strict_constant)
+    assert data["fnu"][1] is None


### PR DESCRIPTION
## Problem

`snake_ls1_ddt` deployed cleanly but its spectra would not render on the portal. The colleague suspected the R2→OSN migration.

**It is not the migration.** The OSN object is present at the exact key the web signs (`data/products/nirspec/snake_ls1_ddt/…_spec.json`, size matches the registry), `storage_objects` is correct (`backend=osn`, `status=active`), `OSN_READ_ENABLED` is on, and `resolveObjectBackends` resolves via a service-role client. A sibling OSN-only observation (`egs4106_p7`) renders fine — proving the whole OSN read path works.

The failure is in the **payload**. Snake's `spec.json` contains one bare `NaN` token, so it **fails strict `JSON.parse`** — which is what the browser and Next.js `response.json()` use. `/api/spectrum` fetches the (present) object, `await response.json()` throws on `NaN`, the route errors, and the plot never receives data.

## Root cause

`read_spectrum_data` / `generate_spectrum_json` (`python/campfire/deploy/generate.py`) sanitize every array that can be non-finite — `snr_2d` → 0, `fnu`/`fnu_err` → `null`, `collapsed_norm` → 0 — **except `profile_fit`** (the optimal-extraction weights, `opt_norm`). When `PROF1D['opt']` has a non-finite masked/edge weight (snake's `profile_fit[0]`), the `NaN` survives and `json.dump(..., allow_nan=True)` (the default) writes the invalid literal `NaN`. It is data-dependent, so only some sources break.

## Fix

- Guard `opt_norm` with `np.where(np.isfinite(...), ..., 0)`, matching the existing `snr_2d` / `collapsed_norm` treatment.
- `json.dump(..., allow_nan=False)` as a backstop — any future non-finite leak fails loudly at deploy time instead of silently shipping invalid JSON.
- `test_generate.py`: regression coverage (non-finite `opt` → valid strict JSON; `allow_nan=False` backstop; non-finite `fnu` → `null`).
- Ignore root `.env` (now holds OSN read creds) so credentials can't be committed.

Verified by regenerating snake's JSON from its actual FITS with the patched code: valid strict JSON, `profile_fit[0] = 0.0`, zero non-finite floats remaining.

## Follow-up (not in this PR)

- **Re-deploy `snake_ls1_ddt`** to regenerate its `spec.json` (FITS is fine; no re-reduction).
- **Audit** other already-deployed `*_spec.json` for the same latent `NaN` so any silently-broken spectra can be batch re-deployed.

No changelog entry (touches `python/` only, not `pipeline/**`).

Generated with Claude Code

https://claude.ai/code/session_01MJG4szxcgRHiaJY3F9mc1X