### PR TITLE
feat(deploy): field-scoped deployments + `campfire deploy --field` for NIRCam exposures (N1, #263)

### DIFF
--- a/python/campfire/deploy/cli.py
+++ b/python/campfire/deploy/cli.py
@@ -84,7 +84,8 @@ from campfire.deploy.deploy import (
 )
 from campfire.deploy.supabase import (
     get_supabase_client, upsert_programs, refresh_filter_options,
-    refresh_programs_overview, get_latest_deployment_id, set_deployment_status,
+    refresh_programs_overview, get_latest_deployment_id,
+    get_latest_field_deployment_id, set_deployment_status,
     get_user_id_from_token,
 )
 
@@ -209,7 +210,12 @@ def source_ids_option(f):
 @click.group(invoke_without_command=True)
 @click.option('--config', 'config_path', default=None, help='Path to deploy config TOML.')
 @click.option('--obs', default=None, multiple=True, type=str, cls=_VariadicOption,
-              help='Observation name(s) (e.g. ember_uds_p4).')
+              help='NIRSpec observation name(s) (e.g. ember_uds_p4).')
+@click.option('--field', default=None, type=str,
+              help='NIRCam field name (e.g. cosmos). Deploys exposures/mosaics for '
+                   'the field; mutually exclusive with --obs.')
+@click.option('--filter', 'filter_names', multiple=True, cls=_VariadicOption,
+              help='NIRCam filter(s) to deploy with --field (default: all).')
 @click.option('--dry-run', is_flag=True, help='Show what would happen without making changes.')
 @click.option('--source-ids', multiple=True, type=str, default=None,
               cls=_VariadicOption, callback=_parse_source_ids,
@@ -236,10 +242,17 @@ def source_ids_option(f):
                    '(bypasses RLS + presigned URLs). For unattended / CI deploys. '
                    'Equivalent to CAMPFIRE_DEPLOY_MODE=service-role.')
 @click.pass_context
-def deploy_group(ctx, config_path, obs, dry_run, source_ids, supabase_only,
-                 force_overwrite, auto_approve, rgb, no_sed, no_shutters,
-                 no_photometry, skip_astrometry, draft, local, service_role):
-    """Deploy CAMPFIRE pipeline products to Supabase + object storage."""
+def deploy_group(ctx, config_path, obs, field, filter_names, dry_run, source_ids,
+                 supabase_only, force_overwrite, auto_approve, rgb, no_sed,
+                 no_shutters, no_photometry, skip_astrometry, draft, local,
+                 service_role):
+    """Deploy CAMPFIRE pipeline products to Supabase + object storage.
+
+    NIRSpec: `campfire deploy --obs <obs>`.  NIRCam:
+    `campfire deploy --field <field> [--filter f1 --filter f2] [--draft]` —
+    first-class parity, recording a field-scoped deployment (published by default;
+    --draft holds it admin-only for review, then `deploy publish --field`).
+    """
     ctx.ensure_object(dict)
     ctx.obj['local'] = local
     # Propagate the flag to subcommands via the env switch load_config reads, so
@@ -254,11 +267,25 @@ def deploy_group(ctx, config_path, obs, dry_run, source_ids, supabase_only,
         _gate_admin(load_config(config_path, local=local,
                                 service_role=ctx.obj['service_role']))
 
-    # When invoked without a subcommand, --obs is required
+    # When invoked without a subcommand: NIRCam field deploy (--field) or NIRSpec
+    # observation deploy (--obs).
     if ctx.invoked_subcommand is None:
+        if field and obs:
+            print("Error: --field (NIRCam) and --obs (NIRSpec) are mutually exclusive.")
+            sys.exit(1)
+        if field:
+            config = load_config(config_path, local=local,
+                                 service_role=ctx.obj['service_role'])
+            _announce_auth_mode(config)
+            from campfire.deploy.nircam import deploy_nircam
+            deploy_nircam(field, config,
+                          filters=list(filter_names) if filter_names else None,
+                          dry_run=dry_run, draft=draft)
+            return
         if not obs:
-            print("Error: --obs is required for full deployment.")
+            print("Error: --obs (NIRSpec) or --field (NIRCam) is required for full deployment.")
             print("Usage: campfire deploy --obs <observation_name>")
+            print("       campfire deploy --field <field> [--filter <f> ...] [--draft]")
             sys.exit(1)
 
         config = load_config(config_path, local=local,
@@ -422,16 +449,31 @@ def slits(ctx, config_path, obs, dry_run, local):
         deploy_slits(obs_name, config, dry_run=dry_run)
 
 
-def _lifecycle_transition(ctx, config_path, obs, dry_run, local, *, to_status, verb):
-    """Shared body for the publish/revoke subcommands (epic #210, B2).
+def _lifecycle_transition(ctx, config_path, obs, dry_run, local, *, to_status, verb,
+                          field=None):
+    """Shared body for the publish/revoke subcommands (epic #210, B2 / #261).
 
-    Resolves each observation's latest deployment and calls set_deployment_status,
-    which flips the deployment + its spectra + recomputes has_published_spectrum +
-    writes audit rows server-side.
+    Resolves each observation's (or a NIRCam field's) latest deployment and calls
+    set_deployment_status, which flips the deployment + its spectra / nircam_images
+    + writes audit rows server-side.
     """
     config = load_config(config_path, local=_resolve_local(ctx, local))
     sb = get_supabase_client(config)
     actor = get_user_id_from_token(config)
+    if field:
+        dep_id = get_latest_field_deployment_id(sb, field)
+        if dep_id is None:
+            print(f"  field {field}: no deployment found, skipping")
+            return
+        if dry_run:
+            print(f"  [dry-run] {verb} field {field} (deployment #{dep_id})")
+            return
+        result = set_deployment_status(sb, dep_id, to_status, actor=actor)
+        if result is None:
+            print(f"  field {field}: {verb.lower()} failed")
+            return
+        print(f"  {verb}ed field {field} (deployment #{dep_id}) -> {to_status}")
+        return
     for obs_name in obs:
         dep_id = get_latest_deployment_id(sb, obs_name)
         if dep_id is None:
@@ -451,20 +493,22 @@ def _lifecycle_transition(ctx, config_path, obs, dry_run, local, *, to_status, v
 
 @deploy_group.command()
 @shared_options
+@click.option('--field', default=None, help='NIRCam field to publish (instead of --obs).')
 @click.pass_context
-def publish(ctx, config_path, obs, dry_run, local):
-    """Publish draft observation(s): make their spectra visible to users."""
+def publish(ctx, config_path, obs, dry_run, local, field):
+    """Publish draft observation(s) or a NIRCam field: make products public."""
     _lifecycle_transition(ctx, config_path, obs, dry_run, local,
-                          to_status='published', verb='Publish')
+                          to_status='published', verb='Publish', field=field)
 
 
 @deploy_group.command()
 @shared_options
+@click.option('--field', default=None, help='NIRCam field to revoke (instead of --obs).')
 @click.pass_context
-def revoke(ctx, config_path, obs, dry_run, local):
-    """Revoke published observation(s): hide their spectra from users (bytes retained)."""
+def revoke(ctx, config_path, obs, dry_run, local, field):
+    """Revoke published observation(s) or a NIRCam field: hide products (bytes retained)."""
     _lifecycle_transition(ctx, config_path, obs, dry_run, local,
-                          to_status='revoked', verb='Revoke')
+                          to_status='revoked', verb='Revoke', field=field)
 
 
 @deploy_group.command('delete-local')
@@ -1298,44 +1342,13 @@ def fetch_config_cmd(ctx, config_path, obs, output_dir, local):
 
 @deploy_group.group('nircam')
 def nircam():
-    """NIRCam field deploy commands (epic #261).
+    """NIRCam mask utilities (epic #261).
 
-    `exposures` uploads the canonical exposure FITS (+ expmaps) to OSN,
-    content-hash deduped, and upserts nircam_exposures (admin-only
-    intermediates). `import-masks` / `pull-masks` round-trip the DB-resident
-    region masks with local reference/.../masks/*.reg files.
+    Field deploy is the top-level `campfire deploy --field <field>` (parity with
+    `--obs`); `import-masks` / `pull-masks` here round-trip the DB-resident region
+    masks with local reference/.../masks/*.reg files.
     """
     pass
-
-
-@nircam.command('exposures')
-@click.option('--config', 'config_path', default=None,
-              help='Path to deploy config TOML.')
-@click.option('--field', required=True,
-              help='Field name (e.g. cosmos).')
-@click.option('--filter', 'filter_names', multiple=True, cls=_VariadicOption,
-              help='Filter(s) to process (default: all).')
-@click.option('--dry-run', is_flag=True,
-              help='Show what would be deployed without making changes.')
-@click.option('--local', is_flag=True,
-              help='Use local Supabase (127.0.0.1:54321).')
-@click.pass_context
-def nircam_exposures(ctx, config_path, field, filter_names, dry_run, local):
-    """Push NIRCam exposure state to OSN + Supabase.
-
-    Uploads the canonical exposure FITS (+ any field expmaps) to OSN under
-    campfire-layout canonical keys — content-hash deduped on sha256(SCI+DQ) so
-    unchanged exposures are not re-uploaded — uploads preview PNGs to R2, and
-    upserts nircam_exposures (registered admin-only; deployment_id=NULL).
-
-    Reviewer-set exclusions (review_status='excluded') are surfaced in the
-    web admin UI for copy-paste into the field's skip=[] block in fields.toml.
-    """
-    from campfire.deploy.nircam import deploy_nircam
-    config = load_config(config_path, local=_resolve_local(ctx, local))
-    deploy_nircam(field, config,
-                  filters=list(filter_names) if filter_names else None,
-                  dry_run=dry_run)
 
 
 @nircam.command('import-masks')

--- a/python/campfire/deploy/cli.py
+++ b/python/campfire/deploy/cli.py
@@ -950,13 +950,19 @@ def registry_reconcile(ctx, config_path, no_bucket, local):
     reg_keys = reg.registry_keys(sb)
 
     bucket_keys = None
+    danglable_keys = None
     if not no_bucket:
         try:
             bucket_keys = list(reg.list_bucket_keys(config))
+            # The bucket LIST only enumerates the data backend (R2 in F1); an
+            # OSN-native object (NIRCam FITS/expmaps, #261/N1) has no R2 twin, so
+            # scope dangling to registry rows homed on the LISTed backend, else
+            # every deployed NIRCam object is reported spuriously dangling.
+            danglable_keys = reg.registry_keys(sb, backend=reg.resolve_backend_label(config))
         except Exception as e:
             print(f"(bucket LIST unavailable — coverage only: {e})")
 
-    report = reg.compute_reconcile(live, reg_keys, bucket_keys)
+    report = reg.compute_reconcile(live, reg_keys, bucket_keys, danglable_keys=danglable_keys)
     print(f"live pointers: {len(set(live))}  registry rows: {len(set(reg_keys))}")
     print(report.summary())
     if report.missing:
@@ -1290,7 +1296,19 @@ def fetch_config_cmd(ctx, config_path, obs, output_dir, local):
 # NIRCam subcommand group (exposure tracking)
 # ---------------------------------------------------------------------------
 
-@deploy_group.command()
+@deploy_group.group('nircam')
+def nircam():
+    """NIRCam field deploy commands (epic #261).
+
+    `exposures` uploads the canonical exposure FITS (+ expmaps) to OSN,
+    content-hash deduped, and upserts nircam_exposures (admin-only
+    intermediates). `import-masks` / `pull-masks` round-trip the DB-resident
+    region masks with local reference/.../masks/*.reg files.
+    """
+    pass
+
+
+@nircam.command('exposures')
 @click.option('--config', 'config_path', default=None,
               help='Path to deploy config TOML.')
 @click.option('--field', required=True,
@@ -1299,21 +1317,28 @@ def fetch_config_cmd(ctx, config_path, obs, output_dir, local):
               help='Filter(s) to process (default: all).')
 @click.option('--dry-run', is_flag=True,
               help='Show what would be deployed without making changes.')
-def nircam(config_path, field, filter_names, dry_run):
-    """Push NIRCam exposure state (preview PNGs + metadata) to Supabase.
+@click.option('--local', is_flag=True,
+              help='Use local Supabase (127.0.0.1:54321).')
+@click.pass_context
+def nircam_exposures(ctx, config_path, field, filter_names, dry_run, local):
+    """Push NIRCam exposure state to OSN + Supabase.
+
+    Uploads the canonical exposure FITS (+ any field expmaps) to OSN under
+    campfire-layout canonical keys — content-hash deduped on sha256(SCI+DQ) so
+    unchanged exposures are not re-uploaded — uploads preview PNGs to R2, and
+    upserts nircam_exposures (registered admin-only; deployment_id=NULL).
 
     Reviewer-set exclusions (review_status='excluded') are surfaced in the
-    web admin UI for copy-paste into the field's skip=[] block in
-    fields.toml — there is no longer a pull/contract-file workflow.
+    web admin UI for copy-paste into the field's skip=[] block in fields.toml.
     """
     from campfire.deploy.nircam import deploy_nircam
-    config = load_config(config_path)
+    config = load_config(config_path, local=_resolve_local(ctx, local))
     deploy_nircam(field, config,
                   filters=list(filter_names) if filter_names else None,
                   dry_run=dry_run)
 
 
-@deploy_group.command('import-masks')
+@nircam.command('import-masks')
 @click.option('--config', 'config_path', default=None,
               help='Path to deploy config TOML.')
 @click.option('--field', required=True, help='Field name (e.g. cosmos).')
@@ -1334,7 +1359,7 @@ def nircam_import_masks(ctx, config_path, field, dry_run, local):
     import_masks(field, config, dry_run=dry_run)
 
 
-@deploy_group.command('pull-masks')
+@nircam.command('pull-masks')
 @click.option('--config', 'config_path', default=None,
               help='Path to deploy config TOML.')
 @click.option('--field', required=True, help='Field name (e.g. cosmos).')

--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -8,20 +8,20 @@ keys), derives a ``stage`` value from the highest completed CFP key, and:
 * uploads the **canonical exposure FITS** (and any field ``expmap`` coverage
   files) to **OSN** under ``campfire-layout`` canonical keys, content-hash-
   deduped so an unchanged exposure is not re-uploaded (epic #261, N1 / D1);
-* registers those objects in ``storage_objects`` (``nircam_exposure`` /
-  ``nircam_expmap``) with ``deployment_id=NULL`` so they stay **admin-only** — a
-  NIRCam exposure is a reduction intermediate, never public science, exactly the
-  "backfilled NIRCam is admin-only until a deployment lands" case the
-  ``storage_objects`` RLS anticipates;
+* records a **field-scoped deployment** (provenance + lifecycle anchor) and
+  registers those objects in ``storage_objects`` (``nircam_exposure`` /
+  ``nircam_expmap``) tagged with its ``deployment_id`` — visibility rides
+  ``deployment.status`` via the storage gate: ``published`` is public to everyone
+  (NIRCam fields span multiple programs, so there is no per-program scope),
+  ``draft`` is admin-only for review;
 * uploads ``*_preview.png`` / ``*_full.png`` thumbnails (unchanged from before —
   still on R2 legacy keys; their migration to canonical OSN keys rides N5 with
   the inspection-UI rework that retires ``*_full.png``);
 * upserts ``nircam_exposures`` while preserving web-triage fields
   (``review_status``, ``correction``, ``notes``).
 
-There is no ``--draft`` / publish toggle for exposures: they are admin-only
-unconditionally (the storage gate), so the public/draft lifecycle lives at the
-mosaic level (N3), matching design decision D4.
+A normal deploy publishes immediately; ``--draft`` holds the field admin-only for
+portal inspection, then ``campfire deploy publish --field`` makes it public.
 
 Excluded exposures flagged by reviewers in the admin UI are surfaced for
 copy-paste into the field's ``skip = [...]`` block in ``fields.toml``; we no
@@ -42,7 +42,7 @@ from campfire_layout import KeyScheme, Scope, storage_key
 from campfire.deploy.r2 import UploadTask, upload_files_parallel
 from campfire.deploy.supabase import (
     claim_deploy_scope, get_deploy_scope_version, get_supabase_client,
-    get_user_id_from_token, log_deploy_event,
+    get_user_id_from_token, insert_deployment, log_deploy_event,
 )
 
 # The OSN data backend NIRCam canonical intermediates are homed on (epic #210/#216,
@@ -332,14 +332,20 @@ def discover_expmap_tasks(dirs, field):
 # Deploy (push)
 # ---------------------------------------------------------------------------
 
-def deploy_nircam(field, config, filters=None, dry_run=False):
-    """Push NIRCam exposure state to OSN + Supabase.
+def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
+    """Push NIRCam exposure state to OSN + Supabase (epic #261, N1).
 
-    Uploads the canonical exposure FITS (+ any field expmaps) to OSN under
-    ``campfire-layout`` canonical keys (content-hash deduped on ``sha256(SCI+DQ)``
-    so unchanged exposures are not re-uploaded), uploads preview PNGs to R2,
-    upserts ``nircam_exposures``, and registers every landed object in
-    ``storage_objects`` with ``deployment_id=NULL`` (admin-only intermediates).
+    Records a **field-scoped deployment** (provenance + the draft->published
+    lifecycle), uploads the canonical exposure FITS (+ any field expmaps) to OSN
+    under ``campfire-layout`` canonical keys (content-hash deduped on
+    ``sha256(SCI+DQ)``), uploads preview PNGs to R2, upserts ``nircam_exposures``,
+    and registers every landed object in ``storage_objects`` tagged with that
+    ``deployment_id``.
+
+    Visibility rides the deployment (not a bespoke admin-only special case): a
+    ``published`` field deployment is public to everyone (NIRCam fields span
+    multiple programs, so there is no per-program scope); ``--draft`` keeps it
+    admin-only for portal inspection until ``campfire deploy publish --field``.
 
     Parameters
     ----------
@@ -352,6 +358,9 @@ def deploy_nircam(field, config, filters=None, dry_run=False):
         ``products/nircam/{field}/``.
     dry_run : bool
         If True, print what would be done without making changes.
+    draft : bool
+        If True, record the deployment as ``draft`` (admin-only) for review;
+        otherwise ``published`` (public) immediately.
     """
     dirs = _resolve_nircam_dirs(field)
 
@@ -435,7 +444,8 @@ def deploy_nircam(field, config, filters=None, dry_run=False):
         mask_count = sum(1 for r in records if r.get('masking') == 'done')
         if mask_count:
             print(f"  with masks: {mask_count}")
-        print(f"\nWould upload {len(fits_tasks)} canonical FITS (subject to "
+        print(f"\nWould record a {'draft' if draft else 'published'} field "
+              f"deployment and upload {len(fits_tasks)} canonical FITS (subject to "
               f"SCI+DQ content-hash dedup) + {len(expmap_tasks)} expmap(s) to OSN, "
               f"and {len(png_tasks)} preview PNG(s) to R2.")
         print("Dry run — no changes made.")
@@ -443,7 +453,7 @@ def deploy_nircam(field, config, filters=None, dry_run=False):
 
     from campfire.deploy.registry import (
         build_registry_rows, fetch_active_sci_dq_hashes, resolve_backend_label,
-        upsert_storage_objects,
+        set_active_deployment, upsert_storage_objects,
     )
 
     client = get_supabase_client(config)
@@ -452,6 +462,14 @@ def deploy_nircam(field, config, filters=None, dry_run=False):
     # Read the field's optimistic-concurrency version BEFORE any work so a
     # concurrent same-field deploy is detected at finalize (epic #210, B4 / D12).
     scope_version = get_deploy_scope_version(client, 'field', field)
+
+    # Record the field-scoped deployment up front — it is the provenance anchor and
+    # the draft/published visibility gate every registered object hangs off.
+    deployment_id = insert_deployment(
+        client, field=field, deployed_by=user_id,
+        status='draft' if draft else 'published', n_targets=len(records))
+    print(f"Deployment #{deployment_id} recorded "
+          f"({'draft — admin-only' if draft else 'published — public'})")
 
     # --- Content-hash dedup for the canonical FITS (D1) ---------------------
     # Compare each exposure's local sha256(SCI+DQ) to the digest already stored in
@@ -496,25 +514,33 @@ def deploy_nircam(field, config, filters=None, dry_run=False):
     _upsert_exposures(client, records)
     print(f"  Upserted {len(records)} exposures")
 
-    # --- Register storage objects (admin-only: deployment_id=NULL) ----------
-    # NIRCam exposures are reduction intermediates with no spectrum_id and no
-    # deployment, so the storage_objects RLS + sync/presign RPCs keep them
-    # admin-only (the "backfilled NIRCam" case the schema anticipates). The FITS
-    # carry a science-only sci_dq_hash for change detection; content_hash stays
-    # the authoritative whole-file digest for download/copy verification.
+    # --- Register storage objects, tagged with the field deployment ---------
+    # Visibility rides deployment.status via the storage_objects gate: published ->
+    # public to everyone, draft -> admin-only. The FITS carry a science-only
+    # sci_dq_hash for change detection; content_hash stays the authoritative
+    # whole-file digest for download/copy verification.
     n_reg = 0
     if osn_uploaded:
         reg_rows = build_registry_rows(
-            osn_tasks, backend=_CANONICAL_BACKEND, uploaded_by=user_id,
-            succeeded_keys=osn_uploaded, sci_dq_hashes=local_sci_dq)
+            osn_tasks, backend=_CANONICAL_BACKEND, deployment_id=deployment_id,
+            uploaded_by=user_id, succeeded_keys=osn_uploaded, sci_dq_hashes=local_sci_dq)
         n_reg += upsert_storage_objects(client, reg_rows)
     if png_uploaded:
         reg_rows = build_registry_rows(
             png_upload_list, backend=resolve_backend_label(config),
-            uploaded_by=user_id, succeeded_keys=png_uploaded)
+            deployment_id=deployment_id, uploaded_by=user_id, succeeded_keys=png_uploaded)
         n_reg += upsert_storage_objects(client, reg_rows)
     if n_reg:
-        print(f"  Registered {n_reg} storage object(s) (admin-only intermediates)")
+        print(f"  Registered {n_reg} storage object(s)")
+
+    # Re-point dedup-skipped exposures (unchanged bytes, not re-registered) to this
+    # deployment so a publish / re-deploy flips the whole field's visibility.
+    skipped_keys = ([t.r2_key for t in fits_tasks if t.r2_key not in osn_uploaded]
+                    if deployment_id else [])
+    if skipped_keys:
+        n_moved = set_active_deployment(client, skipped_keys, deployment_id)
+        if n_moved:
+            print(f"  Re-pointed {n_moved} unchanged exposure(s) to deployment #{deployment_id}")
 
     # --- Multi-reducer scope claim + audit (epic #210, B4 / D12) -----------
     claim = claim_deploy_scope(client, 'field', field, scope_version, actor=user_id)
@@ -522,9 +548,9 @@ def deploy_nircam(field, config, filters=None, dry_run=False):
         print(f"⚠  CONCURRENT DEPLOY DETECTED for field '{field}': another reducer "
               f"advanced this field while this deploy was running. Re-run to reconcile.")
     log_deploy_event(
-        client, action='upload', actor=user_id, observation=None,
-        affected_count=len(records),
-        metadata={'nircam': True, 'field': field, 'filters': filters,
+        client, action='upload', actor=user_id, deployment_id=deployment_id,
+        observation=None, affected_count=len(records),
+        metadata={'nircam': True, 'field': field, 'filters': filters, 'draft': draft,
                   'exposures': len(records), 'fits_uploaded': len(osn_uploaded),
                   'fits_skipped': n_skipped})
 

--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -1,12 +1,27 @@
 """
-NIRCam exposure deployment — push canonical exposure state to Supabase + R2.
+NIRCam exposure deployment — push canonical exposure state to OSN + Supabase.
 
-Scans the per-filter flat directories (the new canonical layout where each
-exposure is a single ``{rootname}.fits`` mutated in place through the
-``CFP_*`` provenance keys), derives a ``stage`` value from the highest
-completed CFP key, uploads ``*_preview.png`` thumbnails to R2, and upserts
-``nircam_exposures`` while preserving any web-triage fields
-(``review_status``, ``correction``, ``notes``).
+Scans the per-filter flat directories (the canonical layout where each exposure
+is a single ``{rootname}.fits`` mutated in place through the ``CFP_*`` provenance
+keys), derives a ``stage`` value from the highest completed CFP key, and:
+
+* uploads the **canonical exposure FITS** (and any field ``expmap`` coverage
+  files) to **OSN** under ``campfire-layout`` canonical keys, content-hash-
+  deduped so an unchanged exposure is not re-uploaded (epic #261, N1 / D1);
+* registers those objects in ``storage_objects`` (``nircam_exposure`` /
+  ``nircam_expmap``) with ``deployment_id=NULL`` so they stay **admin-only** — a
+  NIRCam exposure is a reduction intermediate, never public science, exactly the
+  "backfilled NIRCam is admin-only until a deployment lands" case the
+  ``storage_objects`` RLS anticipates;
+* uploads ``*_preview.png`` / ``*_full.png`` thumbnails (unchanged from before —
+  still on R2 legacy keys; their migration to canonical OSN keys rides N5 with
+  the inspection-UI rework that retires ``*_full.png``);
+* upserts ``nircam_exposures`` while preserving web-triage fields
+  (``review_status``, ``correction``, ``notes``).
+
+There is no ``--draft`` / publish toggle for exposures: they are admin-only
+unconditionally (the storage gate), so the public/draft lifecycle lives at the
+mosaic level (N3), matching design decision D4.
 
 Excluded exposures flagged by reviewers in the admin UI are surfaced for
 copy-paste into the field's ``skip = [...]`` block in ``fields.toml``; we no
@@ -14,18 +29,27 @@ longer maintain a local ``exposures.json`` contract since nothing in the
 pipeline consumes it.
 """
 
+import hashlib
 import os
 import sys
 from collections import Counter
 from datetime import datetime, timezone
-from glob import glob
 from pathlib import Path
 
 from astropy.io import fits
 
-from campfire_layout import Scope, storage_key
+from campfire_layout import KeyScheme, Scope, storage_key
 from campfire.deploy.r2 import UploadTask, upload_files_parallel
-from campfire.deploy.supabase import get_supabase_client
+from campfire.deploy.supabase import (
+    claim_deploy_scope, get_deploy_scope_version, get_supabase_client,
+    get_user_id_from_token, log_deploy_event,
+)
+
+# The OSN data backend NIRCam canonical intermediates are homed on (epic #210/#216,
+# same as NIRSpec canonical spectrum-exposures). Preview PNGs stay on the legacy R2
+# 'data' keys until N5 migrates them alongside the inspection-UI rework.
+_CANONICAL_BACKEND = 'osn'
+_FITS_CONTENT_TYPE = 'application/fits'
 
 
 # ---------------------------------------------------------------------------
@@ -64,6 +88,33 @@ def _stage_from_header(header):
         if key in header:
             stage = name
     return stage
+
+
+def _sci_dq_hash(path):
+    """Return ``'sha256:<hex>'`` over just the SCI+DQ arrays, or None.
+
+    The science-only change-detection digest for the deploy dedup (epic #261, D1).
+    Reproduces ``campfire_pipeline.nircam.manifest.compute_file_hash`` deploy-side
+    (deploy must not import the pipeline): ``do_not_scale_image_data=True`` hashes
+    the raw stored bytes regardless of BZERO/BSCALE, ``memmap=False`` forces a real
+    read. Whole-file hashes churn on every pipeline re-save (header timestamps), so
+    they can't drive dedup; the SCI+DQ digest is stable across a science-identical
+    re-save. Returns None if neither array is present (never dedup on an empty hash).
+    """
+    h = hashlib.sha256()
+    hashed_any = False
+    try:
+        with fits.open(path, memmap=False, do_not_scale_image_data=True) as hdul:
+            for extname in ('SCI', 'DQ'):
+                if extname not in hdul:
+                    continue
+                data = hdul[extname].data
+                if data is not None:
+                    h.update(data.tobytes())
+                    hashed_any = True
+    except Exception:
+        return None
+    return f'sha256:{h.hexdigest()}' if hashed_any else None
 
 
 # ---------------------------------------------------------------------------
@@ -118,8 +169,8 @@ def discover_exposures(dirs, filters):
     -------
     dict
         ``{(filter, basename): info}`` where info has keys ``basename``,
-        ``filter``, ``stage``, ``visit``, ``detector``, ``date_obs``,
-        ``ra_center``, ``dec_center``.
+        ``filter``, ``path`` (the canonical FITS Path), ``stage``, ``visit``,
+        ``detector``, ``date_obs``, ``ra_center``, ``dec_center``.
     """
     exposures = {}
     for filtname in filters:
@@ -134,6 +185,7 @@ def discover_exposures(dirs, filters):
             info = _read_exposure_metadata(path)
             info['basename'] = basename
             info['filter'] = filtname
+            info['path'] = path
             exposures[(filtname, basename)] = info
     return exposures
 
@@ -235,18 +287,66 @@ def _read_full_png_dimensions(png_path):
 
 
 # ---------------------------------------------------------------------------
+# Canonical FITS + expmap discovery (epic #261, N1)
+# ---------------------------------------------------------------------------
+
+def build_fits_upload_tasks(field, exposures):
+    """Build canonical-key OSN upload tasks for the exposure FITS.
+
+    One ``nircam_exposure`` task per discovered exposure, keyed under the
+    ``campfire-layout`` CANONICAL scheme (``data/products/nircam/<field>/<filter>/
+    <rootname>.fits``). Returns a list of ``UploadTask``; content-hash dedup is
+    applied by the caller (unchanged exposures are dropped before upload).
+    """
+    tasks = []
+    for (filtname, basename), info in sorted(exposures.items()):
+        path = info['path']
+        key = storage_key('nircam_exposure', Scope(field=field, filt=filtname),
+                          path.name, scheme=KeyScheme.CANONICAL)
+        tasks.append(UploadTask(local_path=path, r2_key=key,
+                                content_type=_FITS_CONTENT_TYPE))
+    return tasks
+
+
+def discover_expmap_tasks(dirs, field):
+    """Build canonical-key OSN upload tasks for any field expmap coverage files.
+
+    Expmaps are per-``(field, filter)`` coverage maps written under
+    ``products/nircam/<field>/expmaps/``. They are produced at combine time, so a
+    process-only field may have none yet — deploy is idempotent and picks them up
+    on a later run. Returns a list of ``UploadTask`` (empty if the dir is absent).
+    """
+    expmap_dir = dirs['products'] / 'expmaps'
+    if not expmap_dir.exists():
+        return []
+    tasks = []
+    for path in sorted(expmap_dir.glob('*.fits')):
+        key = storage_key('nircam_expmap', Scope(field=field), path.name,
+                          scheme=KeyScheme.CANONICAL)
+        tasks.append(UploadTask(local_path=path, r2_key=key,
+                                content_type=_FITS_CONTENT_TYPE))
+    return tasks
+
+
+# ---------------------------------------------------------------------------
 # Deploy (push)
 # ---------------------------------------------------------------------------
 
 def deploy_nircam(field, config, filters=None, dry_run=False):
-    """Push NIRCam exposure state: upload PNGs to R2, upsert nircam_exposures.
+    """Push NIRCam exposure state to OSN + Supabase.
+
+    Uploads the canonical exposure FITS (+ any field expmaps) to OSN under
+    ``campfire-layout`` canonical keys (content-hash deduped on ``sha256(SCI+DQ)``
+    so unchanged exposures are not re-uploaded), uploads preview PNGs to R2,
+    upserts ``nircam_exposures``, and registers every landed object in
+    ``storage_objects`` with ``deployment_id=NULL`` (admin-only intermediates).
 
     Parameters
     ----------
     field : str
         Field name.
     config : dict
-        Deploy config (Supabase + R2 credentials).
+        Deploy config (Supabase + R2/OSN credentials).
     filters : list of str, optional
         Filters to deploy. If None, discovers every directory under
         ``products/nircam/{field}/``.
@@ -299,6 +399,10 @@ def deploy_nircam(field, config, filters=None, dry_run=False):
     print(f"Preview PNGs to upload: {len(png_tasks)} "
           f"({len(thumb_r2_keys)} thumb, {len(full_r2_keys)} full)")
 
+    fits_tasks = build_fits_upload_tasks(field, exposures)
+    expmap_tasks = discover_expmap_tasks(dirs, field)
+    print(f"Canonical FITS: {len(fits_tasks)} exposure(s), {len(expmap_tasks)} expmap(s) → OSN")
+
     records = []
     for (filtname, basename), info in sorted(exposures.items()):
         masking = _detect_masking(dirs, basename, filtname)
@@ -331,42 +435,98 @@ def deploy_nircam(field, config, filters=None, dry_run=False):
         mask_count = sum(1 for r in records if r.get('masking') == 'done')
         if mask_count:
             print(f"  with masks: {mask_count}")
-        print("\nDry run — no changes made.")
+        print(f"\nWould upload {len(fits_tasks)} canonical FITS (subject to "
+              f"SCI+DQ content-hash dedup) + {len(expmap_tasks)} expmap(s) to OSN, "
+              f"and {len(png_tasks)} preview PNG(s) to R2.")
+        print("Dry run — no changes made.")
         return
 
-    upload_task_list: list = []
-    uploaded_keys: set[str] = set()
-    if png_tasks:
-        print("\nUploading PNGs to R2...")
-        upload_task_list = [t[0] for t in png_tasks]
+    from campfire.deploy.registry import (
+        build_registry_rows, fetch_active_sci_dq_hashes, resolve_backend_label,
+        upsert_storage_objects,
+    )
+
+    client = get_supabase_client(config)
+    user_id = get_user_id_from_token(config)
+
+    # Read the field's optimistic-concurrency version BEFORE any work so a
+    # concurrent same-field deploy is detected at finalize (epic #210, B4 / D12).
+    scope_version = get_deploy_scope_version(client, 'field', field)
+
+    # --- Content-hash dedup for the canonical FITS (D1) ---------------------
+    # Compare each exposure's local sha256(SCI+DQ) to the digest already stored in
+    # the registry; skip the upload when the science is unchanged (a pipeline
+    # re-save with fresh header timestamps shifts the whole-file hash but not this).
+    local_sci_dq = {t.r2_key: _sci_dq_hash(t.local_path) for t in fits_tasks}
+    existing_sci_dq = fetch_active_sci_dq_hashes(client, [t.r2_key for t in fits_tasks])
+    fits_to_upload = [
+        t for t in fits_tasks
+        if not (local_sci_dq.get(t.r2_key)
+                and existing_sci_dq.get(t.r2_key) == local_sci_dq[t.r2_key])
+    ]
+    n_skipped = len(fits_tasks) - len(fits_to_upload)
+    if n_skipped:
+        print(f"\nSkipping {n_skipped} unchanged exposure(s) (SCI+DQ hash match)")
+
+    # --- Upload canonical FITS + expmaps to OSN ----------------------------
+    osn_tasks = fits_to_upload + expmap_tasks
+    osn_uploaded: set[str] = set()
+    if osn_tasks:
+        print(f"\nUploading {len(osn_tasks)} canonical FITS/expmap(s) to OSN...")
         success, failed, failures = upload_files_parallel(
-            config, upload_task_list,
-            desc='Uploading PNGs',
-            succeeded_out=uploaded_keys,
-        )
+            config, osn_tasks, desc='OSN uploads',
+            succeeded_out=osn_uploaded, backend=_CANONICAL_BACKEND)
+        print(f"  Uploaded: {success}, Failed: {failed}")
+        for msg in failures:
+            print(f"  Error: {msg}")
+
+    # --- Upload preview PNGs to R2 (legacy keys — migrated in N5) -----------
+    png_upload_list = [t[0] for t in png_tasks]
+    png_uploaded: set[str] = set()
+    if png_upload_list:
+        print("\nUploading preview PNGs to R2...")
+        success, failed, failures = upload_files_parallel(
+            config, png_upload_list, desc='Uploading PNGs',
+            succeeded_out=png_uploaded)
         print(f"  Uploaded: {success}, Failed: {failed}")
         for msg in failures:
             print(f"  Error: {msg}")
 
     print("\nUpserting exposures to Supabase...")
-    client = get_supabase_client(config)
     _upsert_exposures(client, records)
     print(f"  Upserted {len(records)} exposures")
 
-    # Storage registry (#214): index the preview/full PNGs that landed.
-    if uploaded_keys:
-        from campfire.deploy.registry import (
-            build_registry_rows, resolve_backend_label, upsert_storage_objects,
-        )
-        from campfire.deploy.supabase import get_user_id_from_token
+    # --- Register storage objects (admin-only: deployment_id=NULL) ----------
+    # NIRCam exposures are reduction intermediates with no spectrum_id and no
+    # deployment, so the storage_objects RLS + sync/presign RPCs keep them
+    # admin-only (the "backfilled NIRCam" case the schema anticipates). The FITS
+    # carry a science-only sci_dq_hash for change detection; content_hash stays
+    # the authoritative whole-file digest for download/copy verification.
+    n_reg = 0
+    if osn_uploaded:
         reg_rows = build_registry_rows(
-            upload_task_list,
-            backend=resolve_backend_label(config),
-            uploaded_by=get_user_id_from_token(config),
-            succeeded_keys=uploaded_keys,
-        )
-        n_reg = upsert_storage_objects(client, reg_rows)
-        print(f"  Registered {n_reg} storage objects")
+            osn_tasks, backend=_CANONICAL_BACKEND, uploaded_by=user_id,
+            succeeded_keys=osn_uploaded, sci_dq_hashes=local_sci_dq)
+        n_reg += upsert_storage_objects(client, reg_rows)
+    if png_uploaded:
+        reg_rows = build_registry_rows(
+            png_upload_list, backend=resolve_backend_label(config),
+            uploaded_by=user_id, succeeded_keys=png_uploaded)
+        n_reg += upsert_storage_objects(client, reg_rows)
+    if n_reg:
+        print(f"  Registered {n_reg} storage object(s) (admin-only intermediates)")
+
+    # --- Multi-reducer scope claim + audit (epic #210, B4 / D12) -----------
+    claim = claim_deploy_scope(client, 'field', field, scope_version, actor=user_id)
+    if claim.get('conflict'):
+        print(f"⚠  CONCURRENT DEPLOY DETECTED for field '{field}': another reducer "
+              f"advanced this field while this deploy was running. Re-run to reconcile.")
+    log_deploy_event(
+        client, action='upload', actor=user_id, observation=None,
+        affected_count=len(records),
+        metadata={'nircam': True, 'field': field, 'filters': filters,
+                  'exposures': len(records), 'fits_uploaded': len(osn_uploaded),
+                  'fits_skipped': n_skipped})
 
 
 def _upsert_exposures(client, records, batch_size=500):

--- a/python/campfire/deploy/registry.py
+++ b/python/campfire/deploy/registry.py
@@ -118,16 +118,17 @@ def normalize_etag(etag: str | None) -> str | None:
 # ---------------------------------------------------------------------------
 
 def _exposure_ref_for(product_type: str, filename: str) -> str | None:
-    """Stable per-exposure reference for exposure-level intermediates (epic #210).
+    """Stable per-exposure reference for exposure-level intermediates (epic #210/#261).
 
     For ``nirspec_spectrum_exposure`` the canonical filename
-    (``{root}_{nod}_nrs[12]_{source}.fits``) IS the natural unique exposure key, so
-    the ref is the filename stem (drop ``.fits``). Backs the partial-unique
+    (``{root}_{nod}_nrs[12]_{source}.fits``) IS the natural unique exposure key, and
+    for ``nircam_exposure`` the JWST rootname (``jw..._nrc{a,b}{1-4,long}.fits``) is,
+    so the ref is the filename stem (drop ``.fits``). Backs the partial-unique
     ``(product_type, exposure_ref) WHERE status='active'`` registry contract
     (one current object per product/exposure). None for non-exposure products
     (their exposure_ref stays NULL; NULLs are distinct, so finals never collide).
     """
-    if product_type == 'nirspec_spectrum_exposure' and filename.endswith('.fits'):
+    if product_type in ('nirspec_spectrum_exposure', 'nircam_exposure') and filename.endswith('.fits'):
         return filename[: -len('.fits')]
     return None
 
@@ -158,6 +159,7 @@ def row_for_key(
     cfpipe_version: Optional[str] = None,
     status: str = 'active',
     bucket: Optional[str] = None,
+    sci_dq_hash: Optional[str] = None,
 ) -> dict | None:
     """Build one ``storage_objects`` row dict from a storage key + integrity info.
 
@@ -193,6 +195,9 @@ def row_for_key(
         'bucket': obj_bucket,
         'storage_key': storage_key,
         'content_hash': content_hash,
+        # Science-only change-detection digest (epic #261, N1). Only NIRCam
+        # canonical exposures carry one today; None leaves the column NULL.
+        'sci_dq_hash': sci_dq_hash,
         'size_bytes': int(size_bytes),
         'content_type': content_type,
         'product_type': product_type,
@@ -220,13 +225,20 @@ def build_registry_rows(
     uploaded_by: Optional[str] = None,
     cfpipe_version: Optional[str] = None,
     succeeded_keys: Optional[set[str]] = None,
+    sci_dq_hashes: Optional[dict[str, str]] = None,
 ) -> list[dict]:
     """Build ``storage_objects`` rows for the objects an upload actually landed.
 
     For each :class:`UploadTask` whose ``r2_key`` is in ``succeeded_keys`` (or
     all, if ``succeeded_keys`` is None), hashes the local file and maps the key
     to a row via :func:`row_for_key`. Tiles and non-cloud products are skipped.
+
+    ``sci_dq_hashes`` optionally supplies a precomputed ``sha256:<hex>`` science-only
+    digest per storage key (NIRCam exposures, epic #261) — the ``content_hash`` is
+    still the whole-file sha256, but ``sci_dq_hash`` carries the science-only digest
+    that change-detection compares against.
     """
+    sci_dq_hashes = sci_dq_hashes or {}
     rows: list[dict] = []
     for task in tasks:
         if succeeded_keys is not None and task.r2_key not in succeeded_keys:
@@ -244,10 +256,38 @@ def build_registry_rows(
             deployment_id=deployment_id,
             uploaded_by=uploaded_by,
             cfpipe_version=cfpipe_version,
+            sci_dq_hash=sci_dq_hashes.get(task.r2_key),
         )
         if row is not None:
             rows.append(row)
     return rows
+
+
+def fetch_active_sci_dq_hashes(client, keys: list[str]) -> dict[str, str]:
+    """Return ``{storage_key: sci_dq_hash}`` for the active registry rows among *keys*.
+
+    The change-detection read for the NIRCam exposure dedup (epic #261, N1): deploy
+    compares each candidate exposure's local ``sha256(SCI+DQ)`` against the stored
+    digest and skips the upload when they match. Only rows that both exist and carry
+    a non-NULL ``sci_dq_hash`` are returned, so a first-time deploy (or a legacy row
+    with no digest) always re-uploads. Chunked to keep the ``in_`` filter small.
+    """
+    if not keys:
+        return {}
+    out: dict[str, str] = {}
+    for i in range(0, len(keys), 200):
+        chunk = keys[i:i + 200]
+        resp = (
+            client.table('storage_objects')
+            .select('storage_key, sci_dq_hash')
+            .in_('storage_key', chunk)
+            .eq('status', 'active')
+            .execute()
+        )
+        for r in (resp.data or []):
+            if r.get('sci_dq_hash'):
+                out[r['storage_key']] = r['sci_dq_hash']
+    return out
 
 
 def upsert_storage_objects(client, rows: list[dict], batch_size: int = UPSERT_BATCH) -> int:
@@ -363,6 +403,8 @@ def compute_reconcile(
     live_pointers: Iterable[str],
     registry_keys: Iterable[str],
     bucket_keys: Optional[Iterable[str]] = None,
+    *,
+    danglable_keys: Optional[Iterable[str]] = None,
 ) -> ReconcileReport:
     """Classify the three storage vocabularies against each other **by canonical
     identity**, reporting the original keys.
@@ -380,10 +422,17 @@ def compute_reconcile(
     (legacy + canonical duplicates of the same object coincide), then report the
     original keys so the operator sees the real fits_path / bucket key.
 
-    NOTE: ``bucket_keys`` today comes from a single data-bucket (R2) LIST; migrated
-    objects live on OSN but R2 retains their legacy copies, so canonicalizing keeps
-    dangling/orphan correct. When R2 *data* is retired (deferred A2 work), the LIST
-    must union OSN so dangling detection stays honest.
+    NOTE: ``bucket_keys`` today comes from a single data-bucket (R2) LIST. Objects
+    that live on OSN fall into two classes: (a) A1-migrated finals, whose legacy R2
+    twin is still in the bucket, so canonicalizing keeps them covered; and (b) since
+    #261/N1, **OSN-native** NIRCam FITS/expmaps with *no* R2 twin. A row in class (b)
+    is absent from an R2 LIST by design, not because it's dangling — so ``dangling``
+    is computed only over ``danglable_keys`` (the registry rows whose home is the
+    LISTed backend; the caller passes the R2-backed subset). ``missing``/``orphans``
+    still use the full ``registry_keys`` so A1 OSN rows keep covering their R2 twins.
+    When R2 *data* is retired (deferred A2 work) and the LIST unions OSN, class (b)
+    gets real dangling detection. ``danglable_keys=None`` ⇒ all registry keys are
+    danglable (back-compat: the pre-N1 world where every object had an R2 presence).
     """
     # canonical identity -> original key, per vocabulary (last-writer-wins on a
     # legacy+canonical collision is fine: same logical object).
@@ -395,7 +444,9 @@ def compute_reconcile(
         return ReconcileReport(missing, set(), set(), set())
 
     bucket = {_canonical_identity(k): k for k in bucket_keys if k}
-    dangling = {registry[c] for c in (registry.keys() - bucket.keys())}
+    danglable = (registry if danglable_keys is None
+                 else {_canonical_identity(k): k for k in danglable_keys if k})
+    dangling = {danglable[c] for c in (danglable.keys() - bucket.keys())}
     orphans = {bucket[c] for c in (bucket.keys() - registry.keys())}
     adoptable = {k for k in orphans if is_known_key(k)}
     return ReconcileReport(missing, dangling, orphans, adoptable)
@@ -449,12 +500,18 @@ def live_pointers(client) -> dict[str, list[str]]:
     }
 
 
-def registry_keys(client, bucket: str = 'data') -> list[str]:
-    """All storage keys currently in the registry for a bucket."""
+def registry_keys(client, bucket: str = 'data', backend: str | None = None) -> list[str]:
+    """All storage keys currently in the registry for a bucket.
+
+    ``backend`` optionally restricts to one storage backend ('r2' | 'osn') — used by
+    reconcile to compute dangling only over rows whose home is the LISTed backend
+    (an OSN-native object can't be confirmed against an R2-only bucket LIST).
+    """
     return [
         r['storage_key']
-        for r in _iter_rows(client, 'storage_objects', 'storage_key, bucket')
+        for r in _iter_rows(client, 'storage_objects', 'storage_key, bucket, backend')
         if r.get('bucket') == bucket and r.get('storage_key')
+        and (backend is None or r.get('backend') == backend)
     ]
 
 

--- a/python/campfire/deploy/registry.py
+++ b/python/campfire/deploy/registry.py
@@ -263,6 +263,25 @@ def build_registry_rows(
     return rows
 
 
+def set_active_deployment(client, keys: list[str], deployment_id: int) -> int:
+    """Point active registry rows at a deployment without re-uploading (epic #261).
+
+    Re-deploying a NIRCam field records a NEW deployment, but exposures/mosaics whose
+    bytes are unchanged are dedup-skipped (not re-registered), so their rows would
+    keep the PRIOR deployment_id — and thus its (possibly draft) visibility. This
+    re-points those skipped rows to the current deployment so a publish or re-deploy
+    flips the whole field's visibility consistently. Chunked; returns keys touched.
+    """
+    if not keys:
+        return 0
+    for i in range(0, len(keys), 200):
+        chunk = keys[i:i + 200]
+        (client.table('storage_objects')
+         .update({'deployment_id': deployment_id})
+         .in_('storage_key', chunk).eq('status', 'active').execute())
+    return len(keys)
+
+
 def fetch_active_sci_dq_hashes(client, keys: list[str]) -> dict[str, str]:
     """Return ``{storage_key: sci_dq_hash}`` for the active registry rows among *keys*.
 

--- a/python/campfire/deploy/supabase.py
+++ b/python/campfire/deploy/supabase.py
@@ -136,9 +136,10 @@ def get_user_id_from_token(config: dict) -> str | None:
 
 def insert_deployment(
     client: Client,
-    observation: str,
-    deployed_by: str | None,
+    observation: str | None = None,
+    deployed_by: str | None = None,
     *,
+    field: str | None = None,
     cfpipe_version: str | None = None,
     jwst_version: str | None = None,
     crds_context: str | None = None,
@@ -159,13 +160,20 @@ def insert_deployment(
     ``status`` is the deployment lifecycle (epic #210): 'published' for a normal
     deploy (stamps published_at=now), 'draft' for a draft / incomplete deploy.
 
+    A deployment is anchored to EXACTLY ONE of a NIRSpec ``observation`` or a NIRCam
+    ``field`` (epic #261; enforced by deployments_scope_check). NIRCam field deploys
+    record the same provenance and drive the same draft->published->revoked lifecycle.
+
     The deployment record is ALWAYS written (it is the admin-review anchor for the
     draft lifecycle). On a service-role / `--local` deploy there is no user JWT, so
     ``deployed_by`` is NULL (the column is nullable as of B5); prod `login` deploys
     still record the real user. Returns the new id, or None only on insert failure.
     """
+    if (observation is None) == (field is None):
+        raise ValueError("insert_deployment requires exactly one of observation/field")
     data = {
         'observation': observation,
+        'field': field,
         'deployed_by': deployed_by,  # may be NULL on service-role / local deploys
         'force_overwrite': force_overwrite,
         'supabase_only': supabase_only,
@@ -296,6 +304,19 @@ def get_latest_deployment_id(client: Client, observation: str) -> int | None:
     resp = (client.table('deployments')
             .select('id')
             .eq('observation', observation)
+            .order('id', desc=True)
+            .limit(1)
+            .execute())
+    if resp.data:
+        return resp.data[0]['id']
+    return None
+
+
+def get_latest_field_deployment_id(client: Client, field: str) -> int | None:
+    """The most recent deployment id for a NIRCam field (epic #261 lifecycle anchor)."""
+    resp = (client.table('deployments')
+            .select('id')
+            .eq('field', field)
             .order('id', desc=True)
             .limit(1)
             .execute())

--- a/python/tests/sql/nircam_exposure_admin_only.sql
+++ b/python/tests/sql/nircam_exposure_admin_only.sql
@@ -1,0 +1,139 @@
+-- =============================================================================
+-- NIRCam exposure admin-only leak harness (epic #261, N1) — the exit gate for
+-- deploying canonical NIRCam exposures to the registry.
+-- =============================================================================
+-- A NIRCam canonical exposure is a reduction intermediate, never public science.
+-- N1 registers it in storage_objects with spectrum_id=NULL AND deployment_id=NULL,
+-- so the existing #210/#217 two-surface enforcement keeps it admin-only WITHOUT any
+-- new policy — the "backfilled NIRCam is admin-only until a deployment lands" case
+-- the storage_objects RLS explicitly anticipates. This harness proves that a
+-- NON-ADMIN authenticated user (with full public-program access) gets ZERO NIRCam
+-- exposure objects through every reader — RLS, get_storage_objects_for_sync, and
+-- filter_accessible_storage_keys — while an ADMIN sees them, and that the same is
+-- true for the admin-only nircam_exposures triage table.
+--
+-- Runs in one ROLLBACK'd transaction. Seed-anchored: user@=2222…, admin@=1111….
+--
+-- Run:  docker exec -i supabase_db_campfire psql -U postgres -d postgres \
+--          -v ON_ERROR_STOP=1 -f python/tests/sql/nircam_exposure_admin_only.sql
+-- =============================================================================
+\set ON_ERROR_STOP on
+BEGIN;
+
+-- ---- fixtures (bootstrap superuser, bypasses RLS) ---------------------------
+-- One canonical exposure storage object + expmap, admin-only by construction
+-- (no spectrum_id, no deployment_id), and one nircam_exposures triage row.
+CREATE TEMP TABLE _nc_keys (storage_key text);
+INSERT INTO _nc_keys VALUES
+  ('data/products/nircam/leaktest/f444w/jw01727028001_04101_00003_nrcalong.fits'),
+  ('data/products/nircam/leaktest/expmaps/leaktest_f444w_expmap.fits');
+
+INSERT INTO storage_objects
+  (backend, bucket, storage_key, content_hash, sci_dq_hash, size_bytes,
+   content_type, product_type, instrument, status, field,
+   spectrum_id, deployment_id)
+VALUES
+  ('osn', 'data', 'data/products/nircam/leaktest/f444w/jw01727028001_04101_00003_nrcalong.fits',
+   'sha256:1111111111111111111111111111111111111111111111111111111111111111',
+   'sha256:2222222222222222222222222222222222222222222222222222222222222222',
+   1024, 'application/fits', 'nircam_exposure', 'nircam', 'active', 'leaktest',
+   NULL, NULL),
+  ('osn', 'data', 'data/products/nircam/leaktest/expmaps/leaktest_f444w_expmap.fits',
+   'sha256:3333333333333333333333333333333333333333333333333333333333333333',
+   NULL,
+   2048, 'application/fits', 'nircam_expmap', 'nircam', 'active', 'leaktest',
+   NULL, NULL);
+
+INSERT INTO nircam_exposures (field, filter, detector, filename, stage)
+VALUES ('leaktest', 'f444w', 'nrcalong', 'jw01727028001_04101_00003_nrcalong', 'outlier');
+
+GRANT SELECT ON _nc_keys TO authenticated, service_role;
+
+-- =========================================================================
+-- 1. RLS as NON-ADMIN (user@, full public-program access) -> zero leak
+-- =========================================================================
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claims',
+  json_build_object('sub', '22222222-2222-2222-2222-222222222222', 'role', 'authenticated')::text, true);
+
+DO $$
+DECLARE n int;
+BEGIN
+  SELECT count(*) INTO n FROM storage_objects
+    WHERE storage_key IN (SELECT storage_key FROM _nc_keys);
+  IF n <> 0 THEN
+    RAISE EXCEPTION 'RLS LEAK: non-admin sees % NIRCam exposure storage object(s) (expected 0)', n;
+  END IF;
+
+  SELECT count(*) INTO n FROM nircam_exposures WHERE field = 'leaktest';
+  IF n <> 0 THEN
+    RAISE EXCEPTION 'RLS LEAK: non-admin sees % nircam_exposures triage row(s) (expected 0)', n;
+  END IF;
+END $$;
+
+-- =========================================================================
+-- 2. RLS as ADMIN (admin@) -> the objects ARE visible
+-- =========================================================================
+SELECT set_config('request.jwt.claims',
+  json_build_object('sub', '11111111-1111-1111-1111-111111111111', 'role', 'authenticated')::text, true);
+
+DO $$
+DECLARE n int;
+BEGIN
+  SELECT count(*) INTO n FROM storage_objects
+    WHERE storage_key IN (SELECT storage_key FROM _nc_keys);
+  IF n <> 2 THEN RAISE EXCEPTION 'ADMIN BLOCKED: admin sees %/2 NIRCam exposure objects', n; END IF;
+
+  SELECT count(*) INTO n FROM nircam_exposures WHERE field = 'leaktest';
+  IF n <> 1 THEN RAISE EXCEPTION 'ADMIN BLOCKED: admin sees %/1 nircam_exposures row', n; END IF;
+END $$;
+
+-- =========================================================================
+-- 3. Service-role RPC predicates (RLS bypassed) -> admin-only both ways
+-- =========================================================================
+RESET ROLE;
+SET LOCAL ROLE service_role;
+SELECT set_config('request.jwt.claims', '', true);
+
+DO $$
+DECLARE pubs text[];
+        keys text[];
+        leaked int; shown int;
+BEGIN
+  pubs := ARRAY(SELECT slug FROM programs WHERE is_public);
+  keys := ARRAY(SELECT storage_key FROM _nc_keys);
+
+  -- filter_accessible_storage_keys (presign gate): a member is authorized for NONE
+  -- of the exposure keys (no spectrum, no published deployment), admin for ALL.
+  SELECT count(*) INTO leaked FROM public.filter_accessible_storage_keys(keys, pubs, false);
+  IF leaked <> 0 THEN
+    RAISE EXCEPTION 'PRESIGN LEAK: % NIRCam exposure key(s) authorized for a member (expected 0)', leaked;
+  END IF;
+
+  SELECT count(*) INTO shown FROM public.filter_accessible_storage_keys(keys, pubs, true);
+  IF shown <> 2 THEN
+    RAISE EXCEPTION 'PRESIGN ADMIN: include_unpublished=true authorized %/2 exposure keys', shown;
+  END IF;
+
+  -- get_storage_objects_for_sync: absent from a member sync, present for admin.
+  SELECT count(*) INTO leaked FROM (
+    SELECT jsonb_array_elements(objects)->>'storage_key' AS k
+    FROM public.get_storage_objects_for_sync(pubs, NULL, 100000, 0, false, false)
+  ) q WHERE k IN (SELECT storage_key FROM _nc_keys);
+  IF leaked <> 0 THEN
+    RAISE EXCEPTION 'SYNC LEAK: % NIRCam exposure row(s) in a member sync (expected 0)', leaked;
+  END IF;
+
+  SELECT count(*) INTO shown FROM (
+    SELECT jsonb_array_elements(objects)->>'storage_key' AS k
+    FROM public.get_storage_objects_for_sync(pubs, NULL, 100000, 0, false, true)
+  ) q WHERE k IN (SELECT storage_key FROM _nc_keys);
+  IF shown <> 2 THEN
+    RAISE EXCEPTION 'SYNC ADMIN: admin sync returns %/2 NIRCam exposure rows', shown;
+  END IF;
+END $$;
+
+RESET ROLE;
+SELECT '✅ NIRCAM EXPOSURE ADMIN-ONLY HARNESS: ALL ASSERTIONS PASSED' AS result;
+
+ROLLBACK;

--- a/python/tests/sql/nircam_field_deploy_gate.sql
+++ b/python/tests/sql/nircam_field_deploy_gate.sql
@@ -1,0 +1,138 @@
+-- =============================================================================
+-- NIRCam field-deployment visibility gate (epic #261, N1) — the exit gate for
+-- making NIRCam deploy first-class with the draft->published lifecycle.
+-- =============================================================================
+-- A NIRCam field spans multiple JWST programs, so there is no per-program scope:
+-- a *published* field-scoped deployment is public to EVERYONE; a *draft* one is
+-- admin-only. This proves, in one ROLLBACK'd transaction, that the storage_objects
+-- gate (RLS + filter_accessible_storage_keys + get_storage_objects_for_sync)
+-- enforces exactly that for a nircam_exposure object, and that set_deployment_status
+-- flips a field deployment without the "not found" raise (observation is NULL).
+--
+-- Seed-anchored: user@=2222… (non-admin, public-program access), admin@=1111….
+-- Run:  docker exec -i supabase_db_campfire psql -U postgres -d postgres \
+--          -v ON_ERROR_STOP=1 -f python/tests/sql/nircam_field_deploy_gate.sql
+-- =============================================================================
+\set ON_ERROR_STOP on
+BEGIN;
+
+-- ---- fixtures (bootstrap superuser, bypasses RLS) ---------------------------
+-- A DRAFT field deployment + a nircam_exposure storage object linked to it.
+CREATE TEMP TABLE _dep AS
+  WITH ins AS (
+    INSERT INTO deployments (field, status) VALUES ('leaktest', 'draft') RETURNING id)
+  SELECT id FROM ins;
+
+INSERT INTO storage_objects
+  (backend, bucket, storage_key, content_hash, size_bytes, content_type,
+   product_type, instrument, status, field, spectrum_id, deployment_id)
+VALUES
+  ('osn', 'data', 'data/products/nircam/leaktest/f444w/jw_gate_nrcalong.fits',
+   'sha256:1111111111111111111111111111111111111111111111111111111111111111',
+   1024, 'application/fits', 'nircam_exposure', 'nircam', 'active', 'leaktest',
+   NULL, (SELECT id FROM _dep));
+
+GRANT SELECT ON _dep TO authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION pg_temp.gate_key() RETURNS text LANGUAGE sql AS
+  $f$ SELECT 'data/products/nircam/leaktest/f444w/jw_gate_nrcalong.fits'::text $f$;
+
+-- =========================================================================
+-- 1. DRAFT field deployment -> NON-ADMIN sees ZERO (RLS)
+-- =========================================================================
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claims',
+  json_build_object('sub','22222222-2222-2222-2222-222222222222','role','authenticated')::text, true);
+DO $$
+DECLARE n int;
+BEGIN
+  SELECT count(*) INTO n FROM storage_objects WHERE storage_key = pg_temp.gate_key();
+  IF n <> 0 THEN RAISE EXCEPTION 'RLS LEAK: non-admin sees a DRAFT field-deploy object (expected 0)'; END IF;
+END $$;
+
+-- =========================================================================
+-- 2. DRAFT -> ADMIN sees it (RLS)
+-- =========================================================================
+SELECT set_config('request.jwt.claims',
+  json_build_object('sub','11111111-1111-1111-1111-111111111111','role','authenticated')::text, true);
+DO $$
+DECLARE n int;
+BEGIN
+  SELECT count(*) INTO n FROM storage_objects WHERE storage_key = pg_temp.gate_key();
+  IF n <> 1 THEN RAISE EXCEPTION 'ADMIN BLOCKED: admin does not see the draft field-deploy object (got %)', n; END IF;
+END $$;
+
+-- =========================================================================
+-- 3. Service-role RPCs: DRAFT hidden from member view, shown to admin view
+-- =========================================================================
+RESET ROLE;
+SET LOCAL ROLE service_role;
+SELECT set_config('request.jwt.claims', '', true);
+DO $$
+DECLARE pubs text[]; k text[]; n int;
+BEGIN
+  pubs := ARRAY(SELECT slug FROM programs WHERE is_public);
+  k := ARRAY[pg_temp.gate_key()];
+  SELECT count(*) INTO n FROM public.filter_accessible_storage_keys(k, pubs, false);
+  IF n <> 0 THEN RAISE EXCEPTION 'PRESIGN LEAK: draft field object authorized for member (got %)', n; END IF;
+  SELECT count(*) INTO n FROM (
+    SELECT jsonb_array_elements(objects)->>'storage_key' AS s
+    FROM public.get_storage_objects_for_sync(pubs, NULL, 100000, 0, false, false)) q
+    WHERE s = pg_temp.gate_key();
+  IF n <> 0 THEN RAISE EXCEPTION 'SYNC LEAK: draft field object in member sync (got %)', n; END IF;
+END $$;
+
+-- =========================================================================
+-- 4. PUBLISH via set_deployment_status AS ADMIN (must NOT raise on NULL observation)
+-- =========================================================================
+RESET ROLE;
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claims',
+  json_build_object('sub','11111111-1111-1111-1111-111111111111','role','authenticated')::text, true);
+DO $$
+DECLARE r json;
+BEGIN
+  r := public.set_deployment_status((SELECT id FROM _dep), 'published', NULL, 'testhost');
+  IF (r->>'status') <> 'published' THEN
+    RAISE EXCEPTION 'set_deployment_status(field) did not publish (got %)', r;
+  END IF;
+  IF (SELECT status FROM deployments WHERE id = (SELECT id FROM _dep)) <> 'published' THEN
+    RAISE EXCEPTION 'deployment row not flipped to published';
+  END IF;
+END $$;
+
+-- =========================================================================
+-- 5. PUBLISHED field deployment -> PUBLIC to everyone (member RPCs + non-admin RLS)
+-- =========================================================================
+RESET ROLE;
+SET LOCAL ROLE service_role;
+SELECT set_config('request.jwt.claims', '', true);
+DO $$
+DECLARE pubs text[]; k text[]; n int;
+BEGIN
+  pubs := ARRAY(SELECT slug FROM programs WHERE is_public);
+  k := ARRAY[pg_temp.gate_key()];
+  SELECT count(*) INTO n FROM public.filter_accessible_storage_keys(k, pubs, false);
+  IF n <> 1 THEN RAISE EXCEPTION 'PRESIGN: published field object NOT public (got %/1)', n; END IF;
+  SELECT count(*) INTO n FROM (
+    SELECT jsonb_array_elements(objects)->>'storage_key' AS s
+    FROM public.get_storage_objects_for_sync(pubs, NULL, 100000, 0, false, false)) q
+    WHERE s = pg_temp.gate_key();
+  IF n <> 1 THEN RAISE EXCEPTION 'SYNC: published field object NOT in member sync (got %/1)', n; END IF;
+END $$;
+
+RESET ROLE;
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claims',
+  json_build_object('sub','22222222-2222-2222-2222-222222222222','role','authenticated')::text, true);
+DO $$
+DECLARE n int;
+BEGIN
+  SELECT count(*) INTO n FROM storage_objects WHERE storage_key = pg_temp.gate_key();
+  IF n <> 1 THEN RAISE EXCEPTION 'RLS: non-admin cannot see PUBLISHED field-deploy object (got %/1)', n; END IF;
+END $$;
+
+RESET ROLE;
+SELECT '✅ NIRCAM FIELD-DEPLOY GATE HARNESS: ALL ASSERTIONS PASSED' AS result;
+
+ROLLBACK;

--- a/python/tests/test_nircam_deploy.py
+++ b/python/tests/test_nircam_deploy.py
@@ -97,17 +97,19 @@ def test_exposure_ref_for_nircam_exposure():
     assert reg._exposure_ref_for("nircam_exposure_preview", f"{ROOT}_preview.png") is None
 
 
-def test_row_for_nircam_exposure_is_admin_only_and_carries_sci_dq():
+def test_row_for_nircam_exposure_identity_and_sci_dq():
+    # Deploy tags the row with a field deployment_id (visibility rides
+    # deployment.status); row_for_key defaults it to None when not supplied.
     row = reg.row_for_key(
         EXP_KEY, backend="osn", content_hash="sha256:" + "a" * 64,
         size_bytes=100, content_type="application/fits",
-        sci_dq_hash="sha256:" + "b" * 64)
+        deployment_id=42, sci_dq_hash="sha256:" + "b" * 64)
     assert row["product_type"] == "nircam_exposure"
     assert row["instrument"] == "nircam"
     assert row["field"] == "cosmos"
     assert row["observation"] is None
     assert row["spectrum_id"] is None       # not a spectrum
-    assert row["deployment_id"] is None      # admin-only intermediate
+    assert row["deployment_id"] == 42        # tagged with the field deployment
     assert row["exposure_ref"] == ROOT       # one active row per exposure
     assert row["sci_dq_hash"] == "sha256:" + "b" * 64
 

--- a/python/tests/test_nircam_deploy.py
+++ b/python/tests/test_nircam_deploy.py
@@ -1,0 +1,135 @@
+"""Unit tests for the NIRCam canonical-exposure deploy (epic #261, N1).
+
+Pure/local: the science-only content hash (SCI+DQ, stable across a header-only
+re-save), canonical FITS/expmap upload-task keys, the registry row identity for a
+NIRCam exposure (field-scoped, admin-only, carrying a sci_dq_hash + exposure_ref),
+and sci_dq_hash threading through build_registry_rows. The full upload + registry
+round-trip is exercised live against local Supabase in CI.
+"""
+import numpy as np
+import pytest
+from astropy.io import fits
+
+from campfire.deploy import nircam as nc
+from campfire.deploy import registry as reg
+from campfire.deploy.r2 import UploadTask
+from campfire_layout import KeyScheme, Scope, storage_key
+
+ROOT = "jw01727028001_04101_00003_nrcalong"
+EXP_KEY = f"data/products/nircam/cosmos/f444w/{ROOT}.fits"
+
+
+def _make_exposure(path, sci, dq, *, extra_header=None, with_sci=True, with_dq=True):
+    hdus = [fits.PrimaryHDU()]
+    for k, v in (extra_header or {}).items():
+        hdus[0].header[k] = v
+    if with_sci:
+        hdus.append(fits.ImageHDU(data=sci.astype("float32"), name="SCI"))
+    if with_dq:
+        hdus.append(fits.ImageHDU(data=dq.astype("int32"), name="DQ"))
+    fits.HDUList(hdus).writeto(path, overwrite=True)
+    return path
+
+
+# --- _sci_dq_hash -----------------------------------------------------------
+
+def test_sci_dq_hash_prefixed_and_stable_over_header_change(tmp_path):
+    sci = np.arange(16, dtype="float32").reshape(4, 4)
+    dq = np.zeros((4, 4), dtype="int32")
+    a = _make_exposure(tmp_path / "a.fits", sci, dq)
+    # Same SCI+DQ, different primary header (mimics a pipeline re-save that only
+    # bumps timestamps) → identical digest.
+    b = _make_exposure(tmp_path / "b.fits", sci, dq, extra_header={"DATE": "2026-07-01"})
+    ha, hb = nc._sci_dq_hash(a), nc._sci_dq_hash(b)
+    assert ha.startswith("sha256:") and len(ha) == len("sha256:") + 64
+    assert ha == hb
+
+
+def test_sci_dq_hash_changes_when_science_changes(tmp_path):
+    dq = np.zeros((4, 4), dtype="int32")
+    a = _make_exposure(tmp_path / "a.fits", np.zeros((4, 4), "float32"), dq)
+    c = _make_exposure(tmp_path / "c.fits", np.ones((4, 4), "float32"), dq)
+    assert nc._sci_dq_hash(a) != nc._sci_dq_hash(c)
+    # A DQ change also flips it.
+    d = _make_exposure(tmp_path / "d.fits", np.zeros((4, 4), "float32"),
+                       np.ones((4, 4), "int32"))
+    assert nc._sci_dq_hash(a) != nc._sci_dq_hash(d)
+
+
+def test_sci_dq_hash_none_without_sci_or_dq(tmp_path):
+    p = tmp_path / "e.fits"
+    fits.HDUList([fits.PrimaryHDU()]).writeto(p, overwrite=True)
+    assert nc._sci_dq_hash(p) is None
+
+
+# --- upload-task builders ---------------------------------------------------
+
+def test_build_fits_upload_tasks_uses_canonical_keys(tmp_path):
+    path = tmp_path / f"{ROOT}.fits"
+    path.write_bytes(b"\x00")
+    exposures = {("f444w", ROOT): {"path": path, "filter": "f444w", "basename": ROOT}}
+    tasks = nc.build_fits_upload_tasks("cosmos", exposures)
+    assert len(tasks) == 1
+    assert tasks[0].r2_key == EXP_KEY
+    assert tasks[0].content_type == "application/fits"
+
+
+def test_discover_expmap_tasks_canonical_keys(tmp_path):
+    expdir = tmp_path / "products" / "nircam" / "cosmos" / "expmaps"
+    expdir.mkdir(parents=True)
+    (expdir / "cosmos_f444w_expmap.fits").write_bytes(b"\x00")
+    dirs = {"products": tmp_path / "products" / "nircam" / "cosmos"}
+    tasks = nc.discover_expmap_tasks(dirs, "cosmos")
+    assert len(tasks) == 1
+    assert tasks[0].r2_key == "data/products/nircam/cosmos/expmaps/cosmos_f444w_expmap.fits"
+
+
+def test_discover_expmap_tasks_empty_when_absent(tmp_path):
+    dirs = {"products": tmp_path / "nope"}
+    assert nc.discover_expmap_tasks(dirs, "cosmos") == []
+
+
+# --- registry identity ------------------------------------------------------
+
+def test_exposure_ref_for_nircam_exposure():
+    assert reg._exposure_ref_for("nircam_exposure", f"{ROOT}.fits") == ROOT
+    # A preview PNG is not an exposure-level object → no ref.
+    assert reg._exposure_ref_for("nircam_exposure_preview", f"{ROOT}_preview.png") is None
+
+
+def test_row_for_nircam_exposure_is_admin_only_and_carries_sci_dq():
+    row = reg.row_for_key(
+        EXP_KEY, backend="osn", content_hash="sha256:" + "a" * 64,
+        size_bytes=100, content_type="application/fits",
+        sci_dq_hash="sha256:" + "b" * 64)
+    assert row["product_type"] == "nircam_exposure"
+    assert row["instrument"] == "nircam"
+    assert row["field"] == "cosmos"
+    assert row["observation"] is None
+    assert row["spectrum_id"] is None       # not a spectrum
+    assert row["deployment_id"] is None      # admin-only intermediate
+    assert row["exposure_ref"] == ROOT       # one active row per exposure
+    assert row["sci_dq_hash"] == "sha256:" + "b" * 64
+
+
+def test_row_sci_dq_hash_none_by_default():
+    # An expmap (and every non-exposure product) carries no science digest.
+    row = reg.row_for_key(
+        "data/products/nircam/cosmos/expmaps/cosmos_f444w_expmap.fits",
+        backend="osn", content_hash="sha256:" + "a" * 64, size_bytes=1,
+        content_type="application/fits")
+    assert row["product_type"] == "nircam_expmap"
+    assert row["sci_dq_hash"] is None
+
+
+def test_build_registry_rows_threads_sci_dq_hashes(tmp_path):
+    p = tmp_path / f"{ROOT}.fits"
+    p.write_bytes(b"\x00" * 512)
+    tasks = [UploadTask(p, EXP_KEY, "application/fits")]
+    rows = reg.build_registry_rows(
+        tasks, backend="osn", succeeded_keys={EXP_KEY},
+        sci_dq_hashes={EXP_KEY: "sha256:" + "c" * 64})
+    assert len(rows) == 1
+    assert rows[0]["content_hash"].startswith("sha256:")   # whole-file digest
+    assert rows[0]["content_hash"] != "sha256:" + "c" * 64  # not the sci_dq one
+    assert rows[0]["sci_dq_hash"] == "sha256:" + "c" * 64

--- a/python/tests/test_nircam_exposure_rls.py
+++ b/python/tests/test_nircam_exposure_rls.py
@@ -1,0 +1,59 @@
+"""NIRCam exposure admin-only leak gate (epic #261, N1).
+
+DB-backed integration test: runs ``sql/nircam_exposure_admin_only.sql`` against
+the local Supabase Postgres via ``docker exec ... psql`` and asserts the harness
+reaches its PASS marker. The SQL inserts a canonical NIRCam exposure storage
+object (spectrum_id=NULL, deployment_id=NULL) plus a nircam_exposures triage row
+(inside a rolled-back transaction) and asserts a non-admin sees ZERO of them
+through RLS, get_storage_objects_for_sync, and filter_accessible_storage_keys —
+while an admin does. This is the exit criterion for deploying NIRCam canonical
+exposures admin-only (no public/draft tier for exposures; that lives at the
+mosaic level, N3).
+
+Skips automatically when the local Supabase DB container is not reachable.
+"""
+import subprocess
+from pathlib import Path
+
+import pytest
+
+CONTAINER = "supabase_db_campfire"
+SQL_FILE = Path(__file__).parent / "sql" / "nircam_exposure_admin_only.sql"
+PASS_MARKER = "ALL ASSERTIONS PASSED"
+
+
+def _docker_psql_available() -> bool:
+    try:
+        r = subprocess.run(
+            ["docker", "exec", "-i", CONTAINER,
+             "psql", "-U", "postgres", "-d", "postgres", "-tA", "-c", "SELECT 1"],
+            capture_output=True, text=True, timeout=15,
+        )
+        return r.returncode == 0 and r.stdout.strip().startswith("1")
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return False
+
+
+requires_local_db = pytest.mark.skipif(
+    not _docker_psql_available(),
+    reason=f"local Supabase container '{CONTAINER}' not reachable (run `supabase start` + `supabase db reset`)",
+)
+
+
+@requires_local_db
+def test_nircam_exposures_admin_only_no_leak():
+    """Non-admin gets zero NIRCam exposure objects/rows; admin sees them."""
+    sql = SQL_FILE.read_text()
+    result = subprocess.run(
+        ["docker", "exec", "-i", CONTAINER,
+         "psql", "-U", "postgres", "-d", "postgres", "-v", "ON_ERROR_STOP=1", "-f", "-"],
+        input=sql, capture_output=True, text=True, timeout=120,
+    )
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, (
+        f"NIRCam exposure admin-only harness FAILED (psql exit {result.returncode}).\n"
+        f"A non-admin saw a NIRCam exposure storage object or triage row. Output:\n{combined}"
+    )
+    assert PASS_MARKER in result.stdout, (
+        f"NIRCam exposure admin-only harness did not reach its PASS marker.\nOutput:\n{combined}"
+    )

--- a/python/tests/test_nircam_field_deploy_gate.py
+++ b/python/tests/test_nircam_field_deploy_gate.py
@@ -1,0 +1,58 @@
+"""NIRCam field-deployment visibility gate (epic #261, N1).
+
+DB-backed integration test: runs ``sql/nircam_field_deploy_gate.sql`` against the
+local Supabase Postgres and asserts the harness reaches its PASS marker. Proves
+that a *draft* field-scoped deployment is admin-only and a *published* one is
+public to everyone (NIRCam fields span multiple programs, so there is no
+per-program scope), enforced across the storage_objects RLS +
+filter_accessible_storage_keys + get_storage_objects_for_sync, and that
+set_deployment_status flips a field deployment without the observation-NULL raise.
+
+Skips automatically when the local Supabase DB container is not reachable.
+"""
+import subprocess
+from pathlib import Path
+
+import pytest
+
+CONTAINER = "supabase_db_campfire"
+SQL_FILE = Path(__file__).parent / "sql" / "nircam_field_deploy_gate.sql"
+PASS_MARKER = "ALL ASSERTIONS PASSED"
+
+
+def _docker_psql_available() -> bool:
+    try:
+        r = subprocess.run(
+            ["docker", "exec", "-i", CONTAINER,
+             "psql", "-U", "postgres", "-d", "postgres", "-tA", "-c", "SELECT 1"],
+            capture_output=True, text=True, timeout=15,
+        )
+        return r.returncode == 0 and r.stdout.strip().startswith("1")
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return False
+
+
+requires_local_db = pytest.mark.skipif(
+    not _docker_psql_available(),
+    reason=f"local Supabase container '{CONTAINER}' not reachable (run `supabase start` + `supabase db reset`)",
+)
+
+
+@requires_local_db
+def test_nircam_field_deploy_gate():
+    """Draft field deploy admin-only; published field deploy public to everyone."""
+    sql = SQL_FILE.read_text()
+    result = subprocess.run(
+        ["docker", "exec", "-i", CONTAINER,
+         "psql", "-U", "postgres", "-d", "postgres", "-v", "ON_ERROR_STOP=1", "-f", "-"],
+        input=sql, capture_output=True, text=True, timeout=120,
+    )
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, (
+        f"NIRCam field-deploy gate harness FAILED (psql exit {result.returncode}).\n"
+        f"A draft field deploy leaked to a non-admin, or a published one wasn't public. "
+        f"Output:\n{combined}"
+    )
+    assert PASS_MARKER in result.stdout, (
+        f"NIRCam field-deploy gate harness did not reach its PASS marker.\nOutput:\n{combined}"
+    )

--- a/python/tests/test_registry.py
+++ b/python/tests/test_registry.py
@@ -206,6 +206,26 @@ def test_reconcile_no_bucket_skips_dangling_orphan():
     assert rep.covered
 
 
+def test_reconcile_osn_native_key_not_dangling_when_scoped(tmp_path):
+    # #261/N1: an OSN-native NIRCam exposure has no R2 twin, so it's absent from the
+    # R2-only bucket LIST by design — not because it's dangling. With danglable_keys
+    # scoped to the R2-backed registry rows, the OSN key is NOT flagged; with the
+    # legacy default (danglable_keys=None) it WOULD be (the pre-N1 assumption).
+    osn_key = "data/products/nircam/cosmos/f444w/jw1_nrcalong.fits"
+    r2_key = SPEC_KEY
+    registry = [r2_key, osn_key]        # both registered
+    bucket = [r2_key]                    # R2 LIST — osn object never appears here
+
+    # Legacy behaviour: the OSN key looks dangling.
+    naive = reg.compute_reconcile([r2_key], registry, bucket)
+    assert osn_key in naive.dangling
+
+    # Scoped: dangling only over the R2-backed rows -> OSN key excluded, clean.
+    scoped = reg.compute_reconcile([r2_key], registry, bucket, danglable_keys=[r2_key])
+    assert scoped.dangling == set()
+    assert scoped.covered
+
+
 def test_reconcile_matches_legacy_pointer_to_canonical_registry_key():
     # #249: A1 re-keyed migrated objects legacy->canonical, but the live pointer
     # (spectra.fits_path) stays legacy. Reconcile must match them by canonical

--- a/supabase/migrations/20260701220913_nircam_exposure_sci_dq_hash.sql
+++ b/supabase/migrations/20260701220913_nircam_exposure_sci_dq_hash.sql
@@ -1,0 +1,22 @@
+-- epic #261, N1 — NIRCam canonical exposures on OSN.
+--
+-- Adds a science-only change-detection digest to the storage registry. content_hash
+-- stays the authoritative whole-file sha256 (download/copy verification), but a
+-- NIRCam canonical exposure re-saved by the pipeline gets fresh header timestamps
+-- that shift the whole-file hash even when SCI+DQ are unchanged — so deploy compares
+-- this stable sha256(SCI+DQ) to skip re-uploading a science-identical exposure (D1).
+-- Additive + nullable (NULL for every existing row and every product without a
+-- partial digest), so no backfill and no seed change.
+--
+-- The generated diff also drop+recreated four unrelated views/matviews
+-- (mv_filter_options, mv_programs_overview, nircam_reduction_progress,
+-- spectrum_flag_summary) — a known migra limitation (it re-serializes all views on
+-- any schema change; none reference storage_objects). Stripped: those definitions
+-- are unchanged, so the drop+recreate is a no-op that would needlessly churn the
+-- materialized views.
+
+alter table "public"."storage_objects" add column "sci_dq_hash" text;
+
+alter table "public"."storage_objects"
+  add constraint "storage_objects_sci_dq_hash_check"
+  CHECK (((sci_dq_hash IS NULL) OR (sci_dq_hash ~ '^sha256:'::text)));

--- a/supabase/migrations/20260702134930_nircam_field_deployments.sql
+++ b/supabase/migrations/20260702134930_nircam_field_deployments.sql
@@ -1,0 +1,234 @@
+-- epic #261, N1 — NIRCam deploy first-class: field-scoped deployments.
+-- deployments can anchor to a NIRCam FIELD (exactly one of observation/field,
+-- via deployments_scope_check), recording the same provenance + draft/published/
+-- revoked lifecycle. The storage_objects gate (RLS + filter_accessible_storage_keys
+-- + get_storage_objects_for_sync) gains a field branch: a published field deployment
+-- is public to EVERYONE (NIRCam fields span multiple programs), NIRSpec obs stay
+-- program-scoped. set_deployment_status branches on field vs observation. (Spurious
+-- view/matview drop+recreate churn stripped — migra artifact, definitions unchanged.)
+
+drop policy "select_storage_objects_by_access" on "public"."storage_objects";
+
+alter table "public"."deployments" add column "field" text;
+
+alter table "public"."deployments" alter column "observation" drop not null;
+
+alter table "public"."deployments" add constraint "deployments_scope_check" CHECK ((num_nonnulls(observation, field) = 1)) not valid;
+
+alter table "public"."deployments" validate constraint "deployments_scope_check";
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.filter_accessible_storage_keys(p_keys text[], p_program_slugs text[], p_include_unpublished boolean DEFAULT false)
+ RETURNS TABLE(storage_key text)
+ LANGUAGE sql
+ STABLE
+AS $function$
+  SELECT so.storage_key
+  FROM storage_objects so
+  WHERE so.storage_key = ANY(p_keys)
+    AND so.status = 'active'
+    AND (
+      p_include_unpublished
+      OR (so.spectrum_id IS NOT NULL AND EXISTS (
+            SELECT 1 FROM spectra s
+            JOIN targets t ON t.target_id = s.target_id
+            WHERE s.spectrum_id = so.spectrum_id
+              AND s.deploy_status = 'published'
+              AND t.program_slug = ANY(p_program_slugs)))
+      OR (so.spectrum_id IS NULL AND so.deployment_id IS NOT NULL AND EXISTS (
+            SELECT 1 FROM deployments d
+            LEFT JOIN observations o ON o.name = d.observation
+            WHERE d.id = so.deployment_id
+              AND d.status = 'published'
+              -- NIRCam field deploy (epic #261, N1): multi-program, public to all
+              -- when published. NIRSpec obs deploy stays program-scoped.
+              AND (d.field IS NOT NULL OR o.program_slug = ANY(p_program_slugs))))
+    );
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_storage_objects_for_sync(p_program_slugs text[], p_updated_since timestamp with time zone DEFAULT NULL::timestamp with time zone, p_limit integer DEFAULT 1000, p_offset integer DEFAULT 0, p_include_counts boolean DEFAULT true, p_include_unpublished boolean DEFAULT false)
+ RETURNS TABLE(objects jsonb, total_count bigint, total_accessible_count bigint)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+ SET statement_timeout TO '120s'
+AS $function$
+BEGIN
+  RETURN QUERY
+  WITH scoped AS (
+    SELECT so.*
+    FROM storage_objects so
+    WHERE so.status = 'active'
+      AND (
+        p_include_unpublished
+        OR (so.spectrum_id IS NOT NULL AND EXISTS (
+              SELECT 1 FROM spectra s
+              JOIN targets t ON t.target_id = s.target_id
+              WHERE s.spectrum_id = so.spectrum_id
+                AND s.deploy_status = 'published'
+                AND t.program_slug = ANY(p_program_slugs)))
+        OR (so.spectrum_id IS NULL AND so.deployment_id IS NOT NULL AND EXISTS (
+              SELECT 1 FROM deployments d
+              LEFT JOIN observations o ON o.name = d.observation
+              WHERE d.id = so.deployment_id
+                AND d.status = 'published'
+                -- NIRCam field deploy (epic #261, N1): multi-program, public to all
+                -- when published. NIRSpec obs deploy stays program-scoped.
+                AND (d.field IS NOT NULL OR o.program_slug = ANY(p_program_slugs))))
+      )
+  ),
+  matched AS MATERIALIZED (
+    SELECT * FROM scoped
+    WHERE (p_updated_since IS NULL OR scoped.updated_at > p_updated_since)
+    ORDER BY scoped.storage_key
+    LIMIT p_limit OFFSET p_offset
+  ),
+  total AS (
+    SELECT COUNT(*) AS cnt FROM scoped
+    WHERE p_include_counts
+      AND (p_updated_since IS NULL OR scoped.updated_at > p_updated_since)
+  ),
+  accessible AS (
+    SELECT COUNT(*) AS cnt FROM scoped
+    WHERE p_include_counts
+  )
+  SELECT
+    COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'id', m.id,
+        'backend', m.backend,
+        'bucket', m.bucket,
+        'storage_key', m.storage_key,
+        'content_hash', m.content_hash,
+        'size_bytes', m.size_bytes,
+        'content_type', m.content_type,
+        'product_type', m.product_type,
+        'instrument', m.instrument,
+        'status', m.status,
+        'observation', m.observation,
+        'field', m.field,
+        'spectrum_id', m.spectrum_id,
+        'exposure_ref', m.exposure_ref,
+        'deployment_id', m.deployment_id,
+        'cfpipe_version', m.cfpipe_version,
+        'created_at', m.created_at,
+        'updated_at', m.updated_at
+      )
+    ), '[]'::jsonb),
+    COALESCE((SELECT cnt FROM total), 0)::BIGINT,
+    COALESCE((SELECT cnt FROM accessible), 0)::BIGINT
+  FROM matched m;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.set_deployment_status(p_deployment_id integer, p_to text, p_actor uuid DEFAULT NULL::uuid, p_host text DEFAULT NULL::text)
+ RETURNS json
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_is_admin boolean;
+  v_obs text;
+  v_field text;
+  v_action text;
+  v_spectrum_ids integer[];
+  v_result json;
+BEGIN
+  SELECT COALESCE(up.is_admin, false) INTO v_is_admin
+  FROM user_profiles up WHERE up.user_id = auth.uid();
+  IF NOT (COALESCE(v_is_admin, false) OR COALESCE(auth.role(), '') = 'service_role') THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+
+  IF p_to NOT IN ('draft', 'published', 'revoked') THEN
+    RAISE EXCEPTION 'Invalid status: %', p_to;
+  END IF;
+
+  SELECT observation, field INTO v_obs, v_field FROM deployments WHERE id = p_deployment_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Deployment % not found', p_deployment_id;
+  END IF;
+
+  -- NIRCam field-scoped deployment (epic #261, N1): no spectra to flip — the
+  -- exposure/mosaic FITS visibility rides deployment.status via the storage_objects
+  -- gate, so flipping the deployment row is the whole transition. (N2 extends this
+  -- to also flip nircam_images.deploy_status for the public mosaic index.)
+  IF v_field IS NOT NULL THEN
+    v_action := CASE WHEN p_to = 'revoked' THEN 'revoke'
+                     WHEN p_to = 'draft' THEN 'upload' ELSE 'publish' END;
+    UPDATE deployments SET
+      status = p_to,
+      published_at = CASE WHEN p_to = 'published' THEN now() ELSE published_at END,
+      revoked_at = CASE WHEN p_to = 'revoked' THEN now() ELSE revoked_at END
+    WHERE id = p_deployment_id;
+    INSERT INTO deploy_events (actor, action, deployment_id, status_to, host, metadata)
+      VALUES (p_actor, v_action, p_deployment_id, p_to, p_host,
+              jsonb_build_object('field', v_field));
+    RETURN json_build_object(
+      'deployment_id', p_deployment_id, 'field', v_field,
+      'status', p_to, 'spectra', json_build_object('updated', 0, 'action', v_action));
+  END IF;
+
+  -- Which current statuses transition to p_to:
+  --   p_to='published'  -> draft (first publish) OR revoked (recover) become visible
+  --   p_to='revoked'    -> published spectra are hidden
+  --   p_to='draft'    -> published spectra go back to draft
+  -- The prior version matched only 'draft' for the published case, so recovering
+  -- a REVOKED deployment flipped the deployment row but left its spectra revoked
+  -- and hidden ("0 updated", silently inconsistent) — #233 review.
+  SELECT array_agg(s.id) INTO v_spectrum_ids
+  FROM spectra s JOIN targets t ON s.target_id = t.target_id
+  WHERE t.observation = v_obs
+    AND s.deploy_status = ANY (
+      CASE p_to WHEN 'published' THEN ARRAY['draft', 'revoked']
+                WHEN 'revoked'   THEN ARRAY['published']
+                ELSE                  ARRAY['published'] END);
+
+  -- Audit label: publishing previously-revoked spectra is a 'recover', not a
+  -- first 'publish'. Computed before the transition (spectra still hold old status).
+  v_action := CASE
+    WHEN p_to = 'revoked' THEN 'revoke'
+    WHEN p_to = 'draft' THEN 'upload'
+    WHEN EXISTS (SELECT 1 FROM spectra s JOIN targets t ON s.target_id = t.target_id
+                 WHERE t.observation = v_obs AND s.deploy_status = 'revoked')
+      THEN 'recover'
+    ELSE 'publish'
+  END;
+
+  UPDATE deployments SET
+    status = p_to,
+    published_at = CASE WHEN p_to = 'published' THEN now() ELSE published_at END,
+    revoked_at = CASE WHEN p_to = 'revoked' THEN now() ELSE revoked_at END
+  WHERE id = p_deployment_id;
+
+  IF v_spectrum_ids IS NOT NULL THEN
+    v_result := public.set_spectra_deploy_status(
+      p_spectrum_db_ids := v_spectrum_ids, p_to := p_to, p_action := v_action,
+      p_actor := p_actor, p_deployment_id := p_deployment_id, p_host := p_host);
+  ELSE
+    v_result := json_build_object('updated', 0, 'action', v_action);
+  END IF;
+
+  RETURN json_build_object(
+    'deployment_id', p_deployment_id, 'observation', v_obs,
+    'status', p_to, 'spectra', v_result);
+END;
+$function$
+;
+
+  create policy "select_storage_objects_by_access"
+  on "public"."storage_objects"
+  as permissive
+  for select
+  to authenticated
+using (((status = 'active'::text) AND (((spectrum_id IS NOT NULL) AND (EXISTS ( SELECT 1
+   FROM (public.spectra s
+     JOIN public.targets t ON ((t.target_id = s.target_id)))
+  WHERE ((s.spectrum_id = storage_objects.spectrum_id) AND (s.deploy_status = 'published'::text) AND (t.program_slug = ANY (( SELECT public.accessible_program_slugs() AS accessible_program_slugs)::text[])))))) OR ((spectrum_id IS NULL) AND (deployment_id IS NOT NULL) AND (EXISTS ( SELECT 1
+   FROM (public.deployments d
+     LEFT JOIN public.observations o ON ((o.name = d.observation)))
+  WHERE ((d.id = storage_objects.deployment_id) AND (d.status = 'published'::text) AND ((d.field IS NOT NULL) OR (o.program_slug = ANY (( SELECT public.accessible_program_slugs() AS accessible_program_slugs)::text[]))))))))));
+

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -2527,10 +2527,12 @@ BEGIN
                 AND t.program_slug = ANY(p_program_slugs)))
         OR (so.spectrum_id IS NULL AND so.deployment_id IS NOT NULL AND EXISTS (
               SELECT 1 FROM deployments d
-              JOIN observations o ON o.name = d.observation
+              LEFT JOIN observations o ON o.name = d.observation
               WHERE d.id = so.deployment_id
                 AND d.status = 'published'
-                AND o.program_slug = ANY(p_program_slugs)))
+                -- NIRCam field deploy (epic #261, N1): multi-program, public to all
+                -- when published. NIRSpec obs deploy stays program-scoped.
+                AND (d.field IS NOT NULL OR o.program_slug = ANY(p_program_slugs))))
       )
   ),
   matched AS MATERIALIZED (
@@ -2611,10 +2613,12 @@ AS $$
               AND t.program_slug = ANY(p_program_slugs)))
       OR (so.spectrum_id IS NULL AND so.deployment_id IS NOT NULL AND EXISTS (
             SELECT 1 FROM deployments d
-            JOIN observations o ON o.name = d.observation
+            LEFT JOIN observations o ON o.name = d.observation
             WHERE d.id = so.deployment_id
               AND d.status = 'published'
-              AND o.program_slug = ANY(p_program_slugs)))
+              -- NIRCam field deploy (epic #261, N1): multi-program, public to all
+              -- when published. NIRSpec obs deploy stays program-scoped.
+              AND (d.field IS NOT NULL OR o.program_slug = ANY(p_program_slugs))))
     );
 $$;
 
@@ -3349,6 +3353,7 @@ AS $$
 DECLARE
   v_is_admin boolean;
   v_obs text;
+  v_field text;
   v_action text;
   v_spectrum_ids integer[];
   v_result json;
@@ -3363,9 +3368,29 @@ BEGIN
     RAISE EXCEPTION 'Invalid status: %', p_to;
   END IF;
 
-  SELECT observation INTO v_obs FROM deployments WHERE id = p_deployment_id;
-  IF v_obs IS NULL THEN
+  SELECT observation, field INTO v_obs, v_field FROM deployments WHERE id = p_deployment_id;
+  IF NOT FOUND THEN
     RAISE EXCEPTION 'Deployment % not found', p_deployment_id;
+  END IF;
+
+  -- NIRCam field-scoped deployment (epic #261, N1): no spectra to flip — the
+  -- exposure/mosaic FITS visibility rides deployment.status via the storage_objects
+  -- gate, so flipping the deployment row is the whole transition. (N2 extends this
+  -- to also flip nircam_images.deploy_status for the public mosaic index.)
+  IF v_field IS NOT NULL THEN
+    v_action := CASE WHEN p_to = 'revoked' THEN 'revoke'
+                     WHEN p_to = 'draft' THEN 'upload' ELSE 'publish' END;
+    UPDATE deployments SET
+      status = p_to,
+      published_at = CASE WHEN p_to = 'published' THEN now() ELSE published_at END,
+      revoked_at = CASE WHEN p_to = 'revoked' THEN now() ELSE revoked_at END
+    WHERE id = p_deployment_id;
+    INSERT INTO deploy_events (actor, action, deployment_id, status_to, host, metadata)
+      VALUES (p_actor, v_action, p_deployment_id, p_to, p_host,
+              jsonb_build_object('field', v_field));
+    RETURN json_build_object(
+      'deployment_id', p_deployment_id, 'field', v_field,
+      'status', p_to, 'spectra', json_build_object('updated', 0, 'action', v_action));
   END IF;
 
   -- Which current statuses transition to p_to:

--- a/supabase/schemas/policies.sql
+++ b/supabase/schemas/policies.sql
@@ -769,10 +769,15 @@ CREATE POLICY "select_storage_objects_by_access"
       OR
       (storage_objects.spectrum_id IS NULL AND storage_objects.deployment_id IS NOT NULL AND EXISTS (
          SELECT 1 FROM deployments d
-         JOIN observations o ON o.name = d.observation
+         LEFT JOIN observations o ON o.name = d.observation
          WHERE d.id = storage_objects.deployment_id
            AND d.status = 'published'
-           AND o.program_slug = ANY((SELECT public.accessible_program_slugs())::text[])))
+           AND (
+             -- NIRCam field-scoped deploy (epic #261, N1): a field spans multiple
+             -- programs, so there is no per-program scope — a published field
+             -- deployment is public to everyone. Draft/revoked stay admin-only.
+             d.field IS NOT NULL
+             OR o.program_slug = ANY((SELECT public.accessible_program_slugs())::text[]))))
     )
   );
 

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -622,7 +622,14 @@ ALTER TABLE "public"."observations" OWNER TO "postgres";
 
 CREATE TABLE IF NOT EXISTS "public"."deployments" (
     "id" integer NOT NULL,
-    "observation" "text" NOT NULL,
+    -- A deployment is anchored to EITHER a NIRSpec observation OR a NIRCam field
+    -- (epic #261, N1): exactly one is non-null. `observation` was NOT NULL before
+    -- NIRCam deploy became first-class; it is now nullable so a field-scoped deploy
+    -- can record the same provenance (deployed_by/at, cfpipe_version, crds_context,
+    -- config_snapshot) and drive the same draft->published->revoked lifecycle. The
+    -- observation FK still holds (NULL references nothing).
+    "observation" "text",
+    "field" "text",
     "deployed_by" "uuid",
     "deployed_at" timestamp with time zone DEFAULT "now"(),
     "cfpipe_version" "text",
@@ -645,7 +652,9 @@ CREATE TABLE IF NOT EXISTS "public"."deployments" (
     -- spectra.deploy_status; this column is the provenance/audit record.
     "status" "text" NOT NULL DEFAULT 'published' CONSTRAINT "deployments_status_check" CHECK (("status" = ANY (ARRAY['draft'::"text", 'published'::"text", 'revoked'::"text"]))),
     "published_at" timestamp with time zone,
-    "revoked_at" timestamp with time zone
+    "revoked_at" timestamp with time zone,
+    -- Exactly one scope: a NIRSpec observation or a NIRCam field (epic #261, N1).
+    CONSTRAINT "deployments_scope_check" CHECK (("num_nonnulls"("observation", "field") = 1))
 );
 
 

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -818,6 +818,15 @@ CREATE TABLE IF NOT EXISTS "public"."storage_objects" (
     "bucket" "text" NOT NULL,
     "storage_key" "text" NOT NULL,
     "content_hash" "text" NOT NULL,
+    -- Secondary, science-only content digest (epic #261, N1 / D1). For products
+    -- that re-save identical science with volatile bytes (a NIRCam canonical
+    -- exposure re-written by the pipeline gets fresh header timestamps, so its
+    -- whole-file sha256 changes even when SCI+DQ do not), deploy compares this
+    -- stable sha256(SCI+DQ) to skip re-uploading unchanged exposures. content_hash
+    -- stays the authoritative whole-file hash that download/copy verification
+    -- checks; sci_dq_hash is only a change-detection key. NULL for products with
+    -- no partial digest (everything except nircam_exposure today).
+    "sci_dq_hash" "text",
     "size_bytes" bigint NOT NULL,
     "content_type" "text" NOT NULL,
     "product_type" "text" NOT NULL,
@@ -841,6 +850,9 @@ CREATE TABLE IF NOT EXISTS "public"."storage_objects" (
     -- provisional from an S3 LIST/HEAD (no GET) for backfilled objects with no stored
     -- sha256, upgraded to sha256 by the A1 copy+verify pass (#215). No raw/bare hex.
     CONSTRAINT "storage_objects_content_hash_check" CHECK (("content_hash" ~ '^(sha256|etag):'::"text")),
+    -- sci_dq_hash, when present, is always an authoritative sha256 (no provisional
+    -- etag form — it is computed from the local FITS arrays, never a HEAD).
+    CONSTRAINT "storage_objects_sci_dq_hash_check" CHECK (("sci_dq_hash" IS NULL OR "sci_dq_hash" ~ '^sha256:'::"text")),
     -- product_type tracks the campfire_layout PRODUCTS registry (every entry with a
     -- non-null bucket). A new cloud-backed product type requires a migration here.
     CONSTRAINT "storage_objects_product_type_check" CHECK (("product_type" = ANY (ARRAY[
@@ -881,6 +893,8 @@ COMMENT ON COLUMN "public"."storage_objects"."content_hash" IS 'Scheme-prefixed 
 COMMENT ON COLUMN "public"."storage_objects"."spectrum_id" IS 'Typed, indexed scope column (not an FK). spectra.spectrum_id is GENERATED from fits_path and not uniquely constrained, so an FK would over-constrain; an index provides the joinability the registry needs.';
 
 COMMENT ON COLUMN "public"."storage_objects"."exposure_ref" IS 'Stable per-exposure reference for intermediate products (nircam rootname; nirspec (root,nod,detector,source) tuple). Backs the partial unique (product_type, exposure_ref) WHERE status=''active'' — one current object per product/exposure.';
+
+COMMENT ON COLUMN "public"."storage_objects"."sci_dq_hash" IS 'Science-only sha256(SCI+DQ) change-detection digest (epic #261, N1). Lets deploy skip re-uploading a NIRCam canonical exposure whose science is unchanged even though its whole-file content_hash shifted (pipeline re-save bumps header timestamps). content_hash remains the authoritative whole-file integrity token; this is never used for download/copy verification. NULL for products without a partial digest.';
 
 COMMENT ON COLUMN "public"."storage_objects"."status" IS 'active = current object; superseded = replaced by a newer hash (tombstone, GC-eligible later); revoked = un-published. Only active rows count toward the budget and the partial-unique constraint.';
 


### PR DESCRIPTION
## N1 — NIRCam deploy becomes first-class: field-scoped deployments + `campfire deploy --field` (epic #261)

Reworked (per the 2026-07-02 decision) to full NIRSpec parity with **field-scoped deployments** — not an admin-only special case. Merges inert (a normal deploy is published; nothing runs automatically). Closes #263.

### The keystone — field-scoped deployments + visibility gate
- `deployments` can now anchor to a NIRCam **field** instead of a NIRSpec observation: `observation` nullable, new `field` column, CHECK exactly-one (`deployments_scope_check`). A field deploy records the same provenance (deployed_by/at, cfpipe_version, crds_context, config_snapshot) and drives the same `draft→published→revoked` lifecycle.
- **Visibility gate** (the security core): the `storage_objects` RLS policy + `filter_accessible_storage_keys` + `get_storage_objects_for_sync` gain a field branch (`LEFT JOIN observations … d.status='published' AND (d.field IS NOT NULL OR o.program_slug = ANY(…))`). A **published field deployment is public to everyone** — NIRCam fields span multiple JWST programs, so there's no per-program scope; **draft is admin-only**. NIRSpec obs deployments stay program-scoped (unchanged).
- `set_deployment_status` branches on field vs observation. Proven by the **`nircam_field_deploy_gate.sql`** harness (draft→admin-only, publish→public-to-all) with NIRSpec/B1 regressions green.

### `campfire deploy --field`
- `campfire deploy --field <field> [--filter f1 --filter f2] [--draft]` — top-level, parallel to `--obs` (mutually exclusive). Records one field deployment (published by default, `--draft` for review), uploads exposure FITS (+expmaps) to OSN under canonical keys (SCI+DQ content-hash deduped), tags every registered row with `deployment_id`, and preserves web-triage state. `deploy publish|revoke --field` flip the field. Retires the `deploy nircam exposures` subgroup (mask utilities stay under `deploy nircam`).
- Dedup-skipped (unchanged) exposures are re-pointed to the current deployment on a published re-deploy so the whole field's visibility stays consistent (a `--draft` re-deploy leaves them live — staging).

### Notes / scoping
- New `storage_objects.sci_dq_hash` column (SCI+DQ change-detection; `content_hash` stays the whole-file integrity digest). Reconcile dangling detection is backend-scoped (OSN-native objects have no R2 twin).
- Preview PNGs stay on R2 (migrate in N5 with the inspection-UI rework); `nircam_exposures` stays an admin-only triage table (exposure FITS visibility rides the deployment).
- Stack-wide review fixes land in N3 (#275): publish/revoke flips all of a field's deployments; draft-staging; etc.

Full python suite 309 passed; `db reset`/`diff` reconcile clean.

Generated with Claude Code