### PR TITLE
feat(nircam): mosaic deploy (field-deployment) + retire the version axis (N2, #264)

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -71,6 +71,19 @@ Release procedure: edit the `## Unreleased` section below, then run
   feature failed for fixed-slit sources.
 
 ### Algorithm
+- **BREAKING (MAJOR):** the NIRCam mosaic `version` axis is retired (epic #261,
+  N2 / D3). Mosaic products are now named `mosaic_nircam_<filter>_<field>_<scale>_<tile>_<ext>.fits`
+  with **no** `_<version>_` segment — one canonical mosaic per
+  `(field, filter, tile, pixel_scale, extension)`, overwritten in place on
+  re-combine. The `[nircam.resample].version` config key and the `--version`
+  option on `cfpipe nircam refcat extract` are removed; the `_latest_` symlink
+  farm is gone (the canonical name *is* the latest). The `version` key is dropped
+  from mosaic manifests. **Consequence:** existing `..._v0_1_..._i2d.fits` mosaics
+  become orphaned vs the new name, so the first post-upgrade `combine` rebuilds
+  every tile fresh — intended (the portal re-serves mosaics from OSN per field/
+  filter as they are re-reduced; see #261 N3). Readers (`rgb`, `refcat`) resolve
+  the direct version-free name and intentionally do **not** fall back to a stale
+  versioned/`_latest_` file.
 - NIRSpec optimal extraction no longer bounds the cross-dispersion profile to
   the nominal aperture for fixed-slit sources. The aperture bounding in
   `optext_profile` exists to keep the profile from picking up flux from

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -406,8 +406,9 @@
     # ERR agrees to ~1%. See issue #138.
     implementation = "jwst"
     pixel_scale = "30mas"
-    version = "v0_1"
-    mosaic_name = "mosaic_nircam_[filter]_[field_name]_[pixel_scale]_[version]_[tile]"
+    # Version-free mosaic naming (epic #261, N2 / D3): one canonical mosaic per
+    # (field, filter, tile, pixel_scale). Do not reintroduce a [version] segment.
+    mosaic_name = "mosaic_nircam_[filter]_[field_name]_[pixel_scale]_[tile]"
     pixfrac = 1
     kernel = "square"
     background_subtract = true

--- a/pipeline/campfire_pipeline/nircam/manifest.py
+++ b/pipeline/campfire_pipeline/nircam/manifest.py
@@ -89,11 +89,38 @@ def input_entry(filepath, extra=None):
 
 
 # ---------------------------------------------------------------------------
+# Mosaic naming (epic #261, N2 / D3 — the version axis is retired)
+# ---------------------------------------------------------------------------
+
+# One logical mosaic per (field, filter, tile, pixel_scale, extension); no
+# version segment. The single builder below is the sole authority for the
+# basename, shared by the resample step and the staleness check so the two can
+# never disagree.
+DEFAULT_MOSAIC_NAME = 'mosaic_nircam_[filter]_[field_name]_[pixel_scale]_[tile]'
+
+
+def build_mosaic_name(filtname, field_name, pixel_scale, tile, template=None):
+    """Version-free mosaic basename (without ``_i2d.fits``).
+
+    Expands the ``[filter]`` / ``[field_name]`` / ``[pixel_scale]`` / ``[tile]``
+    placeholders. A ``template`` override (from ``resample.mosaic_name`` config)
+    may omit some placeholders but must NOT reintroduce ``[version]`` — that axis
+    is retired (D3).
+    """
+    tmpl = template or DEFAULT_MOSAIC_NAME
+    return (tmpl
+            .replace('[filter]', filtname)
+            .replace('[field_name]', field_name)
+            .replace('[pixel_scale]', pixel_scale)
+            .replace('[tile]', tile))
+
+
+# ---------------------------------------------------------------------------
 # Manifest creation / I/O
 # ---------------------------------------------------------------------------
 
 def create_manifest(mosaic_name, field, filtname, tile, pixel_scale,
-                    version, input_files, stage_config):
+                    input_files, stage_config):
     """Build a manifest dict for a completed mosaic tile.
 
     Parameters
@@ -108,8 +135,6 @@ def create_manifest(mosaic_name, field, filtname, tile, pixel_scale,
         Tile name.
     pixel_scale : str
         Pixel scale string (e.g. ``'60mas'``).
-    version : str
-        Mosaic version string (e.g. ``'v0_1'``).
     input_files : list of str
         Paths to the CRF files that were drizzled into this tile.
     stage_config : dict
@@ -153,7 +178,6 @@ def create_manifest(mosaic_name, field, filtname, tile, pixel_scale,
         'filter': filtname,
         'tile': tile,
         'pixel_scale': pixel_scale,
-        'version': version,
         'created_at': datetime.now(timezone.utc).isoformat(),
         'pipeline_version': pipeline_version,
         'config_hash': config_hash,
@@ -308,7 +332,6 @@ def get_stale_tiles(field, filtname, stage_config):
     from campfire_pipeline.nircam.geometry import select_overlapping_files
 
     resample_cfg = stage_config.get('resample', {})
-    version = resample_cfg.get('version', 'v0_1')
     pixel_scale = resample_cfg.get('pixel_scale', '60mas')
     if isinstance(pixel_scale, (float, int)):
         if pixel_scale > 1:
@@ -333,15 +356,10 @@ def get_stale_tiles(field, filtname, stage_config):
 
     results = []
     for tile in tiles:
-        mosaic_name = resample_cfg.get(
-            'mosaic_name',
-            'mosaic_nircam_[filter]_[field_name]_[pixel_scale]_[version]_[tile]',
+        mosaic_name = build_mosaic_name(
+            filtname, field.name, pixel_scale, tile,
+            template=resample_cfg.get('mosaic_name'),
         )
-        mosaic_name = mosaic_name.replace('[filter]', filtname)
-        mosaic_name = mosaic_name.replace('[field_name]', field.name)
-        mosaic_name = mosaic_name.replace('[pixel_scale]', pixel_scale)
-        mosaic_name = mosaic_name.replace('[version]', version)
-        mosaic_name = mosaic_name.replace('[tile]', tile)
 
         manifest_path = os.path.join(
             field.filter_dir(filtname), f'{mosaic_name}_manifest.json',

--- a/pipeline/campfire_pipeline/nircam/refcat/cli.py
+++ b/pipeline/campfire_pipeline/nircam/refcat/cli.py
@@ -192,8 +192,6 @@ def query(config, field_name, backend, center, radius_deg, mag_band, mag_max,
               help="Tile name (must exist in fields.toml).")
 @click.option("--scale", default="30mas",
               help="Pixel-scale tag (default 30mas).")
-@click.option("--version", default="latest",
-              help="Mosaic version tag (default 'latest').")
 @click.option("--err", "err_path", default=None,
               help="Override error-map path; auto-detected otherwise.")
 @click.option("--snr-thresh", default=3.0, type=float,
@@ -210,7 +208,7 @@ def query(config, field_name, backend, center, radius_deg, mag_band, mag_max,
 @click.option("--notes", default=None,
               help="Free-form note stamped into the catalog meta.")
 @click.option("--overwrite", is_flag=True)
-def extract(config, field_name, mosaic_path, filter_name, tile, scale, version,
+def extract(config, field_name, mosaic_path, filter_name, tile, scale,
             err_path, snr_thresh, minarea, snr_min, mag_range, out_path,
             notes, overwrite):
     """Build a refcat by extracting sources from a mosaic.
@@ -219,8 +217,7 @@ def extract(config, field_name, mosaic_path, filter_name, tile, scale, version,
 
       \b
       --mosaic <path>                          (explicit, anywhere on disk)
-      --filter F277W --tile A1 [--scale 30mas] [--version latest]
-                                               (resolves under
+      --filter F277W --tile A1 [--scale 30mas] (resolves under
                                                 field.filter_dir(<filter>)/)
     """
     _, field_obj = _refcat_setup(config, field_name)
@@ -233,11 +230,10 @@ def extract(config, field_name, mosaic_path, filter_name, tile, scale, version,
         if not (filter_name and tile):
             raise click.UsageError(
                 "Provide either --mosaic <path> or --filter <name> --tile "
-                "<name> [--scale 30mas] [--version latest]."
+                "<name> [--scale 30mas]."
             )
         mosaic_path = resolve_mosaic_path(
-            field_obj, filter_name=filter_name, tile=tile,
-            scale=scale, version=version,
+            field_obj, filter_name=filter_name, tile=tile, scale=scale,
         )
 
     mag_range_t = _parse_mag_range(mag_range)

--- a/pipeline/campfire_pipeline/nircam/refcat/extract.py
+++ b/pipeline/campfire_pipeline/nircam/refcat/extract.py
@@ -24,15 +24,16 @@ from campfire_pipeline.common.io import log
 
 
 # Mosaic naming convention: produced by `cfpipe nircam resample`. See
-# pipeline/campfire_pipeline/nircam/steps/resample.py.
+# pipeline/campfire_pipeline/nircam/steps/resample.py. The version axis is
+# retired (epic #261, N2 / D3) — one canonical name per (field, filter, tile,
+# scale):
 #
-#   mosaic_nircam_<filter>_<field>_<scale>mas_<version>_<tile>_i2d.fits
+#   mosaic_nircam_<filter>_<field>_<scale>_<tile>_i2d.fits
 #
-# Examples:
-#   mosaic_nircam_f277w_rj0911_30mas_v0_1_venus_i2d.fits
-#   mosaic_nircam_f277w_rj0911_30mas_latest_venus_i2d.fits
+# Example:
+#   mosaic_nircam_f277w_rj0911_30mas_venus_i2d.fits
 _MOSAIC_TEMPLATE = (
-    "mosaic_nircam_{filter}_{field}_{scale}_{version}_{tile}_i2d.fits"
+    "mosaic_nircam_{filter}_{field}_{scale}_{tile}_i2d.fits"
 )
 
 
@@ -40,9 +41,8 @@ _MOSAIC_TEMPLATE = (
 # Mosaic resolution + IO
 # ---------------------------------------------------------------------------
 
-def resolve_mosaic_path(field, *, filter_name, tile, scale="30mas",
-                        version="latest"):
-    """Build the canonical mosaic path for ``filter / tile / scale / version``.
+def resolve_mosaic_path(field, *, filter_name, tile, scale="30mas"):
+    """Build the canonical mosaic path for ``filter / tile / scale``.
 
     ``field`` is a :class:`Field` with workspace already set up. Returns
     the full path; raises ``FileNotFoundError`` if the mosaic does not
@@ -50,8 +50,7 @@ def resolve_mosaic_path(field, *, filter_name, tile, scale="30mas",
     SEP failure.
     """
     fname = _MOSAIC_TEMPLATE.format(
-        filter=filter_name.lower(), field=field.name, scale=scale,
-        version=version, tile=tile,
+        filter=filter_name.lower(), field=field.name, scale=scale, tile=tile,
     )
     path = os.path.join(field.filter_dir(filter_name.lower()), fname)
     if not os.path.exists(path):

--- a/pipeline/campfire_pipeline/nircam/rgb.py
+++ b/pipeline/campfire_pipeline/nircam/rgb.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import multiprocessing as mp
 import os
-from glob import glob
 
 import numpy as np
 from astropy.io import fits
@@ -49,28 +48,18 @@ def _resolve_pixel_scale_str(value):
 
 
 def _find_mosaic(filter_dir, field_name, filtname, pixel_scale_str, tile):
-    """Find the i2d cube for a (filter, tile) pair, agnostic to ``version``.
+    """Find the i2d cube for a (filter, tile) pair.
 
-    The resample step bakes ``version`` into the filename as ``v0_1``
-    (or whatever override is configured); we glob it out so the RGB
-    command works against existing reductions without having to know
-    the reduction version. If multiple versions are present, the
-    lexicographically last (typically the newest) is used and a warning
-    is logged.
+    The mosaic basename is version-free (epic #261, N2 / D3): one canonical
+    ``mosaic_nircam_<filter>_<field>_<scale>_<tile>_i2d.fits`` per slot, so this
+    resolves it directly. A stray pre-N2 ``_v0_1_``/``_latest_`` file (from a
+    reduction that predates the retirement) is intentionally NOT matched — that
+    slot is re-reduced fresh (D6).
     """
-    pattern = os.path.join(
-        filter_dir,
-        f'mosaic_nircam_{filtname}_{field_name}_{pixel_scale_str}_*_{tile}_i2d.fits',
-    )
-    matches = sorted(glob(pattern))
-    if not matches:
-        return None
-    if len(matches) > 1:
-        log(
-            f"  [{tile}/{filtname}] multiple mosaic versions found, "
-            f"using {os.path.basename(matches[-1])}"
-        )
-    return matches[-1]
+    from campfire_pipeline.nircam.manifest import build_mosaic_name
+    name = build_mosaic_name(filtname, field_name, pixel_scale_str, tile)
+    path = os.path.join(filter_dir, f'{name}_i2d.fits')
+    return path if os.path.exists(path) else None
 
 
 def _load_sci_wht(path):

--- a/pipeline/campfire_pipeline/nircam/steps/resample.py
+++ b/pipeline/campfire_pipeline/nircam/steps/resample.py
@@ -11,11 +11,11 @@ Input source for the canonical-exposure layout is
 ``field.get_exposure_files(filter, with_step='CFP_OUT')`` — only exposures
 that have completed outlier detection are eligible to be drizzled.
 
-Mosaic outputs and the manifest format are unchanged from the legacy
-implementation: ``CMPFRTIM`` / ``CMPFRVER`` stamping on the primary header,
-optional 2D background subtraction via ``SubtractBackground``, optional
-extension splitting into ``_sci/_err/_wht/_srcmask`` files, and a
-``_latest_`` symlink to the versioned output.
+Mosaic outputs: ``CMPFRTIM`` / ``CMPFRVER`` stamping on the primary header,
+optional 2D background subtraction via ``SubtractBackground``, and optional
+extension splitting into ``_sci/_err/_wht/_srcmask`` files. The mosaic
+basename is version-free (epic #261, N2 / D3) — one canonical name per
+``(field, filter, tile, pixel_scale)`` — so there is no ``_latest_`` alias.
 """
 
 import os
@@ -182,7 +182,7 @@ def resample_step(filtname, exposure_files, field, step_config,
     overwrite : bool
     """
     from campfire_pipeline.nircam.manifest import (
-        check_config_changed, check_inputs_changed,
+        build_mosaic_name, check_config_changed, check_inputs_changed,
         create_manifest, write_manifest,
     )
 
@@ -193,7 +193,6 @@ def resample_step(filtname, exposure_files, field, step_config,
     if mode != 'tile':
         raise NotImplementedError(f"resample mode {mode!r} not supported")
 
-    version = step_config.get('version', 'v0_1')
     tiles = step_config.get('tile', None) or list(field.tiles.keys())
     if isinstance(tiles, str):
         tiles = [tiles]
@@ -201,16 +200,10 @@ def resample_step(filtname, exposure_files, field, step_config,
     for tile in tiles:
         log(f"resample: tile {tile}, {filtname}, {pixel_scale_str}")
 
-        mosaic_name = step_config.get(
-            'mosaic_name',
-            'mosaic_nircam_[filter]_[field_name]_[pixel_scale]_[version]_[tile]',
+        mosaic_name = build_mosaic_name(
+            filtname, field.name, pixel_scale_str, tile,
+            template=step_config.get('mosaic_name'),
         )
-        mosaic_name = (mosaic_name
-                       .replace('[filter]', filtname)
-                       .replace('[field_name]', field.name)
-                       .replace('[pixel_scale]', pixel_scale_str)
-                       .replace('[version]', version)
-                       .replace('[tile]', tile))
         mosaic_outdir = field.filter_dir(filtname)
         mosaic_file = os.path.join(mosaic_outdir, f'{mosaic_name}_i2d.fits')
         manifest_path = os.path.join(
@@ -279,7 +272,7 @@ def resample_step(filtname, exposure_files, field, step_config,
 
             manifest = create_manifest(
                 mosaic_name, field, filtname, tile, pixel_scale_str,
-                version, selected, {'resample': step_config},
+                selected, {'resample': step_config},
             )
             write_manifest(manifest, manifest_path)
 
@@ -448,26 +441,8 @@ def resample_step(filtname, exposure_files, field, step_config,
                     )
                     log(f"  saved {os.path.basename(bkg_png)}")
 
-        latest_name = mosaic_name.replace(f'_{version}_', '_latest_')
-        latest_link = os.path.join(mosaic_outdir, f'{latest_name}_i2d.fits')
-        if os.path.islink(latest_link) or os.path.exists(latest_link):
-            os.remove(latest_link)
-        os.symlink(os.path.basename(mosaic_file), latest_link)
-        log(f"  symlinked {os.path.basename(latest_link)} → "
-            f"{os.path.basename(mosaic_file)}")
-
-        if step_config.get('split_extensions', True):
-            base = os.path.basename(mosaic_file)
-            for suffix in ('_sci.fits', '_err.fits',
-                           '_wht.fits', '_srcmask.fits'):
-                ver_ext = os.path.join(
-                    mosaic_outdir, base.replace('_i2d.fits', suffix),
-                )
-                if os.path.exists(ver_ext):
-                    latest_ext = os.path.join(
-                        mosaic_outdir, f'{latest_name}{suffix}',
-                    )
-                    if (os.path.islink(latest_ext)
-                            or os.path.exists(latest_ext)):
-                        os.remove(latest_ext)
-                    os.symlink(os.path.basename(ver_ext), latest_ext)
+        # The `version` axis is retired (epic #261, N2 / D3): the mosaic basename
+        # is now the single canonical name per (field, filter, tile, pixel_scale),
+        # so the old `_latest_` symlink farm that aliased a versioned output has no
+        # target to point at and is gone. Readers (rgb, refcat, deploy) resolve the
+        # direct version-free name.

--- a/pipeline/tests/test_nircam_mosaic_naming.py
+++ b/pipeline/tests/test_nircam_mosaic_naming.py
@@ -1,0 +1,50 @@
+"""Lock the version-free NIRCam mosaic naming contract (epic #261, N2 / D3).
+
+The `version` axis is retired: one canonical mosaic name per
+(field, filter, tile, pixel_scale), no `_<version>_` segment, no `_latest_`
+alias. These tests pin that so a regression can't silently reintroduce it.
+"""
+import pytest
+
+from campfire_pipeline.nircam.manifest import (
+    DEFAULT_MOSAIC_NAME, build_mosaic_name, create_manifest,
+)
+
+
+def test_default_template_has_no_version_placeholder():
+    assert '[version]' not in DEFAULT_MOSAIC_NAME
+    assert DEFAULT_MOSAIC_NAME == \
+        'mosaic_nircam_[filter]_[field_name]_[pixel_scale]_[tile]'
+
+
+def test_build_mosaic_name_is_version_free():
+    name = build_mosaic_name('f444w', 'cosmos', '30mas', 'A1')
+    assert name == 'mosaic_nircam_f444w_cosmos_30mas_A1'
+    assert '_v0_1_' not in name and 'latest' not in name
+
+
+def test_build_mosaic_name_honors_template_override():
+    name = build_mosaic_name('f200w', 'rj0911', '60mas', 'venus',
+                             template='m_[filter]_[tile]')
+    assert name == 'm_f200w_venus'
+
+
+def test_build_mosaic_name_multiunderscore_field():
+    # A field whose name contains underscores must survive (the builder does a
+    # placeholder substitution, not a positional split).
+    name = build_mosaic_name('f356w', 'ember_egs_p1', '30mas', 'tile3')
+    assert name == 'mosaic_nircam_f356w_ember_egs_p1_30mas_tile3'
+
+
+class _FakeField:
+    name = 'cosmos'
+
+
+def test_create_manifest_drops_version_key():
+    manifest = create_manifest(
+        'mosaic_nircam_f444w_cosmos_30mas_A1', _FakeField(), 'f444w', 'A1',
+        '30mas', input_files=[], stage_config={'resample': {}})
+    assert 'version' not in manifest
+    assert manifest['mosaic_name'] == 'mosaic_nircam_f444w_cosmos_30mas_A1'
+    assert manifest['tile'] == 'A1'
+    assert manifest['pixel_scale'] == '30mas'

--- a/pipeline/tests/test_nircam_rgb.py
+++ b/pipeline/tests/test_nircam_rgb.py
@@ -125,14 +125,21 @@ class TestFindMosaic:
     def test_returns_none_when_missing(self, tmp_path):
         assert _find_mosaic(str(tmp_path), 'cosmos', 'f444w', '60mas', 'A1') is None
 
-    def test_picks_latest_version(self, tmp_path):
-        for ver in ('v0_1', 'v0_2', 'v0_3'):
-            (tmp_path / f'mosaic_nircam_f444w_cosmos_60mas_{ver}_A1_i2d.fits').touch()
-        # Add an unrelated file the glob should ignore.
-        (tmp_path / 'mosaic_nircam_f444w_cosmos_60mas_v0_3_A1_i2d_thumb.png').touch()
+    def test_resolves_version_free_name(self, tmp_path):
+        # epic #261, N2 / D3: the mosaic basename is version-free — one canonical
+        # name per slot, resolved directly (no glob, no _latest_).
+        target = tmp_path / 'mosaic_nircam_f444w_cosmos_60mas_A1_i2d.fits'
+        target.touch()
         path = _find_mosaic(str(tmp_path), 'cosmos', 'f444w', '60mas', 'A1')
         assert path is not None
-        assert os.path.basename(path) == 'mosaic_nircam_f444w_cosmos_60mas_v0_3_A1_i2d.fits'
+        assert os.path.basename(path) == 'mosaic_nircam_f444w_cosmos_60mas_A1_i2d.fits'
+
+    def test_ignores_stale_versioned_files(self, tmp_path):
+        # A pre-N2 versioned/`_latest_` mosaic is NOT matched — that slot is
+        # re-reduced fresh (D6), never silently served from a stale reduction.
+        (tmp_path / 'mosaic_nircam_f444w_cosmos_60mas_v0_3_A1_i2d.fits').touch()
+        (tmp_path / 'mosaic_nircam_f444w_cosmos_60mas_latest_A1_i2d.fits').touch()
+        assert _find_mosaic(str(tmp_path), 'cosmos', 'f444w', '60mas', 'A1') is None
 
 
 class TestFieldRgbParsing:

--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -410,7 +410,9 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
 
     fits_tasks = build_fits_upload_tasks(field, exposures)
     expmap_tasks = discover_expmap_tasks(dirs, field)
-    print(f"Canonical FITS: {len(fits_tasks)} exposure(s), {len(expmap_tasks)} expmap(s) → OSN")
+    n_mosaics = len(discover_mosaics(dirs, field, filters))
+    print(f"Canonical FITS: {len(fits_tasks)} exposure(s), {len(expmap_tasks)} expmap(s), "
+          f"{n_mosaics} mosaic(s) → OSN")
 
     records = []
     for (filtname, basename), info in sorted(exposures.items()):
@@ -445,9 +447,9 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
         if mask_count:
             print(f"  with masks: {mask_count}")
         print(f"\nWould record a {'draft' if draft else 'published'} field "
-              f"deployment and upload {len(fits_tasks)} canonical FITS (subject to "
-              f"SCI+DQ content-hash dedup) + {len(expmap_tasks)} expmap(s) to OSN, "
-              f"and {len(png_tasks)} preview PNG(s) to R2.")
+              f"deployment and upload {len(fits_tasks)} canonical FITS + "
+              f"{len(expmap_tasks)} expmap(s) + {n_mosaics} mosaic(s) to OSN "
+              f"(subject to content-hash dedup), and {len(png_tasks)} preview PNG(s) to R2.")
         print("Dry run — no changes made.")
         return
 
@@ -542,6 +544,10 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
         if n_moved:
             print(f"  Re-pointed {n_moved} unchanged exposure(s) to deployment #{deployment_id}")
 
+    # --- Mosaics: deploy under the same field deployment (epic #261, N2) ----
+    _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
+                          draft, user_id)
+
     # --- Multi-reducer scope claim + audit (epic #210, B4 / D12) -----------
     claim = claim_deploy_scope(client, 'field', field, scope_version, actor=user_id)
     if claim.get('conflict'):
@@ -634,3 +640,175 @@ def _upsert_exposures(client, records, batch_size=500):
             batch,
             on_conflict='field,filter,filename',
         ).execute()
+
+
+# ---------------------------------------------------------------------------
+# Mosaic deploy (epic #261, N2) — combined mosaics → OSN + nircam_images index
+# ---------------------------------------------------------------------------
+
+# Split-extension products the resample step emits, mapped to the nircam_images
+# `extension` value. A slot deploys only the files that exist on disk.
+_MOSAIC_EXTENSIONS = (
+    ('_i2d.fits', 'i2d'),
+    ('_sci.fits', 'sci'),
+    ('_err.fits', 'err'),
+    ('_wht.fits', 'wht'),
+    ('_srcmask.fits', 'srcmask'),
+)
+
+
+def discover_mosaics(dirs, field, filters):
+    """Discover deployable mosaic products via their manifests.
+
+    Each ``mosaic_*_manifest.json`` (written by the resample step) carries the
+    authoritative ``(mosaic_name, filter, tile, pixel_scale)`` — read from the
+    manifest rather than parsed from the filename, so a multi-underscore field
+    name can't break a positional split. Returns one dict per existing mosaic
+    file: ``{path, filter, tile, pixel_scale, extension, storage_key}`` under the
+    version-free canonical key (epic #261, N2 / D3).
+    """
+    import json
+    products = dirs['products']
+    out = []
+    for filtname in filters:
+        filter_dir = products / filtname
+        if not filter_dir.exists():
+            continue
+        for manifest_path in sorted(filter_dir.glob('mosaic_*_manifest.json')):
+            try:
+                m = json.loads(manifest_path.read_text())
+            except Exception:
+                continue
+            base = m.get('mosaic_name')
+            tile = m.get('tile')
+            pixel_scale = m.get('pixel_scale')
+            mfilter = m.get('filter') or filtname
+            mfield = m.get('field') or field
+            if not (base and tile and pixel_scale):
+                continue
+            # Skip stale pre-N2 versioned / `_latest_` manifests: only the
+            # canonical version-free name is deployable (epic #261, D3). A field
+            # reduced before N2 keeps its old `..._v0_1_..._manifest.json` on
+            # disk after re-combine; without this guard that stale slot would
+            # both re-upload a version-bearing key to OSN AND collide with the
+            # version-free row on the nircam_images (field,tile,filter,scale,
+            # extension) conflict key, crashing the batch upsert. Reconstruct the
+            # expected name deploy-side (deploy must not import the pipeline) —
+            # the same version-free contract rgb._find_mosaic enforces.
+            if base != f'mosaic_nircam_{mfilter}_{mfield}_{pixel_scale}_{tile}':
+                continue
+            for suffix, ext in _MOSAIC_EXTENSIONS:
+                fpath = filter_dir / f'{base}{suffix}'
+                if not fpath.exists():
+                    continue
+                key = storage_key('nircam_mosaic', Scope(field=field, filt=filtname),
+                                  fpath.name, scheme=KeyScheme.CANONICAL)
+                out.append({
+                    'path': fpath, 'filter': mfilter, 'tile': tile,
+                    'pixel_scale': pixel_scale, 'extension': ext, 'storage_key': key,
+                })
+    return out
+
+
+def _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
+                          draft, user_id):
+    """Deploy this field's mosaics under the field deployment (epic #261, N2).
+
+    Called from :func:`deploy_nircam` so ``campfire deploy --field`` ships exposures
+    and mosaics as one field deployment. Uploads each mosaic product (the ``_i2d``
+    cube + any split ``_sci/_err/_wht/_srcmask`` extensions) to OSN under canonical
+    keys — whole-file content-hash deduped — upserts one ``nircam_images`` row per
+    ``(field, tile, filter, pixel_scale, extension)`` carrying ``deploy_status``
+    (draft/published to match the deployment) + ``deployment_id``, and registers
+    ``nircam_mosaic`` storage objects tagged with the deployment. Re-combine
+    overwrites the same key in place (stable, version-free — D3/D4); visibility
+    rides the deployment (published => public to everyone).
+    """
+    from campfire.deploy.registry import (
+        fetch_active_content_hashes, hash_file, row_for_key,
+        set_active_deployment, upsert_storage_objects,
+    )
+    mosaics = discover_mosaics(dirs, field, filters)
+    if not mosaics:
+        return
+    print(f"\nMosaics: {len(mosaics)} product(s)")
+
+    # Whole-file content-hash dedup: skip re-uploading a byte-identical mosaic.
+    existing = fetch_active_content_hashes(client, [m['storage_key'] for m in mosaics])
+    upload_tasks = []
+    for m in mosaics:
+        local_hash, local_size = hash_file(m['path'])
+        m['content_hash'] = local_hash
+        m['size'] = local_size
+        if existing.get(m['storage_key']) != local_hash:
+            upload_tasks.append(UploadTask(local_path=m['path'],
+                                           r2_key=m['storage_key'],
+                                           content_type=_FITS_CONTENT_TYPE))
+    n_skipped = len(mosaics) - len(upload_tasks)
+    if n_skipped:
+        print(f"  Skipping {n_skipped} unchanged mosaic file(s)")
+
+    uploaded: set[str] = set()
+    if upload_tasks:
+        print(f"  Uploading {len(upload_tasks)} mosaic file(s) to OSN...")
+        success, failed, failures = upload_files_parallel(
+            config, upload_tasks, desc='OSN mosaic uploads',
+            succeeded_out=uploaded, backend=_CANONICAL_BACKEND)
+        print(f"    Uploaded: {success}, Failed: {failed}")
+        for msg in failures:
+            print(f"    Error: {msg}")
+
+    # Index only mosaics actually present in OSN — uploaded this run or unchanged +
+    # already registered. A failed upload must NOT get a nircam_images row (it would
+    # advertise a file_path with no object + no registry row; the slot 404s). A
+    # re-run heals. deploy_status matches the deployment so the public page shows
+    # only published mosaics; deployment_id ties them to the lifecycle batch.
+    present = set(uploaded) | {
+        m['storage_key'] for m in mosaics
+        if existing.get(m['storage_key']) == m['content_hash']
+    }
+    img_status = 'draft' if draft else 'published'
+    img_rows = [{
+        'field': field, 'tile': m['tile'], 'filter': m['filter'],
+        'pixel_scale': m['pixel_scale'], 'extension': m['extension'],
+        'file_path': m['storage_key'], 'file_size': m['size'],
+        'deploy_status': img_status, 'deployment_id': deployment_id,
+    } for m in mosaics if m['storage_key'] in present]
+    n_img = _upsert_nircam_images(client, img_rows)
+    print(f"  Indexed {n_img} nircam_images row(s) ({img_status})")
+    n_failed = len(mosaics) - len(img_rows)
+    if n_failed:
+        print(f"  ({n_failed} mosaic(s) not indexed — upload failed; re-run to retry)")
+
+    # Register landed objects, reusing the dedup hash (no re-hash of multi-GB files).
+    reg_rows = []
+    for m in mosaics:
+        if m['storage_key'] not in uploaded:
+            continue
+        row = row_for_key(
+            m['storage_key'], backend=_CANONICAL_BACKEND,
+            content_hash=m['content_hash'], size_bytes=m['size'],
+            content_type=_FITS_CONTENT_TYPE, deployment_id=deployment_id,
+            uploaded_by=user_id)
+        if row is not None:
+            reg_rows.append(row)
+    if reg_rows:
+        print(f"  Registered {upsert_storage_objects(client, reg_rows)} mosaic storage object(s)")
+
+    # Re-point unchanged (skipped) mosaics to the current deployment.
+    skipped_keys = [m['storage_key'] for m in mosaics
+                    if m['storage_key'] in present and m['storage_key'] not in uploaded]
+    if skipped_keys:
+        set_active_deployment(client, skipped_keys, deployment_id)
+
+
+def _upsert_nircam_images(client, rows, batch_size=500):
+    """Upsert nircam_images rows keyed on (field, tile, filter, pixel_scale, extension)."""
+    if not rows:
+        return 0
+    for i in range(0, len(rows), batch_size):
+        batch = rows[i:i + batch_size]
+        client.table('nircam_images').upsert(
+            batch, on_conflict='field,tile,filter,pixel_scale,extension',
+        ).execute()
+    return len(rows)

--- a/python/campfire/deploy/registry.py
+++ b/python/campfire/deploy/registry.py
@@ -282,6 +282,33 @@ def set_active_deployment(client, keys: list[str], deployment_id: int) -> int:
     return len(keys)
 
 
+def fetch_active_content_hashes(client, keys: list[str]) -> dict[str, str]:
+    """Return ``{storage_key: content_hash}`` for the active registry rows among *keys*.
+
+    The whole-file change-detection read for the NIRCam mosaic dedup (epic #261,
+    N2): deploy skips re-uploading a mosaic whose bytes are unchanged. Only rows
+    with an authoritative ``sha256:`` hash are returned (a provisional ``etag:``
+    can't be compared to a fresh local sha256, so those always re-upload).
+    """
+    if not keys:
+        return {}
+    out: dict[str, str] = {}
+    for i in range(0, len(keys), 200):
+        chunk = keys[i:i + 200]
+        resp = (
+            client.table('storage_objects')
+            .select('storage_key, content_hash')
+            .in_('storage_key', chunk)
+            .eq('status', 'active')
+            .execute()
+        )
+        for r in (resp.data or []):
+            h = r.get('content_hash')
+            if h and h.startswith('sha256:'):
+                out[r['storage_key']] = h
+    return out
+
+
 def fetch_active_sci_dq_hashes(client, keys: list[str]) -> dict[str, str]:
     """Return ``{storage_key: sci_dq_hash}`` for the active registry rows among *keys*.
 

--- a/python/tests/sql/nircam_images_lifecycle.sql
+++ b/python/tests/sql/nircam_images_lifecycle.sql
@@ -1,0 +1,78 @@
+-- =============================================================================
+-- NIRCam mosaic (nircam_images) lifecycle gate (epic #261, N2).
+-- =============================================================================
+-- The public NIRCam page reads nircam_images. A published mosaic is public to
+-- everyone (a field spans multiple programs); draft/revoked are admin-only. This
+-- proves the nircam_images RLS enforces that, and that set_deployment_status on a
+-- NIRCam field deployment flips its mosaics' deploy_status (publish -> revoke).
+--
+-- Seed-anchored: user@=2222… (non-admin), admin@=1111….
+-- Run:  docker exec -i supabase_db_campfire psql -U postgres -d postgres \
+--          -v ON_ERROR_STOP=1 -f python/tests/sql/nircam_images_lifecycle.sql
+-- =============================================================================
+\set ON_ERROR_STOP on
+BEGIN;
+
+-- ---- fixtures (superuser) ---------------------------------------------------
+CREATE TEMP TABLE _dep AS
+  WITH ins AS (
+    INSERT INTO deployments (field, status) VALUES ('leaktest', 'draft') RETURNING id)
+  SELECT id FROM ins;
+
+INSERT INTO nircam_images
+  (field, tile, filter, pixel_scale, extension, file_path, deploy_status, deployment_id)
+VALUES
+  ('leaktest', 'A1', 'f444w', '30mas', 'i2d',
+   'data/products/nircam/leaktest/f444w/mosaic_nircam_f444w_leaktest_30mas_A1_i2d.fits',
+   'draft', (SELECT id FROM _dep));
+
+GRANT SELECT ON _dep TO authenticated, service_role;
+
+-- 1. DRAFT -> non-admin sees ZERO
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claims',
+  json_build_object('sub','22222222-2222-2222-2222-222222222222','role','authenticated')::text, true);
+DO $$ DECLARE n int; BEGIN
+  SELECT count(*) INTO n FROM nircam_images WHERE field='leaktest';
+  IF n <> 0 THEN RAISE EXCEPTION 'RLS LEAK: non-admin sees a DRAFT mosaic (expected 0)'; END IF;
+END $$;
+
+-- 2. DRAFT -> admin sees it
+SELECT set_config('request.jwt.claims',
+  json_build_object('sub','11111111-1111-1111-1111-111111111111','role','authenticated')::text, true);
+DO $$ DECLARE n int; BEGIN
+  SELECT count(*) INTO n FROM nircam_images WHERE field='leaktest';
+  IF n <> 1 THEN RAISE EXCEPTION 'ADMIN BLOCKED: admin does not see the draft mosaic (got %)', n; END IF;
+END $$;
+
+-- 3. PUBLISH via set_deployment_status (as admin) flips nircam_images.deploy_status
+DO $$ DECLARE r json; BEGIN
+  r := public.set_deployment_status((SELECT id FROM _dep), 'published', NULL, 'testhost');
+  IF ((r->'nircam_images')->>'updated')::int <> 1 THEN
+    RAISE EXCEPTION 'set_deployment_status did not flip 1 mosaic (got %)', r;
+  END IF;
+END $$;
+
+-- 4. PUBLISHED -> non-admin sees it
+SELECT set_config('request.jwt.claims',
+  json_build_object('sub','22222222-2222-2222-2222-222222222222','role','authenticated')::text, true);
+DO $$ DECLARE n int; BEGIN
+  SELECT count(*) INTO n FROM nircam_images WHERE field='leaktest';
+  IF n <> 1 THEN RAISE EXCEPTION 'RLS: non-admin cannot see PUBLISHED mosaic (got %/1)', n; END IF;
+END $$;
+
+-- 5. REVOKE (as admin) -> non-admin sees ZERO again
+SELECT set_config('request.jwt.claims',
+  json_build_object('sub','11111111-1111-1111-1111-111111111111','role','authenticated')::text, true);
+DO $$ BEGIN PERFORM public.set_deployment_status((SELECT id FROM _dep), 'revoked', NULL, 'testhost'); END $$;
+SELECT set_config('request.jwt.claims',
+  json_build_object('sub','22222222-2222-2222-2222-222222222222','role','authenticated')::text, true);
+DO $$ DECLARE n int; BEGIN
+  SELECT count(*) INTO n FROM nircam_images WHERE field='leaktest';
+  IF n <> 0 THEN RAISE EXCEPTION 'RLS LEAK: non-admin sees a REVOKED mosaic (expected 0)'; END IF;
+END $$;
+
+RESET ROLE;
+SELECT '✅ NIRCAM IMAGES LIFECYCLE HARNESS: ALL ASSERTIONS PASSED' AS result;
+
+ROLLBACK;

--- a/python/tests/test_nircam_deploy.py
+++ b/python/tests/test_nircam_deploy.py
@@ -135,3 +135,78 @@ def test_build_registry_rows_threads_sci_dq_hashes(tmp_path):
     assert rows[0]["content_hash"].startswith("sha256:")   # whole-file digest
     assert rows[0]["content_hash"] != "sha256:" + "c" * 64  # not the sci_dq one
     assert rows[0]["sci_dq_hash"] == "sha256:" + "c" * 64
+
+
+# --- mosaic deploy (N2) -----------------------------------------------------
+
+def _write_manifest(filter_dir, base, *, field, filt, tile, scale):
+    import json
+    (filter_dir / f"{base}_manifest.json").write_text(json.dumps({
+        "mosaic_name": base, "field": field, "filter": filt,
+        "tile": tile, "pixel_scale": scale,
+    }))
+
+
+def test_discover_mosaics_manifest_based_version_free_keys(tmp_path):
+    # A version-free mosaic slot with i2d + split extensions, discovered via its
+    # manifest and keyed under canonical nircam_mosaic keys.
+    fdir = tmp_path / "products" / "nircam" / "cosmos" / "f444w"
+    fdir.mkdir(parents=True)
+    base = "mosaic_nircam_f444w_cosmos_30mas_A1"
+    _write_manifest(fdir, base, field="cosmos", filt="f444w", tile="A1", scale="30mas")
+    for suffix in ("_i2d.fits", "_sci.fits", "_err.fits", "_wht.fits"):
+        (fdir / f"{base}{suffix}").write_bytes(b"\x00")
+    # a stray split with no i2d/manifest twin must be ignored
+    (fdir / "orphan_sci.fits").write_bytes(b"\x00")
+
+    dirs = {"products": tmp_path / "products" / "nircam" / "cosmos"}
+    found = nc.discover_mosaics(dirs, "cosmos", ["f444w"])
+    exts = sorted(m["extension"] for m in found)
+    assert exts == ["err", "i2d", "sci", "wht"]
+    i2d = next(m for m in found if m["extension"] == "i2d")
+    assert i2d["tile"] == "A1" and i2d["pixel_scale"] == "30mas"
+    assert i2d["storage_key"] == \
+        "data/products/nircam/cosmos/f444w/mosaic_nircam_f444w_cosmos_30mas_A1_i2d.fits"
+    # every discovered key registers as nircam_mosaic (no version segment)
+    row = reg.row_for_key(i2d["storage_key"], backend="osn",
+                          content_hash="sha256:" + "a" * 64, size_bytes=1,
+                          content_type="application/fits")
+    assert row["product_type"] == "nircam_mosaic"
+    assert row["field"] == "cosmos"
+
+
+def test_discover_mosaics_skips_stale_versioned_manifest(tmp_path):
+    # A field re-reduced after N2 keeps its pre-N2 `..._v0_1_..._manifest.json`
+    # on disk next to the new version-free one. discover_mosaics must accept ONLY
+    # the canonical version-free slot — else it emits a duplicate (field, tile,
+    # filter, scale, extension) row that crashes the batch upsert and re-uploads
+    # a version-bearing key to OSN.
+    fdir = tmp_path / "products" / "nircam" / "cosmos" / "f444w"
+    fdir.mkdir(parents=True)
+    canon = "mosaic_nircam_f444w_cosmos_30mas_A1"
+    stale = "mosaic_nircam_f444w_cosmos_30mas_v0_1_A1"
+    for base in (canon, stale):
+        _write_manifest(fdir, base, field="cosmos", filt="f444w", tile="A1", scale="30mas")
+        (fdir / f"{base}_i2d.fits").write_bytes(b"\x00")
+
+    dirs = {"products": tmp_path / "products" / "nircam" / "cosmos"}
+    found = nc.discover_mosaics(dirs, "cosmos", ["f444w"])
+    assert len(found) == 1
+    assert found[0]["storage_key"].endswith(f"{canon}_i2d.fits")
+    # no version segment leaked into any discovered key
+    assert all("_v0_1_" not in m["storage_key"] for m in found)
+
+
+def test_discover_mosaics_multiunderscore_field(tmp_path):
+    # Field name with underscores survives (manifest-driven, not positional).
+    fdir = tmp_path / "products" / "nircam" / "ember_egs_p1" / "f356w"
+    fdir.mkdir(parents=True)
+    base = "mosaic_nircam_f356w_ember_egs_p1_30mas_t2"
+    _write_manifest(fdir, base, field="ember_egs_p1", filt="f356w", tile="t2", scale="30mas")
+    (fdir / f"{base}_i2d.fits").write_bytes(b"\x00")
+    dirs = {"products": tmp_path / "products" / "nircam" / "ember_egs_p1"}
+    found = nc.discover_mosaics(dirs, "ember_egs_p1", ["f356w"])
+    assert len(found) == 1
+    assert found[0]["tile"] == "t2"
+    assert found[0]["storage_key"].endswith(
+        "ember_egs_p1/f356w/mosaic_nircam_f356w_ember_egs_p1_30mas_t2_i2d.fits")

--- a/python/tests/test_nircam_images_lifecycle.py
+++ b/python/tests/test_nircam_images_lifecycle.py
@@ -1,0 +1,56 @@
+"""NIRCam mosaic (nircam_images) lifecycle gate (epic #261, N2).
+
+DB-backed integration test: runs ``sql/nircam_images_lifecycle.sql`` against the
+local Supabase Postgres and asserts the harness reaches its PASS marker. Proves a
+draft mosaic is admin-only, a published one is public to everyone, a revoked one
+is hidden again, and that set_deployment_status on a NIRCam field deployment flips
+its mosaics' deploy_status.
+
+Skips automatically when the local Supabase DB container is not reachable.
+"""
+import subprocess
+from pathlib import Path
+
+import pytest
+
+CONTAINER = "supabase_db_campfire"
+SQL_FILE = Path(__file__).parent / "sql" / "nircam_images_lifecycle.sql"
+PASS_MARKER = "ALL ASSERTIONS PASSED"
+
+
+def _docker_psql_available() -> bool:
+    try:
+        r = subprocess.run(
+            ["docker", "exec", "-i", CONTAINER,
+             "psql", "-U", "postgres", "-d", "postgres", "-tA", "-c", "SELECT 1"],
+            capture_output=True, text=True, timeout=15,
+        )
+        return r.returncode == 0 and r.stdout.strip().startswith("1")
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return False
+
+
+requires_local_db = pytest.mark.skipif(
+    not _docker_psql_available(),
+    reason=f"local Supabase container '{CONTAINER}' not reachable (run `supabase start` + `supabase db reset`)",
+)
+
+
+@requires_local_db
+def test_nircam_images_lifecycle():
+    """Draft mosaic admin-only; published public; revoked hidden; RPC flips it."""
+    sql = SQL_FILE.read_text()
+    result = subprocess.run(
+        ["docker", "exec", "-i", CONTAINER,
+         "psql", "-U", "postgres", "-d", "postgres", "-v", "ON_ERROR_STOP=1", "-f", "-"],
+        input=sql, capture_output=True, text=True, timeout=120,
+    )
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, (
+        f"NIRCam images lifecycle harness FAILED (psql exit {result.returncode}).\n"
+        f"A draft/revoked mosaic leaked to a non-admin, or publish didn't make it "
+        f"public. Output:\n{combined}"
+    )
+    assert PASS_MARKER in result.stdout, (
+        f"NIRCam images lifecycle harness did not reach its PASS marker.\nOutput:\n{combined}"
+    )

--- a/supabase/migrations/20260701224420_nircam_images_retire_version.sql
+++ b/supabase/migrations/20260701224420_nircam_images_retire_version.sql
@@ -1,0 +1,27 @@
+-- epic #261, N2 / D3 — retire the mosaic `version` axis.
+--
+-- One logical mosaic per (field, tile, filter, pixel_scale, extension). The pipeline
+-- now emits a single canonical mosaic name per slot and re-combine overwrites it in
+-- place, so `nircam_images.version` and its two (redundant) version-bearing unique
+-- constraints are dropped and replaced by a single version-free UNIQUE. The seed has
+-- no nircam_images rows, so no seed change is needed.
+--
+-- The generated diff also drop+recreated four unrelated views/matviews
+-- (mv_filter_options, mv_programs_overview, nircam_reduction_progress,
+-- spectrum_flag_summary) — a known migra limitation (it re-serializes all views on
+-- any schema change). None reference nircam_images.version (nircam_reduction_progress
+-- reads nircam_exposures), so their definitions are unchanged and the drop+recreate
+-- is stripped.
+
+alter table "public"."nircam_images"
+  drop constraint "nircam_images_field_tile_filter_pixel_scale_version_extensi_key";
+
+alter table "public"."nircam_images" drop constraint "nircam_images_unique";
+
+alter table "public"."nircam_images" drop column "version";
+
+create unique index nircam_images_unique
+  on public.nircam_images using btree (field, tile, filter, pixel_scale, extension);
+
+alter table "public"."nircam_images"
+  add constraint "nircam_images_unique" unique using index "nircam_images_unique";

--- a/supabase/migrations/20260702141534_nircam_images_lifecycle.sql
+++ b/supabase/migrations/20260702141534_nircam_images_lifecycle.sql
@@ -1,0 +1,131 @@
+-- epic #261, N2 — NIRCam mosaic lifecycle. nircam_images (the public mosaic index)
+-- gains deploy_status (draft/published/revoked, default published) + deployment_id
+-- (FK -> deployments), mirroring spectra: published mosaics are public to everyone
+-- (a field spans multiple programs), draft/revoked are admin-only via the RLS.
+-- set_deployment_status flips a field deployment's nircam_images.deploy_status.
+-- (Spurious view/matview churn stripped — migra artifact, definitions unchanged.)
+
+drop policy "authenticated_select_nircam" on "public"."nircam_images";
+
+alter table "public"."nircam_images" add column "deploy_status" text not null default 'published'::text;
+
+alter table "public"."nircam_images" add column "deployment_id" integer;
+
+alter table "public"."nircam_images" add constraint "nircam_images_deploy_status_check" CHECK ((deploy_status = ANY (ARRAY['draft'::text, 'published'::text, 'revoked'::text]))) not valid;
+
+alter table "public"."nircam_images" validate constraint "nircam_images_deploy_status_check";
+
+alter table "public"."nircam_images" add constraint "nircam_images_deployment_id_fkey" FOREIGN KEY (deployment_id) REFERENCES public.deployments(id) ON DELETE SET NULL not valid;
+
+alter table "public"."nircam_images" validate constraint "nircam_images_deployment_id_fkey";
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.set_deployment_status(p_deployment_id integer, p_to text, p_actor uuid DEFAULT NULL::uuid, p_host text DEFAULT NULL::text)
+ RETURNS json
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_is_admin boolean;
+  v_obs text;
+  v_field text;
+  v_action text;
+  v_spectrum_ids integer[];
+  v_n_images integer;
+  v_result json;
+BEGIN
+  SELECT COALESCE(up.is_admin, false) INTO v_is_admin
+  FROM user_profiles up WHERE up.user_id = auth.uid();
+  IF NOT (COALESCE(v_is_admin, false) OR COALESCE(auth.role(), '') = 'service_role') THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+
+  IF p_to NOT IN ('draft', 'published', 'revoked') THEN
+    RAISE EXCEPTION 'Invalid status: %', p_to;
+  END IF;
+
+  SELECT observation, field INTO v_obs, v_field FROM deployments WHERE id = p_deployment_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Deployment % not found', p_deployment_id;
+  END IF;
+
+  -- NIRCam field-scoped deployment (epic #261, N1/N2): exposure/mosaic FITS
+  -- visibility rides deployment.status via the storage_objects gate; the public
+  -- mosaic index (nircam_images) carries its own deploy_status, flipped here to
+  -- match (mirrors how the observation path flips spectra.deploy_status).
+  IF v_field IS NOT NULL THEN
+    v_action := CASE WHEN p_to = 'revoked' THEN 'revoke'
+                     WHEN p_to = 'draft' THEN 'upload' ELSE 'publish' END;
+    UPDATE deployments SET
+      status = p_to,
+      published_at = CASE WHEN p_to = 'published' THEN now() ELSE published_at END,
+      revoked_at = CASE WHEN p_to = 'revoked' THEN now() ELSE revoked_at END
+    WHERE id = p_deployment_id;
+    WITH flipped AS (
+      UPDATE nircam_images SET deploy_status = p_to
+      WHERE deployment_id = p_deployment_id AND deploy_status <> p_to
+      RETURNING 1)
+    SELECT count(*) INTO v_n_images FROM flipped;
+    INSERT INTO deploy_events (actor, action, deployment_id, status_to, host, affected_count, metadata)
+      VALUES (p_actor, v_action, p_deployment_id, p_to, p_host, v_n_images,
+              jsonb_build_object('field', v_field));
+    RETURN json_build_object(
+      'deployment_id', p_deployment_id, 'field', v_field, 'status', p_to,
+      'nircam_images', json_build_object('updated', v_n_images, 'action', v_action));
+  END IF;
+
+  -- Which current statuses transition to p_to:
+  --   p_to='published'  -> draft (first publish) OR revoked (recover) become visible
+  --   p_to='revoked'    -> published spectra are hidden
+  --   p_to='draft'    -> published spectra go back to draft
+  -- The prior version matched only 'draft' for the published case, so recovering
+  -- a REVOKED deployment flipped the deployment row but left its spectra revoked
+  -- and hidden ("0 updated", silently inconsistent) — #233 review.
+  SELECT array_agg(s.id) INTO v_spectrum_ids
+  FROM spectra s JOIN targets t ON s.target_id = t.target_id
+  WHERE t.observation = v_obs
+    AND s.deploy_status = ANY (
+      CASE p_to WHEN 'published' THEN ARRAY['draft', 'revoked']
+                WHEN 'revoked'   THEN ARRAY['published']
+                ELSE                  ARRAY['published'] END);
+
+  -- Audit label: publishing previously-revoked spectra is a 'recover', not a
+  -- first 'publish'. Computed before the transition (spectra still hold old status).
+  v_action := CASE
+    WHEN p_to = 'revoked' THEN 'revoke'
+    WHEN p_to = 'draft' THEN 'upload'
+    WHEN EXISTS (SELECT 1 FROM spectra s JOIN targets t ON s.target_id = t.target_id
+                 WHERE t.observation = v_obs AND s.deploy_status = 'revoked')
+      THEN 'recover'
+    ELSE 'publish'
+  END;
+
+  UPDATE deployments SET
+    status = p_to,
+    published_at = CASE WHEN p_to = 'published' THEN now() ELSE published_at END,
+    revoked_at = CASE WHEN p_to = 'revoked' THEN now() ELSE revoked_at END
+  WHERE id = p_deployment_id;
+
+  IF v_spectrum_ids IS NOT NULL THEN
+    v_result := public.set_spectra_deploy_status(
+      p_spectrum_db_ids := v_spectrum_ids, p_to := p_to, p_action := v_action,
+      p_actor := p_actor, p_deployment_id := p_deployment_id, p_host := p_host);
+  ELSE
+    v_result := json_build_object('updated', 0, 'action', v_action);
+  END IF;
+
+  RETURN json_build_object(
+    'deployment_id', p_deployment_id, 'observation', v_obs,
+    'status', p_to, 'spectra', v_result);
+END;
+$function$
+;
+
+  create policy "authenticated_select_nircam"
+  on "public"."nircam_images"
+  as permissive
+  for select
+  to authenticated
+using (((deploy_status = 'published'::text) OR ( SELECT public.is_admin() AS is_admin)));
+

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -3356,6 +3356,7 @@ DECLARE
   v_field text;
   v_action text;
   v_spectrum_ids integer[];
+  v_n_images integer;
   v_result json;
 BEGIN
   SELECT COALESCE(up.is_admin, false) INTO v_is_admin
@@ -3373,10 +3374,10 @@ BEGIN
     RAISE EXCEPTION 'Deployment % not found', p_deployment_id;
   END IF;
 
-  -- NIRCam field-scoped deployment (epic #261, N1): no spectra to flip — the
-  -- exposure/mosaic FITS visibility rides deployment.status via the storage_objects
-  -- gate, so flipping the deployment row is the whole transition. (N2 extends this
-  -- to also flip nircam_images.deploy_status for the public mosaic index.)
+  -- NIRCam field-scoped deployment (epic #261, N1/N2): exposure/mosaic FITS
+  -- visibility rides deployment.status via the storage_objects gate; the public
+  -- mosaic index (nircam_images) carries its own deploy_status, flipped here to
+  -- match (mirrors how the observation path flips spectra.deploy_status).
   IF v_field IS NOT NULL THEN
     v_action := CASE WHEN p_to = 'revoked' THEN 'revoke'
                      WHEN p_to = 'draft' THEN 'upload' ELSE 'publish' END;
@@ -3385,12 +3386,17 @@ BEGIN
       published_at = CASE WHEN p_to = 'published' THEN now() ELSE published_at END,
       revoked_at = CASE WHEN p_to = 'revoked' THEN now() ELSE revoked_at END
     WHERE id = p_deployment_id;
-    INSERT INTO deploy_events (actor, action, deployment_id, status_to, host, metadata)
-      VALUES (p_actor, v_action, p_deployment_id, p_to, p_host,
+    WITH flipped AS (
+      UPDATE nircam_images SET deploy_status = p_to
+      WHERE deployment_id = p_deployment_id AND deploy_status <> p_to
+      RETURNING 1)
+    SELECT count(*) INTO v_n_images FROM flipped;
+    INSERT INTO deploy_events (actor, action, deployment_id, status_to, host, affected_count, metadata)
+      VALUES (p_actor, v_action, p_deployment_id, p_to, p_host, v_n_images,
               jsonb_build_object('field', v_field));
     RETURN json_build_object(
-      'deployment_id', p_deployment_id, 'field', v_field,
-      'status', p_to, 'spectra', json_build_object('updated', 0, 'action', v_action));
+      'deployment_id', p_deployment_id, 'field', v_field, 'status', p_to,
+      'nircam_images', json_build_object('updated', v_n_images, 'action', v_action));
   END IF;
 
   -- Which current statuses transition to p_to:

--- a/supabase/schemas/policies.sql
+++ b/supabase/schemas/policies.sql
@@ -641,11 +641,13 @@ CREATE POLICY "insert_audit_by_access"
 
 ALTER TABLE nircam_images ENABLE ROW LEVEL SECURITY;
 
--- All authenticated users can read (reference data, no program association).
+-- Published mosaics are public science (a field spans multiple programs, so there
+-- is no per-program scope — published => visible to everyone); draft/revoked are
+-- admin-only (epic #261, N2). Mirrors the spectra deploy_status gate.
 DROP POLICY IF EXISTS "authenticated_select_nircam" ON nircam_images;
 CREATE POLICY "authenticated_select_nircam"
   ON nircam_images FOR SELECT TO authenticated
-  USING (true);
+  USING (deploy_status = 'published' OR (SELECT public.is_admin()));
 
 
 -- =============================================================================

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -690,17 +690,26 @@ CREATE TABLE IF NOT EXISTS "public"."programs" (
 ALTER TABLE "public"."programs" OWNER TO "postgres";
 
 
+-- One logical mosaic per (field, tile, filter, pixel_scale, extension). The
+-- `version` axis is retired (epic #261, N2 / D3): the pipeline emits a single
+-- canonical mosaic name per slot and re-combine overwrites it in place.
 CREATE TABLE IF NOT EXISTS "public"."nircam_images" (
     "id" integer NOT NULL,
     "field" "text" NOT NULL,
     "tile" "text" NOT NULL,
     "filter" "text" NOT NULL,
     "pixel_scale" "text" NOT NULL,
-    "version" "text" NOT NULL,
     "extension" "text" NOT NULL,
     "file_path" "text" NOT NULL,
     "created_at" timestamp without time zone DEFAULT "now"(),
-    "file_size" bigint
+    "file_size" bigint,
+    -- Lifecycle (epic #261, N2): mosaics are public science with the same
+    -- draft->published->revoked gate as spectra, flipped by set_deployment_status.
+    -- `deployment_id` links the mosaic to its NIRCam field deployment (provenance +
+    -- the batch the lifecycle transition acts on). `deploy_status` is the public
+    -- visibility gate the RLS reads (published => everyone; draft/revoked => admin).
+    "deploy_status" "text" NOT NULL DEFAULT 'published' CONSTRAINT "nircam_images_deploy_status_check" CHECK (("deploy_status" = ANY (ARRAY['draft'::"text", 'published'::"text", 'revoked'::"text"]))),
+    "deployment_id" integer
 );
 
 
@@ -1447,17 +1456,15 @@ ALTER TABLE ONLY "public"."map_layers"
 
 
 ALTER TABLE ONLY "public"."nircam_images"
-    ADD CONSTRAINT "nircam_images_field_tile_filter_pixel_scale_version_extensi_key" UNIQUE ("field", "tile", "filter", "pixel_scale", "version", "extension");
-
-
-
-ALTER TABLE ONLY "public"."nircam_images"
     ADD CONSTRAINT "nircam_images_pkey" PRIMARY KEY ("id");
 
 
 
+-- Single version-free uniqueness (epic #261, N2 / D3). The former redundant
+-- twin `nircam_images_field_tile_filter_pixel_scale_version_extensi_key` is
+-- dropped alongside the `version` axis.
 ALTER TABLE ONLY "public"."nircam_images"
-    ADD CONSTRAINT "nircam_images_unique" UNIQUE ("field", "tile", "filter", "pixel_scale", "version", "extension");
+    ADD CONSTRAINT "nircam_images_unique" UNIQUE ("field", "tile", "filter", "pixel_scale", "extension");
 
 
 ALTER TABLE ONLY "public"."nircam_exposures"
@@ -1692,6 +1699,9 @@ ALTER TABLE ONLY "public"."storage_objects"
 
 ALTER TABLE ONLY "public"."storage_objects"
     ADD CONSTRAINT "storage_objects_deployment_id_fkey" FOREIGN KEY ("deployment_id") REFERENCES "public"."deployments"("id") ON DELETE SET NULL;
+
+ALTER TABLE ONLY "public"."nircam_images"
+    ADD CONSTRAINT "nircam_images_deployment_id_fkey" FOREIGN KEY ("deployment_id") REFERENCES "public"."deployments"("id") ON DELETE SET NULL;
 
 
 

--- a/web/app/nircam/page.tsx
+++ b/web/app/nircam/page.tsx
@@ -25,7 +25,6 @@ export default function NircamPage() {
   const [availableTiles, setAvailableTiles] = useState<string[]>([]);
   const [availableFilters, setAvailableFilters] = useState<string[]>([]);
   const [availablePixelScales, setAvailablePixelScales] = useState<string[]>([]);
-  const [availableVersions, setAvailableVersions] = useState<string[]>([]);
   const [availableExtensions, setAvailableExtensions] = useState<string[]>([]);
 
   // Fetch data
@@ -53,7 +52,6 @@ export default function NircamPage() {
         setAvailableTiles(filterOptionsResult.tiles);
         setAvailableFilters(filterOptionsResult.filters);
         setAvailablePixelScales(filterOptionsResult.pixel_scales);
-        setAvailableVersions(filterOptionsResult.versions);
         setAvailableExtensions(filterOptionsResult.extensions);
       }
     } catch (err) {
@@ -143,7 +141,6 @@ export default function NircamPage() {
           availableTiles={availableTiles}
           availableFilters={availableFilters}
           availablePixelScales={availablePixelScales}
-          availableVersions={availableVersions}
           availableExtensions={availableExtensions}
         />
       </div>

--- a/web/components/nircam/NircamFilterBar.tsx
+++ b/web/components/nircam/NircamFilterBar.tsx
@@ -9,7 +9,6 @@ export interface NircamFilterOptions {
   tiles: string[];
   filters: string[];
   pixel_scales: string[];
-  versions: string[];
   extensions: string[];
 }
 
@@ -18,7 +17,6 @@ export const DEFAULT_NIRCAM_FILTERS: NircamFilterOptions = {
   tiles: [],
   filters: [],
   pixel_scales: [],
-  versions: [],
   extensions: [],
 };
 
@@ -29,7 +27,6 @@ interface NircamFilterBarProps {
   availableTiles: string[];
   availableFilters: string[];
   availablePixelScales: string[];
-  availableVersions: string[];
   availableExtensions: string[];
   className?: string;
 }
@@ -41,7 +38,6 @@ export const NircamFilterBar: React.FC<NircamFilterBarProps> = ({
   availableTiles,
   availableFilters,
   availablePixelScales,
-  availableVersions,
   availableExtensions,
   className = '',
 }) => {
@@ -73,11 +69,6 @@ export const NircamFilterBar: React.FC<NircamFilterBarProps> = ({
     label: p,
   }));
 
-  const versionOptions: FilterOption[] = availableVersions.map((v) => ({
-    value: v,
-    label: v,
-  }));
-
   const extensionOptions: FilterOption[] = availableExtensions.map((e) => ({
     value: e,
     label: e.toUpperCase(),
@@ -89,7 +80,6 @@ export const NircamFilterBar: React.FC<NircamFilterBarProps> = ({
     filterState.tiles.length > 0 ||
     filterState.filters.length > 0 ||
     filterState.pixel_scales.length > 0 ||
-    filterState.versions.length > 0 ||
     filterState.extensions.length > 0;
 
   const handleClearAll = () => {
@@ -133,14 +123,6 @@ export const NircamFilterBar: React.FC<NircamFilterBarProps> = ({
           options={pixelScaleOptions}
           selected={filterState.pixel_scales}
           onChange={(selected) => updateFilter('pixel_scales', selected as string[])}
-        />
-
-        {/* Version filter */}
-        <FilterChip
-          label="Version"
-          options={versionOptions}
-          selected={filterState.versions}
-          onChange={(selected) => updateFilter('versions', selected as string[])}
         />
 
         {/* Extension filter */}

--- a/web/components/nircam/NircamTable.tsx
+++ b/web/components/nircam/NircamTable.tsx
@@ -93,9 +93,6 @@ export const NircamTable: React.FC<NircamTableProps> = ({
       if (filters.pixel_scales.length > 0 && !filters.pixel_scales.includes(image.pixel_scale)) {
         return false;
       }
-      if (filters.versions.length > 0 && !filters.versions.includes(image.version)) {
-        return false;
-      }
       if (filters.extensions.length > 0 && !filters.extensions.includes(image.extension)) {
         return false;
       }
@@ -174,18 +171,6 @@ export const NircamTable: React.FC<NircamTableProps> = ({
         cell: ({ row }) => (
           <span className="text-sm font-mono text-text-primary">
             {row.original.pixel_scale}
-          </span>
-        ),
-        sortingFn: 'alphanumeric',
-      },
-      {
-        accessorKey: 'version',
-        header: ({ column }) => (
-          <SortableHeader column={column}>Version</SortableHeader>
-        ),
-        cell: ({ row }) => (
-          <span className="text-sm font-mono text-text-primary">
-            {row.original.version}
           </span>
         ),
         sortingFn: 'alphanumeric',

--- a/web/lib/actions/nircam.ts
+++ b/web/lib/actions/nircam.ts
@@ -15,7 +15,6 @@ export interface NircamFilterOptionsResult {
   tiles: string[];
   filters: string[];
   pixel_scales: string[];
-  versions: string[];
   extensions: string[];
   error?: string;
 }
@@ -88,7 +87,6 @@ export async function getNircamFilterOptions(): Promise<NircamFilterOptionsResul
       tiles: [],
       filters: [],
       pixel_scales: [],
-      versions: [],
       extensions: [],
     };
   }
@@ -96,11 +94,11 @@ export async function getNircamFilterOptions(): Promise<NircamFilterOptionsResul
   try {
     const { data: images, error } = await paginateQuery<{
       field: string; tile: string; filter: string;
-      pixel_scale: string; version: string; extension: string;
+      pixel_scale: string; extension: string;
     }>(
       () => supabase
         .from('nircam_images')
-        .select('field, tile, filter, pixel_scale, version, extension')
+        .select('field, tile, filter, pixel_scale, extension')
         .order('field')
         .order('filter')
         .order('tile'),
@@ -113,7 +111,6 @@ export async function getNircamFilterOptions(): Promise<NircamFilterOptionsResul
         tiles: [],
         filters: [],
         pixel_scales: [],
-        versions: [],
         extensions: [],
         error: error.message,
       };
@@ -122,7 +119,6 @@ export async function getNircamFilterOptions(): Promise<NircamFilterOptionsResul
     const fields = [...new Set(images.map(i => i.field))].sort();
     const filters = [...new Set(images.map(i => i.filter))].sort();
     const pixel_scales = [...new Set(images.map(i => i.pixel_scale))].sort();
-    const versions = [...new Set(images.map(i => i.version))].sort();
     const extensions = [...new Set(images.map(i => i.extension))].sort((a, b) => {
       // Sort extensions by priority: sci > err > rms > srcmask
       const order = ['sci', 'err', 'rms', 'srcmask'];
@@ -157,7 +153,6 @@ export async function getNircamFilterOptions(): Promise<NircamFilterOptionsResul
       tiles,
       filters,
       pixel_scales,
-      versions,
       extensions,
     };
   } catch (err) {
@@ -167,7 +162,6 @@ export async function getNircamFilterOptions(): Promise<NircamFilterOptionsResul
       tiles: [],
       filters: [],
       pixel_scales: [],
-      versions: [],
       extensions: [],
       error: 'An unexpected error occurred',
     };

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -283,7 +283,6 @@ export interface NircamImage {
   tile: string;
   filter: string;
   pixel_scale: string;
-  version: string;
   extension: string;  // sci, err, rms, srcmask
   file_path: string;
   file_size?: number; // in bytes, if available


### PR DESCRIPTION
## N2 — NIRCam mosaic deploy (field-deployment) + retire the `version` axis (epic #261)

Stacked on #271 (N1). Retires the mosaic `version` axis **and** deploys mosaics as first-class public science under the field deployment. **Pipeline MAJOR** (not tagged — you tag/release when ready). Closes #264.

### Retire the version axis (D3)
- Version-free pipeline mosaic name `mosaic_nircam_<filter>_<field>_<scale>_<tile>` via a single `manifest.build_mosaic_name` authority (shared by resample + the staleness check). Dropped: `[nircam.resample].version`, the `[version]` placeholder, the manifest `version` key, the `_latest_` symlink farm, refcat `--version`.
- Schema: drop `nircam_images.version`; collapse the two redundant version-bearing unique constraints into one `UNIQUE(field,tile,filter,pixel_scale,extension)` (the migration **de-dups multi-version rows first** — review fix). Removed `version` from the web (types, filter options/bar, table column).
- CHANGELOG `Algorithm / BREAKING (MAJOR)`.

### Mosaic deploy — folded into `campfire deploy --field`
One field deployment ships exposures **and** mosaics (parity with `deploy --obs`). `_deploy_field_mosaics` uploads each product (i2d + split `_sci/_err/_wht/_srcmask`) to OSN, whole-file content-hash deduped, registers `nircam_mosaic` storage objects tagged with the `deployment_id`, and upserts one `nircam_images` row per `(field,tile,filter,pixel_scale,extension)` carrying `deploy_status` (matches the deployment) + `deployment_id`. Manifest-driven discovery (robust to underscore field names); only mosaics present in OSN are indexed.

### `nircam_images` lifecycle
New `deploy_status` (draft/published/revoked) + `deployment_id` (FK → deployments) + RLS (`published OR is_admin` — published mosaics public to everyone; a field spans multiple programs). `set_deployment_status` flips a field deployment's `nircam_images.deploy_status`. Proven by **`nircam_images_lifecycle.sql`** (draft admin-only → publish public → revoke hidden).

Full python suite 309 passed; pipeline nircam 111 passed; `db reset`/`diff` reconcile clean; web build green. Stack-wide review fixes in N3 (#275).

Generated with Claude Code