### PR TITLE
feat(nircam): classify + report jhat alignment failures, exclude from mosaics

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -193,6 +193,47 @@ Release procedure: edit the `## Unreleased` section below, then run
   `clean_flicker_noise` is not adopted — its `fit_method="fft"` is NIRSpec-only
   (skipped for `NRC_IMAGE`) and its `"median"` mode underperforms our amp-row
   estimators and introduces per-amp DC steps.
+- NIRCam `jhat` WCS-alignment failures are now caught, classified, and
+  reported instead of aborting the whole `process` run (one bad exposure used
+  to kill the other 1600+), and exposures that fail to align are excluded from
+  mosaics. A new `campfire_pipeline/nircam/jhat_report.py` centralizes the
+  handling:
+  - *Catch-all + classify.* `jhat_step` wraps the align call, catches any
+    exception, and maps it to a `CFP_JHAT` sentinel: `NO_REFCAT_OVERLAP` (zero
+    refcat sources on the detector — off-footprint, benign), `ALIGN_FAILED`
+    (refcat coverage exists but the cross-matched set is too sparse/degenerate
+    to fit — needs attention), or `ERROR` (an unexpected exception, caught so it
+    can't abort the pool and logged with a traceback). The input WCS is always
+    preserved. The same root cause (too few usable cross-matches) previously
+    surfaced as three unrelated crashes — `KeyError(None)`,
+    `ValueError("No valid polygons provided")` from `SphericalPolygon.multi_union`
+    on a collinear hull, and `tweakwcs.NotEnoughPointsError` — each of which
+    took the run down; all three are now classified and survived.
+  - *Triage diagnostics.* On failure, jhat's verbose stdout is tee'd and scraped
+    for source/match statistics (`n_detected`, `n_refcat_in_bounds`,
+    `n_matched`, and the 1st-iteration match-median pixel offset). These drive a
+    one-line hint distinguishing the two actionable `ALIGN_FAILED` modes: many
+    sources detected but matches collapse ⇒ likely a bad input (MAST) WCS, with
+    the rough offset reported as a seed for a `wcs_shift` rule; few sources
+    detected ⇒ likely too shallow, tune the jhat cuts. Each failing exposure
+    drops a lock-free `<rootname>.jhat_fail.json` sidecar; a successful
+    (re-)alignment clears it.
+  - *End-of-run summary.* `run_process` / `run_combine` / `run_step` print a
+    grouped jhat alignment report (off-footprint vs. failed-with-coverage vs.
+    errored, with per-exposure hints) and write an aggregated
+    `jhat_alignment_report.ecsv`. It re-reads the sidecars each run, so the
+    lists re-surface until the exposures are fixed.
+  - *Mosaic exclusion (changes mosaic outputs).* `resample` now drops exposures
+    whose `CFP_JHAT` is a failure sentinel (they kept their original,
+    possibly-wrong WCS) so a bad alignment can't smear the stack; they re-enter
+    automatically once they align. This changes mosaic pixels for any tile that
+    previously co-added an off-footprint (`NO_REFCAT_OVERLAP`) exposure, hence
+    the Algorithm/MINOR categorization.
+  The *degenerate diagnostic plot* crash (jhat's dx/dy plotters raising
+  `ValueError: Axis limits cannot be NaN or Inf` on a degenerate best-match
+  panel, sometimes after a valid WCS was already written) remains fixed by
+  no-op'ing jhat's plot functions; plotting defaults off and re-enables per
+  field with `[<field>.jhat].saveplots = true`.
 - NIRCam campfire-native drizzle (`resample.implementation = "campfire"`): the
   ERR map no longer fills with `inf`/`nan`. The variance pass summed the three
   variance components before drizzling, so a single input pixel with a
@@ -344,30 +385,6 @@ Release procedure: edit the `## Unreleased` section below, then run
   for an otherwise up-to-date tile and re-splits from the existing i2d (no
   re-drizzle, no bkgsub redo). SRCMASK is only re-split when the i2d actually
   carries that extension.
-- NIRCam `jhat` WCS-alignment step no longer aborts the entire `process` run
-  on exposures near/over the edge of the reference-catalog footprint. Two
-  distinct jhat crash modes were taking down the whole run (one bad exposure
-  killed the other 1600+):
-  - *Zero refcat overlap.* When no refcat sources land on the detector, jhat
-    skips its matching steps leaving `refcat_xcol` unset, then indexes
-    `phot.t[None]` and raises a bare `KeyError(None)`. `jhat_step` now catches
-    that specific signature, leaves the input WCS untouched, and stamps
-    `CFP_JHAT=NO_REFCAT_OVERLAP` so the exposure reads as
-    intentionally-not-aligned and isn't retried every run.
-  - *Degenerate diagnostic plot.* jhat's dx/dy plotters compute a NaN axis
-    limit from a degenerate best-match panel (few matches, common at the
-    footprint edge) and raise `ValueError: Axis limits cannot be NaN or Inf` —
-    sometimes *after* a perfectly good WCS solution has already been written,
-    so the crash discarded a valid alignment. The plots are diagnostic-only,
-    but jhat gates them on several independent flags not all reachable through
-    `align_wcs`, so the `saveplots` config flag alone can't suppress them.
-    Diagnostic plotting now defaults to off and is enforced by no-op'ing jhat's
-    plot functions at the source; the affected exposures align normally. Plots
-    re-enable per-field with `[<field>.jhat].saveplots = true` (restoring the
-    crash risk on edge exposures).
-  Net effect: the `process` run completes, edge exposures with real refcat
-  coverage are aligned and included, and only the truly-uncoverable ones are
-  skipped (and recorded as such). Genuine alignment errors still propagate.
 - `Observation.load` now validates the observations.toml `program` field
   against `programs.toml` (when present): if the value is not a known program
   *slug* it raises immediately, with a hint when the value matches a program

--- a/pipeline/campfire_pipeline/common/cfp.py
+++ b/pipeline/campfire_pipeline/common/cfp.py
@@ -170,6 +170,21 @@ def has_step(path_or_header, key, *, keyset=NIRCAM):
         return key in hdul[0].header
 
 
+def get_value(path_or_header, key, default=None, *, keyset=NIRCAM):
+    """Return the value of CFP ``key`` on an exposure, or ``default`` if absent.
+
+    Accepts a path or an already-open ``fits.Header``. Unlike ``has_step`` this
+    hands back the recorded value (e.g. the refcat name or a failure sentinel in
+    ``CFP_JHAT``) so callers can branch on it. ``keyset`` selects the instrument
+    namespace (default :data:`NIRCAM`).
+    """
+    keyset.validate(key)
+    if isinstance(path_or_header, fits.Header):
+        return path_or_header.get(key, default)
+    with fits.open(path_or_header, memmap=False) as hdul:
+        return hdul[0].header.get(key, default)
+
+
 def should_skip(exposure_file, key, rootname, step_name, status, overwrite,
                 *, keyset=NIRCAM):
     """Skip-check shared across per-exposure/per-source step modules.

--- a/pipeline/campfire_pipeline/nircam/jhat_report.py
+++ b/pipeline/campfire_pipeline/nircam/jhat_report.py
@@ -1,0 +1,327 @@
+"""
+jhat_report: classification, diagnostics, and end-of-run reporting for the
+NIRCam ``jhat`` WCS-alignment step.
+
+jhat alignment terminates in one of two ways. On success the refcat *filename*
+is written to the ``CFP_JHAT`` header keyword. On failure one of three
+sentinels is written instead, and (for the cases worth triaging) a small
+per-exposure JSON sidecar is dropped next to the exposure so the end-of-run
+summary can re-surface it:
+
+* ``NO_REFCAT_OVERLAP`` -- zero reference-catalog sources land on the detector.
+  The exposure is off the refcat footprint (expected near a field edge). Benign.
+* ``ALIGN_FAILED`` -- refcat sources are present but the cross-matched set is too
+  sparse or degenerate to fit a WCS correction. Needs attention: either the input
+  WCS shipped too far off for jhat to find matches (fixable with a ``wcs_shift``
+  rule) or the exposure is too shallow (tune the jhat cuts).
+* ``ERROR`` -- an unexpected exception. Caught so one bad exposure can't abort
+  the whole worker pool; surfaced loudly in the report so it gets investigated.
+
+``is_failure`` tells a sentinel apart from a (successful) refcat filename by
+membership in ``FAILURE_SENTINELS``. Downstream (``resample``) uses it to drop
+non-aligned exposures from the mosaic so a bad WCS can't smear the stack.
+
+The diagnostics that drive the triage hint are scraped from jhat's own verbose
+stdout (see ``parse_diagnostics``) rather than its in-memory object model: at the
+point alignment raises, the useful quantities (the 1st-iteration match-median
+offset in particular) live only in locals that are gone after the exception, but
+they have already been *printed*. The printed strings are user-facing and stable
+across jhat versions; version drift only degrades the hint, never the
+classification.
+"""
+
+import glob
+import json
+import os
+import re
+
+from campfire_pipeline.common.io import log
+
+
+# CFP_JHAT sentinel values (see module docstring).
+NO_REFCAT_SENTINEL = 'NO_REFCAT_OVERLAP'
+ALIGN_FAILED_SENTINEL = 'ALIGN_FAILED'
+ERROR_SENTINEL = 'ERROR'
+FAILURE_SENTINELS = frozenset(
+    {NO_REFCAT_SENTINEL, ALIGN_FAILED_SENTINEL, ERROR_SENTINEL})
+
+# Per-exposure failure sidecar: ``<rootname>.jhat_fail.json`` next to the
+# canonical exposure. One file per failing exposure keeps the worker pool
+# lock-free (no shared append target).
+SHARD_SUFFIX = '.jhat_fail.json'
+
+# Fewer detected image sources than this and a failure reads as "too shallow"
+# rather than "bad WCS". 20 is comfortably below a normal NIRCam field's source
+# count (hundreds) yet above the handful a genuinely empty/striped frame yields.
+_SHALLOW_NDETECT = 20
+
+
+def is_failure(cfp_jhat_value):
+    """True if a ``CFP_JHAT`` value marks a non-aligned exposure.
+
+    Success stores the refcat filename, so only the explicit sentinels count as
+    failures. A falsy value (keyword absent) is *not* treated as a failure here
+    so fields that don't run jhat aren't penalized downstream.
+    """
+    return cfp_jhat_value in FAILURE_SENTINELS
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics: scrape jhat's verbose stdout
+# ---------------------------------------------------------------------------
+
+class TeeStdout:
+    """File-like that fans writes out to several streams.
+
+    Wrapped around the align call so jhat's verbose output still reaches the
+    real stdout (unchanged console behavior) while a copy lands in an in-memory
+    buffer we can parse if the call raises.
+    """
+
+    def __init__(self, *streams):
+        self._streams = streams
+
+    def write(self, s):
+        for st in self._streams:
+            st.write(s)
+        return len(s)
+
+    def flush(self):
+        for st in self._streams:
+            try:
+                st.flush()
+            except Exception:
+                pass
+
+
+_RE_MATCHING = re.compile(r'Matching (\d+) image objects to (\d+) refcat objects')
+_RE_KEEPING = re.compile(r'Keeping (\d+) out of \d+ .*?objects within x=')
+_RE_PASSED = re.compile(r'(\d+) matches are passed to tweakreg')
+_RE_DXDY = re.compile(
+    r'dx median of best matched objects of 1st iteration:\s*([-+0-9.eE]+|nan)\s+'
+    r'dy median of best matched objects of 1st iteration:\s*([-+0-9.eE]+|nan)')
+_RE_ZERO_REF = re.compile(
+    r'0 sources from reference catalog within the image bounderies')
+
+
+def parse_diagnostics(text):
+    """Best-effort source/match statistics from jhat's verbose stdout.
+
+    Every field is optional; if jhat changes its wording the dict just comes
+    back sparser and the hint degrades to "inspect manually".
+    """
+    d = {}
+    m = _RE_MATCHING.search(text)
+    if m:
+        d['n_detected'] = int(m.group(1))
+        d['n_refcat_in_bounds'] = int(m.group(2))
+    else:
+        km = _RE_KEEPING.search(text)
+        if km:
+            d['n_refcat_in_bounds'] = int(km.group(1))
+    passed = _RE_PASSED.findall(text)
+    if passed:
+        # Last value is the count handed to the (failing) final fit.
+        d['n_matched'] = int(passed[-1])
+    xm = _RE_DXDY.search(text)
+    if xm and 'nan' not in (xm.group(1), xm.group(2)):
+        try:
+            d['rough_dx_px'] = float(xm.group(1))
+            d['rough_dy_px'] = float(xm.group(2))
+        except ValueError:
+            pass
+    if _RE_ZERO_REF.search(text):
+        d['n_refcat_in_bounds'] = 0
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Classification + triage hint
+# ---------------------------------------------------------------------------
+
+def _is_alignment_failure(exc):
+    """True for the known "matched set too sparse/degenerate to fit" signatures.
+
+    These all mean refcat coverage exists but cross-matching collapsed; they
+    surface at different points in the tweakwcs/stcal stack depending on exactly
+    how few matches survive jhat's cuts:
+
+    * ``ValueError("No valid polygons provided")`` -- the matched-source convex
+      hull is collinear/zero-area, so ``SphericalPolygon.multi_union`` rejects it.
+    * ``NotEnoughPointsError`` -- fewer than 2 matched points reach the linear
+      fit.
+    * stcal's own "Not enough sources" / "Too few input images" /
+      "Number of output coordinates exceeded allocation" guards.
+    """
+    if isinstance(exc, ValueError) and 'No valid polygons provided' in str(exc):
+        return True
+    if type(exc).__name__ == 'NotEnoughPointsError':
+        return True
+    msg = str(exc)
+    return ('Not enough sources' in msg
+            or 'Too few input images' in msg
+            or 'Number of output coordinates exceeded allocation' in msg)
+
+
+def classify(exc, diag):
+    """Map a caught jhat exception (+ scraped diagnostics) to a sentinel."""
+    if ((isinstance(exc, KeyError) and exc.args == (None,))
+            or diag.get('n_refcat_in_bounds') == 0):
+        return NO_REFCAT_SENTINEL
+    if _is_alignment_failure(exc):
+        return ALIGN_FAILED_SENTINEL
+    return ERROR_SENTINEL
+
+
+def hint(category, diag):
+    """One-line, actionable triage note for the report."""
+    if category == NO_REFCAT_SENTINEL:
+        return 'off refcat footprint (expected near a field edge); skip is benign'
+    if category == ERROR_SENTINEL:
+        return 'unexpected error — inspect the run-log traceback'
+    nd = diag.get('n_detected')
+    if nd is None:
+        return 'coverage present but alignment failed; inspect manually'
+    if nd < _SHALLOW_NDETECT:
+        return (f'only {nd} sources detected — likely too shallow; relax jhat '
+                f'cuts (SNR_min / objmag_lim) or accept the skip')
+    off = ''
+    if diag.get('rough_dx_px') is not None:
+        off = (f'; 1st-iter match-median offset ~dx={diag["rough_dx_px"]:.1f}, '
+               f'dy={diag["rough_dy_px"]:.1f} px — seed for a wcs_shift rule')
+    return (f'{nd} sources detected but matches collapse — likely bad input '
+            f'WCS{off}')
+
+
+# ---------------------------------------------------------------------------
+# Per-exposure failure sidecar I/O (lock-free across the worker pool)
+# ---------------------------------------------------------------------------
+
+def _shard_path(input_dir, rootname):
+    return os.path.join(input_dir, rootname + SHARD_SUFFIX)
+
+
+def write_failure(input_dir, rootname, filtname, category, exc, diag, hint_text):
+    """Atomically drop a failure sidecar next to the exposure."""
+    rec = {
+        'rootname': rootname,
+        'filter': filtname,
+        'category': category,
+        'exception': f'{type(exc).__name__}: {exc}',
+        'hint': hint_text,
+    }
+    rec.update(diag)
+    path = _shard_path(input_dir, rootname)
+    tmp = path + '.tmp'
+    try:
+        with open(tmp, 'w') as fp:
+            json.dump(rec, fp, indent=2, sort_keys=True)
+        os.replace(tmp, path)
+    except OSError as e:
+        log(f"jhat: could not write failure record for {rootname}: {e}")
+
+
+def clear_failure(input_dir, rootname):
+    """Remove a stale failure sidecar after a (re-)successful alignment."""
+    try:
+        os.remove(_shard_path(input_dir, rootname))
+    except FileNotFoundError:
+        pass
+    except OSError as e:
+        log(f"jhat: could not clear stale failure record for {rootname}: {e}")
+
+
+# ---------------------------------------------------------------------------
+# End-of-run summary
+# ---------------------------------------------------------------------------
+
+def collect_failures(field, filters):
+    """Load every failure sidecar across ``filters`` into a list of dicts."""
+    out = []
+    for filt in filters:
+        try:
+            d = field.filter_dir(filt)
+        except Exception:
+            continue
+        for p in sorted(glob.glob(os.path.join(d, '*' + SHARD_SUFFIX))):
+            try:
+                with open(p) as fp:
+                    out.append(json.load(fp))
+            except (OSError, ValueError):
+                continue
+    return out
+
+
+def _write_report_table(field, records):
+    """Write the aggregated failures as an ECSV alongside the field products."""
+    try:
+        from astropy.table import Table
+    except Exception:
+        return None
+    cols = ['rootname', 'filter', 'category', 'n_detected',
+            'n_refcat_in_bounds', 'n_matched', 'rough_dx_px', 'rough_dy_px',
+            'hint']
+    rows = {c: [] for c in cols}
+    for r in records:
+        for c in cols:
+            rows[c].append(r.get(c, ''))
+    path = os.path.join(field.products_dir, 'jhat_alignment_report.ecsv')
+    try:
+        Table({c: rows[c] for c in cols}).write(
+            path, format='ascii.ecsv', overwrite=True)
+        return path
+    except Exception as e:
+        log(f"jhat: could not write alignment report table: {e}")
+        return None
+
+
+def report(field, filters):
+    """Print the end-of-run jhat alignment summary and write an ECSV.
+
+    Silent when no failures were recorded. Reads the per-exposure sidecars, so
+    it re-surfaces the same lists on every run until the exposures are fixed
+    (and their sidecars cleared by a successful re-alignment).
+    """
+    records = collect_failures(field, filters)
+    if not records:
+        return
+
+    by_cat = {NO_REFCAT_SENTINEL: [], ALIGN_FAILED_SENTINEL: [], ERROR_SENTINEL: []}
+    for r in records:
+        by_cat.setdefault(r.get('category', ERROR_SENTINEL), []).append(r)
+
+    def _label(r):
+        return f"{r.get('rootname', '?')} [{r.get('filter', '?')}]"
+
+    log('')
+    log('=' * 74)
+    log(f"jhat alignment report — field '{field.name}': "
+        f"{len(records)} exposure(s) not aligned")
+    log('=' * 74)
+
+    no_cov = by_cat.get(NO_REFCAT_SENTINEL, [])
+    if no_cov:
+        log(f"  • {len(no_cov)} off refcat footprint (skipped, benign) — "
+            f"OK unless you expected coverage here:")
+        for r in no_cov:
+            log(f"      {_label(r)}")
+
+    failed = by_cat.get(ALIGN_FAILED_SENTINEL, [])
+    if failed:
+        log(f"  • {len(failed)} have coverage but FAILED to align — action "
+            f"needed (wcs_shift rule or relax jhat cuts):")
+        for r in failed:
+            log(f"      {_label(r)}: {r.get('hint', '')}")
+
+    errored = by_cat.get(ERROR_SENTINEL, [])
+    if errored:
+        log(f"  • {len(errored)} hit an UNEXPECTED error (caught; not aligned) "
+            f"— investigate:")
+        for r in errored:
+            log(f"      {_label(r)}: {r.get('exception', '')}")
+
+    path = _write_report_table(field, records)
+    if path:
+        log(f"  full table: {path}")
+    log('=' * 74)
+    log('')

--- a/pipeline/campfire_pipeline/nircam/orchestrate.py
+++ b/pipeline/campfire_pipeline/nircam/orchestrate.py
@@ -505,6 +505,28 @@ def _run_resample(field, config, filtname, n_processes, overwrite, status,
     if not exposures:
         log(f"resample: no CFP_OUT-stamped exposures for {filtname}")
         return
+
+    # Drop exposures that jhat could not align (off-footprint, failed-with-
+    # coverage, or errored). They kept their original, possibly-wrong WCS, so
+    # co-adding them would smear the mosaic. They re-enter automatically once a
+    # wcs_shift rule or param change lets them align (sentinel → refcat name).
+    from campfire_pipeline.nircam import jhat_report
+    aligned, excluded = [], []
+    for f in exposures:
+        if jhat_report.is_failure(status.value(f, 'CFP_JHAT')):
+            excluded.append(f)
+        else:
+            aligned.append(f)
+    if excluded:
+        log(f"resample: excluding {len(excluded)}/{len(exposures)} exposures "
+            f"from {filtname} mosaic — jhat did not align them (see jhat "
+            f"alignment report). Resolve via a wcs_shift rule or accept the "
+            f"loss.")
+        exposures = aligned
+    if not exposures:
+        log(f"resample: all {filtname} exposures failed jhat alignment; "
+            f"nothing to drizzle")
+        return
     from campfire_pipeline.nircam.steps.resample import resample_step
     cfg = get_nircam_step_config('resample', config, field)
     resample_step(filtname, exposures, field, cfg, reduction_version,
@@ -602,6 +624,8 @@ def run_process(field, config, filters=None, n_processes=1, overwrite=False):
         for step_name, _ in PROCESS_STEPS:
             _RUNNERS[step_name](field, config, filt, n_processes, overwrite,
                                 status)
+    from campfire_pipeline.nircam import jhat_report
+    jhat_report.report(field, filters)
 
 
 def run_combine(field, config, filters=None, n_processes=1, overwrite=False):
@@ -620,6 +644,8 @@ def run_combine(field, config, filters=None, n_processes=1, overwrite=False):
             else:
                 _RUNNERS[step_name](field, config, filt, n_processes, overwrite,
                                     status)
+    from campfire_pipeline.nircam import jhat_report
+    jhat_report.report(field, filters)
 
 
 def run_step(step_name, field, config, filters=None, n_processes=1,
@@ -649,3 +675,8 @@ def run_step(step_name, field, config, filters=None, n_processes=1,
         else:
             _RUNNERS[step_name](field, config, filt, n_processes, overwrite,
                                 status)
+
+    # Surface the jhat alignment summary whenever alignment state is relevant.
+    if step_name in ('jhat', 'resample'):
+        from campfire_pipeline.nircam import jhat_report
+        jhat_report.report(field, filters)

--- a/pipeline/campfire_pipeline/nircam/status.py
+++ b/pipeline/campfire_pipeline/nircam/status.py
@@ -22,16 +22,29 @@ from astropy.io import fits
 from campfire_pipeline.common import cfp
 
 
-class StepStatus:
-    """A path → set-of-CFP-keys snapshot, plus optional in-memory updates."""
+# CFP keys whose *value* (not just presence) is cached during the scan, so
+# consumers can branch on it without re-opening the FITS. Kept tiny: only
+# CFP_JHAT, whose value is a refcat name on success or a failure sentinel that
+# ``resample`` reads to exclude unaligned exposures from the mosaic.
+_VALUE_KEYS = ('CFP_JHAT',)
 
-    def __init__(self, present=None):
+
+class StepStatus:
+    """A path → set-of-CFP-keys snapshot, plus optional in-memory updates.
+
+    Also caches the *value* of a few keys (``_VALUE_KEYS``) read during the
+    same single header scan, exposed via ``value``.
+    """
+
+    def __init__(self, present=None, values=None):
         self._present = dict(present) if present else {}
+        self._values = dict(values) if values else {}
 
     @classmethod
     def scan(cls, paths):
         """Read primary headers once and record which CFP keys are present."""
         present = {}
+        values = {}
         for p in paths:
             if not os.path.exists(p):
                 present[p] = set()
@@ -40,12 +53,13 @@ class StepStatus:
                 with fits.open(p, memmap=False) as hdul:
                     hdr = hdul[0].header
                     present[p] = {k for k in cfp.CFP_KEYS if k in hdr}
+                    values[p] = {k: hdr[k] for k in _VALUE_KEYS if k in hdr}
             except (OSError, IOError):
                 # Corrupt or unreadable: treat as no keys present so the
                 # step itself can decide to fail loudly instead of being
                 # silently skipped here.
                 present[p] = set()
-        return cls(present)
+        return cls(present, values)
 
     def has(self, path, key):
         """True if ``key`` is recorded on ``path``.
@@ -60,6 +74,19 @@ class StepStatus:
         if not os.path.exists(path):
             return False
         return cfp.has_step(path, key)
+
+    def value(self, path, key, default=None):
+        """Return the cached value of ``key`` on ``path``.
+
+        Falls back to a live header read for paths not seen during the scan
+        (or scanned before this key was written). Only ``_VALUE_KEYS`` are
+        cached; other keys always take the live path.
+        """
+        if key in _VALUE_KEYS and path in self._values:
+            return self._values[path].get(key, default)
+        if not os.path.exists(path):
+            return default
+        return cfp.get_value(path, key, default)
 
     def mark(self, path, key):
         self._present.setdefault(path, set()).add(key)
@@ -80,5 +107,6 @@ class StepStatus:
                 with fits.open(p, memmap=False) as hdul:
                     hdr = hdul[0].header
                     self._present[p] = {k for k in cfp.CFP_KEYS if k in hdr}
+                    self._values[p] = {k: hdr[k] for k in _VALUE_KEYS if k in hdr}
             except (OSError, IOError):
                 self._present[p] = set()

--- a/pipeline/campfire_pipeline/nircam/steps/jhat.py
+++ b/pipeline/campfire_pipeline/nircam/steps/jhat.py
@@ -12,10 +12,19 @@ trip without extra handling.
 JHAT also writes diagnostic PDFs and photometry tables alongside its
 output; we copy those into the canonical exposure's directory so they're
 preserved when the scratch directory goes away.
+
+Alignment failures never abort the worker pool: any exception is caught,
+classified into a ``CFP_JHAT`` sentinel, and recorded for the end-of-run
+report (see ``campfire_pipeline.nircam.jhat_report``). The input WCS is
+preserved and ``resample`` later excludes any exposure left with a failure
+sentinel so a bad WCS can't smear the mosaic.
 """
 
+import contextlib
+import io
 import os
 import shutil
+import sys
 import tempfile
 import warnings
 
@@ -23,13 +32,10 @@ from astropy.io import fits
 
 from campfire_pipeline.common.io import log, atomic_save
 from campfire_pipeline.common import cfp
-
-
-# Sentinel stamped into CFP_JHAT when an exposure cannot be aligned because it
-# lies at/beyond the edge of the reference catalog footprint (zero refcat
-# sources land on the detector). The input WCS is left untouched. Recorded so
-# the exposure reads as intentionally-not-aligned and isn't retried every run.
-NO_REFCAT_SENTINEL = 'NO_REFCAT_OVERLAP'
+# CFP_JHAT sentinels plus the classify/diagnostics/report machinery live in
+# jhat_report so resample (mosaic exclusion) and the orchestrator (end-of-run
+# summary) can share them without importing this heavy module.
+from campfire_pipeline.nircam import jhat_report
 
 
 def _disable_jhat_plots():
@@ -192,67 +198,80 @@ def jhat_step(exposure_file, field, step_config, overwrite=False, status=None):
             addfilter2outsubdir=False,
         )
 
+        # Tee jhat's verbose stdout into a buffer: on failure we scrape it for
+        # the source/match statistics that drive the report's triage hint. The
+        # tee keeps the output visible on the console for successful exposures.
+        diag_buf = io.StringIO()
+        tee = jhat_report.TeeStdout(sys.stdout, diag_buf)
         try:
-            align_batch.align_wcs(
-                ixs, overwrite=True, outrootdir=scratch, outsubdir=filtname,
-                addfilter2outsubdir=False,
-                photometry_method='aperture',
-                find_stars_threshold=3.0,
-                sci_xy_catalog=None,
-                use_dq=False,
-                refcatname=refcat,
-                refcat_racol='RA',
-                refcat_deccol='DEC',
-                refcat_magcol='mag',
-                refcat_magerrcol='mag_err',
-                refcat_colorcol=None,
-                pmflag=False,
-                pm_median=False,
-                load_photcat_if_exists=False,
-                rematch_refcat=False,
-                SNR_min=10.0,
-                d2d_max=step_config.get('d2d_max', 1.5),
-                dmag_max=0.1,
-                sharpness_lim=(None, None),
-                roundness1_lim=(None, None),
-                delta_mag_lim=step_config.get('delta_mag_lim', [-3, 4]),
-                objmag_lim=step_config.get('objmag_lim', [19, 28]),
-                refmag_lim=(None, None),
-                slope_min=-10 / 2048.0,
-                Nbright4match=None, Nbright=None,
-                histocut_order=step_config.get('histocut_order', 'dxdy'),
-                xshift=0.0, yshift=0.0,
-                iterate_with_xyshifts=step_config.get('iterate_with_xyshifts',
-                                                     True),
-                showplots=0,
-                # Off by default; jhat's plotters are also no-op'd above unless
-                # this is set (see _disable_jhat_plots). Re-enable diagnostics
-                # per-field via [<field>.jhat].saveplots = true.
-                saveplots=step_config.get('saveplots', False),
-                savephottable=step_config.get('savephottable', True),
-            )
-        except KeyError as e:
-            # jhat raises a bare ``KeyError(None)`` when it finds zero
-            # reference sources within the image bounds: it prints
-            # "0 sources from reference catalog within the image bounderies"
-            # and skips the matching steps, leaving ``refcat_xcol`` unset, then
-            # indexes ``phot.t[None]``. This means the exposure lies at/over
-            # the edge of the refcat footprint -- a data-coverage condition,
-            # not a campfire failure -- so it must not abort the whole run.
-            # Record the skip and move on; the input WCS is preserved.
-            if e.args == (None,):
-                log(f"jhat: no refcat overlap for {rootname}; skipping "
-                    f"alignment (input WCS preserved, CFP_JHAT="
-                    f"{NO_REFCAT_SENTINEL})")
-                _stamp_jhat(exposure_file, NO_REFCAT_SENTINEL)
-                return
-            log(f"jhat failed on {exposure_file}")
-            raise
-        except Exception:
-            log(f"jhat failed on {exposure_file}")
-            raise
+            with contextlib.redirect_stdout(tee):
+                align_batch.align_wcs(
+                    ixs, overwrite=True, outrootdir=scratch, outsubdir=filtname,
+                    addfilter2outsubdir=False,
+                    photometry_method='aperture',
+                    find_stars_threshold=3.0,
+                    sci_xy_catalog=None,
+                    use_dq=False,
+                    refcatname=refcat,
+                    refcat_racol='RA',
+                    refcat_deccol='DEC',
+                    refcat_magcol='mag',
+                    refcat_magerrcol='mag_err',
+                    refcat_colorcol=None,
+                    pmflag=False,
+                    pm_median=False,
+                    load_photcat_if_exists=False,
+                    rematch_refcat=False,
+                    SNR_min=10.0,
+                    d2d_max=step_config.get('d2d_max', 1.5),
+                    dmag_max=0.1,
+                    sharpness_lim=(None, None),
+                    roundness1_lim=(None, None),
+                    delta_mag_lim=step_config.get('delta_mag_lim', [-3, 4]),
+                    objmag_lim=step_config.get('objmag_lim', [19, 28]),
+                    refmag_lim=(None, None),
+                    slope_min=-10 / 2048.0,
+                    Nbright4match=None, Nbright=None,
+                    histocut_order=step_config.get('histocut_order', 'dxdy'),
+                    xshift=0.0, yshift=0.0,
+                    iterate_with_xyshifts=step_config.get(
+                        'iterate_with_xyshifts', True),
+                    showplots=0,
+                    # Off by default; jhat's plotters are also no-op'd above
+                    # unless this is set (see _disable_jhat_plots). Re-enable
+                    # diagnostics per-field via [<field>.jhat].saveplots = true.
+                    saveplots=step_config.get('saveplots', False),
+                    savephottable=step_config.get('savephottable', True),
+                )
+        except Exception as exc:
+            # No single exposure may abort the pool (one bad frame used to kill
+            # 1600+). Classify the failure, preserve the input WCS, drop a
+            # per-exposure diagnostics sidecar for the end-of-run report, and
+            # move on. The same root cause (too few usable cross-matches)
+            # surfaces as several unrelated exception types depending on exactly
+            # how the matched set collapses; jhat_report.classify maps them to a
+            # CFP_JHAT sentinel. Truly unexpected exceptions are caught too, but
+            # categorized ERROR and logged with a traceback so they get noticed.
+            diag = jhat_report.parse_diagnostics(diag_buf.getvalue())
+            category = jhat_report.classify(exc, diag)
+            hint = jhat_report.hint(category, diag)
+            if category == jhat_report.ERROR_SENTINEL:
+                log(f"jhat: UNEXPECTED error on {rootname} "
+                    f"(caught; CFP_JHAT={category}, WCS preserved):")
+                import traceback
+                log(traceback.format_exc())
+            else:
+                log(f"jhat: {rootname} not aligned (CFP_JHAT={category}, WCS "
+                    f"preserved) — {hint}")
+            jhat_report.write_failure(input_dir, rootname, filtname, category,
+                                      exc, diag, hint)
+            _stamp_jhat(exposure_file, category)
+            return
 
         align_batch.write()
+        # Alignment succeeded: clear any stale failure sidecar from a prior run
+        # (e.g. a wcs_shift rule was added and this exposure now aligns).
+        jhat_report.clear_failure(input_dir, rootname)
 
         scratch_out = align_batch.t.loc[ixs[0], 'outfilename']
         if not os.path.exists(scratch_out):


### PR DESCRIPTION
## Summary

Makes NIRCam `jhat` WCS-alignment failures non-fatal, classified, and reported, and excludes unaligned exposures from mosaics. Previously a single bad exposure (near/over the refcat footprint edge, or with a degenerate cross-match) would raise and abort the entire `process` run — taking down the other 1600+ exposures.

A new `campfire_pipeline/nircam/jhat_report.py` centralizes the shared machinery (sentinels, `classify`, `parse_diagnostics`, `hint`, sidecar I/O, `TeeStdout`, end-of-run `report`) so both `resample` (mosaic exclusion) and the orchestrator (summary) can use it without importing the heavy `jhat` step module.

### What changed
- **Catch-all + classify** (`steps/jhat.py`): the align call is wrapped; any exception is caught and mapped to a `CFP_JHAT` sentinel — `NO_REFCAT_OVERLAP` (off-footprint, benign), `ALIGN_FAILED` (coverage exists but cross-match too sparse/degenerate), or `ERROR` (unexpected, logged with traceback). Input WCS is always preserved. The three previously-fatal crash signatures (`KeyError(None)`, `SphericalPolygon` "No valid polygons", `tweakwcs.NotEnoughPointsError`) are now all classified and survived.
- **Triage diagnostics**: jhat's verbose stdout is tee'd and scraped for source/match stats to drive a one-line hint (bad MAST WCS vs. too shallow), with a rough pixel offset seed for a `wcs_shift` rule. Each failure drops a lock-free `<rootname>.jhat_fail.json` sidecar; a later successful alignment clears it.
- **End-of-run summary** (`orchestrate.py`): `run_process` / `run_combine` / `run_step` print a grouped alignment report and write `jhat_alignment_report.ecsv`.
- **Mosaic exclusion** (`orchestrate.py`, changes mosaic outputs): `resample` drops failure-sentinel exposures so a bad WCS can't smear the stack; they re-enter automatically once they align.
- **Value caching** (`status.py`): `StepStatus` now caches `CFP_JHAT`'s value during the single header scan (`.value()`), so `resample` branches without re-opening FITS. Backed by a new `cfp.get_value()` helper.

### Categorization
**Algorithm / MINOR** — mosaic exclusion changes mosaic pixels for any tile that previously co-added an off-footprint exposure. Changelog updated under `## Unreleased`.

## Test plan
- [x] Imports + smoke test pass in the `campfire` env against the rebased tree (`get_value` keyset validation, `StepStatus.value` cache, `jhat_report.is_failure`).
- [ ] Full `cfpipe nircam run --field <field> process` on a field with known edge/degenerate exposures — confirm the run completes, the report lists them, and the mosaic excludes them.

## Notes
Rebased onto current `main` (135 commits). Resolved conflicts in `cfp.py` (adapted `get_value` to the new per-instrument keyset API) and `CHANGELOG.md` (additive).

Generated with Claude Code