### PR TITLE
feat(nircam): serve mosaics from OSN, retire CANDIDE (N3, #265)

### DIFF
--- a/python/campfire/deploy/cli.py
+++ b/python/campfire/deploy/cli.py
@@ -85,8 +85,7 @@ from campfire.deploy.deploy import (
 from campfire.deploy.supabase import (
     get_supabase_client, upsert_programs, refresh_filter_options,
     refresh_programs_overview, get_latest_deployment_id,
-    get_latest_field_deployment_id, set_deployment_status,
-    get_user_id_from_token,
+    get_field_deployment_ids, set_deployment_status, get_user_id_from_token,
 )
 
 
@@ -461,18 +460,23 @@ def _lifecycle_transition(ctx, config_path, obs, dry_run, local, *, to_status, v
     sb = get_supabase_client(config)
     actor = get_user_id_from_token(config)
     if field:
-        dep_id = get_latest_field_deployment_id(sb, field)
-        if dep_id is None:
+        # Flip EVERY deployment the field has, not just the latest: a --filter
+        # subset re-deploy spreads a field's objects across deployments, so flipping
+        # only the newest would partially publish (or leave part of a revoked field
+        # public). set_deployment_status per deployment also flips its nircam_images.
+        dep_ids = get_field_deployment_ids(sb, field)
+        if not dep_ids:
             print(f"  field {field}: no deployment found, skipping")
             return
         if dry_run:
-            print(f"  [dry-run] {verb} field {field} (deployment #{dep_id})")
+            print(f"  [dry-run] {verb} field {field} ({len(dep_ids)} deployment(s): "
+                  f"{', '.join('#'+str(d) for d in dep_ids)})")
             return
-        result = set_deployment_status(sb, dep_id, to_status, actor=actor)
-        if result is None:
-            print(f"  field {field}: {verb.lower()} failed")
-            return
-        print(f"  {verb}ed field {field} (deployment #{dep_id}) -> {to_status}")
+        n_ok = 0
+        for dep_id in dep_ids:
+            if set_deployment_status(sb, dep_id, to_status, actor=actor) is not None:
+                n_ok += 1
+        print(f"  {verb}ed field {field}: {n_ok}/{len(dep_ids)} deployment(s) -> {to_status}")
         return
     for obs_name in obs:
         dep_id = get_latest_deployment_id(sb, obs_name)

--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -385,8 +385,15 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
     print(f"Filters: {', '.join(filters)}")
 
     exposures = discover_exposures(dirs, filters)
-    print(f"Discovered {len(exposures)} canonical exposures")
-    if not exposures:
+    expmap_tasks = discover_expmap_tasks(dirs, field)
+    n_mosaics = len(discover_mosaics(dirs, field, filters))
+    print(f"Discovered {len(exposures)} canonical exposure(s), "
+          f"{len(expmap_tasks)} expmap(s), {n_mosaics} mosaic(s)")
+    # Deploy whatever the field has — mosaics/expmaps are independent of the
+    # per-exposure FITS (a field can keep its science mosaics after the large cal
+    # exposures are pruned). Only bail if there is genuinely nothing to ship.
+    if not exposures and not expmap_tasks and not n_mosaics:
+        print("Nothing to deploy for this field.")
         return
 
     png_tasks = build_upload_tasks(dirs, field, filters)
@@ -409,10 +416,8 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
           f"({len(thumb_r2_keys)} thumb, {len(full_r2_keys)} full)")
 
     fits_tasks = build_fits_upload_tasks(field, exposures)
-    expmap_tasks = discover_expmap_tasks(dirs, field)
-    n_mosaics = len(discover_mosaics(dirs, field, filters))
-    print(f"Canonical FITS: {len(fits_tasks)} exposure(s), {len(expmap_tasks)} expmap(s), "
-          f"{n_mosaics} mosaic(s) → OSN")
+    print(f"→ OSN: {len(fits_tasks)} exposure(s), {len(expmap_tasks)} expmap(s), "
+          f"{n_mosaics} mosaic(s)")
 
     records = []
     for (filtname, basename), info in sorted(exposures.items()):
@@ -536,9 +541,12 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
         print(f"  Registered {n_reg} storage object(s)")
 
     # Re-point dedup-skipped exposures (unchanged bytes, not re-registered) to this
-    # deployment so a publish / re-deploy flips the whole field's visibility.
+    # deployment so a PUBLISHED re-deploy flips the whole field consistently. NOT on
+    # a --draft re-deploy: draft is staging — leave already-published unchanged
+    # objects on their published deployment (only the new/changed ones stage as
+    # draft), else the whole live field goes dark.
     skipped_keys = ([t.r2_key for t in fits_tasks if t.r2_key not in osn_uploaded]
-                    if deployment_id else [])
+                    if (deployment_id and not draft) else [])
     if skipped_keys:
         n_moved = set_active_deployment(client, skipped_keys, deployment_id)
         if n_moved:
@@ -758,25 +766,27 @@ def _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
         for msg in failures:
             print(f"    Error: {msg}")
 
-    # Index only mosaics actually present in OSN — uploaded this run or unchanged +
-    # already registered. A failed upload must NOT get a nircam_images row (it would
-    # advertise a file_path with no object + no registry row; the slot 404s). A
-    # re-run heals. deploy_status matches the deployment so the public page shows
-    # only published mosaics; deployment_id ties them to the lifecycle batch.
+    # A failed upload must NOT get a nircam_images row (it would advertise a
+    # file_path with no object + no registry row; the slot 404s). A re-run heals.
     present = set(uploaded) | {
         m['storage_key'] for m in mosaics
         if existing.get(m['storage_key']) == m['content_hash']
     }
+    # PUBLISHED: (re-)index every present mosaic under this deployment. DRAFT is
+    # staging — only index the NEW/CHANGED (uploaded) mosaics as draft; leave
+    # unchanged, already-published mosaics on their live deployment so the field
+    # doesn't go dark. (A first-time deploy has uploaded == present anyway.)
     img_status = 'draft' if draft else 'published'
+    indexable = uploaded if draft else present
     img_rows = [{
         'field': field, 'tile': m['tile'], 'filter': m['filter'],
         'pixel_scale': m['pixel_scale'], 'extension': m['extension'],
         'file_path': m['storage_key'], 'file_size': m['size'],
         'deploy_status': img_status, 'deployment_id': deployment_id,
-    } for m in mosaics if m['storage_key'] in present]
+    } for m in mosaics if m['storage_key'] in indexable]
     n_img = _upsert_nircam_images(client, img_rows)
     print(f"  Indexed {n_img} nircam_images row(s) ({img_status})")
-    n_failed = len(mosaics) - len(img_rows)
+    n_failed = len(present) - len(img_rows) if not draft else 0
     if n_failed:
         print(f"  ({n_failed} mosaic(s) not indexed — upload failed; re-run to retry)")
 
@@ -795,11 +805,14 @@ def _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
     if reg_rows:
         print(f"  Registered {upsert_storage_objects(client, reg_rows)} mosaic storage object(s)")
 
-    # Re-point unchanged (skipped) mosaics to the current deployment.
-    skipped_keys = [m['storage_key'] for m in mosaics
-                    if m['storage_key'] in present and m['storage_key'] not in uploaded]
-    if skipped_keys:
-        set_active_deployment(client, skipped_keys, deployment_id)
+    # Re-point unchanged (skipped) mosaics to the current deployment — only on a
+    # PUBLISHED deploy. On --draft, leave unchanged mosaics on their live deployment
+    # (staging: don't take the published field dark).
+    if not draft:
+        skipped_keys = [m['storage_key'] for m in mosaics
+                        if m['storage_key'] in present and m['storage_key'] not in uploaded]
+        if skipped_keys:
+            set_active_deployment(client, skipped_keys, deployment_id)
 
 
 def _upsert_nircam_images(client, rows, batch_size=500):

--- a/python/campfire/deploy/supabase.py
+++ b/python/campfire/deploy/supabase.py
@@ -325,6 +325,23 @@ def get_latest_field_deployment_id(client: Client, field: str) -> int | None:
     return None
 
 
+def get_field_deployment_ids(client: Client, field: str) -> list[int]:
+    """ALL deployment ids for a NIRCam field, newest first (epic #261).
+
+    publish/revoke act on a whole field, but a field's objects can be spread across
+    several deployments (a ``--filter`` subset re-deploy re-points only that subset,
+    leaving other filters on an earlier deployment). Flipping just the latest would
+    partially publish — or, worse, leave part of a revoked field public — so the
+    lifecycle transition flips every deployment the field has.
+    """
+    resp = (client.table('deployments')
+            .select('id')
+            .eq('field', field)
+            .order('id', desc=True)
+            .execute())
+    return [r['id'] for r in (resp.data or [])]
+
+
 def set_deployment_status(
     client: Client,
     deployment_id: int,

--- a/supabase/migrations/20260701224420_nircam_images_retire_version.sql
+++ b/supabase/migrations/20260701224420_nircam_images_retire_version.sql
@@ -20,6 +20,16 @@ alter table "public"."nircam_images" drop constraint "nircam_images_unique";
 
 alter table "public"."nircam_images" drop column "version";
 
+-- Collapse pre-existing multi-version rows before the version-free UNIQUE, else the
+-- index build aborts on production (older reductions kept a row per version, so a
+-- slot can hold >1 row once `version` is dropped). Keep the newest (highest id) per
+-- (field, tile, filter, pixel_scale, extension). No-op on a fresh DB (0 rows).
+DELETE FROM public.nircam_images a
+  USING public.nircam_images b
+ WHERE a.field = b.field AND a.tile = b.tile AND a.filter = b.filter
+   AND a.pixel_scale = b.pixel_scale AND a.extension = b.extension
+   AND a.id < b.id;
+
 create unique index nircam_images_unique
   on public.nircam_images using btree (field, tile, filter, pixel_scale, extension);
 

--- a/supabase/migrations/20260702150000_retire_candide_mosaics.sql
+++ b/supabase/migrations/20260702150000_retire_candide_mosaics.sql
@@ -1,0 +1,19 @@
+-- epic #261, N3 / D6 — retire CANDIDE: hide the dead CANDIDE-pointing mosaics.
+--
+-- Before this epic, nircam_images.file_path held a CANDIDE-relative path
+-- (<field>/<filename>); the public page prepended a hardcoded CANDIDE base URL +
+-- shipped plaintext credentials. NIRCam now serves from OSN, where file_path is
+-- the canonical storage key (starts 'data/'). CANDIDE is retired, so the legacy
+-- rows point at a dead host — revoke them (D6): they go dark per (field, filter)
+-- until that field is re-reduced and re-deployed fresh, which republishes the slot
+-- with its OSN key (the mosaic deploy upserts on the same
+-- (field,tile,filter,pixel_scale,extension) slot).
+--
+-- Revoke rather than delete so the change is reversible and a re-deploy simply
+-- flips the slot back to published. No-op on a fresh DB (the seed has no
+-- nircam_images rows) and on any DB already on OSN keys.
+
+UPDATE public.nircam_images
+   SET deploy_status = 'revoked'
+ WHERE file_path NOT LIKE 'data/%'
+   AND deploy_status <> 'revoked';

--- a/web/components/nircam/CurlScriptGenerator.tsx
+++ b/web/components/nircam/CurlScriptGenerator.tsx
@@ -4,11 +4,7 @@ import React, { useState, useMemo } from 'react';
 import { ChevronDown, ChevronUp, Download, Copy, Check } from 'lucide-react';
 import type { NircamImage } from '@/lib/types';
 import { Button } from '@/components/ui/Button';
-
-// CANDIDE server configuration
-const CDN_BASE_URL = 'https://exchg.calet.org/hakins/data/data/nircam';
-const CDN_USERNAME = 'ember';
-const CDN_PASSWORD = 'ember!jwst';
+import { generateNircamMosaicDownloadUrls } from '@/lib/actions/download';
 
 interface CurlScriptGeneratorProps {
   selectedImages: NircamImage[];
@@ -30,37 +26,47 @@ export const CurlScriptGenerator: React.FC<CurlScriptGeneratorProps> = ({
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [script, setScript] = useState('');
+  const [generating, setGenerating] = useState(false);
 
   // Calculate total size
   const totalSize = useMemo(() => {
     return selectedImages.reduce((sum, img) => sum + (img.file_size || 0), 0);
   }, [selectedImages]);
 
-  // Generate the curl script
-  const script = useMemo(() => {
+  // Build the curl script. Presigned + HMAC-authorized proxy URLs come from the
+  // server action (authorized per-viewer against nircam_images RLS), so the
+  // script carries no credentials — just `curl` against the proxy URL. Async
+  // because it awaits the presign round-trip.
+  const buildScript = React.useCallback(async (): Promise<string> => {
     if (selectedImages.length === 0) return '';
 
+    const { urls } = await generateNircamMosaicDownloadUrls(
+      selectedImages.map((img) => img.file_path)
+    );
+
+    // Only include images we were authorized to presign.
+    const images = selectedImages.filter((img) => urls[img.file_path]);
+    if (images.length === 0) return '';
+
     // Group by field for organization
-    const fields = [...new Set(selectedImages.map((img) => img.field))];
+    const fields = [...new Set(images.map((img) => img.field))];
 
     let scriptContent = `#!/bin/bash
 # CAMPFIRE NIRCam Data Download Script
 # Generated: ${new Date().toISOString()}
-# Files: ${selectedImages.length}
+# Files: ${images.length}
 # Total size: ${formatFileSize(totalSize)}
+#
+# Download URLs below are pre-signed and expire after ~6 hours. Re-generate
+# this script if the links have expired.
 
 echo "============================="
 echo "CAMPFIRE NIRCam Data Download"
 echo "============================="
 echo ""
-echo "This script will download ${selectedImages.length} files (${formatFileSize(totalSize)} total)"
+echo "This script will download ${images.length} files (${formatFileSize(totalSize)} total)"
 echo ""
-
-# CDN credentials (pre-configured)
-USERNAME="${CDN_USERNAME}"
-PASSWORD="${CDN_PASSWORD}"
-
-BASE_URL="${CDN_BASE_URL}"
 
 # Create output directory
 mkdir -p nircam_data
@@ -73,7 +79,7 @@ echo ""
 
     // Add download commands grouped by field
     fields.forEach((field) => {
-      const fieldImages = selectedImages.filter((img) => img.field === field);
+      const fieldImages = images.filter((img) => img.field === field);
       scriptContent += `# Field: ${field.toUpperCase()} (${fieldImages.length} files)\n`;
       scriptContent += `mkdir -p ${field}\n`;
       scriptContent += `cd ${field}\n\n`;
@@ -82,7 +88,7 @@ echo ""
         const filename = img.file_path.split('/').pop() || img.file_path;
         scriptContent += `# File ${index + 1}/${fieldImages.length}: ${filename}\n`;
         scriptContent += `echo "Downloading ${filename}..."\n`;
-        scriptContent += `curl -L -u "$USERNAME:$PASSWORD" --progress-bar -o "${filename}" "$BASE_URL/${img.file_path}"\n`;
+        scriptContent += `curl -L --progress-bar -o "${filename}" "${urls[img.file_path]}"\n`;
         if (index < fieldImages.length - 1) {
           scriptContent += `\n`;
         }
@@ -98,6 +104,31 @@ echo "Files saved in: $(pwd)"
 
     return scriptContent;
   }, [selectedImages, totalSize]);
+
+  // (Re)generate the script whenever the panel is open and the selection
+  // changes. Presigned URLs are per-request, so we rebuild rather than memoize.
+  React.useEffect(() => {
+    if (!isExpanded || selectedImages.length === 0) {
+      setScript('');
+      return;
+    }
+    let cancelled = false;
+    setGenerating(true);
+    buildScript()
+      .then((content) => {
+        if (!cancelled) setScript(content);
+      })
+      .catch((err) => {
+        console.error('Failed to generate NIRCam download script:', err);
+        if (!cancelled) setScript('');
+      })
+      .finally(() => {
+        if (!cancelled) setGenerating(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isExpanded, buildScript, selectedImages.length]);
 
   const handleCopy = async () => {
     try {
@@ -160,6 +191,7 @@ echo "Files saved in: $(pwd)"
                     variant="ghost"
                     size="sm"
                     onClick={handleCopy}
+                    disabled={generating || !script}
                     className="text-gray-400 hover:text-white"
                   >
                     {copied ? (
@@ -178,6 +210,7 @@ echo "Files saved in: $(pwd)"
                     variant="ghost"
                     size="sm"
                     onClick={handleDownload}
+                    disabled={generating || !script}
                     className="text-gray-400 hover:text-white"
                   >
                     <Download className="w-4 h-4 mr-1.5" />
@@ -186,7 +219,7 @@ echo "Files saved in: $(pwd)"
                 </div>
               </div>
               <pre className="p-4 text-sm text-gray-300 font-mono overflow-x-auto max-h-96 overflow-y-auto">
-                <code>{script}</code>
+                <code>{generating ? 'Generating pre-signed download links…' : script}</code>
               </pre>
             </div>
           </div>

--- a/web/components/nircam/NircamTable.tsx
+++ b/web/components/nircam/NircamTable.tsx
@@ -16,9 +16,7 @@ import type { NircamImage } from '@/lib/types';
 import type { NircamFilterOptions } from './NircamFilterBar';
 import { Card } from '@/components/ui/Card';
 import { TablePagination } from '@/components/ui/TablePagination';
-
-// CANDIDE server base URL for NIRCam data
-const CDN_BASE_URL = 'https://exchg.calet.org/hakins/data/data/nircam';
+import { generateNircamMosaicDownloadUrls } from '@/lib/actions/download';
 
 interface NircamTableProps {
   images: NircamImage[];
@@ -60,9 +58,44 @@ const formatFileSize = (bytes: number | undefined): string => {
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
 };
 
-// Helper to construct download URL
-const getDownloadUrl = (image: NircamImage): string => {
-  return `${CDN_BASE_URL}/${image.file_path}`;
+// Per-row download button: authorizes + presigns the mosaic key server-side,
+// then navigates the browser to the credential-free proxy URL to start the
+// download. Kept as a small component so each row owns its loading state.
+const DownloadCell: React.FC<{ image: NircamImage }> = ({ image }) => {
+  const [busy, setBusy] = useState(false);
+
+  const handleDownload = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const { urls } = await generateNircamMosaicDownloadUrls([image.file_path]);
+      const proxyUrl = urls[image.file_path];
+      if (proxyUrl) {
+        const link = document.createElement('a');
+        link.href = proxyUrl;
+        link.download = image.file_path.split('/').pop() || image.file_path;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+      }
+    } catch (err) {
+      console.error('Failed to start NIRCam mosaic download:', err);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleDownload}
+      disabled={busy}
+      className="inline-flex items-center gap-1.5 text-sm text-primary hover:text-primary-hover hover:underline disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      <Download className="w-4 h-4" />
+      <span>{busy ? 'Preparing…' : 'Download'}</span>
+    </button>
+  );
 };
 
 export const NircamTable: React.FC<NircamTableProps> = ({
@@ -213,16 +246,7 @@ export const NircamTable: React.FC<NircamTableProps> = ({
       {
         id: 'download',
         header: () => <span>Download</span>,
-        cell: ({ row }) => (
-          <a
-            href={getDownloadUrl(row.original)}
-            className="inline-flex items-center gap-1.5 text-sm text-primary hover:text-primary-hover hover:underline"
-            download
-          >
-            <Download className="w-4 h-4" />
-            <span>Download</span>
-          </a>
-        ),
+        cell: ({ row }) => <DownloadCell image={row.original} />,
       },
     ],
     []

--- a/web/lib/actions/download.ts
+++ b/web/lib/actions/download.ts
@@ -487,6 +487,68 @@ export async function generateFitsDownloadUrl(
 }
 
 /**
+ * Authorize NIRCam mosaic downloads and return ready-to-fetch Worker proxy URLs,
+ * keyed by canonical storage key (file_path).
+ *
+ * Client-supplied keys are never trusted: the authorized set is re-derived
+ * server-side by querying `nircam_images` under the caller's RLS session. Because
+ * the table's RLS returns only published mosaics to non-admins (and all rows to
+ * admins), the intersection of the requested paths with what the query returns is
+ * exactly the set the caller may download — a draft/revoked or forged key simply
+ * never gets presigned. Each authorized key is presigned against its home backend
+ * (dual-read: OSN or R2) and HMAC-signed so the credential-free proxy Worker will
+ * fetch only URLs we authorized. Requested keys that aren't authorized are absent
+ * from the returned map.
+ */
+export async function generateNircamMosaicDownloadUrls(
+  filePaths: string[]
+): Promise<{ urls: Record<string, string>; error: string | null }> {
+  try {
+    if (!JWT_SECRET) {
+      return { urls: {}, error: 'Server configuration error: JWT secret not set' };
+    }
+
+    if (filePaths.length === 0) {
+      return { urls: {}, error: null };
+    }
+
+    // Re-derive the authorized key set server-side under the caller's RLS
+    // session. Never presign a client-supplied path we can't see in the DB.
+    const supabase = await createClient();
+    const { data: rows, error: queryError } = await supabase
+      .from('nircam_images')
+      .select('file_path')
+      .in('file_path', filePaths);
+
+    if (queryError) {
+      console.error('Error authorizing NIRCam mosaic download:', queryError);
+      return { urls: {}, error: 'Failed to authorize download' };
+    }
+
+    const authorizedKeys = [...new Set((rows || []).map((r) => r.file_path as string))];
+    if (authorizedKeys.length === 0) {
+      return { urls: {}, error: null };
+    }
+
+    // Presign each authorized key against its home backend (dual-read), then
+    // HMAC-sign the presigned URL so the proxy only fetches URLs we authorized.
+    const signed = await generateDownloadUrls(authorizedKeys, PRESIGN_TTL_SECONDS);
+    const urls: Record<string, string> = {};
+    await Promise.all(
+      authorizedKeys.map(async (key, i) => {
+        const sig = await signUrlSignature(signed[i], JWT_SECRET);
+        urls[key] = `${WORKER_URL}/proxy?url=${encodeURIComponent(signed[i])}&sig=${sig}`;
+      })
+    );
+
+    return { urls, error: null };
+  } catch (error) {
+    console.error('Error generating NIRCam mosaic download URLs:', error);
+    return { urls: {}, error: 'Failed to generate download URLs' };
+  }
+}
+
+/**
  * HMAC-SHA256(secret, url), base64url-encoded — the per-URL signature the proxy
  * Worker verifies. Web Crypto API (same primitive both ends).
  */


### PR DESCRIPTION
## N3 — serve NIRCam mosaics from OSN; retire CANDIDE (epic #261)

Moves public mosaic distribution off CANDIDE onto OSN. The visibility gate landed in N2 (`nircam_images.deploy_status` RLS), so N3 is the serving swap + CANDIDE retirement. Stacked on #273 (N2). Closes #265.

### Serving swap
- New server action `generateNircamMosaicDownloadUrls(filePaths)` in `web/lib/actions/download.ts`, mirroring `generateFitsDownloadUrl`: **authorizes server-side** by re-reading `nircam_images` through the user-scoped RLS client (so a non-admin can only get URLs for *published* mosaics — a draft/forged key is filtered out), then presigns each OSN key via `generateDownloadUrls` (dual-read backend) and wraps it in the HMAC-signed `${WORKER_URL}/proxy` (the #216 storage-agnostic proxy).
- `NircamTable.tsx`: the per-row download now calls the action → proxy URL, instead of `${CDN_BASE_URL}/${file_path}`.
- `CurlScriptGenerator.tsx`: emits `curl -o … "<presigned-proxy-url>"` from the action.

### Retire CANDIDE
- **Deleted the plaintext credentials** `CDN_USERNAME='ember'` / `CDN_PASSWORD='ember!jwst'` that shipped to every authenticated browser, plus the hardcoded `exchg.calet.org` base URL.
- **D6 data migration** (`20260702150000_retire_candide_mosaics.sql`): revokes the legacy CANDIDE-pointing `nircam_images` rows (`file_path NOT LIKE 'data/%'`) so they go dark per `(field, filter)` until re-reduced fresh — reversible (a re-deploy republishes the slot with its OSN key), no-op on a fresh DB.

### Deferred (functional via CLI)
Publish/revoke already reach NIRCam via `campfire deploy publish|revoke --field <field>`. A one-click admin **web** publish/revoke control for mosaics is a small follow-up (not blocking — the CLI is the reducer's primary path).

### Testing
`npm run build` green; the `nircam_images` lifecycle security harness (from N2) proves published-public / draft-admin-only; full migration chain `db reset` clean.

Generated with Claude Code