### PR TITLE
Accept comma-separated coordinates in `cfpipe download --target`

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -214,6 +214,19 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- **`cfpipe download --target` accepts comma-separated coordinates.** MAST's
+  JWST search API resolves the top-level `target` field as either an object
+  name or a *space*-separated `"RA Dec"` pair in decimal degrees (matching
+  astroquery's `MastMissions`, which sends `f"{ra.deg} {dec.deg}"`). A
+  comma-separated pair such as `--target 215.0,52.9` is not a valid name, so
+  the resolver raised server-side and the whole search failed with an opaque
+  `HTTPError: 500 Server Error` traceback. The download tool now folds an exact
+  `"num,num"` coordinate pair into the space-separated form before querying
+  (object names and already-spaced coords are untouched), MAST error bodies are
+  surfaced instead of discarded by `raise_for_status`, and the `download`
+  command catches `HTTPError` to print an actionable `--target`-format hint
+  rather than a stack trace. **No change to scientific output** (download CLI
+  ergonomics only).
 - **`migrate_layout_212.py` now delegates to a shared migrator (#244).** The
   one-time `$CAMPFIRE_ROOT` re-org logic moved verbatim into the zero-dependency
   `campfire_layout.migrate` core, so the operator script and `campfire sync` run

--- a/pipeline/campfire_pipeline/cli.py
+++ b/pipeline/campfire_pipeline/cli.py
@@ -178,6 +178,7 @@ def download(program, instrument, obs_ids, filters, targets, radius, radius_unit
     Auxiliary metafiles (e.g. NIRSpec MSA metadata) are fetched first so
     reduction can begin while uncal files are still downloading.
     """
+    import requests
     from campfire_pipeline.common.query import download_jwst_data
 
     instrument_upper = instrument.upper()
@@ -228,6 +229,16 @@ def download(program, instrument, obs_ids, filters, targets, radius, radius_unit
             token=token,
             workers=processes,
         )
+    except requests.HTTPError as e:
+        msg = f"MAST API error: {e}"
+        if targets:
+            msg += (
+                "\n\nHint: --target must be a resolvable object name (e.g. "
+                '"M1") or a "RA Dec" pair in decimal degrees separated by a '
+                'space (e.g. --target "215.0 52.9"). A comma-separated pair '
+                "is rejected by MAST's resolver."
+            )
+        raise click.ClickException(msg)
     except KeyboardInterrupt:
         click.echo("\n\nInterrupted. Re-run to resume (existing files will be skipped).")
         sys.exit(130)

--- a/pipeline/campfire_pipeline/common/query.py
+++ b/pipeline/campfire_pipeline/common/query.py
@@ -28,6 +28,55 @@ from campfire_layout import Scope, raw_dir as layout_raw_dir, raw_path
 BASE_URL = "https://mast.stsci.edu/search/jwst/api/v0.1"
 
 
+def _looks_like_float(token):
+    """True if ``token`` parses as a Python float (e.g. ``"215.0"``, ``"-3.5"``)."""
+    try:
+        float(token)
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
+def _normalize_target(target):
+    """Normalize one cone-search ``--target`` value for MAST's ``target`` field.
+
+    MAST resolves each entry either as an object name (``"M1"``) or as a
+    *space*-separated ``"RA Dec"`` pair in decimal degrees — matching
+    astroquery's ``MastMissions``, which sends ``f"{ra.deg} {dec.deg}"``. A
+    comma-separated coordinate pair such as ``"215.0,52.9"`` is *not* a valid
+    name, so the server-side resolver raises and the search returns HTTP 500.
+    Users habitually type coordinates with a comma, so fold an exact
+    ``"num,num"`` pair into the space-separated form MAST expects. Anything
+    else (object names, already-spaced coords) is returned unchanged.
+    """
+    s = (target or "").strip()
+    parts = [p.strip() for p in s.split(",")]
+    if len(parts) == 2 and all(_looks_like_float(p) for p in parts):
+        return f"{parts[0]} {parts[1]}"
+    return s
+
+
+def _raise_for_status_verbose(resp, context=""):
+    """Like ``resp.raise_for_status()`` but surface the response body.
+
+    MAST returns an explanatory message in the body on 4xx/5xx; the stock
+    ``raise_for_status`` discards it, which is exactly what turned this
+    endpoint's errors into opaque tracebacks. Preserves the
+    ``requests.HTTPError`` type so existing handlers still catch it.
+    """
+    if resp.ok:
+        return
+    body = (resp.text or "").strip()
+    if len(body) > 500:
+        body = body[:500] + "…"
+    ctx = f" ({context})" if context else ""
+    suffix = f"\n  server said: {body}" if body else ""
+    raise requests.HTTPError(
+        f"{resp.status_code} {resp.reason} for url: {resp.url}{ctx}{suffix}",
+        response=resp,
+    )
+
+
 def search_filesets(program_id, instrument="NIRSPEC", exp_type="NRS_MSASPEC",
                     obs_ids=None, filters=None, targets=None, radius=None,
                     radius_units=None, token=None):
@@ -53,6 +102,12 @@ def search_filesets(program_id, instrument="NIRSPEC", exp_type="NRS_MSASPEC",
     radius_units : str, optional
         ``"arcminutes"`` (default) or ``"arcseconds"``.
     """
+    # Fold comma-separated coordinate pairs ("215.0,52.9") into the
+    # space-separated "RA Dec" form MAST's resolver requires; a raw comma
+    # 500s server-side. Object names and already-spaced coords pass through.
+    if targets:
+        targets = [_normalize_target(t) for t in targets]
+
     obs_list = list(obs_ids) if obs_ids else [None]
     filt_list = list(filters) if filters else [None]
 
@@ -110,7 +165,8 @@ def search_filesets(program_id, instrument="NIRSPEC", exp_type="NRS_MSASPEC",
                 json=payload,
                 headers=headers,
             )
-            resp.raise_for_status()
+            _raise_for_status_verbose(
+                resp, context=f"searching program {program_id}")
             data = resp.json()
             for r in data["results"]:
                 key = r["fileSetName"]

--- a/pipeline/tests/test_query_target.py
+++ b/pipeline/tests/test_query_target.py
@@ -1,0 +1,50 @@
+"""Tests for cone-search ``--target`` normalization in the download tool.
+
+Regression coverage for the MAST HTTP 500 raised when a comma-separated
+coordinate pair (``"215.0,52.9"``) was forwarded verbatim to the JWST search
+API's ``target`` field, which only accepts an object name or a *space*-
+separated ``"RA Dec"`` pair.
+"""
+
+from campfire_pipeline.common.query import _looks_like_float, _normalize_target
+
+
+class TestNormalizeTarget:
+    def test_comma_coords_folded_to_space(self):
+        assert _normalize_target("215.0,52.9") == "215.0 52.9"
+
+    def test_comma_with_whitespace(self):
+        assert _normalize_target("215.0, 52.9") == "215.0 52.9"
+        assert _normalize_target("  -5.1 , +2.2  ") == "-5.1 +2.2"
+
+    def test_scientific_notation(self):
+        assert _normalize_target("1e2,-3.5") == "1e2 -3.5"
+
+    def test_space_coords_unchanged(self):
+        assert _normalize_target("150.1163 2.2070") == "150.1163 2.2070"
+
+    def test_object_names_unchanged(self):
+        assert _normalize_target("M1") == "M1"
+        assert _normalize_target("NGC 1300") == "NGC 1300"
+
+    def test_two_names_not_coords_unchanged(self):
+        # Two comma-separated names are not a coordinate pair — leave as-is.
+        assert _normalize_target("M1, M2") == "M1, M2"
+
+    def test_three_numbers_unchanged(self):
+        # Only an exact two-token pair is a coordinate; anything else is left
+        # untouched rather than silently mangled.
+        assert _normalize_target("1,2,3") == "1,2,3"
+
+
+class TestLooksLikeFloat:
+    def test_accepts_numbers(self):
+        assert _looks_like_float("215.0")
+        assert _looks_like_float("-3.5")
+        assert _looks_like_float("+2.2")
+        assert _looks_like_float("1e2")
+
+    def test_rejects_non_numbers(self):
+        assert not _looks_like_float("M1")
+        assert not _looks_like_float("")
+        assert not _looks_like_float(None)


### PR DESCRIPTION
## Summary

The `cfpipe download --target` command now accepts comma-separated coordinate pairs (e.g., `--target 215.0,52.9`) and automatically converts them to the space-separated format required by MAST's JWST search API. Additionally, HTTP error responses from MAST now surface their explanatory message bodies instead of being silently discarded, and the CLI provides a helpful hint when target-related errors occur.

## Changes

- **Target normalization** (`_normalize_target`): Folds exact `"num,num"` coordinate pairs into the space-separated `"RA Dec"` form MAST expects. Object names and already-spaced coordinates pass through unchanged.

- **Float detection** (`_looks_like_float`): Helper to identify numeric tokens, supporting standard Python float syntax including scientific notation.

- **Verbose HTTP error handling** (`_raise_for_status_verbose`): Replaces stock `raise_for_status()` to preserve MAST's server-side error messages (up to 500 chars) in the exception, making opaque 500 errors actionable.

- **CLI error handling**: The `download` command now catches `requests.HTTPError` and prints a user-friendly message with a hint about `--target` format requirements when targets are involved.

- **Comprehensive test coverage** (`test_query_target.py`): Regression tests for coordinate normalization (comma/space variants, scientific notation, edge cases) and float detection.

- **Changelog entry**: Documents the change as Infrastructure (CLI ergonomics only; no scientific output change).

## Implementation Details

- The normalization is applied early in `search_filesets()` before any API calls, ensuring all downstream code works with the canonical space-separated form.
- The verbose error handler preserves the `requests.HTTPError` type so existing exception handlers remain compatible.
- The CLI hint is only shown when `--target` was actually provided, avoiding noise for unrelated errors.

https://claude.ai/code/session_01MSFAiyf3b892kskWbaftC1