### PR TITLE
Enable Claude Code Review to run on PR updates

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,9 @@
     "allow": [
       "Bash(*)",
       "WebSearch",
-      "WebFetch(domain:github.com)"
+      "WebFetch(domain:github.com)",
+      "mcp__github_inline_comment",
+      "mcp__github_comment"
     ],
     "deny": [
       "Bash(rm -rf:*)",

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,10 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review, reopened]
+    # `synchronize` is required so the review also re-runs when new commits are
+    # pushed to an existing PR — without it the review only fired on open/reopen/
+    # ready-for-review, which looked like "it didn't run" after follow-up pushes.
+    types: [opened, synchronize, reopened, ready_for_review]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -39,6 +42,16 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
+          # Post a single updating summary comment in addition to inline comments,
+          # so the PR always gets visible feedback even when the review has no
+          # line-specific inline nits to buffer.
+          use_sticky_comment: true
+          # TEMPORARY (debugging, remove after we confirm posting works): surface the
+          # full agent transcript in the Actions log so we can see the exact tool that
+          # `permission_denials_count` is blocking. Note: this prints everything the
+          # agent read/ran into the (world-readable, on a public repo) job log, so it
+          # must be turned back off once the denied tool is identified.
+          show_full_output: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary

Updates the Claude Code Review GitHub Action workflow to re-run when new commits are pushed to an existing pull request, and adds configuration to post a summary comment alongside inline review feedback.

## Changes

- **Trigger on `synchronize` events**: Added `synchronize` to the PR trigger types so the review runs not just on open/reopen/ready-for-review, but also when new commits are pushed. This fixes the appearance that the review "didn't run" after follow-up pushes.

- **Enable sticky summary comment**: Set `use_sticky_comment: true` to post a single updating summary comment in addition to inline comments, ensuring the PR always gets visible feedback even when there are no line-specific nits.

- **Temporary debug output**: Set `show_full_output: true` to surface the full agent transcript in the Actions log for debugging permission denial issues. This is marked for removal once the blocked tool is identified.

- **Grant inline comment permissions**: Updated `.claude/settings.json` to allow `mcp__github_inline_comment` and `mcp__github_comment` tools, enabling the review action to post comments to the PR.

## Implementation Details

The `synchronize` event is essential for the workflow to feel responsive — without it, users pushing follow-up commits would see no new review run, creating the false impression the action wasn't working. The sticky comment feature ensures visibility of review feedback even when all issues are inline-only.

https://claude.ai/code/session_01HeYz5w2zq11XG9MSETjU4K