### PR TITLE
fix(ci): allow the Skill tool so Claude Code Review can post reviews

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,7 @@
       "Bash(*)",
       "WebSearch",
       "WebFetch(domain:github.com)",
+      "Skill",
       "mcp__github_inline_comment",
       "mcp__github_comment"
     ],


### PR DESCRIPTION
## Summary

Follow-up to #280. The Claude Code Review action was running green but posting nothing. The `show_full_output` transcript from a live run pinned the exact cause: the review agent's **`Skill` tool invocation was permission-denied**, so the `code-review` skill — which *is* the review — never launched.

```
permission_denials: [{
  tool_name: "Skill",
  tool_input: { skill: "code-review:code-review", args: ".../pull/281 --comment" }
}]
```

The action loads this repo's `.claude/settings.json` (`settingSources: user/project/local`), and its `permissions.allow` list didn't include `Skill`. The agent completed its gate-check, was denied when it went to run the review skill, ended its turn, and posted nothing ("No buffered inline comments") while the job still reported success.

## Change

- Add `Skill` to `permissions.allow` in `.claude/settings.json`, so the review workflow's `/code-review:code-review <pr> --comment` prompt can actually launch the skill.

The `mcp__github_inline_comment` / `mcp__github_comment` allows added in #280 cover the downstream comment-posting step once the skill runs, so they're kept.

## Note

`show_full_output: true` (added in #280 for debugging) is intentionally left on for one confirming run after this merges — so if anything still blocks after `Skill`, the transcript will show it. Once a review comment is confirmed to post on the next PR, a small follow-up will remove `show_full_output` (it prints the agent transcript into the job log and shouldn't stay on).

## Activation

The allow-list only takes effect from `main` (the action restores `.claude` from `origin/main`), so this has no effect until merged; the next PR after merge is the confirming run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeYz5w2zq11XG9MSETjU4K)_