### PR TITLE
fix(ci): scope the Skill allow to Skill(code-review:code-review)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,7 @@
       "Bash(*)",
       "WebSearch",
       "WebFetch(domain:github.com)",
-      "Skill",
+      "Skill(code-review:code-review)",
       "mcp__github_inline_comment",
       "mcp__github_comment"
     ],


### PR DESCRIPTION
## Summary

Follow-up to #282. That PR added a bare `Skill` to the allow-list, but the review still posted nothing on the PRs that ran afterwards. With the fix live on `main`, the `show_full_output` transcript of #283's run showed the `Skill` tool **still denied**:

```
permission_denials: [{ tool_name: "Skill",
  tool_input: { skill: "code-review:code-review", args: ".../pull/283 --comment" } }]
permissionMode: "default"
```

Per the Claude Code Skills docs, the permission rule for the `Skill` tool is `Skill(name)` (exact) or `Skill(name *)` (prefix). A **bare `Skill` entry does not reliably match a namespaced plugin-skill invocation** (`code-review:code-review`), so under the non-interactive `default` permission mode the call fell through to a denial and the review skill never launched.

## Change

- `.claude/settings.json`: `"Skill"` → `"Skill(code-review:code-review)"` — scope the allow to the exact plugin skill the review workflow invokes.

The `mcp__github_inline_comment` / `mcp__github_comment` allows (from #280) still cover the downstream comment-posting step once the skill runs.

## Note

`show_full_output: true` stays on for one more confirming run after this merges — this is the third iteration on the permission rule, so I want the transcript to prove the skill launches (and surface any *next* blocker inside the skill, e.g. its own `allowed-tools`). Once a review is confirmed posting, a small follow-up removes `show_full_output`.

## Activation

Only takes effect from `main` (the action restores `.claude` from `origin/main`), so no effect until merged; the next PR after merge is the confirming run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeYz5w2zq11XG9MSETjU4K)_