### PR TITLE
feat(nircam): field-scoped download + delete-local — the restore round-trip (#261 N6)

### DIFF
--- a/python/campfire/cli.py
+++ b/python/campfire/cli.py
@@ -744,7 +744,8 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
             click.echo(output)
         return
 
-    # Determine which observations to download
+    # Determine which observations (NIRSpec) + fields (NIRCam) to download
+    target_fields = set()
     if stale:
         stale_files = store.get_stale_objects()
         if not stale_files:
@@ -783,15 +784,17 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
             for fld in field_filter:
                 spectra = store.query_spectra(fields=[fld], limit=999999)
                 obs_for_field = set(s["observation"] for s in spectra if s.get("observation"))
-                if not obs_for_field:
-                    click.echo(f"✗ No observations found for field '{fld}'", err=True)
-                    store.close()
-                    sys.exit(1)
-                target_obs.update(obs_for_field)
+                if obs_for_field:
+                    target_obs.update(obs_for_field)  # NIRSpec field → its observations
+                else:
+                    # NIRCam (or spectra-less) field: field-scoped storage objects
+                    # (observation NULL), selected directly by field below.
+                    target_fields.add(fld)
 
         target_obs = sorted(target_obs)
 
-    if not target_obs:
+    target_fields = sorted(target_fields)
+    if not target_obs and not target_fields:
         click.echo("Nothing to download.")
         store.close()
         return
@@ -815,14 +818,15 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
         observations=list(target_obs),
         product_types=product_types,
         gratings=grating_list,
+        fields=list(target_fields),
     )
 
-    # Show per-observation status
+    # Show per-scope status (observation for NIRSpec, field for NIRCam)
     obs_with_downloads = []
     total_download = 0
     total_files = 0
 
-    for obs in target_obs:
+    for obs in list(target_obs) + list(target_fields):
         obs_pending = pending.get(obs, [])
         if not obs_pending:
             click.echo(f"  {obs}: up to date")
@@ -868,13 +872,14 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
 
     stats = download_objects(
         api,
-        obs_with_downloads,
+        list(target_obs),
         product_types,
         store,
         _products_dir(),
         max_workers=workers,
         download_session=dl_session,
         gratings=grating_list,
+        fields=list(target_fields),
     )
 
     click.echo(f"\n✓ Download complete")

--- a/python/campfire/db/store.py
+++ b/python/campfire/db/store.py
@@ -25,8 +25,10 @@ SCHEMA_VERSION = 6
 # default download set; --intermediate adds the canonical spectrum-exposures.
 # Both are layout-mirrored (have a local relpath), so the same engine places
 # them. Widen these tuples as more product types become client-fetchable.
-FINAL_PRODUCT_TYPES = ("nirspec_spec",)
-INTERMEDIATE_PRODUCT_TYPES = ("nirspec_spectrum_exposure",)
+FINAL_PRODUCT_TYPES = ("nirspec_spec", "nircam_mosaic")
+INTERMEDIATE_PRODUCT_TYPES = (
+    "nirspec_spectrum_exposure", "nircam_exposure", "nircam_expmap",
+)
 DOWNLOADABLE_PRODUCT_TYPES = FINAL_PRODUCT_TYPES + INTERMEDIATE_PRODUCT_TYPES
 
 
@@ -1175,13 +1177,16 @@ class LocalStore:
         observations: Optional[List[str]] = None,
         product_types: Optional[List[str]] = None,
         gratings: Optional[List[str]] = None,
+        fields: Optional[List[str]] = None,
     ) -> Dict[str, List[dict]]:
-        """Find storage objects that need downloading, grouped by observation.
+        """Find storage objects that need downloading, grouped by scope.
 
         A row is pending if it isn't materialized locally, or its local hash no
         longer matches the server's content_hash. ``--grating`` narrows finals
         (joined to the science spectrum); the registry has no grating column, so
-        exposure-level intermediates are always included.
+        exposure-level intermediates are always included. ``fields`` selects
+        field-scoped NIRCam rows (``observation IS NULL``); results are grouped by
+        ``observation`` for NIRSpec and by ``field`` for NIRCam.
         """
         where = ["so.status = 'active'"]
         params: list = []
@@ -1191,10 +1196,18 @@ class LocalStore:
             where.append(f"so.product_type IN ({ph})")
             params.extend(product_types)
 
+        # Scope: observations (NIRSpec) and/or fields (NIRCam, observation NULL).
+        scope = []
         if observations:
             ph = ",".join("?" * len(observations))
-            where.append(f"so.observation IN ({ph})")
+            scope.append(f"so.observation IN ({ph})")
             params.extend(observations)
+        if fields:
+            ph = ",".join("?" * len(fields))
+            scope.append(f"so.field IN ({ph})")
+            params.extend(fields)
+        if scope:
+            where.append("(" + " OR ".join(scope) + ")")
 
         join = ""
         if gratings:
@@ -1212,11 +1225,12 @@ class LocalStore:
         rows = self._conn.execute(
             f"""
             SELECT so.storage_key, so.content_hash, so.size_bytes, so.product_type,
-                   so.observation, so.spectrum_id, so.exposure_ref, so.local_file_hash
+                   so.observation, so.field, so.spectrum_id, so.exposure_ref,
+                   so.local_file_hash
             FROM storage_objects so
             {join}
             WHERE {where_sql}
-            ORDER BY so.observation, so.storage_key
+            ORDER BY so.observation, so.field, so.storage_key
             """,
             params,
         ).fetchall()
@@ -1225,7 +1239,9 @@ class LocalStore:
         for row in rows:
             d = dict(row)
             d["status"] = "new" if d["local_file_hash"] is None else "updated"
-            result.setdefault(d["observation"], []).append(d)
+            # NIRSpec rows key on observation; field-scoped NIRCam rows
+            # (observation NULL) key on field.
+            result.setdefault(d["observation"] or d.get("field"), []).append(d)
         return result
 
     def mark_object_synced(

--- a/python/campfire/deploy/cli.py
+++ b/python/campfire/deploy/cli.py
@@ -517,27 +517,32 @@ def revoke(ctx, config_path, obs, dry_run, local, field):
 
 @deploy_group.command('delete-local')
 @click.option('--config', 'config_path', default=None, help='Path to deploy config TOML.')
-@click.option('--obs', required=True, multiple=True, cls=_VariadicOption,
-              help='Observation name(s) whose local product files to delete.')
+@click.option('--obs', multiple=True, cls=_VariadicOption,
+              help='NIRSpec observation name(s) whose local product files to delete.')
+@click.option('--field', 'fields', multiple=True, cls=_VariadicOption,
+              help='NIRCam field name(s) whose local product files to delete.')
 @click.option('--verify', is_flag=True,
               help='Hash each local file and require it to match the registry sha256 '
                    'before deleting (default: trust the registry row exists + has a hash).')
 @click.option('--yes', is_flag=True, help='Actually delete (default is a dry-run preview).')
 @click.option('--local', is_flag=True, help='Use local Supabase (127.0.0.1:54321).')
 @click.pass_context
-def delete_local(ctx, config_path, obs, verify, yes, local):
+def delete_local(ctx, config_path, obs, fields, verify, yes, local):
     """Delete local product files that are verified-present in cloud storage (B4).
 
-    The verified-in-cloud interlock: only files that have an *active registry row
-    carrying a sha256 hash* are candidates, so a local file is never deleted
-    unless a verified cloud copy exists. --verify additionally requires the local
-    file to hash-match the cloud copy. Files with no registry row are never
-    touched. Dry-run by default — pass --yes to unlink. The delete half of the
-    reduce -> deploy -> delete-local -> re-download restore loop (intermediate
-    resume-set fetch lands with the canonical-exposure upload follow-up).
+    Scope by NIRSpec `--obs` and/or NIRCam `--field`. The verified-in-cloud
+    interlock: only files that have an *active registry row carrying a sha256
+    hash* are candidates, so a local file is never deleted unless a verified cloud
+    copy exists. --verify additionally requires the local file to hash-match the
+    cloud copy. Files with no registry row are never touched. Dry-run by default —
+    pass --yes to unlink. The delete half of the reduce -> deploy -> delete-local
+    -> re-download restore loop.
     """
     from campfire.deploy import registry as reg
     from campfire.config import products_dir
+
+    if not obs and not fields:
+        raise click.UsageError("Pass --obs <observation> and/or --field <field>.")
 
     config = load_config(config_path, local=_resolve_local(ctx, local))
     _gate_admin(config)
@@ -546,9 +551,12 @@ def delete_local(ctx, config_path, obs, verify, yes, local):
 
     grand_deleted = 0
     grand_bytes = 0
-    for obs_name in obs:
-        plan = reg.plan_delete_local(sb, obs_name, proot, verify=verify)
-        print(f"\n{obs_name}: {len(plan.deletable)} deletable "
+    scopes = [('obs', o) for o in obs] + [('field', f) for f in fields]
+    for kind, name in scopes:
+        plan = (reg.plan_delete_local(sb, None, proot, field=name, verify=verify)
+                if kind == 'field'
+                else reg.plan_delete_local(sb, name, proot, verify=verify))
+        print(f"\n{name}: {len(plan.deletable)} deletable "
               f"({_fmt_bytes(plan.total_bytes)}), {len(plan.skipped)} skipped, "
               f"{len(plan.absent)} registered-but-absent")
         for local_path, _key, reason in plan.skipped:
@@ -569,7 +577,8 @@ def delete_local(ctx, config_path, obs, verify, yes, local):
 
     if yes:
         print(f"\nDeleted {grand_deleted} files ({_fmt_bytes(grand_bytes)} freed). "
-              f"Restore with: campfire download --obs <name>")
+              f"Restore with: campfire download --obs <name> "
+              f"(or --field <name> --intermediate for NIRCam).")
     else:
         print(f"\nDry run — pass --yes to delete. Interlock: only registered, "
               f"sha256-hashed{'+verified' if verify else ''} files are candidates.")

--- a/python/campfire/deploy/registry.py
+++ b/python/campfire/deploy/registry.py
@@ -585,26 +585,27 @@ class DeleteLocalPlan:
 
 
 def plan_delete_local(
-    client, observation: str, products_root: Path, *,
-    verify: bool = False, bucket: str = 'data',
+    client, observation, products_root: Path, *,
+    field: Optional[str] = None, verify: bool = False, bucket: str = 'data',
 ) -> DeleteLocalPlan:
-    """Build a safe delete plan for an observation's local product files.
+    """Build a safe delete plan for a scope's local product files.
 
-    Enumerates the observation's *active registry rows* (objects known to be in
-    the cloud), maps each to its local path via the layout contract, and clears
-    only those that pass the interlock. Files with no registry row are never
-    touched — they are not in the candidate set.
+    Scope is an ``observation`` (NIRSpec) or a ``field`` (NIRCam, whose rows carry
+    ``observation IS NULL``) — pass exactly one. Enumerates that scope's *active
+    registry rows* (objects known to be in the cloud), maps each to its local path
+    via the layout contract, and clears only those that pass the interlock. Files
+    with no registry row are never touched — they are not in the candidate set.
     """
     from campfire.config import products_relpath
 
-    resp = (
+    q = (
         client.table('storage_objects')
         .select('storage_key, content_hash, size_bytes')
-        .eq('observation', observation)
         .eq('bucket', bucket)
         .eq('status', 'active')
-        .execute()
     )
+    q = q.eq('field', field) if field is not None else q.eq('observation', observation)
+    resp = q.execute()
     rows = resp.data or []
     plan = DeleteLocalPlan()
     for r in rows:

--- a/python/campfire/sync.py
+++ b/python/campfire/sync.py
@@ -313,18 +313,21 @@ def download_objects(
     dry_run: bool = False,
     download_session: Optional[requests.Session] = None,
     gratings: Optional[List[str]] = None,
+    fields: Optional[List[str]] = None,
 ) -> dict:
-    """Download storage objects for the given observations + product types.
+    """Download storage objects for the given observations/fields + product types.
 
     The single, product-type-agnostic download engine: plan locally from the
     storage_objects mirror, presign the to-download set, fetch in parallel,
-    verify ``content_hash``, and record local state. Used for finals,
-    intermediates, and (later) NIRCam alike.
+    verify ``content_hash``, and record local state. ``fields`` selects
+    field-scoped NIRCam rows (``observation IS NULL``); used for NIRSpec finals,
+    intermediates, and NIRCam alike.
     """
     pending = store.get_pending_objects(
         observations=list(observations),
         product_types=list(product_types),
         gratings=gratings,
+        fields=list(fields) if fields else None,
     )
     to_download = [row for rows in pending.values() for row in rows]
 

--- a/python/tests/test_delete_local.py
+++ b/python/tests/test_delete_local.py
@@ -121,3 +121,24 @@ def test_unregistered_local_file_is_never_a_candidate(tmp_path):
     _make_local(tmp_path, SPEC_KEY, b"orphan-local")
     plan = reg.plan_delete_local(_FakeClient([]), OBS, tmp_path)
     assert not plan.deletable and not plan.skipped and not plan.absent
+
+
+NIRCAM_KEY = "data/products/nircam/cosmos/f444w/jw1_nrcalong.fits"
+
+
+def test_field_scope_selects_nircam_rows(tmp_path):
+    # NIRCam exposure: observation IS NULL, field set (#261 N6). Field mode must
+    # select it; observation mode for the same name must not.
+    body = b"nircam-sci" * 100
+    local = _make_local(tmp_path, NIRCAM_KEY, body)
+    rows = [{
+        "storage_key": NIRCAM_KEY, "content_hash": _sha256(body),
+        "size_bytes": len(body), "observation": None, "field": "cosmos",
+        "bucket": "data", "status": "active",
+    }]
+    plan = reg.plan_delete_local(_FakeClient(rows), None, tmp_path, field="cosmos")
+    assert [k for _, k, _ in plan.deletable] == [NIRCAM_KEY]
+    assert local.exists()  # planning never deletes
+    # observation mode with the field name finds nothing (row has observation NULL)
+    plan_obs = reg.plan_delete_local(_FakeClient(rows), "cosmos", tmp_path)
+    assert not plan_obs.deletable

--- a/python/tests/test_store.py
+++ b/python/tests/test_store.py
@@ -460,6 +460,26 @@ class TestDownloadTracking:
         pending = store.get_pending_objects(product_types=["nirspec_spec"])
         assert sum(len(v) for v in pending.values()) == 3
 
+    def test_get_pending_by_field_nircam(self, store):
+        # A field-scoped NIRCam exposure: observation IS NULL, field set (#261 N6).
+        store.upsert_storage_objects([{
+            "storage_key": "data/products/nircam/cosmos/f444w/jw1_nrcalong.fits",
+            "id": None, "backend": "osn", "bucket": "data",
+            "content_hash": "sha256:nc1", "size_bytes": 16777216,
+            "content_type": "application/fits", "product_type": "nircam_exposure",
+            "instrument": "nircam", "status": "active",
+            "observation": None, "field": "cosmos", "spectrum_id": None,
+            "exposure_ref": None, "deployment_id": 1, "cfpipe_version": "v1.0",
+            "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+        }])
+        # Observation-keyed selection can't reach it (observation IS NULL)...
+        assert store.get_pending_objects(observations=["cosmos"]) == {}
+        # ...but field selection finds it, grouped under the field name.
+        pending = store.get_pending_objects(fields=["cosmos"])
+        assert list(pending.keys()) == ["cosmos"]
+        assert len(pending["cosmos"]) == 1
+        assert pending["cosmos"][0]["product_type"] == "nircam_exposure"
+
 
 class TestStatusView:
     """get_object_summary / get_object_stats drive `campfire status`."""


### PR DESCRIPTION
Epic #261, **N6 Part D** — the clean-local → re-fetch restore round-trip for NIRCam. Independent of #285 (the loop); both are N6.

## Why

The server/storage/download engine are already product-agnostic and serve published NIRCam field rows. The only gap was the client **selection** layer, which is **observation-keyed** — and NIRCam field rows carry `observation=NULL`, so they were unreachable by `download`/`delete-local`.

## What

- **`store.py`** — widen the downloadable tuples: `nircam_mosaic` (final), `nircam_exposure` + `nircam_expmap` (intermediate). `get_pending_objects` gains a `fields=` param (matches `so.field`) and keys field-scoped rows by **field** instead of observation, so the same engine plans them.
- **`sync.py`** — `download_objects` threads `fields=` through to the planner.
- **`download --field <f>`** — resolves to NIRCam field-scoped storage objects when the field has no NIRSpec spectra (instead of erroring), displayed + downloaded alongside observations. `--intermediate` pulls the canonical exposures for re-reduction.
- **`delete-local --field <f>`** (alongside/instead of `--obs`) — `plan_delete_local` filters by field for the `observation=NULL` NIRCam rows. **Same sha256 verified-in-cloud interlock**: a local file is never deleted without an active registry row carrying a sha256 (and, with `--verify`, a hash match). Files with no registry row are never touched.

## Restore a re-reducible field

`campfire download --field <f> --intermediate` (canonical exposures from OSN) + `campfire deploy nircam pull --field <f>` (re-materialize masks + exclusions from the DB). Raw uncal inputs come from MAST (out of scope).

## Tests

2 new (`get_pending_objects` by field; `delete-local` field scope preserving the interlock); 56 client + 95 deploy/store tests green. **No schema change.**

Generated with Claude Code

https://claude.ai/code/session_01RNb7rkgTctaSBQADpsPtQN