### PR TITLE
Update default Chi2 ylims

### DIFF
--- a/web/components/spectra/RedshiftFitPlot.tsx
+++ b/web/components/spectra/RedshiftFitPlot.tsx
@@ -259,7 +259,7 @@ export const RedshiftFitPlot: React.FC<RedshiftFitPlotProps> = ({
     // Best-fit vertical line
     traces.push({
       x: [fitData.redshift, fitData.redshift],
-      y: [chi2Min * 0.5, chi2Max * 2],
+      y: [chi2Min * 0.9, chi2Max * 1.1],
       type: 'scatter' as const,
       mode: 'lines' as const,
       name: 'Best fit',

--- a/web/components/spectra/RedshiftFitPlot.tsx
+++ b/web/components/spectra/RedshiftFitPlot.tsx
@@ -280,7 +280,7 @@ export const RedshiftFitPlot: React.FC<RedshiftFitPlotProps> = ({
     // Layout configuration
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const layout: any = {
-      uirevision: 'debug-1',
+      uirevision: 'constant',
       title: {
         text: `${grating} Redshift Fit (z = ${fitData.redshift.toFixed(4)}, χ² = ${fitData.chi2_min.toFixed(2)}, conf = ${fitData.confidence.toFixed(1)}%)`,
         font: { size: 16, color: colors.text },
@@ -320,6 +320,7 @@ export const RedshiftFitPlot: React.FC<RedshiftFitPlotProps> = ({
         zerolinecolor: colors.grid,
         domain: [0, 0.3],
         range: [Math.log10(chi2Min * 0.9), Math.log10(chi2Max * 1.1)],
+        autorange: false,
       },
       margin: { l: 80, r: 120, t: 50, b: 50 },
       paper_bgcolor: colors.paper,

--- a/web/components/spectra/RedshiftFitPlot.tsx
+++ b/web/components/spectra/RedshiftFitPlot.tsx
@@ -280,7 +280,7 @@ export const RedshiftFitPlot: React.FC<RedshiftFitPlotProps> = ({
     // Layout configuration
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const layout: any = {
-      uirevision: 'constant',
+      uirevision: 'debug-1',
       title: {
         text: `${grating} Redshift Fit (z = ${fitData.redshift.toFixed(4)}, χ² = ${fitData.chi2_min.toFixed(2)}, conf = ${fitData.confidence.toFixed(1)}%)`,
         font: { size: 16, color: colors.text },

--- a/web/components/spectra/RedshiftFitPlot.tsx
+++ b/web/components/spectra/RedshiftFitPlot.tsx
@@ -319,6 +319,7 @@ export const RedshiftFitPlot: React.FC<RedshiftFitPlotProps> = ({
         gridcolor: colors.grid,
         zerolinecolor: colors.grid,
         domain: [0, 0.3],
+        range: [Math.log10(chi2Min * 0.9), Math.log10(chi2Max * 1.1)],
       },
       margin: { l: 80, r: 120, t: 50, b: 50 },
       paper_bgcolor: colors.paper,

--- a/web/components/spectra/SpectrumPlot.tsx
+++ b/web/components/spectra/SpectrumPlot.tsx
@@ -625,6 +625,8 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
           type: 'log' as const,
           gridcolor: plotColors.grid,
           zerolinecolor: plotColors.grid,
+          range: [Math.log10(chi2Min * 0.9), Math.log10(chi2Max * 1.1)],
+          autorange: false,
         },
         margin: { l: 80, r: 20, t: 40, b: 40 },
         paper_bgcolor: plotColors.paper,


### PR DESCRIPTION
Zoomed in on Chi2 by default.
Old: 0.5x min, 2.0x max
New: 0.9x min, 1.1x max