### PR TITLE
Change chi2 yaxis bounds

### DIFF
--- a/web/components/spectra/SpectrumPlot.tsx
+++ b/web/components/spectra/SpectrumPlot.tsx
@@ -625,6 +625,8 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
           type: 'log' as const,
           gridcolor: plotColors.grid,
           zerolinecolor: plotColors.grid,
+          range: [Math.log10(chi2Min * 0.9), Math.log10(chi2Max * 1.1)],
+          autorange: false,
         },
         margin: { l: 80, r: 20, t: 40, b: 40 },
         paper_bgcolor: plotColors.paper,


### PR DESCRIPTION
Zoomed in on Chi2 by default.
Old: 0.5x min, 2.0x max
New: 0.9x min, 1.1x max