### PR TITLE
feat(nircam): freeze canonical exposures — combine on a local working tree (#261 N7)

### DIFF
--- a/layout/campfire_layout/__init__.py
+++ b/layout/campfire_layout/__init__.py
@@ -34,6 +34,7 @@ from .paths import (
     glob_pattern,
     local_path,
     local_relpath,
+    nircam_work_dir,
     raw_dir,
     raw_path,
     reference_dir,
@@ -56,6 +57,7 @@ __all__ = [
     "PRODUCTS", "ProductSpec", "get",
     # paths
     "Roots", "roots", "campfire_root", "dir_for", "local_path", "local_relpath",
+    "nircam_work_dir",
     "reference_dir", "shared_reference_dir", "raw_dir", "raw_path", "cache_path",
     "glob_pattern",
     # keys

--- a/layout/campfire_layout/paths.py
+++ b/layout/campfire_layout/paths.py
@@ -85,6 +85,26 @@ def local_path(product_type: str, scope: Scope, filename: Optional[str] = None,
     return roots(root).campfire_root / PurePosixPath(local_relpath(product_type, scope, filename))
 
 
+def nircam_work_dir(scope: Scope, *, root: Optional[Path] = None) -> Path:
+    """Local combine working-copy dir: ``products/nircam_work/<field>/<filt>/``.
+
+    The combine phase (bad-pixel, outlier, resample) mutates disposable working
+    copies of the per-exposure FITS here so the canonical ``nircam_exposure``
+    under ``products/nircam/<field>/<filt>/`` stays frozen as the process-phase
+    output.
+
+    Deliberately *not* a ``PRODUCTS`` entry, for the same reason ``cache_path`` /
+    ``raw_dir`` are plain helpers: it is a regenerable, local-only tree that
+    carries no storage key, is never deployed (deploy globs
+    ``products/nircam/…``, not this sibling ``nircam_work``), and is never
+    reverse-dispatched (:func:`~campfire_layout.bijection.parse_relpath`). The
+    ``<filt>`` leaf mirrors the canonical tree's path tail so the pipeline's
+    ``split('/')[-2]`` filter parse keeps working on a work copy.
+    """
+    scope.require("field", "filt")
+    return roots(root).campfire_root / "products" / "nircam_work" / scope.field / scope.filt
+
+
 # ---------------------------------------------------------------------------
 # Tree-level helpers (span products, used by Observation/Field setup)
 # ---------------------------------------------------------------------------

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -26,6 +26,18 @@ Release procedure: edit the `## Unreleased` section below, then run
 ## Unreleased
 
 ### Calibration
+- NIRCam manual masks now actually reach the mosaic, and uncovered pixels are
+  `NaN` (epic #261, N7). The `apply_mask` step painted user region masks as DQ
+  bit `1024` (`DEAD`), which `good_bits='~DO_NOT_USE'` **ignores** — so a mask
+  had no effect on the mosaic unless the (default-off) `mask_set_nan` knob was
+  set. Masks are now honored via `DO_NOT_USE` (fused onto the combine working
+  copy), so masked pixels are correctly dropped from outlier detection and
+  resample. Separately, both drizzle backends now use `fillval='NaN'`, so mosaic
+  pixels with no coverage — or masked in every overlapping exposure — read as
+  `NaN` instead of `0`, retiring the post-drizzle "SCI=NaN where WHT=0" pass
+  (`bkgsub` is NaN-safe, so covered pixels are unchanged). Both change mosaic
+  pixel values. The `[nircam.apply_mask]` `mask_flag` / `mask_set_nan` config
+  knobs are removed — the mask now lives purely in the DQ contract.
 - NIRCam `striping` now runs **after** `image2`, on flat-fielded, flux-
   calibrated cal-stage data, and fits *and applies* the 1/f correction in that
   same frame. Process order is now detector1 → persistence → wisp → image2 →
@@ -81,6 +93,21 @@ Release procedure: edit the `## Unreleased` section below, then run
   file is exactly today's behavior, and un-excluding in the portal + re-pulling
   re-includes the exposure on the next combine. No change to any exposure's
   pixel values.
+- **NIRCam combine no longer mutates the canonical per-exposure FITS** (epic
+  #261, N7). `bad_pixel`, `outlier`, and `resample` now run on disposable
+  working copies under `products/nircam_work/<field>/<filter>/`, materialized
+  from the frozen canonical by `Field.materialize_work` (copy where stale + fuse
+  `CFMASK` → `DO_NOT_USE`). Only `apply_mask` still writes the canonical, and
+  only its `CFMASK` extension — the canonical's SCI/DQ stay byte-identical to the
+  process-phase output. This is what lets a mosaic re-deploy leave the pristine
+  exposure in OSN untouched (instead of overwriting it with outlier-rejected
+  bytes) and lets a restored exposure re-combine from a clean input. The working
+  tree is local-only and never deployed; combine stays incremental because the
+  working copies retain their `CFP_OUT` stamps across runs (re-copied only when
+  the canonical is re-processed or its mask changes). `campfire deploy`
+  additionally hard-refuses to upload a canonical carrying combine-phase CFP
+  stamps (`CFP_BPIX`/`CFP_OUT`) — a field reduced by the old in-place combine
+  must be re-run through `cfpipe nircam process` before it can deploy.
 - **BREAKING (MAJOR):** the NIRCam mosaic `version` axis is retired (epic #261,
   N2 / D3). Mosaic products are now named `mosaic_nircam_<filter>_<field>_<scale>_<tile>_<ext>.fits`
   with **no** `_<version>_` segment — one canonical mosaic per

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -349,8 +349,10 @@
 # --- combine phase (ensemble) ---
 
 [nircam.apply_mask]
-    mask_flag = 1024
-    mask_set_nan = false
+    # No tunable keys: the user region masks are recorded as a CFMASK extension
+    # on the canonical exposure and honored via DO_NOT_USE on the combine
+    # working copy (good_bits='~DO_NOT_USE'). The former mask_flag / mask_set_nan
+    # knobs are gone — the mask now lives purely in the DQ contract.
 
 [nircam.bad_pixel]
     # Opt-in "consistently bad" pixel detector: stacks the DO_NOT_USE bit

--- a/pipeline/campfire_pipeline/nircam/cli.py
+++ b/pipeline/campfire_pipeline/nircam/cli.py
@@ -42,6 +42,11 @@ _SCI_MUTATING_STEPS = {
     'wisp', 'striping', 'image2', 'sky', 'variance',
 }
 
+# Combine ensemble steps whose CFP stamp (CFP_BPIX/CFP_OUT) lives on the working
+# copy rather than the frozen canonical — `reset --from` must target the work
+# tree for these. apply_mask is excluded: its CFP_MASK lives on the canonical.
+_COMBINE_WORK_CFP_STEPS = {'bad_pixel', 'outlier'}
+
 # Short labels for the status command's column headers (max 4 chars).
 _STEP_LABELS = {
     'detector1':   'det1',
@@ -347,11 +352,21 @@ def status(config, field, filters):
                 f'{field_obj.filter_dir(filt)}')
             continue
 
-        # Read CFP_* once per exposure
-        per_exp = {
-            os.path.basename(f).removesuffix('.fits'): cfp_mod.get_steps(f)
-            for f in sorted(exposures)
-        }
+        # Read CFP_* once per exposure. Process stamps + CFP_MASK live on the
+        # canonical; the combine ensemble stamps (CFP_BPIX/CFP_OUT) live on the
+        # working copy, so overlay those from the work tree when it exists —
+        # otherwise combine steps would always render as "not done".
+        per_exp = {}
+        for f in sorted(exposures):
+            rootname = os.path.basename(f).removesuffix('.fits')
+            steps = cfp_mod.get_steps(f)
+            work = field_obj.get_exposure_path(rootname, filt, work=True)
+            if os.path.exists(work):
+                work_steps = cfp_mod.get_steps(work)
+                for k in ('CFP_BPIX', 'CFP_OUT'):
+                    if k in work_steps:
+                        steps[k] = work_steps[k]
+            per_exp[rootname] = steps
 
         rootname_width = max(len(r) for r in per_exp) + 2
         log('')
@@ -398,8 +413,9 @@ def status(config, field, filters):
               help='Filters to reset (default: all from field).')
 @click.option('--from', 'from_step', default=None,
               type=click.Choice(STEP_NAMES),
-              help='Clear CFP_<step> + every later CFP key on each '
-                   'canonical exposure. Refuses SCI-mutating steps.')
+              help='Clear CFP_<step> + every later CFP key on each exposure '
+                   '(the combine working copies for bad_pixel/outlier, the '
+                   'canonical otherwise). Refuses SCI-mutating steps.')
 @click.option('--uncal', 'uncal', is_flag=True,
               help='Delete every canonical exposure file (and any '
                    '_jump.fits sidecars) for the selected filters.')
@@ -452,16 +468,23 @@ def reset(config, field, filters, from_step, uncal, yes):
             f"across filters {filter_list}"
         )
     else:
+        cfp_key = _step_to_cfp_key(from_step)
+        # CFP_BPIX / CFP_OUT live on the combine working copies, not the frozen
+        # canonical, so resetting those steps must target the work tree.
+        # Resetting a process step or apply_mask clears canonical keys, and the
+        # combine re-run cascades automatically (materialize_work re-copies the
+        # work tree once the canonical is rewritten with a newer mtime).
+        on_work = from_step in _COMBINE_WORK_CFP_STEPS
         affected = []
         for filt in filter_list:
             affected.extend(
-                f for f in field_obj.get_exposure_files(filt)
-                if cfp_mod.has_step(f, _step_to_cfp_key(from_step))
+                f for f in field_obj.get_exposure_files(filt, work=on_work)
+                if cfp_mod.has_step(f, cfp_key)
             )
+        where = 'working copies' if on_work else 'canonical exposures'
         action = (
-            f"CLEAR CFP_{_step_to_cfp_key(from_step)[4:]}+ keys on "
-            f"{len(affected)} canonical exposures across filters "
-            f"{filter_list}"
+            f"CLEAR {cfp_key}+ keys on "
+            f"{len(affected)} {where} across filters {filter_list}"
         )
 
     log(f'Reset action: {action}')

--- a/pipeline/campfire_pipeline/nircam/drizzle.py
+++ b/pipeline/campfire_pipeline/nircam/drizzle.py
@@ -514,9 +514,14 @@ def drizzle_tile(
     n_planes = max(1, (n_inputs + 31) // 32)
     outctx = np.zeros((n_planes, ny, nx), dtype=np.int32)
 
+    # fillval='NaN' leaves every zero-weight output pixel — no coverage OR masked
+    # in all overlapping inputs — as NaN in SCI, which is why the mosaic no longer
+    # needs a post-drizzle "set SCI=NaN where WHT=0" pass. The variance drizzle
+    # keeps 'INDEF' (0): outvarw==0 pixels are turned into NaN by the
+    # outvar/outvarw normalization below, so ERR is already NaN there.
     sci_drizzle = Drizzle(
         out_img=outsci, out_wht=outwht, out_ctx=outctx,
-        kernel=kernel, fillval='INDEF',
+        kernel=kernel, fillval='NaN',
         max_ctx_id=n_inputs,
     )
     var_drizzle = Drizzle(

--- a/pipeline/campfire_pipeline/nircam/field.py
+++ b/pipeline/campfire_pipeline/nircam/field.py
@@ -18,10 +18,12 @@ from typing import List, Optional
 
 import toml
 import numpy as np
+from astropy.io import fits
 
 from campfire_layout import (
     Scope,
     dir_for,
+    nircam_work_dir as layout_nircam_work_dir,
     raw_dir as layout_raw_dir,
     reference_dir as layout_reference_dir,
     roots,
@@ -67,6 +69,34 @@ def _expand_braces(pattern):
     for opt in options:
         result.extend(_expand_braces(prefix + opt + suffix))
     return result
+
+
+# DO_NOT_USE == 1 (jwst.datamodels.dqflags.pixel['DO_NOT_USE']). Hardcoded so
+# field.py stays free of the jwst/CRDS import chain (which, imported at module
+# top, would lock CRDS into serverless mode before setup_environment runs).
+_DO_NOT_USE = np.uint32(1)
+
+
+def _prime_work_copy(path):
+    """Prime a freshly-copied combine working copy for the ensemble steps.
+
+    Fuses the canonical's CFMASK extension into the working copy's DQ as
+    ``DO_NOT_USE`` (so ``good_bits='~DO_NOT_USE'`` excludes the user-masked
+    pixels in outlier detection and resample), and clears any ``CFP_BPIX`` /
+    ``CFP_OUT`` provenance so those ensemble steps re-derive their flags on the
+    fresh copy. Operates on the copy only — the canonical is never touched.
+    """
+    with fits.open(path, mode='update', memmap=False) as hdul:
+        if 'CFMASK' in hdul and 'DQ' in hdul:
+            masked = np.asarray(hdul['CFMASK'].data).astype(bool)
+            dq = np.asarray(hdul['DQ'].data)
+            dq[masked] |= _DO_NOT_USE
+            hdul['DQ'].data = dq          # reassign so astropy flushes the change
+        hdr = hdul[0].header
+        for key in ('CFP_BPIX', 'CFP_OUT'):
+            if key in hdr:
+                del hdr[key]
+        hdul.flush()
 
 
 def _is_pixel_scale_section(value):
@@ -380,18 +410,26 @@ class Field:
 
         log(f"Workspace ready for field '{self.name}' at {self.products_dir}")
 
-    def filter_dir(self, filter_name):
+    def filter_dir(self, filter_name, work=False):
         """Return the flat per-filter products directory for this field.
 
         ``$CAMPFIRE_ROOT/products/nircam/<field>/<filter>/`` holds every
         output for the (field, filter) pair: per-exposure FITS files,
         drizzled mosaic tiles, split extension files, diagnostic PDFs,
         and outlier/mosaic manifest JSON.
+
+        With ``work=True`` return the combine *working-copy* directory
+        ``products/nircam_work/<field>/<filter>/`` instead — the disposable,
+        never-deployed tree the combine phase (bad_pixel / outlier / resample)
+        mutates so the canonical per-exposure FITS stay frozen as the
+        process-phase output. See :meth:`materialize_work`.
         """
         if self.products_dir is None:
             raise RuntimeError("setup_workspace() must be called first")
-        return str(dir_for('nircam_exposure', Scope(field=self.name, filt=filter_name),
-                           root=self.campfire_root))
+        scope = Scope(field=self.name, filt=filter_name)
+        if work:
+            return str(layout_nircam_work_dir(scope, root=self.campfire_root))
+        return str(dir_for('nircam_exposure', scope, root=self.campfire_root))
 
     def _load_excluded_exposures(self):
         """Load reviewer exclusions from ``reference/<field>/exposures.json``.
@@ -457,12 +495,18 @@ class Field:
         return sorted(result)
 
     def get_exposure_files(self, filter_name, skip=None, with_step=None,
-                           status=None):
+                           status=None, work=False):
         """Get canonical per-exposure files from the filter's flat dir.
 
-        These are the files that the new pipeline mutates in place — one FITS
-        file per exposure, named simply ``<rootname>.fits`` (no ``_rate`` /
-        ``_cal`` / ``_jhat`` / ``_crf`` suffix).
+        These are the files that the process phase writes — one FITS file per
+        exposure, named simply ``<rootname>.fits`` (no ``_rate`` / ``_cal`` /
+        ``_jhat`` / ``_crf`` suffix).
+
+        With ``work=True`` enumerate the combine working-copy tree
+        (``products/nircam_work/…``) instead of the canonical tree — used by the
+        combine steps, which operate on working copies (see
+        :meth:`materialize_work`). The glob, skip list, and ``with_step`` CFP
+        filtering are identical; only the directory differs.
 
         Mosaic outputs share the same directory but are named ``mosaic_*``,
         which the ``jw*`` field globs naturally exclude.
@@ -485,13 +529,15 @@ class Field:
             in the orchestrator (which marks fresh CFP_OUT keys onto the
             cache as outlier finishes); other callers can omit it and pay
             the per-file fits.open.
+        work : bool, optional
+            Enumerate the working-copy tree instead of the canonical tree.
 
         Returns
         -------
         list of str
             Sorted absolute paths.
         """
-        filter_dir = self.filter_dir(filter_name)
+        filter_dir = self.filter_dir(filter_name, work=work)
 
         result = []
         for pattern in self.files:
@@ -526,13 +572,68 @@ class Field:
 
         return sorted(result)
 
-    def get_exposure_path(self, rootname, filter_name):
+    def get_exposure_path(self, rootname, filter_name, work=False):
         """Return the canonical path for a given exposure rootname.
 
         ``rootname`` is the JWST filename stem without any ``_<suffix>.fits``
-        (e.g. ``'jw01727028001_04101_00003_nrcalong'``).
+        (e.g. ``'jw01727028001_04101_00003_nrcalong'``). With ``work=True``
+        return the working-copy path under ``products/nircam_work/…``.
         """
-        return os.path.join(self.filter_dir(filter_name), f'{rootname}.fits')
+        return os.path.join(self.filter_dir(filter_name, work=work),
+                            f'{rootname}.fits')
+
+    def materialize_work(self, filter_name, status=None, overwrite=False):
+        """Refresh the combine working copies for a filter; return their paths.
+
+        The combine phase must not mutate the canonical per-exposure FITS (those
+        are the frozen process-phase output that gets deployed to OSN). Instead
+        it works on disposable copies under ``products/nircam_work/…``. This
+        method brings that tree up to date:
+
+        * A canonical exposure is (re)copied to its working path when the working
+          copy is missing, ``overwrite`` is set, or the canonical is newer than
+          the working copy (i.e. it was re-processed, or its manual mask changed
+          — both rewrite the canonical). Up-to-date working copies are left
+          untouched so their ``CFP_BPIX`` / ``CFP_OUT`` stamps survive and
+          bad_pixel / outlier skip them — this is what keeps combine incremental.
+        * Each freshly-copied working copy is *primed*: the canonical's CFMASK
+          extension is fused into its DQ as ``DO_NOT_USE`` (so downstream steps'
+          ``good_bits='~DO_NOT_USE'`` exclude masked pixels), and any stale
+          ``CFP_BPIX`` / ``CFP_OUT`` provenance is cleared so combine re-derives
+          those flags on the fresh copy. The canonical is never modified.
+
+        The freshness test is an mtime comparison, which is reliable here because
+        the canonical and its working copy live on the same filesystem (one
+        clock). ``--overwrite`` forces a full re-copy.
+
+        If a ``StepStatus`` is passed, the working paths are rescanned into it so
+        the combine steps' skip checks reflect the working tree's current state.
+        """
+        import shutil
+
+        canon = self.get_exposure_files(filter_name)          # frozen process outputs
+        work_dir = self.filter_dir(filter_name, work=True)
+        os.makedirs(work_dir, exist_ok=True)
+
+        work_paths = []
+        for src in canon:
+            dst = os.path.join(work_dir, os.path.basename(src))
+            work_paths.append(dst)
+            stale = (
+                overwrite
+                or not os.path.exists(dst)
+                or os.path.getmtime(src) > os.path.getmtime(dst)
+            )
+            if not stale:
+                continue
+            tmp = dst + '.tmp'
+            shutil.copyfile(src, tmp)      # content only → work copy gets a fresh mtime
+            _prime_work_copy(tmp)          # fuse mask + clear combine stamps on the tmp
+            os.replace(tmp, dst)           # atomic reveal of the primed copy
+
+        if status is not None:
+            status.rescan(work_paths)
+        return sorted(work_paths)
 
     def get_tile_wcs(self, tile_name, pixel_scale='30mas'):
         """Get WCS parameters for a tile at the requested pixel scale.

--- a/pipeline/campfire_pipeline/nircam/manifest.py
+++ b/pipeline/campfire_pipeline/nircam/manifest.py
@@ -346,12 +346,15 @@ def get_stale_tiles(field, filtname, stage_config):
         tiles = [tiles]
 
     files_to_skip = stage_config.get('files_to_skip', [])
-    # Resample's input source: canonical exposures whose outlier detection
-    # has finished (CFP_OUT keyword stamped).
+    # Resample's input source: the combine working copies whose outlier
+    # detection has finished (CFP_OUT keyword stamped). CFP_OUT lives on the
+    # working copies, never the frozen canonical, so this must match the set
+    # resample_step actually drizzles (work=True).
     candidate_files = field.get_exposure_files(
         filtname,
         skip=files_to_skip if files_to_skip else None,
         with_step='CFP_OUT',
+        work=True,
     )
 
     results = []

--- a/pipeline/campfire_pipeline/nircam/orchestrate.py
+++ b/pipeline/campfire_pipeline/nircam/orchestrate.py
@@ -66,6 +66,12 @@ COMBINE_STEPS = [
 ALL_STEPS = PROCESS_STEPS + COMBINE_STEPS
 STEP_NAMES = [name for name, _ in ALL_STEPS]
 
+# Combine steps that read/write the disposable working copies rather than the
+# frozen canonical (apply_mask is excluded — it writes the canonical's CFMASK).
+# Running any of these standalone via ``run_step`` must materialize the work
+# tree first.
+_COMBINE_WORK_STEPS = {'bad_pixel', 'outlier', 'resample'}
+
 # Steps that hit CRDS — used by run_step() to decide when to pre-fetch
 # reference files before parallel dispatch. striping now runs *after* image2
 # (on flat-fielded, flux-calibrated cal-stage data) so it no longer resolves a
@@ -352,7 +358,8 @@ def _run_wcs_shift(field, config, filtname, n_processes, overwrite, status):
 
 
 def _run_bad_pixel(field, config, filtname, n_processes, overwrite, status):
-    exposures = field.get_exposure_files(filtname)
+    # Combine phase: operate on the working copies, never the frozen canonical.
+    exposures = field.get_exposure_files(filtname, work=True)
     if not exposures:
         log(f"bad_pixel: no exposures for {filtname}")
         return
@@ -413,10 +420,12 @@ def _run_outlier_per_visit(field, cfg, filtname, n_processes, overwrite, status,
     Parallelization
     ---------------
     Visits are dispatched in parallel across ``n_processes`` workers.
-    Each visit writes only to its own canonical files (via ``atomic_save``)
-    while reading other visits' files as cross-visit overlap padding.
-    Because reads/writes are atomic and outlier_detection only ADDS DQ
-    bits (SCI is unchanged), parallel runs cannot crash; the only
+    Each visit writes only to its own working copies (via ``atomic_save``)
+    while reading other visits' working copies as cross-visit overlap padding.
+    The frozen canonical exposures are never touched (see
+    ``Field.materialize_work``). Because reads/writes are atomic and
+    outlier_detection only ADDS DQ bits (SCI is unchanged), parallel runs
+    cannot crash; the only
     observable difference vs. serial is that a worker may read an overlap
     file's DQ before the visit owning that file has stamped its new
     outlier bits, producing a small median bias in those overlap pixels.
@@ -430,7 +439,8 @@ def _run_outlier_per_visit(field, cfg, filtname, n_processes, overwrite, status,
         outlier_step_campfire if implementation == 'campfire' else outlier_step
     )
 
-    exposures = field.get_exposure_files(filtname)
+    # Combine phase: operate on the working copies, never the frozen canonical.
+    exposures = field.get_exposure_files(filtname, work=True)
     if not exposures:
         log(f"outlier: no exposures for {filtname}")
         return
@@ -500,8 +510,10 @@ def _run_outlier_per_visit(field, cfg, filtname, n_processes, overwrite, status,
 
 def _run_resample(field, config, filtname, n_processes, overwrite, status,
                   reduction_version):
+    # Read the outlier-finished working copies; the mosaic itself is written to
+    # the canonical filter dir (resample_step derives it from field.filter_dir).
     exposures = field.get_exposure_files(filtname, with_step='CFP_OUT',
-                                         status=status)
+                                         status=status, work=True)
     if not exposures:
         log(f"resample: no CFP_OUT-stamped exposures for {filtname}")
         return
@@ -614,7 +626,16 @@ def run_combine(field, config, filters=None, n_processes=1, overwrite=False):
     for filt in filters:
         log(f"--- Combine: {filt} ---")
         for step_name, _ in COMBINE_STEPS:
-            if step_name == 'resample':
+            if step_name == 'apply_mask':
+                # apply_mask writes the canonical (CFMASK extension only) — the
+                # last thing to touch the frozen canonical this phase. Then
+                # refresh the disposable working copies the ensemble steps
+                # mutate (copy canonical -> work where stale, fuse CFMASK ->
+                # DO_NOT_USE) and rescan them into the status cache.
+                _RUNNERS[step_name](field, config, filt, n_processes,
+                                    overwrite, status)
+                field.materialize_work(filt, status=status, overwrite=overwrite)
+            elif step_name == 'resample':
                 _run_resample(field, config, filt, n_processes, overwrite,
                               status, reduction_version)
             else:
@@ -642,6 +663,10 @@ def run_step(step_name, field, config, filters=None, n_processes=1,
                                     overwrite=overwrite)
 
     for filt in filters:
+        # A standalone combine ensemble step needs the working copies present
+        # and primed (canonical -> work, CFMASK -> DO_NOT_USE) before it runs.
+        if step_name in _COMBINE_WORK_STEPS:
+            field.materialize_work(filt, status=status, overwrite=overwrite)
         if step_name == 'resample':
             reduction_version = _resolve_reduction_version(config)
             _run_resample(field, config, filt, n_processes, overwrite,

--- a/pipeline/campfire_pipeline/nircam/status.py
+++ b/pipeline/campfire_pipeline/nircam/status.py
@@ -82,3 +82,15 @@ class StepStatus:
                     self._present[p] = {k for k in cfp.CFP_KEYS if k in hdr}
             except (OSError, IOError):
                 self._present[p] = set()
+
+    def rescan(self, paths):
+        """Force a re-read of ``paths``, overwriting any cached entry.
+
+        Unlike :meth:`add_paths` (which leaves already-seen paths untouched),
+        this refreshes the snapshot from disk — used when a file's on-disk CFP
+        state was reset out from under the cache, e.g. a combine working copy
+        re-materialized from its canonical, which drops CFP_BPIX / CFP_OUT.
+        """
+        for p in paths:
+            self._present.pop(p, None)
+        self.add_paths(paths)

--- a/pipeline/campfire_pipeline/nircam/steps/apply_masks.py
+++ b/pipeline/campfire_pipeline/nircam/steps/apply_masks.py
@@ -1,18 +1,24 @@
 """
-apply_masks: paint user region-file masks into the canonical exposure DQ.
+apply_masks: record user region-file masks on the canonical exposure.
 
-First step of the mosaic phase. Reads ``.reg`` files from
+First step of the combine phase. Reads ``.reg`` files from
 ``mask_dir/<filter>/<rootname>.reg``, rasterizes each region to a pixel mask
-using the exposure WCS, and writes the result to a ``CFMASK`` extension on
-the canonical file. Then OR's ``CFMASK`` into ``DQ`` (with the user-chosen
-flag bit, default ``1024``) so downstream JWST steps (outlier detection,
-resample) honor it through their ``dqbits`` parameters.
+using the exposure WCS, and writes the union as a ``CFMASK`` extension on the
+canonical file. The canonical's SCI and DQ are left untouched — the mask is a
+per-exposure property recorded *alongside* the science data, not baked into it.
 
-CFMASK is rebuilt from scratch every run, replacing any existing CFMASK
-extension on the canonical file. This gives the user a clean way to *add*
-mask regions iteratively (re-running with ``--overwrite`` widens DQ
-correctly). Mask *removal* requires ``--reset-from apply_masks`` because
-DQ updates are cumulative — the orchestrator enforces this.
+The mask's actual effect on the mosaic (exclusion from outlier detection and
+resample, via ``good_bits='~DO_NOT_USE'``) happens later, on the disposable
+combine working copy, where ``Field.materialize_work`` fuses CFMASK into the
+working DQ as ``DO_NOT_USE``. Keeping the canonical DQ mask-free means (a) the
+canonical stays byte-identical to the process output apart from the added
+CFMASK extension — so it deploys and re-reviews cleanly — and (b) mask edits
+are non-destructive and fully reversible, since CFMASK is rebuilt from scratch
+every run.
+
+Because ``apply_masks`` short-circuits when the canonical already carries
+``CFP_MASK``, re-run with ``--reset-from apply_masks`` (or ``--overwrite``) to
+pick up an edited ``.reg`` file.
 
 If there is no ``.reg`` file for an exposure, the step still stamps
 ``CFP_MASK = 'no .reg file'`` so the status command can distinguish
@@ -38,9 +44,9 @@ def apply_masks_step(exposure_file, field, step_config, overwrite=False,
     exposure_file : str
     field : Field
     step_config : dict
-        ``[nircam.apply_mask]`` (legacy ``[nircam.stage2.apply_mask]``).
-        Keys: ``mask_flag`` (DQ bit, default 1024), ``mask_set_nan``
-        (boolean, default False — also write NaN to SCI for masked pixels).
+        ``[nircam.apply_mask]`` (legacy ``[nircam.stage2.apply_mask]``). No
+        tunable keys — the mask is recorded as a CFMASK extension and honored
+        via DO_NOT_USE on the combine working copy (``Field.materialize_work``).
     overwrite : bool
     status : StepStatus, optional
         Pre-scanned CFP_* status cache.
@@ -64,9 +70,6 @@ def apply_masks_step(exposure_file, field, step_config, overwrite=False,
             )
         return
 
-    flag = step_config.get('mask_flag', 1024)
-    set_to_nan = step_config.get('mask_set_nan', False)
-
     log(f"Applying masks from {os.path.basename(reg_file)} to {rootname}")
 
     from regions import Regions
@@ -78,7 +81,11 @@ def apply_masks_step(exposure_file, field, step_config, overwrite=False,
             wcs = model.get_fits_wcs()
         shape = model.data.shape
 
-        cfmask = np.zeros(shape, np.uint32)
+        # CFMASK is a plain 0/1 union of the user regions, rebuilt from scratch
+        # each run. It records *what* is masked; the DO_NOT_USE fuse (how the
+        # mask is honored) happens on the combine working copy, so the canonical
+        # SCI/DQ are never touched here.
+        cfmask = np.zeros(shape, np.uint8)
         regs = Regions.read(reg_file)
         for reg in regs:
             try:
@@ -90,14 +97,7 @@ def apply_masks_step(exposure_file, field, step_config, overwrite=False,
                 log(f"Warning: skipping region in {reg_file}: {e}")
                 continue
 
-            cfmask |= (mask_arr * flag).astype(np.uint32)
-            if set_to_nan:
-                model.data[mask_arr] = np.nan
-
-        # OR user mask into DQ. Note: DQ updates are cumulative — re-running
-        # with a smaller .reg does not unflag previously masked pixels.
-        # Use --reset-from apply_masks for clean removal.
-        model.dq |= cfmask
+            cfmask |= mask_arr.astype(np.uint8)
 
         cfmask_hdu = fits.ImageHDU(cfmask, name='CFMASK')
         atomic_save(

--- a/pipeline/campfire_pipeline/nircam/steps/resample.py
+++ b/pipeline/campfire_pipeline/nircam/steps/resample.py
@@ -139,7 +139,7 @@ def _drizzle_tile_via_jwst(
             'output_shape': shape,
             'crpix': crpix,
             'crval': crval,
-            'fillval': 'indef',
+            'fillval': 'NaN',
             'weight_type': 'ivm',
             'single': False,
             'blendheaders': True,
@@ -324,24 +324,10 @@ def resample_step(filtname, exposure_files, field, step_config,
                 log(f"  skipping background subtraction "
                     f"for {os.path.basename(mosaic_file)}")
 
-        if needs_rebuild:
-            # Set SCI = NaN where WHT = 0 (matches the ERR=NaN convention).
-            # bkgsub subtracts a smooth background everywhere, so without
-            # this pass uncovered pixels carry small nonzero residuals.
-            # Applied after bkgsub and before extension splitting so the
-            # NaN-fill propagates to _sci.fits / _i2d.fits.
-            with fits.open(mosaic_file, mode='update') as hdul:
-                wht = hdul['WHT'].data
-                sci = hdul['SCI'].data
-                no_cov = wht == 0
-                n_no_cov = int(no_cov.sum())
-                if n_no_cov:
-                    sci[no_cov] = np.nan
-                    hdul['SCI'].data = sci
-                    log(
-                        f"  set SCI=NaN at {n_no_cov:,} WHT=0 pixels "
-                        f"({n_no_cov / sci.size * 100:.1f}%)"
-                    )
+        # No post-drizzle "SCI=NaN where WHT=0" pass is needed: both drizzle
+        # backends use fillval='NaN', so uncovered / fully-masked pixels are
+        # already NaN, and bkgsub preserves that (it masks isnan(sci) before
+        # fitting and subtracts elementwise, so NaN - background = NaN).
 
         split_enabled = step_config.get('split_extensions', True)
 

--- a/pipeline/tests/test_nircam_work_tree.py
+++ b/pipeline/tests/test_nircam_work_tree.py
@@ -1,0 +1,117 @@
+"""Combine working-tree tests (epic #261, N7).
+
+The combine phase must not mutate the canonical per-exposure FITS. These cover
+the two new pieces of machinery:
+
+* ``_prime_work_copy`` — fuse CFMASK -> DO_NOT_USE, reset combine-phase stamps.
+* ``Field.materialize_work`` — copy/freshness/incrementality, canonical frozen.
+
+Synthetic FITS only (no jwst / CRDS), so the module imports cleanly.
+"""
+
+import os
+
+import numpy as np
+from astropy.io import fits
+
+from campfire_pipeline.nircam.field import Field, _prime_work_copy
+
+_DO_NOT_USE = 1
+_ROOT = 'jw01727028001_04101_00003_nrcalong'
+
+
+def _write_canonical(path, *, sci=None, cfmask=None,
+                     stamps=('CFP_JHAT', 'CFP_MASK', 'CFP_BPIX', 'CFP_OUT')):
+    """Write a minimal canonical exposure (primary + SCI + DQ [+ CFMASK])."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    if sci is None:
+        sci = np.arange(16, dtype=np.float32).reshape(4, 4)
+    dq = np.zeros((4, 4), dtype=np.uint32)
+    prim = fits.PrimaryHDU()
+    for k in stamps:
+        prim.header[k] = '2026-07-03T00:00:00'
+    hdus = [prim, fits.ImageHDU(sci, name='SCI'), fits.ImageHDU(dq, name='DQ')]
+    if cfmask is not None:
+        hdus.append(fits.ImageHDU(cfmask.astype(np.uint8), name='CFMASK'))
+    fits.HDUList(hdus).writeto(path, overwrite=True)
+
+
+def test_prime_fuses_mask_and_clears_combine_stamps(tmp_path):
+    cf = np.zeros((4, 4), np.uint8)
+    cf[1, 1] = 1
+    cf[2, 3] = 1
+    p = str(tmp_path / f'{_ROOT}.fits')
+    _write_canonical(p, cfmask=cf)
+
+    _prime_work_copy(p)
+
+    with fits.open(p) as hdul:
+        dq = hdul['DQ'].data
+        hdr = hdul[0].header
+    # DO_NOT_USE set on exactly the masked pixels, nowhere else.
+    assert np.array_equal((dq & _DO_NOT_USE).astype(bool), cf.astype(bool))
+    # Combine-phase stamps are cleared so the fresh copy re-runs those steps;
+    # the mask + process stamps are retained.
+    assert 'CFP_BPIX' not in hdr and 'CFP_OUT' not in hdr
+    assert 'CFP_MASK' in hdr and 'CFP_JHAT' in hdr
+
+
+def test_prime_without_cfmask_leaves_dq_untouched(tmp_path):
+    p = str(tmp_path / f'{_ROOT}.fits')
+    _write_canonical(p, cfmask=None, stamps=('CFP_JHAT',))
+    _prime_work_copy(p)
+    with fits.open(p) as hdul:
+        assert not hdul['DQ'].data.any()
+
+
+def _make_field(tmp_path):
+    f = Field(name='cosmos', filters=['f444w'], files=['jw01727*'],
+              tangent_point=(150.0, 2.0), tiles={})
+    f.setup_workspace(campfire_root=str(tmp_path))
+    return f
+
+
+def test_materialize_copies_to_work_tree_and_freezes_canonical(tmp_path):
+    f = _make_field(tmp_path)
+    cf = np.zeros((4, 4), np.uint8)
+    cf[0, 0] = 1
+    sci = np.arange(16, dtype=np.float32).reshape(4, 4)
+    canon = os.path.join(f.filter_dir('f444w'), f'{_ROOT}.fits')
+    _write_canonical(canon, sci=sci, cfmask=cf)
+
+    work_paths = f.materialize_work('f444w')
+
+    assert len(work_paths) == 1
+    wp = work_paths[0]
+    assert os.path.exists(wp) and 'nircam_work' in wp
+    with fits.open(wp) as hdul:
+        assert hdul['DQ'].data[0, 0] & _DO_NOT_USE       # mask fused on the work copy
+        np.testing.assert_array_equal(hdul['SCI'].data, sci)
+    # The canonical DQ stays frozen — no DO_NOT_USE baked in.
+    with fits.open(canon) as hdul:
+        assert not hdul['DQ'].data.any()
+
+
+def test_materialize_is_incremental(tmp_path):
+    f = _make_field(tmp_path)
+    canon = os.path.join(f.filter_dir('f444w'), f'{_ROOT}.fits')
+    _write_canonical(canon, cfmask=None, stamps=('CFP_JHAT', 'CFP_MASK'))
+    wp = f.materialize_work('f444w')[0]
+
+    # Simulate outlier stamping CFP_OUT onto the work copy.
+    with fits.open(wp, mode='update') as hdul:
+        hdul[0].header['CFP_OUT'] = '2026-07-03T01:00:00'
+        hdul.flush()
+
+    # Canonical unchanged -> work copy kept -> its CFP_OUT survives (combine skips).
+    f.materialize_work('f444w')
+    with fits.open(wp) as hdul:
+        assert 'CFP_OUT' in hdul[0].header
+
+    # Canonical re-processed (newer mtime) -> work copy re-copied fresh, dropping
+    # CFP_OUT so combine re-runs on it.
+    wm = os.path.getmtime(wp)
+    os.utime(canon, (wm + 10, wm + 10))
+    f.materialize_work('f444w')
+    with fits.open(wp) as hdul:
+        assert 'CFP_OUT' not in hdul[0].header

--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -92,21 +92,29 @@ def _stage_from_header(header):
 
 
 def _sci_dq_hash(path):
-    """Return ``'sha256:<hex>'`` over just the SCI+DQ arrays, or None.
+    """Return ``'sha256:<hex>'`` over the SCI+DQ+CFMASK arrays, or None.
 
     The science-only change-detection digest for the deploy dedup (epic #261, D1).
     Reproduces ``campfire_pipeline.nircam.manifest.compute_file_hash`` deploy-side
     (deploy must not import the pipeline): ``do_not_scale_image_data=True`` hashes
     the raw stored bytes regardless of BZERO/BSCALE, ``memmap=False`` forces a real
     read. Whole-file hashes churn on every pipeline re-save (header timestamps), so
-    they can't drive dedup; the SCI+DQ digest is stable across a science-identical
-    re-save. Returns None if neither array is present (never dedup on an empty hash).
+    they can't drive dedup; the SCI+DQ+CFMASK digest is stable across a
+    science-identical re-save.
+
+    CFMASK (the user manual-mask extension) is included so a mask edit — which the
+    N7 freeze records as CFMASK on the canonical without touching SCI/DQ — still
+    re-uploads the exposure. It is hashed *last*, and the ``not in hdul`` guard
+    skips it when absent, so an un-masked exposure hashes byte-identically to the
+    old SCI+DQ-only digest (no spurious re-upload on the first post-N7 deploy).
+
+    Returns None if none of the arrays are present (never dedup on an empty hash).
     """
     h = hashlib.sha256()
     hashed_any = False
     try:
         with fits.open(path, memmap=False, do_not_scale_image_data=True) as hdul:
-            for extname in ('SCI', 'DQ'):
+            for extname in ('SCI', 'DQ', 'CFMASK'):
                 if extname not in hdul:
                     continue
                 data = hdul[extname].data
@@ -200,6 +208,7 @@ def _read_exposure_metadata(path):
         'date_obs': None,
         'ra_center': None,
         'dec_center': None,
+        'combine_stamped': False,
     }
     # JWST naming convention: {visit}_{activity}_{exposure}_{detector}.fits
     parts = path.stem.split('_')
@@ -212,6 +221,9 @@ def _read_exposure_metadata(path):
         with fits.open(path, memmap=True) as hdul:
             hdr0 = hdul[0].header
             info['stage'] = _stage_from_header(hdr0)
+            # A canonical exposure must be the frozen process output; a
+            # combine-phase stamp means it was mutated in place (old pipeline).
+            info['combine_stamped'] = ('CFP_BPIX' in hdr0 or 'CFP_OUT' in hdr0)
             info['date_obs'] = hdr0.get('DATE-OBS')
             info['detector'] = hdr0.get('DETECTOR', info['detector'])
             if len(hdul) > 1:
@@ -306,7 +318,29 @@ def build_fits_upload_tasks(field, exposures):
     ``campfire-layout`` CANONICAL scheme (``data/products/nircam/<field>/<filter>/
     <rootname>.fits``). Returns a list of ``UploadTask``; content-hash dedup is
     applied by the caller (unchanged exposures are dropped before upload).
+
+    Freeze guard (epic #261, N7): the canonical ``nircam_exposure`` must be the
+    frozen process-phase output. An exposure carrying a combine-phase CFP stamp
+    (``CFP_BPIX`` / ``CFP_OUT``) was mutated in place by an old-pipeline combine;
+    uploading it would overwrite the pristine canonical in OSN with
+    outlier-rejected bytes and poison a later restore. Refuse loudly rather than
+    silently clobber — the fix is to regenerate the canonical with
+    ``cfpipe nircam process``. ``CFP_MASK`` is allowed: apply_mask legitimately
+    records the manual mask on the canonical.
     """
+    stamped = sorted(
+        f'{filtname}/{basename}'
+        for (filtname, basename), info in exposures.items()
+        if info.get('combine_stamped')
+    )
+    if stamped:
+        raise RuntimeError(
+            "Refusing to deploy combine-mutated canonical exposures — these carry "
+            "CFP_BPIX/CFP_OUT (bad-pixel/outlier flags baked into the canonical by "
+            "an old-pipeline combine). Re-run `cfpipe nircam process` to regenerate "
+            "the frozen canonical, then redeploy:\n  " + "\n  ".join(stamped)
+        )
+
     tasks = []
     for (filtname, basename), info in sorted(exposures.items()):
         path = info['path']
@@ -347,7 +381,7 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
     Records a **field-scoped deployment** (provenance + the draft->published
     lifecycle), uploads the canonical exposure FITS (+ any field expmaps) to OSN
     under ``campfire-layout`` canonical keys (content-hash deduped on
-    ``sha256(SCI+DQ)``), uploads preview PNGs to OSN, upserts ``nircam_exposures``,
+    ``sha256(SCI+DQ+CFMASK)``), uploads preview PNGs to OSN, upserts ``nircam_exposures``,
     and registers every landed object in ``storage_objects`` tagged with that
     ``deployment_id``.
 

--- a/python/tests/test_nircam_deploy.py
+++ b/python/tests/test_nircam_deploy.py
@@ -62,6 +62,22 @@ def test_sci_dq_hash_none_without_sci_or_dq(tmp_path):
     assert nc._sci_dq_hash(p) is None
 
 
+def test_sci_dq_hash_includes_cfmask(tmp_path):
+    # A manual-mask edit (N7 records it as a CFMASK extension on the canonical,
+    # without touching SCI/DQ) must still change the digest so the exposure
+    # re-uploads; an un-masked exposure (no CFMASK) hashes as before.
+    sci = np.arange(16, dtype="float32").reshape(4, 4)
+    dq = np.zeros((4, 4), dtype="int32")
+    plain = _make_exposure(tmp_path / "p.fits", sci, dq)
+    masked = _make_exposure(tmp_path / "m.fits", sci, dq)
+    cf = np.zeros((4, 4), dtype="uint8")
+    cf[1, 1] = 1
+    with fits.open(masked, mode="update") as hdul:
+        hdul.append(fits.ImageHDU(data=cf, name="CFMASK"))
+        hdul.flush()
+    assert nc._sci_dq_hash(masked) != nc._sci_dq_hash(plain)
+
+
 # --- upload-task builders ---------------------------------------------------
 
 def test_build_fits_upload_tasks_uses_canonical_keys(tmp_path):
@@ -72,6 +88,30 @@ def test_build_fits_upload_tasks_uses_canonical_keys(tmp_path):
     assert len(tasks) == 1
     assert tasks[0].r2_key == EXP_KEY
     assert tasks[0].content_type == "application/fits"
+
+
+def test_read_metadata_flags_only_combine_stamps(tmp_path):
+    # CFP_MASK (apply_mask on the canonical) is allowed; CFP_BPIX / CFP_OUT
+    # (ensemble steps) mark a mutated canonical the freeze guard must reject.
+    sci = np.zeros((4, 4), "float32")
+    dq = np.zeros((4, 4), "int32")
+    clean = _make_exposure(tmp_path / "clean.fits", sci, dq,
+                           extra_header={"CFP_JHAT": "t", "CFP_MASK": "t"})
+    stamped = _make_exposure(tmp_path / "stamped.fits", sci, dq,
+                             extra_header={"CFP_JHAT": "t", "CFP_OUT": "t"})
+    assert nc._read_exposure_metadata(clean)["combine_stamped"] is False
+    assert nc._read_exposure_metadata(stamped)["combine_stamped"] is True
+
+
+def test_build_fits_upload_tasks_refuses_combine_stamped(tmp_path):
+    path = tmp_path / f"{ROOT}.fits"
+    path.write_bytes(b"\x00")
+    exposures = {
+        ("f444w", ROOT): {"path": path, "filter": "f444w", "basename": ROOT,
+                          "combine_stamped": True},
+    }
+    with pytest.raises(RuntimeError, match="combine-mutated"):
+        nc.build_fits_upload_tasks("cosmos", exposures)
 
 
 def test_discover_expmap_tasks_canonical_keys(tmp_path):


### PR DESCRIPTION
## Why

Epic #261, N7. The NIRCam combine phase mutated the **canonical** per-exposure FITS in place — `apply_mask` (CFP_MASK), `bad_pixel` (CFP_BPIX), and `outlier` (CFP_OUT) all `atomic_save`'d DQ back to `products/nircam/<field>/<filt>/<root>.fits`. Because `campfire deploy --field` has no mosaic-only path (it always re-scans exposures alongside the mosaic and re-uploads any whose content hash changed), **deploying a re-combined mosaic overwrote the pristine canonical exposure in OSN with outlier-rejected bytes**, and poisoned a later `download --intermediate` restore (which re-fetched the now-outlier'd input). Re-combining from an already-outlier-flagged exposure is also scientifically wrong (double-flagging).

Investigation surfaced two coupled correctness bugs in the same code path:
- **Manual masks were inert in the mosaic.** `apply_mask` painted DQ bit `1024` (`DEAD`), which every drizzle/outlier/resample `good_bits='~DO_NOT_USE'` *ignores* — so a mask had no effect unless the default-off `mask_set_nan` knob was set.
- **Uncovered/masked mosaic pixels were `0`, not `NaN`** — `fillval='INDEF'` over a zeroed accumulator, patched up by a separate post-drizzle pass.

## What

**Freeze the canonical at the process/combine boundary.**
- `bad_pixel` / `outlier` / `resample` now run on disposable working copies under `products/nircam_work/<field>/<filt>/`, materialized from the frozen canonical by `Field.materialize_work` (copy-where-stale by mtime + fuse `CFMASK → DO_NOT_USE`, clearing `CFP_BPIX`/`CFP_OUT` so a fresh copy re-derives them). The working tree is **local-only, never deployed** (a `campfire_layout.nircam_work_dir` path helper — not a `PRODUCTS`/bijection entry, same pattern as `cache_path`/`raw_dir`), and keeps its `CFP_OUT` stamps across runs so combine stays incremental.
- `apply_mask` still writes the canonical but **only its CFMASK extension** — SCI/DQ stay byte-identical to the process output, so the canonical deploys + re-reviews cleanly and mask edits are non-destructive/reversible (CFMASK is rebuilt from scratch every run).

**Fix the two mask/fillval bugs.**
- Masks are honored via `DO_NOT_USE` on the working copy (existing `good_bits` unchanged). `[nircam.apply_mask]` `mask_flag` / `mask_set_nan` knobs removed.
- Both SCI drizzle backends use `fillval='NaN'`; the post-mosaic `SCI=NaN where WHT=0` pass is retired (`bkgsub` is NaN-safe: masks `isnan(sci)` before fitting, subtracts elementwise). Variance drizzle unchanged (ERR already NaN via normalization).

**Deploy.**
- `_sci_dq_hash` now hashes `SCI+DQ+CFMASK` — backward-compatible (un-masked exposures, which have no CFMASK, hash identically → no spurious re-upload), so a mask edit re-uploads the canonical.
- `build_fits_upload_tasks` hard-refuses a canonical carrying `CFP_BPIX`/`CFP_OUT` (an old-pipeline in-place combine), pointing the deployer at `cfpipe nircam process`.

**Split-aware diagnostics** (CFP provenance now lives across two trees):
- `manifest.get_stale_tiles` selects the `CFP_OUT` **work copies** (was reading the frozen canonical → empty → broken mosaic-staleness).
- `cfpipe nircam status` overlays the combine stamps from the work tree.
- `cfpipe nircam reset --from bad_pixel|outlier` targets the work tree.

## Migration

- The first post-merge `deploy --field` re-uploads only the **masked** exposures once (DQ no longer baked + CFMASK now hashed) — bounded, self-healing, no backfill.
- A field reduced by the **old** in-place combine has combine-stamped canonicals on disk; the deploy guard hard-errors until it's re-run through `cfpipe nircam process`. Worth auditing which NIRCam fields already had a post-combine mosaic redeploy.

## Versioning

Pipeline **MINOR** (Calibration + Algorithm — masks now apply, `fillval` NaN changes mosaic pixel values). CHANGELOG `## Unreleased` updated. **No schema/migration** (`sci_dq_hash` stays `sha256:…`).

## Tests

- `pipeline/tests/test_nircam_work_tree.py` (new): `_prime_work_copy` fuse + stamp-reset, `materialize_work` copy/freeze/incrementality.
- `python/tests/test_nircam_deploy.py`: CFMASK-hash backward-compat + sensitivity, `combine_stamped` metadata (CFP_MASK allowed, CFP_OUT rejected), freeze-guard.
- **222 pipeline + 314 python green.**

## Not covered

The real-field `process → deploy exposures → combine → re-deploy mosaic` round-trip (needs data + jwst + cloud) is **not** exercised here — that's the manual e2e. An adversarial multi-agent review pass was launched but errored out on a session limit before any finder ran, so it did **not** vet this diff.

## Stacked PR

Base is `feat/n6-restore` (this depends on N6's `deploy/nircam.py` dedup + `download`/`delete-local`). Merge N6 first, then **retarget this to `main` before deleting the N6 branch**.

Generated with Claude Code

https://claude.ai/code/session_01RNb7rkgTctaSBQADpsPtQN
