### PR TITLE
Admin Phase 2: OSN transparency — download, object detail, HEAD verify, bucket list, key search

### DIFF
--- a/supabase/migrations/20260703210000_admin_phase2_storage_search.sql
+++ b/supabase/migrations/20260703210000_admin_phase2_storage_search.sql
@@ -1,0 +1,100 @@
+-- Admin audit 2026-07-03, Phase 2 (docs/admin_audit_2026-07-03.md Theme C / §5):
+-- substring key search on the registry browser.
+--
+-- Appending p_search CHANGES the arity of get_admin_storage_objects, so a bare
+-- CREATE OR REPLACE would leave the old 9-arg overload in place and PostgREST
+-- would then see two candidates (PGRST203). DROP the old overload first, then
+-- create the 10-arg version. The DROP signature must match the deployed one
+-- exactly (7 text + 2 integer).
+--
+-- Hand-authored (function body matches supabase/schemas/functions.sql verbatim;
+-- supabase db diff unavailable in the authoring environment).
+
+DROP FUNCTION IF EXISTS public.get_admin_storage_objects(
+  text, text, text, text, text, text, text, integer, integer);
+
+-- Trigram GIN for substring ILIKE on storage_key (opclass schema-qualified —
+-- pg_trgm lives in public, like idx_comments_content_trgm).
+CREATE INDEX IF NOT EXISTS idx_storage_objects_key_trgm
+    ON public.storage_objects USING gin (storage_key public.gin_trgm_ops);
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_admin_storage_objects(
+  p_product_type text DEFAULT NULL,
+  p_status text DEFAULT NULL,
+  p_field text DEFAULT NULL,
+  p_observation text DEFAULT NULL,
+  p_backend text DEFAULT NULL,
+  p_sort_column text DEFAULT 'created_at',
+  p_sort_direction text DEFAULT 'desc',
+  p_page integer DEFAULT 1,
+  p_page_size integer DEFAULT 50,
+  p_search text DEFAULT NULL              -- substring ILIKE on storage_key
+)
+RETURNS TABLE (
+  id bigint,
+  storage_key text,
+  product_type text,
+  instrument text,
+  observation text,
+  field text,
+  exposure_ref text,
+  size_bytes bigint,
+  content_hash text,
+  backend text,
+  status text,
+  cfpipe_version text,
+  created_at timestamptz,
+  total_count bigint
+)
+LANGUAGE plpgsql STABLE
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_limit integer := LEAST(GREATEST(COALESCE(p_page_size, 50), 1), 200);
+  v_offset integer := GREATEST(COALESCE(p_page, 1) - 1, 0) * LEAST(GREATEST(COALESCE(p_page_size, 50), 1), 200);
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'desc'; END IF;
+  IF p_sort_column NOT IN ('created_at', 'size_bytes', 'product_type', 'storage_key',
+                           'observation', 'field', 'status') THEN
+    p_sort_column := 'created_at';
+  END IF;
+
+  RETURN QUERY
+  SELECT so.id, so.storage_key, so.product_type, so.instrument, so.observation,
+         so.field, so.exposure_ref, so.size_bytes, so.content_hash, so.backend,
+         so.status, so.cfpipe_version, so.created_at,
+         count(*) OVER ()
+  FROM storage_objects so
+  WHERE (p_product_type IS NULL OR so.product_type = p_product_type)
+    AND (p_status IS NULL OR so.status = p_status)
+    AND (p_field IS NULL OR so.field = p_field)
+    AND (p_observation IS NULL OR so.observation = p_observation)
+    AND (p_backend IS NULL OR so.backend = p_backend)
+    AND (p_search IS NULL OR so.storage_key ILIKE '%' || p_search || '%')
+  ORDER BY
+    CASE WHEN p_sort_column = 'created_at' AND p_sort_direction = 'desc' THEN so.created_at END DESC,
+    CASE WHEN p_sort_column = 'created_at' AND p_sort_direction = 'asc'  THEN so.created_at END ASC,
+    CASE WHEN p_sort_column = 'size_bytes' AND p_sort_direction = 'desc' THEN so.size_bytes END DESC,
+    CASE WHEN p_sort_column = 'size_bytes' AND p_sort_direction = 'asc'  THEN so.size_bytes END ASC,
+    CASE WHEN p_sort_column = 'product_type' AND p_sort_direction = 'desc' THEN so.product_type END DESC,
+    CASE WHEN p_sort_column = 'product_type' AND p_sort_direction = 'asc'  THEN so.product_type END ASC,
+    CASE WHEN p_sort_column = 'storage_key' AND p_sort_direction = 'desc' THEN so.storage_key END DESC,
+    CASE WHEN p_sort_column = 'storage_key' AND p_sort_direction = 'asc'  THEN so.storage_key END ASC,
+    CASE WHEN p_sort_column = 'observation' AND p_sort_direction = 'desc' THEN so.observation END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'observation' AND p_sort_direction = 'asc'  THEN so.observation END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN so.field END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc'  THEN so.field END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'status' AND p_sort_direction = 'desc' THEN so.status END DESC,
+    CASE WHEN p_sort_column = 'status' AND p_sort_direction = 'asc'  THEN so.status END ASC,
+    so.id DESC
+  OFFSET v_offset LIMIT v_limit;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_admin_storage_objects TO authenticated;
+

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -3330,7 +3330,8 @@ CREATE OR REPLACE FUNCTION public.get_admin_storage_objects(
   p_sort_column text DEFAULT 'created_at',
   p_sort_direction text DEFAULT 'desc',
   p_page integer DEFAULT 1,
-  p_page_size integer DEFAULT 50
+  p_page_size integer DEFAULT 50,
+  p_search text DEFAULT NULL              -- substring ILIKE on storage_key
 )
 RETURNS TABLE (
   id bigint,
@@ -3375,6 +3376,7 @@ BEGIN
     AND (p_field IS NULL OR so.field = p_field)
     AND (p_observation IS NULL OR so.observation = p_observation)
     AND (p_backend IS NULL OR so.backend = p_backend)
+    AND (p_search IS NULL OR so.storage_key ILIKE '%' || p_search || '%')
   ORDER BY
     CASE WHEN p_sort_column = 'created_at' AND p_sort_direction = 'desc' THEN so.created_at END DESC,
     CASE WHEN p_sort_column = 'created_at' AND p_sort_direction = 'asc'  THEN so.created_at END ASC,

--- a/supabase/schemas/indexes.sql
+++ b/supabase/schemas/indexes.sql
@@ -433,6 +433,13 @@ CREATE INDEX IF NOT EXISTS idx_storage_objects_field
     ON public.storage_objects USING btree (field)
     WHERE field IS NOT NULL;
 
+-- Substring key search in the admin registry browser (admin audit 2026-07-03,
+-- C2 / Phase 2): operators search by a fragment anywhere in the canonical key,
+-- so a left-anchored btree can't serve it — trigram GIN does. Opclass is
+-- schema-qualified (pg_trgm lives in public, like idx_comments_content_trgm).
+CREATE INDEX IF NOT EXISTS idx_storage_objects_key_trgm
+    ON public.storage_objects USING gin (storage_key public.gin_trgm_ops);
+
 
 -- =============================================================================
 -- access_codes

--- a/web/app/admin/intermediate-products/page.tsx
+++ b/web/app/admin/intermediate-products/page.tsx
@@ -1,19 +1,28 @@
 'use client';
 
-import React, { Suspense, useMemo } from 'react';
+import React, { Suspense, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { ColumnDef } from '@tanstack/react-table';
 import { Card } from '@/components/ui/Card';
-import { Loader2, Database, HardDrive } from 'lucide-react';
+import { Loader2, Database, HardDrive, Download } from 'lucide-react';
 import { AdminTable } from '@/components/admin/AdminTable';
 import { AdminFilterBar, type FacetOption } from '@/components/admin/AdminFilterBar';
+import { StorageObjectDrawer } from '@/components/admin/StorageObjectDrawer';
 import { flatFilterCodec, useTableUrlState, type SortState } from '@/lib/hooks/useTableUrlState';
 import { useAdminTableQuery } from '@/lib/hooks/useAdminTableQuery';
 import {
   getStorageObjects, getStorageBudget, getStorageFacets,
+  presignStorageObjectDownload,
   STORAGE_OBJECT_SORT_KEYS,
   type StorageObjectRow, type StorageBudget,
 } from '@/lib/actions/storage-registry';
+
+async function downloadObject(id: number) {
+  const res = await presignStorageObjectDownload(id);
+  const dl = res[id];
+  if (dl?.url) window.location.assign(dl.url);
+  else alert(dl?.error ?? 'Failed to presign download');
+}
 
 function fmtBytes(n: number): string {
   let v = Number(n);
@@ -51,7 +60,7 @@ function statusBadge(status: string) {
 // URL-state config (module-level: codec/whitelist must be stable references).
 // status defaults to 'active' so the initial view hides superseded/revoked
 // tombstones, matching the page's pre-framework behavior.
-const FILTER_KEYS = ['product', 'status', 'backend', 'field', 'obs'] as const;
+const FILTER_KEYS = ['product', 'status', 'backend', 'field', 'obs', 'key'] as const;
 const codec = flatFilterCodec(FILTER_KEYS, { status: 'active' });
 const DEFAULT_SORT: SortState = { column: 'created_at', direction: 'desc' };
 
@@ -120,9 +129,24 @@ const columns: ColumnDef<StorageObjectRow, unknown>[] = [
     ),
     meta: { sortKey: 'created_at' },
   },
+  {
+    id: 'download',
+    header: '',
+    cell: ({ row }) => (
+      <button
+        onClick={(e) => { e.stopPropagation(); void downloadObject(row.original.id); }}
+        className="text-text-secondary hover:text-primary transition-colors"
+        title="Download"
+      >
+        <Download className="w-4 h-4" />
+      </button>
+    ),
+    meta: { align: 'right' },
+  },
 ];
 
 function StoragePageInner() {
+  const [selectedId, setSelectedId] = useState<number | null>(null);
   const state = useTableUrlState({
     codec,
     sortWhitelist: STORAGE_OBJECT_SORT_KEYS,
@@ -143,6 +167,7 @@ function StoragePageInner() {
         backend: f.backend || undefined,
         field: f.field || undefined,
         observation: f.obs || undefined,
+        search: f.key || undefined,
         sortColumn: state.sort.column,
         sortDirection: state.sort.direction,
         page,
@@ -165,6 +190,7 @@ function StoragePageInner() {
   });
 
   const facetDescriptors = useMemo(() => [
+    { kind: 'search' as const, key: 'key', placeholder: 'Search key…' },
     { kind: 'pills' as const, key: 'status', options: STATUS_OPTIONS },
     {
       kind: 'select' as const, key: 'product', label: 'Product',
@@ -234,7 +260,12 @@ function StoragePageInner() {
         onPageChange={state.setPage}
         onPageSizeChange={state.setPageSize}
         getRowKey={(o) => o.id}
+        onRowClick={(o) => setSelectedId(o.id)}
       />
+
+      {selectedId != null && (
+        <StorageObjectDrawer id={selectedId} onClose={() => setSelectedId(null)} />
+      )}
     </div>
   );
 }

--- a/web/components/admin/StorageObjectDrawer.tsx
+++ b/web/components/admin/StorageObjectDrawer.tsx
@@ -1,0 +1,286 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import {
+  X, Download, RefreshCw, FolderOpen, CheckCircle2, XCircle, Loader2, AlertCircle,
+} from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { parseKey } from '@/lib/layout';
+import {
+  getStorageObjectDetail,
+  presignStorageObjectDownload,
+  headStorageObject,
+  listBucketObjects,
+  type StorageObjectDetail,
+  type HeadResult,
+  type BucketObject,
+} from '@/lib/actions/storage-registry';
+import type { DataBackend } from '@/lib/storage';
+
+// ---------------------------------------------------------------------------
+// Right-side slide-over drawer: full provenance for one registry object, plus
+// the Phase-2 OSN-transparency actions (download / live HEAD verify / list the
+// actual bucket prefix). Read-only inspection — nothing writes back.
+// ---------------------------------------------------------------------------
+
+function fmtBytes(n: number | null): string {
+  if (n == null) return '—';
+  let v = Number(n);
+  for (const u of ['B', 'KB', 'MB', 'GB', 'TB', 'PB']) {
+    if (Math.abs(v) < 1024 || u === 'PB') return u === 'B' ? `${v} B` : `${v.toFixed(1)} ${u}`;
+    v /= 1024;
+  }
+  return `${v} B`;
+}
+
+function fmtDate(ts: string | null): string {
+  if (!ts) return '—';
+  let iso = ts;
+  if (iso.includes(' ') && !iso.includes('T')) iso = iso.replace(' ', 'T');
+  if (iso.endsWith('+00')) iso = iso + ':00';
+  else if (!iso.endsWith('Z') && !iso.includes('+')) iso = iso + 'Z';
+  const d = new Date(iso);
+  return isNaN(d.getTime()) ? ts : d.toLocaleString(undefined, {
+    year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+  });
+}
+
+function parentPrefix(key: string): string {
+  const i = key.lastIndexOf('/');
+  return i >= 0 ? key.slice(0, i + 1) : '';
+}
+
+function knownKeyLabel(key: string): string {
+  try {
+    const parsed = parseKey(key);
+    const scope = Object.entries(parsed.scope)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(', ');
+    return `${parsed.productType}${scope ? ` (${scope})` : ''}`;
+  } catch {
+    return 'unrecognized key';
+  }
+}
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="grid grid-cols-[9rem_1fr] gap-2 py-1 text-sm">
+      <span className="text-text-secondary">{label}</span>
+      <span className="text-text-primary break-all">{children}</span>
+    </div>
+  );
+}
+
+export function StorageObjectDrawer({ id, onClose }: { id: number; onClose: () => void }) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['admin-storage-object-detail', id],
+    queryFn: () => getStorageObjectDetail(id),
+    staleTime: 30_000,
+  });
+
+  const [downloading, setDownloading] = useState(false);
+  const [head, setHead] = useState<HeadResult | null>(null);
+  const [headLoading, setHeadLoading] = useState(false);
+  const [listing, setListing] = useState<BucketObject[] | null>(null);
+  const [listLoading, setListLoading] = useState(false);
+  const [listError, setListError] = useState<string | null>(null);
+
+  const obj: StorageObjectDetail | null = data?.object ?? null;
+
+  const onDownload = async () => {
+    setDownloading(true);
+    const res = await presignStorageObjectDownload(id);
+    setDownloading(false);
+    const dl = res[id];
+    if (dl?.url) window.location.assign(dl.url);
+    else alert(dl?.error ?? 'Failed to presign download');
+  };
+
+  const onVerify = async () => {
+    setHeadLoading(true);
+    setHead(await headStorageObject(id));
+    setHeadLoading(false);
+  };
+
+  const onList = async () => {
+    if (!obj) return;
+    setListLoading(true);
+    setListError(null);
+    const res = await listBucketObjects(obj.backend as DataBackend, parentPrefix(obj.storage_key));
+    setListLoading(false);
+    if (res.error) setListError(res.error);
+    else setListing(res.objects);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end">
+      {/* Scrim */}
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      {/* Panel */}
+      <div className="relative w-full max-w-xl bg-card border-l border-border h-full overflow-y-auto shadow-xl">
+        <div className="sticky top-0 bg-card border-b border-border px-5 py-3 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-text-primary">Object detail</h2>
+          <button onClick={onClose} className="text-text-secondary hover:text-text-primary">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="p-5 space-y-5">
+          {isLoading ? (
+            <div className="flex items-center gap-2 text-text-secondary">
+              <Loader2 className="w-4 h-4 animate-spin" /> Loading…
+            </div>
+          ) : error || data?.error || !obj ? (
+            <div className="flex items-center gap-2 text-red-700 dark:text-red-400 text-sm">
+              <AlertCircle className="w-4 h-4" /> {data?.error ?? 'Failed to load object'}
+            </div>
+          ) : (
+            <>
+              {/* Key + actions */}
+              <div>
+                <p className="font-mono text-xs text-text-primary break-all bg-card-hover rounded p-2">
+                  {obj.storage_key}
+                </p>
+                <p className="text-xs text-text-secondary mt-1">{knownKeyLabel(obj.storage_key)}</p>
+                <div className="flex flex-wrap gap-2 mt-3">
+                  <Button size="sm" onClick={onDownload} disabled={downloading}>
+                    {downloading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Download className="w-4 h-4" />}
+                    Download
+                  </Button>
+                  <Button size="sm" variant="secondary" onClick={onVerify} disabled={headLoading}>
+                    {headLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : <RefreshCw className="w-4 h-4" />}
+                    Verify in bucket
+                  </Button>
+                  <Button size="sm" variant="secondary" onClick={onList} disabled={listLoading}>
+                    {listLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : <FolderOpen className="w-4 h-4" />}
+                    List prefix
+                  </Button>
+                </div>
+              </div>
+
+              {/* HEAD result */}
+              {head && (
+                <div className="rounded border border-border p-3 text-sm">
+                  {head.error ? (
+                    <span className="text-red-700 dark:text-red-400">{head.error}</span>
+                  ) : head.present ? (
+                    <div className="space-y-1">
+                      <div className="flex items-center gap-2 text-green-700 dark:text-green-400">
+                        <CheckCircle2 className="w-4 h-4" /> Present in bucket
+                      </div>
+                      <Row label="Live size">
+                        {fmtBytes(head.contentLength)}
+                        {head.sizeMatches === false && (
+                          <span className="text-amber-600 dark:text-amber-400">
+                            {' '}— differs from registry ({fmtBytes(head.registrySize)})
+                          </span>
+                        )}
+                      </Row>
+                      <Row label="Live ETag">{head.etag ?? '—'}</Row>
+                      <Row label="Last modified">{fmtDate(head.lastModified)}</Row>
+                    </div>
+                  ) : (
+                    <div className="flex items-center gap-2 text-red-700 dark:text-red-400">
+                      <XCircle className="w-4 h-4" /> Not found in bucket — registry row is stale
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Metadata */}
+              <div className="border-t border-border pt-3">
+                <Row label="Product">{obj.product_type}</Row>
+                <Row label="Scope">{obj.observation ?? obj.field ?? '—'}</Row>
+                <Row label="Exposure ref">{obj.exposure_ref ?? '—'}</Row>
+                <Row label="Size">{fmtBytes(obj.size_bytes)}</Row>
+                <Row label="Content type">{obj.content_type}</Row>
+                <Row label="Backend / bucket">
+                  <span className="uppercase">{obj.backend}</span> / {obj.bucket}
+                </Row>
+                <Row label="Status">{obj.status}</Row>
+                <Row label="Content hash">{obj.content_hash}</Row>
+                <Row label="SCI+DQ hash">{obj.sci_dq_hash ?? '—'}</Row>
+                <Row label="cfpipe version">{obj.cfpipe_version ?? '—'}</Row>
+                <Row label="Created">{fmtDate(obj.created_at)}</Row>
+                <Row label="Updated">{fmtDate(obj.updated_at)}</Row>
+              </div>
+
+              {/* Producing deployment */}
+              {data?.deployment && (
+                <div className="border-t border-border pt-3">
+                  <h3 className="text-sm font-medium text-text-primary mb-1">
+                    Deployment #{data.deployment.id}
+                  </h3>
+                  <Row label="Status">{data.deployment.status}</Row>
+                  <Row label="Deployed">{fmtDate(data.deployment.deployed_at)}</Row>
+                  <Row label="cfpipe">{data.deployment.cfpipe_version ?? '—'}</Row>
+                  <Row label="jwst">{data.deployment.jwst_version ?? '—'}</Row>
+                  <Row label="CRDS">{data.deployment.crds_context ?? '—'}</Row>
+                </div>
+              )}
+
+              {/* Lifecycle history */}
+              {data && data.events.length > 0 && (
+                <div className="border-t border-border pt-3">
+                  <h3 className="text-sm font-medium text-text-primary mb-2">Lifecycle</h3>
+                  <ul className="space-y-1 text-sm">
+                    {data.events.map((e) => (
+                      <li key={e.id} className="flex items-center justify-between gap-2">
+                        <span className="text-text-primary">
+                          {e.action}
+                          {e.status_to ? ` → ${e.status_to}` : ''}
+                        </span>
+                        <span className="text-text-secondary whitespace-nowrap text-xs">
+                          {e.actor_name ? `${e.actor_name} · ` : ''}{fmtDate(e.occurred_at)}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {/* Bucket prefix listing */}
+              {(listing || listError) && (
+                <div className="border-t border-border pt-3">
+                  <h3 className="text-sm font-medium text-text-primary mb-2">
+                    Bucket prefix <span className="font-mono text-xs text-text-secondary">{parentPrefix(obj.storage_key)}</span>
+                  </h3>
+                  {listError ? (
+                    <span className="text-red-700 dark:text-red-400 text-sm">{listError}</span>
+                  ) : listing && listing.length === 0 ? (
+                    <span className="text-text-secondary text-sm">No objects under this prefix.</span>
+                  ) : (
+                    <ul className="space-y-0.5 text-xs font-mono">
+                      {listing!.map((o) => (
+                        <li key={o.key} className="flex items-center justify-between gap-2">
+                          <span className="truncate text-text-primary" title={o.key}>
+                            {o.key.slice(parentPrefix(obj.storage_key).length)}
+                          </span>
+                          <span className="flex items-center gap-2 whitespace-nowrap text-text-secondary">
+                            {fmtBytes(o.size)}
+                            {o.registered ? (
+                              <span className="text-green-600 dark:text-green-400" title="Registered">●</span>
+                            ) : (
+                              <span className="text-amber-500" title="Not in registry">○</span>
+                            )}
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                  {listing && (
+                    <p className="text-xs text-text-secondary mt-2">
+                      <span className="text-green-600 dark:text-green-400">●</span> registered ·{' '}
+                      <span className="text-amber-500">○</span> unregistered (blind to the registry)
+                    </p>
+                  )}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/lib/actions/storage-registry.ts
+++ b/web/lib/actions/storage-registry.ts
@@ -1,6 +1,17 @@
 'use server';
 
 import { createClient } from '@/lib/supabase/server';
+import {
+  GetObjectCommand,
+  HeadObjectCommand,
+  ListObjectsV2Command,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import {
+  getS3ClientForBackend,
+  getBucketNameForBackend,
+  type DataBackend,
+} from '@/lib/storage';
 
 // ---------------------------------------------------------------------------
 // Storage-registry (Axis A) admin actions — epic #210, B5.
@@ -63,6 +74,7 @@ export async function getStorageObjects(params?: {
   productType?: string;
   status?: string;
   backend?: string;
+  search?: string;
   sortColumn?: string;
   sortDirection?: 'asc' | 'desc';
   page?: number;      // 1-based
@@ -81,6 +93,7 @@ export async function getStorageObjects(params?: {
       p_sort_direction: params?.sortDirection ?? 'desc',
       p_page: params?.page ?? 1,
       p_page_size: params?.pageSize ?? 50,
+      p_search: params?.search ?? null,
     });
 
     if (error) return { objects: [], total: 0, error: error.message };
@@ -149,5 +162,358 @@ export async function getStorageBudget(): Promise<StorageBudget | { error: strin
     return data as unknown as StorageBudget;
   } catch (err) {
     return { error: err instanceof Error ? err.message : 'Failed to load budget' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Object detail (Phase 2, audit C3) — the drawer's data
+// ---------------------------------------------------------------------------
+
+export interface StorageObjectDetail {
+  id: number;
+  storage_key: string;
+  product_type: string;
+  instrument: string | null;
+  observation: string | null;
+  field: string | null;
+  exposure_ref: string | null;
+  size_bytes: number;
+  content_hash: string;
+  sci_dq_hash: string | null;
+  content_type: string;
+  backend: string;
+  bucket: string;
+  status: string;
+  cfpipe_version: string | null;
+  deployment_id: number | null;
+  uploaded_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface StorageDeployment {
+  id: number;
+  observation: string | null;
+  field: string | null;
+  status: string;
+  cfpipe_version: string | null;
+  jwst_version: string | null;
+  crds_context: string | null;
+  deployed_at: string | null;
+  published_at: string | null;
+  revoked_at: string | null;
+}
+
+export interface StorageDeployEvent {
+  id: string;
+  action: string;
+  status_to: string | null;
+  affected_count: number | null;
+  occurred_at: string;
+  actor_name: string | null;
+}
+
+export interface StorageObjectDetailResult {
+  object: StorageObjectDetail | null;
+  deployment: StorageDeployment | null;
+  events: StorageDeployEvent[];
+  error?: string;
+}
+
+// Full provenance for a single registry object plus its lifecycle history:
+// the storage_objects row, the deployment that produced it, and the
+// deploy_events that touched either the object or its deployment. Plain selects
+// under admin RLS — no RPC / no reserved-word surface.
+export async function getStorageObjectDetail(
+  id: number,
+): Promise<StorageObjectDetailResult> {
+  try {
+    const supabase = await requireAdmin();
+
+    const { data: objectRaw, error } = await supabase
+      .from('storage_objects')
+      .select(
+        'id, storage_key, product_type, instrument, observation, field, exposure_ref, ' +
+        'size_bytes, content_hash, sci_dq_hash, content_type, backend, bucket, status, ' +
+        'cfpipe_version, deployment_id, uploaded_by, created_at, updated_at',
+      )
+      .eq('id', id)
+      .single();
+
+    if (error || !objectRaw) {
+      return { object: null, deployment: null, events: [], error: error?.message ?? 'Not found' };
+    }
+    const object = objectRaw as unknown as StorageObjectDetail;
+
+    let deployment: StorageDeployment | null = null;
+    if (object.deployment_id != null) {
+      const { data: dep } = await supabase
+        .from('deployments')
+        .select(
+          'id, observation, field, status, cfpipe_version, jwst_version, crds_context, ' +
+          'deployed_at, published_at, revoked_at',
+        )
+        .eq('id', object.deployment_id)
+        .single();
+      deployment = (dep as unknown as StorageDeployment) ?? null;
+    }
+
+    // Lifecycle history: events on this object, or on its deployment batch.
+    let eventsQuery = supabase
+      .from('deploy_events')
+      .select('id, action, status_to, affected_count, occurred_at, actor')
+      .order('occurred_at', { ascending: false })
+      .limit(50);
+    eventsQuery = object.deployment_id != null
+      ? eventsQuery.or(`object_id.eq.${id},deployment_id.eq.${object.deployment_id}`)
+      : eventsQuery.eq('object_id', id);
+    const { data: rawEvents } = await eventsQuery;
+
+    const events = (rawEvents ?? []) as unknown as {
+      id: string; action: string; status_to: string | null;
+      affected_count: number | null; occurred_at: string; actor: string | null;
+    }[];
+
+    // Resolve actor uuids → names in one batch (no FK to embed on).
+    const actorIds = Array.from(new Set(events.map((e) => e.actor).filter(Boolean))) as string[];
+    const nameById = new Map<string, string>();
+    if (actorIds.length) {
+      const { data: profiles } = await supabase
+        .from('user_profiles')
+        .select('user_id, username, full_name')
+        .in('user_id', actorIds);
+      for (const p of profiles ?? []) {
+        nameById.set(p.user_id, p.full_name || p.username);
+      }
+    }
+
+    return {
+      object,
+      deployment,
+      events: events.map(({ actor, ...e }) => ({
+        ...e,
+        actor_name: actor ? nameById.get(actor) ?? null : null,
+      })),
+    };
+  } catch (err) {
+    return {
+      object: null, deployment: null, events: [],
+      error: err instanceof Error ? err.message : 'Failed to load object detail',
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Direct download (Phase 2, audit C1) — the headline gap
+// ---------------------------------------------------------------------------
+
+export interface PresignedDownload {
+  url: string | null;
+  filename: string;
+  error?: string;
+}
+
+const DOWNLOAD_TTL_SECONDS = 300;
+
+function basename(key: string): string {
+  const parts = key.split('/');
+  return parts[parts.length - 1] || key;
+}
+
+// Presign a GET for one or more registry objects, by id (never a client-
+// supplied key — mirrors presignExposurePngs). Presigns the object's EXACT
+// recorded key on its recorded backend; deliberately does NOT route through
+// r2.ts's dual-read resolver (which fails open to R2 under the legacy key and
+// is gated by OSN_READ_ENABLED) — an admin download wants the literal object.
+// No status filter: admins may pull superseded/revoked/draft objects (RLS
+// already allows them to see those rows). ResponseContentDisposition forces a
+// download with the real filename cross-origin, so a plain navigation works
+// without a streaming proxy.
+export async function presignStorageObjectDownload(
+  ids: number | number[],
+): Promise<Record<number, PresignedDownload>> {
+  const idList = Array.isArray(ids) ? ids : [ids];
+  const out: Record<number, PresignedDownload> = {};
+  if (idList.length === 0) return out;
+  try {
+    const supabase = await requireAdmin();
+    const { data, error } = await supabase
+      .from('storage_objects')
+      .select('id, storage_key, backend')
+      .in('id', idList);
+    if (error || !data) {
+      for (const id of idList) out[id] = { url: null, filename: '', error: error?.message ?? 'Not found' };
+      return out;
+    }
+
+    await Promise.all(data.map(async (row) => {
+      const key = row.storage_key as string;
+      const filename = basename(key);
+      try {
+        const backend: DataBackend = row.backend === 'r2' ? 'r2' : 'osn';
+        const url = await getSignedUrl(
+          getS3ClientForBackend(backend),
+          new GetObjectCommand({
+            Bucket: getBucketNameForBackend(backend),
+            Key: key,
+            ResponseContentDisposition: `attachment; filename="${filename}"`,
+          }),
+          { expiresIn: DOWNLOAD_TTL_SECONDS },
+        );
+        out[row.id] = { url, filename };
+      } catch (err) {
+        out[row.id] = {
+          url: null, filename,
+          error: err instanceof Error ? err.message : 'Failed to presign',
+        };
+      }
+    }));
+    return out;
+  } catch (err) {
+    for (const id of idList) {
+      out[id] = { url: null, filename: '', error: err instanceof Error ? err.message : 'Failed' };
+    }
+    return out;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Live bucket verification (Phase 2, audit C3) — read-only HEAD
+// ---------------------------------------------------------------------------
+
+export interface HeadResult {
+  present: boolean;
+  contentLength: number | null;
+  etag: string | null;
+  lastModified: string | null;
+  registrySize: number | null;
+  registryHash: string | null;
+  sizeMatches: boolean | null;
+  error?: string;
+}
+
+// Issue a live HEAD against the bucket to confirm an object is actually there
+// and compare its size to what the registry recorded — surfacing registry-vs-
+// bucket drift per object. Object-absent (404) is a valid result, not an
+// error. Read-only: never writes back to the registry (reconciliation is
+// Phase 3 ledger work).
+export async function headStorageObject(id: number): Promise<HeadResult> {
+  const empty: HeadResult = {
+    present: false, contentLength: null, etag: null, lastModified: null,
+    registrySize: null, registryHash: null, sizeMatches: null,
+  };
+  try {
+    const supabase = await requireAdmin();
+    const { data: row, error } = await supabase
+      .from('storage_objects')
+      .select('storage_key, backend, size_bytes, content_hash')
+      .eq('id', id)
+      .single();
+    if (error || !row) return { ...empty, error: error?.message ?? 'Not found' };
+
+    const registrySize = Number(row.size_bytes);
+    const registryHash = row.content_hash as string;
+    const backend: DataBackend = row.backend === 'r2' ? 'r2' : 'osn';
+
+    try {
+      const head = await getS3ClientForBackend(backend).send(
+        new HeadObjectCommand({
+          Bucket: getBucketNameForBackend(backend),
+          Key: row.storage_key as string,
+        }),
+      );
+      const contentLength = head.ContentLength ?? null;
+      return {
+        present: true,
+        contentLength,
+        etag: head.ETag ?? null,
+        lastModified: head.LastModified ? head.LastModified.toISOString() : null,
+        registrySize,
+        registryHash,
+        sizeMatches: contentLength != null ? contentLength === registrySize : null,
+      };
+    } catch (err: unknown) {
+      const e = err as { name?: string; $metadata?: { httpStatusCode?: number } };
+      if (e?.name === 'NotFound' || e?.name === 'NoSuchKey' || e?.$metadata?.httpStatusCode === 404) {
+        return { ...empty, present: false, registrySize, registryHash };
+      }
+      return {
+        ...empty, registrySize, registryHash,
+        error: err instanceof Error ? err.message : 'HEAD failed',
+      };
+    }
+  } catch (err) {
+    return { ...empty, error: err instanceof Error ? err.message : 'Failed to verify' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bucket LIST (Phase 2, audit C4) — the honest "what's actually in the bucket"
+// ---------------------------------------------------------------------------
+
+export interface BucketObject {
+  key: string;
+  size: number;
+  etag: string | null;
+  lastModified: string | null;
+  registered: boolean;
+}
+
+export interface BucketListing {
+  objects: BucketObject[];
+  nextToken: string | null;
+  error?: string;
+}
+
+// List the actual bucket under a prefix (the web tier's first LIST capability).
+// Cross-marks which listed keys are registered in storage_objects, exposing the
+// registry's blind corners — tiles / rgb / sed / out-of-band writes that sit in
+// the bucket with no row. Admin-only; read creds already configured.
+export async function listBucketObjects(
+  backend: DataBackend,
+  prefix: string,
+  continuationToken?: string,
+): Promise<BucketListing> {
+  try {
+    const supabase = await requireAdmin();
+
+    const res = await getS3ClientForBackend(backend).send(
+      new ListObjectsV2Command({
+        Bucket: getBucketNameForBackend(backend),
+        Prefix: prefix,
+        MaxKeys: 100,
+        ContinuationToken: continuationToken,
+      }),
+    );
+
+    const contents = res.Contents ?? [];
+    const keys = contents.map((c) => c.Key).filter(Boolean) as string[];
+
+    // Which of these keys are registered (on this backend)?
+    const registered = new Set<string>();
+    if (keys.length) {
+      const { data: rows } = await supabase
+        .from('storage_objects')
+        .select('storage_key')
+        .eq('backend', backend)
+        .in('storage_key', keys);
+      for (const r of rows ?? []) registered.add(r.storage_key as string);
+    }
+
+    return {
+      objects: contents.map((c) => ({
+        key: c.Key as string,
+        size: Number(c.Size ?? 0),
+        etag: c.ETag ?? null,
+        lastModified: c.LastModified ? c.LastModified.toISOString() : null,
+        registered: registered.has(c.Key as string),
+      })),
+      nextToken: res.NextContinuationToken ?? null,
+    };
+  } catch (err) {
+    return {
+      objects: [], nextToken: null,
+      error: err instanceof Error ? err.message : 'Failed to list bucket',
+    };
   }
 }


### PR DESCRIPTION
## Summary

Phase 2 of the admin panel overhaul (docs/admin_audit_2026-07-03.md, **Theme C — OSN transparency**). Phases 0–1 (#288) made the registry browsable; this phase makes it **actionable**: an admin can now download an object, inspect its full provenance and lifecycle, verify it's actually present in the bucket, search by key fragment, and see what the registry omits.

Built on the Phase 1 framework (`AdminTable`, `AdminFilterBar`, `useTableUrlState`) — no framework changes.

## Key changes

**Database**
- `get_admin_storage_objects` gains a `p_search` param (substring `ILIKE` on `storage_key`). Because the new param changes the function arity, the migration **`DROP`s the old 9-arg overload first** — a bare `CREATE OR REPLACE` would leave two candidates and trip PostgREST's `PGRST203` on the preview branch.
- New trigram GIN index `idx_storage_objects_key_trgm` (schema-qualified `public.gin_trgm_ops`) backing the substring search.

**Server actions (`web/lib/actions/storage-registry.ts`, all `requireAdmin`)**
- `presignStorageObjectDownload(id[])` — the headline gap (audit C1): presigns a GET for the object's **exact recorded key on its recorded backend**, deliberately bypassing `r2.ts`'s fail-open dual-read resolver; `ResponseContentDisposition` forces the filename; 300 s TTL. Admins may pull superseded/revoked/draft rows.
- `getStorageObjectDetail(id)` — full provenance row + producing deployment + lifecycle `deploy_events` (plain selects; no RPC, so no reserved-word surface).
- `headStorageObject(id)` — live `HeadObject` verification; **404 is a valid "absent" result**, not an error; compares live size to the registry. Read-only (writeback is Phase 3).
- `listBucketObjects(backend, prefix)` — the web tier's **first `ListObjectsV2`**; cross-marks registered vs unregistered keys, exposing the registry's by-design blind corners (tiles/rgb/sed/out-of-band writes).

**UI**
- Storage page: substring key-search box, per-row download button, and a row-click **slide-over drawer** showing all of the above (metadata, provenance, deployment, lifecycle, Download / Verify-in-bucket / List-prefix actions).

## Notes / deferred

- **Download logging is intentionally not included.** `download_log.download_type` and `deploy_events.action` both have CHECK enums with no admin/download value; adding one is a table change (→ seed regen) that belongs with the Phase 3 ledger rework.
- **Drawer selection is local state, not URL** — the shared `useTableUrlState` serializer would strip an extra param; deep-linking a detail view is an explicit non-goal this phase.
- **Full bucket-browser page and the reconcile orphan/dangling report are deferred** — this phase ships the minimal LIST (parent-prefix, from the drawer) as the honest-transparency lever; the standalone browser overlaps the Phase 3 ledger.
- Migration is **hand-authored, additive-only** (no Docker for `supabase db diff`); the Supabase preview branch is the real validator. No table columns change, so `seed.sql` is untouched.

Generated with Claude Code
https://claude.ai/code/session_01SQiCGrfdaQu5cF9dbVCJNd

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQiCGrfdaQu5cF9dbVCJNd)_