### PR TITLE
Admin Phase 3: complete the deploy ledger — field column, provenance, actual counts, delete events

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -264,6 +264,14 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- **NIRCam canonical exposures now carry `CMPFRVER` provenance.** `detector1`
+  stamps the CAMPFIRE reduction version (+ `CMPFRTIM`) on each canonical
+  exposure's primary header at creation, mirroring the mosaic stamp in
+  `resample.py` (jwst already writes `CAL_VER` / `CRDS_CTX`, but not the
+  CAMPFIRE version). This lets `campfire deploy` record real pipeline-version
+  provenance for a mid-reduction `--draft` exposure deploy — before any mosaic
+  exists — instead of leaving `deployments.cfpipe_version` NULL (admin audit
+  2026-07-03, B2). Additive header card only; no pixel/flux change.
 - **`cfpipe download --target` accepts comma-separated coordinates.** MAST's
   JWST search API resolves the top-level `target` field as either an object
   name or a *space*-separated `"RA Dec"` pair in decimal degrees (matching

--- a/pipeline/campfire_pipeline/nircam/orchestrate.py
+++ b/pipeline/campfire_pipeline/nircam/orchestrate.py
@@ -236,7 +236,7 @@ def _run_detector1(field, config, filtname, n_processes, overwrite, status):
     log(f"detector1: dispatching {len(pending)} files for {filtname}")
     dispatch(detector1_step, pending, n_processes=n_processes,
              field=field, step_config=cfg, overwrite=overwrite,
-             status=status)
+             status=status, reduction_version=_resolve_reduction_version(config))
     new_canonical = [
         field.get_exposure_path(
             os.path.basename(u).removesuffix('_uncal.fits'), filtname,

--- a/pipeline/campfire_pipeline/nircam/steps/detector1.py
+++ b/pipeline/campfire_pipeline/nircam/steps/detector1.py
@@ -20,7 +20,7 @@ from campfire_pipeline.nircam.constants import SW_FILTERS, LW_FILTERS
 
 
 def detector1_step(uncal_file, field, step_config, overwrite=False,
-                   status=None):
+                   status=None, reduction_version=None):
     """Run JWST Detector1Pipeline on a single ``_uncal.fits`` exposure.
 
     Parameters
@@ -37,6 +37,13 @@ def detector1_step(uncal_file, field, step_config, overwrite=False,
     status : StepStatus, optional
         Pre-scanned CFP_* status cache (consulted instead of reopening the
         FITS for the skip check). Falls back to a live header read when None.
+    reduction_version : str, optional
+        CAMPFIRE reduction version, stamped as ``CMPFRVER`` on the canonical
+        exposure's primary header at creation (mirrors the mosaic stamp in
+        ``resample.py``). This is the only place exposure-level pipeline-version
+        provenance is recorded — jwst already stamps ``CAL_VER`` / ``CRDS_CTX``,
+        but not the CAMPFIRE version. ``None`` (e.g. a bare ``detector1_step``
+        call) leaves it unstamped.
     """
     from jwst.pipeline import calwebb_detector1
 
@@ -168,6 +175,14 @@ def detector1_step(uncal_file, field, step_config, overwrite=False,
     if result is None:
         return
 
-    atomic_save(result, canonical, header_updates=cfp.format(CFP_DET1=None))
+    header_updates = cfp.format(CFP_DET1=None)
+    if reduction_version:
+        # Stamp the CAMPFIRE version at canonical creation so every exposure
+        # carries pipeline-version provenance (mirrors the mosaic CMPFRVER).
+        header_updates['CMPFRVER'] = (
+            reduction_version, 'CAMPFIRE git commit (or pinned version)')
+        header_updates['CMPFRTIM'] = (
+            cfp.iso_now(), 'UTC date/time of CAMPFIRE reduction (ISO 8601)')
+    atomic_save(result, canonical, header_updates=header_updates)
     result.close()
     log(f"Saved {os.path.basename(canonical)} (CFP_DET1)")

--- a/python/campfire/deploy/cli.py
+++ b/python/campfire/deploy/cli.py
@@ -1225,6 +1225,17 @@ def registry_prune(ctx, config_path, duplicates, dead_products, execute, local):
     n = reg.delete_objects(sb, list(ids))
     print(f"\nDeleted {n} row(s).")
 
+    # Audit the registry prune (audit B3): registry-row deletion was silent.
+    from campfire.deploy.supabase import (
+        deploy_event_metadata, get_user_id_from_token, log_deploy_event,
+    )
+    log_deploy_event(
+        sb, action='delete', actor=get_user_id_from_token(config),
+        affected_count=n,
+        metadata=deploy_event_metadata(
+            'registry', items=n, prune=True,
+            duplicates=bool(duplicates), dead_products=bool(dead_products)))
+
 
 # ---------------------------------------------------------------------------
 # photometry subcommand

--- a/python/campfire/deploy/deploy.py
+++ b/python/campfire/deploy/deploy.py
@@ -41,6 +41,7 @@ from campfire.deploy.supabase import (
     batch_upsert_objects,
     batch_upsert_spectra,
     check_existing_objects,
+    deploy_event_metadata,
     deploy_shutters as db_deploy_shutters,
     deploy_slits as db_deploy_slits,
     fetch_deployment_config,
@@ -195,6 +196,26 @@ def _jwst_pid_from_obs_cfg(obs_cfg: dict) -> int:
     return int(m.group(1)) if m else 0
 
 
+def _read_exposure_provenance(exposure_files):
+    """Best-effort ``(cfpipe_version, jwst_version, crds_context)`` from the first
+    spectrum-exposure header (Phase 3).
+
+    Reads whatever provenance cards the reduction stamped
+    (``CMPFRVER`` / ``CAL_VER`` / ``CRDS_CTX``); any absent card is None. Purely
+    additive over the old ``cfpipe_version=None`` on the intermediates-draft
+    path — a missing/unreadable header just yields all-None.
+    """
+    if not exposure_files:
+        return None, None, None
+    try:
+        from astropy.io import fits
+        with fits.open(exposure_files[0], memmap=False) as hdul:
+            hdr = hdul[0].header
+            return hdr.get('CMPFRVER'), hdr.get('CAL_VER'), hdr.get('CRDS_CTX')
+    except Exception:
+        return None, None, None
+
+
 def _deploy_intermediates_only(
     obs_name: str, obs_dir, config: dict, *,
     dry_run: bool = False, auto_approve: bool = False,
@@ -288,17 +309,25 @@ def _deploy_intermediates_only(
         backend='osn')
     print(f"Uploaded {success}/{len(upload_tasks)} files")
 
+    # Best-effort provenance from the first exposure header (Phase 3): the
+    # intermediates carry whatever cards the reduction stamped. Absent → NULL.
+    cfpipe_version, jwst_version, crds_context = _read_exposure_provenance(exposure_files)
+
     deployment_id = insert_deployment(
         sb, observation=obs_name, deployed_by=user_id, status='draft',
-        cfpipe_version=None, n_targets=0, n_spectra=0,
+        cfpipe_version=cfpipe_version, jwst_version=jwst_version,
+        crds_context=crds_context, n_targets=0, n_spectra=0,
     )
     if deployment_id:
         update_latest_deployment(sb, obs_name, deployment_id)
         print(f"\nDeployment #{deployment_id} recorded (draft — intermediates only)")
         log_deploy_event(
             sb, action='upload', actor=user_id, deployment_id=deployment_id,
-            observation=obs_name, affected_count=len(exposure_files),
-            metadata={'intermediates_only': True, 'draft': True})
+            observation=obs_name, affected_count=success,
+            metadata=deploy_event_metadata(
+                'nirspec', observation=obs_name, planned=len(upload_tasks),
+                succeeded=success, failed=failed, items=len(exposure_files),
+                draft=True, intermediates_only=True))
 
     if uploaded_keys:
         from campfire.deploy.registry import (
@@ -308,7 +337,7 @@ def _deploy_intermediates_only(
         reg_rows = build_registry_rows(
             upload_tasks, backend='osn',
             deployment_id=deployment_id, uploaded_by=user_id,
-            succeeded_keys=uploaded_keys)
+            cfpipe_version=cfpipe_version, succeeded_keys=uploaded_keys)
         n_reg = upsert_storage_objects(sb, reg_rows)
         print(f"Registered {n_reg} storage objects")
 
@@ -819,7 +848,9 @@ def deploy_observation(
             update_latest_deployment(sb, obs_name, deployment_id)
             print(f"\nDeployment #{deployment_id} recorded"
                   f"{' (draft)' if draft else ''}")
-            # B2: record the deploy in the lifecycle audit log.
+            # B2: record the deploy in the lifecycle audit log (normalized
+            # envelope, Phase 3). `success`/`failed` are the actual OSN+R2 upload
+            # tallies; `affected_count` stays the spectra count for continuity.
             log_deploy_event(
                 sb,
                 action='upload',
@@ -827,7 +858,10 @@ def deploy_observation(
                 deployment_id=deployment_id,
                 observation=obs_name,
                 affected_count=len(spectra),
-                metadata={'draft': draft, 'n_objects': len(objects)},
+                metadata=deploy_event_metadata(
+                    'nirspec', observation=obs_name, planned=total_tasks,
+                    succeeded=success, failed=failed, items=len(spectra),
+                    draft=draft, n_objects=len(objects)),
             )
 
         # B4 multi-reducer safety: compare-and-set the scope version. A conflict

--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -378,31 +378,48 @@ def discover_expmap_tasks(dirs, field):
 # Deploy (push)
 # ---------------------------------------------------------------------------
 
-def _read_field_provenance(dirs, field, filters):
-    """Best-effort ``(cfpipe_version, jwst_version, crds_context)`` for a field.
-
-    Read from a deployed mosaic's primary header — mosaics are the only NIRCam
-    product stamped with ``CMPFRVER`` / ``CAL_VER`` / ``CRDS_CTX`` (canonical
-    exposures carry only ``CFP_*`` step keys). Returns ``(None, None, None)``
-    when no mosaic exists yet, which is the normal case for a mid-reduction
-    ``--draft`` exposure deploy: the pipeline version that produced the
-    exposures is not recorded in exposure headers, so a draft-only deploy
-    legitimately has no batch-level provenance (audit B2). A follow-on could
-    stamp ``CMPFRVER`` on canonical exposures at reduction time to close this.
-    """
+def _provenance_from_header(path):
+    """``(CMPFRVER, CAL_VER, CRDS_CTX)`` from a FITS primary header, or a None
+    triple on any read failure."""
     try:
-        mosaics = discover_mosaics(dirs, field, filters)
-    except Exception:
-        return None, None, None
-    if not mosaics:
-        return None, None, None
-    chosen = next((m for m in mosaics if m.get('extension') == 'i2d'), mosaics[0])
-    try:
-        with fits.open(chosen['path'], memmap=False) as hdul:
+        with fits.open(path, memmap=False) as hdul:
             hdr = hdul[0].header
             return hdr.get('CMPFRVER'), hdr.get('CAL_VER'), hdr.get('CRDS_CTX')
     except Exception:
         return None, None, None
+
+
+def _read_field_provenance(dirs, field, filters):
+    """Best-effort ``(cfpipe_version, jwst_version, crds_context)`` for a field.
+
+    Prefer a deployed mosaic's ``i2d`` header (the combined science product);
+    fall back to any canonical exposure header. Both now carry the CAMPFIRE
+    ``CMPFRVER`` — the mosaic from ``resample.py``, the exposure from
+    ``detector1`` at creation — plus the jwst-native ``CAL_VER`` / ``CRDS_CTX``.
+    So a mid-reduction ``--draft`` exposure deploy (no mosaic yet) now records
+    real provenance instead of NULL (audit B2). Returns ``(None, None, None)``
+    only when the field has neither a mosaic nor a readable exposure.
+    """
+    try:
+        mosaics = discover_mosaics(dirs, field, filters)
+    except Exception:
+        mosaics = []
+    if mosaics:
+        chosen = next((m for m in mosaics if m.get('extension') == 'i2d'), mosaics[0])
+        prov = _provenance_from_header(chosen['path'])
+        if any(prov):
+            return prov
+
+    # No mosaic (or an unstamped one): read a representative exposure header.
+    try:
+        exposures = discover_exposures(dirs, filters)
+    except Exception:
+        return None, None, None
+    for info in exposures.values():
+        prov = _provenance_from_header(info['path'])
+        if any(prov):
+            return prov
+    return None, None, None
 
 
 def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):

--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -45,8 +45,8 @@ from astropy.io import fits
 from campfire_layout import KeyScheme, Scope, storage_key
 from campfire.deploy.r2 import UploadTask, upload_files_parallel
 from campfire.deploy.supabase import (
-    claim_deploy_scope, get_deploy_scope_version, get_supabase_client,
-    get_user_id_from_token, insert_deployment, log_deploy_event,
+    claim_deploy_scope, deploy_event_metadata, get_deploy_scope_version,
+    get_supabase_client, get_user_id_from_token, insert_deployment, log_deploy_event,
 )
 
 # The OSN data backend NIRCam canonical intermediates are homed on (epic #210/#216,
@@ -378,6 +378,33 @@ def discover_expmap_tasks(dirs, field):
 # Deploy (push)
 # ---------------------------------------------------------------------------
 
+def _read_field_provenance(dirs, field, filters):
+    """Best-effort ``(cfpipe_version, jwst_version, crds_context)`` for a field.
+
+    Read from a deployed mosaic's primary header — mosaics are the only NIRCam
+    product stamped with ``CMPFRVER`` / ``CAL_VER`` / ``CRDS_CTX`` (canonical
+    exposures carry only ``CFP_*`` step keys). Returns ``(None, None, None)``
+    when no mosaic exists yet, which is the normal case for a mid-reduction
+    ``--draft`` exposure deploy: the pipeline version that produced the
+    exposures is not recorded in exposure headers, so a draft-only deploy
+    legitimately has no batch-level provenance (audit B2). A follow-on could
+    stamp ``CMPFRVER`` on canonical exposures at reduction time to close this.
+    """
+    try:
+        mosaics = discover_mosaics(dirs, field, filters)
+    except Exception:
+        return None, None, None
+    if not mosaics:
+        return None, None, None
+    chosen = next((m for m in mosaics if m.get('extension') == 'i2d'), mosaics[0])
+    try:
+        with fits.open(chosen['path'], memmap=False) as hdul:
+            hdr = hdul[0].header
+            return hdr.get('CMPFRVER'), hdr.get('CAL_VER'), hdr.get('CRDS_CTX')
+    except Exception:
+        return None, None, None
+
+
 def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
     """Push NIRCam exposure state to OSN + Supabase (epic #261, N1).
 
@@ -516,11 +543,18 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
     # concurrent same-field deploy is detected at finalize (epic #210, B4 / D12).
     scope_version = get_deploy_scope_version(client, 'field', field)
 
+    # Batch-level provenance (audit B2, Phase 3). Best-effort: only mosaics carry
+    # the version cards, so an exposure-only --draft deploy (no mosaic yet)
+    # records NULL provenance — the pipeline version that produced the exposures
+    # is not stamped on exposure headers.
+    cfpipe_version, jwst_version, crds_context = _read_field_provenance(dirs, field, filters)
+
     # Record the field-scoped deployment up front — it is the provenance anchor and
     # the draft/published visibility gate every registered object hangs off.
     deployment_id = insert_deployment(
         client, field=field, deployed_by=user_id,
-        status='draft' if draft else 'published', n_targets=len(records))
+        status='draft' if draft else 'published', n_targets=len(records),
+        cfpipe_version=cfpipe_version, jwst_version=jwst_version, crds_context=crds_context)
     print(f"Deployment #{deployment_id} recorded "
           f"({'draft — admin-only' if draft else 'published — public'})")
 
@@ -540,6 +574,7 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
         print(f"\nSkipping {n_skipped} unchanged exposure(s) (SCI+DQ hash match)")
 
     # --- Upload canonical FITS + expmaps to OSN ----------------------------
+    n_failed = 0
     osn_tasks = fits_to_upload + expmap_tasks
     osn_uploaded: set[str] = set()
     if osn_tasks:
@@ -547,6 +582,7 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
         success, failed, failures = upload_files_parallel(
             config, osn_tasks, desc='OSN uploads',
             succeeded_out=osn_uploaded, backend=_CANONICAL_BACKEND)
+        n_failed += failed
         print(f"  Uploaded: {success}, Failed: {failed}")
         for msg in failures:
             print(f"  Error: {msg}")
@@ -559,6 +595,7 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
         success, failed, failures = upload_files_parallel(
             config, png_upload_list, desc='Uploading PNGs',
             succeeded_out=png_uploaded, backend=_CANONICAL_BACKEND)
+        n_failed += failed
         print(f"  Uploaded: {success}, Failed: {failed}")
         for msg in failures:
             print(f"  Error: {msg}")
@@ -576,11 +613,12 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
     if osn_uploaded:
         reg_rows = build_registry_rows(
             osn_tasks, backend=_CANONICAL_BACKEND, deployment_id=deployment_id,
-            uploaded_by=user_id, succeeded_keys=osn_uploaded, sci_dq_hashes=local_sci_dq)
+            uploaded_by=user_id, cfpipe_version=cfpipe_version,
+            succeeded_keys=osn_uploaded, sci_dq_hashes=local_sci_dq)
         n_reg += upsert_storage_objects(client, reg_rows)
     if png_uploaded:
         reg_rows = build_registry_rows(
-            png_upload_list, backend=_CANONICAL_BACKEND,
+            png_upload_list, backend=_CANONICAL_BACKEND, cfpipe_version=cfpipe_version,
             deployment_id=deployment_id, uploaded_by=user_id, succeeded_keys=png_uploaded)
         n_reg += upsert_storage_objects(client, reg_rows)
     if n_reg:
@@ -609,10 +647,12 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
               f"advanced this field while this deploy was running. Re-run to reconcile.")
     log_deploy_event(
         client, action='upload', actor=user_id, deployment_id=deployment_id,
-        observation=None, affected_count=len(records),
-        metadata={'nircam': True, 'field': field, 'filters': filters, 'draft': draft,
-                  'exposures': len(records), 'fits_uploaded': len(osn_uploaded),
-                  'fits_skipped': n_skipped})
+        observation=None, field=field, affected_count=len(osn_uploaded),
+        metadata=deploy_event_metadata(
+            'nircam', field=field, filters=filters, planned=len(records),
+            succeeded=len(osn_uploaded), failed=n_failed, skipped=n_skipped,
+            items=len(records), draft=draft,
+            fits_uploaded=len(osn_uploaded), fits_skipped=n_skipped))
 
 
 def _upsert_exposures(client, records, batch_size=500):

--- a/python/campfire/deploy/remove.py
+++ b/python/campfire/deploy/remove.py
@@ -20,7 +20,10 @@ from supabase import Client
 
 from campfire_layout import Scope, key_prefix
 from campfire.deploy.supabase import (
+    deploy_event_metadata,
     get_supabase_client,
+    get_user_id_from_token,
+    log_deploy_event,
     refresh_filter_options,
     refresh_programs_overview,
 )
@@ -271,11 +274,25 @@ def remove_observation(
     _delete_db_rows(sb, obs_name, target_ids)
     print(f"  Done.")
 
+    n_r2_deleted = 0
     if not supabase_only:
         print(f"\nDeleting R2 prefixes...")
         counts = _delete_r2_prefixes(config, obs_name)
         for prefix, n in counts.items():
             print(f"  {prefix}/{obs_name}/: {n} object(s)")
+        n_r2_deleted = sum(counts.values())
+
+    # Audit the un-deploy (audit B3): a hard delete was previously silent — no
+    # deploy_events row, so the ledger drifted from the bucket. Best-effort.
+    log_deploy_event(
+        sb, action='delete', actor=get_user_id_from_token(config),
+        observation=obs_name, affected_count=n_spectra,
+        metadata=deploy_event_metadata(
+            'nirspec', observation=obs_name, items=len(targets),
+            supabase_only=supabase_only,
+            targets=len(targets), spectra=n_spectra, shutters=n_shutters,
+            slit_regions=n_slits, comments=n_comments,
+            r2_objects_deleted=n_r2_deleted))
 
     if not skip_rebuild:
         from campfire.deploy.reconcile import reconcile_field_objects

--- a/python/campfire/deploy/supabase.py
+++ b/python/campfire/deploy/supabase.py
@@ -232,6 +232,54 @@ def get_lifecycle_status(client: Client) -> dict:
     return {'enabled': False, 'error': 'unexpected get_lifecycle_status response'}
 
 
+def deploy_event_metadata(
+    instrument: str,
+    *,
+    field: str | None = None,
+    observation: str | None = None,
+    filters: list[str] | None = None,
+    planned: int | None = None,
+    succeeded: int | None = None,
+    failed: int | None = None,
+    skipped: int | None = None,
+    items: int | None = None,
+    draft: bool = False,
+    supabase_only: bool = False,
+    **extra,
+) -> dict:
+    """Build the normalized deploy_events metadata envelope (audit B5, Phase 3).
+
+    One shape across every producer, so the consumer parses one thing:
+        {instrument, scope:{field, observation, filters},
+         counts:{planned, succeeded, failed, skipped, items},
+         flags:{draft, partial, supabase_only}}
+    ``partial`` is derived (failed > 0). Only non-None counts are included so a
+    producer that doesn't track a given count leaves it absent rather than 0.
+    ``extra`` folds in any producer-specific keys (e.g. exposures details).
+    """
+    scope = {}
+    if field is not None:
+        scope['field'] = field
+    if observation is not None:
+        scope['observation'] = observation
+    if filters:
+        scope['filters'] = filters
+
+    counts = {}
+    for k, v in (('planned', planned), ('succeeded', succeeded),
+                 ('failed', failed), ('skipped', skipped), ('items', items)):
+        if v is not None:
+            counts[k] = v
+
+    flags = {'draft': draft, 'partial': bool(failed)}
+    if supabase_only:
+        flags['supabase_only'] = True
+
+    meta = {'instrument': instrument, 'scope': scope, 'counts': counts, 'flags': flags}
+    meta.update(extra)
+    return meta
+
+
 def log_deploy_event(
     client: Client,
     *,
@@ -239,6 +287,7 @@ def log_deploy_event(
     actor: str | None = None,
     deployment_id: int | None = None,
     observation: str | None = None,
+    field: str | None = None,
     affected_count: int | None = None,
     metadata: dict | None = None,
     host: str | None = None,
@@ -253,6 +302,7 @@ def log_deploy_event(
             'p_actor': actor,
             'p_deployment_id': deployment_id,
             'p_observation': observation,
+            'p_field': field,
             'p_affected_count': affected_count,
             'p_metadata': metadata,
             'p_host': host,

--- a/python/tests/test_deploy_events.py
+++ b/python/tests/test_deploy_events.py
@@ -63,9 +63,24 @@ def test_log_deploy_event_best_effort_swallows_errors():
 
 # --- provenance header reads (best-effort) ----------------------------------
 
-def test_read_field_provenance_none_when_no_mosaic(tmp_path, monkeypatch):
+def test_read_field_provenance_none_when_no_mosaic_or_exposure(monkeypatch):
     monkeypatch.setattr(nc, "discover_mosaics", lambda *a, **k: [])
+    monkeypatch.setattr(nc, "discover_exposures", lambda *a, **k: {})
     assert nc._read_field_provenance({}, "cosmos", ["f444w"]) == (None, None, None)
+
+
+def test_read_field_provenance_falls_back_to_exposure(tmp_path, monkeypatch):
+    # No mosaic yet (mid-reduction --draft): read the stamped exposure header.
+    epath = tmp_path / "jw123_nrcalong.fits"
+    hdu = fits.PrimaryHDU(data=np.zeros((2, 2), dtype="float32"))
+    hdu.header["CMPFRVER"] = "2.0.0"
+    hdu.header["CAL_VER"] = "1.14.0"
+    fits.HDUList([hdu]).writeto(epath)
+    monkeypatch.setattr(nc, "discover_mosaics", lambda *a, **k: [])
+    monkeypatch.setattr(
+        nc, "discover_exposures",
+        lambda *a, **k: {("f444w", "jw123_nrcalong"): {"path": str(epath)}})
+    assert nc._read_field_provenance({}, "cosmos", ["f444w"]) == ("2.0.0", "1.14.0", None)
 
 
 def test_read_field_provenance_reads_mosaic_cards(tmp_path, monkeypatch):

--- a/python/tests/test_deploy_events.py
+++ b/python/tests/test_deploy_events.py
@@ -1,0 +1,129 @@
+"""Unit tests for the Phase 3 deploy ledger (admin audit 2026-07-03, Theme B).
+
+Pure/local: the normalized deploy_events metadata envelope, the field→p_field
+forwarding through log_deploy_event, best-effort provenance header reads, and
+the new delete events emitted by remove/prune. Full SQL (the field column,
+backfill, log_deploy_event arity) is exercised on the Supabase preview branch.
+"""
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from astropy.io import fits
+
+from campfire.deploy import nircam as nc
+from campfire.deploy import deploy as dep
+from campfire.deploy.supabase import deploy_event_metadata, log_deploy_event
+
+
+# --- deploy_event_metadata (the envelope) -----------------------------------
+
+def test_envelope_shape_and_partial_derivation():
+    m = deploy_event_metadata(
+        "nircam", field="cosmos", filters=["f444w"],
+        planned=10, succeeded=8, failed=2, skipped=1, draft=True)
+    assert m["instrument"] == "nircam"
+    assert m["scope"] == {"field": "cosmos", "filters": ["f444w"]}
+    assert m["counts"] == {"planned": 10, "succeeded": 8, "failed": 2, "skipped": 1}
+    assert m["flags"] == {"draft": True, "partial": True}
+
+
+def test_envelope_partial_false_and_absent_counts_omitted():
+    m = deploy_event_metadata("nirspec", observation="obs1", succeeded=5)
+    assert m["scope"] == {"observation": "obs1"}
+    assert m["counts"] == {"succeeded": 5}          # planned/failed/etc absent, not 0
+    assert m["flags"]["partial"] is False
+
+
+def test_envelope_supabase_only_and_extra_keys():
+    m = deploy_event_metadata(
+        "nirspec", observation="o", supabase_only=True, spectra=3, r2_objects_deleted=0)
+    assert m["flags"]["supabase_only"] is True
+    assert m["spectra"] == 3 and m["r2_objects_deleted"] == 0   # extra folds through
+
+
+# --- log_deploy_event forwards field → p_field ------------------------------
+
+def test_log_deploy_event_forwards_field():
+    client = MagicMock()
+    client.rpc.return_value.execute.return_value.data = "evt-id"
+    log_deploy_event(client, action="upload", field="cosmos", observation=None)
+    args, _ = client.rpc.call_args
+    assert args[0] == "log_deploy_event"
+    assert args[1]["p_field"] == "cosmos"
+    assert args[1]["p_action"] == "upload"
+
+
+def test_log_deploy_event_best_effort_swallows_errors():
+    client = MagicMock()
+    client.rpc.side_effect = RuntimeError("boom")
+    # Audit is best-effort; a failure must never raise into the deploy path.
+    assert log_deploy_event(client, action="delete") is None
+
+
+# --- provenance header reads (best-effort) ----------------------------------
+
+def test_read_field_provenance_none_when_no_mosaic(tmp_path, monkeypatch):
+    monkeypatch.setattr(nc, "discover_mosaics", lambda *a, **k: [])
+    assert nc._read_field_provenance({}, "cosmos", ["f444w"]) == (None, None, None)
+
+
+def test_read_field_provenance_reads_mosaic_cards(tmp_path, monkeypatch):
+    mpath = tmp_path / "mosaic_cosmos_f444w_i2d.fits"
+    hdu = fits.PrimaryHDU()
+    hdu.header["CMPFRVER"] = "1.2.3"
+    hdu.header["CAL_VER"] = "1.14.0"
+    hdu.header["CRDS_CTX"] = "jwst_1234.pmap"
+    fits.HDUList([hdu]).writeto(mpath)
+    monkeypatch.setattr(
+        nc, "discover_mosaics",
+        lambda *a, **k: [{"extension": "i2d", "path": str(mpath)}])
+    assert nc._read_field_provenance({}, "cosmos", ["f444w"]) == (
+        "1.2.3", "1.14.0", "jwst_1234.pmap")
+
+
+def test_read_exposure_provenance_none_when_empty():
+    assert dep._read_exposure_provenance([]) == (None, None, None)
+
+
+def test_read_exposure_provenance_reads_first(tmp_path):
+    p = tmp_path / "exp.fits"
+    hdu = fits.PrimaryHDU(data=np.zeros((2, 2), dtype="float32"))
+    hdu.header["CMPFRVER"] = "9.9.9"
+    fits.HDUList([hdu]).writeto(p)
+    cf, jw, crds = dep._read_exposure_provenance([str(p)])
+    assert cf == "9.9.9" and jw is None and crds is None
+
+
+# --- silent-mutation delete events ------------------------------------------
+
+def test_remove_observation_emits_delete_event(monkeypatch):
+    from campfire.deploy import remove as rm
+
+    sb = MagicMock()
+    monkeypatch.setattr(rm, "get_supabase_client", lambda cfg: sb)
+    monkeypatch.setattr(rm, "get_user_id_from_token", lambda cfg: "user-1")
+    monkeypatch.setattr(rm, "_fetch_observation",
+                        lambda sb, o: {"field": "cosmos", "latest_deployment_id": None})
+    monkeypatch.setattr(rm, "_fetch_targets", lambda sb, o: [{"target_id": "t1", "id": 1}])
+    monkeypatch.setattr(rm, "_count_spectra", lambda sb, ids: 3)
+    monkeypatch.setattr(rm, "_count_by_obs", lambda sb, t, o: 0)
+    monkeypatch.setattr(rm, "_count_comments", lambda sb, ids: 0)
+    monkeypatch.setattr(rm, "_is_inspected", lambda t: False)
+    monkeypatch.setattr(rm, "_delete_db_rows", lambda *a, **k: None)
+    monkeypatch.setattr(rm, "refresh_filter_options", lambda sb: None)
+    monkeypatch.setattr(rm, "refresh_programs_overview", lambda sb: None)
+    events = []
+    monkeypatch.setattr(rm, "log_deploy_event",
+                        lambda sb, **kw: events.append(kw))
+
+    rm.remove_observation("obs1", {}, supabase_only=True, auto_approve=True,
+                          skip_rebuild=True)
+
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["action"] == "delete"
+    assert ev["observation"] == "obs1"
+    assert ev["metadata"]["scope"]["observation"] == "obs1"
+    assert ev["metadata"]["spectra"] == 3
+    assert ev["metadata"]["flags"]["supabase_only"] is True

--- a/supabase/migrations/20260703230000_complete_deploy_ledger.sql
+++ b/supabase/migrations/20260703230000_complete_deploy_ledger.sql
@@ -1,0 +1,307 @@
+-- Admin audit 2026-07-03, Phase 3 (docs/admin_audit_2026-07-03.md Theme B / §5):
+-- complete the deploy ledger.
+--
+-- 1. deploy_events.field — first-class NIRCam scope column (was buried in
+--    metadata->>'field'). Backfilled from the legacy metadata so all history is
+--    reachable, then get_admin_deploy_events reads the column, not metadata.
+-- 2. log_deploy_event gains p_field. Appending a param changes the arity, so the
+--    old 7-arg overload MUST be dropped first or PostgREST sees two candidates
+--    (PGRST203).
+-- 3. The two lifecycle emitters (set_deployment_status NIRCam branch,
+--    set_spectra_deploy_status) write the normalized metadata envelope
+--    {instrument, scope, counts, flags} and set the field column.
+--
+-- Hand-authored (function bodies match supabase/schemas/functions.sql verbatim;
+-- supabase db diff unavailable in the authoring environment). deploy_events is
+-- not in seed.sql, so no seed regen.
+
+ALTER TABLE public.deploy_events ADD COLUMN IF NOT EXISTS field text;
+
+-- Backfill legacy NIRCam events (scope only ever lived in metadata).
+UPDATE public.deploy_events
+   SET field = metadata ->> 'field'
+ WHERE field IS NULL AND metadata ? 'field';
+
+COMMENT ON COLUMN public.deploy_events.field IS
+  'NIRCam field scope (audit B5, Phase 3). Mirrors deployments.field; NULL for NIRSpec (observation) events. Authoritative — get_admin_deploy_events reads this, not metadata.';
+
+CREATE INDEX IF NOT EXISTS idx_deploy_events_field
+    ON public.deploy_events USING btree (field)
+    WHERE field IS NOT NULL;
+
+-- Arity change: drop the old 7-arg log_deploy_event before recreating with p_field.
+DROP FUNCTION IF EXISTS public.log_deploy_event(text, uuid, integer, text, integer, jsonb, text);
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.log_deploy_event(
+  p_action text,
+  p_actor uuid DEFAULT NULL,
+  p_deployment_id integer DEFAULT NULL,
+  p_observation text DEFAULT NULL,
+  p_field text DEFAULT NULL,
+  p_affected_count integer DEFAULT NULL,
+  p_metadata jsonb DEFAULT NULL,
+  p_host text DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_is_admin boolean;
+  v_id uuid;
+BEGIN
+  SELECT COALESCE(up.is_admin, false) INTO v_is_admin
+  FROM user_profiles up WHERE up.user_id = auth.uid();
+  IF NOT (COALESCE(v_is_admin, false) OR COALESCE(auth.role(), '') = 'service_role') THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+
+  IF p_action NOT IN ('upload', 'publish', 'revoke', 'recover', 'supersede', 'delete') THEN
+    RAISE EXCEPTION 'Invalid deploy_event action: %', p_action;
+  END IF;
+
+  INSERT INTO deploy_events(actor, action, deployment_id, observation, field, affected_count, metadata, host)
+  VALUES (p_actor, p_action, p_deployment_id, p_observation, p_field, p_affected_count, p_metadata, p_host)
+  RETURNING id INTO v_id;
+  RETURN v_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.log_deploy_event(text, uuid, integer, text, text, integer, jsonb, text) TO authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.get_admin_deploy_events(
+  p_action text DEFAULT NULL,
+  p_observation text DEFAULT NULL,
+  p_field text DEFAULT NULL,
+  p_sort_column text DEFAULT 'occurred_at',
+  p_sort_direction text DEFAULT 'desc',
+  p_page integer DEFAULT 1,
+  p_page_size integer DEFAULT 50
+)
+RETURNS TABLE (
+  id uuid,
+  action text,
+  observation text,
+  field text,
+  deployment_id integer,
+  status_to text,
+  affected_count integer,
+  occurred_at timestamptz,
+  actor uuid,
+  actor_name text,
+  total_count bigint
+)
+LANGUAGE plpgsql STABLE
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_limit integer := LEAST(GREATEST(COALESCE(p_page_size, 50), 1), 200);
+  v_offset integer := GREATEST(COALESCE(p_page, 1) - 1, 0) * LEAST(GREATEST(COALESCE(p_page_size, 50), 1), 200);
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'desc'; END IF;
+  IF p_sort_column NOT IN ('occurred_at', 'action') THEN
+    p_sort_column := 'occurred_at';
+  END IF;
+
+  RETURN QUERY
+  SELECT e.id, e.action, e.observation,
+         e.field,
+         e.deployment_id, e.status_to, e.affected_count, e.occurred_at,
+         e.actor,
+         COALESCE(up.full_name, up.username) AS actor_name,
+         count(*) OVER ()
+  FROM deploy_events e
+  LEFT JOIN user_profiles up ON up.user_id = e.actor
+  WHERE (p_action IS NULL OR e.action = p_action)
+    AND (p_observation IS NULL OR e.observation = p_observation)
+    AND (p_field IS NULL OR e.field = p_field)
+  ORDER BY
+    CASE WHEN p_sort_column = 'occurred_at' AND p_sort_direction = 'desc' THEN e.occurred_at END DESC,
+    CASE WHEN p_sort_column = 'occurred_at' AND p_sort_direction = 'asc'  THEN e.occurred_at END ASC,
+    CASE WHEN p_sort_column = 'action' AND p_sort_direction = 'desc' THEN e.action END DESC,
+    CASE WHEN p_sort_column = 'action' AND p_sort_direction = 'asc'  THEN e.action END ASC,
+    e.occurred_at DESC
+  OFFSET v_offset LIMIT v_limit;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_admin_deploy_events TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.set_spectra_deploy_status(
+  p_spectrum_db_ids integer[],
+  p_to text,
+  p_action text DEFAULT NULL,
+  p_actor uuid DEFAULT NULL,
+  p_deployment_id integer DEFAULT NULL,
+  p_host text DEFAULT NULL
+)
+RETURNS json
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_is_admin boolean;
+  v_action text;
+  v_updated int := 0;
+  v_target_ids text[];
+  v_recompute json;
+BEGIN
+  SELECT COALESCE(up.is_admin, false) INTO v_is_admin
+  FROM user_profiles up WHERE up.user_id = auth.uid();
+  IF NOT (COALESCE(v_is_admin, false) OR COALESCE(auth.role(), '') = 'service_role') THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+
+  IF p_to NOT IN ('draft', 'published', 'revoked') THEN
+    RAISE EXCEPTION 'Invalid deploy_status: %', p_to;
+  END IF;
+
+  v_action := COALESCE(p_action,
+    CASE p_to WHEN 'published' THEN 'publish' WHEN 'revoked' THEN 'revoke' ELSE 'upload' END);
+  IF v_action NOT IN ('upload', 'publish', 'revoke', 'recover', 'supersede', 'delete') THEN
+    RAISE EXCEPTION 'Invalid action: %', v_action;
+  END IF;
+
+  IF p_spectrum_db_ids IS NULL OR array_length(p_spectrum_db_ids, 1) IS NULL THEN
+    RETURN json_build_object('updated', 0, 'action', v_action);
+  END IF;
+
+  SELECT array_agg(DISTINCT s.target_id) INTO v_target_ids
+  FROM spectra s WHERE s.id = ANY(p_spectrum_db_ids);
+
+  UPDATE spectra s SET deploy_status = p_to
+  WHERE s.id = ANY(p_spectrum_db_ids) AND s.deploy_status <> p_to;
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+
+  IF v_target_ids IS NOT NULL THEN
+    v_recompute := public.recompute_has_published_spectrum(p_target_ids := v_target_ids);
+  END IF;
+
+  INSERT INTO deploy_events(actor, action, deployment_id, status_to, affected_count, host, metadata)
+  VALUES (p_actor, v_action, p_deployment_id, p_to, v_updated, p_host,
+          jsonb_build_object(
+            'instrument', 'nirspec',
+            'counts', jsonb_build_object(
+              'succeeded', v_updated,
+              'targets', COALESCE(array_length(v_target_ids, 1), 0)),
+            'flags', jsonb_build_object('lifecycle', true)));
+
+  RETURN json_build_object('updated', v_updated, 'action', v_action, 'recompute', v_recompute);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.set_spectra_deploy_status(integer[], text, text, uuid, integer, text) TO authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.set_deployment_status(
+  p_deployment_id integer,
+  p_to text,
+  p_actor uuid DEFAULT NULL,
+  p_host text DEFAULT NULL
+)
+RETURNS json
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_is_admin boolean;
+  v_obs text;
+  v_field text;
+  v_action text;
+  v_spectrum_ids integer[];
+  v_n_images integer;
+  v_result json;
+BEGIN
+  SELECT COALESCE(up.is_admin, false) INTO v_is_admin
+  FROM user_profiles up WHERE up.user_id = auth.uid();
+  IF NOT (COALESCE(v_is_admin, false) OR COALESCE(auth.role(), '') = 'service_role') THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+
+  IF p_to NOT IN ('draft', 'published', 'revoked') THEN
+    RAISE EXCEPTION 'Invalid status: %', p_to;
+  END IF;
+
+  SELECT observation, field INTO v_obs, v_field FROM deployments WHERE id = p_deployment_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Deployment % not found', p_deployment_id;
+  END IF;
+
+  -- NIRCam field-scoped deployment (epic #261, N1/N2): exposure/mosaic FITS
+  -- visibility rides deployment.status via the storage_objects gate; the public
+  -- mosaic index (nircam_images) carries its own deploy_status, flipped here to
+  -- match (mirrors how the observation path flips spectra.deploy_status).
+  IF v_field IS NOT NULL THEN
+    v_action := CASE WHEN p_to = 'revoked' THEN 'revoke'
+                     WHEN p_to = 'draft' THEN 'upload' ELSE 'publish' END;
+    UPDATE deployments SET
+      status = p_to,
+      published_at = CASE WHEN p_to = 'published' THEN now() ELSE published_at END,
+      revoked_at = CASE WHEN p_to = 'revoked' THEN now() ELSE revoked_at END
+    WHERE id = p_deployment_id;
+    WITH flipped AS (
+      UPDATE nircam_images SET deploy_status = p_to
+      WHERE deployment_id = p_deployment_id AND deploy_status <> p_to
+      RETURNING 1)
+    SELECT count(*) INTO v_n_images FROM flipped;
+    INSERT INTO deploy_events (actor, action, deployment_id, field, status_to, host, affected_count, metadata)
+      VALUES (p_actor, v_action, p_deployment_id, v_field, p_to, p_host, v_n_images,
+              jsonb_build_object(
+                'instrument', 'nircam',
+                'scope', jsonb_build_object('field', v_field),
+                'counts', jsonb_build_object('succeeded', v_n_images),
+                'flags', jsonb_build_object('lifecycle', true)));
+    RETURN json_build_object(
+      'deployment_id', p_deployment_id, 'field', v_field, 'status', p_to,
+      'nircam_images', json_build_object('updated', v_n_images, 'action', v_action));
+  END IF;
+
+  -- Which current statuses transition to p_to:
+  --   p_to='published'  -> draft (first publish) OR revoked (recover) become visible
+  --   p_to='revoked'    -> published spectra are hidden
+  --   p_to='draft'    -> published spectra go back to draft
+  -- The prior version matched only 'draft' for the published case, so recovering
+  -- a REVOKED deployment flipped the deployment row but left its spectra revoked
+  -- and hidden ("0 updated", silently inconsistent) — #233 review.
+  SELECT array_agg(s.id) INTO v_spectrum_ids
+  FROM spectra s JOIN targets t ON s.target_id = t.target_id
+  WHERE t.observation = v_obs
+    AND s.deploy_status = ANY (
+      CASE p_to WHEN 'published' THEN ARRAY['draft', 'revoked']
+                WHEN 'revoked'   THEN ARRAY['published']
+                ELSE                  ARRAY['published'] END);
+
+  -- Audit label: publishing previously-revoked spectra is a 'recover', not a
+  -- first 'publish'. Computed before the transition (spectra still hold old status).
+  v_action := CASE
+    WHEN p_to = 'revoked' THEN 'revoke'
+    WHEN p_to = 'draft' THEN 'upload'
+    WHEN EXISTS (SELECT 1 FROM spectra s JOIN targets t ON s.target_id = t.target_id
+                 WHERE t.observation = v_obs AND s.deploy_status = 'revoked')
+      THEN 'recover'
+    ELSE 'publish'
+  END;
+
+  UPDATE deployments SET
+    status = p_to,
+    published_at = CASE WHEN p_to = 'published' THEN now() ELSE published_at END,
+    revoked_at = CASE WHEN p_to = 'revoked' THEN now() ELSE revoked_at END
+  WHERE id = p_deployment_id;
+
+  IF v_spectrum_ids IS NOT NULL THEN
+    v_result := public.set_spectra_deploy_status(
+      p_spectrum_db_ids := v_spectrum_ids, p_to := p_to, p_action := v_action,
+      p_actor := p_actor, p_deployment_id := p_deployment_id, p_host := p_host);
+  ELSE
+    v_result := json_build_object('updated', 0, 'action', v_action);
+  END IF;
+
+  RETURN json_build_object(
+    'deployment_id', p_deployment_id, 'observation', v_obs,
+    'status', p_to, 'spectra', v_result);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.set_deployment_status(integer, text, uuid, text) TO authenticated, service_role;
+

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -3256,9 +3256,9 @@ $$;
 
 GRANT EXECUTE ON FUNCTION public.get_admin_deployments TO authenticated;
 
--- Audit-log browse. Folds the NIRCam scope (metadata->>'field' until
--- deploy_events grows a field column in Phase 3) and the actor display name
--- (full_name, falling back to username) into the row, replacing two extra
+-- Audit-log browse. Reads the first-class deploy_events.field column (Phase 3;
+-- backfilled from the legacy metadata->>'field') and folds the actor display
+-- name (full_name, falling back to username) into the row, replacing two extra
 -- client round-trips.
 CREATE OR REPLACE FUNCTION public.get_admin_deploy_events(
   p_action text DEFAULT NULL,
@@ -3299,7 +3299,7 @@ BEGIN
 
   RETURN QUERY
   SELECT e.id, e.action, e.observation,
-         (e.metadata ->> 'field') AS field,
+         e.field,
          e.deployment_id, e.status_to, e.affected_count, e.occurred_at,
          e.actor,
          COALESCE(up.full_name, up.username) AS actor_name,
@@ -3308,7 +3308,7 @@ BEGIN
   LEFT JOIN user_profiles up ON up.user_id = e.actor
   WHERE (p_action IS NULL OR e.action = p_action)
     AND (p_observation IS NULL OR e.observation = p_observation)
-    AND (p_field IS NULL OR e.metadata ->> 'field' = p_field)
+    AND (p_field IS NULL OR e.field = p_field)
   ORDER BY
     CASE WHEN p_sort_column = 'occurred_at' AND p_sort_direction = 'desc' THEN e.occurred_at END DESC,
     CASE WHEN p_sort_column = 'occurred_at' AND p_sort_direction = 'asc'  THEN e.occurred_at END ASC,
@@ -3861,6 +3861,7 @@ CREATE OR REPLACE FUNCTION public.log_deploy_event(
   p_actor uuid DEFAULT NULL,
   p_deployment_id integer DEFAULT NULL,
   p_observation text DEFAULT NULL,
+  p_field text DEFAULT NULL,
   p_affected_count integer DEFAULT NULL,
   p_metadata jsonb DEFAULT NULL,
   p_host text DEFAULT NULL
@@ -3882,14 +3883,14 @@ BEGIN
     RAISE EXCEPTION 'Invalid deploy_event action: %', p_action;
   END IF;
 
-  INSERT INTO deploy_events(actor, action, deployment_id, observation, affected_count, metadata, host)
-  VALUES (p_actor, p_action, p_deployment_id, p_observation, p_affected_count, p_metadata, p_host)
+  INSERT INTO deploy_events(actor, action, deployment_id, observation, field, affected_count, metadata, host)
+  VALUES (p_actor, p_action, p_deployment_id, p_observation, p_field, p_affected_count, p_metadata, p_host)
   RETURNING id INTO v_id;
   RETURN v_id;
 END;
 $$;
 
-GRANT EXECUTE ON FUNCTION public.log_deploy_event(text, uuid, integer, text, integer, jsonb, text) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.log_deploy_event(text, uuid, integer, text, text, integer, jsonb, text) TO authenticated, service_role;
 
 
 -- set_spectra_deploy_status: the publish/revoke/recover primitive. Transitions a
@@ -3947,7 +3948,12 @@ BEGIN
 
   INSERT INTO deploy_events(actor, action, deployment_id, status_to, affected_count, host, metadata)
   VALUES (p_actor, v_action, p_deployment_id, p_to, v_updated, p_host,
-          jsonb_build_object('n_targets', COALESCE(array_length(v_target_ids, 1), 0)));
+          jsonb_build_object(
+            'instrument', 'nirspec',
+            'counts', jsonb_build_object(
+              'succeeded', v_updated,
+              'targets', COALESCE(array_length(v_target_ids, 1), 0)),
+            'flags', jsonb_build_object('lifecycle', true)));
 
   RETURN json_build_object('updated', v_updated, 'action', v_action, 'recompute', v_recompute);
 END;
@@ -4010,9 +4016,13 @@ BEGIN
       WHERE deployment_id = p_deployment_id AND deploy_status <> p_to
       RETURNING 1)
     SELECT count(*) INTO v_n_images FROM flipped;
-    INSERT INTO deploy_events (actor, action, deployment_id, status_to, host, affected_count, metadata)
-      VALUES (p_actor, v_action, p_deployment_id, p_to, p_host, v_n_images,
-              jsonb_build_object('field', v_field));
+    INSERT INTO deploy_events (actor, action, deployment_id, field, status_to, host, affected_count, metadata)
+      VALUES (p_actor, v_action, p_deployment_id, v_field, p_to, p_host, v_n_images,
+              jsonb_build_object(
+                'instrument', 'nircam',
+                'scope', jsonb_build_object('field', v_field),
+                'counts', jsonb_build_object('succeeded', v_n_images),
+                'flags', jsonb_build_object('lifecycle', true)));
     RETURN json_build_object(
       'deployment_id', p_deployment_id, 'field', v_field, 'status', p_to,
       'nircam_images', json_build_object('updated', v_n_images, 'action', v_action));

--- a/supabase/schemas/indexes.sql
+++ b/supabase/schemas/indexes.sql
@@ -382,6 +382,11 @@ CREATE INDEX IF NOT EXISTS idx_deploy_events_observation
     ON public.deploy_events USING btree (observation)
     WHERE observation IS NOT NULL;
 
+-- NIRCam events filter by field, now a first-class column (audit B5, Phase 3).
+CREATE INDEX IF NOT EXISTS idx_deploy_events_field
+    ON public.deploy_events USING btree (field)
+    WHERE field IS NOT NULL;
+
 
 -- =============================================================================
 -- storage_objects (epic #210, F1)

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -928,6 +928,9 @@ CREATE TABLE IF NOT EXISTS "public"."deploy_events" (
     "action" "text" NOT NULL,
     "deployment_id" integer,
     "observation" "text",
+    -- NIRCam field scope (audit B5, Phase 3). Mirrors deployments.field; first-
+    -- class column (was buried in metadata->>'field'). NULL for NIRSpec events.
+    "field" "text",
     "spectrum_id" "text",
     "object_id" integer,
     "status_from" "text",

--- a/web/lib/actions/deployments.ts
+++ b/web/lib/actions/deployments.ts
@@ -103,8 +103,8 @@ export interface DeployEventRow {
   id: string;
   action: string;
   observation: string | null;
-  // deploy_events has no field column yet — the RPC extracts metadata->>'field'
-  // (NIRCam events carry their scope there) so the UI has one shape.
+  // NIRCam scope. First-class deploy_events.field column (Phase 3), surfaced by
+  // the get_admin_deploy_events RPC; NULL for NIRSpec (observation) events.
   field: string | null;
   deployment_id: number | null;
   status_to: string | null;


### PR DESCRIPTION
## Summary

Phase 3 of the admin panel overhaul (docs/admin_audit_2026-07-03.md, **Theme B — deployment logging**). Where Phase 0 fixed the *rendering* of deploy records, this phase fixes the *producer + schema*: the ledger was capturing only three write paths, NIRCam rows had no provenance, counts were intended-not-actual, and event metadata had four divergent shapes. This makes `deploy_events` a faithful, provenance-rich, uniformly-shaped record of what's in the bucket.

## Key changes

**Database (one migration)**
- `deploy_events.field` — first-class NIRCam scope column (audit B5), **backfilled** from the legacy `metadata->>'field'`; `get_admin_deploy_events` now reads the column and filters on it. `idx_deploy_events_field`.
- `log_deploy_event` gains `p_field`. The arity change means the migration **DROPs the old 7-arg overload first** (else PGRST203 on the preview branch).
- The two lifecycle emitters (`set_deployment_status` NIRCam branch, `set_spectra_deploy_status`) write the normalized `{instrument, scope, counts, flags}` envelope and set the `field` column. Their return JSON is unchanged (Phase-0 `spectra ?? nircam_images` parse still works).

**Producer (`python/campfire/deploy/`)**
- `deploy_event_metadata()` — one envelope builder for every producer; `partial` derived from `failed > 0`, absent counts stay absent, `**extra` folds producer-specific keys.
- **NIRCam** upload event: sets `field=`, the envelope with **actual** succeeded/failed/skipped counts; batch + per-object provenance.
- **NIRSpec** full path: envelope + real upload tallies. Intermediates-draft: provenance from the first exposure header (was hardcoded `None`) + `cfpipe_version` into `build_registry_rows`.
- **Silent mutations now audited** (audit B3): `remove_observation` and `registry prune` emit `action='delete'` events (the enum already reserved `delete`) with counts.

**NIRCam exposure provenance — gap closed at the source (`pipeline/**`)**
Digging in disproved the audit's B2 premise: NIRCam canonical exposures carry only `CFP_*` step keys — the pipeline-version card `CMPFRVER` was stamped **only on mosaics**, so a mid-reduction `--draft` exposure deploy (before any mosaic exists) had no version to record. Rather than accept a NULL, this PR **stamps `CMPFRVER` (+ `CMPFRTIM`) on each canonical exposure at `detector1` creation**, mirroring the mosaic stamp in `resample.py` (jwst already writes `CAL_VER`/`CRDS_CTX`). `_read_field_provenance` now prefers a mosaic i2d header and **falls back to a representative exposure header**, so draft exposure deploys record real provenance end-to-end. Additive header card, no pixel/flux change → **Infrastructure/PATCH**; CHANGELOG updated.

**Tests** — `test_deploy_events.py`: envelope shape/partial derivation, `field→p_field` forwarding + best-effort error swallowing, mosaic + exposure-fallback provenance reads, and the remove delete-event. Full deploy suite green; pipeline provenance-reader + cfp tests green.

## Notes / deferred

- **Download logging** (deferred from Phase 2) stays deferred: an admin download belongs in `download_log` (a `download_type` value + a hook in `presignStorageObjectDownload`), not the deploy `action` CHECK — a small separate follow-on.
- **`supersede` events** scoped out — no producer path exists (re-pointing rides the normal `upload` event via `set_active_deployment`).
- Migration is **hand-authored, additive-only** (no Docker for `supabase db diff`); the Supabase preview branch validates it. `deploy_events` isn't in `seed.sql`, so no seed regen.
- The pipeline change rides the `pipeline-vX.Y.Z` tag cadence (Infrastructure/PATCH); the CHANGELOG `## Unreleased` entry is included per the deploy-workflow rules.

Generated with Claude Code
https://claude.ai/code/session_01SQiCGrfdaQu5cF9dbVCJNd