### PR TITLE
fix(ci): match the code-review skill invocation with args — Skill(code-review:code-review *)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,7 @@
       "Bash(*)",
       "WebSearch",
       "WebFetch(domain:github.com)",
-      "Skill(code-review:code-review)",
+      "Skill(code-review:code-review *)",
       "mcp__github_inline_comment",
       "mcp__github_comment"
     ],


### PR DESCRIPTION
## Summary

Follow-up to #284. That PR scoped the allow to `Skill(code-review:code-review)` (**exact** match), but #292's run — with that rule live on `main` — **still denied the `Skill` tool**. The `show_full_output` transcript shows why: the skill is always invoked **with arguments**:

```
tool_use Skill { skill: "code-review:code-review",
                 args: "hollisakins/campfire/pull/292 --comment" }
permission_denials: [{ tool_name: "Skill", ... }]
```

Per the Claude Code Skills docs, `Skill(name)` is an **exact, no-argument** match; a call carrying arguments requires the **prefix** form `Skill(name *)` (space before the `*`). Our review prompt always passes `<pr> --comment`, so the exact rule never matched.

## Change

- `.claude/settings.json`: `Skill(code-review:code-review)` → `Skill(code-review:code-review *)`.

## Why the other denials in #292 aren't the target

That run also logged 14 `Bash`/`gh` denials (`"This command requires approval"`, `"Output redirection … was blocked"`). Those were the agent **flailing after the Skill denial** — trying to fetch the diff manually via `gh` — and are blocked by the action's review **sandbox**, which is independent of the `Bash(*)` allow-rule. Once the skill launches, the plugin gathers the diff its own (sandbox-safe) way and posts via the MCP comment tools, so those `gh` calls won't happen.

## Note

`show_full_output: true` stays on for **one** more confirming run. Per the docs, a skill can *also* gate on its own frontmatter `allowed-tools`, so I want the transcript to prove the skill both **launches** and **posts** before removing it. Once confirmed, a small follow-up removes `show_full_output`.

## Activation

Only takes effect from `main` (the action restores `.claude` from `origin/main`), so no effect until merged; the next PR after merge is the confirming run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeYz5w2zq11XG9MSETjU4K)_