### PR TITLE
fix(admin): move sort-key consts out of 'use server' modules (prod 500 hotfix)

### DIFF
--- a/web/app/admin/deployments/page.tsx
+++ b/web/app/admin/deployments/page.tsx
@@ -15,9 +15,9 @@ import {
 import { useAdminTableQuery } from '@/lib/hooks/useAdminTableQuery';
 import {
   getDeployments, getDeployEvents, setDeploymentLifecycle,
-  DEPLOYMENT_SORT_KEYS,
   type DeploymentRow, type DeployEventRow, type DeployStatus, type LifecycleAction,
 } from '@/lib/actions/deployments';
+import { DEPLOYMENT_SORT_KEYS } from '@/lib/admin/sort-keys';
 
 // ---------------------------------------------------------------------------
 // Display helpers

--- a/web/app/admin/intermediate-products/page.tsx
+++ b/web/app/admin/intermediate-products/page.tsx
@@ -13,9 +13,9 @@ import { useAdminTableQuery } from '@/lib/hooks/useAdminTableQuery';
 import {
   getStorageObjects, getStorageBudget, getStorageFacets,
   presignStorageObjectDownload,
-  STORAGE_OBJECT_SORT_KEYS,
   type StorageObjectRow, type StorageBudget,
 } from '@/lib/actions/storage-registry';
+import { STORAGE_OBJECT_SORT_KEYS } from '@/lib/admin/sort-keys';
 
 async function downloadObject(id: number) {
   const res = await presignStorageObjectDownload(id);

--- a/web/app/admin/nircam/page.tsx
+++ b/web/app/admin/nircam/page.tsx
@@ -15,10 +15,10 @@ import {
   getReductionProgress,
   getExposureFilterOptions,
   getExcludedExposures,
-  EXPOSURE_SORT_KEYS,
   type ReductionProgress,
   type ExcludedExposure,
 } from '@/lib/actions/nircam-exposures';
+import { EXPOSURE_SORT_KEYS } from '@/lib/admin/sort-keys';
 import type { NircamExposure } from '@/lib/types';
 import {
   stageBadgeClasses,

--- a/web/lib/actions/deployments.ts
+++ b/web/lib/actions/deployments.ts
@@ -50,8 +50,8 @@ export interface DeploymentsResult {
   error?: string;
 }
 
-/** Sort keys accepted by get_admin_deployments — mirror the RPC whitelist. */
-export const DEPLOYMENT_SORT_KEYS = ['id', 'deployed_at', 'status', 'scope'] as const;
+// Sort-key whitelists live in @/lib/admin/sort-keys — a 'use server' module
+// may only export async functions.
 
 // ---------------------------------------------------------------------------
 // Read: deployments (the lifecycle units)
@@ -119,9 +119,6 @@ export interface DeployEventsResult {
   total: number;
   error?: string;
 }
-
-/** Sort keys accepted by get_admin_deploy_events — mirror the RPC whitelist. */
-export const DEPLOY_EVENT_SORT_KEYS = ['occurred_at', 'action'] as const;
 
 // Backed by get_admin_deploy_events: the NIRCam scope extraction and the
 // actor-name join happen in SQL (one scan), replacing two extra round-trips.

--- a/web/lib/actions/nircam-exposures.ts
+++ b/web/lib/actions/nircam-exposures.ts
@@ -55,14 +55,9 @@ export interface ExposureSort {
   sortDirection?: 'asc' | 'desc';
 }
 
-/**
- * Sort keys accepted by get_admin_exposures / get_admin_exposure_neighbors —
- * mirror the RPC whitelist. 'filename' is the compound (field, filter,
- * filename) list order.
- */
-export const EXPOSURE_SORT_KEYS = [
-  'filename', 'field', 'filter', 'detector', 'stage', 'review_status', 'date_obs', 'updated_at',
-] as const;
+// Sort-key whitelist (accepted by get_admin_exposures /
+// get_admin_exposure_neighbors) lives in @/lib/admin/sort-keys — a 'use server'
+// module may only export async functions.
 
 function rpcExposureParams(params?: ExposureFilters & ExposureSort) {
   return {

--- a/web/lib/actions/storage-registry.ts
+++ b/web/lib/actions/storage-registry.ts
@@ -60,10 +60,8 @@ export interface StorageObjectsResult {
   error?: string;
 }
 
-/** Sort keys accepted by get_admin_storage_objects — mirror the RPC whitelist. */
-export const STORAGE_OBJECT_SORT_KEYS = [
-  'created_at', 'size_bytes', 'product_type', 'storage_key', 'observation', 'field', 'status',
-] as const;
+// Sort-key whitelist lives in @/lib/admin/sort-keys — a 'use server' module
+// may only export async functions.
 
 // Backed by the get_admin_storage_objects RPC: whitelisted server-side sort +
 // windowed total in one scan (the previous count:'exact' ran a second full

--- a/web/lib/admin/sort-keys.ts
+++ b/web/lib/admin/sort-keys.ts
@@ -1,0 +1,19 @@
+// Admin list sort-key whitelists — the single source of truth shared by each
+// page's useTableUrlState (client) and the backing RPC's ORDER BY validation.
+//
+// These MUST live outside the 'use server' action modules: a "use server" file
+// may only export async functions, so exporting these const arrays from
+// deployments.ts / storage-registry.ts / nircam-exposures.ts throws at runtime
+// ("A 'use server' file can only export async functions, found object").
+
+export const DEPLOYMENT_SORT_KEYS = ['id', 'deployed_at', 'status', 'scope'] as const;
+
+export const DEPLOY_EVENT_SORT_KEYS = ['occurred_at', 'action'] as const;
+
+export const STORAGE_OBJECT_SORT_KEYS = [
+  'created_at', 'size_bytes', 'product_type', 'storage_key', 'observation', 'field', 'status',
+] as const;
+
+export const EXPOSURE_SORT_KEYS = [
+  'filename', 'field', 'filter', 'detector', 'stage', 'review_status', 'date_obs', 'updated_at',
+] as const;

--- a/web/lib/nircam-exposure-nav.ts
+++ b/web/lib/nircam-exposure-nav.ts
@@ -6,7 +6,7 @@
 // nav survives refresh, direct entry, and shared links.
 
 import type { ExposureFilters, ExposureSort } from '@/lib/actions/nircam-exposures';
-import { EXPOSURE_SORT_KEYS } from '@/lib/actions/nircam-exposures';
+import { EXPOSURE_SORT_KEYS } from '@/lib/admin/sort-keys';
 
 export const EXPOSURE_FILTER_PARAM_KEYS = [
   'field', 'filter', 'detector', 'review', 'stage', 'masking', 'correction',


### PR DESCRIPTION
## Summary

**Production hotfix.** Every admin data fetch was 500ing in production with:

```
Error: A "use server" file can only export async functions, found object.
```

A `'use server'` module may only export async functions. The sort-key const arrays added in Phase 1 — `DEPLOYMENT_SORT_KEYS`, `DEPLOY_EVENT_SORT_KEYS`, `STORAGE_OBJECT_SORT_KEYS`, `EXPOSURE_SORT_KEYS` — were `export const` object exports living inside the `'use server'` action modules (`deployments.ts`, `storage-registry.ts`, `nircam-exposures.ts`). That's illegal, and it throws **at module load in production**, taking down every admin page's server actions (which is why the UI showed "failed to load data" everywhere and the network tab showed `POST /admin → 500`).

`npm run build` did **not** catch this — it compiled clean and the Vercel build went green — so it only surfaced at runtime once the merged code was live.

## Fix

- New plain module `web/lib/admin/sort-keys.ts` holds the four const arrays (single source of truth for each page's `useTableUrlState` whitelist and the RPC ORDER BY validation).
- Removed the `export const`s from the three action modules — they now export only async functions and types.
- Rewired the four import sites (`deployments`, `intermediate-products`, `nircam` pages + `nircam-exposure-nav.ts`).
- Scanned every `'use server'` file to confirm none exports a non-async-function value (const/let/var/default/re-export).

Typecheck clean, production build green.

## Follow-up worth considering (not in this PR)
The build not catching this is the real gap. A lightweight lint rule (or a CI check that greps `'use server'` files for value exports) would prevent a repeat. Happy to add it if you want.

Generated with Claude Code
https://claude.ai/code/session_01SQiCGrfdaQu5cF9dbVCJNd

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQiCGrfdaQu5cF9dbVCJNd)_