### PR TITLE
fix(ci): work around claude-code-action#1462 — headless silent no-op in code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,7 +41,22 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
+          # Headless-CI workaround for anthropics/claude-code-action#1462. In a
+          # one-shot (`-p`) run the model otherwise spawns background sub-agents +
+          # ScheduleWakeup and ends its turn — which kills the sub-agents, so the
+          # step goes green while posting nothing. Force fully-synchronous work.
+          prompt: |
+            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment
+
+            This is a headless, non-interactive CI run: your turn cannot be resumed
+            once it ends, and any background agents or scheduled wakeups are killed
+            when the turn ends. Do NOT call ScheduleWakeup and do NOT run agents in
+            the background. Run every sub-agent synchronously (run_in_background:
+            false) and complete the entire review — posting all inline comments —
+            before you end your turn.
+          # Strip the interactive-only tools the model reaches for in headless runs
+          # (anthropics/claude-code-action#1462) so it cannot defer work off-turn.
+          claude_args: '--disallowedTools "ScheduleWakeup,SendMessage,Monitor"'
           # Post a single updating summary comment in addition to inline comments,
           # so the PR always gets visible feedback even when the review has no
           # line-specific inline nits to buffer.


### PR DESCRIPTION
## Summary

The permission chain is now fully fixed (#280→#294) and the `code-review` skill launches — but #295's transcript showed it fail a **new** way, which turns out to be a **known, open bug in the action itself**: [anthropics/claude-code-action#1462](https://github.com/anthropics/claude-code-action/issues/1462).

In a headless (`-p`) CI run, the model is still offered interactive-only tools. The `code-review` skill spawns **background sub-agents** and calls **`ScheduleWakeup{delaySeconds:90}`** to resume later, then ends its turn. There is no resumption in a one-shot run, so the sub-agents are killed, **nothing is posted, and the step still reports `success`** (silent green no-op). That's exactly what #295 did (`"result": "Waiting for the background agents to complete before continuing."`, `permission_denials: []`, `No buffered inline comments`).

Version check: latest action is **v1.0.165** (our `@v1` already floats to it), the issue is **still open**, so upgrading doesn't help.

## Change — the reporter's validated workaround

- `claude_args: --disallowedTools "ScheduleWakeup,SendMessage,Monitor"` — remove the off-turn/interactive tools so the model can't defer work.
- Prompt guidance: tell the agent the run is headless — work **synchronously** (`run_in_background: false`) and post the full review **before ending the turn**.

## Note

`show_full_output: true` stays on until we confirm a review actually posts. Verification will be done on a **throwaway test PR**, not a real one.

## Activation

Workflow + settings changes only take effect from `main` (and a PR that edits the workflow is skipped by the action's workflow-validation gate), so this has no effect until merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeYz5w2zq11XG9MSETjU4K)_