### PR TITLE
chore(ci): remove temporary show_full_output from claude-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -61,12 +61,6 @@ jobs:
           # so the PR always gets visible feedback even when the review has no
           # line-specific inline nits to buffer.
           use_sticky_comment: true
-          # TEMPORARY (debugging, remove after we confirm posting works): surface the
-          # full agent transcript in the Actions log so we can see the exact tool that
-          # `permission_denials_count` is blocking. Note: this prints everything the
-          # agent read/ran into the (world-readable, on a public repo) job log, so it
-          # must be turned back off once the denied tool is identified.
-          show_full_output: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
The claude-review action is confirmed working end-to-end — the throwaway smoke-test PR #297 got a full posted review that caught all three planted bugs (mutable default arg, unclosed file handle, div-by-zero).

`show_full_output: true` was only enabled to debug the permission/headless chain. It prints the entire agent transcript into the (world-readable) Actions log, so it should not stay on. This removes it. The workflow keeps the trigger fix, sticky comment, and the #1462 headless workaround (`--disallowedTools` + synchronous prompt).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeYz5w2zq11XG9MSETjU4K)_