### PR TITLE
Concurrent sync fetches + auth cache + object aggregate fast path

### DIFF
--- a/python/campfire/api/client.py
+++ b/python/campfire/api/client.py
@@ -4,6 +4,7 @@ Centralizes all URL construction and response parsing. Used by both the
 ``Campfire`` client class and the CLI.
 """
 
+import os
 from typing import Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 from ..exceptions import (
@@ -17,6 +18,27 @@ from ..flags import (
     parse_flag_input,
 )
 from .session import APISession
+
+#: Default page size for the /sync/* paginators. Overridable per run via the
+#: ``CAMPFIRE_SYNC_PAGE_SIZE`` env var — larger pages cut the per-page fixed cost
+#: (HTTP round-trip + server auth preamble + count-gating) at the price of wider
+#: responses and higher peak memory. Clamped to a sane range.
+DEFAULT_SYNC_PAGE_SIZE = 1000
+_MAX_SYNC_PAGE_SIZE = 50000
+
+
+def _resolve_sync_page_size() -> int:
+    """Resolve the sync page size from ``CAMPFIRE_SYNC_PAGE_SIZE`` (or the default)."""
+    raw = os.environ.get("CAMPFIRE_SYNC_PAGE_SIZE")
+    if not raw:
+        return DEFAULT_SYNC_PAGE_SIZE
+    try:
+        val = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_SYNC_PAGE_SIZE
+    if val < 1:
+        return DEFAULT_SYNC_PAGE_SIZE
+    return min(val, _MAX_SYNC_PAGE_SIZE)
 
 
 def _build_query_params(
@@ -110,6 +132,7 @@ class APIClient:
 
     def __init__(self, session: APISession):
         self._session = session
+        self._page_size = _resolve_sync_page_size()
 
     # ------------------------------------------------------------------
     # Objects
@@ -282,7 +305,7 @@ class APIClient:
             # count CTEs when include_counts=false, saving a full scan per
             # subsequent page.
             params: dict = {
-                "limit": 1000,
+                "limit": self._page_size,
                 "offset": offset,
                 "include_counts": "true" if first_page else "false",
             }
@@ -377,7 +400,7 @@ class APIClient:
         total_count = 0
         while True:
             self._session._ensure_valid_token()
-            params: dict = {"limit": 1000, "offset": offset}
+            params: dict = {"limit": self._page_size, "offset": offset}
             if updated_since:
                 params["updated_since"] = updated_since
             response = self._session.get("/sync/photometry", params=params, timeout=60)

--- a/python/campfire/api/session.py
+++ b/python/campfire/api/session.py
@@ -5,6 +5,7 @@ consolidating session creation that was previously duplicated across modules.
 """
 
 import os
+import threading
 from typing import Optional
 
 import requests
@@ -56,6 +57,9 @@ class APISession:
         self._token_manager: Optional[TokenManager] = None
         self._auth_type: Optional[str] = None
         self._auth_token: Optional[str] = None
+        # Serializes OAuth refresh so concurrent sync workers can't both rotate
+        # the (single-use) refresh token or race on the shared auth header.
+        self._token_lock = threading.Lock()
 
         # Load credentials
         self._load_credentials()
@@ -90,16 +94,26 @@ class APISession:
         self._session.headers["Authorization"] = f"Bearer {self._auth_token}"
 
     def _ensure_valid_token(self) -> None:
-        """Ensure we have a valid token, refreshing if necessary."""
+        """Ensure we have a valid token, refreshing if necessary.
+
+        Thread-safe: the /sync/* paginators call this from concurrent worker
+        threads. Double-checked locking keeps the common (no-refresh) path
+        lock-free while ensuring only one thread performs an actual refresh.
+        """
         if self._auth_type != "oauth" or not self._auto_refresh:
             return
 
-        if self._token_manager and self._token_manager.needs_refresh():
-            try:
-                self._auth_token = self._token_manager.get_valid_token(auto_refresh=True)
-                self._update_auth_header()
-            except AuthenticationError:
-                pass
+        if not (self._token_manager and self._token_manager.needs_refresh()):
+            return
+
+        with self._token_lock:
+            # Re-check under the lock: a peer thread may have refreshed already.
+            if self._token_manager.needs_refresh():
+                try:
+                    self._auth_token = self._token_manager.get_valid_token(auto_refresh=True)
+                    self._update_auth_header()
+                except AuthenticationError:
+                    pass
 
     def request(self, method: str, path: str, **kwargs) -> requests.Response:
         """Make an authenticated request with automatic token refresh.

--- a/python/campfire/sync.py
+++ b/python/campfire/sync.py
@@ -5,6 +5,7 @@ Session creation and manifest fetching are delegated to the ``api`` subpackage.
 """
 
 import hashlib
+import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
@@ -26,41 +27,36 @@ def compute_file_hash(path: Path) -> str:
     return f"sha256:{hasher.hexdigest()}"
 
 
-def _make_progress(show, unit, desc):
-    """Create a tqdm progress bar and page-complete callback."""
+def _make_progress(show, unit, desc, position=None):
+    """Create a tqdm progress bar and page-complete callback.
+
+    ``position`` pins the bar to a fixed terminal row so the four sync streams
+    render as a stable stacked group while they fetch concurrently. When
+    ``show`` is False, returns ``(None, None)`` and the paginator skips progress
+    reporting entirely.
+    """
     if not show:
         return None, None
-    pbar = tqdm(unit=unit, desc=desc)
+    pbar = tqdm(unit=unit, desc=desc, position=position, leave=True)
 
     def callback(fetched, total):
-        pbar.total = total
+        # total is only known once the first page returns (include_counts); until
+        # then the bar renders indeterminate, then snaps to a percentage.
+        if total:
+            pbar.total = total
         pbar.n = fetched
         pbar.refresh()
 
     return pbar, callback
 
 
-def _sync_objects(api, store, full, show_progress):
-    """Sync objects from the server.
+def _apply_objects(store, fetched, updated_since, sync_ts):
+    """Apply fetched objects to the local store (main-thread write phase).
 
-    Returns (object_count, purged_count, incremental, needs_full_sync,
-    server_total, sync_timestamp).
+    Returns (object_count, purged_count, incremental, needs_full_sync).
     """
-    updated_since = None
-    if not full:
-        updated_since = store.get_max_objects_updated_at()
+    all_objects, server_total = fetched
     incremental = updated_since is not None
-
-    sync_timestamp = datetime.now(timezone.utc).isoformat()
-
-    pbar, callback = _make_progress(show_progress, "obj", "Objects")
-
-    all_objects, server_total = api.fetch_all_objects(
-        updated_since=updated_since,
-        on_page_complete=callback,
-    )
-    if pbar:
-        pbar.close()
 
     obj_count = store.upsert_objects(all_objects)
 
@@ -72,66 +68,40 @@ def _sync_objects(api, store, full, show_progress):
 
     purged = 0
     if not incremental:
-        purged = store.purge_stale_objects(sync_timestamp)
+        purged = store.purge_stale_objects(sync_ts)
 
-    return obj_count, purged, incremental, needs_full_sync, server_total, sync_timestamp
+    return obj_count, purged, incremental, needs_full_sync
 
 
-def _sync_spectra(api, store, full, show_progress):
-    """Sync spectra from the server.
+def _apply_spectra(store, fetched, updated_since, sync_ts):
+    """Apply fetched spectra to the local store.
 
-    Returns (spectra_count, purge_result, incremental, sync_timestamp).
+    Returns (spectra_count, purge_result, incremental).
     """
-    updated_since = None
-    if not full:
-        updated_since = store.get_max_spectra_updated_at()
+    all_spectra, _server_total = fetched
     incremental = updated_since is not None
-
-    sync_timestamp = datetime.now(timezone.utc).isoformat()
-
-    pbar, callback = _make_progress(show_progress, "spec", "Spectra")
-
-    all_spectra, _server_total = api.fetch_all_spectra(
-        updated_since=updated_since,
-        on_page_complete=callback,
-    )
-    if pbar:
-        pbar.close()
 
     spec_count = store.upsert_spectra(all_spectra)
 
     purge_result = None
     if not incremental:
-        purge_result = store.purge_stale_spectra(sync_timestamp)
+        purge_result = store.purge_stale_spectra(sync_ts)
 
-    return spec_count, purge_result, incremental, sync_timestamp
+    return spec_count, purge_result, incremental
 
 
-def _sync_photometry(api, store, full, show_progress):
-    """Sync object photometry from the server.
+def _apply_photometry(store, fetched, updated_since, sync_ts):
+    """Apply fetched photometry to the local store.
 
     Returns (record_count, purged_count).
     """
-    updated_since = None
-    if not full:
-        updated_since = store.get_max_photometry_updated_at()
-
-    sync_timestamp = datetime.now(timezone.utc).isoformat()
-
-    pbar, callback = _make_progress(show_progress, "rec", "Photometry")
-
-    all_records, _total_count = api.fetch_all_photometry(
-        updated_since=updated_since,
-        on_page_complete=callback,
-    )
-    if pbar:
-        pbar.close()
+    all_records, _total_count = fetched
 
     rec_count = store.upsert_photometry(all_records)
 
     purged = 0
     if updated_since is None:
-        purged = store.purge_stale_photometry(sync_timestamp)
+        purged = store.purge_stale_photometry(sync_ts)
 
     return rec_count, purged
 
@@ -145,34 +115,80 @@ def _sync_tags(api, store, show_progress):
         return 0
 
 
-def _sync_storage_objects(api, store, full, show_progress):
-    """Sync the storage_objects mirror (the download/availability layer).
+def _apply_storage(store, fetched, updated_since, sync_ts):
+    """Apply the fetched storage_objects mirror to the local store.
 
-    Program-scoped server-side: admins mirror everything, others get published
-    rows in their accessible programs. Returns (row_count, purged, orphaned).
+    Returns (row_count, purged, orphaned).
     """
-    updated_since = None if full else store.get_max_storage_updated_at()
+    all_rows, _server_total = fetched
     incremental = updated_since is not None
-    sync_timestamp = datetime.now(timezone.utc).isoformat()
-
-    pbar, callback = _make_progress(show_progress, "obj", "Storage")
-    all_rows, _server_total = api.fetch_all_storage(
-        updated_since=updated_since,
-        on_page_complete=callback,
-    )
-    if pbar:
-        pbar.close()
 
     n = store.upsert_storage_objects(all_rows)
 
     purged = 0
     orphaned: List[str] = []
     if not incremental:
-        res = store.purge_stale_storage_objects(sync_timestamp)
+        res = store.purge_stale_storage_objects(sync_ts)
         purged = res["purged"]
         orphaned = res["orphaned_files"]
 
     return n, purged, orphaned
+
+
+# The four independent /sync/* catalogs, each pinned to a fixed progress row
+# (option A): a stable stacked group so every count stays anchored to a real
+# per-entity total instead of a meaningless catalog-wide sum. Fields:
+# (result key, APIClient method name, tqdm unit, padded bar label).
+_FETCH_STREAMS = (
+    ("objects", "fetch_all_objects", "obj", "Objects   "),
+    ("spectra", "fetch_all_spectra", "spec", "Spectra   "),
+    ("storage", "fetch_all_storage", "obj", "Storage   "),
+    ("photometry", "fetch_all_photometry", "rec", "Photometry"),
+)
+
+
+def _fetch_all_concurrent(api, cursors, use_bars, show_progress):
+    """Fetch the four independent /sync/* catalogs concurrently.
+
+    Each stream is network-bound and independent, so wall time collapses from the
+    sum of the four fetches toward the slowest single one. The SQLite store is
+    single-threaded, so workers only touch the network here; every write happens
+    on the caller's thread afterwards. Returns ``{key: (rows, server_total)}``.
+    """
+    bars = []
+    results: Dict[str, Tuple[List[dict], int]] = {}
+    try:
+        with ThreadPoolExecutor(max_workers=len(_FETCH_STREAMS)) as executor:
+            future_to_key = {}
+            for position, (key, method_name, unit, desc) in enumerate(_FETCH_STREAMS):
+                pbar, callback = _make_progress(use_bars, unit, desc, position=position)
+                bars.append(pbar)
+                method = getattr(api, method_name)
+                future = executor.submit(
+                    method, updated_since=cursors[key], on_page_complete=callback
+                )
+                future_to_key[future] = key
+            # Surfaces the first failing stream's exception once the pool drains.
+            for future in as_completed(future_to_key):
+                results[future_to_key[future]] = future.result()
+    finally:
+        for pbar in bars:
+            if pbar is not None:
+                pbar.close()
+        if use_bars:
+            # Drop the cursor below the (leave=True) stacked bars so whatever the
+            # caller prints next doesn't overwrite them.
+            sys.stderr.write("\n" * len(_FETCH_STREAMS))
+            sys.stderr.flush()
+
+    if show_progress and not use_bars:
+        # Non-TTY (CI, redirected logs): no live bars, so emit one completion
+        # line per stream instead.
+        for key, _method_name, _unit, desc in _FETCH_STREAMS:
+            rows = results.get(key, ([], 0))[0]
+            print(f"  {desc.strip()}: {len(rows):,}", file=sys.stderr)
+
+    return results
 
 
 def sync_metadata(
@@ -194,30 +210,46 @@ def sync_metadata(
     """
     from .db.export import export_catalogs
 
-    # 1. Sync objects
-    (obj_count, obj_purged, incremental, needs_full_sync,
-     server_total, _obj_ts) = _sync_objects(api, store, full, show_progress)
+    use_bars = show_progress and sys.stderr.isatty()
 
-    # 2. Sync spectra
-    spec_count, spec_purge, spec_incremental, _spec_ts = _sync_spectra(
-        api, store, full, show_progress
+    # One timestamp captured before any fetch. Purge removes rows whose
+    # _synced_at predates it; every upsert below stamps a strictly later time, so
+    # only rows the server no longer returns get purged.
+    sync_ts = datetime.now(timezone.utc).isoformat()
+
+    # Incremental cursors are store reads, so resolve them here on the main thread
+    # before the workers start (workers must not touch the single-threaded
+    # SQLite connection).
+    cursors = {
+        "objects": None if full else store.get_max_objects_updated_at(),
+        "spectra": None if full else store.get_max_spectra_updated_at(),
+        "storage": None if full else store.get_max_storage_updated_at(),
+        "photometry": None if full else store.get_max_photometry_updated_at(),
+    }
+
+    # 1. Fetch all four catalogs concurrently (network only).
+    fetched = _fetch_all_concurrent(api, cursors, use_bars, show_progress)
+
+    # 2. Apply to the local store serially (single-threaded SQLite connection).
+    obj_count, obj_purged, incremental, needs_full_sync = _apply_objects(
+        store, fetched["objects"], cursors["objects"], sync_ts
+    )
+    spec_count, spec_purge, spec_incremental = _apply_spectra(
+        store, fetched["spectra"], cursors["spectra"], sync_ts
+    )
+    storage_count, storage_purged, storage_orphaned = _apply_storage(
+        store, fetched["storage"], cursors["storage"], sync_ts
+    )
+    phot_count, phot_purged = _apply_photometry(
+        store, fetched["photometry"], cursors["photometry"], sync_ts
     )
 
-    # 3. Sync the storage_objects mirror (download/availability layer)
-    storage_count, storage_purged, storage_orphaned = _sync_storage_objects(
-        api, store, full, show_progress
-    )
-
-    # 4. Sync photometry
-    phot_count, phot_purged = _sync_photometry(api, store, full, show_progress)
-
-    # 5. Sync tag metadata
+    # 3. Sync tag metadata (single request), then export CSVs.
     tags_count = _sync_tags(api, store, show_progress)
 
-    # 6. Export CSVs
     export_catalogs(store, meta_dir)
 
-    # 7. Detect stale local files (server hash != local hash, via the mirror)
+    # 4. Detect stale local files (server hash != local hash, via the mirror)
     stale = store.get_stale_objects()
 
     obs_set = set(store.get_synced_observations())

--- a/python/tests/test_sync_concurrent.py
+++ b/python/tests/test_sync_concurrent.py
@@ -1,0 +1,183 @@
+"""Tests for the concurrent /sync/* fetch orchestration and page-size config.
+
+Covers the refactor that fetches the four independent catalogs (objects,
+spectra, storage, photometry) concurrently and then applies them to the local
+store serially, plus the ``CAMPFIRE_SYNC_PAGE_SIZE`` override.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from campfire.api.client import (
+    APIClient,
+    DEFAULT_SYNC_PAGE_SIZE,
+    _resolve_sync_page_size,
+)
+from campfire.sync import sync_metadata
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+def _make_fake_api(objects, spectra, storage, photometry, tags):
+    """A stand-in APIClient whose fetch_all_* return canned data.
+
+    Each fetch invokes its on_page_complete callback once (as the real
+    paginators do) so the progress plumbing is exercised even though bars are
+    disabled in tests.
+    """
+    api = MagicMock()
+
+    def _fetcher(rows):
+        def fetch(updated_since=None, on_page_complete=None):
+            if on_page_complete:
+                on_page_complete(len(rows), len(rows))
+            return rows, len(rows)
+        return fetch
+
+    api.fetch_all_objects.side_effect = _fetcher(objects)
+    api.fetch_all_spectra.side_effect = _fetcher(spectra)
+    api.fetch_all_storage.side_effect = _fetcher(storage)
+    api.fetch_all_photometry.side_effect = _fetcher(photometry)
+    api.fetch_tags.return_value = tags
+    return api
+
+
+def _make_fake_store():
+    store = MagicMock()
+    # Full sync path: no incremental cursors.
+    store.get_max_objects_updated_at.return_value = None
+    store.get_max_spectra_updated_at.return_value = None
+    store.get_max_storage_updated_at.return_value = None
+    store.get_max_photometry_updated_at.return_value = None
+    store.upsert_objects.side_effect = lambda rows: len(rows)
+    store.upsert_spectra.side_effect = lambda rows: len(rows)
+    store.upsert_storage_objects.side_effect = lambda rows: len(rows)
+    store.upsert_photometry.side_effect = lambda rows: len(rows)
+    store.upsert_tags.side_effect = lambda data: len(data)
+    store.purge_stale_objects.return_value = 0
+    store.purge_stale_spectra.return_value = {"purged_spectra": 0}
+    store.purge_stale_storage_objects.return_value = {"purged": 0, "orphaned_files": []}
+    store.purge_stale_photometry.return_value = 0
+    store.get_stale_objects.return_value = []
+    store.get_synced_observations.return_value = []
+    return store
+
+
+@pytest.fixture(autouse=True)
+def _stub_export(monkeypatch):
+    """CSV export reads the real store; stub it out for these orchestration tests."""
+    monkeypatch.setattr(
+        "campfire.db.export.export_catalogs", lambda store, meta_dir: (0, 0)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+def test_sync_metadata_fetches_all_streams_and_routes_results():
+    objects = [{"object_id": f"O{i}"} for i in range(5)]
+    spectra = [{"spectrum_id": f"S{i}"} for i in range(3)]
+    storage = [{"storage_key": f"k{i}"} for i in range(7)]
+    photometry = [{"id": i} for i in range(2)]
+    tags = [{"slug": "t1"}]
+
+    api = _make_fake_api(objects, spectra, storage, photometry, tags)
+    store = _make_fake_store()
+
+    result = sync_metadata(api, store, Path("/tmp/meta"), show_progress=False, full=True)
+
+    # Every stream fetched exactly once.
+    api.fetch_all_objects.assert_called_once()
+    api.fetch_all_spectra.assert_called_once()
+    api.fetch_all_storage.assert_called_once()
+    api.fetch_all_photometry.assert_called_once()
+
+    # Each stream's rows routed to the matching upsert (no cross-wiring).
+    store.upsert_objects.assert_called_once_with(objects)
+    store.upsert_spectra.assert_called_once_with(spectra)
+    store.upsert_storage_objects.assert_called_once_with(storage)
+    store.upsert_photometry.assert_called_once_with(photometry)
+
+    assert result["objects"] == 5
+    assert result["spectra"] == 3
+    assert result["storage_objects"] == 7
+    assert result["photometry"] == 2
+    assert result["tags"] == 1
+    assert result["incremental"] is False
+    assert result["needs_full_sync"] is False
+
+
+def test_sync_metadata_full_passes_no_cursor_to_fetchers():
+    api = _make_fake_api([], [], [], [], [])
+    store = _make_fake_store()
+
+    sync_metadata(api, store, Path("/tmp/meta"), show_progress=False, full=True)
+
+    # full=True => updated_since=None for every stream.
+    assert api.fetch_all_objects.call_args.kwargs["updated_since"] is None
+    assert api.fetch_all_spectra.call_args.kwargs["updated_since"] is None
+    assert api.fetch_all_storage.call_args.kwargs["updated_since"] is None
+    assert api.fetch_all_photometry.call_args.kwargs["updated_since"] is None
+
+
+def test_sync_metadata_incremental_threads_cursor_and_skips_purge():
+    api = _make_fake_api([{"object_id": "O1"}], [{"spectrum_id": "S1"}], [], [], [])
+    store = _make_fake_store()
+    store.get_max_objects_updated_at.return_value = "2026-01-01T00:00:00Z"
+    store.get_max_spectra_updated_at.return_value = "2026-01-02T00:00:00Z"
+    store.get_max_storage_updated_at.return_value = "2026-01-03T00:00:00Z"
+    store.get_max_photometry_updated_at.return_value = "2026-01-04T00:00:00Z"
+    # server_total != local -> needs_full_sync path exercised
+    store._conn.execute.return_value.fetchone.return_value = [0]
+
+    result = sync_metadata(api, store, Path("/tmp/meta"), show_progress=False, full=False)
+
+    assert api.fetch_all_objects.call_args.kwargs["updated_since"] == "2026-01-01T00:00:00Z"
+    assert result["incremental"] is True
+    # Incremental syncs never purge (the server only sends deltas).
+    store.purge_stale_objects.assert_not_called()
+    store.purge_stale_spectra.assert_not_called()
+    store.purge_stale_storage_objects.assert_not_called()
+    store.purge_stale_photometry.assert_not_called()
+
+
+def test_sync_metadata_propagates_stream_failure():
+    api = _make_fake_api([], [], [], [], [])
+    api.fetch_all_storage.side_effect = RuntimeError("boom")
+    store = _make_fake_store()
+
+    with pytest.raises(RuntimeError, match="boom"):
+        sync_metadata(api, store, Path("/tmp/meta"), show_progress=False, full=True)
+
+
+# ---------------------------------------------------------------------------
+# Page-size config
+# ---------------------------------------------------------------------------
+def test_resolve_sync_page_size_default(monkeypatch):
+    monkeypatch.delenv("CAMPFIRE_SYNC_PAGE_SIZE", raising=False)
+    assert _resolve_sync_page_size() == DEFAULT_SYNC_PAGE_SIZE
+
+
+def test_resolve_sync_page_size_override(monkeypatch):
+    monkeypatch.setenv("CAMPFIRE_SYNC_PAGE_SIZE", "2500")
+    assert _resolve_sync_page_size() == 2500
+
+
+@pytest.mark.parametrize("bad", ["notanint", "0", "-5", ""])
+def test_resolve_sync_page_size_invalid_falls_back(monkeypatch, bad):
+    monkeypatch.setenv("CAMPFIRE_SYNC_PAGE_SIZE", bad)
+    assert _resolve_sync_page_size() == DEFAULT_SYNC_PAGE_SIZE
+
+
+def test_resolve_sync_page_size_clamps_large(monkeypatch):
+    monkeypatch.setenv("CAMPFIRE_SYNC_PAGE_SIZE", "999999")
+    assert _resolve_sync_page_size() == 50000
+
+
+def test_api_client_reads_env_page_size(monkeypatch):
+    monkeypatch.setenv("CAMPFIRE_SYNC_PAGE_SIZE", "1234")
+    client = APIClient(session=MagicMock())
+    assert client._page_size == 1234

--- a/supabase/migrations/20260701120000_object_scoped_aggregates_fast_path.sql
+++ b/supabase/migrations/20260701120000_object_scoped_aggregates_fast_path.sql
@@ -1,0 +1,77 @@
+-- Fast path for object_scoped_aggregates (perf, issue #103).
+--
+-- The helper recomputes an object's aggregate columns (programs, gratings,
+-- observations, n_targets, n_spectra, max_snr, max_exposure_time) scoped to the
+-- caller's accessible programs, so a partial-access viewer of a mixed-program
+-- object does not see proprietary members. It is invoked once per returned row
+-- (LEFT JOIN LATERAL) by get_objects_for_sync, get_filtered_objects_paginated,
+-- and get_csv_export_objects, and each invocation scanned targets + spectra --
+-- the dominant per-page cost of the /sync/objects RPC at ~30k objects.
+--
+-- For the common full-access case (the caller can access every program the
+-- object belongs to) and the published-only gate (NOT p_include_unpublished),
+-- that recompute is provably identical to the aggregate columns already stored
+-- on the object: both are the deploy-time builder's aggregation over published
+-- members, kept in lockstep by reconcile_field_objects(), and restricting to a
+-- superset of the object's programs drops nothing. So `o.programs <@
+-- p_program_slugs` is exactly the "recompute == stored" condition, and the fast
+-- path returns the stored columns via a single PK lookup instead of two scans.
+-- Partial-access or draft-inclusive callers fall through to the unchanged
+-- recompute, preserving the anti-leak scoping guarded by
+-- supabase/tests/check_object_aggregate_scoping.sql.
+--
+-- Signature is unchanged (CREATE OR REPLACE), so existing GRANTs are preserved.
+
+CREATE OR REPLACE FUNCTION public.object_scoped_aggregates(
+  p_object_id INTEGER,
+  p_program_slugs TEXT[],
+  p_include_unpublished BOOLEAN DEFAULT false
+)
+RETURNS TABLE(
+  programs          TEXT[],
+  gratings          TEXT[],
+  observations      TEXT[],
+  n_targets         INTEGER,
+  n_spectra         INTEGER,
+  max_snr           DOUBLE PRECISION,
+  max_exposure_time DOUBLE PRECISION
+)
+LANGUAGE plpgsql STABLE
+AS $$
+BEGIN
+  IF NOT p_include_unpublished THEN
+    RETURN QUERY
+    SELECT o.programs, o.gratings, o.observations,
+           o.n_targets, o.n_spectra, o.max_snr, o.max_exposure_time
+    FROM objects o
+    WHERE o.id = p_object_id
+      AND o.programs <@ p_program_slugs;
+    IF FOUND THEN
+      RETURN;
+    END IF;
+  END IF;
+
+  RETURN QUERY
+  WITH m AS (
+    SELECT t.target_id, t.program_slug, t.observation
+    FROM targets t
+    WHERE t.object_id = p_object_id
+      AND t.program_slug = ANY(p_program_slugs)
+      AND (p_include_unpublished OR t.has_published_spectrum)
+  ),
+  sp AS (
+    SELECT s.grating, s.signal_to_noise, s.exposure_time
+    FROM spectra s
+    WHERE s.target_id IN (SELECT target_id FROM m)
+      AND (p_include_unpublished OR s.deploy_status = 'published')
+  )
+  SELECT
+    COALESCE((SELECT array_agg(DISTINCT m.program_slug ORDER BY m.program_slug) FROM m), '{}')::text[],
+    COALESCE((SELECT array_agg(DISTINCT sp.grating ORDER BY sp.grating) FROM sp WHERE sp.grating IS NOT NULL), '{}')::text[],
+    COALESCE((SELECT array_agg(DISTINCT m.observation ORDER BY m.observation) FROM m WHERE m.observation IS NOT NULL), '{}')::text[],
+    (SELECT COUNT(*) FROM m)::integer,
+    (SELECT COUNT(*) FROM sp)::integer,
+    (SELECT MAX(sp.signal_to_noise) FROM sp),
+    (SELECT MAX(sp.exposure_time) FROM sp);
+END;
+$$;

--- a/supabase/migrations/20260701120000_object_scoped_aggregates_fast_path.sql
+++ b/supabase/migrations/20260701120000_object_scoped_aggregates_fast_path.sql
@@ -39,6 +39,19 @@ RETURNS TABLE(
 LANGUAGE plpgsql STABLE
 AS $$
 BEGIN
+  -- Fast path (perf, issue #103): when the caller can access every program this
+  -- object belongs to AND unpublished members are excluded, the viewer-scoped
+  -- recompute below is provably identical to the aggregate columns already
+  -- stored on the object -- both are the deploy-time builder's aggregation over
+  -- published members (reconcile_field_objects keeps the stored columns in
+  -- lockstep with the object row, and targets/spectra only change at deploy).
+  -- Restricting the recompute to a superset of the object's programs drops
+  -- nothing, so `o.programs <@ p_program_slugs` is exactly the "recompute ==
+  -- stored" condition. Returning the stored columns via a single PK lookup skips
+  -- the per-row targets+spectra scans that dominated get_objects_for_sync (and
+  -- the catalog list RPCs) at scale. Partial-access or draft-inclusive callers
+  -- fall through to the recompute, preserving the anti-leak scoping (see the
+  -- header comment and supabase/tests/check_object_aggregate_scoping.sql).
   IF NOT p_include_unpublished THEN
     RETURN QUERY
     SELECT o.programs, o.gratings, o.observations,
@@ -57,6 +70,8 @@ BEGIN
     FROM targets t
     WHERE t.object_id = p_object_id
       AND t.program_slug = ANY(p_program_slugs)
+      -- B1: only count targets that contribute a published spectrum so
+      -- n_targets / programs / observations don't include draft-only members.
       AND (p_include_unpublished OR t.has_published_spectrum)
   ),
   sp AS (

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -137,8 +137,35 @@ RETURNS TABLE(
   max_snr           DOUBLE PRECISION,
   max_exposure_time DOUBLE PRECISION
 )
-LANGUAGE sql STABLE
+LANGUAGE plpgsql STABLE
 AS $$
+BEGIN
+  -- Fast path (perf, issue #103): when the caller can access every program this
+  -- object belongs to AND unpublished members are excluded, the viewer-scoped
+  -- recompute below is provably identical to the aggregate columns already
+  -- stored on the object -- both are the deploy-time builder's aggregation over
+  -- published members (reconcile_field_objects keeps the stored columns in
+  -- lockstep with the object row, and targets/spectra only change at deploy).
+  -- Restricting the recompute to a superset of the object's programs drops
+  -- nothing, so `o.programs <@ p_program_slugs` is exactly the "recompute ==
+  -- stored" condition. Returning the stored columns via a single PK lookup skips
+  -- the per-row targets+spectra scans that dominated get_objects_for_sync (and
+  -- the catalog list RPCs) at scale. Partial-access or draft-inclusive callers
+  -- fall through to the recompute, preserving the anti-leak scoping (see the
+  -- header comment and supabase/tests/check_object_aggregate_scoping.sql).
+  IF NOT p_include_unpublished THEN
+    RETURN QUERY
+    SELECT o.programs, o.gratings, o.observations,
+           o.n_targets, o.n_spectra, o.max_snr, o.max_exposure_time
+    FROM objects o
+    WHERE o.id = p_object_id
+      AND o.programs <@ p_program_slugs;
+    IF FOUND THEN
+      RETURN;
+    END IF;
+  END IF;
+
+  RETURN QUERY
   WITH m AS (
     SELECT t.target_id, t.program_slug, t.observation
     FROM targets t
@@ -162,6 +189,7 @@ AS $$
     (SELECT COUNT(*) FROM sp)::integer,
     (SELECT MAX(sp.signal_to_noise) FROM sp),
     (SELECT MAX(sp.exposure_time) FROM sp);
+END;
 $$;
 
 GRANT EXECUTE ON FUNCTION public.object_scoped_aggregates(INTEGER, TEXT[], BOOLEAN) TO authenticated;

--- a/web/app/api/v1/sync/lists/route.ts
+++ b/web/app/api/v1/sync/lists/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { validateAuth } from '@/lib/api-auth';
-import { isAdminUser } from '@/lib/api-helpers';
+import { isAdminUserCached } from '@/lib/api-helpers';
 
 /**
  * GET /api/v1/sync/lists
@@ -28,7 +28,7 @@ export async function GET(request: NextRequest) {
     // List member counts may reference unpublished-backed objects; admins can
     // opt in to include them, everyone else is fail-closed. No-op in B1.
     const includeUnpublished =
-      request.nextUrl.searchParams.get('include_unpublished') === 'true' && (await isAdminUser(userId));
+      request.nextUrl.searchParams.get('include_unpublished') === 'true' && (await isAdminUserCached(userId));
 
     const { data, error } = await supabase.rpc('get_lists_for_sync', {
       p_user_id: userId,

--- a/web/app/api/v1/sync/objects/route.ts
+++ b/web/app/api/v1/sync/objects/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { validateAuth } from '@/lib/api-auth';
-import { getAccessiblePrograms, isAdminUser } from '@/lib/api-helpers';
+import { getAccessibleProgramsCached, isAdminUserCached } from '@/lib/api-helpers';
 
 /**
  * GET /api/v1/sync/objects
@@ -28,7 +28,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const accessibleProgramSlugs = await getAccessiblePrograms(userId);
+    const accessibleProgramSlugs = await getAccessibleProgramsCached(userId);
 
     if (accessibleProgramSlugs.length === 0) {
       return NextResponse.json({
@@ -50,7 +50,7 @@ export async function GET(request: NextRequest) {
     // Admins can opt in to syncing objects with no published spectrum;
     // everyone else is fail-closed to published-backed objects. No-op in B1.
     const includeUnpublished =
-      searchParams.get('include_unpublished') === 'true' && (await isAdminUser(userId));
+      searchParams.get('include_unpublished') === 'true' && (await isAdminUserCached(userId));
 
     const { data, error } = await supabase.rpc('get_objects_for_sync', {
       p_program_slugs: accessibleProgramSlugs,

--- a/web/app/api/v1/sync/photometry/route.ts
+++ b/web/app/api/v1/sync/photometry/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { validateAuth } from '@/lib/api-auth';
-import { getAccessiblePrograms, isAdminUser } from '@/lib/api-helpers';
+import { getAccessibleProgramsCached, isAdminUserCached } from '@/lib/api-helpers';
 
 /**
  * GET /api/v1/sync/photometry
@@ -27,7 +27,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const accessibleProgramSlugs = await getAccessiblePrograms(userId);
+    const accessibleProgramSlugs = await getAccessibleProgramsCached(userId);
 
     if (accessibleProgramSlugs.length === 0) {
       return NextResponse.json({
@@ -48,7 +48,7 @@ export async function GET(request: NextRequest) {
     // Photometry for objects with no published spectrum is admin-only and
     // gated behind explicit opt-in. Fail-closed otherwise; no-op in B1.
     const includeUnpublished =
-      searchParams.get('include_unpublished') === 'true' && (await isAdminUser(userId));
+      searchParams.get('include_unpublished') === 'true' && (await isAdminUserCached(userId));
 
     const { data, error } = await supabase.rpc('get_photometry_for_sync', {
       p_program_slugs: accessibleProgramSlugs,

--- a/web/app/api/v1/sync/spectra/route.ts
+++ b/web/app/api/v1/sync/spectra/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { validateAuth } from '@/lib/api-auth';
-import { getAccessiblePrograms, isAdminUser } from '@/lib/api-helpers';
+import { getAccessibleProgramsCached, isAdminUserCached } from '@/lib/api-helpers';
 
 /**
  * GET /api/v1/sync/spectra
@@ -27,7 +27,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const accessibleProgramSlugs = await getAccessiblePrograms(userId);
+    const accessibleProgramSlugs = await getAccessibleProgramsCached(userId);
 
     if (accessibleProgramSlugs.length === 0) {
       return NextResponse.json({
@@ -49,7 +49,7 @@ export async function GET(request: NextRequest) {
     // Admins can opt in to syncing unpublished spectra; everyone else is
     // fail-closed to published rows only. No-op in B1.
     const includeUnpublished =
-      searchParams.get('include_unpublished') === 'true' && (await isAdminUser(userId));
+      searchParams.get('include_unpublished') === 'true' && (await isAdminUserCached(userId));
 
     const { data, error } = await supabase.rpc('get_spectra_for_sync', {
       p_program_slugs: accessibleProgramSlugs,

--- a/web/app/api/v1/sync/storage/route.ts
+++ b/web/app/api/v1/sync/storage/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { validateAuth } from '@/lib/api-auth';
-import { getAccessiblePrograms, isAdminUser } from '@/lib/api-helpers';
+import { getAccessibleProgramsCached, isAdminUserCached } from '@/lib/api-helpers';
 
 /**
  * GET /api/v1/sync/storage
@@ -32,8 +32,8 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const accessibleProgramSlugs = await getAccessiblePrograms(userId);
-    const admin = await isAdminUser(userId);
+    const accessibleProgramSlugs = await getAccessibleProgramsCached(userId);
+    const admin = await isAdminUserCached(userId);
 
     // Non-admins with no program access have nothing to mirror. Admins fall
     // through (the RPC returns the full mirror regardless of program list).

--- a/web/lib/api-helpers.ts
+++ b/web/lib/api-helpers.ts
@@ -81,6 +81,71 @@ export async function getAccessiblePrograms(userId: string): Promise<string[]> {
   return [...new Set([...publicProgramSlugs, ...explicitAccessSlugs])];
 }
 
+// ---------------------------------------------------------------------------
+// Sync auth preamble cache
+// ---------------------------------------------------------------------------
+// A full `campfire sync` fans out hundreds of /sync/* requests that each
+// re-derive the same invariant for the same user: the accessible-program list
+// (2 Supabase queries) and the admin flag (1 query). Recomputing it per page is
+// pure fixed tax. Memoize per user for a short window so warm serverless
+// instances collapse the repeats to a single lookup. Fail-open: a miss just
+// falls back to the uncached query. The TTL bounds staleness if a user's access
+// changes mid-sync (a rare event that a subsequent sync picks up anyway).
+//
+// Scoped to the sync routes on purpose -- other call sites keep the uncached
+// helpers so their behavior is unchanged.
+const SYNC_AUTH_TTL_MS = 60_000;
+const SYNC_AUTH_CACHE_MAX = 1000;
+
+type CacheEntry<T> = { value: T; expiresAt: number };
+
+function cacheGet<T>(cache: Map<string, CacheEntry<T>>, key: string, now: number): T | undefined {
+  const hit = cache.get(key);
+  if (hit && hit.expiresAt > now) return hit.value;
+  if (hit) cache.delete(key);
+  return undefined;
+}
+
+function cacheSet<T>(cache: Map<string, CacheEntry<T>>, key: string, value: T, now: number): void {
+  // Opportunistically drop expired entries before growing an unbounded map on a
+  // long-lived warm instance.
+  if (cache.size >= SYNC_AUTH_CACHE_MAX) {
+    for (const [k, v] of cache) {
+      if (v.expiresAt <= now) cache.delete(k);
+    }
+  }
+  cache.set(key, { value, expiresAt: now + SYNC_AUTH_TTL_MS });
+}
+
+const accessibleProgramsCache = new Map<string, CacheEntry<string[]>>();
+const isAdminCache = new Map<string, CacheEntry<boolean>>();
+
+/**
+ * getAccessiblePrograms with a short-TTL per-instance cache. Use ONLY on the
+ * high-fanout /sync/* routes; see the cache note above.
+ */
+export async function getAccessibleProgramsCached(userId: string): Promise<string[]> {
+  const now = Date.now();
+  const cached = cacheGet(accessibleProgramsCache, userId, now);
+  if (cached !== undefined) return cached;
+  const value = await getAccessiblePrograms(userId);
+  cacheSet(accessibleProgramsCache, userId, value, now);
+  return value;
+}
+
+/**
+ * isAdminUser with a short-TTL per-instance cache. Use ONLY on the /sync/*
+ * routes; see the cache note above.
+ */
+export async function isAdminUserCached(userId: string): Promise<boolean> {
+  const now = Date.now();
+  const cached = cacheGet(isAdminCache, userId, now);
+  if (cached !== undefined) return cached;
+  const value = await isAdminUser(userId);
+  cacheSet(isAdminCache, userId, value, now);
+  return value;
+}
+
 /**
  * Check if user has any proprietary program access (granted programs, not public)
  * Used to determine if user needs to be prompted for an access code


### PR DESCRIPTION
## Summary

This PR refactors the sync pipeline for performance and scalability:

1. **Concurrent fetch orchestration** — The four independent `/sync/*` catalogs (objects, spectra, storage, photometry) now fetch concurrently from the network, collapsing wall time from the sum of four requests toward the slowest single one. Writes remain serial (single-threaded SQLite).

2. **Auth preamble caching** — Sync routes now cache the per-user accessible-program list and admin flag for 60 seconds, eliminating redundant Supabase queries across the hundreds of paginated requests in a full sync.

3. **Object aggregate fast path** — When a caller can access all programs an object belongs to and unpublished members are excluded, `object_scoped_aggregates()` now returns pre-computed columns via a single PK lookup instead of scanning targets and spectra.

4. **Configurable sync page size** — The `/sync/*` paginators now respect `CAMPFIRE_SYNC_PAGE_SIZE` env var (clamped to 1–50k, default 1000) to tune the per-page fixed cost (HTTP round-trip, auth, count-gating) vs. response width.

5. **Thread-safe token refresh** — OAuth token refresh in concurrent workers uses double-checked locking to prevent races on the shared refresh token.

## Key Changes

**Python (`python/campfire/sync.py`)**
- Refactored `_sync_objects()`, `_sync_spectra()`, `_sync_photometry()`, `_sync_storage_objects()` into separate fetch and apply phases
- New `_fetch_all_concurrent()` orchestrates four concurrent network fetches via `ThreadPoolExecutor`, then applies results serially
- `_make_progress()` now accepts `position` parameter to pin progress bars to fixed terminal rows (stable stacked group)
- Progress bars only render on TTY; non-TTY (CI) emits one completion line per stream instead
- Captures single `sync_ts` before any fetch; all upserts stamp strictly later times so purge removes only stale rows

**Python (`python/campfire/api/client.py`)**
- Added `DEFAULT_SYNC_PAGE_SIZE` (1000) and `_resolve_sync_page_size()` to read `CAMPFIRE_SYNC_PAGE_SIZE` env var
- `APIClient._page_size` initialized from env; used in `_paginate_sync_endpoint()` and `fetch_all_photometry()`

**Python (`python/campfire/api/session.py`)**
- Added `threading.Lock()` for token refresh serialization
- `_ensure_valid_token()` uses double-checked locking: common (no-refresh) path is lock-free; actual refresh is serialized

**Web (`web/lib/api-helpers.ts`)**
- New `getAccessibleProgramsCached()` and `isAdminUserCached()` with 60-second per-instance TTL
- Cache evicts expired entries opportunistically when approaching max size (1000 entries)
- Updated all `/sync/*` routes to use cached variants

**Database (`supabase/schemas/functions.sql` + migration)**
- `object_scoped_aggregates()` now checks fast-path condition: `NOT p_include_unpublished AND o.programs <@ p_program_slugs`
- If true, returns stored aggregate columns via single PK lookup; otherwise falls through to unchanged recompute
- Preserves anti-leak scoping for partial-access and draft-inclusive callers

**Tests (`python/tests/test_sync_concurrent.py`)**
- New test suite covering concurrent fetch orchestration, result routing, cursor threading, incremental vs. full sync, stream failure propagation, and page-size config resolution

## Implementation Details

- **Concurrent fetch safety**: Workers only touch the network; all SQLite writes happen on the caller's thread after fetches complete
- **Progress bar positioning**: Uses `tqdm` `position` parameter to render four bars as a stable stacked group; `leave=True` preserves them after completion
- **TTY detection**: `sys.stderr.isatty()` determines whether to render live bars or emit completion lines

https://claude.ai/code/session_013XQ2ERAh9MrAckkUUnHWwA