### PR TITLE
Add separate page size configuration for /sync/storage endpoint

### DIFF
--- a/python/campfire/api/client.py
+++ b/python/campfire/api/client.py
@@ -24,21 +24,51 @@ from .session import APISession
 #: (HTTP round-trip + server auth preamble + count-gating) at the price of wider
 #: responses and higher peak memory. Clamped to a sane range.
 DEFAULT_SYNC_PAGE_SIZE = 1000
+
+#: storage_objects is the largest sync catalog: every spectrum fans out into
+#: finals plus intermediate-lifecycle products, and NIRCam exposures pile on top,
+#: so its row count runs several times that of objects/spectra. It therefore
+#: paginates with a larger default page to cut the per-page round-trips. Override
+#: with ``CAMPFIRE_SYNC_STORAGE_PAGE_SIZE``; absent that, it tracks the shared
+#: ``CAMPFIRE_SYNC_PAGE_SIZE`` but never drops below this floor.
+DEFAULT_STORAGE_SYNC_PAGE_SIZE = 5000
+
 _MAX_SYNC_PAGE_SIZE = 50000
 
 
-def _resolve_sync_page_size() -> int:
-    """Resolve the sync page size from ``CAMPFIRE_SYNC_PAGE_SIZE`` (or the default)."""
-    raw = os.environ.get("CAMPFIRE_SYNC_PAGE_SIZE")
+def _resolve_page_size(env_var: str, default: int) -> int:
+    """Resolve a sync page size from ``env_var`` (or ``default``), clamped to range."""
+    raw = os.environ.get(env_var)
     if not raw:
-        return DEFAULT_SYNC_PAGE_SIZE
+        return default
     try:
         val = int(raw)
     except (TypeError, ValueError):
-        return DEFAULT_SYNC_PAGE_SIZE
+        return default
     if val < 1:
-        return DEFAULT_SYNC_PAGE_SIZE
+        return default
     return min(val, _MAX_SYNC_PAGE_SIZE)
+
+
+def _resolve_sync_page_size() -> int:
+    """Resolve the shared /sync/* page size from ``CAMPFIRE_SYNC_PAGE_SIZE``."""
+    return _resolve_page_size("CAMPFIRE_SYNC_PAGE_SIZE", DEFAULT_SYNC_PAGE_SIZE)
+
+
+def _resolve_storage_sync_page_size() -> int:
+    """Resolve the /sync/storage page size.
+
+    ``CAMPFIRE_SYNC_STORAGE_PAGE_SIZE`` pins storage precisely when set. Absent
+    that, storage tracks the shared ``CAMPFIRE_SYNC_PAGE_SIZE`` but is floored at
+    ``DEFAULT_STORAGE_SYNC_PAGE_SIZE`` — so it is always at least as large as the
+    other streams, and larger by default.
+    """
+    raw = os.environ.get("CAMPFIRE_SYNC_STORAGE_PAGE_SIZE")
+    if raw:
+        return _resolve_page_size(
+            "CAMPFIRE_SYNC_STORAGE_PAGE_SIZE", DEFAULT_STORAGE_SYNC_PAGE_SIZE
+        )
+    return max(_resolve_sync_page_size(), DEFAULT_STORAGE_SYNC_PAGE_SIZE)
 
 
 def _build_query_params(
@@ -133,6 +163,7 @@ class APIClient:
     def __init__(self, session: APISession):
         self._session = session
         self._page_size = _resolve_sync_page_size()
+        self._storage_page_size = _resolve_storage_sync_page_size()
 
     # ------------------------------------------------------------------
     # Objects
@@ -255,9 +286,14 @@ class APIClient:
         updated_since: Optional[str] = None,
         on_page_complete: Optional[Callable[[int, int], None]] = None,
     ) -> Tuple[List[dict], int]:
-        """Fetch the storage_objects mirror via /sync/storage (program-scoped)."""
+        """Fetch the storage_objects mirror via /sync/storage (program-scoped).
+
+        Paginates with the larger storage page size (``_storage_page_size``) since
+        storage_objects is the biggest sync catalog.
+        """
         return self._paginate_sync_endpoint(
             "/sync/storage", updated_since, on_page_complete,
+            page_size=self._storage_page_size,
         )
 
     def presign_keys(self, keys: List[str]) -> Dict[str, str]:
@@ -289,11 +325,17 @@ class APIClient:
         path: str,
         updated_since: Optional[str] = None,
         on_page_complete: Optional[Callable[[int, int], None]] = None,
+        page_size: Optional[int] = None,
     ) -> Tuple[List[dict], int]:
         """Paginate through a /sync/* endpoint.
 
+        ``page_size`` overrides the shared per-client page size for endpoints that
+        want a different one (e.g. the larger storage page); defaults to
+        ``self._page_size``.
+
         Returns (items, total_accessible_count).
         """
+        page_size = page_size or self._page_size
         all_items: List[dict] = []
         total_accessible_count = 0
         total = 0
@@ -305,7 +347,7 @@ class APIClient:
             # count CTEs when include_counts=false, saving a full scan per
             # subsequent page.
             params: dict = {
-                "limit": self._page_size,
+                "limit": page_size,
                 "offset": offset,
                 "include_counts": "true" if first_page else "false",
             }

--- a/python/tests/test_sync_concurrent.py
+++ b/python/tests/test_sync_concurrent.py
@@ -12,7 +12,9 @@ import pytest
 
 from campfire.api.client import (
     APIClient,
+    DEFAULT_STORAGE_SYNC_PAGE_SIZE,
     DEFAULT_SYNC_PAGE_SIZE,
+    _resolve_storage_sync_page_size,
     _resolve_sync_page_size,
 )
 from campfire.sync import sync_metadata
@@ -181,3 +183,77 @@ def test_api_client_reads_env_page_size(monkeypatch):
     monkeypatch.setenv("CAMPFIRE_SYNC_PAGE_SIZE", "1234")
     client = APIClient(session=MagicMock())
     assert client._page_size == 1234
+
+
+# ---------------------------------------------------------------------------
+# Storage page-size config (storage_objects paginates with a larger page)
+# ---------------------------------------------------------------------------
+def test_resolve_storage_page_size_default(monkeypatch):
+    monkeypatch.delenv("CAMPFIRE_SYNC_STORAGE_PAGE_SIZE", raising=False)
+    monkeypatch.delenv("CAMPFIRE_SYNC_PAGE_SIZE", raising=False)
+    assert _resolve_storage_sync_page_size() == DEFAULT_STORAGE_SYNC_PAGE_SIZE
+    # Storage default is deliberately larger than the shared default.
+    assert DEFAULT_STORAGE_SYNC_PAGE_SIZE > DEFAULT_SYNC_PAGE_SIZE
+
+
+def test_resolve_storage_page_size_explicit_override(monkeypatch):
+    monkeypatch.setenv("CAMPFIRE_SYNC_STORAGE_PAGE_SIZE", "8000")
+    # The storage-specific var wins, even against the shared one.
+    monkeypatch.setenv("CAMPFIRE_SYNC_PAGE_SIZE", "2000")
+    assert _resolve_storage_sync_page_size() == 8000
+
+
+def test_resolve_storage_page_size_tracks_shared_when_higher(monkeypatch):
+    # No storage-specific var: storage tracks the shared page size once it rises
+    # above the storage floor.
+    monkeypatch.delenv("CAMPFIRE_SYNC_STORAGE_PAGE_SIZE", raising=False)
+    monkeypatch.setenv("CAMPFIRE_SYNC_PAGE_SIZE", str(DEFAULT_STORAGE_SYNC_PAGE_SIZE + 3000))
+    assert _resolve_storage_sync_page_size() == DEFAULT_STORAGE_SYNC_PAGE_SIZE + 3000
+
+
+def test_resolve_storage_page_size_floored_by_default(monkeypatch):
+    # A shared page size below the storage floor does not shrink storage.
+    monkeypatch.delenv("CAMPFIRE_SYNC_STORAGE_PAGE_SIZE", raising=False)
+    monkeypatch.setenv("CAMPFIRE_SYNC_PAGE_SIZE", "500")
+    assert _resolve_storage_sync_page_size() == DEFAULT_STORAGE_SYNC_PAGE_SIZE
+
+
+def test_resolve_storage_page_size_clamps_large(monkeypatch):
+    monkeypatch.setenv("CAMPFIRE_SYNC_STORAGE_PAGE_SIZE", "999999")
+    assert _resolve_storage_sync_page_size() == 50000
+
+
+@pytest.mark.parametrize("bad", ["notanint", "0", "-5"])
+def test_resolve_storage_page_size_invalid_falls_back_to_floor(monkeypatch, bad):
+    monkeypatch.delenv("CAMPFIRE_SYNC_PAGE_SIZE", raising=False)
+    monkeypatch.setenv("CAMPFIRE_SYNC_STORAGE_PAGE_SIZE", bad)
+    assert _resolve_storage_sync_page_size() == DEFAULT_STORAGE_SYNC_PAGE_SIZE
+
+
+def test_api_client_reads_storage_page_size(monkeypatch):
+    monkeypatch.setenv("CAMPFIRE_SYNC_STORAGE_PAGE_SIZE", "7777")
+    client = APIClient(session=MagicMock())
+    assert client._storage_page_size == 7777
+
+
+def test_fetch_all_storage_requests_storage_page_size(monkeypatch):
+    """/sync/storage paginates with the storage page size, not the shared one."""
+    monkeypatch.setenv("CAMPFIRE_SYNC_PAGE_SIZE", "1000")
+    monkeypatch.setenv("CAMPFIRE_SYNC_STORAGE_PAGE_SIZE", "6000")
+
+    session = MagicMock()
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {
+        "data": [],
+        "pagination": {"total": 0},
+        "total_accessible_count": 0,
+    }
+    session.get.return_value = response
+
+    client = APIClient(session=session)
+    client.fetch_all_storage()
+
+    # The first (and only) page is requested with the storage limit.
+    _path, kwargs = session.get.call_args
+    assert kwargs["params"]["limit"] == 6000


### PR DESCRIPTION
## Summary

Introduces a dedicated page size configuration for the `/sync/storage` endpoint, which paginates with a larger default than other sync endpoints. The storage_objects catalog is the largest sync table (every spectrum fans out into finals plus intermediate products, and NIRCam exposures multiply this further), so a larger page size reduces per-page round-trips.

## Key Changes

- **New constant `DEFAULT_STORAGE_SYNC_PAGE_SIZE = 5000`**: Larger than the shared `DEFAULT_SYNC_PAGE_SIZE = 1000` to optimize storage pagination
- **New function `_resolve_storage_sync_page_size()`**: Resolves storage page size with the following logic:
  - If `CAMPFIRE_SYNC_STORAGE_PAGE_SIZE` is set, use it (pinned precisely)
  - Otherwise, track the shared `CAMPFIRE_SYNC_PAGE_SIZE` but floor it at `DEFAULT_STORAGE_SYNC_PAGE_SIZE`
  - This ensures storage always paginates with at least as large a page as other endpoints, and larger by default
- **Refactored `_resolve_sync_page_size()`**: Extracted common page-size resolution logic into a new `_resolve_page_size(env_var, default)` helper
- **Updated `APIClient`**: 
  - Added `_storage_page_size` attribute initialized via `_resolve_storage_sync_page_size()`
  - Modified `fetch_all_storage()` to pass `page_size=self._storage_page_size` to `_paginate_sync_endpoint()`
  - Updated `_paginate_sync_endpoint()` to accept optional `page_size` parameter (defaults to `self._page_size`)
- **Comprehensive test coverage**: Added 8 new tests covering default behavior, explicit overrides, fallback logic, clamping, invalid inputs, and integration with the API client

## Implementation Details

The storage page size resolution implements a "floor with override" pattern: the storage endpoint respects an explicit storage-specific environment variable but otherwise inherits from the shared page size configuration while maintaining a minimum threshold. This allows operators to tune storage pagination independently while keeping the common case simple (no new env var needed, just larger by default).

https://claude.ai/code/session_01BMuXvD2zL9f6bJWi2mFCSn