### PR TITLE
Add filter scope column to storage_objects for NIRCam filtering

### DIFF
--- a/layout/campfire_layout/bijection.py
+++ b/layout/campfire_layout/bijection.py
@@ -98,8 +98,6 @@ def parse_relpath(relpath: str) -> ParsedKey:
         field = seg[2]
         if len(seg) == 4 and seg[3].endswith("_rgb.png"):
             return ParsedKey("nircam_rgb", Scope(field=field), seg[3])
-        if len(seg) == 5 and seg[3] == "expmaps":
-            return ParsedKey("nircam_expmap", Scope(field=field), seg[4])
         if len(seg) == 5:
             filt, fname = seg[3], seg[4]
             scope = Scope(field=field, filt=filt)
@@ -108,6 +106,8 @@ def parse_relpath(relpath: str) -> ParsedKey:
                 return ParsedKey(ptype, scope, fname)
             if fname.startswith("mosaic"):
                 return ParsedKey("nircam_mosaic", scope, fname)
+            if fname.startswith("expmap"):
+                return ParsedKey("nircam_expmap", scope, fname)
             if fname.endswith(".fits"):
                 return ParsedKey("nircam_exposure", scope, fname)
 

--- a/layout/campfire_layout/products.py
+++ b/layout/campfire_layout/products.py
@@ -166,11 +166,14 @@ _register(ProductSpec(
     lifecycle=LC.CLOUD_PRODUCT, scope_keys=("field",), subdir=_nircam_field_dir,
     suffix="_rgb.png", legacy_prefix=None,
 ))
-# Exposure-coverage maps.
+# Per-(field, filter) exposure-coverage maps. Live in the canonical filter dir
+# alongside the mosaics/exposures (products/nircam/<field>/<filter>/), keyed off
+# an ``expmap_`` filename prefix; scoped by filt so the registry carries a real
+# filter for them like every other per-filter NIRCam product.
 _register(ProductSpec(
     name="nircam_expmap", instrument=NC, tree="products", bucket="data",
-    lifecycle=LC.CLOUD_PRODUCT, scope_keys=("field",),
-    subdir=lambda s: f"nircam/{s.field}/expmaps", suffix=None, legacy_prefix=None,
+    lifecycle=LC.CLOUD_PRODUCT, scope_keys=("field", "filt"),
+    subdir=_nircam_field_filter_dir, suffix=None, legacy_prefix=None,
 ))
 
 # --- Map tiles (separate 'tiles' bucket, scheme-invariant, stays on R2) ---------

--- a/layout/conformance/layout_golden.json
+++ b/layout/conformance/layout_golden.json
@@ -103,11 +103,11 @@
     },
     {
       "product_type": "nircam_expmap",
-      "scope": {"field": "cosmos"},
-      "filename": "cosmos_f444w_expmap.fits",
-      "relpath": "products/nircam/cosmos/expmaps/cosmos_f444w_expmap.fits",
+      "scope": {"field": "cosmos", "filt": "f444w"},
+      "filename": "expmap_cosmos_f444w_canonical.fits",
+      "relpath": "products/nircam/cosmos/f444w/expmap_cosmos_f444w_canonical.fits",
       "key_legacy": null,
-      "key_canonical": "data/products/nircam/cosmos/expmaps/cosmos_f444w_expmap.fits",
+      "key_canonical": "data/products/nircam/cosmos/f444w/expmap_cosmos_f444w_canonical.fits",
       "bucket": "data",
       "tree_class": "cloud-backed-product"
     },

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -264,6 +264,18 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- **NIRCam expmaps now live in the canonical filter directory.** `cfpipe nircam
+  expmap` writes each per-filter coverage map to
+  `products/nircam/<field>/<filter>/expmap_<field>_<filter>_<stage>.fits` (with
+  its diagnostic `.pdf` alongside) instead of a shared `<field>/expmaps/` dir;
+  the combined `footprints_<stage>.reg` and metadata cache now sit at the field
+  products root. This puts the expmap under the same `<field>/<filter>/` key
+  shape as every other per-filter NIRCam product, so the deployed coverage map
+  carries a real `filter` in the storage registry. Breaking file-location change
+  for the expmap product only; pixel/flux values are unchanged (the `--out-dir`
+  override now names the *base* products dir under which `<filter>/` subdirs are
+  created). Categorized Infrastructure — no scientific-output change — though it
+  does move where a product file lands.
 - **NIRCam canonical exposures now carry `CMPFRVER` provenance.** `detector1`
   stamps the CAMPFIRE reduction version (+ `CMPFRTIM`) on each canonical
   exposure's primary header at creation, mirroring the mosaic stamp in

--- a/pipeline/campfire_pipeline/nircam/cli.py
+++ b/pipeline/campfire_pipeline/nircam/cli.py
@@ -261,7 +261,8 @@ def rgb(config, field, tiles, pixel_scale, preview_max_dim, processes, overwrite
 @click.option('--padding', type=float, default=30.0, show_default=True,
               help='Sky padding around the union footprint, arcsec.')
 @click.option('--out-dir', default=None,
-              help='Output directory (default: {products}/<field>/expmaps/).')
+              help='Base products dir; per-filter FITS/PDFs land in '
+                   '<out-dir>/<filter>/ (default: {products}/nircam/<field>/).')
 @click.option('--processes', '-p', default=1, type=int, show_default=True,
               help='Per-filter parallelism (one filter per worker).')
 @click.option('--overwrite', is_flag=True,

--- a/pipeline/campfire_pipeline/nircam/expmap.py
+++ b/pipeline/campfire_pipeline/nircam/expmap.py
@@ -14,11 +14,15 @@ pixel-registered for direct stacking/comparison. No tile dependency —
 works on fields without a ``[tiles]`` block, suitable for full-field
 diagnostics.
 
-Outputs (per invocation, under ``{products_dir}/expmaps/``):
+Outputs (per invocation, rooted at ``{products_dir}`` = ``products/nircam/<field>/``):
 
-    expmap_{field}_{filter}_{stage}.fits   float32, ``BUNIT='s'``, WCS in header
-    expmap_{field}_{filter}_{stage}.pdf    diagnostic with RA/Dec gridlines + colorbar
-    footprints_{stage}.reg                 ds9 fk5 polygons across all filters
+    <filter>/expmap_{field}_{filter}_{stage}.fits   float32, ``BUNIT='s'``, WCS in header
+    <filter>/expmap_{field}_{filter}_{stage}.pdf    diagnostic with RA/Dec gridlines + colorbar
+    footprints_{stage}.reg                          ds9 fk5 polygons across all filters
+
+The per-filter FITS sits in the canonical filter directory alongside the
+mosaics/exposures so the deployed coverage map carries a real filter in the
+registry (same key shape as every other per-filter NIRCam product).
 
 All per-filter PDFs in one invocation share the same colorbar
 ``vmin``/``vmax`` (log-norm across the union of nonzero pixels) so the
@@ -386,10 +390,17 @@ def _collect_metas(field, filter_name, stage, *,
     return metas
 
 
-def _expmap_paths(out_dir, field_name, filter_name, stage):
-    base = f'expmap_{field_name}_{filter_name}_{stage}'
-    return (os.path.join(out_dir, base + '.fits'),
-            os.path.join(out_dir, base + '.pdf'))
+def _expmap_paths(base_dir, field_name, filter_name, stage):
+    """Canonical per-filter FITS + PDF paths.
+
+    Expmaps live in the filter directory alongside the mosaics/exposures
+    (``<base_dir>/<filter>/expmap_<field>_<filter>_<stage>.{fits,pdf}``) so the
+    deployed FITS carries a real filter in the registry — same key shape as every
+    other per-filter NIRCam product. ``base_dir`` is the per-field products dir.
+    """
+    d = os.path.join(base_dir, filter_name)
+    base = os.path.join(d, f'expmap_{field_name}_{filter_name}_{stage}')
+    return base + '.fits', base + '.pdf'
 
 
 def _nz_range(expmap):
@@ -427,6 +438,7 @@ def _accumulate_filter(args):
 
     expmap = _accumulate_expmap(metas, wcs, shape,
                                 desc=f'[{filter_name}] stacking')
+    os.makedirs(os.path.dirname(fits_path), exist_ok=True)
     _write_fits(fits_path, expmap, wcs,
                 field_name=field.name, filter_name=filter_name,
                 stage=stage, metas=metas)
@@ -475,7 +487,10 @@ def run_expmap(
     padding
         Sky padding in arcsec around the union footprint.
     out_dir
-        Output directory. Defaults to ``{field.products_dir}/expmaps/``.
+        Base products directory. Per-filter FITS + PDFs land in
+        ``<out_dir>/<filter>/``; the combined ``footprints_<stage>.reg`` and the
+        metadata cache land at its root. Defaults to ``field.products_dir``
+        (``products/nircam/<field>/``).
     n_processes
         Per-filter parallelism (one filter per worker).
     overwrite
@@ -491,7 +506,7 @@ def run_expmap(
         return
 
     if out_dir is None:
-        out_dir = os.path.join(field.products_dir, 'expmaps')
+        out_dir = field.products_dir
     os.makedirs(out_dir, exist_ok=True)
 
     log(f'Expmap: field={field.name}, filters={filter_list}, '

--- a/python/campfire/cli.py
+++ b/python/campfire/cli.py
@@ -617,24 +617,35 @@ class _VariadicOption(click.Option):
 @click.option("--obs", "obs_filter", multiple=True, cls=_VariadicOption, help="Download by observation name")
 @click.option("--program", "program_filter", multiple=True, cls=_VariadicOption, help="Download by program slug")
 @click.option("--field", "field_filter", multiple=True, cls=_VariadicOption, help="Download by field name")
-@click.option("--grating", "grating_filter", multiple=True, cls=_VariadicOption, help="Filter by grating type")
+@click.option("--grating", "grating_filter", multiple=True, cls=_VariadicOption,
+              help="NIRSpec: narrow finals to these gratings (e.g. PRISM G395M)")
+@click.option("--filters", "filter_filter", multiple=True, cls=_VariadicOption,
+              help="NIRCam: narrow to these filters (e.g. f277w f356w f444w)")
 @click.option("--stale", is_flag=True, help="Re-download files updated on the server")
 @click.option("--intermediate", "include_intermediate", is_flag=True,
-              help="Also fetch canonical spectrum-exposure intermediates (the resume set)")
+              help="Also fetch canonical intermediates (NIRSpec spectrum-exposures, NIRCam exposures + expmaps)")
 @click.option("--all", "download_all", is_flag=True, help="Download everything accessible")
 @click.option("--workers", default=4, help="Parallel download workers")
 @click.option("--yes", is_flag=True, help="Skip confirmation")
 @click.option("--dry-run", is_flag=True, help="Show plan without downloading")
 @click.option("--base-url", default=None, help="API base URL")
-def download(obs_filter, program_filter, field_filter, grating_filter,
+def download(obs_filter, program_filter, field_filter, grating_filter, filter_filter,
              stale, include_intermediate, download_all, workers, yes, dry_run, base_url):
-    """Download data products.
+    """Download data products (NIRSpec spectra + NIRCam field products).
 
-    Requires a prior 'campfire sync' to populate the local catalog. Use filters
-    to select which observations to download. By default only final spectra are
-    fetched; --intermediate also pulls the canonical spectrum-exposures (so you
-    can restore a deleted-local observation or inspect a stage-1/2 draft).
-    --grating narrows finals only.
+    Requires a prior 'campfire sync' to populate the local catalog. Select what
+    to download with --obs / --program (NIRSpec) or --field (NIRSpec observations
+    in a field, or NIRCam field products), then optionally scope within a
+    selection:
+
+    \b
+      --grating   NIRSpec: narrow finals to these gratings (e.g. PRISM G395M)
+      --filters   NIRCam:  narrow to these filters (e.g. f277w f356w f444w)
+
+    By default only finals are fetched (NIRSpec spectra, NIRCam mosaics);
+    --intermediate also pulls the canonical intermediates (NIRSpec spectrum-
+    exposures, NIRCam exposures + expmaps) so you can restore a deleted-local
+    observation or inspect a stage-1/2 draft.
 
     \b
     Examples:
@@ -642,7 +653,8 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
       campfire download --obs ember_uds_p4 ember_uds_p5
       campfire download --program EMBER-UDS --grating PRISM
       campfire download --obs ember_egs_p1 --intermediate
-      campfire download --field COSMOS
+      campfire download --field egs --filters f277w f356w f444w --intermediate
+      campfire download --field cosmos
       campfire download --stale
       campfire download --all
     """
@@ -799,6 +811,11 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
         store.close()
         return
 
+    filter_list = list(filter_filter) if filter_filter else None
+    if filter_list and not target_fields:
+        click.echo("Note: --filters scopes NIRCam field products; this selection "
+                   "has no NIRCam field, so it has no effect.")
+
     # Reconcile DB with filesystem before planning
     verify = store.verify_local_objects(
         _products_dir(), product_types=product_types, show_progress=True
@@ -819,6 +836,7 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
         product_types=product_types,
         gratings=grating_list,
         fields=list(target_fields),
+        filters=filter_list,
     )
 
     # Show per-scope status (observation for NIRSpec, field for NIRCam)
@@ -880,6 +898,7 @@ def download(obs_filter, program_filter, field_filter, grating_filter,
         download_session=dl_session,
         gratings=grating_list,
         fields=list(target_fields),
+        filters=filter_list,
     )
 
     click.echo(f"\n✓ Download complete")

--- a/python/campfire/db/store.py
+++ b/python/campfire/db/store.py
@@ -18,7 +18,9 @@ from typing import Dict, List, Optional, Tuple
 #   v6 (epic #210): storage_objects is now the single download/availability
 #   layer. The spectra table holds science metadata only; file keys, hashes, and
 #   local-download bookkeeping moved to the storage_objects mirror.
-SCHEMA_VERSION = 6
+#   v7: storage_objects.filter — per-filter NIRCam scope column (mirrors the
+#   server registry), so `campfire download --filters` scopes without key parsing.
+SCHEMA_VERSION = 7
 
 
 # Product-type classes the client download engine understands. Finals are the
@@ -193,6 +195,7 @@ CREATE TABLE IF NOT EXISTS storage_objects (
     status TEXT,
     observation TEXT,
     field TEXT,
+    filter TEXT,
     spectrum_id TEXT,
     exposure_ref TEXT,
     deployment_id INTEGER,
@@ -211,6 +214,7 @@ CREATE INDEX IF NOT EXISTS idx_so_observation ON storage_objects(observation);
 CREATE INDEX IF NOT EXISTS idx_so_product_type ON storage_objects(product_type);
 CREATE INDEX IF NOT EXISTS idx_so_spectrum_id ON storage_objects(spectrum_id);
 CREATE INDEX IF NOT EXISTS idx_so_obs_product ON storage_objects(observation, product_type);
+CREATE INDEX IF NOT EXISTS idx_so_field_filter ON storage_objects(field, filter);
 
 CREATE TABLE IF NOT EXISTS object_photometry (
     id INTEGER PRIMARY KEY,
@@ -1096,9 +1100,9 @@ class LocalStore:
                 INSERT INTO storage_objects
                     (storage_key, id, backend, bucket, content_hash, size_bytes,
                      content_type, product_type, instrument, status, observation,
-                     field, spectrum_id, exposure_ref, deployment_id, cfpipe_version,
+                     field, filter, spectrum_id, exposure_ref, deployment_id, cfpipe_version,
                      created_at, updated_at, _synced_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(storage_key) DO UPDATE SET
                     id=excluded.id,
                     backend=excluded.backend,
@@ -1111,6 +1115,7 @@ class LocalStore:
                     status=excluded.status,
                     observation=excluded.observation,
                     field=excluded.field,
+                    filter=excluded.filter,
                     spectrum_id=excluded.spectrum_id,
                     exposure_ref=excluded.exposure_ref,
                     deployment_id=excluded.deployment_id,
@@ -1132,6 +1137,7 @@ class LocalStore:
                     r.get("status"),
                     r.get("observation"),
                     r.get("field"),
+                    r.get("filter"),
                     r.get("spectrum_id"),
                     r.get("exposure_ref"),
                     r.get("deployment_id"),
@@ -1178,15 +1184,19 @@ class LocalStore:
         product_types: Optional[List[str]] = None,
         gratings: Optional[List[str]] = None,
         fields: Optional[List[str]] = None,
+        filters: Optional[List[str]] = None,
     ) -> Dict[str, List[dict]]:
         """Find storage objects that need downloading, grouped by scope.
 
         A row is pending if it isn't materialized locally, or its local hash no
-        longer matches the server's content_hash. ``--grating`` narrows finals
-        (joined to the science spectrum); the registry has no grating column, so
-        exposure-level intermediates are always included. ``fields`` selects
-        field-scoped NIRCam rows (``observation IS NULL``); results are grouped by
-        ``observation`` for NIRSpec and by ``field`` for NIRCam.
+        longer matches the server's content_hash. ``gratings`` narrows NIRSpec
+        finals (joined to the science spectrum); the registry has no grating
+        column, so exposure-level intermediates are always included. ``filters``
+        narrows per-filter NIRCam products against the typed ``filter`` scope
+        column; rows without a filter (NIRSpec, field-level) are always included,
+        mirroring the grating rule. ``fields`` selects field-scoped NIRCam rows
+        (``observation IS NULL``); results are grouped by ``observation`` for
+        NIRSpec and by ``field`` for NIRCam.
         """
         where = ["so.status = 'active'"]
         params: list = []
@@ -1195,6 +1205,11 @@ class LocalStore:
             ph = ",".join("?" * len(product_types))
             where.append(f"so.product_type IN ({ph})")
             params.extend(product_types)
+
+        if filters:
+            ph = ",".join("?" * len(filters))
+            where.append(f"(so.filter IS NULL OR UPPER(so.filter) IN ({ph}))")
+            params.extend(f.upper() for f in filters)
 
         # Scope: observations (NIRSpec) and/or fields (NIRCam, observation NULL).
         scope = []
@@ -1225,7 +1240,7 @@ class LocalStore:
         rows = self._conn.execute(
             f"""
             SELECT so.storage_key, so.content_hash, so.size_bytes, so.product_type,
-                   so.observation, so.field, so.spectrum_id, so.exposure_ref,
+                   so.observation, so.field, so.filter, so.spectrum_id, so.exposure_ref,
                    so.local_file_hash
             FROM storage_objects so
             {join}

--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -155,13 +155,18 @@ def _resolve_nircam_dirs(field):
 
 
 def _discover_filters(dirs):
-    """List available filters by scanning the products directory."""
+    """List available filters by scanning the products directory.
+
+    Each real filter is a subdirectory (``<field>/<filter>/``). A stray legacy
+    ``expmaps/`` dir (expmaps now live per-filter) is skipped so it is never
+    treated as a filter.
+    """
     products = dirs['products']
     if not products.exists():
         return []
     return sorted(
         d.name for d in products.iterdir()
-        if d.is_dir() and not d.name.startswith('.')
+        if d.is_dir() and not d.name.startswith('.') and d.name != 'expmaps'
     )
 
 
@@ -354,23 +359,26 @@ def build_fits_upload_tasks(field, exposures):
     return tasks
 
 
-def discover_expmap_tasks(dirs, field):
-    """Build canonical-key OSN upload tasks for any field expmap coverage files.
+def discover_expmap_tasks(dirs, field, filters):
+    """Build canonical-key OSN upload tasks for any per-filter expmap coverage files.
 
-    Expmaps are per-``(field, filter)`` coverage maps written under
-    ``products/nircam/<field>/expmaps/``. They are produced at combine time, so a
+    Expmaps are per-``(field, filter)`` coverage maps written into the canonical
+    filter directory (``products/nircam/<field>/<filter>/expmap_*.fits``),
+    alongside the mosaics/exposures. They are produced at combine time, so a
     process-only field may have none yet — deploy is idempotent and picks them up
-    on a later run. Returns a list of ``UploadTask`` (empty if the dir is absent).
+    on a later run. Returns a list of ``UploadTask`` (empty if none found).
     """
-    expmap_dir = dirs['products'] / 'expmaps'
-    if not expmap_dir.exists():
-        return []
+    products = dirs['products']
     tasks = []
-    for path in sorted(expmap_dir.glob('*.fits')):
-        key = storage_key('nircam_expmap', Scope(field=field), path.name,
-                          scheme=KeyScheme.CANONICAL)
-        tasks.append(UploadTask(local_path=path, r2_key=key,
-                                content_type=_FITS_CONTENT_TYPE))
+    for filtname in filters:
+        filter_dir = products / filtname
+        if not filter_dir.exists():
+            continue
+        for path in sorted(filter_dir.glob('expmap_*.fits')):
+            key = storage_key('nircam_expmap', Scope(field=field, filt=filtname),
+                              path.name, scheme=KeyScheme.CANONICAL)
+            tasks.append(UploadTask(local_path=path, r2_key=key,
+                                    content_type=_FITS_CONTENT_TYPE))
     return tasks
 
 
@@ -475,7 +483,7 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
     print(f"Filters: {', '.join(filters)}")
 
     exposures = discover_exposures(dirs, filters)
-    expmap_tasks = discover_expmap_tasks(dirs, field)
+    expmap_tasks = discover_expmap_tasks(dirs, field, filters)
     n_mosaics = len(discover_mosaics(dirs, field, filters))
     print(f"Discovered {len(exposures)} canonical exposure(s), "
           f"{len(expmap_tasks)} expmap(s), {n_mosaics} mosaic(s)")

--- a/python/campfire/deploy/registry.py
+++ b/python/campfire/deploy/registry.py
@@ -205,6 +205,10 @@ def row_for_key(
         'status': status,
         'observation': scope.obs,
         'field': scope.field,
+        # Typed scope column for per-filter NIRCam products (mosaic/exposure/
+        # expmap/previews); None for NIRSpec and field-level products. Lets the
+        # registry + download plan scope by filter without parsing keys.
+        'filter': scope.filt,
         'spectrum_id': _spectrum_id_for(parsed.filename),
         # Exposure-level intermediates (nirspec_spectrum_exposure) carry a stable
         # exposure_ref (filename stem) backing the partial-unique registry contract;

--- a/python/campfire/sync.py
+++ b/python/campfire/sync.py
@@ -346,20 +346,23 @@ def download_objects(
     download_session: Optional[requests.Session] = None,
     gratings: Optional[List[str]] = None,
     fields: Optional[List[str]] = None,
+    filters: Optional[List[str]] = None,
 ) -> dict:
     """Download storage objects for the given observations/fields + product types.
 
     The single, product-type-agnostic download engine: plan locally from the
     storage_objects mirror, presign the to-download set, fetch in parallel,
     verify ``content_hash``, and record local state. ``fields`` selects
-    field-scoped NIRCam rows (``observation IS NULL``); used for NIRSpec finals,
-    intermediates, and NIRCam alike.
+    field-scoped NIRCam rows (``observation IS NULL``); ``filters`` narrows those
+    to specific NIRCam filters. Used for NIRSpec finals, intermediates, and
+    NIRCam alike.
     """
     pending = store.get_pending_objects(
         observations=list(observations),
         product_types=list(product_types),
         gratings=gratings,
         fields=list(fields) if fields else None,
+        filters=list(filters) if filters else None,
     )
     to_download = [row for rows in pending.values() for row in rows]
 

--- a/python/tests/test_download_objects.py
+++ b/python/tests/test_download_objects.py
@@ -31,14 +31,15 @@ def store(tmp_path):
     s.close()
 
 
-def _so(key, product_type, content_hash, spectrum_id=None, exposure_ref=None):
+def _so(key, product_type, content_hash, spectrum_id=None, exposure_ref=None,
+        observation="test_obs", field="cosmos", filter=None, instrument="nirspec"):
     return {
         "storage_key": key, "backend": "r2", "bucket": "data",
         "content_hash": content_hash, "size_bytes": len(CONTENT),
         "content_type": "application/fits", "product_type": product_type,
-        "instrument": "nirspec", "status": "active", "observation": "test_obs",
-        "field": "cosmos", "spectrum_id": spectrum_id, "exposure_ref": exposure_ref,
-        "deployment_id": 1,
+        "instrument": instrument, "status": "active", "observation": observation,
+        "field": field, "filter": filter, "spectrum_id": spectrum_id,
+        "exposure_ref": exposure_ref, "deployment_id": 1,
     }
 
 
@@ -137,6 +138,64 @@ def test_dry_run_plans_without_fetching(store, tmp_path):
     assert stats["to_download"] == 1
     assert stats["downloaded"] == 0
     sess.get.assert_not_called()
+
+
+def _nircam_mosaic(filt):
+    """A NIRCam field mosaic row (observation NULL, field-scoped, per-filter)."""
+    key = f"data/products/nircam/egs/{filt}/mosaic_nircam_{filt}_egs_30mas_sci.fits"
+    return _so(key, "nircam_mosaic", CONTENT_SHA, observation=None,
+               field="egs", filter=filt, instrument="nircam")
+
+
+def test_get_pending_filters_narrows_nircam(store):
+    store.upsert_storage_objects([
+        _nircam_mosaic("f277w"), _nircam_mosaic("f356w"), _nircam_mosaic("f444w"),
+    ])
+    pending = store.get_pending_objects(
+        product_types=["nircam_mosaic"], fields=["egs"], filters=["f277w", "f444w"],
+    )
+    got = sorted(r["filter"] for rows in pending.values() for r in rows)
+    assert got == ["f277w", "f444w"]  # f356w excluded
+
+
+def test_get_pending_filters_case_insensitive(store):
+    store.upsert_storage_objects([_nircam_mosaic("f444w")])
+    pending = store.get_pending_objects(
+        product_types=["nircam_mosaic"], fields=["egs"], filters=["F444W"],
+    )
+    assert [r["filter"] for rows in pending.values() for r in rows] == ["f444w"]
+
+
+def test_get_pending_filters_keeps_null_filter_rows(store):
+    # A filter-less row (NIRSpec final) is never excluded by --filters, mirroring
+    # the grating rule for attribute-less rows.
+    store.upsert_storage_objects([
+        _so(FINAL_KEY, "nirspec_spec", CONTENT_SHA, "test_obs_prism_100"),
+        _nircam_mosaic("f444w"),
+    ])
+    pending = store.get_pending_objects(
+        product_types=["nirspec_spec", "nircam_mosaic"],
+        observations=["test_obs"], fields=["egs"], filters=["f150w"],
+    )
+    keys = {r["storage_key"] for rows in pending.values() for r in rows}
+    assert FINAL_KEY in keys          # NULL-filter NIRSpec row survives
+    assert all("f444w" not in k for k in keys)  # non-matching NIRCam filter dropped
+
+
+def test_download_objects_filters_scope(store, tmp_path):
+    store.upsert_storage_objects([_nircam_mosaic("f277w"), _nircam_mosaic("f444w")])
+    products = tmp_path / "products"
+    keys = [_nircam_mosaic(f)["storage_key"] for f in ("f277w", "f444w")]
+
+    stats = download_objects(
+        _FakeAPI(keys), [], ["nircam_mosaic"], store, products,
+        fields=["egs"], filters=["f444w"], download_session=_fake_session(),
+    )
+
+    assert stats["downloaded"] == 1
+    assert (products / "nircam" / "egs" / "f444w" /
+            "mosaic_nircam_f444w_egs_30mas_sci.fits").exists()
+    assert not (products / "nircam" / "egs" / "f277w").exists()
 
 
 def test_skips_already_local(store, tmp_path):

--- a/python/tests/test_nircam_deploy.py
+++ b/python/tests/test_nircam_deploy.py
@@ -115,18 +115,23 @@ def test_build_fits_upload_tasks_refuses_combine_stamped(tmp_path):
 
 
 def test_discover_expmap_tasks_canonical_keys(tmp_path):
-    expdir = tmp_path / "products" / "nircam" / "cosmos" / "expmaps"
-    expdir.mkdir(parents=True)
-    (expdir / "cosmos_f444w_expmap.fits").write_bytes(b"\x00")
-    dirs = {"products": tmp_path / "products" / "nircam" / "cosmos"}
-    tasks = nc.discover_expmap_tasks(dirs, "cosmos")
+    # Expmaps now live in the canonical per-filter dir (alongside mosaics), keyed
+    # off an ``expmap_`` filename prefix so they carry a real filter.
+    products = tmp_path / "products" / "nircam" / "cosmos"
+    (products / "f444w").mkdir(parents=True)
+    (products / "f444w" / "expmap_cosmos_f444w_canonical.fits").write_bytes(b"\x00")
+    # A non-expmap FITS in the same dir must not be picked up by the expmap glob.
+    (products / "f444w" / "jw01_00001_nrcalong.fits").write_bytes(b"\x00")
+    dirs = {"products": products}
+    tasks = nc.discover_expmap_tasks(dirs, "cosmos", ["f444w"])
     assert len(tasks) == 1
-    assert tasks[0].r2_key == "data/products/nircam/cosmos/expmaps/cosmos_f444w_expmap.fits"
+    assert tasks[0].r2_key == \
+        "data/products/nircam/cosmos/f444w/expmap_cosmos_f444w_canonical.fits"
 
 
 def test_discover_expmap_tasks_empty_when_absent(tmp_path):
     dirs = {"products": tmp_path / "nope"}
-    assert nc.discover_expmap_tasks(dirs, "cosmos") == []
+    assert nc.discover_expmap_tasks(dirs, "cosmos", ["f444w"]) == []
 
 
 # --- registry identity ------------------------------------------------------
@@ -147,6 +152,7 @@ def test_row_for_nircam_exposure_identity_and_sci_dq():
     assert row["product_type"] == "nircam_exposure"
     assert row["instrument"] == "nircam"
     assert row["field"] == "cosmos"
+    assert row["filter"] == "f444w"
     assert row["observation"] is None
     assert row["spectrum_id"] is None       # not a spectrum
     assert row["deployment_id"] == 42        # tagged with the field deployment
@@ -155,12 +161,15 @@ def test_row_for_nircam_exposure_identity_and_sci_dq():
 
 
 def test_row_sci_dq_hash_none_by_default():
-    # An expmap (and every non-exposure product) carries no science digest.
+    # An expmap (and every non-exposure product) carries no science digest, but
+    # does carry its per-filter scope column now that it lives in the filter dir.
     row = reg.row_for_key(
-        "data/products/nircam/cosmos/expmaps/cosmos_f444w_expmap.fits",
+        "data/products/nircam/cosmos/f444w/expmap_cosmos_f444w_canonical.fits",
         backend="osn", content_hash="sha256:" + "a" * 64, size_bytes=1,
         content_type="application/fits")
     assert row["product_type"] == "nircam_expmap"
+    assert row["field"] == "cosmos"
+    assert row["filter"] == "f444w"
     assert row["sci_dq_hash"] is None
 
 

--- a/supabase/migrations/20260704000000_storage_objects_filter_column.sql
+++ b/supabase/migrations/20260704000000_storage_objects_filter_column.sql
@@ -1,0 +1,111 @@
+-- storage_objects.filter — a typed, indexed scope column for per-filter NIRCam
+-- products, denormalized from the campfire_layout key's <field>/<filter>/ segment.
+--
+-- Motivation: `campfire download --field <f> --filters <...>` (and any per-filter
+-- registry aggregate/MV) needs to scope by filter without parsing storage keys at
+-- query time. This mirrors the existing observation/field/spectrum_id/exposure_ref
+-- scope columns. deploy/row_for_key populates it from parse_key(...).scope.filt;
+-- the sync RPC now ships it to the client mirror.
+--
+-- Additive + nullable: NULL for every existing row, for NIRSpec, and for field-
+-- level products (no filter concept). Existing NIRCam rows are repopulated by
+-- re-running `campfire deploy registry backfill` / a re-deploy (both route through
+-- row_for_key). No seed change required.
+--
+-- Companion layout change (same PR): NIRCam expmaps moved from
+-- products/nircam/<field>/expmaps/ into the canonical filter dir
+-- products/nircam/<field>/<filter>/expmap_*.fits, so they too carry a real filter.
+-- Their old-key rows are superseded on the next deploy.
+
+alter table "public"."storage_objects" add column "filter" text;
+
+comment on column "public"."storage_objects"."filter" is
+  'Typed, indexed scope column for per-filter NIRCam products (nircam_exposure/_preview/_full, nircam_mosaic, nircam_expmap), denormalized from the campfire_layout key''s <field>/<filter>/ segment by deploy/row_for_key. NULL for NIRSpec and field-level products (no filter concept). Mirrors observation/field/spectrum_id — lets the registry filter/aggregate by filter without parsing keys.';
+
+-- Partial: only per-filter NIRCam rows carry a filter (most rows are NIRSpec).
+create index if not exists idx_storage_objects_field_filter
+    on public.storage_objects using btree ("field", "filter")
+    where "filter" is not null;
+
+-- Ship the new column to the Python client's local storage_objects mirror.
+CREATE OR REPLACE FUNCTION public.get_storage_objects_for_sync(
+  p_program_slugs TEXT[],
+  p_updated_since TIMESTAMPTZ DEFAULT NULL,
+  p_limit INTEGER DEFAULT 1000,
+  p_offset INTEGER DEFAULT 0,
+  p_include_counts BOOLEAN DEFAULT TRUE,
+  p_include_unpublished BOOLEAN DEFAULT FALSE
+)
+RETURNS TABLE(objects JSONB, total_count BIGINT, total_accessible_count BIGINT)
+LANGUAGE plpgsql STABLE
+SET plan_cache_mode = 'force_custom_plan'
+SET statement_timeout = '120s'
+AS $$
+BEGIN
+  RETURN QUERY
+  WITH scoped AS (
+    SELECT so.*
+    FROM storage_objects so
+    WHERE so.status = 'active'
+      AND (
+        p_include_unpublished
+        OR (so.spectrum_id IS NOT NULL AND EXISTS (
+              SELECT 1 FROM spectra s
+              JOIN targets t ON t.target_id = s.target_id
+              WHERE s.spectrum_id = so.spectrum_id
+                AND s.deploy_status = 'published'
+                AND t.program_slug = ANY(p_program_slugs)))
+        OR (so.spectrum_id IS NULL AND so.deployment_id IS NOT NULL AND EXISTS (
+              SELECT 1 FROM deployments d
+              LEFT JOIN observations o ON o.name = d.observation
+              WHERE d.id = so.deployment_id
+                AND d.status = 'published'
+                -- NIRCam field deploy (epic #261, N1): multi-program, public to all
+                -- when published. NIRSpec obs deploy stays program-scoped.
+                AND (d.field IS NOT NULL OR o.program_slug = ANY(p_program_slugs))))
+      )
+  ),
+  matched AS MATERIALIZED (
+    SELECT * FROM scoped
+    WHERE (p_updated_since IS NULL OR scoped.updated_at > p_updated_since)
+    ORDER BY scoped.storage_key
+    LIMIT p_limit OFFSET p_offset
+  ),
+  total AS (
+    SELECT COUNT(*) AS cnt FROM scoped
+    WHERE p_include_counts
+      AND (p_updated_since IS NULL OR scoped.updated_at > p_updated_since)
+  ),
+  accessible AS (
+    SELECT COUNT(*) AS cnt FROM scoped
+    WHERE p_include_counts
+  )
+  SELECT
+    COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'id', m.id,
+        'backend', m.backend,
+        'bucket', m.bucket,
+        'storage_key', m.storage_key,
+        'content_hash', m.content_hash,
+        'size_bytes', m.size_bytes,
+        'content_type', m.content_type,
+        'product_type', m.product_type,
+        'instrument', m.instrument,
+        'status', m.status,
+        'observation', m.observation,
+        'field', m.field,
+        'filter', m.filter,
+        'spectrum_id', m.spectrum_id,
+        'exposure_ref', m.exposure_ref,
+        'deployment_id', m.deployment_id,
+        'cfpipe_version', m.cfpipe_version,
+        'created_at', m.created_at,
+        'updated_at', m.updated_at
+      )
+    ), '[]'::jsonb),
+    COALESCE((SELECT cnt FROM total), 0)::BIGINT,
+    COALESCE((SELECT cnt FROM accessible), 0)::BIGINT
+  FROM matched m;
+END;
+$$;

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -2593,6 +2593,7 @@ BEGIN
         'status', m.status,
         'observation', m.observation,
         'field', m.field,
+        'filter', m.filter,
         'spectrum_id', m.spectrum_id,
         'exposure_ref', m.exposure_ref,
         'deployment_id', m.deployment_id,

--- a/supabase/schemas/indexes.sql
+++ b/supabase/schemas/indexes.sql
@@ -438,6 +438,13 @@ CREATE INDEX IF NOT EXISTS idx_storage_objects_field
     ON public.storage_objects USING btree (field)
     WHERE field IS NOT NULL;
 
+-- NIRCam download/registry scoping by (field, filter) — the `campfire download
+-- --field <f> --filters <...>` plan and any per-filter aggregate. Partial: only
+-- per-filter NIRCam rows carry a filter (most rows are NIRSpec, filter NULL).
+CREATE INDEX IF NOT EXISTS idx_storage_objects_field_filter
+    ON public.storage_objects USING btree ("field", "filter")
+    WHERE "filter" IS NOT NULL;
+
 -- Substring key search in the admin registry browser (admin audit 2026-07-03,
 -- C2 / Phase 2): operators search by a fragment anywhere in the canonical key,
 -- so a left-anchored btree can't serve it — trigram GIN does. Opclass is

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -852,6 +852,7 @@ CREATE TABLE IF NOT EXISTS "public"."storage_objects" (
     "status" "text" NOT NULL DEFAULT 'active'::"text",
     "observation" "text",
     "field" "text",
+    "filter" "text",
     "spectrum_id" "text",
     "exposure_ref" "text",
     "deployment_id" integer,
@@ -908,7 +909,7 @@ COMMENT ON TABLE "public"."storage_objects" IS 'Shadow index of every object in 
 
 COMMENT ON COLUMN "public"."storage_objects"."content_hash" IS 'Scheme-prefixed integrity token. ''sha256:<hex>'' is authoritative (deploy hashes the local file; spectra backfill reuses spectra.file_hash). ''etag:<hex>'' is provisional from an S3 LIST/HEAD (no GET) for backfilled objects with no stored sha256; the A1 copy+verify pass (#215) upgrades it to sha256.';
 
-COMMENT ON COLUMN "public"."storage_objects"."spectrum_id" IS 'Typed, indexed scope column (not an FK). spectra.spectrum_id is GENERATED from fits_path and not uniquely constrained, so an FK would over-constrain; an index provides the joinability the registry needs.';
+COMMENT ON COLUMN "public"."storage_objects"."filter" IS 'Typed, indexed scope column for per-filter NIRCam products (nircam_exposure/_preview/_full, nircam_mosaic, nircam_expmap), denormalized from the campfire_layout key''s <field>/<filter>/ segment by deploy/row_for_key. NULL for NIRSpec and field-level products (no filter concept). Mirrors observation/field/spectrum_id — lets the registry filter/aggregate by filter without parsing keys.';
 
 COMMENT ON COLUMN "public"."storage_objects"."exposure_ref" IS 'Stable per-exposure reference for intermediate products (nircam rootname; nirspec (root,nod,detector,source) tuple). Backs the partial unique (product_type, exposure_ref) WHERE status=''active'' — one current object per product/exposure.';
 

--- a/web/lib/layout.ts
+++ b/web/lib/layout.ts
@@ -84,7 +84,7 @@ reg(spec({ name: 'nircam_exposure_preview', tree: 'products', bucket: 'data', sc
 reg(spec({ name: 'nircam_exposure_full', tree: 'products', bucket: 'data', scopeKeys: ['field', 'filt'], subdir: nircamFieldFilter, suffix: '_full.png', legacyPrefix: (s) => `nircam/exposures/${s.field}/${s.filt}` }));
 reg(spec({ name: 'nircam_mosaic', tree: 'products', bucket: 'data', scopeKeys: ['field', 'filt'], subdir: nircamFieldFilter, suffix: null }));
 reg(spec({ name: 'nircam_rgb', tree: 'products', bucket: 'data', scopeKeys: ['field'], subdir: (s) => `nircam/${s.field}`, suffix: '_rgb.png' }));
-reg(spec({ name: 'nircam_expmap', tree: 'products', bucket: 'data', scopeKeys: ['field'], subdir: (s) => `nircam/${s.field}/expmaps`, suffix: null }));
+reg(spec({ name: 'nircam_expmap', tree: 'products', bucket: 'data', scopeKeys: ['field', 'filt'], subdir: nircamFieldFilter, suffix: null }));
 
 // --- Map tiles (separate bucket, scheme-invariant) ---
 reg(spec({
@@ -226,13 +226,13 @@ export function parseRelpath(relpath: string): ParsedKey {
   if (tree === 'products' && seg.length >= 4 && seg[1] === 'nircam') {
     const field = seg[2];
     if (seg.length === 4 && seg[3].endsWith('_rgb.png')) return { productType: 'nircam_rgb', scope: { field }, filename: seg[3] };
-    if (seg.length === 5 && seg[3] === 'expmaps') return { productType: 'nircam_expmap', scope: { field }, filename: seg[4] };
     if (seg.length === 5) {
       const filt = seg[3];
       const fname = seg[4];
       const pt = dispatch(fname, NIRCAM_FILTER_SUFFIXES);
       if (pt) return { productType: pt, scope: { field, filt }, filename: fname };
       if (fname.startsWith('mosaic')) return { productType: 'nircam_mosaic', scope: { field, filt }, filename: fname };
+      if (fname.startsWith('expmap')) return { productType: 'nircam_expmap', scope: { field, filt }, filename: fname };
       if (fname.endsWith('.fits')) return { productType: 'nircam_exposure', scope: { field, filt }, filename: fname };
     }
   }


### PR DESCRIPTION
## Summary

Adds a typed `filter` scope column to `storage_objects` to enable `campfire download --filters` scoping for NIRCam field products without parsing storage keys at query time. Moves NIRCam expmaps from a shared `expmaps/` directory into the canonical per-filter directory structure, so they carry a real filter in the registry like all other per-filter NIRCam products.

## Key Changes

**Database & Registry:**
- Add `storage_objects.filter` column (nullable, indexed with `field` for per-filter NIRCam rows)
- Update `get_storage_objects_for_sync()` RPC to ship the new column to the Python client mirror
- Increment schema version to 7

**NIRCam Expmap Relocation:**
- Move expmaps from `products/nircam/<field>/expmaps/` to `products/nircam/<field>/<filter>/expmap_*.fits`
- Update `discover_expmap_tasks()` to scan per-filter directories and pass filter list
- Update `_expmap_paths()` to generate paths in the canonical filter subdirectory
- Update `run_expmap()` documentation and default output directory handling
- Update layout spec: `nircam_expmap` now scoped by `(field, filt)` instead of `field` only

**Download CLI & Engine:**
- Add `--filters` option to `campfire download` command for NIRCam filter selection
- Update `get_pending_objects()` to filter by `filter` column (case-insensitive, NULL-safe)
- Update `download_objects()` to accept and pass through `filters` parameter
- Add informational note when `--filters` is used without NIRCam field selection

**Layout & Key Parsing:**
- Update `parse_relpath()` to recognize per-filter expmap keys (removed legacy `expmaps/` path parsing)
- Update `row_for_key()` to populate the `filter` scope column from parsed key
- Update `_discover_filters()` to skip legacy `expmaps/` directory when scanning for real filters

**Tests & Documentation:**
- Add test cases for filter narrowing in `get_pending_objects()`
- Add test for case-insensitive filter matching
- Add test verifying NULL-filter rows (NIRSpec) are never excluded by `--filters`
- Add integration test for `download_objects()` with filter scoping
- Update expmap test to verify new per-filter directory structure and canonical key format
- Update CHANGELOG with Infrastructure categorization (file location change, no scientific output change)

## Implementation Details

- The `filter` column is **additive and nullable**: existing rows remain NULL, NIRSpec rows stay NULL, field-level products stay NULL. Only per-filter NIRCam products (exposure, mosaic, expmap, preview) carry a real filter value.
- Filter matching in `get_pending_objects()` is **case-insensitive** (normalized to lowercase) and **NULL-safe**: rows with `filter IS NULL` are never excluded by filter constraints, mirroring the existing grating behavior for attribute-less rows.
- The partial index `idx_storage_objects_field_filter` only indexes rows where `filter IS NOT NULL`, keeping the index lean since most rows are NIRSpec.
- Expmaps now sit in the same `<field>/<filter>/` key shape as every other per-filter NIRCam product, enabling consistent registry scoping and download planning.

https://claude.ai/code/session_01MDTDYX4JsaN7yeVSjnJ78F