### PR TITLE
NIRSpec review loop P1 — deploy rate files to OSN

### DIFF
--- a/python/campfire/deploy/deploy.py
+++ b/python/campfire/deploy/deploy.py
@@ -21,6 +21,7 @@ from campfire.deploy.discover import (
     discover_pointings_ecsv,
     discover_rgb_images,
     discover_sed_plots,
+    discover_rate_files,
     discover_shutters_ecsv,
     discover_spectrum_exposures,
     discover_slits_json,
@@ -234,6 +235,11 @@ def _deploy_intermediates_only(
         exposure_files = _filter_exposures_by_source_ids(exposure_files, source_ids)
         print(f"Filtered {total} spectrum-exposures to {len(exposure_files)} "
               f"matching {len(source_ids)} source IDs")
+    # Detector rate files (P1, design §3.1) — source-INDEPENDENT, never source-filtered.
+    # The rate deploy runs after stage 1 / before stage 2, precisely when no
+    # spectrum-exposures exist yet, so this path must handle rate-only deploys (see
+    # the guard below).
+    rate_files = discover_rate_files(obs_dir)
     obs_cfg = load_observations().get(obs_name, {})
     field = obs_cfg.get('field', '')
     program_slug = obs_cfg.get('program', '')
@@ -257,15 +263,17 @@ def _deploy_intermediates_only(
     print(f"  Field: {field}")
     print(f"  Program: {program_slug}")
     print(f"  Canonical spectrum-exposures: {len(exposure_files)}")
+    print(f"  Detector rate files: {len(rate_files)}")
 
-    if not exposure_files:
-        print("No canonical spectrum-exposures and no finals — nothing to deploy.")
+    if not exposure_files and not rate_files:
+        print("No canonical spectrum-exposures, rate files, or finals — nothing to deploy.")
         return {'field': field, 'needs_reconcile': False}
 
     if dry_run:
         print("\n=== DRY RUN (intermediates-only → auto-draft) ===")
         print(f"Would upload {len(exposure_files)} canonical spectrum-exposures "
-              f"and record a draft deployment for {obs_name}.")
+              f"and {len(rate_files)} detector rate files, and record a draft "
+              f"deployment for {obs_name}.")
         return {'field': field, 'needs_reconcile': False}
 
     sb = get_supabase_client(config)
@@ -301,9 +309,14 @@ def _deploy_intermediates_only(
         UploadTask(p, storage_key('nirspec_spectrum_exposure', scope, p.name,
                                   scheme=KeyScheme.CANONICAL), 'application/fits')
         for p in exposure_files
+    ] + [
+        UploadTask(p, storage_key('nirspec_rate', scope, p.name,
+                                  scheme=KeyScheme.CANONICAL), 'application/fits')
+        for p in rate_files
     ]
     uploaded_keys: set[str] = set()
-    print(f"Uploading {len(upload_tasks)} canonical spectrum-exposures to OSN...")
+    print(f"Uploading {len(upload_tasks)} intermediates "
+          f"({len(exposure_files)} spectrum-exposures + {len(rate_files)} rate files) to OSN...")
     success, failed, failed_msgs = upload_files_parallel(
         config, upload_tasks, desc="OSN uploads", succeeded_out=uploaded_keys,
         backend='osn')
@@ -311,7 +324,10 @@ def _deploy_intermediates_only(
 
     # Best-effort provenance from the first exposure header (Phase 3): the
     # intermediates carry whatever cards the reduction stamped. Absent → NULL.
-    cfpipe_version, jwst_version, crds_context = _read_exposure_provenance(exposure_files)
+    # For a rate-only deploy (stage 1 done, stage 2 not yet) there are no
+    # spectrum-exposures, so fall back to a rate header for provenance.
+    cfpipe_version, jwst_version, crds_context = _read_exposure_provenance(
+        exposure_files or rate_files)
 
     deployment_id = insert_deployment(
         sb, observation=obs_name, deployed_by=user_id, status='draft',
@@ -326,7 +342,7 @@ def _deploy_intermediates_only(
             observation=obs_name, affected_count=success,
             metadata=deploy_event_metadata(
                 'nirspec', observation=obs_name, planned=len(upload_tasks),
-                succeeded=success, failed=failed, items=len(exposure_files),
+                succeeded=success, failed=failed, items=len(upload_tasks),
                 draft=True, intermediates_only=True))
 
     if uploaded_keys:
@@ -347,7 +363,8 @@ def _deploy_intermediates_only(
               f"this observation while this one was running.")
 
     print(f"\nDeployed {len(exposure_files)} canonical spectrum-exposures "
-          f"(draft — no finals yet). Finish stage3 + re-deploy to publish.")
+          f"+ {len(rate_files)} detector rate files (draft — no finals yet). "
+          f"Finish stage3 + re-deploy to publish.")
     return {'field': field, 'needs_reconcile': False}
 
 
@@ -662,6 +679,20 @@ def deploy_observation(
                     'application/fits'))
             if exposure_files:
                 print(f"  + {len(exposure_files)} canonical spectrum-exposure intermediates")
+
+            # Detector rate-file intermediates (P1, design §3.1). SOURCE-INDEPENDENT:
+            # uploaded on every deploy regardless of --source-ids (rate-level masks are
+            # per-detector, not per-source), so we deliberately do NOT run these
+            # through _filter_exposures_by_source_ids. Registered
+            # product_type='nirspec_rate' with a per-(exposure,detector) exposure_ref;
+            # uploaded uncompressed (the web SCI decoder rejects fpack ZIMAGE).
+            rate_files = discover_rate_files(obs_dir)
+            for rate_path in rate_files:
+                upload_tasks.append(UploadTask(
+                    rate_path, storage_key('nirspec_rate', scope, rate_path.name, scheme=KeyScheme.CANONICAL),
+                    'application/fits'))
+            if rate_files:
+                print(f"  + {len(rate_files)} detector rate files")
 
             total_tasks = len(upload_tasks) + len(legacy_tasks)
             print(f"Uploading {total_tasks} files ({len(upload_tasks)} NIRSpec → OSN)...")

--- a/python/campfire/deploy/discover.py
+++ b/python/campfire/deploy/discover.py
@@ -28,11 +28,31 @@ def discover_spectrum_exposures(obs_dir: Path) -> list[Path]:
     directory as the final ``*_spec.fits`` products; the ``_nrs[12]_`` segment is
     what distinguishes a per-exposure intermediate from a final (whose name is
     grating/filter-based and ends ``_spec.fits``). Excludes finals defensively.
+
+    Also excludes the stage-1 detector rate files (``{root}_{nrsN}_rate.fits``,
+    see discover_rate_files): they too match ``*_nrs[12]_*.fits`` but are a
+    separate product (``nirspec_rate``), so without this guard a rate file would be
+    double-discovered here and mis-registered as a spectrum-exposure.
     """
     return sorted(
         p for p in obs_dir.glob('*_nrs[12]_*.fits')
         if not p.name.endswith('_spec.fits')
+        and not p.name.endswith('_rate.fits')
     )
+
+
+def discover_rate_files(obs_dir: Path) -> list[Path]:
+    """Find the NIRSpec stage-1 detector rate files (P1, design §3.1).
+
+    Named ``{root}_{nrsN}_rate.fits`` — e.g.
+    ``jw07076020001_04101_00001_nrs1_rate.fits`` — one per (exposure, detector),
+    living in the same products directory as the spectrum-exposures and finals.
+    These are SOURCE-INDEPENDENT detector products (rate-level masks are
+    per-detector, not per-source), so unlike discover_spectrum_exposures the caller
+    must NOT filter them by source id. Deployed uncompressed (the web SCI decoder
+    rejects fpack ZIMAGE); we upload the pipeline's plain rate FITS as-is.
+    """
+    return sorted(obs_dir.glob('*_nrs[12]_rate.fits'))
 
 
 def discover_slits_json(obs_dir: Path, obs_name: str) -> Path | None:

--- a/python/campfire/deploy/registry.py
+++ b/python/campfire/deploy/registry.py
@@ -121,14 +121,15 @@ def _exposure_ref_for(product_type: str, filename: str) -> str | None:
     """Stable per-exposure reference for exposure-level intermediates (epic #210/#261).
 
     For ``nirspec_spectrum_exposure`` the canonical filename
-    (``{root}_{nod}_nrs[12]_{source}.fits``) IS the natural unique exposure key, and
-    for ``nircam_exposure`` the JWST rootname (``jw..._nrc{a,b}{1-4,long}.fits``) is,
-    so the ref is the filename stem (drop ``.fits``). Backs the partial-unique
-    ``(product_type, exposure_ref) WHERE status='active'`` registry contract
-    (one current object per product/exposure). None for non-exposure products
+    (``{root}_{nod}_nrs[12]_{source}.fits``) IS the natural unique exposure key, for
+    ``nircam_exposure`` the JWST rootname (``jw..._nrc{a,b}{1-4,long}.fits``) is, and
+    for ``nirspec_rate`` the rate rootname stem (``jw..._nrsN_rate``, one per
+    exposure×detector) is, so the ref is the filename stem (drop ``.fits``). Backs
+    the partial-unique ``(product_type, exposure_ref) WHERE status='active'`` registry
+    contract (one current object per product/exposure). None for non-exposure products
     (their exposure_ref stays NULL; NULLs are distinct, so finals never collide).
     """
-    if product_type in ('nirspec_spectrum_exposure', 'nircam_exposure') and filename.endswith('.fits'):
+    if product_type in ('nirspec_spectrum_exposure', 'nircam_exposure', 'nirspec_rate') and filename.endswith('.fits'):
         return filename[: -len('.fits')]
     return None
 
@@ -851,6 +852,7 @@ DEFAULT_COPY_PRODUCT_TYPES = (
     'zfit',
     'photometry_pz',
     'nirspec_spectrum_exposure',
+    'nirspec_rate',
 )
 
 

--- a/python/tests/test_deploy_osn_routing.py
+++ b/python/tests/test_deploy_osn_routing.py
@@ -126,6 +126,22 @@ def test_canonical_exposure_row_carries_osn_key_and_exposure_ref():
     assert row["exposure_ref"] == "jw07076020001_04101_00001_nrs1_117757"
 
 
+def test_canonical_rate_row_carries_osn_key_and_exposure_ref():
+    # P1: rate files register like spectrum-exposures — canonical OSN key under the
+    # obs products dir, with a per-(exposure,detector) exposure_ref (rate stem) so
+    # a re-deploy UPDATEs in place on the partial-unique (product_type, exposure_ref).
+    fname = "jw07076020001_04101_00001_nrs1_rate.fits"
+    canon = storage_key("nirspec_rate", Scope(obs="ember_egs_p1"),
+                        fname, scheme=KeyScheme.CANONICAL)
+    row = row_for_key(canon, backend="osn", content_hash=SHA, size_bytes=1,
+                      content_type="application/fits")
+    assert row["backend"] == "osn"
+    assert row["storage_key"].startswith("data/products/nirspec/")
+    assert row["product_type"] == "nirspec_rate"
+    assert row["observation"] == "ember_egs_p1"
+    assert row["exposure_ref"] == "jw07076020001_04101_00001_nrs1_rate"
+
+
 def test_canonical_photometry_pz_registers_as_osn_field_scoped():
     # photometry_pz is a migrated (DEFAULT_COPY_PRODUCT_TYPES) data-bucket product;
     # deploy_field_photometry must write it canonical+osn like the NIRSpec paths,

--- a/python/tests/test_intermediate_upload.py
+++ b/python/tests/test_intermediate_upload.py
@@ -5,7 +5,7 @@ exposure_ref derivation, and the no-summary JWST-PID fallback. The end-to-end
 upload + registration + auto-draft is exercised live against local Supabase in CI
 (`campfire deploy --obs … --local`).
 """
-from campfire.deploy.discover import discover_spectrum_exposures
+from campfire.deploy.discover import discover_rate_files, discover_spectrum_exposures
 from campfire.deploy.deploy import _filter_exposures_by_source_ids, _jwst_pid_from_obs_cfg
 from campfire.deploy.registry import _exposure_ref_for
 
@@ -25,6 +25,10 @@ def test_discover_spectrum_exposures_excludes_finals(tmp_path):
     _touch(tmp_path, "ember_egs_p1_prism_clear_117757_spec.fits")
     _touch(tmp_path, "ember_egs_p1_summary.ecsv")
     _touch(tmp_path, "117757_rgb.png")
+    # rate files (P1): match *_nrs[12]_*.fits but are a SEPARATE product; must NOT
+    # be picked up here or they'd be double-discovered + mis-registered as exposures.
+    _touch(tmp_path, "jw07076020001_04101_00001_nrs1_rate.fits")
+    _touch(tmp_path, "jw07076020001_04101_00001_nrs2_rate.fits")
 
     found = discover_spectrum_exposures(tmp_path)
     names = sorted(p.name for p in found)
@@ -34,6 +38,37 @@ def test_discover_spectrum_exposures_excludes_finals(tmp_path):
         "jw07076020001_04101_00002_nrs1_120383.fits",
     ]
     assert all("_spec.fits" not in n for n in names)
+    assert all("_rate.fits" not in n for n in names)
+
+
+def test_discover_rate_files(tmp_path):
+    # one rate file per (exposure, detector)
+    _touch(tmp_path, "jw07076020001_04101_00001_nrs1_rate.fits")
+    _touch(tmp_path, "jw07076020001_04101_00001_nrs2_rate.fits")
+    _touch(tmp_path, "jw07076020001_04101_00002_nrs1_rate.fits")
+    # neighbours that must NOT be picked up: spectrum-exposures, finals, non-fits
+    _touch(tmp_path, "jw07076020001_04101_00001_nrs1_117757.fits")
+    _touch(tmp_path, "ember_egs_p1_prism_clear_117757_spec.fits")
+    _touch(tmp_path, "jw07076020001_04101_00001_nrs1_rate.reg")
+
+    found = discover_rate_files(tmp_path)
+    names = sorted(p.name for p in found)
+    assert names == [
+        "jw07076020001_04101_00001_nrs1_rate.fits",
+        "jw07076020001_04101_00001_nrs2_rate.fits",
+        "jw07076020001_04101_00002_nrs1_rate.fits",
+    ]
+    assert all(n.endswith("_rate.fits") for n in names)
+
+
+def test_discover_rate_files_is_source_independent(tmp_path):
+    # discover_rate_files takes no source-id parameter and applies no per-source
+    # filter — rate masks are per-detector, so both detectors survive regardless of
+    # which sources are being deployed. (The deploy call sites deliberately never
+    # wrap this in _filter_exposures_by_source_ids.)
+    _touch(tmp_path, "jw07076020001_04101_00001_nrs1_rate.fits")
+    _touch(tmp_path, "jw07076020001_04101_00001_nrs2_rate.fits")
+    assert len(discover_rate_files(tmp_path)) == 2
 
 
 def test_filter_exposures_by_source_ids(tmp_path):
@@ -53,6 +88,11 @@ def test_exposure_ref_is_stem_for_intermediates_else_none():
     assert _exposure_ref_for(
         "nirspec_spectrum_exposure", "jw07076020001_04101_00001_nrs1_117757.fits"
     ) == "jw07076020001_04101_00001_nrs1_117757"
+    # rate files (P1): one current object per (exposure, detector), keyed by the
+    # rate rootname stem.
+    assert _exposure_ref_for(
+        "nirspec_rate", "jw07076020001_04101_00001_nrs1_rate.fits"
+    ) == "jw07076020001_04101_00001_nrs1_rate"
     # finals / other products carry no exposure_ref (NULL; never collide on the
     # partial-unique (product_type, exposure_ref) registry index)
     assert _exposure_ref_for("nirspec_spec", "x_spec.fits") is None

--- a/supabase/migrations/20260704170000_add_nirspec_rate_product_type.sql
+++ b/supabase/migrations/20260704170000_add_nirspec_rate_product_type.sql
@@ -1,0 +1,19 @@
+-- Add 'nirspec_rate' to the storage_objects.product_type CHECK (P1, NIRSpec review
+-- loop, design §3.1/§5). The stage-1 detector rate file ('<root>_<nrsN>_rate.fits')
+-- is now a registered cloud-backed layout product deployed to OSN, so the registry
+-- must accept its product_type. Purely additive enum widening: no existing row is
+-- invalidated, no column/table changes, so seed.sql needs no regen.
+--
+-- Mirrors the drop + re-add (NOT VALID) + validate shape used when the constraint
+-- was first authored (20260628221623_add_storage_objects_registry.sql). Keep the
+-- ARRAY membership textually identical to supabase/schemas/tables.sql (the source
+-- of truth) or the preview-branch db diff check goes red.
+
+alter table "public"."storage_objects"
+    drop constraint "storage_objects_product_type_check";
+
+alter table "public"."storage_objects"
+    add constraint "storage_objects_product_type_check" CHECK ((product_type = ANY (ARRAY['nirspec_spec'::text, 'spectrum_json'::text, 'zfit'::text, 'nirspec_spectrum_exposure'::text, 'nirspec_rate'::text, 'rgb'::text, 'sed'::text, 'nircam_exposure'::text, 'nircam_exposure_preview'::text, 'nircam_exposure_full'::text, 'nircam_mosaic'::text, 'nircam_rgb'::text, 'nircam_expmap'::text, 'tile'::text, 'photometry_pz'::text, 'nirspec_manual_mask'::text, 'nirspec_stuck_shutters'::text, 'nirspec_bkg_override'::text, 'nircam_mask'::text, 'nircam_astrom_cat'::text, 'nircam_bad_pixel'::text, 'nircam_flat'::text, 'nircam_wisp'::text]))) not valid;
+
+alter table "public"."storage_objects"
+    validate constraint "storage_objects_product_type_check";

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -876,7 +876,8 @@ CREATE TABLE IF NOT EXISTS "public"."storage_objects" (
     -- non-null bucket). A new cloud-backed product type requires a migration here.
     CONSTRAINT "storage_objects_product_type_check" CHECK (("product_type" = ANY (ARRAY[
         'nirspec_spec'::"text", 'spectrum_json'::"text", 'zfit'::"text",
-        'nirspec_spectrum_exposure'::"text", 'rgb'::"text", 'sed'::"text",
+        'nirspec_spectrum_exposure'::"text", 'nirspec_rate'::"text",
+        'rgb'::"text", 'sed'::"text",
         'nircam_exposure'::"text", 'nircam_exposure_preview'::"text",
         'nircam_exposure_full'::"text", 'nircam_mosaic'::"text", 'nircam_rgb'::"text",
         'nircam_expmap'::"text", 'tile'::"text", 'photometry_pz'::"text",


### PR DESCRIPTION
**P1** of the NIRSpec web review loop (`docs/design-nirspec-review-loop.md` §3.1/§9-P1), building on the merged P0 layout contract. Deploys the stage-1 detector rate files (`<root>_<nrsN>_rate.fits`) to OSN as registered intermediate products, so later phases can render + mask them on the web.

## What changed

- **`discover.py`** — new `discover_rate_files` (source-**independent** — rate-level masks are per-detector, so it takes no source-id and is never filtered). Also **excludes `_rate.fits` from `discover_spectrum_exposures`**: a rate file matches its `*_nrs[12]_*.fits` glob, so without this it would be double-discovered and mis-registered as a spectrum-exposure (and since P0 now reverse-parses `_rate.fits` → `nirspec_rate`, the forward/reverse identities would diverge).
- **`deploy.py`** — rate upload block wired into **both** NIRSpec entry points (`deploy_observation` + `_deploy_intermediates_only`), reusing the existing `upload_files_parallel(osn)` + `build_registry_rows` + `upsert_storage_objects` plumbing (no new upload/presign code). Uploaded **uncompressed** (the web SCI decoder rejects fpack `ZIMAGE`) and never source-filtered.
- **`registry.py`** — `_exposure_ref_for` returns the rate rootname stem for `nirspec_rate` (backs the partial-unique `(product_type, exposure_ref) WHERE status='active'`); `nirspec_rate` added to `DEFAULT_COPY_PRODUCT_TYPES`.
- **`supabase`** — `'nirspec_rate'` added to the `storage_objects.product_type` CHECK, in the declarative schema (`tables.sql`, source of truth) **and** a matching hand-authored additive migration (drop / re-add `NOT VALID` / validate; member set verified identical to the schema). Purely additive enum widening — no `seed.sql` regen needed (no new column/table, no row invalidated).
- **tests** — `discover_rate_files`, its source-independence, the `_rate.fits` exclusion **regression guard**, the rate `exposure_ref`, and a canonical-OSN rate registry-row test.

## Notable design-vs-code fixes found during implementation

1. **Double-discovery bug (mandatory fix).** `discover_spectrum_exposures` globs `*_nrs[12]_*.fits` excluding only `_spec.fits`; a `_rate.fits` file slipped through both. Fixed + pinned by a regression test.
2. **Rate-only deploy path.** Rate files are pushed after stage 1 / before stage 2 — exactly when no spectrum-exposures exist yet. The intermediates-only entry point returned "nothing to deploy" on empty `exposure_files`, which would have silently no-op'd the feature's primary case. The guard now deploys when either exposures **or** rate files exist, and provenance falls back to a rate header.

## Testing

- New + existing deploy tests: `python/tests/` — 117 passed, 4 skipped, no regressions; the 14 discovery/registry/OSN-routing cases (incl. the 5 new P1 tests) pass.
- Schema ↔ migration CHECK arrays verified to carry an identical 23-member set.
- The Supabase preview branch on this PR applies the migration end-to-end (the real validator, since `db diff` can't run locally without Docker).

## Scope / safety

No `pipeline/**` changes → no pipeline CHANGELOG entry. No `web/**`. Merges inert: the upload block only fires when local `_rate.fits` exist, and nothing public/user-facing is touched.

Generated with Claude Code

https://claude.ai/code/session_01SQiCGrfdaQu5cF9dbVCJNd

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQiCGrfdaQu5cF9dbVCJNd)_