### PR TITLE
NIRSpec review loop P2 — nirspec_rate_exposures triage table + deploy upsert

### DIFF
--- a/python/campfire/deploy/deploy.py
+++ b/python/campfire/deploy/deploy.py
@@ -357,6 +357,16 @@ def _deploy_intermediates_only(
         n_reg = upsert_storage_objects(sb, reg_rows)
         print(f"Registered {n_reg} storage objects")
 
+    # Rate-mask triage rows (P2, design §3.2): one per (obs, exposure, detector),
+    # split-ownership upsert so re-deploy never clobbers web review state.
+    if rate_files:
+        from campfire.deploy.rate_exposures import (
+            build_rate_exposure_records, upsert_rate_exposures,
+        )
+        n_rate = upsert_rate_exposures(
+            sb, build_rate_exposure_records(rate_files, observation=obs_name, scope=scope))
+        print(f"Upserted {n_rate} rate-exposure triage rows")
+
     claim = claim_deploy_scope(sb, 'observation', obs_name, scope_version_at_start, actor=user_id)
     if claim.get('conflict'):
         print(f"⚠  CONCURRENT DEPLOY DETECTED for {obs_name}: another deploy advanced "
@@ -639,6 +649,7 @@ def deploy_observation(
     try:
         upload_tasks: list[UploadTask] = []
         uploaded_keys: set[str] = set()  # r2_keys that actually landed (for the registry)
+        rate_files: list = []  # populated in the not-supabase_only block; drives P2 triage upsert
         scope = Scope(obs=obs_name)
 
         # NIRSpec science products are homed on OSN under CANONICAL keys (epic #210 /
@@ -927,6 +938,16 @@ def deploy_observation(
             )
             n_reg = upsert_storage_objects(sb, reg_rows)
             print(f"Registered {n_reg} storage objects")
+
+        # Rate-mask triage rows (P2, design §3.2): split-ownership upsert so a
+        # re-deploy refreshes render columns without clobbering web review state.
+        if rate_files:
+            from campfire.deploy.rate_exposures import (
+                build_rate_exposure_records, upsert_rate_exposures,
+            )
+            n_rate = upsert_rate_exposures(
+                sb, build_rate_exposure_records(rate_files, observation=obs_name, scope=scope))
+            print(f"Upserted {n_rate} rate-exposure triage rows")
 
         print()
         msg = f"Deployed {len(spectra)} spectra from {len(objects)} objects"

--- a/python/campfire/deploy/rate_exposures.py
+++ b/python/campfire/deploy/rate_exposures.py
@@ -1,0 +1,151 @@
+"""NIRSpec rate-exposure triage upsert (P2, design §3.2).
+
+Populates the ``nirspec_rate_exposures`` table — the detector-grain analogue of
+``nircam_exposures`` — from the rate files ``discover_rate_files`` finds. Split
+ownership mirrors ``nircam._upsert_exposures``: a re-deploy UPDATE writes ONLY the
+identity/render columns and OMITS ``review_status``/``masking``/``mask_regions``/
+``notes`` so it never clobbers web triage; new rows seed ``review_status='pending'``,
+``masking='none'``. Unlike NIRCam, deploy has no ``.reg`` knowledge here (the
+mask-pull is P3b), so ``masking`` is entirely web-owned and never set to ``'done'``
+by deploy.
+
+Pure helpers (``parse_rate_filename``, ``partition_rate_records``) are unit-tested
+without a DB; the full insert/upsert round-trip is exercised live against local
+Supabase in CI (``campfire deploy … --local``).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from campfire_layout import KeyScheme, Scope, storage_key
+
+_RATE_SUFFIX = "_rate.fits"
+
+
+def parse_rate_filename(name: str) -> tuple[str, str]:
+    """``jw07076020001_04101_00001_nrs1_rate.fits`` → (exposure_root, detector).
+
+    ``exposure_root`` is the rate rootname stem WITHOUT the detector token
+    (``jw07076020001_04101_00001``); ``detector`` is ``nrs1``|``nrs2``. Note this
+    differs from the registry ``exposure_ref`` (P1), which keeps the full stem
+    including detector + ``_rate``. Unambiguous because the detector token is
+    always exactly ``nrs1``/``nrs2``.
+    """
+    if not name.endswith(_RATE_SUFFIX):
+        raise ValueError(f"not a rate filename: {name!r}")
+    stem = name[: -len(_RATE_SUFFIX)]           # jw..._nrs1
+    root, detector = stem.rsplit("_", 1)
+    if detector not in ("nrs1", "nrs2"):
+        raise ValueError(f"unexpected detector token {detector!r} in {name!r}")
+    return root, detector
+
+
+def read_rate_metadata(path: Path) -> tuple[str | None, int | None, int | None]:
+    """Best-effort ``(grating, image_width, image_height)`` from a rate FITS.
+
+    ``GRATING`` from the primary header (mirrors the pipeline, stage1.py); dims
+    from the SCI extension's NAXIS1/NAXIS2. Any failure (missing card/extension,
+    unreadable file) degrades to all-None, exactly like ``_read_exposure_provenance``.
+    """
+    try:
+        from astropy.io import fits
+        with fits.open(path, memmap=False) as hdul:
+            grating = hdul[0].header.get("GRATING")
+            sci_hdr = hdul["SCI"].header
+            return grating, sci_hdr.get("NAXIS1"), sci_hdr.get("NAXIS2")
+    except Exception:
+        return None, None, None
+
+
+def build_rate_exposure_records(
+    rate_files: list[Path], *, observation: str, scope: Scope,
+) -> list[dict]:
+    """One triage record per rate file (pre-partition; identity + render columns)."""
+    records = []
+    for path in rate_files:
+        root, detector = parse_rate_filename(path.name)
+        grating, width, height = read_rate_metadata(path)
+        records.append({
+            "observation": observation,
+            "exposure_root": root,
+            "detector": detector,
+            "filename": path.name,
+            "grating": grating,
+            "image_width": width,
+            "image_height": height,
+            "storage_key": storage_key(
+                "nirspec_rate", scope, path.name, scheme=KeyScheme.CANONICAL),
+            "stage": "rate",
+        })
+    return records
+
+
+# Columns deploy owns on a re-register (everything else is web-owned triage).
+_IDENTITY_COLS = ("observation", "exposure_root", "detector", "filename", "stage")
+_RENDER_COLS = ("grating", "image_width", "image_height", "storage_key")
+
+
+def partition_rate_records(
+    records: list[dict], existing_keys: set[tuple[str, str, str]], now: str,
+) -> tuple[list[dict], list[dict]]:
+    """Split into (new_rows, update_rows) with split ownership.
+
+    New rows seed ``review_status='pending'``/``masking='none'``. Update rows carry
+    ONLY identity + non-null render columns (+ ``updated_at``) — never the
+    web-owned triage columns — so a re-deploy leaves reviewer decisions intact.
+    """
+    new_records, update_records = [], []
+    for r in records:
+        key = (r["observation"], r["exposure_root"], r["detector"])
+        if key in existing_keys:
+            update = {c: r[c] for c in _IDENTITY_COLS}
+            update["updated_at"] = now
+            for c in _RENDER_COLS:
+                if r.get(c) is not None:
+                    update[c] = r[c]
+            update_records.append(update)
+        else:
+            new_records.append({
+                **r,
+                "review_status": "pending",
+                "masking": "none",
+                "created_at": now,
+                "updated_at": now,
+            })
+    return new_records, update_records
+
+
+def upsert_rate_exposures(client, records: list[dict], batch_size: int = 500) -> int:
+    """Upsert triage rows, preserving web triage on existing rows. Returns the row count.
+
+    Mirrors ``nircam._upsert_exposures``: batched SELECT to find existing conflict
+    tuples, then a plain ``.insert()`` for new rows and an ``.upsert(on_conflict=…)``
+    for existing rows with the identity/render-only update dict.
+    """
+    if not records:
+        return 0
+
+    filenames = [r["filename"] for r in records]
+    existing: set[tuple[str, str, str]] = set()
+    for i in range(0, len(filenames), batch_size):
+        batch = filenames[i:i + batch_size]
+        resp = (client.table("nirspec_rate_exposures")
+                .select("observation, exposure_root, detector, filename")
+                .in_("filename", batch)
+                .execute())
+        for row in resp.data:
+            existing.add((row["observation"], row["exposure_root"], row["detector"]))
+
+    now = datetime.now(timezone.utc).isoformat()
+    new_records, update_records = partition_rate_records(records, existing, now)
+
+    for i in range(0, len(new_records), batch_size):
+        client.table("nirspec_rate_exposures").insert(new_records[i:i + batch_size]).execute()
+    for i in range(0, len(update_records), batch_size):
+        client.table("nirspec_rate_exposures").upsert(
+            update_records[i:i + batch_size],
+            on_conflict="observation,exposure_root,detector",
+        ).execute()
+
+    return len(records)

--- a/python/tests/test_rate_exposures.py
+++ b/python/tests/test_rate_exposures.py
@@ -1,0 +1,112 @@
+"""Unit tests for the P2 rate-exposure triage upsert (design §3.2).
+
+Pure functions, no DB/cloud: the rate-filename → (exposure_root, detector) parse,
+the record builder's key columns, and the split-ownership partition (which columns
+a re-deploy UPDATE is allowed to touch). The full insert/upsert round-trip against
+Postgres is exercised live by `campfire deploy … --local` in CI.
+"""
+import pytest
+
+from campfire_layout import Scope
+from campfire.deploy.rate_exposures import (
+    build_rate_exposure_records,
+    parse_rate_filename,
+    partition_rate_records,
+)
+
+
+def test_parse_rate_filename():
+    assert parse_rate_filename("jw07076020001_04101_00001_nrs1_rate.fits") == (
+        "jw07076020001_04101_00001", "nrs1")
+    assert parse_rate_filename("jw07076020001_04101_00002_nrs2_rate.fits") == (
+        "jw07076020001_04101_00002", "nrs2")
+
+
+def test_parse_rate_filename_rejects_non_rate_and_bad_detector():
+    with pytest.raises(ValueError):
+        parse_rate_filename("jw07076020001_04101_00001_nrs1_117757.fits")  # spectrum-exposure
+    with pytest.raises(ValueError):
+        parse_rate_filename("jw07076020001_04101_00001_nrca_rate.fits")    # not nrs1/nrs2
+
+
+def test_exposure_root_excludes_detector_unlike_registry_ref():
+    # P1's registry exposure_ref keeps the full stem (…_nrs1_rate); this table's
+    # exposure_root drops both the detector and the _rate suffix.
+    root, det = parse_rate_filename("jw07076020001_04101_00001_nrs1_rate.fits")
+    assert root == "jw07076020001_04101_00001"
+    assert det == "nrs1"
+    assert "nrs1" not in root and "rate" not in root
+
+
+def test_build_rate_exposure_records_shape(tmp_path):
+    # touch a real file so the (best-effort) header read runs and degrades to None
+    p = tmp_path / "jw07076020001_04101_00001_nrs1_rate.fits"
+    p.write_bytes(b"\x00")
+    recs = build_rate_exposure_records(
+        [p], observation="ember_egs_p1", scope=Scope(obs="ember_egs_p1"))
+    assert len(recs) == 1
+    r = recs[0]
+    assert r["observation"] == "ember_egs_p1"
+    assert r["exposure_root"] == "jw07076020001_04101_00001"
+    assert r["detector"] == "nrs1"
+    assert r["filename"] == p.name
+    assert r["stage"] == "rate"
+    assert r["storage_key"] == (
+        "data/products/nirspec/ember_egs_p1/jw07076020001_04101_00001_nrs1_rate.fits")
+    # unreadable stub → metadata degrades to None, never raises
+    assert r["grating"] is None and r["image_width"] is None and r["image_height"] is None
+
+
+def _record(**over):
+    base = {
+        "observation": "ember_egs_p1",
+        "exposure_root": "jw07076020001_04101_00001",
+        "detector": "nrs1",
+        "filename": "jw07076020001_04101_00001_nrs1_rate.fits",
+        "grating": "PRISM",
+        "image_width": 2048,
+        "image_height": 2048,
+        "storage_key": "data/products/nirspec/ember_egs_p1/x_rate.fits",
+        "stage": "rate",
+    }
+    base.update(over)
+    return base
+
+
+def test_partition_new_row_seeds_pending_and_none():
+    new, upd = partition_rate_records([_record()], existing_keys=set(), now="T")
+    assert upd == []
+    assert len(new) == 1
+    assert new[0]["review_status"] == "pending"
+    assert new[0]["masking"] == "none"
+    assert new[0]["created_at"] == "T" and new[0]["updated_at"] == "T"
+
+
+def test_partition_existing_row_omits_web_owned_columns():
+    key = {("ember_egs_p1", "jw07076020001_04101_00001", "nrs1")}
+    new, upd = partition_rate_records([_record()], existing_keys=key, now="T")
+    assert new == []
+    assert len(upd) == 1
+    update = upd[0]
+    # split ownership: the UPDATE must NOT carry any web-owned triage column
+    for web_col in ("review_status", "masking", "mask_regions", "notes",
+                    "created_at"):
+        assert web_col not in update, web_col
+    # it DOES carry identity + render + updated_at
+    assert update["updated_at"] == "T"
+    for col in ("observation", "exposure_root", "detector", "filename", "stage",
+                "grating", "image_width", "image_height", "storage_key"):
+        assert col in update
+
+
+def test_partition_existing_row_skips_null_render_columns():
+    # a re-deploy where the header read failed must not overwrite good render
+    # columns with NULLs — null render columns are simply omitted from the UPDATE.
+    rec = _record(grating=None, image_width=None, image_height=None)
+    key = {("ember_egs_p1", "jw07076020001_04101_00001", "nrs1")}
+    _, upd = partition_rate_records([rec], existing_keys=key, now="T")
+    update = upd[0]
+    assert "grating" not in update
+    assert "image_width" not in update
+    assert "image_height" not in update
+    assert update["storage_key"] == rec["storage_key"]  # non-null render kept

--- a/supabase/migrations/20260704180000_add_nirspec_rate_exposures.sql
+++ b/supabase/migrations/20260704180000_add_nirspec_rate_exposures.sql
@@ -1,0 +1,64 @@
+-- NIRSpec rate-mask triage table (P2, NIRSpec review loop, design §3.2). The
+-- detector-grain analogue of nircam_exposures, keyed on
+-- (observation, exposure_root, detector). Admin-only (RLS); deploy-populated via a
+-- split-ownership upsert (campfire.deploy.rate_exposures) that refreshes identity/
+-- render columns without clobbering web review state. Additive: a brand-new table
+-- with no rows and no dependents; seed.sql is unaffected (the seed generator does
+-- not emit this table, same as nircam_exposures/spectrum_exposures).
+--
+-- Mirrors the create idiom of 20260629025904_add_intermediate_lifecycle_b2.sql.
+-- Grants match the schema file (authenticated + service_role only; no anon).
+
+create sequence "public"."nirspec_rate_exposures_id_seq";
+
+create table "public"."nirspec_rate_exposures" (
+    "id" integer not null default nextval('public.nirspec_rate_exposures_id_seq'::regclass),
+    "observation" text not null,
+    "exposure_root" text not null,
+    "detector" text not null,
+    "filename" text not null,
+    "grating" text,
+    "image_width" integer,
+    "image_height" integer,
+    "storage_key" text,
+    "stage" text not null default 'rate'::text,
+    "review_status" text not null default 'pending'::text,
+    "masking" text not null default 'none'::text,
+    "mask_regions" jsonb,
+    "notes" text,
+    "created_at" timestamp with time zone not null default now(),
+    "updated_at" timestamp with time zone not null default now()
+);
+
+alter table "public"."nirspec_rate_exposures" enable row level security;
+
+alter sequence "public"."nirspec_rate_exposures_id_seq" owned by "public"."nirspec_rate_exposures"."id";
+
+CREATE UNIQUE INDEX nirspec_rate_exposures_pkey ON public.nirspec_rate_exposures USING btree (id);
+
+CREATE UNIQUE INDEX nirspec_rate_exposures_unique ON public.nirspec_rate_exposures USING btree (observation, exposure_root, detector);
+
+CREATE INDEX idx_nirspec_rate_exposures_observation ON public.nirspec_rate_exposures USING btree (observation);
+
+CREATE INDEX idx_nirspec_rate_exposures_review ON public.nirspec_rate_exposures USING btree (review_status) WHERE (review_status <> 'approved'::text);
+
+alter table "public"."nirspec_rate_exposures" add constraint "nirspec_rate_exposures_pkey" PRIMARY KEY using index "nirspec_rate_exposures_pkey";
+
+alter table "public"."nirspec_rate_exposures" add constraint "nirspec_rate_exposures_unique" UNIQUE using index "nirspec_rate_exposures_unique";
+
+grant all on table "public"."nirspec_rate_exposures" to "authenticated";
+
+grant all on table "public"."nirspec_rate_exposures" to "service_role";
+
+create policy "admin_select_nirspec_rate_exposures"
+  on "public"."nirspec_rate_exposures" as permissive for select to authenticated
+  using (( SELECT public.is_admin() AS is_admin));
+
+create policy "admin_insert_nirspec_rate_exposures"
+  on "public"."nirspec_rate_exposures" as permissive for insert to authenticated
+  with check (( SELECT public.is_admin() AS is_admin));
+
+create policy "admin_update_nirspec_rate_exposures"
+  on "public"."nirspec_rate_exposures" as permissive for update to authenticated
+  using (( SELECT public.is_admin() AS is_admin))
+  with check (( SELECT public.is_admin() AS is_admin));

--- a/supabase/schemas/indexes.sql
+++ b/supabase/schemas/indexes.sql
@@ -352,6 +352,18 @@ CREATE INDEX IF NOT EXISTS idx_nircam_exposures_review
 
 
 -- =============================================================================
+-- nirspec_rate_exposures (design §3.2)
+-- =============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_nirspec_rate_exposures_observation
+    ON public.nirspec_rate_exposures USING btree (observation);
+
+CREATE INDEX IF NOT EXISTS idx_nirspec_rate_exposures_review
+    ON public.nirspec_rate_exposures USING btree (review_status)
+    WHERE review_status != 'approved';
+
+
+-- =============================================================================
 -- spectrum_exposures (epic #210, B2)
 -- =============================================================================
 

--- a/supabase/schemas/policies.sql
+++ b/supabase/schemas/policies.sql
@@ -677,6 +677,32 @@ CREATE POLICY "admin_update_exposures"
 
 
 -- =============================================================================
+-- nirspec_rate_exposures (admin-only — NIRSpec rate-mask triage, design §3.2)
+-- =============================================================================
+
+ALTER TABLE nirspec_rate_exposures ENABLE ROW LEVEL SECURITY;
+
+-- Admins can read all rate exposures.
+DROP POLICY IF EXISTS "admin_select_nirspec_rate_exposures" ON nirspec_rate_exposures;
+CREATE POLICY "admin_select_nirspec_rate_exposures"
+  ON nirspec_rate_exposures FOR SELECT TO authenticated
+  USING ((SELECT public.is_admin()));
+
+-- Admins can insert rate exposures.
+DROP POLICY IF EXISTS "admin_insert_nirspec_rate_exposures" ON nirspec_rate_exposures;
+CREATE POLICY "admin_insert_nirspec_rate_exposures"
+  ON nirspec_rate_exposures FOR INSERT TO authenticated
+  WITH CHECK ((SELECT public.is_admin()));
+
+-- Admins can update rate exposures.
+DROP POLICY IF EXISTS "admin_update_nirspec_rate_exposures" ON nirspec_rate_exposures;
+CREATE POLICY "admin_update_nirspec_rate_exposures"
+  ON nirspec_rate_exposures FOR UPDATE TO authenticated
+  USING ((SELECT public.is_admin()))
+  WITH CHECK ((SELECT public.is_admin()));
+
+
+-- =============================================================================
 -- spectrum_exposures (admin-only — NIRSpec intermediates, epic #210 B2)
 -- =============================================================================
 -- Reduction intermediates, never user-facing science. Admin-only, mirroring

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -774,6 +774,47 @@ ALTER SEQUENCE "public"."nircam_exposures_id_seq" OWNER TO "postgres";
 ALTER SEQUENCE "public"."nircam_exposures_id_seq" OWNED BY "public"."nircam_exposures"."id";
 
 
+-- NIRSpec rate-mask triage (P2, design §3.2). Detector-grain analogue of
+-- nircam_exposures, keyed on (observation, exposure_root, detector). Admin-only
+-- (RLS); deploy-populated (split-ownership upsert preserves web review state).
+CREATE TABLE IF NOT EXISTS "public"."nirspec_rate_exposures" (
+    "id" integer NOT NULL,
+    "observation" "text" NOT NULL,
+    "exposure_root" "text" NOT NULL,
+    "detector" "text" NOT NULL,
+    "filename" "text" NOT NULL,
+    "grating" "text",
+    "image_width" integer,
+    "image_height" integer,
+    "storage_key" "text",
+    "stage" "text" NOT NULL DEFAULT 'rate'::"text",
+    "review_status" "text" NOT NULL DEFAULT 'pending'::"text",
+    "masking" "text" NOT NULL DEFAULT 'none'::"text",
+    "mask_regions" "jsonb",
+    "notes" "text",
+    "created_at" timestamp with time zone NOT NULL DEFAULT "now"(),
+    "updated_at" timestamp with time zone NOT NULL DEFAULT "now"()
+);
+
+
+ALTER TABLE "public"."nirspec_rate_exposures" OWNER TO "postgres";
+
+
+CREATE SEQUENCE IF NOT EXISTS "public"."nirspec_rate_exposures_id_seq"
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE "public"."nirspec_rate_exposures_id_seq" OWNER TO "postgres";
+
+
+ALTER SEQUENCE "public"."nirspec_rate_exposures_id_seq" OWNED BY "public"."nirspec_rate_exposures"."id";
+
+
 -- spectrum_exposures: NIRSpec canonical spectrum-exposure intermediates (epic
 -- #210, B2). One logical row per (exposure, detector, source) that combines into
 -- a final spectrum — the NIRSpec analogue of nircam_exposures. Child of spectra
@@ -1330,6 +1371,9 @@ ALTER TABLE ONLY "public"."nircam_images" ALTER COLUMN "id" SET DEFAULT "nextval
 ALTER TABLE ONLY "public"."nircam_exposures" ALTER COLUMN "id" SET DEFAULT "nextval"('"public"."nircam_exposures_id_seq"'::"regclass");
 
 
+ALTER TABLE ONLY "public"."nirspec_rate_exposures" ALTER COLUMN "id" SET DEFAULT "nextval"('"public"."nirspec_rate_exposures_id_seq"'::"regclass");
+
+
 
 ALTER TABLE ONLY "public"."spectrum_exposures" ALTER COLUMN "id" SET DEFAULT "nextval"('"public"."spectrum_exposures_id_seq"'::"regclass");
 
@@ -1477,6 +1521,12 @@ ALTER TABLE ONLY "public"."nircam_exposures"
 
 ALTER TABLE ONLY "public"."nircam_exposures"
     ADD CONSTRAINT "nircam_exposures_unique" UNIQUE ("field", "filter", "filename");
+
+ALTER TABLE ONLY "public"."nirspec_rate_exposures"
+    ADD CONSTRAINT "nirspec_rate_exposures_pkey" PRIMARY KEY ("id");
+
+ALTER TABLE ONLY "public"."nirspec_rate_exposures"
+    ADD CONSTRAINT "nirspec_rate_exposures_unique" UNIQUE ("observation", "exposure_root", "detector");
 
 ALTER TABLE ONLY "public"."spectrum_exposures"
     ADD CONSTRAINT "spectrum_exposures_pkey" PRIMARY KEY ("id");
@@ -2016,6 +2066,11 @@ GRANT ALL ON TABLE "public"."nircam_exposures" TO "authenticated";
 GRANT ALL ON TABLE "public"."nircam_exposures" TO "service_role";
 
 
+-- nirspec_rate_exposures is admin-only (RLS); not granted to anon. Mirrors nircam_exposures.
+GRANT ALL ON TABLE "public"."nirspec_rate_exposures" TO "authenticated";
+GRANT ALL ON TABLE "public"."nirspec_rate_exposures" TO "service_role";
+
+
 -- spectrum_exposures is admin-only (RLS); not granted to anon. Mirrors nircam_exposures.
 GRANT ALL ON TABLE "public"."spectrum_exposures" TO "authenticated";
 GRANT ALL ON TABLE "public"."spectrum_exposures" TO "service_role";
@@ -2126,6 +2181,10 @@ GRANT ALL ON SEQUENCE "public"."nircam_images_id_seq" TO "service_role";
 
 GRANT ALL ON SEQUENCE "public"."nircam_exposures_id_seq" TO "authenticated";
 GRANT ALL ON SEQUENCE "public"."nircam_exposures_id_seq" TO "service_role";
+
+
+GRANT ALL ON SEQUENCE "public"."nirspec_rate_exposures_id_seq" TO "authenticated";
+GRANT ALL ON SEQUENCE "public"."nirspec_rate_exposures_id_seq" TO "service_role";
 
 
 GRANT ALL ON SEQUENCE "public"."spectrum_exposures_id_seq" TO "authenticated";


### PR DESCRIPTION
**P2** of the NIRSpec web review loop (`docs/design-nirspec-review-loop.md` §3.2/§9-P2), building on merged P0 (layout contract) and P1 (rate deploy → OSN). Adds the detector-grain triage table the P3 web rate-mask editor will read/write, and populates it from the rate files P1 already deploys.

## What changed

- **Schema (source of truth) + migration.** New `nirspec_rate_exposures` table — the direct `nircam_exposures` analogue — keyed `UNIQUE(observation, exposure_root, detector)`, with `review_status`/`masking`/`mask_regions`/`notes` triage columns. Three admin-only RLS policies (`policies.sql`), a btree `(observation)` index + a partial review-queue index (`indexes.sql`). Hand-authored additive migration mirrors the proven `add_nircam_exposures` idiom (create sequence/table, RLS, indexes, `using index` constraints, grants, policies).
- **Deploy — split-ownership upsert.** New `campfire.deploy.rate_exposures`, mirroring `nircam._upsert_exposures`: the re-register UPDATE writes **only** identity/render columns (`observation, exposure_root, detector, filename, stage` + non-null `grating`/dims/`storage_key`) and **omits** `review_status`/`masking`/`mask_regions`/`notes`, so a re-deploy never clobbers web triage; new rows seed `pending`/`none`. Wired into **both** NIRSpec entry points (`deploy_observation` + `_deploy_intermediates_only`) after the storage-registry upsert. `grating` from the primary header, dims from the SCI extension, best-effort (degrade to NULL on any read failure).
- **`exposure_root`** deliberately excludes the detector token (`jw07076020001_04101_00001`) — distinct from P1's registry `exposure_ref`, which keeps the full stem including detector + `_rate`. Parse is unambiguous (detector is always `nrs1`/`nrs2`).

## Design-vs-template reconciliation
Matched the real `nircam_exposures` template rather than the design's sketch where they differed: `integer` id + sequence (not `bigint IDENTITY`) so the migration is a verbatim copy of the proven idiom and `db diff` stays empty; `timestamptz NOT NULL` (the closer NIRSpec analogue). All column identifiers reserved-word-checked (`stage`/`detector`/`grating`/`notes` etc. are all live column names elsewhere; the `position` word that broke a prior branch is not used).

## seed.sql
**No regen.** `scripts/generate_seed.py` never emits this family of tables (`nircam_exposures`/`spectrum_exposures`), and a brand-new empty table with no dependents cannot break preview-branch seeding.

## Testing
- New `test_rate_exposures.py` (7 cases): rate-filename parse (+ rejection of non-rate/bad-detector names), record shape, and the **split-ownership partition** — asserts the UPDATE dict omits every web-owned triage column and skips null render columns (so a failed header read never nulls out good data). 21/21 pass across the rate/intermediate/OSN-routing suites; no regressions.
- The Supabase preview branch on this PR applies the migration + policies end-to-end (the real validator). Full insert/upsert round-trip runs live against local Supabase in CI.

## Scope / safety
No `pipeline/**` (no CHANGELOG entry), no `web/**`. One schema-changing PR at a time — P1's migration already merged, so P2 adds the next. Merges inert: additive admin-only table + deploy upsert that no-ops until rate files exist.

Generated with Claude Code

https://claude.ai/code/session_01SQiCGrfdaQu5cF9dbVCJNd

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQiCGrfdaQu5cF9dbVCJNd)_