### PR TITLE
NIRSpec review loop P3 — admin web rate-mask editor

### DIFF
--- a/web/app/admin/layout.tsx
+++ b/web/app/admin/layout.tsx
@@ -23,6 +23,7 @@ const adminNavSections: {
     title: 'Reduction',
     items: [
       { href: '/admin/nircam', label: 'NIRCam', icon: Camera },
+      { href: '/admin/nirspec/rate', label: 'NIRSpec Rate', icon: Telescope },
       { href: '/admin/deployments', label: 'Deployments', icon: GitBranch },
       { href: '/admin/intermediate-products', label: 'Storage', icon: Database },
     ],

--- a/web/app/admin/nirspec/rate/[id]/page.tsx
+++ b/web/app/admin/nirspec/rate/[id]/page.tsx
@@ -1,0 +1,440 @@
+'use client';
+
+import React, { Suspense, useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { Card } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import {
+  Loader2, ArrowLeft, Save, Check, ChevronLeft, ChevronRight, Keyboard,
+} from 'lucide-react';
+import {
+  getNirspecRateExposureById,
+  getNirspecRateNeighbors,
+  updateNirspecRateReview,
+  saveRateMaskRegions,
+  type RateNeighbors,
+} from '@/lib/actions/nirspec-rate';
+import type { NirspecRateExposure, MaskRegionsPayload } from '@/lib/types';
+import MaskEditor from '@/components/nircam/MaskEditor';
+import { parseRateNavParams } from '@/lib/nirspec-rate-nav';
+import { getCachedRate, setCachedRate } from '@/lib/nirspec-rate-cache';
+
+function RateDetailPageInner() {
+  const params = useParams();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const id = Number(params.id);
+
+  // The list page's filter+sort state, carried in the URL (see
+  // lib/nirspec-rate-nav.ts). Defines the ordered set prev/next walks; empty
+  // params (direct entry) = the full unfiltered set, so nav always works.
+  const navFilters = useMemo(
+    () => parseRateNavParams(new URLSearchParams(searchParams.toString())),
+    [searchParams],
+  );
+  const navQuery = searchParams.toString();
+
+  const [exposure, setExposure] = useState<NirspecRateExposure | null>(null);
+  const [exposureForId, setExposureForId] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Editable triage fields
+  const [reviewStatus, setReviewStatus] = useState<string>('pending');
+  const [masking, setMasking] = useState<string>('none');
+  const [notes, setNotes] = useState<string>('');
+
+  const [nav, setNav] = useState<RateNeighbors | null>(null);
+  const [showHelp, setShowHelp] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    getNirspecRateNeighbors(id, { ...navFilters, window: 3 }).then((res) => {
+      if (cancelled) return;
+      setNav(res.error || res.total === 0 ? null : res);
+    });
+    return () => { cancelled = true; };
+  }, [id, navFilters]);
+
+  // Reset state synchronously from the in-memory cache on route-id change so the
+  // new row paints in the same frame (React's "set state during render" pattern,
+  // bounded by the exposureForId guard). Server hit in the background revalidates.
+  if (exposureForId !== id) {
+    const cached = getCachedRate(id);
+    setExposureForId(id);
+    setExposure(cached);
+    setReviewStatus(cached?.review_status || 'pending');
+    setMasking(cached?.masking || 'none');
+    setNotes(cached?.notes || '');
+    setLoading(!cached);
+    setError(null);
+    setSaved(false);
+  }
+
+  // Background revalidation against the DB on every id change.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const result = await getNirspecRateExposureById(id);
+      if (cancelled) return;
+      if (result.error) {
+        setError(result.error);
+        setLoading(false);
+        return;
+      }
+      if (result.exposure) {
+        setCachedRate(result.exposure);
+        setExposure(result.exposure);
+        setReviewStatus(result.exposure.review_status);
+        setMasking(result.exposure.masking);
+        setNotes(result.exposure.notes || '');
+      }
+      setLoading(false);
+    })();
+    return () => { cancelled = true; };
+  }, [id]);
+
+  // Warm the sibling data cache (prev/next) so navigation paints instantly.
+  useEffect(() => {
+    if (!nav) return;
+    for (const sibId of [nav.nextId, nav.prevId]) {
+      if (sibId == null || getCachedRate(sibId)) continue;
+      getNirspecRateExposureById(sibId).then((res) => {
+        if (res.exposure) setCachedRate(res.exposure);
+      });
+    }
+  }, [nav]);
+
+  const hasChanges = !!(exposure && (
+    reviewStatus !== exposure.review_status ||
+    masking !== exposure.masking ||
+    notes !== (exposure.notes || '')
+  ));
+
+  const stateRef = useRef({ reviewStatus, masking, notes, hasChanges });
+  stateRef.current = { reviewStatus, masking, notes, hasChanges };
+
+  const handleSave = useCallback(async (): Promise<{ ok: boolean }> => {
+    const s = stateRef.current;
+    setSaving(true);
+    setSaved(false);
+    setError(null);
+    const result = await updateNirspecRateReview(id, {
+      review_status: s.reviewStatus as NirspecRateExposure['review_status'],
+      masking: s.masking as NirspecRateExposure['masking'],
+      notes: s.notes || undefined,
+    });
+    setSaving(false);
+    if (result.error) {
+      setError(result.error);
+      return { ok: false };
+    }
+    if (result.exposure) {
+      setCachedRate(result.exposure);
+      setExposure(result.exposure);
+    }
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+    return { ok: true };
+  }, [id]);
+
+  // Auto-save on nav: flush dirty triage so the operator can blast through a
+  // queue with arrow keys without losing state.
+  const goTo = useCallback(async (targetId: number | null) => {
+    if (targetId == null) return;
+    if (stateRef.current.hasChanges) {
+      const result = await handleSave();
+      if (!result.ok) return; // don't navigate on a save failure
+    }
+    router.push(`/admin/nirspec/rate/${targetId}${navQuery ? `?${navQuery}` : ''}`);
+  }, [handleSave, router, navQuery]);
+
+  const handleNext = useCallback(() => goTo(nav?.nextId ?? null), [goTo, nav]);
+  const handlePrev = useCallback(() => goTo(nav?.prevId ?? null), [goTo, nav]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const t = e.target as HTMLElement;
+      const isInput = t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.tagName === 'SELECT';
+      if (e.key === 'Escape' && isInput) { t.blur(); return; }
+      if (isInput) return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      switch (e.key) {
+        case '1': e.preventDefault(); setReviewStatus('pending');  break;
+        case '2': e.preventDefault(); setReviewStatus('approved'); break;
+        case '3': e.preventDefault(); setReviewStatus('excluded'); break;
+        case 'ArrowRight':
+        case 'n':
+        case 'N': e.preventDefault(); handleNext(); break;
+        case 'ArrowLeft':
+        case 'p':
+        case 'P': e.preventDefault(); handlePrev(); break;
+        case 's':
+        case 'S': e.preventDefault(); handleSave(); break;
+        case '?': e.preventDefault(); setShowHelp(prev => !prev); break;
+        case 'Escape': if (showHelp) setShowHelp(false); break;
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [handleNext, handlePrev, handleSave, showHelp]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <Loader2 className="w-8 h-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (!exposure) {
+    return (
+      <div className="py-8">
+        <p className="text-text-secondary">Rate exposure not found.</p>
+        <Link href="/admin/nirspec/rate" className="text-primary hover:underline mt-2 inline-block">
+          Back to NIRSpec Rate
+        </Link>
+      </div>
+    );
+  }
+
+  // FITS masking needs the canonical key (carried on the P2 row) plus the pixel
+  // dims for the overlay viewBox. Any null → render an explanatory fallback
+  // instead of crashing the canvas (e.g. deploy couldn't read the rate header).
+  const fitsMaskAvailable = Boolean(
+    exposure.storage_key && exposure.image_width && exposure.image_height,
+  );
+
+  const handleSaveMasks = async (regions: MaskRegionsPayload) => {
+    const res = await saveRateMaskRegions(exposure.id, regions);
+    if (res.exposure) {
+      setCachedRate(res.exposure);
+      setExposure(res.exposure);
+    }
+    return { error: res.error };
+  };
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-6">
+        <button
+          onClick={() => router.push(`/admin/nirspec/rate${navQuery ? `?${navQuery}` : ''}`)}
+          className="text-text-secondary hover:text-text-primary"
+          title="Back to list"
+        >
+          <ArrowLeft className="w-5 h-5" />
+        </button>
+        <div className="flex-1 min-w-0">
+          <h1 className="text-xl font-semibold font-mono text-text-primary truncate">
+            {exposure.filename}
+          </h1>
+          <p className="text-sm text-text-secondary">
+            {exposure.observation} / {exposure.detector}
+            {exposure.grating ? ` / ${exposure.grating}` : ''}
+          </p>
+        </div>
+        {nav && (
+          <div className="flex items-center gap-1 text-sm text-text-secondary">
+            <button
+              onClick={handlePrev}
+              disabled={nav.prevId == null}
+              title="Previous (← / P)"
+              className="p-1.5 rounded hover:bg-card-hover disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              <ChevronLeft className="w-5 h-5" />
+            </button>
+            <span className="font-mono tabular-nums text-xs px-1">
+              {nav.position} / {nav.total}
+            </span>
+            <button
+              onClick={handleNext}
+              disabled={nav.nextId == null}
+              title="Next (→ / N)"
+              className="p-1.5 rounded hover:bg-card-hover disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              <ChevronRight className="w-5 h-5" />
+            </button>
+          </div>
+        )}
+        <button
+          onClick={() => setShowHelp(prev => !prev)}
+          title="Keyboard shortcuts (?)"
+          className="p-1.5 rounded text-text-secondary hover:bg-card-hover"
+        >
+          <Keyboard className="w-5 h-5" />
+        </button>
+      </div>
+
+      {showHelp && (
+        <div className="mb-6 rounded-lg border border-border bg-card p-4">
+          <div className="flex items-center justify-between mb-2">
+            <h2 className="text-sm font-semibold text-text-primary">Keyboard shortcuts</h2>
+            <button onClick={() => setShowHelp(false)} className="text-xs text-text-secondary hover:underline">close</button>
+          </div>
+          <dl className="grid grid-cols-2 gap-x-6 gap-y-1 text-sm">
+            <div className="flex justify-between"><dt>Next exposure</dt><dd className="font-mono text-text-secondary">→ or N</dd></div>
+            <div className="flex justify-between"><dt>Previous</dt><dd className="font-mono text-text-secondary">← or P</dd></div>
+            <div className="flex justify-between"><dt>Mark pending</dt><dd className="font-mono text-text-secondary">1</dd></div>
+            <div className="flex justify-between"><dt>Mark approved</dt><dd className="font-mono text-text-secondary">2</dd></div>
+            <div className="flex justify-between"><dt>Mark excluded</dt><dd className="font-mono text-text-secondary">3</dd></div>
+            <div className="flex justify-between"><dt>Save</dt><dd className="font-mono text-text-secondary">S</dd></div>
+            <div className="flex justify-between"><dt>Help</dt><dd className="font-mono text-text-secondary">?</dd></div>
+          </dl>
+          <p className="mt-2 text-xs text-text-secondary">
+            Navigation auto-saves the triage panel if there are unsaved changes. Mask edits save separately from the editor toolbar.
+          </p>
+        </div>
+      )}
+
+      {error && (
+        <div className="bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-900 rounded-lg p-4 mb-6">
+          <p className="text-red-800 dark:text-red-400">{error}</p>
+        </div>
+      )}
+
+      <div className="flex gap-6">
+        {/* Image viewer: live FITS render (SCI) + mask editor */}
+        <div className="flex-1 min-w-0">
+          <Card className="overflow-hidden">
+            {fitsMaskAvailable ? (
+              <div className="h-[80vh]">
+                <MaskEditor
+                  fitsKey={exposure.storage_key!}
+                  imageWidth={exposure.image_width!}
+                  imageHeight={exposure.image_height!}
+                  initialRegions={exposure.mask_regions}
+                  onSave={handleSaveMasks}
+                />
+              </div>
+            ) : (
+              <div className="flex flex-col items-center justify-center py-24 text-center text-text-secondary">
+                <p className="mb-1">Rate FITS not available for masking.</p>
+                <p className="text-xs">
+                  The row is missing its <span className="font-mono">storage_key</span> or image
+                  dimensions — re-run <span className="font-mono">campfire deploy</span> for this
+                  observation to register the rate file.
+                </p>
+              </div>
+            )}
+          </Card>
+        </div>
+
+        {/* Sidebar */}
+        <div className="w-80 flex-shrink-0 space-y-4">
+          {/* Metadata */}
+          <Card className="p-4">
+            <h2 className="text-sm font-medium text-text-secondary uppercase tracking-wider mb-3">
+              Metadata
+            </h2>
+            <dl className="space-y-2 text-sm">
+              <div className="flex justify-between">
+                <dt className="text-text-secondary">Observation</dt>
+                <dd className="text-text-primary">{exposure.observation}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="text-text-secondary">Exposure</dt>
+                <dd className="text-text-primary font-mono text-xs">{exposure.exposure_root}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="text-text-secondary">Detector</dt>
+                <dd className="text-text-primary">{exposure.detector}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="text-text-secondary">Grating</dt>
+                <dd className="text-text-primary">{exposure.grating || '—'}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="text-text-secondary">Stage</dt>
+                <dd className="text-text-primary font-mono text-xs">{exposure.stage}</dd>
+              </div>
+            </dl>
+          </Card>
+
+          {/* Triage controls */}
+          <Card className="p-4">
+            <h2 className="text-sm font-medium text-text-secondary uppercase tracking-wider mb-3">
+              Triage
+            </h2>
+            <div className="space-y-3">
+              <div>
+                <label className="block text-xs font-medium text-text-secondary mb-1">
+                  Review Status
+                </label>
+                <select
+                  value={reviewStatus}
+                  onChange={(e) => setReviewStatus(e.target.value)}
+                  className="w-full text-sm border border-border rounded-lg px-3 py-2 bg-card text-text-primary"
+                >
+                  <option value="pending">Pending</option>
+                  <option value="approved">Approved</option>
+                  <option value="excluded">Excluded</option>
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-xs font-medium text-text-secondary mb-1">
+                  Masking
+                </label>
+                <select
+                  value={masking}
+                  onChange={(e) => setMasking(e.target.value)}
+                  className="w-full text-sm border border-border rounded-lg px-3 py-2 bg-card text-text-primary"
+                >
+                  <option value="none">None</option>
+                  <option value="needed">Needed</option>
+                  <option value="done">Done</option>
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-xs font-medium text-text-secondary mb-1">
+                  Notes
+                </label>
+                <textarea
+                  value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                  placeholder="Describe persistence trails, MSA shorts, etc."
+                  rows={4}
+                  className="w-full text-sm border border-border rounded-lg px-3 py-2 bg-card text-text-primary placeholder:text-text-tertiary resize-none"
+                />
+              </div>
+
+              <Button
+                onClick={handleSave}
+                disabled={saving || !hasChanges}
+                className="w-full"
+              >
+                {saving ? (
+                  <><Loader2 className="w-4 h-4 mr-2 animate-spin" /> Saving...</>
+                ) : saved ? (
+                  <><Check className="w-4 h-4 mr-2" /> Saved</>
+                ) : (
+                  <><Save className="w-4 h-4 mr-2" /> Save Changes</>
+                )}
+              </Button>
+            </div>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function RateDetailPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center py-16">
+          <Loader2 className="w-8 h-8 animate-spin text-primary" />
+        </div>
+      }
+    >
+      <RateDetailPageInner />
+    </Suspense>
+  );
+}

--- a/web/app/admin/nirspec/rate/page.tsx
+++ b/web/app/admin/nirspec/rate/page.tsx
@@ -1,0 +1,246 @@
+'use client';
+
+import React, { Suspense, useMemo } from 'react';
+import Link from 'next/link';
+import { useQuery } from '@tanstack/react-query';
+import type { ColumnDef } from '@tanstack/react-table';
+import { Loader2, ChevronRight } from 'lucide-react';
+import { AdminTable } from '@/components/admin/AdminTable';
+import { AdminFilterBar } from '@/components/admin/AdminFilterBar';
+import { flatFilterCodec, useTableUrlState, type SortState } from '@/lib/hooks/useTableUrlState';
+import { useAdminTableQuery } from '@/lib/hooks/useAdminTableQuery';
+import {
+  getNirspecRateExposures,
+  getNirspecRateFilterOptions,
+} from '@/lib/actions/nirspec-rate';
+import { NIRSPEC_RATE_SORT_KEYS } from '@/lib/admin/sort-keys';
+import type { NirspecRateExposure } from '@/lib/types';
+import { buildRateNavQuery } from '@/lib/nirspec-rate-nav';
+
+// ---------------------------------------------------------------------------
+// Status badge helpers (mirror the NIRCam list)
+// ---------------------------------------------------------------------------
+
+function ReviewBadge({ status }: { status: string }) {
+  const colors: Record<string, string> = {
+    pending: 'bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-300',
+    approved: 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-300',
+    excluded: 'bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-300',
+  };
+  return (
+    <span className={`inline-flex px-2 py-0.5 text-xs font-medium rounded-full ${colors[status] || 'bg-surface-2 text-text-primary'}`}>
+      {status}
+    </span>
+  );
+}
+
+function ActionBadge({ status, label }: { status: string; label: string }) {
+  if (status === 'none') return <span className="text-xs text-text-secondary">&mdash;</span>;
+  const colors: Record<string, string> = {
+    needed: 'bg-orange-100 dark:bg-orange-900 text-orange-800 dark:text-orange-300',
+    done: 'bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-300',
+  };
+  return (
+    <span className={`inline-flex px-2 py-0.5 text-xs font-medium rounded-full ${colors[status] || ''}`}>
+      {label}: {status}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// URL-state config (module-level: codec/whitelist must be stable references).
+// The same param names are what the detail page parses for prev/next nav —
+// see lib/nirspec-rate-nav.ts.
+// ---------------------------------------------------------------------------
+
+const FILTER_KEYS = ['observation', 'detector', 'review', 'masking', 'grating'] as const;
+const codec = flatFilterCodec(FILTER_KEYS);
+const DEFAULT_SORT: SortState = { column: 'filename', direction: 'asc' };
+
+const REVIEW_OPTIONS = [
+  { value: 'pending', label: 'Pending' },
+  { value: 'approved', label: 'Approved' },
+  { value: 'excluded', label: 'Excluded' },
+];
+const ACTION_STATE_OPTIONS = [
+  { value: 'needed', label: 'Needed' },
+  { value: 'done', label: 'Done' },
+  { value: 'none', label: 'None' },
+];
+const DETECTOR_OPTIONS = [
+  { value: 'nrs1', label: 'nrs1' },
+  { value: 'nrs2', label: 'nrs2' },
+];
+
+function AdminNirspecRatePageInner() {
+  const state = useTableUrlState({
+    codec,
+    sortWhitelist: NIRSPEC_RATE_SORT_KEYS,
+    defaultSort: DEFAULT_SORT,
+  });
+
+  const exposures = useAdminTableQuery<NirspecRateExposure>({
+    scope: 'admin-nirspec-rate',
+    filters: state.debouncedFilters,
+    sort: state.sort,
+    page: state.page,
+    pageSize: state.pageSize,
+    fetchPage: async (page) => {
+      const f = state.debouncedFilters;
+      const res = await getNirspecRateExposures({
+        observation: f.observation || undefined,
+        detector: f.detector || undefined,
+        reviewStatus: f.review || undefined,
+        masking: f.masking || undefined,
+        grating: f.grating || undefined,
+        sortColumn: state.sort.column,
+        sortDirection: state.sort.direction,
+        page,
+        pageSize: state.pageSize,
+      });
+      return { rows: res.rows, total: res.total, error: res.error };
+    },
+  });
+
+  const { data: facets } = useQuery({
+    queryKey: ['admin-nirspec-rate-facets'],
+    queryFn: getNirspecRateFilterOptions,
+    staleTime: 5 * 60_000,
+  });
+
+  // Row links carry the current filter+sort state so the detail page derives
+  // prev/next from the same set (see lib/nirspec-rate-nav.ts).
+  const navQuery = useMemo(
+    () => buildRateNavQuery(state.filters, state.sort, DEFAULT_SORT),
+    [state.filters, state.sort],
+  );
+  const detailHref = (id: number) => `/admin/nirspec/rate/${id}${navQuery ? `?${navQuery}` : ''}`;
+
+  const columns = useMemo<ColumnDef<NirspecRateExposure, unknown>[]>(() => [
+    {
+      id: 'filename',
+      header: 'Filename',
+      cell: ({ row }) => (
+        <Link
+          href={detailHref(row.original.id)}
+          className="text-sm font-mono text-primary hover:underline"
+        >
+          {row.original.filename}
+        </Link>
+      ),
+      meta: { sortKey: 'filename' },
+    },
+    {
+      id: 'observation',
+      header: 'Observation',
+      cell: ({ row }) => <span className="text-sm text-text-primary">{row.original.observation}</span>,
+      meta: { sortKey: 'observation' },
+    },
+    {
+      id: 'exposure_root',
+      header: 'Exposure',
+      cell: ({ row }) => <span className="text-sm font-mono text-text-secondary">{row.original.exposure_root}</span>,
+      meta: { sortKey: 'exposure_root' },
+    },
+    {
+      id: 'detector',
+      header: 'Detector',
+      cell: ({ row }) => <span className="text-sm text-text-secondary">{row.original.detector}</span>,
+      meta: { sortKey: 'detector' },
+    },
+    {
+      id: 'grating',
+      header: 'Grating',
+      cell: ({ row }) => <span className="text-sm text-text-secondary">{row.original.grating || '—'}</span>,
+      meta: { sortKey: 'grating' },
+    },
+    {
+      id: 'review',
+      header: 'Review',
+      cell: ({ row }) => <ReviewBadge status={row.original.review_status} />,
+      meta: { sortKey: 'review_status' },
+    },
+    {
+      id: 'masking',
+      header: 'Masking',
+      cell: ({ row }) => <ActionBadge status={row.original.masking} label="mask" />,
+    },
+    {
+      id: 'open',
+      header: '',
+      cell: ({ row }) => (
+        <Link href={detailHref(row.original.id)}>
+          <ChevronRight className="w-4 h-4 text-text-secondary" />
+        </Link>
+      ),
+      meta: { align: 'right' },
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  ], [navQuery]);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-semibold text-text-primary">NIRSpec Rate Masks</h1>
+      </div>
+
+      <p className="text-text-secondary text-sm mb-6">
+        Detector rate files (<span className="font-mono">nrs1</span>/<span className="font-mono">nrs2</span>),
+        source-independent. Draw <span className="font-mono">DO_NOT_USE</span> polygons on persistence
+        trails / MSA shorts; <span className="font-mono">campfire deploy nirspec pull-rate-masks</span> materializes
+        them before stage&nbsp;2.
+      </p>
+
+      <AdminFilterBar
+        facets={[
+          {
+            kind: 'select', key: 'observation', label: 'Observation',
+            options: (facets?.observations ?? []).map((o) => ({ value: o, label: o })),
+          },
+          { kind: 'select', key: 'detector', label: 'Detector', options: DETECTOR_OPTIONS },
+          {
+            kind: 'select', key: 'grating', label: 'Grating',
+            options: (facets?.gratings ?? []).map((g) => ({ value: g, label: g })),
+          },
+          { kind: 'select', key: 'review', label: 'Review', options: REVIEW_OPTIONS },
+          { kind: 'select', key: 'masking', label: 'Masking', options: ACTION_STATE_OPTIONS },
+        ]}
+        values={state.filters}
+        onChange={(key, value) => state.setFilters({ ...state.filters, [key]: value })}
+        onReset={state.resetFilters}
+      />
+
+      <AdminTable
+        columns={columns}
+        data={exposures.rows}
+        total={exposures.total}
+        page={state.page}
+        pageSize={state.pageSize}
+        sort={state.sort}
+        loading={exposures.isInitialLoading}
+        fetching={exposures.isFetching || state.isDebouncing}
+        error={exposures.error}
+        emptyTitle="No rate files found."
+        onSortChange={state.setSort}
+        onPageChange={state.setPage}
+        onPageSizeChange={state.setPageSize}
+        getRowKey={(e) => e.id}
+        pageSizeOptions={[25, 50, 100, 200]}
+      />
+    </div>
+  );
+}
+
+export default function AdminNirspecRatePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex items-center justify-center py-16">
+          <Loader2 className="w-8 h-8 animate-spin text-primary" />
+        </div>
+      }
+    >
+      <AdminNirspecRatePageInner />
+    </Suspense>
+  );
+}

--- a/web/app/api/nircam-fits/route.ts
+++ b/web/app/api/nircam-fits/route.ts
@@ -12,6 +12,12 @@ import { isKnownKey, parseKey } from '@/lib/layout';
 
 export const runtime = 'nodejs';
 
+// Product types this proxy is allowed to serve. NIRCam exposures (epic #261) plus
+// NIRSpec rate files (review loop, P3) — both are uncompressed detector FITS the
+// in-browser SCI viewer range-fetches. Keeps the route from being an arbitrary
+// object read.
+const FITS_ALLOWED_PRODUCTS = new Set(['nircam_exposure', 'nirspec_rate']);
+
 /**
  * GET /api/nircam-fits?key=<canonical OSN key>   (HTTP Range required)
  *
@@ -43,7 +49,7 @@ export async function GET(request: NextRequest) {
   if (!key || !isKnownKey(key, { bucket: 'data' })) {
     return new Response('Invalid key', { status: 400 });
   }
-  if (parseKey(key).productType !== 'nircam_exposure') {
+  if (!FITS_ALLOWED_PRODUCTS.has(parseKey(key).productType)) {
     return new Response('Invalid key', { status: 400 });
   }
 

--- a/web/lib/actions/nirspec-rate.ts
+++ b/web/lib/actions/nirspec-rate.ts
@@ -1,0 +1,259 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+import { NIRSPEC_RATE_SORT_KEYS } from '@/lib/admin/sort-keys';
+import type { NirspecRateExposure, MaskRegionsPayload } from '@/lib/types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function requireAdmin() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error('Not authenticated');
+
+  const { data: profile } = await supabase
+    .from('user_profiles')
+    .select('is_admin')
+    .eq('user_id', user.id)
+    .single();
+
+  if (!profile?.is_admin) throw new Error('Admin access required');
+  return supabase;
+}
+
+export interface RateFilters {
+  observation?: string;
+  detector?: string;
+  reviewStatus?: string;
+  masking?: string;
+  grating?: string;
+}
+
+export interface RateSort {
+  sortColumn?: string;
+  sortDirection?: 'asc' | 'desc';
+}
+
+export interface RateExposuresResult {
+  rows: NirspecRateExposure[];
+  total: number;
+  error?: string;
+}
+
+export interface RateNeighbors {
+  prevId: number | null;
+  nextId: number | null;
+  position: number | null;   // 1-based
+  total: number;
+  windowIds: number[];
+  error?: string;
+}
+
+// Sort-key whitelist lives in @/lib/admin/sort-keys (a 'use server' module may
+// only export async functions). Validate here as defense-in-depth even though the
+// client already whitelists — never pass an unvetted column into .order().
+function safeSortColumn(col?: string): string {
+  return col && (NIRSPEC_RATE_SORT_KEYS as readonly string[]).includes(col) ? col : 'filename';
+}
+
+// nirspec_rate_exposures is admin-only via RLS, so a direct authenticated query is
+// safe and correct — no RPC needed (unlike NIRCam, whose large table used a
+// windowed-count RPC). Applies the categorical filters as equality matches.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function applyRateFilters(query: any, f: RateFilters) {
+  if (f.observation) query = query.eq('observation', f.observation);
+  if (f.detector) query = query.eq('detector', f.detector);
+  if (f.reviewStatus) query = query.eq('review_status', f.reviewStatus);
+  if (f.masking) query = query.eq('masking', f.masking);
+  if (f.grating) query = query.eq('grating', f.grating);
+  return query;
+}
+
+// ---------------------------------------------------------------------------
+// Read
+// ---------------------------------------------------------------------------
+
+export async function getNirspecRateExposures(
+  params?: RateFilters & RateSort & { page?: number; pageSize?: number },
+): Promise<RateExposuresResult> {
+  try {
+    const supabase = await requireAdmin();
+    const page = params?.page ?? 1;
+    const pageSize = params?.pageSize ?? 50;
+    const from = (page - 1) * pageSize;
+    const to = from + pageSize - 1;
+
+    let query = supabase
+      .from('nirspec_rate_exposures')
+      .select('*', { count: 'exact' });
+    query = applyRateFilters(query, params ?? {});
+    query = query
+      .order(safeSortColumn(params?.sortColumn), {
+        ascending: params?.sortDirection !== 'desc',
+      })
+      .range(from, to);
+
+    const { data, count, error } = await query;
+    if (error) return { rows: [], total: 0, error: error.message };
+    return { rows: (data ?? []) as NirspecRateExposure[], total: count ?? 0 };
+  } catch (err) {
+    return {
+      rows: [], total: 0,
+      error: err instanceof Error ? err.message : 'Failed to fetch rate exposures',
+    };
+  }
+}
+
+export async function getNirspecRateExposureById(id: number): Promise<{
+  exposure: NirspecRateExposure | null;
+  error?: string;
+}> {
+  try {
+    const supabase = await requireAdmin();
+    const { data, error } = await supabase
+      .from('nirspec_rate_exposures')
+      .select('*')
+      .eq('id', id)
+      .single();
+    if (error) return { exposure: null, error: error.message };
+    return { exposure: data as NirspecRateExposure };
+  } catch (err) {
+    return {
+      exposure: null,
+      error: err instanceof Error ? err.message : 'Failed to fetch rate exposure',
+    };
+  }
+}
+
+// Bounded prev/next nav for the detail page, over the SAME filtered+ordered set
+// the list page shows. The table is tiny (2 detectors × exposures/obs), so we
+// fetch the full ordered id list and compute neighbors in JS — no RPC needed.
+export async function getNirspecRateNeighbors(
+  currentId: number,
+  params?: RateFilters & RateSort & { window?: number },
+): Promise<RateNeighbors> {
+  const empty: RateNeighbors = {
+    prevId: null, nextId: null, position: null, total: 0, windowIds: [],
+  };
+  try {
+    const supabase = await requireAdmin();
+    let query = supabase.from('nirspec_rate_exposures').select('id');
+    query = applyRateFilters(query, params ?? {});
+    query = query.order(safeSortColumn(params?.sortColumn), {
+      ascending: params?.sortDirection !== 'desc',
+    });
+    const { data, error } = await query;
+    if (error) return { ...empty, error: error.message };
+
+    const ids = (data ?? []).map((r) => r.id as number);
+    const idx = ids.indexOf(currentId);
+    if (idx < 0) return empty;  // currentId not in the filtered set (direct entry)
+
+    const win = params?.window ?? 3;
+    return {
+      prevId: idx > 0 ? ids[idx - 1] : null,
+      nextId: idx < ids.length - 1 ? ids[idx + 1] : null,
+      position: idx + 1,
+      total: ids.length,
+      windowIds: ids.slice(Math.max(0, idx - win), idx + win + 1),
+    };
+  } catch (err) {
+    return {
+      ...empty,
+      error: err instanceof Error ? err.message : 'Failed to fetch neighbors',
+    };
+  }
+}
+
+export async function getNirspecRateFilterOptions(): Promise<{
+  observations: string[];
+  gratings: string[];
+  error?: string;
+}> {
+  try {
+    const supabase = await requireAdmin();
+    const { data, error } = await supabase
+      .from('nirspec_rate_exposures')
+      .select('observation, grating');
+    if (error) return { observations: [], gratings: [], error: error.message };
+    const rows = (data ?? []) as { observation: string; grating: string | null }[];
+    const uniq = (xs: (string | null)[]) =>
+      [...new Set(xs.filter((x): x is string => !!x))].sort();
+    return {
+      observations: uniq(rows.map((r) => r.observation)),
+      gratings: uniq(rows.map((r) => r.grating)),
+    };
+  } catch (err) {
+    return {
+      observations: [], gratings: [],
+      error: err instanceof Error ? err.message : 'Failed to fetch filter options',
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Update
+// ---------------------------------------------------------------------------
+
+export async function updateNirspecRateReview(
+  id: number,
+  updates: {
+    review_status?: 'pending' | 'approved' | 'excluded';
+    masking?: 'none' | 'needed' | 'done';
+    notes?: string;
+  },
+): Promise<{ exposure: NirspecRateExposure | null; error?: string }> {
+  try {
+    const supabase = await requireAdmin();
+    const { data, error } = await supabase
+      .from('nirspec_rate_exposures')
+      .update({ ...updates, updated_at: new Date().toISOString() })
+      .eq('id', id)
+      .select()
+      .single();
+    if (error) return { exposure: null, error: error.message };
+    return { exposure: data as NirspecRateExposure };
+  } catch (err) {
+    return {
+      exposure: null,
+      error: err instanceof Error ? err.message : 'Failed to update rate exposure',
+    };
+  }
+}
+
+/**
+ * Persist the polygon list for a single rate exposure.
+ *
+ * Vertices are stored as DS9 ``image`` 1-indexed coords so the payload round-trips
+ * through ``campfire deploy nirspec pull-rate-masks`` (P3b) and ``apply_mask_dq``
+ * without further transform. ``masking`` flips to ``'done'`` iff ≥1 polygon,
+ * mirroring the local-file-exists semantic the deploy code uses.
+ */
+export async function saveRateMaskRegions(
+  id: number,
+  regions: MaskRegionsPayload,
+): Promise<{ exposure: NirspecRateExposure | null; error?: string }> {
+  try {
+    const supabase = await requireAdmin();
+    const hasPolygons = (regions?.polygons?.length ?? 0) > 0;
+    const { data, error } = await supabase
+      .from('nirspec_rate_exposures')
+      .update({
+        mask_regions: hasPolygons ? regions : null,
+        masking: hasPolygons ? 'done' : 'none',
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', id)
+      .select()
+      .single();
+    if (error) return { exposure: null, error: error.message };
+    return { exposure: data as NirspecRateExposure };
+  } catch (err) {
+    return {
+      exposure: null,
+      error: err instanceof Error ? err.message : 'Failed to save mask regions',
+    };
+  }
+}

--- a/web/lib/admin/sort-keys.ts
+++ b/web/lib/admin/sort-keys.ts
@@ -17,3 +17,7 @@ export const STORAGE_OBJECT_SORT_KEYS = [
 export const EXPOSURE_SORT_KEYS = [
   'filename', 'field', 'filter', 'detector', 'stage', 'review_status', 'date_obs', 'updated_at',
 ] as const;
+
+export const NIRSPEC_RATE_SORT_KEYS = [
+  'filename', 'observation', 'exposure_root', 'detector', 'grating', 'review_status', 'updated_at',
+] as const;

--- a/web/lib/nirspec-rate-cache.ts
+++ b/web/lib/nirspec-rate-cache.ts
@@ -1,0 +1,24 @@
+/**
+ * In-memory rate-exposure cache for the /admin/nirspec/rate triage flow.
+ *
+ * Module-scope (per browser-tab session), keyed by row id, so the detail page can
+ * render instantly when stepping to a sibling via prev/next while a background
+ * re-fetch revalidates against the DB. Mirrors nircam-exposure-cache.ts, minus the
+ * PNG prefetch (rate review is FITS-only). Dropped on full reload.
+ */
+
+import type { NirspecRateExposure } from '@/lib/types';
+
+const cache = new Map<number, NirspecRateExposure>();
+
+export function getCachedRate(id: number): NirspecRateExposure | null {
+  return cache.get(id) ?? null;
+}
+
+export function setCachedRate(exp: NirspecRateExposure): void {
+  cache.set(exp.id, exp);
+}
+
+export function clearRateCache(): void {
+  cache.clear();
+}

--- a/web/lib/nirspec-rate-nav.ts
+++ b/web/lib/nirspec-rate-nav.ts
@@ -1,0 +1,57 @@
+// The URL contract between the admin NIRSpec rate list page and the rate detail
+// page. Mirrors nircam-exposure-nav.ts: the list's row links carry the active
+// filter+sort state as query params; the detail page parses them back and derives
+// prev/next within that same filtered, ordered set. Context lives in the URL, so
+// nav survives refresh, direct entry, and shared links.
+
+import type { RateFilters, RateSort } from '@/lib/actions/nirspec-rate';
+import { NIRSPEC_RATE_SORT_KEYS } from '@/lib/admin/sort-keys';
+
+export const RATE_FILTER_PARAM_KEYS = [
+  'observation', 'detector', 'review', 'masking', 'grating',
+] as const;
+
+export type RateFilterParams = Record<
+  (typeof RATE_FILTER_PARAM_KEYS)[number],
+  string
+>;
+
+/** URL params (list page state) → the action filter+sort shape. */
+export function parseRateNavParams(
+  sp: URLSearchParams,
+): RateFilters & RateSort {
+  const sort = sp.get('sort');
+  const dir = sp.get('dir');
+  return {
+    observation: sp.get('observation') || undefined,
+    detector: sp.get('detector') || undefined,
+    reviewStatus: sp.get('review') || undefined,
+    masking: sp.get('masking') || undefined,
+    grating: sp.get('grating') || undefined,
+    sortColumn:
+      sort && (NIRSPEC_RATE_SORT_KEYS as readonly string[]).includes(sort) ? sort : undefined,
+    sortDirection: dir === 'asc' || dir === 'desc' ? dir : undefined,
+  };
+}
+
+/** List page state → the query string appended to detail-page row links. */
+export function buildRateNavQuery(
+  filters: Partial<RateFilterParams>,
+  sort?: { column: string; direction: 'asc' | 'desc' },
+  defaultSort?: { column: string; direction: 'asc' | 'desc' },
+): string {
+  const sp = new URLSearchParams();
+  for (const key of RATE_FILTER_PARAM_KEYS) {
+    const v = filters[key];
+    if (v) sp.set(key, v);
+  }
+  if (
+    sort &&
+    defaultSort &&
+    (sort.column !== defaultSort.column || sort.direction !== defaultSort.direction)
+  ) {
+    sp.set('sort', sort.column);
+    sp.set('dir', sort.direction);
+  }
+  return sp.toString();
+}

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -355,6 +355,28 @@ export interface NircamExposure {
   updated_at: string;
 }
 
+// NIRSpec rate-file detector triage (NIRSpec review loop, P2/P3). Detector-grain
+// analogue of NircamExposure: source-independent rate-level masks reviewed on the
+// web. Mirrors the supabase nirspec_rate_exposures table.
+export interface NirspecRateExposure {
+  id: number;
+  observation: string;
+  exposure_root: string;
+  detector: string;               // 'nrs1' | 'nrs2'
+  filename: string;
+  grating: string | null;
+  image_width: number | null;
+  image_height: number | null;
+  storage_key: string | null;     // canonical nirspec_rate key for the FITS proxy
+  stage: string;
+  review_status: 'pending' | 'approved' | 'excluded';
+  masking: 'none' | 'needed' | 'done';
+  mask_regions: MaskRegionsPayload | null;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 // One entry in observations.pointings — a NIRSpec MSA pointing.
 export interface Pointing {
   msametid: number;


### PR DESCRIPTION
**P3** of the NIRSpec web review loop (`docs/design-nirspec-review-loop.md` §3.4/§6/§9-P3), building on merged P0–P2. Adds the admin cockpit for drawing `DO_NOT_USE` polygons on `nrs1`/`nrs2` rate files, rendering the rate SCI **in-browser** via the reused NIRCam fitsgl stack, backed by the P2 `nirspec_rate_exposures` table.

**This is the first interactive-UI phase** — the Vercel preview is a real deployment worth clicking through (see below).

## What changed (all `web/`)

- **Proxy guard widened** (`app/api/nircam-fits/route.ts`, ~2 lines): the single `productType !== 'nircam_exposure'` check becomes a `{nircam_exposure, nirspec_rate}` allowlist. This is the *only* NIRCam coupling in the shared `FitsCanvas`/`MaskEditor` stack (`FitsCanvas` hardcodes `/api/nircam-fits`), so widening the guard lets both components be **reused verbatim** — no fork, no new prop. Backend resolution, the `CAMPFIRE_LOCAL_DATA_ROOT` local fast-path, and Range forwarding were already generic.
- **Server actions** (`lib/actions/nirspec-rate.ts`, `'use server'`, all `requireAdmin()`-gated): list (direct `.select(count:'exact')` — the table is tiny, no windowed-count RPC needed), by-id, prev/next neighbors computed in JS over the filtered+ordered id list, review update, `saveRateMaskRegions` (mirrors `saveExposureMaskRegions`: `mask_regions` jsonb + `masking='done'` iff ≥1 polygon), and filter options.
- **Pages**: `/admin/nirspec/rate` list (`AdminTable`/`AdminFilterBar`, URL-state filters: observation/detector/review/masking/grating) + `/admin/nirspec/rate/[id]` detail cockpit (in-memory cache, ±window sibling prefetch, keyboard nav, the `MaskEditor` pane). **FITS-only** — no PNG toggle/presign/correction (rate has no PNG product); `fitsKey` comes straight off the P2 row's `storage_key`, with a graceful fallback when `storage_key`/dims are null.
- **Types / helpers**: `NirspecRateExposure` (mirrors the P2 table); nav + cache helpers mirror the NIRCam ones; admin sidebar gains a "NIRSpec Rate" link.

## No schema change
P3 reads/writes the P2 table through **admin RLS via direct PostgREST** — no RPC, no migration, no `seed.sql` regen. (NIRCam only used RPCs for large-table windowed counts; rate cardinality is 2 detectors × exposures/obs.)

## `'use server'` safety
The sort whitelist (`NIRSPEC_RATE_SORT_KEYS`) lives in the plain `lib/admin/sort-keys.ts` module — never a `const` export from a `'use server'` file (the cause of the earlier admin outage). Only async functions are exported from the actions module; interfaces are type-only.

## Testing / build
- `cd web && npm run build`: compiles, type-checks, and lints clean; **both new routes generate** (`○ /admin/nirspec/rate`, `ƒ /admin/nirspec/rate/[id]`). `tsc --noEmit` exits 0. (Locally the build only fails at the env-dependent prerender of the unrelated `/nircam` page — no Supabase creds in the sandbox; with placeholder env the full 85-page build is green. Vercel builds with real creds.)
- **Please click through the preview** once it's up: the list page + a detail row's FITS render. Full end-to-end masking needs a real deployed `_rate.fits` (P1) — I can't exercise the fitsgl render against real pixels here. **Orientation (design OQ-3)** is the one thing to eyeball: the reused `MaskEditor` ds9↔svg transform + `viewer.ts` `origin='lower'` already agree for the shared stack and `masks.py` rasterizes in the same DS9 image frame, so it should round-trip — but a real rate SCI is the confirmation.

## Scope / safety
Admin-only pages + one additive proxy-guard widening (NIRCam behavior unchanged). No public surface, no `pipeline/**`, no schema. Merges inert. The `pull-rate-masks` + `masks.py` `.reg`-source change is P3b (next).

Generated with Claude Code

https://claude.ai/code/session_01SQiCGrfdaQu5cF9dbVCJNd

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQiCGrfdaQu5cF9dbVCJNd)_