### PR TITLE
NIRSpec review loop P4 — exp_group header stamp + revive spectrum_exposures nods grid

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -264,6 +264,15 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- **NIRSpec canonical spectrum-exposure FITS now carry a `CFEXPGRP` primary-header
+  card** recording the pipeline-computed `exp_group` (the sub-pixel-dither grouping
+  id from `Observation.group_files`). Stamped by a final pass at the end of
+  `run_stage2a`/`run_stage2b` (via `canonical.append_extras`, so it's additive and
+  survives stage2b's MultiSlitModel re-save like `CFSCHEMA`). `exp_group` is not
+  derivable from a single filename — it depends on the whole exposure set's dither
+  pattern — so the stamp lets `campfire deploy` populate the web nods-renderer grid
+  (`spectrum_exposures`) with the exact pipeline grouping. Additive provenance only:
+  no change to pixel/flux values or file layout. (NIRSpec review loop, P4.)
 - **NIRSpec rate-mask region strings now come from
   `reference/nirspec/<obs>/masks/*.reg`, not `observations.toml`.** The NIRSpec
   web review loop (design §3.5). `Observation.setup_workspace_directory` populates

--- a/pipeline/campfire_pipeline/nirspec/canonical.py
+++ b/pipeline/campfire_pipeline/nirspec/canonical.py
@@ -78,6 +78,36 @@ def schema_version_card(version=CANONICAL_SCHEMA_VERSION):
     return {SCHEMA_VERSION_KEYWORD: (int(version), SCHEMA_VERSION_COMMENT)}
 
 
+# The pipeline-computed exposure-group id (``observation.group_files``): one int
+# per sub-pixel-dither group, spanning both detectors and all nods within it. It
+# is NOT derivable from a single filename (it depends on the whole exposure set's
+# dither pattern), so the pipeline stamps it here for deploy to populate the web
+# nods-renderer grid with the exact pipeline grouping (NIRSpec review loop, §4.2).
+# A standalone primary-header card (like ``CFSCHEMA``, NOT a ``CFP_*`` state card),
+# so it survives ``cfpipe nirspec reset`` and stage2b's MultiSlitModel re-save.
+EXP_GROUP_KEYWORD = 'CFEXPGRP'
+EXP_GROUP_COMMENT = 'campfire: exposure group id (subpixel-dither)'
+
+
+def exp_group_card(exp_group):
+    """The ``(value, comment)`` dict for the ``CFEXPGRP`` card.
+
+    Returned as a dict so it composes with the other ``header_updates`` passed to
+    the canonical writers (``save_canonical`` / ``append_extras``).
+    """
+    return {EXP_GROUP_KEYWORD: (int(exp_group), EXP_GROUP_COMMENT)}
+
+
+def read_exp_group(path_or_header):
+    """Return a canonical file's stamped ``exp_group`` (int), or None if absent."""
+    if isinstance(path_or_header, fits.Header):
+        header = path_or_header
+    else:
+        header = fits.getheader(path_or_header)
+    val = header.get(EXP_GROUP_KEYWORD)
+    return int(val) if val is not None else None
+
+
 def read_schema_version(path_or_header):
     """Return a canonical file's format version (int).
 

--- a/pipeline/campfire_pipeline/nirspec/stage2.py
+++ b/pipeline/campfire_pipeline/nirspec/stage2.py
@@ -361,6 +361,12 @@ def run_stage2a(obs, stage_config, source_ids='all', overwrite=False,
                 _skip_stuck_detection=True,
             )
 
+    # Stamp the pipeline-computed exp_group (CFEXPGRP) on each canonical's primary
+    # header (§4.2) so deploy populates the nods grid with the exact grouping. Runs
+    # on every run_stage2a invocation (incl. the stuck-shutter re-run above, which
+    # regenerates its canonicals), so all files end up stamped.
+    dispatch(stamp_exp_group_single, list(files), n_processes=n_processes)
+
 
 def run_stage2b(obs, stage_config, source_ids='all', overwrite=False,
                 n_processes=1, data_dir=None, products_dir=None):
@@ -448,6 +454,10 @@ def run_stage2b(obs, stage_config, source_ids='all', overwrite=False,
         use_starmap=True,
         rectify=rectify,
     )
+
+    # Re-stamp exp_group (CFEXPGRP) after bkgsub's canonical re-saves — this is the
+    # final on-disk state deploy reads (§4.2). Idempotent with the stage2a stamp.
+    dispatch(stamp_exp_group_single, list(files), n_processes=n_processes)
 
     # Optional: plot background-subtracted 2D cutouts
     if plot_bkgsub and rectify:
@@ -889,6 +899,20 @@ def _bkgsub_group_done(canonical_path, rectify):
     if str(cfp_bkg).startswith(('skipped', 'excluded')):
         return True
     return (not rectify) or ('CFP_S2D' in hdr)
+
+
+def stamp_exp_group_single(file):
+    """Stamp ``CFEXPGRP`` (the pipeline-computed exp_group) on one canonical's
+    primary header (NIRSpec review loop §4.2).
+
+    Dispatched over the grouped ``files`` table at the end of stage2a/2b so deploy
+    can populate the web nods-renderer grid with the exact pipeline grouping. Uses
+    ``append_extras`` (which copies the existing header) — additive and idempotent,
+    surviving stage2b's re-save the same way ``CFSCHEMA`` does. Mirrors the
+    per-file ``fix_units`` dispatch shape.
+    """
+    from campfire_pipeline.nirspec import canonical as C
+    C.append_extras(file['path'], header_updates=C.exp_group_card(file['exp_group']))
 
 
 def fix_units(file):

--- a/pipeline/tests/test_exp_group_stamp.py
+++ b/pipeline/tests/test_exp_group_stamp.py
@@ -1,0 +1,44 @@
+"""P4: the CFEXPGRP exp_group card round-trips and survives an append_extras re-save.
+
+Guards the design §4.2/§8 contract that the pipeline-stamped exp_group is what
+deploy reads. Uses astropy directly (no jwst), guarded by importorskip so it runs
+in CI and is skipped where campfire_pipeline isn't installed.
+"""
+import pytest
+
+pytest.importorskip("campfire_pipeline")
+import numpy as np  # noqa: E402
+from astropy.io import fits  # noqa: E402
+
+from campfire_pipeline.nirspec import canonical as C  # noqa: E402
+
+
+def _minimal_canonical(path):
+    fits.HDUList([
+        fits.PrimaryHDU(),
+        fits.ImageHDU(np.zeros((4, 4), dtype="float32"), name="SCI"),
+    ]).writeto(path, overwrite=True)
+
+
+def test_exp_group_card_shape():
+    card = C.exp_group_card(np.int64(7))
+    assert card == {C.EXP_GROUP_KEYWORD: (7, C.EXP_GROUP_COMMENT)}
+    assert isinstance(card[C.EXP_GROUP_KEYWORD][0], int)  # numpy int coerced
+
+
+def test_exp_group_round_trips_and_survives_append_extras(tmp_path):
+    p = str(tmp_path / "jw07076020001_04101_00001_nrs1_117757.fits")
+    _minimal_canonical(p)
+
+    C.append_extras(p, header_updates=C.exp_group_card(5))
+    assert C.read_exp_group(p) == 5
+
+    # a subsequent append_extras (e.g. stage2b re-stamp / an S2D append) preserves it
+    C.append_extras(p, header_updates={"OTHERKEY": (1, "unrelated")})
+    assert C.read_exp_group(p) == 5
+
+
+def test_read_exp_group_absent_is_none(tmp_path):
+    p = str(tmp_path / "no_stamp.fits")
+    _minimal_canonical(p)
+    assert C.read_exp_group(p) is None

--- a/python/campfire/deploy/deploy.py
+++ b/python/campfire/deploy/deploy.py
@@ -367,6 +367,18 @@ def _deploy_intermediates_only(
             sb, build_rate_exposure_records(rate_files, observation=obs_name, scope=scope))
         print(f"Upserted {n_rate} rate-exposure triage rows")
 
+    # Nods-renderer grid rows (P4, design §4.2): one per (obs, exposure_root, nod,
+    # detector, source), exp_group from the CFEXPGRP header stamp. Split-ownership
+    # upsert. exposure_files is already source-filtered — correct, the grid is
+    # per-source.
+    if exposure_files:
+        from campfire.deploy.spectrum_grid import (
+            build_spectrum_exposure_records, upsert_spectrum_exposures,
+        )
+        n_grid = upsert_spectrum_exposures(
+            sb, build_spectrum_exposure_records(exposure_files, observation=obs_name, scope=scope))
+        print(f"Upserted {n_grid} spectrum-exposure grid rows")
+
     claim = claim_deploy_scope(sb, 'observation', obs_name, scope_version_at_start, actor=user_id)
     if claim.get('conflict'):
         print(f"⚠  CONCURRENT DEPLOY DETECTED for {obs_name}: another deploy advanced "
@@ -650,6 +662,7 @@ def deploy_observation(
         upload_tasks: list[UploadTask] = []
         uploaded_keys: set[str] = set()  # r2_keys that actually landed (for the registry)
         rate_files: list = []  # populated in the not-supabase_only block; drives P2 triage upsert
+        exposure_files: list = []  # canonical spectrum-exposures; drives the P4 nods grid
         scope = Scope(obs=obs_name)
 
         # NIRSpec science products are homed on OSN under CANONICAL keys (epic #210 /
@@ -948,6 +961,17 @@ def deploy_observation(
             n_rate = upsert_rate_exposures(
                 sb, build_rate_exposure_records(rate_files, observation=obs_name, scope=scope))
             print(f"Upserted {n_rate} rate-exposure triage rows")
+
+        # Nods-renderer grid rows (P4, design §4.2): one per (obs, exposure_root,
+        # nod, detector, source), exp_group from the CFEXPGRP header stamp.
+        # Split-ownership upsert; exposure_files is already source-filtered.
+        if exposure_files:
+            from campfire.deploy.spectrum_grid import (
+                build_spectrum_exposure_records, upsert_spectrum_exposures,
+            )
+            n_grid = upsert_spectrum_exposures(
+                sb, build_spectrum_exposure_records(exposure_files, observation=obs_name, scope=scope))
+            print(f"Upserted {n_grid} spectrum-exposure grid rows")
 
         print()
         msg = f"Deployed {len(spectra)} spectra from {len(objects)} objects"

--- a/python/campfire/deploy/spectrum_grid.py
+++ b/python/campfire/deploy/spectrum_grid.py
@@ -1,0 +1,178 @@
+"""NIRSpec nods-grid population (P4, design §4.2).
+
+Populates the revived ``spectrum_exposures`` table — the render grid the web nods
+renderer (P5) reads — from the canonical per-source spectrum-exposure files deploy
+already discovers/uploads. Rows are grouped ``rows=(exp_group, nod) × cols=detector``
+per ``(observation, source_id)``, matching the pipeline's ``*_nods.pdf`` exactly
+because ``exp_group`` comes from the pipeline-stamped ``CFEXPGRP`` header card (not
+reconstructed here — it depends on the whole exposure set's dither pattern).
+
+Split ownership mirrors ``rate_exposures`` / ``nircam._upsert_exposures``: a
+re-deploy UPDATE writes ONLY identity/render columns and OMITS
+``review_status``/``masking``/``notes`` so web triage is never clobbered; new rows
+seed ``review_status='pending'``, ``masking='none'``.
+
+Terminology note: ``spectrum_exposures.exposure_root`` is the pipeline's 2-token
+root (``jw07076020001_04101``) with the exposure token broken out as ``nod`` — this
+DIFFERS from ``nirspec_rate_exposures.exposure_root`` (3 tokens, detector-stripped).
+The divergence is deliberate: it matches the pipeline's own ``root``/``nod`` split
+(``observation.group_files``) and the nods grid key.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from campfire_layout import KeyScheme, Scope, storage_key
+
+_RATE_SUFFIX = "_rate.fits"
+_SPEC_SUFFIX = "_spec.fits"
+
+
+def parse_spectrum_exposure_filename(name: str) -> tuple[str, str, str, int]:
+    """``jw07076020001_04101_00001_nrs1_117757.fits`` → (exposure_root, nod, detector, source_id).
+
+    Anchors on the ``nrs[12]`` token (the only unambiguous marker — source ids are
+    numeric and could be mistaken for other tokens): ``exposure_root`` is everything
+    before ``nod``, ``nod`` is the token before the detector, ``detector`` is
+    ``nrs1``/``nrs2``, ``source_id`` is the token after. Raises ValueError for
+    non-canonical names (rate files, finals, or a missing/int-unparseable source).
+    """
+    if not name.endswith(".fits") or name.endswith(_RATE_SUFFIX) or name.endswith(_SPEC_SUFFIX):
+        raise ValueError(f"not a canonical spectrum-exposure filename: {name!r}")
+    tokens = name[: -len(".fits")].split("_")
+    det_idx = next((i for i, t in enumerate(tokens) if t in ("nrs1", "nrs2")), None)
+    if det_idx is None or det_idx < 2 or det_idx + 1 >= len(tokens):
+        raise ValueError(f"no nrs[12] token / malformed: {name!r}")
+    detector = tokens[det_idx]
+    nod = tokens[det_idx - 1]
+    exposure_root = "_".join(tokens[:det_idx - 1])
+    try:
+        source_id = int(tokens[det_idx + 1])
+    except ValueError:
+        raise ValueError(f"non-integer source id in {name!r}") from None
+    return exposure_root, nod, detector, source_id
+
+
+def read_spectrum_metadata(path: Path) -> tuple[int | None, str | None, int | None, int | None]:
+    """Best-effort ``(exp_group, grating, image_width, image_height)`` from a canonical FITS.
+
+    ``exp_group`` from the ``CFEXPGRP`` primary card (None if the file predates the
+    P4 stamp — the row is still created, the web falls back gracefully), ``grating``
+    from ``GRATING``, dims from the ``S2D_SCI`` rectified view (what the renderer
+    shows) falling back to ``SCI``. Any failure degrades to None, like
+    ``rate_exposures.read_rate_metadata``.
+    """
+    try:
+        from astropy.io import fits
+        with fits.open(path, memmap=False) as hdul:
+            phdr = hdul[0].header
+            eg = phdr.get("CFEXPGRP")
+            exp_group = int(eg) if eg is not None else None
+            grating = phdr.get("GRATING")
+            width = height = None
+            for ext in ("S2D_SCI", "SCI"):
+                if ext in hdul:
+                    h = hdul[ext].header
+                    width, height = h.get("NAXIS1"), h.get("NAXIS2")
+                    break
+            return exp_group, grating, width, height
+    except Exception:
+        return None, None, None, None
+
+
+def build_spectrum_exposure_records(
+    exposure_files: list[Path], *, observation: str, scope: Scope,
+) -> list[dict]:
+    """One grid record per canonical file (pre-partition; identity + render columns)."""
+    records = []
+    for path in exposure_files:
+        exposure_root, nod, detector, source_id = parse_spectrum_exposure_filename(path.name)
+        exp_group, grating, width, height = read_spectrum_metadata(path)
+        records.append({
+            "observation": observation,
+            "exposure_root": exposure_root,
+            "nod": nod,
+            "detector": detector,
+            "source_id": source_id,
+            "exp_group": exp_group,
+            "grating": grating,
+            "filename": path.name,
+            "image_width": width,
+            "image_height": height,
+            "storage_key": storage_key(
+                "nirspec_spectrum_exposure", scope, path.name, scheme=KeyScheme.CANONICAL),
+            "stage": "cal",
+        })
+    return records
+
+
+# Columns deploy owns on a re-register (everything else is web-owned triage).
+_IDENTITY_COLS = ("observation", "exposure_root", "nod", "detector", "source_id", "filename", "stage")
+_RENDER_COLS = ("exp_group", "grating", "image_width", "image_height", "storage_key")
+
+
+def partition_spectrum_records(
+    records: list[dict], existing_keys: set[tuple], now: str,
+) -> tuple[list[dict], list[dict]]:
+    """Split into (new_rows, update_rows) with split ownership.
+
+    New rows seed ``review_status='pending'``/``masking='none'``. Update rows carry
+    ONLY identity + non-null render columns (+ ``updated_at``) — never the web-owned
+    triage columns — so a re-deploy leaves reviewer decisions intact.
+    """
+    new_records, update_records = [], []
+    for r in records:
+        key = (r["observation"], r["exposure_root"], r["nod"], r["detector"], r["source_id"])
+        if key in existing_keys:
+            update = {c: r[c] for c in _IDENTITY_COLS}
+            update["updated_at"] = now
+            for c in _RENDER_COLS:
+                if r.get(c) is not None:
+                    update[c] = r[c]
+            update_records.append(update)
+        else:
+            new_records.append({
+                **r,
+                "review_status": "pending",
+                "masking": "none",
+                "created_at": now,
+                "updated_at": now,
+            })
+    return new_records, update_records
+
+
+def upsert_spectrum_exposures(client, records: list[dict], batch_size: int = 500) -> int:
+    """Upsert grid rows, preserving web triage on existing rows. Returns the row count.
+
+    Mirrors ``rate_exposures.upsert_rate_exposures``: batched SELECT to find existing
+    conflict tuples, then a plain ``.insert()`` for new rows and an
+    ``.upsert(on_conflict=…)`` for existing rows with the identity/render-only dict.
+    """
+    if not records:
+        return 0
+
+    filenames = [r["filename"] for r in records]
+    existing: set[tuple] = set()
+    for i in range(0, len(filenames), batch_size):
+        batch = filenames[i:i + batch_size]
+        resp = (client.table("spectrum_exposures")
+                .select("observation, exposure_root, nod, detector, source_id, filename")
+                .in_("filename", batch)
+                .execute())
+        for row in resp.data:
+            existing.add((row["observation"], row["exposure_root"], row["nod"],
+                          row["detector"], row["source_id"]))
+
+    now = datetime.now(timezone.utc).isoformat()
+    new_records, update_records = partition_spectrum_records(records, existing, now)
+
+    for i in range(0, len(new_records), batch_size):
+        client.table("spectrum_exposures").insert(new_records[i:i + batch_size]).execute()
+    for i in range(0, len(update_records), batch_size):
+        client.table("spectrum_exposures").upsert(
+            update_records[i:i + batch_size],
+            on_conflict="observation,exposure_root,nod,detector,source_id",
+        ).execute()
+
+    return len(records)

--- a/python/tests/sql/b2_lifecycle.sql
+++ b/python/tests/sql/b2_lifecycle.sql
@@ -41,10 +41,14 @@ DO $$ BEGIN
   END IF;
 END $$;
 
--- A spectrum_exposures row for an object-3 spectrum, so the admin-only RLS on
--- that table is exercised against real data (it is otherwise empty here).
-INSERT INTO public.spectrum_exposures (spectrum_id, exposure_ref, stage)
-  SELECT (SELECT id FROM _o3spec ORDER BY id LIMIT 1), 'harness_root_1_nrs1_999', 'cal';
+-- A spectrum_exposures row so the admin-only RLS on that table is exercised
+-- against real data (it is otherwise empty here). The table no longer FKs to
+-- spectra (review-loop P4 revived it as the nods grid, re-keyed to
+-- observations.name), so a standalone row is valid.
+INSERT INTO public.spectrum_exposures
+    (observation, exposure_root, nod, detector, source_id, filename, stage)
+  VALUES ('harness_obs', 'jw_harness_1', '00001', 'nrs1', 999,
+          'jw_harness_1_00001_nrs1_999.fits', 'cal');
 
 -- A deployment for object 3's observation, to exercise the DEPLOYMENT-level
 -- lifecycle (set_deployment_status) — the path B3's admin UI uses (section H).

--- a/python/tests/test_spectrum_grid.py
+++ b/python/tests/test_spectrum_grid.py
@@ -1,0 +1,116 @@
+"""Unit tests for the P4 nods-grid population (design §4.2).
+
+Pure functions, no DB/cloud: the canonical-filename parse, the record builder's
+key columns, and the split-ownership partition. The full insert/upsert round-trip
+runs live against local Supabase in CI (`campfire deploy … --local`).
+"""
+import pytest
+
+from campfire_layout import Scope
+from campfire.deploy.spectrum_grid import (
+    build_spectrum_exposure_records,
+    parse_spectrum_exposure_filename,
+    partition_spectrum_records,
+)
+
+
+def test_parse_spectrum_exposure_filename():
+    assert parse_spectrum_exposure_filename(
+        "jw07076020001_04101_00001_nrs1_117757.fits"
+    ) == ("jw07076020001_04101", "00001", "nrs1", 117757)
+    assert parse_spectrum_exposure_filename(
+        "jw07076020001_04101_00002_nrs2_120383.fits"
+    ) == ("jw07076020001_04101", "00002", "nrs2", 120383)
+
+
+def test_parse_rejects_rate_and_final_and_bad():
+    with pytest.raises(ValueError):
+        parse_spectrum_exposure_filename("jw07076020001_04101_00001_nrs1_rate.fits")
+    with pytest.raises(ValueError):
+        parse_spectrum_exposure_filename("ember_egs_p1_prism_clear_117757_spec.fits")
+    with pytest.raises(ValueError):
+        parse_spectrum_exposure_filename("jw07076020001_04101_00001_nrs1_notanint.fits")
+
+
+def test_exposure_root_divergence_from_rate_table():
+    # spectrum_exposures.exposure_root = 2 tokens (exposure token split out as nod);
+    # nirspec_rate_exposures.exposure_root = 3 tokens (detector-stripped). Deliberate.
+    root, nod, det, sid = parse_spectrum_exposure_filename(
+        "jw07076020001_04101_00001_nrs1_117757.fits")
+    assert root == "jw07076020001_04101"   # 2 tokens, NOT jw..._04101_00001
+    assert nod == "00001"
+    assert det == "nrs1" and sid == 117757
+
+
+def test_build_records_shape(tmp_path):
+    p = tmp_path / "jw07076020001_04101_00001_nrs1_117757.fits"
+    p.write_bytes(b"\x00")
+    recs = build_spectrum_exposure_records(
+        [p], observation="ember_egs_p1", scope=Scope(obs="ember_egs_p1"))
+    assert len(recs) == 1
+    r = recs[0]
+    assert r["observation"] == "ember_egs_p1"
+    assert r["exposure_root"] == "jw07076020001_04101"
+    assert r["nod"] == "00001"
+    assert r["detector"] == "nrs1"
+    assert r["source_id"] == 117757
+    assert r["stage"] == "cal"
+    assert r["storage_key"] == (
+        "data/products/nirspec/ember_egs_p1/jw07076020001_04101_00001_nrs1_117757.fits")
+    # unreadable stub → metadata degrades to None, never raises
+    assert r["exp_group"] is None and r["grating"] is None
+    assert r["image_width"] is None and r["image_height"] is None
+
+
+def _record(**over):
+    base = {
+        "observation": "ember_egs_p1",
+        "exposure_root": "jw07076020001_04101",
+        "nod": "00001",
+        "detector": "nrs1",
+        "source_id": 117757,
+        "exp_group": 3,
+        "grating": "PRISM",
+        "filename": "jw07076020001_04101_00001_nrs1_117757.fits",
+        "storage_key": "data/products/nirspec/ember_egs_p1/x.fits",
+        "image_width": 40,
+        "image_height": 400,
+        "stage": "cal",
+    }
+    base.update(over)
+    return base
+
+
+def test_partition_new_row_seeds_pending_and_none():
+    new, upd = partition_spectrum_records([_record()], existing_keys=set(), now="T")
+    assert upd == []
+    assert len(new) == 1
+    assert new[0]["review_status"] == "pending"
+    assert new[0]["masking"] == "none"
+    assert new[0]["created_at"] == "T" and new[0]["updated_at"] == "T"
+
+
+def test_partition_existing_row_omits_web_owned_columns():
+    key = {("ember_egs_p1", "jw07076020001_04101", "00001", "nrs1", 117757)}
+    new, upd = partition_spectrum_records([_record()], existing_keys=key, now="T")
+    assert new == []
+    assert len(upd) == 1
+    update = upd[0]
+    for web_col in ("review_status", "masking", "notes", "created_at"):
+        assert web_col not in update, web_col
+    assert update["updated_at"] == "T"
+    for col in ("observation", "exposure_root", "nod", "detector", "source_id",
+                "filename", "stage", "exp_group", "grating", "image_width",
+                "image_height", "storage_key"):
+        assert col in update
+
+
+def test_partition_existing_row_skips_null_render_columns():
+    rec = _record(exp_group=None, grating=None, image_width=None, image_height=None)
+    key = {("ember_egs_p1", "jw07076020001_04101", "00001", "nrs1", 117757)}
+    _, upd = partition_spectrum_records([rec], existing_keys=key, now="T")
+    update = upd[0]
+    assert "exp_group" not in update
+    assert "grating" not in update
+    assert "image_width" not in update
+    assert update["storage_key"] == rec["storage_key"]  # non-null render kept

--- a/supabase/migrations/20260704190000_revise_spectrum_exposures_nods_grid.sql
+++ b/supabase/migrations/20260704190000_revise_spectrum_exposures_nods_grid.sql
@@ -1,0 +1,69 @@
+-- Revive + revise spectrum_exposures as the NIRSpec nods-renderer grid (P4, review
+-- loop, design §2c/§4.2). The table was a dead epic-#210-B2 scaffold: its
+-- spectrum_id NOT NULL FK to spectra was unsatisfiable for an intermediates-only
+-- deploy (which runs BEFORE stage-3 combine makes any spectrum row), and nothing in
+-- production ever read or wrote it (only the b2_lifecycle RLS test inserted a row).
+-- So we DROP + RECREATE it, dropping the spectra FK and re-keying to observations.name
+-- with UNIQUE (observation, exposure_root, nod, detector, source_id) + render columns
+-- (exp_group from the pipeline CFEXPGRP stamp, storage_key, dims). Safe because the
+-- table is empty; seed.sql is unaffected (generate_seed.py never emits it). Mirrors
+-- the 20260704180000_add_nirspec_rate_exposures.sql create idiom.
+
+drop table if exists "public"."spectrum_exposures" cascade;
+drop sequence if exists "public"."spectrum_exposures_id_seq";
+
+create sequence "public"."spectrum_exposures_id_seq";
+
+create table "public"."spectrum_exposures" (
+    "id" integer not null default nextval('public.spectrum_exposures_id_seq'::regclass),
+    "observation" text not null,
+    "exposure_root" text not null,
+    "nod" text not null,
+    "detector" text not null,
+    "source_id" integer not null,
+    "exp_group" integer,
+    "grating" text,
+    "filename" text not null,
+    "storage_key" text,
+    "image_width" integer,
+    "image_height" integer,
+    "stage" text not null default 'cal'::text,
+    "review_status" text not null default 'pending'::text,
+    "masking" text not null default 'none'::text,
+    "notes" text,
+    "created_at" timestamp with time zone not null default now(),
+    "updated_at" timestamp with time zone not null default now()
+);
+
+alter table "public"."spectrum_exposures" enable row level security;
+
+alter sequence "public"."spectrum_exposures_id_seq" owned by "public"."spectrum_exposures"."id";
+
+CREATE UNIQUE INDEX spectrum_exposures_pkey ON public.spectrum_exposures USING btree (id);
+
+CREATE UNIQUE INDEX spectrum_exposures_unique ON public.spectrum_exposures USING btree (observation, exposure_root, nod, detector, source_id);
+
+CREATE INDEX idx_spectrum_exposures_observation ON public.spectrum_exposures USING btree (observation);
+
+CREATE INDEX idx_spectrum_exposures_review ON public.spectrum_exposures USING btree (review_status) WHERE (review_status <> 'approved'::text);
+
+alter table "public"."spectrum_exposures" add constraint "spectrum_exposures_pkey" PRIMARY KEY using index "spectrum_exposures_pkey";
+
+alter table "public"."spectrum_exposures" add constraint "spectrum_exposures_unique" UNIQUE using index "spectrum_exposures_unique";
+
+grant all on table "public"."spectrum_exposures" to "authenticated";
+
+grant all on table "public"."spectrum_exposures" to "service_role";
+
+create policy "admin_select_spectrum_exposures"
+  on "public"."spectrum_exposures" as permissive for select to authenticated
+  using (( SELECT public.is_admin() AS is_admin));
+
+create policy "admin_insert_spectrum_exposures"
+  on "public"."spectrum_exposures" as permissive for insert to authenticated
+  with check (( SELECT public.is_admin() AS is_admin));
+
+create policy "admin_update_spectrum_exposures"
+  on "public"."spectrum_exposures" as permissive for update to authenticated
+  using (( SELECT public.is_admin() AS is_admin))
+  with check (( SELECT public.is_admin() AS is_admin));

--- a/supabase/schemas/indexes.sql
+++ b/supabase/schemas/indexes.sql
@@ -364,14 +364,11 @@ CREATE INDEX IF NOT EXISTS idx_nirspec_rate_exposures_review
 
 
 -- =============================================================================
--- spectrum_exposures (epic #210, B2)
+-- spectrum_exposures (nods-renderer grid; review loop P4)
 -- =============================================================================
 
-CREATE INDEX IF NOT EXISTS idx_spectrum_exposures_spectrum_id
-    ON public.spectrum_exposures USING btree (spectrum_id);
-
-CREATE INDEX IF NOT EXISTS idx_spectrum_exposures_exposure_ref
-    ON public.spectrum_exposures USING btree (exposure_ref);
+CREATE INDEX IF NOT EXISTS idx_spectrum_exposures_observation
+    ON public.spectrum_exposures USING btree (observation);
 
 CREATE INDEX IF NOT EXISTS idx_spectrum_exposures_review
     ON public.spectrum_exposures USING btree (review_status)

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -815,23 +815,32 @@ ALTER SEQUENCE "public"."nirspec_rate_exposures_id_seq" OWNER TO "postgres";
 ALTER SEQUENCE "public"."nirspec_rate_exposures_id_seq" OWNED BY "public"."nirspec_rate_exposures"."id";
 
 
--- spectrum_exposures: NIRSpec canonical spectrum-exposure intermediates (epic
--- #210, B2). One logical row per (exposure, detector, source) that combines into
--- a final spectrum — the NIRSpec analogue of nircam_exposures. Child of spectra
--- (FK to the stable integer PK, not the GENERATED spectrum_id). Admin-only: these
--- are reduction intermediates, never user-facing science. The physical object
--- (key/hash/size/backend) lives in storage_objects (product_type
--- 'nirspec_spectrum_exposure'); this table owns the reviewer-facing lifecycle
--- state (stage, review_status, masking, notes) and the join key (exposure_ref).
+-- spectrum_exposures: NIRSpec nods-renderer grid (NIRSpec review loop, P4, design
+-- §2c/§4.2). One row per canonical per-source spectrum-exposure
+-- (observation, exposure_root, nod, detector, source_id) — the render backbone the
+-- web nods renderer groups as rows=(exp_group, nod) × cols=detector per source.
+-- REVIVED + REVISED from the epic-#210-B2 dead scaffold: the old spectrum_id NOT
+-- NULL FK to spectra was unsatisfiable for an intermediates-only deploy (which runs
+-- BEFORE stage-3 combine makes any spectrum row), so it is dropped and the table is
+-- re-keyed to observations.name (no FK). Deploy-populated (split-ownership upsert,
+-- campfire.deploy.spectrum_grid) — exp_group comes from the pipeline's CFEXPGRP
+-- header stamp. Admin-only: reduction intermediates, never user-facing science. The
+-- physical object (key/hash/size/backend) lives in storage_objects (product_type
+-- 'nirspec_spectrum_exposure'); this table owns render columns + reviewer lifecycle
+-- state (review_status, masking, notes — the last two set by the web, not deploy).
 CREATE TABLE IF NOT EXISTS "public"."spectrum_exposures" (
     "id" integer NOT NULL,
-    "spectrum_id" integer NOT NULL,
-    "exposure_ref" "text" NOT NULL,
-    "root" "text",
-    "nod" integer,
-    "detector" "text",
-    "source_id" integer,
+    "observation" "text" NOT NULL,
+    "exposure_root" "text" NOT NULL,
+    "nod" "text" NOT NULL,
+    "detector" "text" NOT NULL,
+    "source_id" integer NOT NULL,
+    "exp_group" integer,
     "grating" "text",
+    "filename" "text" NOT NULL,
+    "storage_key" "text",
+    "image_width" integer,
+    "image_height" integer,
     "stage" "text" NOT NULL DEFAULT 'cal'::"text",
     "review_status" "text" NOT NULL DEFAULT 'pending'::"text",
     "masking" "text" NOT NULL DEFAULT 'none'::"text",
@@ -859,11 +868,11 @@ ALTER SEQUENCE "public"."spectrum_exposures_id_seq" OWNER TO "postgres";
 ALTER SEQUENCE "public"."spectrum_exposures_id_seq" OWNED BY "public"."spectrum_exposures"."id";
 
 
-COMMENT ON TABLE "public"."spectrum_exposures" IS 'NIRSpec canonical spectrum-exposure intermediates (epic #210, B2). One logical row per (exposure,detector,source); child of spectra (FK to integer PK). Registered to storage_objects with product_type=''nirspec_spectrum_exposure''. Admin-only lifecycle (intermediates are never user-facing science).';
+COMMENT ON TABLE "public"."spectrum_exposures" IS 'NIRSpec nods-renderer grid (review loop P4). One row per canonical per-source spectrum-exposure (observation, exposure_root, nod, detector, source_id); deploy-populated, admin-only. exp_group is the pipeline CFEXPGRP grouping. Revived+revised from the epic-#210-B2 scaffold (dropped the spectra FK; re-keyed to observations.name).';
 
-COMMENT ON COLUMN "public"."spectrum_exposures"."spectrum_id" IS 'FK to spectra.id (the stable integer PK, NOT the GENERATED spectra.spectrum_id text column which is not uniquely constrained). ON DELETE CASCADE: intermediates die with their parent spectrum and are rebuilt on the next deploy.';
+COMMENT ON COLUMN "public"."spectrum_exposures"."exposure_root" IS 'Pipeline 2-token root (e.g. jw07076020001_04101), with the exposure token broken out as `nod`. NB: DIFFERENT semantics from nirspec_rate_exposures.exposure_root (3 tokens, detector-stripped) — deliberate, matching observation.group_files and the nods grid key.';
 
-COMMENT ON COLUMN "public"."spectrum_exposures"."exposure_ref" IS 'Stable (root,nod,detector,source) tuple identifying the input NIRSpec exposure. Matches storage_objects.exposure_ref for the registry join; backs the partial unique (product_type, exposure_ref) WHERE status=''active'' on storage_objects.';
+COMMENT ON COLUMN "public"."spectrum_exposures"."exp_group" IS 'Pipeline-computed exposure-group id (subpixel-dither), read from the canonical FITS CFEXPGRP header card. One value per group, spanning nods+detectors; a render/grouping attribute, NOT part of the unique key. Nullable (files predating the P4 stamp).';
 
 
 -- storage_objects: the keystone shadow index of every object in cloud storage
@@ -1532,7 +1541,7 @@ ALTER TABLE ONLY "public"."spectrum_exposures"
     ADD CONSTRAINT "spectrum_exposures_pkey" PRIMARY KEY ("id");
 
 ALTER TABLE ONLY "public"."spectrum_exposures"
-    ADD CONSTRAINT "spectrum_exposures_unique" UNIQUE ("spectrum_id", "exposure_ref");
+    ADD CONSTRAINT "spectrum_exposures_unique" UNIQUE ("observation", "exposure_root", "nod", "detector", "source_id");
 
 ALTER TABLE ONLY "public"."deploy_events"
     ADD CONSTRAINT "deploy_events_pkey" PRIMARY KEY ("id");
@@ -1613,11 +1622,9 @@ ALTER TABLE ONLY "public"."spectra"
 
 -- B2 (#218) cross-table FKs, placed after the referenced PKs (spectra_pkey above,
 -- deployments_pkey earlier) so the declarative build order resolves them.
--- spectrum_exposures -> spectra.id, CASCADE: intermediates die with their parent
--- spectrum and are rebuilt on the next deploy.
-ALTER TABLE ONLY "public"."spectrum_exposures"
-    ADD CONSTRAINT "spectrum_exposures_spectrum_id_fkey" FOREIGN KEY ("spectrum_id") REFERENCES "public"."spectra"("id") ON DELETE CASCADE;
-
+-- (spectrum_exposures no longer FKs to spectra — the review loop P4 revive re-keyed
+-- it to observations.name so intermediates-only deploys, which precede stage-3
+-- combine, can populate it before any spectrum row exists.)
 -- deploy_events -> deployments.id, SET NULL: audit rows outlive the deployment
 -- they reference (don't cascade-delete history), matching storage_objects.deployment_id.
 ALTER TABLE ONLY "public"."deploy_events"


### PR DESCRIPTION
**P4** — the first **Track N** phase of the NIRSpec web review loop (`docs/design-nirspec-review-loop.md` §2c/§4.2/§9-P4). Builds the render backbone for the live nods renderer (P5): the pipeline stamps the computed `exp_group` onto each canonical FITS header, and the dead `spectrum_exposures` scaffold is revived+revised into the deploy-populated grid. Spans **pipeline + schema + deploy**.

## Pipeline — Infrastructure/PATCH (additive provenance, no pixel/flux change)
- **`canonical.py`**: `exp_group_card` / `read_exp_group` + the `CFEXPGRP` keyword, mirroring the `CFSCHEMA` standalone-card precedent (survives `cfpipe nirspec reset` and stage2b's MultiSlitModel re-save).
- **`stage2.py`**: a final `dispatch(stamp_exp_group_single, list(files))` pass at the end of **both** `run_stage2a` and `run_stage2b` writes `CFEXPGRP` (via `append_extras`, which copies the header) from each grouped `files` row's `exp_group`. `exp_group` is **not** derivable from a filename — it depends on the whole exposure set's subpixel-dither pattern (`observation.group_files`) — so the stamp is what lets deploy reproduce the pipeline grouping exactly.

## Schema — one drop+recreate migration
The table was a **dead scaffold**: empty, no production reader/writer, only the b2 RLS test inserted a row (verified by grepping the whole repo). So:
- **Revise `spectrum_exposures`**: drop the unsatisfiable `spectrum_id NOT NULL` FK to `spectra` (an intermediates-only deploy precedes stage-3 combine, so no spectrum row exists yet), re-key to `UNIQUE(observation, exposure_root, nod, detector, source_id)`, add `exp_group` + render columns (`storage_key`, image dims, `filename`). `tables.sql`/`indexes.sql` + a hand-authored migration mirroring the P2 create idiom; policies unchanged.
- `exp_group` is a **render attribute, not part of the key** (it spans nods+detectors within a dither group).
- **No seed regen** — `generate_seed.py` never emits this table and `seed.sql` has zero rows.
- **`b2_lifecycle.sql`**: fixture INSERT updated to the new shape (standalone row, no `spectra` FK) — still exercises the admin-only RLS count assertions.

## Deploy
New **`campfire.deploy.spectrum_grid`** (mirrors `rate_exposures`): parses `(observation, exposure_root, nod, detector, source_id)` **anchored on the `nrs[12]` token** (source ids are numeric, so positional parsing is unsafe), reads `exp_group`/`grating`/dims (from `S2D_SCI`) off the header, and does a split-ownership upsert (identity/render columns only; never clobbers `review_status`/`masking`/`notes`). Wired into both deploy entry points alongside the P2 rate block.

## One divergence worth flagging
`spectrum_exposures.exposure_root` is **2 tokens** (the exposure token split out as `nod`, matching `observation.group_files` and the grid), whereas `nirspec_rate_exposures.exposure_root` is **3 tokens** (detector-stripped). Same column name, deliberately different semantics — documented in the column comment, the module docstring, and asserted by a test so nobody "harmonizes" them.

## Testing
- **Local:** deploy-side parse/build/partition (7 cases) + the rate suite — **14 passed**. Deploy suite **166 passed, no regressions** (the 1 failure is a pre-existing matplotlib env gap in the sandbox). Schema↔migration column sets verified **identical (18 cols)**.
- **CI:** the `CFEXPGRP` card round-trip + `append_extras`-survival test (`importorskip`), and the full insert/upsert against local Supabase via `campfire deploy … --local`.
- **The Supabase preview branch applies the drop+recreate migration** — the real validator for it.

## Verify on real data (design §8/OQ-7)
The one thing needing a real pipeline run to confirm (as the design flags): after `cfpipe nirspec run`, that `CFEXPGRP` is present, equals the `plots.py` grouping, and survives a stage2b re-run — and that `_deploy_intermediates_only` reads the same value as a full deploy. The stamp is written in stage2 (before either deploy path), so by construction they agree.

## Scope / safety
One schema-changing PR (P2's migration already merged). No `web/` change. Merges inert — the grid is admin-only + deploy-populated and nothing reads it until the P5 renderer; the stamp is additive provenance.

Generated with Claude Code

https://claude.ai/code/session_01SQiCGrfdaQu5cF9dbVCJNd

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQiCGrfdaQu5cF9dbVCJNd)_