### PR TITLE
NIRSpec review loop P5 — live nods renderer

### DIFF
--- a/web/app/admin/layout.tsx
+++ b/web/app/admin/layout.tsx
@@ -24,6 +24,7 @@ const adminNavSections: {
     items: [
       { href: '/admin/nircam', label: 'NIRCam', icon: Camera },
       { href: '/admin/nirspec/rate', label: 'NIRSpec Rate', icon: Telescope },
+      { href: '/admin/nirspec/nods', label: 'NIRSpec Nods', icon: Telescope },
       { href: '/admin/deployments', label: 'Deployments', icon: GitBranch },
       { href: '/admin/intermediate-products', label: 'Storage', icon: Database },
     ],

--- a/web/app/admin/nirspec/nods/[source]/page.tsx
+++ b/web/app/admin/nirspec/nods/[source]/page.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { Card } from '@/components/ui/Card';
+import { Loader2, ArrowLeft } from 'lucide-react';
+import { getNirspecNodGrid } from '@/lib/actions/nirspec-nods';
+import { buildNodGrid, decodeSource, NOD_DETECTORS } from '@/lib/nirspec-nods';
+import { zscaleLimits, type StretchMode, type ColormapName } from '@/lib/fits';
+import type { SpectrumExposure } from '@/lib/types';
+import NodCell from '@/components/nirspec/NodCell';
+
+function sharedRange(arrays: Float32Array[]): [number, number] | null {
+  if (arrays.length === 0) return null;
+  const total = arrays.reduce((n, a) => n + a.length, 0);
+  const concat = new Float32Array(total);
+  let o = 0;
+  for (const a of arrays) { concat.set(a, o); o += a.length; }
+  return zscaleLimits(concat);
+}
+
+function NodGridInner() {
+  const params = useParams();
+  const decoded = decodeSource(String(params.source));
+
+  const [rows, setRows] = useState<SpectrumExposure[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [bkgsub, setBkgsub] = useState(false);
+  const [stretch, setStretch] = useState<StretchMode>('asinh');
+  const colormap: ColormapName = 'gray';
+
+  const [dataById, setDataById] = useState<Map<number, Float32Array>>(new Map());
+  const [range, setRange] = useState<[number, number] | null>(null);
+
+  useEffect(() => {
+    if (!decoded) { setError('Bad source id'); setLoading(false); return; }
+    let cancelled = false;
+    getNirspecNodGrid(decoded.observation, decoded.sourceId).then((res) => {
+      if (cancelled) return;
+      if (res.error) setError(res.error);
+      else setRows(res.rows);
+      setLoading(false);
+    });
+    return () => { cancelled = true; };
+  }, [decoded?.observation, decoded?.sourceId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const grid = useMemo(() => buildNodGrid(rows), [rows]);
+  const multiGroup = useMemo(
+    () => new Set(grid.map((r) => r.exp_group ?? -1)).size > 1, [grid]);
+
+  // Reset the shared-stretch accumulator whenever the view (bkgsub) changes — the
+  // cells refetch the other HDU, so old pixels are stale.
+  useEffect(() => { setDataById(new Map()); setRange(null); }, [bkgsub, rows]);
+
+  const expectedIds = useMemo(
+    () => rows.filter((r) => r.storage_key).map((r) => r.id), [rows]);
+
+  const onData = useCallback((id: number, data: Float32Array) => {
+    setDataById((prev) => {
+      const next = new Map(prev);
+      next.set(id, data);
+      return next;
+    });
+  }, []);
+
+  // Once every expected cell has reported its pixels, compute one shared ZScale.
+  useEffect(() => {
+    if (expectedIds.length === 0) return;
+    if (!expectedIds.every((id) => dataById.has(id))) return;
+    setRange(sharedRange(expectedIds.map((id) => dataById.get(id)!)));
+  }, [dataById, expectedIds]);
+
+  if (loading) {
+    return <div className="flex items-center justify-center py-16"><Loader2 className="w-8 h-8 animate-spin text-primary" /></div>;
+  }
+
+  return (
+    <div>
+      <div className="flex items-center gap-3 mb-4">
+        <Link href="/admin/nirspec/nods" className="text-text-secondary hover:text-text-primary" title="Back">
+          <ArrowLeft className="w-5 h-5" />
+        </Link>
+        <div className="flex-1 min-w-0">
+          <h1 className="text-xl font-semibold font-mono text-text-primary truncate">
+            {decoded?.observation} · source {decoded?.sourceId}
+          </h1>
+          <p className="text-sm text-text-secondary">
+            Live nods view — S2D cutouts grouped by (exp_group, nod) × detector.
+          </p>
+        </div>
+        <div className="flex items-center gap-2 text-xs">
+          <button
+            onClick={() => setBkgsub((v) => !v)}
+            className={`px-2 py-1 rounded border border-border ${bkgsub ? 'bg-primary text-on-primary' : 'text-text-secondary'}`}
+            title="Toggle background-subtracted view (S2D_BKGSUB_SCI)"
+          >
+            {bkgsub ? 'bkgsub' : 'cal'}
+          </button>
+          <select
+            value={stretch}
+            onChange={(e) => setStretch(e.target.value as StretchMode)}
+            className="text-xs border border-border rounded px-2 py-1 bg-card text-text-primary"
+          >
+            {(['linear', 'sqrt', 'log', 'asinh'] as StretchMode[]).map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-900 rounded-lg p-4 mb-4">
+          <p className="text-red-800 dark:text-red-400">{error}</p>
+        </div>
+      )}
+
+      {grid.length === 0 ? (
+        <p className="text-text-secondary text-sm">No spectrum-exposure rows for this source.</p>
+      ) : (
+        <Card className="overflow-x-auto p-3">
+          <div className="min-w-fit">
+            {/* header row: detector labels */}
+            <div className="flex gap-2 mb-1 pl-16 text-xs font-medium text-text-secondary">
+              {NOD_DETECTORS.map((d) => (
+                <div key={d} className="w-64 text-center">{d}</div>
+              ))}
+            </div>
+            {grid.map((row) => (
+              <div key={`${row.exp_group}-${row.nod}`} className="flex items-stretch gap-2 mb-2 h-32">
+                <div className="w-16 flex-shrink-0 flex items-center text-xs font-mono text-text-secondary">
+                  {multiGroup ? row.label : row.nod}
+                </div>
+                {NOD_DETECTORS.map((d) => (
+                  <div key={d} className="w-64 h-32 border border-border rounded">
+                    <NodCell
+                      exposure={row.cells[d]}
+                      range={range}
+                      stretch={stretch}
+                      colormap={colormap}
+                      bkgsub={bkgsub}
+                      onData={onData}
+                    />
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+export default function NodGridPage() {
+  return (
+    <Suspense fallback={<div className="flex items-center justify-center py-16"><Loader2 className="w-8 h-8 animate-spin text-primary" /></div>}>
+      <NodGridInner />
+    </Suspense>
+  );
+}

--- a/web/app/admin/nirspec/nods/[source]/page.tsx
+++ b/web/app/admin/nirspec/nods/[source]/page.tsx
@@ -33,6 +33,7 @@ function NodGridInner() {
   const colormap: ColormapName = 'gray';
 
   const [dataById, setDataById] = useState<Map<number, Float32Array>>(new Map());
+  const [settledIds, setSettledIds] = useState<Set<number>>(new Set());
   const [range, setRange] = useState<[number, number] | null>(null);
 
   useEffect(() => {
@@ -53,25 +54,33 @@ function NodGridInner() {
 
   // Reset the shared-stretch accumulator whenever the view (bkgsub) changes — the
   // cells refetch the other HDU, so old pixels are stale.
-  useEffect(() => { setDataById(new Map()); setRange(null); }, [bkgsub, rows]);
+  useEffect(() => {
+    setDataById(new Map());
+    setSettledIds(new Set());
+    setRange(null);
+  }, [bkgsub, rows]);
 
   const expectedIds = useMemo(
     () => rows.filter((r) => r.storage_key).map((r) => r.id), [rows]);
 
   const onData = useCallback((id: number, data: Float32Array) => {
-    setDataById((prev) => {
-      const next = new Map(prev);
-      next.set(id, data);
-      return next;
-    });
+    setDataById((prev) => new Map(prev).set(id, data));
   }, []);
 
-  // Once every expected cell has reported its pixels, compute one shared ZScale.
+  const onSettled = useCallback((id: number) => {
+    setSettledIds((prev) => (prev.has(id) ? prev : new Set(prev).add(id)));
+  }, []);
+
+  // Once every expected cell has SETTLED (succeeded, or hit the absent/error
+  // fallback — absent cells never produce pixels), compute one shared ZScale from
+  // whichever cells did produce data. Gating on "settled" not "succeeded" is what
+  // keeps a single absent cell from leaving the whole grid unpainted.
   useEffect(() => {
     if (expectedIds.length === 0) return;
-    if (!expectedIds.every((id) => dataById.has(id))) return;
-    setRange(sharedRange(expectedIds.map((id) => dataById.get(id)!)));
-  }, [dataById, expectedIds]);
+    if (!expectedIds.every((id) => settledIds.has(id))) return;
+    const arrays = expectedIds.map((id) => dataById.get(id)).filter((a): a is Float32Array => !!a);
+    if (arrays.length > 0) setRange(sharedRange(arrays));
+  }, [settledIds, dataById, expectedIds]);
 
   if (loading) {
     return <div className="flex items-center justify-center py-16"><Loader2 className="w-8 h-8 animate-spin text-primary" /></div>;
@@ -142,6 +151,7 @@ function NodGridInner() {
                       colormap={colormap}
                       bkgsub={bkgsub}
                       onData={onData}
+                      onSettled={onSettled}
                     />
                   </div>
                 ))}

--- a/web/app/admin/nirspec/nods/page.tsx
+++ b/web/app/admin/nirspec/nods/page.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import React, { Suspense } from 'react';
+import Link from 'next/link';
+import { useQuery } from '@tanstack/react-query';
+import { Card } from '@/components/ui/Card';
+import { Loader2, ChevronRight } from 'lucide-react';
+import { listNirspecNodSources } from '@/lib/actions/nirspec-nods';
+import { encodeSource } from '@/lib/nirspec-nods';
+
+function NodsIndexInner() {
+  const { data, isLoading } = useQuery({
+    queryKey: ['admin-nirspec-nod-sources'],
+    queryFn: listNirspecNodSources,
+    staleTime: 60_000,
+  });
+
+  const sources = data?.sources ?? [];
+
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold text-text-primary mb-2">NIRSpec Nods</h1>
+      <p className="text-text-secondary text-sm mb-6">
+        Per-source live nods view — the browser equivalent of the pipeline&rsquo;s
+        <span className="font-mono"> *_nods.pdf</span>, from the deployed S2D cutouts.
+        Pick a source to see its <span className="font-mono">(exp_group, nod) × detector</span> grid.
+      </p>
+
+      {data?.error && (
+        <div className="bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-900 rounded-lg p-4 mb-6">
+          <p className="text-red-800 dark:text-red-400">{data.error}</p>
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-16"><Loader2 className="w-8 h-8 animate-spin text-primary" /></div>
+      ) : sources.length === 0 ? (
+        <p className="text-text-secondary text-sm">
+          No spectrum-exposure grid rows yet. Deploy an observation with{' '}
+          <span className="font-mono">campfire deploy --obs &lt;obs&gt;</span> to populate the grid.
+        </p>
+      ) : (
+        <Card className="overflow-hidden divide-y divide-border">
+          {sources.map((s) => (
+            <Link
+              key={`${s.observation}-${s.source_id}`}
+              href={`/admin/nirspec/nods/${encodeSource(s.observation, s.source_id)}`}
+              className="flex items-center gap-3 px-4 py-3 hover:bg-card-hover transition-colors"
+            >
+              <div className="flex-1 min-w-0">
+                <div className="font-mono text-sm text-text-primary truncate">
+                  {s.observation} · source {s.source_id}
+                </div>
+                <div className="text-xs text-text-secondary">
+                  {s.exposureRootCount} exposure{s.exposureRootCount === 1 ? '' : 's'} ·{' '}
+                  {s.cellCount} cell{s.cellCount === 1 ? '' : 's'} ·{' '}
+                  {s.detectors.join(', ') || '—'}
+                  {s.grating ? ` · ${s.grating}` : ''}
+                </div>
+              </div>
+              <ChevronRight className="w-4 h-4 text-text-secondary" />
+            </Link>
+          ))}
+        </Card>
+      )}
+    </div>
+  );
+}
+
+export default function NodsIndexPage() {
+  return (
+    <Suspense fallback={<div className="flex items-center justify-center py-16"><Loader2 className="w-8 h-8 animate-spin text-primary" /></div>}>
+      <NodsIndexInner />
+    </Suspense>
+  );
+}

--- a/web/app/api/nircam-fits/route.ts
+++ b/web/app/api/nircam-fits/route.ts
@@ -12,11 +12,13 @@ import { isKnownKey, parseKey } from '@/lib/layout';
 
 export const runtime = 'nodejs';
 
-// Product types this proxy is allowed to serve. NIRCam exposures (epic #261) plus
-// NIRSpec rate files (review loop, P3) — both are uncompressed detector FITS the
-// in-browser SCI viewer range-fetches. Keeps the route from being an arbitrary
-// object read.
-const FITS_ALLOWED_PRODUCTS = new Set(['nircam_exposure', 'nirspec_rate']);
+// Product types this proxy is allowed to serve. NIRCam exposures (epic #261),
+// NIRSpec rate files (review loop P3), and canonical NIRSpec spectrum-exposures
+// (P5 nods renderer — the S2D_* rectified cutouts) — all uncompressed FITS the
+// in-browser decoder range-fetches. Keeps the route from being an arbitrary read.
+const FITS_ALLOWED_PRODUCTS = new Set([
+  'nircam_exposure', 'nirspec_rate', 'nirspec_spectrum_exposure',
+]);
 
 /**
  * GET /api/nircam-fits?key=<canonical OSN key>   (HTTP Range required)

--- a/web/components/nirspec/NodCell.tsx
+++ b/web/components/nirspec/NodCell.tsx
@@ -17,6 +17,10 @@ interface Props {
   bkgsub: boolean;
   /** Report the fetched pixels up so the page can compute the shared stretch. */
   onData: (id: number, data: Float32Array) => void;
+  /** Report that this cell reached a terminal state (success OR absent/error) so
+   * the page can compute the shared stretch once ALL cells have settled — not
+   * only once all have succeeded (absent cells never call onData). */
+  onSettled: (id: number) => void;
 }
 
 /** Median across the dispersion axis (columns) → one value per row. Mirrors the
@@ -59,7 +63,7 @@ function ProfileSvg({ data, width, height }: { data: Float32Array; width: number
   );
 }
 
-export default function NodCell({ exposure, range, stretch, colormap, bkgsub, onData }: Props) {
+export default function NodCell({ exposure, range, stretch, colormap, bkgsub, onData, onSettled }: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [cell, setCell] = useState<S2dCell | null>(null);
   const [state, setState] = useState<'loading' | 'ready' | 'absent' | 'error'>('loading');
@@ -79,16 +83,17 @@ export default function NodCell({ exposure, range, stretch, colormap, bkgsub, on
         setCell(c);
         setState('ready');
         onData(exposure.id, c.data);
+        onSettled(exposure.id);
       })
       .catch((e) => {
         if (cancelled) return;
-        if (e instanceof HduNotFoundError) { setState('absent'); return; }
-        if (e?.name === 'AbortError') return;
-        setState('error');
-        setErrMsg(e instanceof Error ? e.message : 'render failed');
+        if (e?.name === 'AbortError') return;  // unmount/dep change — not settled
+        setState(e instanceof HduNotFoundError ? 'absent' : 'error');
+        if (!(e instanceof HduNotFoundError)) setErrMsg(e instanceof Error ? e.message : 'render failed');
+        onSettled(exposure.id);  // settled without data — unblocks the shared-stretch gate
       });
     return () => { cancelled = true; controller.abort(); };
-  }, [key, bkgsub, exposure, onData]);
+  }, [key, bkgsub, exposure, onData, onSettled]);
 
   // Paint once we have both the pixels and the shared stretch range.
   useEffect(() => {

--- a/web/components/nirspec/NodCell.tsx
+++ b/web/components/nirspec/NodCell.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { fetchS2dCell, HduNotFoundError, paintToImageData, type S2dCell } from '@/lib/fits';
+import type { StretchMode } from '@/lib/fits';
+import type { ColormapName } from '@/lib/fits';
+import type { SpectrumExposure } from '@/lib/types';
+
+interface Props {
+  exposure: SpectrumExposure | null;
+  /** Shared [vmin, vmax] across the whole grid (null until the page computes it). */
+  range: [number, number] | null;
+  stretch: StretchMode;
+  colormap: ColormapName;
+  /** Whether to draw the background-subtracted view (S2D_BKGSUB_SCI) vs S2D_SCI. */
+  bkgsub: boolean;
+  /** Report the fetched pixels up so the page can compute the shared stretch. */
+  onData: (id: number, data: Float32Array) => void;
+}
+
+/** Median across the dispersion axis (columns) → one value per row. Mirrors the
+ * PDF's `np.nanmedian(data, axis=1)`. NaNs dropped per row. */
+function crossDispersionProfile(data: Float32Array, width: number, height: number): Float32Array {
+  const prof = new Float32Array(height);
+  const buf: number[] = [];
+  for (let r = 0; r < height; r++) {
+    buf.length = 0;
+    for (let c = 0; c < width; c++) {
+      const v = data[r * width + c]!;
+      if (Number.isFinite(v)) buf.push(v);
+    }
+    if (buf.length === 0) { prof[r] = NaN; continue; }
+    buf.sort((a, b) => a - b);
+    const m = buf.length >> 1;
+    prof[r] = buf.length % 2 ? buf[m]! : (buf[m - 1]! + buf[m]!) / 2;
+  }
+  return prof;
+}
+
+function ProfileSvg({ data, width, height }: { data: Float32Array; width: number; height: number }) {
+  const prof = crossDispersionProfile(data, width, height);
+  let lo = Infinity, hi = -Infinity;
+  for (const v of prof) if (Number.isFinite(v)) { if (v < lo) lo = v; if (v > hi) hi = v; }
+  if (!Number.isFinite(lo) || hi <= lo) return null;
+  const pts: string[] = [];
+  for (let r = 0; r < height; r++) {
+    const v = prof[r]!;
+    if (!Number.isFinite(v)) continue;
+    const x = ((v - lo) / (hi - lo)) * 100;
+    const y = 100 - (r / (height - 1)) * 100; // origin='lower': row 0 at bottom
+    pts.push(`${x.toFixed(2)},${y.toFixed(2)}`);
+  }
+  return (
+    <svg viewBox="0 0 100 100" preserveAspectRatio="none" className="w-10 h-full">
+      <polyline points={pts.join(' ')} fill="none" stroke="currentColor" strokeWidth={1.5}
+        vectorEffect="non-scaling-stroke" className="text-primary" />
+    </svg>
+  );
+}
+
+export default function NodCell({ exposure, range, stretch, colormap, bkgsub, onData }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [cell, setCell] = useState<S2dCell | null>(null);
+  const [state, setState] = useState<'loading' | 'ready' | 'absent' | 'error'>('loading');
+  const [errMsg, setErrMsg] = useState<string>('');
+
+  const key = exposure?.storage_key ?? null;
+  useEffect(() => {
+    if (!exposure) { setState('absent'); return; }
+    if (!key) { setState('absent'); return; }
+    let cancelled = false;
+    setState('loading');
+    const controller = new AbortController();
+    const url = `/api/nircam-fits?key=${encodeURIComponent(key)}`;
+    fetchS2dCell(url, { extname: bkgsub ? 'S2D_BKGSUB_SCI' : 'S2D_SCI', signal: controller.signal })
+      .then((c) => {
+        if (cancelled) return;
+        setCell(c);
+        setState('ready');
+        onData(exposure.id, c.data);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        if (e instanceof HduNotFoundError) { setState('absent'); return; }
+        if (e?.name === 'AbortError') return;
+        setState('error');
+        setErrMsg(e instanceof Error ? e.message : 'render failed');
+      });
+    return () => { cancelled = true; controller.abort(); };
+  }, [key, bkgsub, exposure, onData]);
+
+  // Paint once we have both the pixels and the shared stretch range.
+  useEffect(() => {
+    if (state !== 'ready' || !cell || !range) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    canvas.width = cell.width;
+    canvas.height = cell.height;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.putImageData(paintToImageData(cell.data, cell.width, cell.height, range[0], range[1], stretch, colormap), 0, 0);
+  }, [state, cell, range, stretch, colormap]);
+
+  if (!exposure) {
+    return <div className="flex items-center justify-center h-full text-text-tertiary text-xs">—</div>;
+  }
+  if (state === 'absent') {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-center text-text-tertiary text-[10px] p-1">
+        <span>no rectified view</span>
+        <span className="opacity-70">re-run with rectify</span>
+      </div>
+    );
+  }
+  if (state === 'error') {
+    return (
+      <div className="flex items-center justify-center h-full text-center text-red-500 text-[10px] p-1" title={errMsg}>
+        render error
+      </div>
+    );
+  }
+
+  const stkshtrs = cell?.primaryHeader.getString('STKSHTRS');
+  const shutsta = cell?.sciHeader?.getString('SHUTSTA');
+
+  return (
+    <div className="flex h-full gap-1">
+      <div className="relative flex-1 min-w-0 bg-black/40 rounded overflow-hidden">
+        {state === 'loading' && (
+          <div className="absolute inset-0 flex items-center justify-center">
+            <Loader2 className="w-4 h-4 animate-spin text-text-secondary" />
+          </div>
+        )}
+        <canvas
+          ref={canvasRef}
+          className="w-full h-full"
+          style={{ imageRendering: 'pixelated', objectFit: 'fill' }}
+        />
+        {(stkshtrs || shutsta) && (
+          <div className="absolute bottom-0 left-0 right-0 px-1 py-0.5 bg-black/50 text-[9px] font-mono text-white/80 truncate"
+            title={`STKSHTRS=${stkshtrs ?? ''} SHUTSTA=${shutsta ?? ''}`}>
+            {shutsta ?? stkshtrs}
+          </div>
+        )}
+      </div>
+      {cell && <ProfileSvg data={cell.data} width={cell.width} height={cell.height} />}
+    </div>
+  );
+}

--- a/web/lib/actions/nirspec-nods.ts
+++ b/web/lib/actions/nirspec-nods.ts
@@ -1,0 +1,108 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+import type { SpectrumExposure } from '@/lib/types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function requireAdmin() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error('Not authenticated');
+
+  const { data: profile } = await supabase
+    .from('user_profiles')
+    .select('is_admin')
+    .eq('user_id', user.id)
+    .single();
+
+  if (!profile?.is_admin) throw new Error('Admin access required');
+  return supabase;
+}
+
+export interface NodSource {
+  observation: string;
+  source_id: number;
+  grating: string | null;
+  cellCount: number;         // rows in the grid (all nod×detector cells)
+  exposureRootCount: number; // distinct exposures
+  detectors: string[];       // which detectors present
+}
+
+// spectrum_exposures is admin-RLS + small, so a direct query + JS aggregation is
+// correct (no RPC), mirroring the P3 nirspec-rate actions.
+export async function listNirspecNodSources(): Promise<{
+  sources: NodSource[];
+  error?: string;
+}> {
+  try {
+    const supabase = await requireAdmin();
+    const { data, error } = await supabase
+      .from('spectrum_exposures')
+      .select('observation, source_id, grating, detector, exposure_root');
+    if (error) return { sources: [], error: error.message };
+
+    const rows = (data ?? []) as {
+      observation: string; source_id: number; grating: string | null;
+      detector: string; exposure_root: string;
+    }[];
+    const byKey = new Map<string, {
+      observation: string; source_id: number; grating: string | null;
+      cellCount: number; roots: Set<string>; detectors: Set<string>;
+    }>();
+    for (const r of rows) {
+      const key = `${r.observation}::${r.source_id}`;
+      let s = byKey.get(key);
+      if (!s) {
+        s = { observation: r.observation, source_id: r.source_id, grating: r.grating,
+              cellCount: 0, roots: new Set(), detectors: new Set() };
+        byKey.set(key, s);
+      }
+      s.cellCount += 1;
+      s.roots.add(r.exposure_root);
+      if (r.detector) s.detectors.add(r.detector);
+    }
+    const sources = [...byKey.values()].map((s) => ({
+      observation: s.observation,
+      source_id: s.source_id,
+      grating: s.grating,
+      cellCount: s.cellCount,
+      exposureRootCount: s.roots.size,
+      detectors: [...s.detectors].sort(),
+    })).sort((a, b) =>
+      a.observation.localeCompare(b.observation) || a.source_id - b.source_id);
+
+    return { sources };
+  } catch (err) {
+    return {
+      sources: [],
+      error: err instanceof Error ? err.message : 'Failed to list nod sources',
+    };
+  }
+}
+
+export async function getNirspecNodGrid(
+  observation: string,
+  sourceId: number,
+): Promise<{ rows: SpectrumExposure[]; error?: string }> {
+  try {
+    const supabase = await requireAdmin();
+    const { data, error } = await supabase
+      .from('spectrum_exposures')
+      .select('*')
+      .eq('observation', observation)
+      .eq('source_id', sourceId)
+      .order('exp_group', { ascending: true, nullsFirst: true })
+      .order('nod', { ascending: true })
+      .order('detector', { ascending: true });
+    if (error) return { rows: [], error: error.message };
+    return { rows: (data ?? []) as SpectrumExposure[] };
+  } catch (err) {
+    return {
+      rows: [],
+      error: err instanceof Error ? err.message : 'Failed to fetch nod grid',
+    };
+  }
+}

--- a/web/lib/fits/fetch.ts
+++ b/web/lib/fits/fetch.ts
@@ -21,6 +21,28 @@ export interface SciImage {
   height: number;
 }
 
+/** A named image HDU (e.g. S2D_SCI) was walked past without being found — the
+ * canonical file has no rectified view for this cutout. Distinct from
+ * IncompleteHeaderError (window too short, grow) so callers render a fallback. */
+export class HduNotFoundError extends Error {}
+
+/** One S2D cutout cell for the NIRSpec nods renderer: the rectified slitlet
+ * pixels plus the header cards the renderer overlays (STKSHTRS on PRIMARY,
+ * SHUTSTA on the live SCI ext) — all captured from the one header window walk. */
+export interface S2dCell {
+  data: Float32Array;
+  width: number;
+  height: number;
+  primaryHeader: FitsHeader;
+  sciHeader: FitsHeader | null;
+}
+
+// The S2D_* HDUs sit behind the slit arrays (SCI/ERR/DQ/VAR*×3 + PRE_BKGSUB_*×5),
+// so its header can be well past the 1 MB NIRCam cap. Cutouts are small rectified
+// slitlets, so a generous contiguous cap virtually always reaches it in one grow
+// loop; if not, we degrade to HduNotFoundError (the OQ-6 "no rectified view" cell).
+const MAX_S2D_HEADER_BYTES = 16 * 1024 * 1024;
+
 /** Initial header-window size; grown on IncompleteHeaderError (large PRIMARY headers). */
 const INITIAL_HEADER_BYTES = 64 * 1024;
 const MAX_HEADER_BYTES = 1024 * 1024;
@@ -129,4 +151,81 @@ export async function fetchSciImage(fitsUrl: string, signal?: AbortSignal): Prom
   }
   const data = swapToFloat32(block.byteLength === sciBytes ? block : block.slice(0, sciBytes));
   return { data, width, height };
+}
+
+/** Walk `buf`'s HDU chain to `extname`, capturing the PRIMARY (i=0) and live-SCI
+ * headers along the way. Throws IncompleteHeaderError if the buffer runs out
+ * mid-walk (caller grows), or HduNotFoundError if all HDUs are walked without a
+ * match (absent → fallback cell). */
+function findS2dHdu(buf: Uint8Array, extname: string): {
+  header: FitsHeader; dataStart: number; primaryHeader: FitsHeader; sciHeader: FitsHeader | null;
+} {
+  let off = 0;
+  let primaryHeader: FitsHeader | null = null;
+  let sciHeader: FitsHeader | null = null;
+  for (let i = 0; i < 64; i++) {
+    if (off + 2880 > buf.length) {
+      throw new IncompleteHeaderError(`${extname} header not reached within ${buf.length} bytes`);
+    }
+    const hdu = hduAt(buf, off);
+    if (i === 0) primaryHeader = hdu.header;
+    if (hdu.extname === 'SCI') sciHeader = hdu.header;
+    if (hdu.extname === extname) {
+      return { header: hdu.header, dataStart: hdu.dataStart, primaryHeader: primaryHeader!, sciHeader };
+    }
+    off = hdu.nextHdu;
+  }
+  throw new HduNotFoundError(`No ${extname} extension in the first 64 HDUs`);
+}
+
+/**
+ * Fetch + decode a named S2D image HDU (default `S2D_SCI`) from a canonical
+ * NIRSpec spectrum-exposure served at `fitsUrl`, plus the header cards the nods
+ * renderer overlays. Throws {@link HduNotFoundError} when the rectified view is
+ * absent (OQ-6), or on a compressed/non-float32 HDU.
+ */
+export async function fetchS2dCell(
+  fitsUrl: string,
+  opts?: { extname?: string; signal?: AbortSignal },
+): Promise<S2dCell> {
+  const extname = opts?.extname ?? 'S2D_SCI';
+  const signal = opts?.signal;
+
+  let headerBytes = INITIAL_HEADER_BYTES;
+  let found: ReturnType<typeof findS2dHdu> | null = null;
+  for (;;) {
+    const head = new Uint8Array(await fetchRange(fitsUrl, 0, headerBytes - 1, signal));
+    try {
+      found = findS2dHdu(head, extname);
+      break;
+    } catch (e) {
+      if (e instanceof IncompleteHeaderError && headerBytes < MAX_S2D_HEADER_BYTES) {
+        headerBytes = Math.min(headerBytes * 4, MAX_S2D_HEADER_BYTES);
+        continue;
+      }
+      if (e instanceof IncompleteHeaderError) {
+        throw new HduNotFoundError(`${extname} not reached within ${headerBytes} bytes`);
+      }
+      throw e; // HduNotFoundError or a parse error
+    }
+  }
+
+  const { header, dataStart, primaryHeader, sciHeader } = found;
+  const width = header.requireInt('NAXIS1');
+  const height = header.requireInt('NAXIS2');
+  const bitpix = header.requireInt('BITPIX');
+  if (bitpix !== -32) {
+    throw new Error(`${extname} is not float32 (BITPIX=${bitpix})`);
+  }
+  if (header.has('ZIMAGE')) {
+    throw new Error(`${extname} is fpack-compressed (ZIMAGE)`);
+  }
+
+  const bytes = width * height * 4;
+  const block = await fetchRange(fitsUrl, dataStart, dataStart + bytes - 1, signal);
+  if (block.byteLength < bytes) {
+    throw new Error(`Short ${extname} read: got ${block.byteLength} of ${bytes} bytes`);
+  }
+  const data = swapToFloat32(block.byteLength === bytes ? block : block.slice(0, bytes));
+  return { data, width, height, primaryHeader, sciHeader };
 }

--- a/web/lib/fits/index.ts
+++ b/web/lib/fits/index.ts
@@ -5,7 +5,8 @@
  */
 
 export { FitsImageViewer, type PixelReadout } from './viewer';
-export { fetchSciImage, type SciImage } from './fetch';
+export { fetchSciImage, fetchS2dCell, HduNotFoundError, type SciImage, type S2dCell } from './fetch';
 export { STRETCH_MODES, type StretchMode, isStretchMode } from './stretch';
-export { COLORMAP_NAMES, type ColormapName, isColormapName } from './colormaps';
+export { COLORMAP_NAMES, type ColormapName, isColormapName, resolveColormap } from './colormaps';
 export { zscaleLimits, DEFAULT_ZSCALE } from './zscale';
+export { paintToImageData } from './paint';

--- a/web/lib/fits/paint.ts
+++ b/web/lib/fits/paint.ts
@@ -1,0 +1,52 @@
+/**
+ * CPU float32 → ImageData paint for the NIRSpec nods renderer (P5).
+ *
+ * The nods grid shows many small rectified S2D slitlet cutouts at once. A WebGL
+ * canvas per cell would exhaust the browser's ~16-context ceiling, and the PDF
+ * uses ONE shared ZScale across all cells (not per-image auto-stretch), so we
+ * paint on a plain 2D canvas: normalize+stretch each pixel through the SAME
+ * `scaleValue` transfer the WebGL shader uses, map through the colormap LUT, and
+ * write ImageData. Cheap here — slitlets are hundreds of px, not 2048².
+ *
+ * origin='lower' (matching viewer.ts): FITS row 0 is painted at the BOTTOM of the
+ * image. NaN/non-finite pixels take the colormap's background colour.
+ */
+
+import { scaleValue, type StretchMode } from './stretch';
+import { resolveColormap, backgroundForColormap, type ColormapName } from './colormaps';
+
+export function paintToImageData(
+  data: Float32Array,
+  width: number,
+  height: number,
+  vmin: number,
+  vmax: number,
+  stretch: StretchMode,
+  colormap: ColormapName,
+): ImageData {
+  const { rgba, size } = resolveColormap(colormap);
+  const [br, bg, bb] = backgroundForColormap(colormap);
+  const out = new Uint8ClampedArray(width * height * 4);
+
+  for (let row = 0; row < height; row++) {
+    const destRow = height - 1 - row; // origin='lower': row 0 → bottom
+    for (let col = 0; col < width; col++) {
+      const v = data[row * width + col]!;
+      const di = (destRow * width + col) * 4;
+      if (!Number.isFinite(v)) {
+        out[di] = br; out[di + 1] = bg; out[di + 2] = bb; out[di + 3] = 255;
+        continue;
+      }
+      const t = scaleValue(v, vmin, vmax, stretch); // [0,1]
+      let idx = Math.round(t * (size - 1));
+      if (idx < 0) idx = 0;
+      else if (idx >= size) idx = size - 1;
+      const ci = idx * 4;
+      out[di] = rgba[ci]!;
+      out[di + 1] = rgba[ci + 1]!;
+      out[di + 2] = rgba[ci + 2]!;
+      out[di + 3] = 255;
+    }
+  }
+  return new ImageData(out, width, height);
+}

--- a/web/lib/nirspec-nods.test.ts
+++ b/web/lib/nirspec-nods.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { encodeSource, decodeSource, buildNodGrid } from './nirspec-nods';
+import type { SpectrumExposure } from './types';
+
+function row(over: Partial<SpectrumExposure>): SpectrumExposure {
+  return {
+    id: 0, observation: 'ember_egs_p1', exposure_root: 'jw07076020001_04101',
+    nod: '00001', detector: 'nrs1', source_id: 117757, exp_group: 0, grating: 'PRISM',
+    filename: 'x.fits', storage_key: 'data/products/nirspec/o/x.fits',
+    image_width: 40, image_height: 400, stage: 'cal', review_status: 'pending',
+    masking: 'none', notes: null, created_at: '', updated_at: '', ...over,
+  };
+}
+
+describe('encode/decode source', () => {
+  it('round-trips, unambiguous on the last __', () => {
+    expect(decodeSource(encodeSource('ember_egs_p1', 117757)))
+      .toEqual({ observation: 'ember_egs_p1', sourceId: 117757 });
+    // an observation name containing '__' still splits on the last one
+    expect(decodeSource(encodeSource('weird__name', 42)))
+      .toEqual({ observation: 'weird__name', sourceId: 42 });
+  });
+  it('rejects malformed', () => {
+    expect(decodeSource('no-delimiter')).toBeNull();
+    expect(decodeSource('obs__notanint')).toBeNull();
+  });
+});
+
+describe('buildNodGrid', () => {
+  it('groups by (exp_group, nod), columns by detector, ordered', () => {
+    const rows = [
+      row({ id: 1, exp_group: 1, nod: '00002', detector: 'nrs2' }),
+      row({ id: 2, exp_group: 0, nod: '00001', detector: 'nrs1' }),
+      row({ id: 3, exp_group: 0, nod: '00001', detector: 'nrs2' }),
+      row({ id: 4, exp_group: 1, nod: '00002', detector: 'nrs1' }),
+    ];
+    const grid = buildNodGrid(rows);
+    expect(grid.length).toBe(2);
+    // ordered by (exp_group, nod)
+    expect(grid[0].exp_group).toBe(0);
+    expect(grid[0].cells.nrs1?.id).toBe(2);
+    expect(grid[0].cells.nrs2?.id).toBe(3);
+    expect(grid[1].exp_group).toBe(1);
+    expect(grid[1].cells.nrs1?.id).toBe(4);
+    expect(grid[1].cells.nrs2?.id).toBe(1);
+    // >1 exp_group → dither-ordinal labels
+    expect(grid[0].label).toBe('d1:00001');
+    expect(grid[1].label).toBe('d2:00002');
+  });
+
+  it('single exp_group → bare nod labels, missing detector cell is null', () => {
+    const grid = buildNodGrid([
+      row({ id: 1, exp_group: 0, nod: '00001', detector: 'nrs1' }),
+    ]);
+    expect(grid.length).toBe(1);
+    expect(grid[0].label).toBe('00001');
+    expect(grid[0].cells.nrs1?.id).toBe(1);
+    expect(grid[0].cells.nrs2).toBeNull();
+  });
+});

--- a/web/lib/nirspec-nods.ts
+++ b/web/lib/nirspec-nods.ts
@@ -1,0 +1,69 @@
+// Plain helpers for the NIRSpec nods renderer (P5). Kept OUT of the 'use server'
+// action module (nirspec-nods actions): a 'use server' file may export only async
+// functions, so any const/helper lives here (mirrors lib/admin/sort-keys.ts).
+
+import type { SpectrumExposure } from '@/lib/types';
+
+export const NOD_DETECTORS = ['nrs1', 'nrs2'] as const;
+export type NodDetector = (typeof NOD_DETECTORS)[number];
+
+// A "source" the renderer groups by is (observation, source_id). Encode both into
+// one URL segment; decode by splitting on the LAST '__' (source_id is a bare int,
+// so the split is unambiguous even if the observation name contains '__').
+export function encodeSource(observation: string, sourceId: number): string {
+  return `${encodeURIComponent(observation)}__${sourceId}`;
+}
+
+export function decodeSource(segment: string): { observation: string; sourceId: number } | null {
+  const i = segment.lastIndexOf('__');
+  if (i < 0) return null;
+  const sourceId = Number(segment.slice(i + 2));
+  if (!Number.isInteger(sourceId)) return null;
+  return { observation: decodeURIComponent(segment.slice(0, i)), sourceId };
+}
+
+/** One row of the nods grid: an (exp_group, nod) group with a cell per detector. */
+export interface NodGridRow {
+  exp_group: number | null;
+  nod: string;
+  label: string;                       // e.g. "d1:00001" (multi-group) or "00001"
+  cells: Record<NodDetector, SpectrumExposure | null>;
+}
+
+/**
+ * Reshape flat spectrum_exposures rows into ordered (exp_group, nod) grid rows ×
+ * detector columns — the `*_nods.pdf` layout (plots.py: rows sorted by exp_group
+ * then nod, columns = detector). Rows are labelled `d{n}:{nod}` when there is more
+ * than one exp_group, else just the nod.
+ */
+export function buildNodGrid(rows: SpectrumExposure[]): NodGridRow[] {
+  const groups = new Map<string, NodGridRow>();
+  const order: string[] = [];
+  for (const r of rows) {
+    const key = `${r.exp_group ?? -1}::${r.nod}`;
+    let row = groups.get(key);
+    if (!row) {
+      row = { exp_group: r.exp_group, nod: r.nod, label: r.nod,
+              cells: { nrs1: null, nrs2: null } };
+      groups.set(key, row);
+      order.push(key);
+    }
+    if (r.detector === 'nrs1' || r.detector === 'nrs2') row.cells[r.detector] = r;
+  }
+  const result = order.map((k) => groups.get(k)!);
+  // sort by (exp_group, nod); null exp_group sorts first
+  result.sort((a, b) => {
+    const ea = a.exp_group ?? -1, eb = b.exp_group ?? -1;
+    if (ea !== eb) return ea - eb;
+    return a.nod.localeCompare(b.nod);
+  });
+  // label with the dither ordinal only when >1 exp_group is present (like the PDF)
+  const distinctGroups = new Set(result.map((r) => r.exp_group ?? -1));
+  if (distinctGroups.size > 1) {
+    const idxByGroup = new Map<number, number>();
+    let n = 0;
+    for (const g of [...distinctGroups].sort((a, b) => a - b)) idxByGroup.set(g, ++n);
+    for (const r of result) r.label = `d${idxByGroup.get(r.exp_group ?? -1)}:${r.nod}`;
+  }
+  return result;
+}

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -377,6 +377,32 @@ export interface NirspecRateExposure {
   updated_at: string;
 }
 
+// NIRSpec nods-renderer grid row (review loop P4/P5). One per canonical per-source
+// spectrum-exposure; the web nods renderer groups these as rows=(exp_group, nod) ×
+// cols=detector per source. Mirrors the supabase spectrum_exposures table. NB:
+// exposure_root here is the 2-token pipeline root (nod split out) — different
+// semantics from NirspecRateExposure.exposure_root (3 tokens).
+export interface SpectrumExposure {
+  id: number;
+  observation: string;
+  exposure_root: string;
+  nod: string;
+  detector: string;               // 'nrs1' | 'nrs2'
+  source_id: number;
+  exp_group: number | null;
+  grating: string | null;
+  filename: string;
+  storage_key: string | null;     // canonical nirspec_spectrum_exposure key
+  image_width: number | null;
+  image_height: number | null;
+  stage: string;
+  review_status: 'pending' | 'approved' | 'excluded';
+  masking: 'none' | 'needed' | 'done';
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 // One entry in observations.pointings — a NIRSpec MSA pointing.
 export interface Pointing {
   msametid: number;


### PR DESCRIPTION
**P5** — the Track N payoff of the NIRSpec web review loop (`docs/design-nirspec-review-loop.md` §4.1/§4.2/§6/§9-P5): a **read-only** admin browser reproduction of the pipeline's `*_nods.pdf`, reading the P4-populated `spectrum_exposures` grid. Renders the deployed `S2D_*` cutouts grouped as `rows=(exp_group, nod) × cols=detector` per source, each with a client-computed 1D cross-dispersion profile. **Web-only, admin-only, no schema/pipeline.**

## What changed
- **Proxy**: widen `nircam-fits`'s `FITS_ALLOWED_PRODUCTS` to include `nirspec_spectrum_exposure` (the canonical per-source FITS carrying the `S2D_*` HDUs).
- **FITS decoder** (`lib/fits/fetch.ts`): new self-contained **`fetchS2dCell`** that reuses the proven `hduAt`/`swapToFloat32` primitives to walk the HDU chain to a **named** S2D HDU (`S2D_SCI` or `S2D_BKGSUB_SCI`), capturing the PRIMARY (`STKSHTRS`) + live-`SCI` (`SHUTSTA`) headers en route, with a raised header cap and a typed **`HduNotFoundError`** for the OQ-6 graceful fallback. The NIRCam `fetchSciImage` path is untouched.
- **CPU paint** (`lib/fits/paint.ts`): two reasons the WebGL `FitsCanvas` can't be reused for the grid — a canvas-per-cell would exhaust the browser's ~16 WebGL-context ceiling, and the PDF uses **one shared ZScale across all cells** (not per-image auto-stretch). So cells paint on a plain 2D canvas through the **same `scaleValue` transfer + colormap LUT** the shader uses, `origin='lower'`. The page collects each cell's pixels and computes one shared `zscaleLimits`, matching the PDF.
- **Pages**: `/admin/nirspec/nods` (source index) + `/admin/nirspec/nods/[source]` (the grid). A `NodCell` component (S2D fetch → CPU paint → inline-SVG 1D profile `nanmedian` over the dispersion axis → per-cell "no rectified view" fallback), the `SpectrumExposure` type, plain nods helpers (`buildNodGrid` + source encode/decode — unit-tested), and a sidebar nav entry.

## Design-vs-code findings
- **Named-HDU rendering** and the **many-small-cutouts** shape genuinely break the "just reuse the NIRCam FITS stack" assumption — hence the CPU-paint cell renderer (documented inline).
- The `*_nods.pdf`'s `SRCFLUX` reference in the design brief was a misattribution — it's an exposure-filter card, not drawn by the nods plot. P5 overlays `SHUTSTA` + `STKSHTRS` only.

## Deliberate scope boundary → P6
The interactive **shutter-boundary overlay** is deferred to **P6**, which introduces the stuck-shutter flags (`nirspec_source_review`) the overlay styles — and the design puts the per-boundary toggle in the flag UI anyway. P5 surfaces `SHUTSTA`/`STKSHTRS` as a text badge on each cell.

## Testing
- `cd web && npm run build`: compiles, type-checks, lints clean; **both routes generate** (`○ /admin/nirspec/nods`, `ƒ /admin/nirspec/nods/[source]`). `tsc --noEmit` exit 0. `vitest` nods-helper tests pass (4: source encode/decode round-trip, grid grouping/ordering/labels).
- ⚠️ **The pixel render itself needs a real preview click-through with deployed S2D data to validate visually** — CI only proves it builds. The FITS byte-parsing (`fetchS2dCell` header walk) and CPU paint can't be exercised against real S2D cutouts in the sandbox. Preview: the source index + a source's grid; empty/fallback states are expected without deployed data.

## Scope / safety
No `pipeline/**`, no schema/migration (P4 shipped the table + `CFEXPGRP` stamp), no `seed.sql`. Admin-only, read-only, no writes, no public surface. The proxy-guard widening is additive. Merges inert.

Generated with Claude Code

https://claude.ai/code/session_01SQiCGrfdaQu5cF9dbVCJNd

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQiCGrfdaQu5cF9dbVCJNd)_