### PR TITLE
fix(nircam): warm full-res exposure PNG across the prefetch window on every step

### DIFF
--- a/web/app/admin/nircam/[id]/page.tsx
+++ b/web/app/admin/nircam/[id]/page.tsx
@@ -25,11 +25,13 @@ import { parseExposureNavParams } from '@/lib/nircam-exposure-nav';
 import {
   getCachedExposure,
   setCachedExposure,
-  prefetchPreviewPng,
+  prefetchPng,
 } from '@/lib/nircam-exposure-cache';
 
-// Eager PNG prefetch window: previews (~1.3 MB) for a few exposures ahead + one
-// back; the heavy full-res mask surface (~5.7 MB) only for the immediate next.
+// Eager PNG prefetch window: warm the full-res mask surface (~5.7 MB) the
+// editor actually renders for a few exposures ahead + one back, so stepping
+// through the queue paints instantly. Falls back to the preview (~1.3 MB) for
+// exposures that have no full PNG (the thumbnail-only view).
 const PREFETCH_AHEAD = 3;
 const PREFETCH_BEHIND = 1;
 
@@ -145,9 +147,12 @@ function ExposureDetailPageInner() {
 
   // Presign the current exposure's PNGs + eagerly prefetch a window of upcoming
   // ones (epic #261, N5). Keys are re-derived server-side; URLs go straight into
-  // <img> (no proxy hop). Preview (~1.3 MB) is prefetched across the whole
-  // window; the heavy full-res mask surface (~5.7 MB) only for the immediate
-  // next, so a fast tab-through stays ahead without flooding the network.
+  // <img> (no proxy hop). We warm the full-res mask surface (~5.7 MB) — the byte
+  // the editor actually renders — across the whole window, keyed off the
+  // *persistent* URL map so a sibling presigned by an earlier window is still
+  // warmed on every step. (Previously the warm keyed off only the freshly-signed
+  // ids, so once the next exposure had been presigned by a prior window its full
+  // PNG was never prefetched again — every Next reloaded it cold from OSN.)
   useEffect(() => {
     if (!nav) return;
     // Derive the prefetch window from the neighbors RPC result: ahead-heavy
@@ -158,18 +163,29 @@ function ExposureDetailPageInner() {
       ...nav.windowIds.slice(idx + 1, idx + 1 + PREFETCH_AHEAD),
       ...nav.windowIds.slice(Math.max(0, idx - PREFETCH_BEHIND), idx),
     ];
-    // Only presign ids we haven't already (prefetched siblings keep their URL).
+    // Warm the exact byte the viewer will show for each windowed exposure: the
+    // full-res mask surface the editor renders, or the preview when there's no
+    // full PNG. Re-warming an already-cached URL is a browser cache hit, so the
+    // only new network per step is the frontier exposure entering the window.
+    const warm = (map: Record<number, ExposurePngUrls>) => {
+      for (const sib of win) {
+        const u = map[sib];
+        if (u) prefetchPng(u.full ?? u.preview);
+      }
+    };
+    // Only presign ids we haven't already (prefetched siblings keep their URL);
+    // when the whole window is already signed, just re-warm from what we have.
     const batch = [id, ...win].filter((x) => pngUrlsRef.current[x] === undefined);
-    if (batch.length === 0) return;
+    if (batch.length === 0) {
+      warm(pngUrlsRef.current);
+      return;
+    }
     let cancelled = false;
     presignExposurePngs(batch).then((urls) => {
       if (cancelled) return;
-      setPngUrls((prev) => ({ ...prev, ...urls }));
-      // `urls` holds only the newly-presigned (previously-absent) ids, so each
-      // sibling is prefetched exactly once, at the URL that will be reused.
-      for (const sib of win) if (urls[sib]) prefetchPreviewPng(urls[sib].preview);
-      // Heavy full-res PNG: only the genuine immediate next (null at the end).
-      if (nav.nextId != null && urls[nav.nextId]) prefetchPreviewPng(urls[nav.nextId].full);
+      const merged = { ...pngUrlsRef.current, ...urls };
+      setPngUrls(merged);
+      warm(merged);
     });
     return () => { cancelled = true; };
   }, [id, nav]);

--- a/web/lib/nircam-exposure-cache.ts
+++ b/web/lib/nircam-exposure-cache.ts
@@ -27,11 +27,13 @@ export function clearExposureCache(): void {
 }
 
 /**
- * Warm browser HTTP cache for a preview PNG so the next render of an
- * <img src=...> is paint-instant. Returns immediately; the fetch continues
- * in the background and lands in the same cache the eventual <img> will use.
+ * Warm browser HTTP cache for a PNG (full-res mask surface or preview) so the
+ * next render of an <img src=...> is paint-instant. Returns immediately; the
+ * fetch continues in the background and lands in the same cache the eventual
+ * <img> will use. Re-warming an already-cached URL is a cache hit (no network),
+ * so it's safe to call on every navigation.
  */
-export function prefetchPreviewPng(url: string | null): void {
+export function prefetchPng(url: string | null): void {
   if (!url || typeof window === 'undefined') return;
   // new Image() triggers a normal HTTP fetch from the renderer with the
   // browser's image cache; safer than fetch() (which can land in a different


### PR DESCRIPTION
## Summary

The NIRCam exposure inspector (`/admin/nircam/[id]`) already had eager PNG prefetching (added in #283, epic #261 N5), but the **image** prefetch was effectively dead after the first exposure — so every Next/Prev reloaded its picture cold from OSN (~1–2 s). The in-memory row cache worked (metadata paints instantly), which masked the problem. This fixes the image warm so stepping through the triage queue paints instantly.

## The bugs

1. **Full-res PNG only warmed on the first landing.** The window warm keyed off the result of `presignExposurePngs(batch)`, but `batch` filters out ids that were *already* presigned by a prior window. Walking one exposure at a time with a 3-ahead window means the immediate-next exposure was signed a step earlier → absent from that result → its full-res mask surface (the ~5.7 MB byte the `MaskEditor` actually renders) was never re-prefetched. Only the very first exposure you landed on ever warmed a full PNG.

2. **The window warmed the wrong asset.** The sliding window prefetched only the ~1.3 MB *preview* PNG, which the editor never displays (it renders the full PNG; preview is only the degraded thumbnail fallback).

Net effect: from the second navigation onward, every exposure downloaded its full PNG from scratch.

## The fix

- Key the warm off the **persistent** `pngUrls` map instead of the just-signed `batch`, so a sibling presigned by an earlier window is re-warmed on **every** step.
- Warm the **full** PNG across the whole window (falling back to the preview when an exposure has no full PNG — the thumbnail-only path). Re-warming an already-cached URL is a browser cache hit, so the only new network per step is the frontier exposure entering the window.
- Rename `prefetchPreviewPng` → `prefetchPng` to match its now-general role.

Scope is PNG-only. The FITS "beta" render path still has no prefetch/pixel cache and is left for a follow-up.

## Files

- `web/app/admin/nircam/[id]/page.tsx` — persistent-map warm + full-PNG window prefetch
- `web/lib/nircam-exposure-cache.ts` — rename + doc

## Verification

- `tsc --noEmit`: clean
- `next lint`: clean (only a pre-existing, unrelated `<img>` warning)
- `vitest`: 122/122 pass

Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrRUzTctbVX7z6mPk93dUJ)_