### PR TITLE
Fix spinner rotating around vertical axis in Firefox

### DIFF
--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -54,10 +54,24 @@ const config: Config = {
           '0%': { opacity: '0', transform: 'scale(0.95)' },
           '100%': { opacity: '1', transform: 'scale(1)' },
         },
+        // Override Tailwind's default `spin` keyframe, which only defines a
+        // `to: rotate(360deg)` frame. With an implicit `from` (the element's
+        // underlying `none`), Firefox interpolates `none -> rotate(360deg)` via
+        // matrix decomposition instead of component-wise angle interpolation.
+        // Because rotate(360deg) decomposes to the identity matrix, Firefox's
+        // decompose/recompose of the intermediate frames leaks a 3D rotation
+        // component, making `animate-spin` flip around a vertical axis instead
+        // of spinning flat (Chrome/Safari are unaffected). Declaring both
+        // endpoints as matching rotate() functions keeps the interpolation 2D.
+        spin: {
+          from: { transform: 'rotate(0deg)' },
+          to: { transform: 'rotate(360deg)' },
+        },
       },
       animation: {
         'fade-in': 'fade-in 200ms ease-out',
         'zoom-in': 'zoom-in 200ms ease-out',
+        spin: 'spin 1s linear infinite',
       },
     }
   },


### PR DESCRIPTION
## Problem

The loading spinner used throughout the CAMPFIRE UI renders incorrectly in Firefox: instead of spinning flat (around the Z-axis), it flips around a vertical axis, appearing to rotate in/out of the page. Chrome and Safari are unaffected.

Every spinner in the app — the ~90 `lucide-react` `Loader2` icons plus the `border-b-2` div spinner in `NearbyObjects.tsx` — uses Tailwind's built-in `animate-spin`, which is driven by a single shared `@keyframes spin`.

## Root cause

Tailwind v3's default `spin` keyframe defines only a `to` frame:

```css
@keyframes spin { to { transform: rotate(360deg); } }
```

The `from` value is implicit — the element's underlying `none`. Firefox interpolates `none → rotate(360deg)` via **matrix decomposition** rather than component-wise angle interpolation (as Chrome/Safari do). Because `rotate(360deg)` decomposes to the identity matrix, Firefox's decompose/recompose of the intermediate frames leaks a 3D rotation component — producing the vertical-axis flip.

There is no `perspective` / `transform-style` / 3D transform anywhere in the codebase, so this is purely the keyframe interpolation path, not a custom 3D context.

## Fix

Override the shared `spin` keyframe in `web/tailwind.config.ts` with explicit `from`/`to` frames so both endpoints are matching `rotate()` functions, forcing Firefox to interpolate the angle (0° → 360°) around Z and stay 2D:

```ts
spin: {
  from: { transform: 'rotate(0deg)' },
  to:   { transform: 'rotate(360deg)' },
},
```

The `.animate-spin` utility is unchanged, so this single edit fixes every spinner at once — no per-component changes.

## Verification

`node_modules` isn't present in the CI/dev container, so I installed Tailwind 3.4.1 standalone and compiled against this repo's config to confirm the emitted CSS:

```css
@keyframes spin {
  to   { transform: rotate(360deg) }
  from { transform: rotate(0deg) }   /* now present */
}
.animate-spin { animation: spin 1s linear infinite }
```

Both frames are emitted and the utility signature is identical to before. A quick visual check in Firefox on the preview deploy is worthwhile to confirm the flat spin.

Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9rSnr2sty2RJR6qJ5yJ2m)_