### PR TITLE
NIRSpec review loop P6 — source-review flags + stuck-shutter/bkg-override UI

### DIFF
--- a/supabase/migrations/20260704200000_add_nirspec_source_review.sql
+++ b/supabase/migrations/20260704200000_add_nirspec_source_review.sql
@@ -1,0 +1,57 @@
+-- NIRSpec source-scoped review flags (P6, NIRSpec review loop, design §4.3). One
+-- row per (observation, exposure_root, source_id) — UNIQUE on that triple. Holds the
+-- two editable flag channels as jsonb mirroring the local reference/nirspec/<obs>/
+-- TOMLs 1:1 so P7's pull serializes without transform:
+--   stuck_shutters = [1,2,3]    ordinal list  (mirrors stuck_closed_shutters.toml)
+--   bkg_overrides  = {"3":[1]}  {nod: [nods]} (mirrors nodded_background_overrides.toml;
+--                               keys/values are exposure-sequence numbers, not indices)
+-- Admin-only (RLS); web-editable (admins INSERT/UPDATE directly, unlike the
+-- deploy-only intermediate tables); NOT deployed to OSN. Additive: a brand-new table
+-- with no rows and no dependents; seed.sql is unaffected (the seed generator does not
+-- emit this table, same as nirspec_rate_exposures/spectrum_exposures).
+--
+-- Mirrors the create idiom of 20260704180000_add_nirspec_rate_exposures.sql.
+-- Grants match the schema file (authenticated + service_role only; no anon).
+
+create sequence "public"."nirspec_source_review_id_seq";
+
+create table "public"."nirspec_source_review" (
+    "id" integer not null default nextval('public.nirspec_source_review_id_seq'::regclass),
+    "observation" text not null,
+    "exposure_root" text not null,
+    "source_id" integer not null,
+    "stuck_shutters" jsonb,
+    "bkg_overrides" jsonb,
+    "notes" text,
+    "created_at" timestamp with time zone not null default now(),
+    "updated_at" timestamp with time zone not null default now()
+);
+
+alter table "public"."nirspec_source_review" enable row level security;
+
+alter sequence "public"."nirspec_source_review_id_seq" owned by "public"."nirspec_source_review"."id";
+
+CREATE UNIQUE INDEX nirspec_source_review_pkey ON public.nirspec_source_review USING btree (id);
+
+CREATE UNIQUE INDEX nirspec_source_review_unique ON public.nirspec_source_review USING btree (observation, exposure_root, source_id);
+
+alter table "public"."nirspec_source_review" add constraint "nirspec_source_review_pkey" PRIMARY KEY using index "nirspec_source_review_pkey";
+
+alter table "public"."nirspec_source_review" add constraint "nirspec_source_review_unique" UNIQUE using index "nirspec_source_review_unique";
+
+grant all on table "public"."nirspec_source_review" to "authenticated";
+
+grant all on table "public"."nirspec_source_review" to "service_role";
+
+create policy "admin_select_nirspec_source_review"
+  on "public"."nirspec_source_review" as permissive for select to authenticated
+  using (( SELECT public.is_admin() AS is_admin));
+
+create policy "admin_insert_nirspec_source_review"
+  on "public"."nirspec_source_review" as permissive for insert to authenticated
+  with check (( SELECT public.is_admin() AS is_admin));
+
+create policy "admin_update_nirspec_source_review"
+  on "public"."nirspec_source_review" as permissive for update to authenticated
+  using (( SELECT public.is_admin() AS is_admin))
+  with check (( SELECT public.is_admin() AS is_admin));

--- a/supabase/migrations/20260704200000_add_nirspec_source_review.sql
+++ b/supabase/migrations/20260704200000_add_nirspec_source_review.sql
@@ -55,3 +55,7 @@ create policy "admin_update_nirspec_source_review"
   on "public"."nirspec_source_review" as permissive for update to authenticated
   using (( SELECT public.is_admin() AS is_admin))
   with check (( SELECT public.is_admin() AS is_admin));
+
+-- Comments are not tracked by the migra diff engine (CLAUDE.md), so the table
+-- comment declared in schemas/tables.sql must be applied by hand here to reach prod.
+comment on table "public"."nirspec_source_review" is 'Editable flag channel for the NIRSpec nods review loop (P6). One row per (observation, exposure_root, source_id); admin-only, web-editable, NOT deployed. stuck_shutters/bkg_overrides jsonb mirror the reference/nirspec/<obs>/ TOMLs 1:1 for the P7 pull-back.';

--- a/supabase/schemas/policies.sql
+++ b/supabase/schemas/policies.sql
@@ -728,6 +728,31 @@ CREATE POLICY "admin_update_spectrum_exposures"
 
 
 -- =============================================================================
+-- nirspec_source_review (admin-only — NIRSpec editable flag channel, P6)
+-- =============================================================================
+-- Reviewer-editable stuck-shutter / bkg-override flags. Admin-only, web-editable
+-- (unlike the deploy-only intermediate tables, admins INSERT/UPDATE directly here).
+
+ALTER TABLE nirspec_source_review ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "admin_select_nirspec_source_review" ON nirspec_source_review;
+CREATE POLICY "admin_select_nirspec_source_review"
+  ON nirspec_source_review FOR SELECT TO authenticated
+  USING ((SELECT public.is_admin()));
+
+DROP POLICY IF EXISTS "admin_insert_nirspec_source_review" ON nirspec_source_review;
+CREATE POLICY "admin_insert_nirspec_source_review"
+  ON nirspec_source_review FOR INSERT TO authenticated
+  WITH CHECK ((SELECT public.is_admin()));
+
+DROP POLICY IF EXISTS "admin_update_nirspec_source_review" ON nirspec_source_review;
+CREATE POLICY "admin_update_nirspec_source_review"
+  ON nirspec_source_review FOR UPDATE TO authenticated
+  USING ((SELECT public.is_admin()))
+  WITH CHECK ((SELECT public.is_admin()));
+
+
+-- =============================================================================
 -- deploy_events (admin-only — lifecycle audit log, epic #210 B2/B3)
 -- =============================================================================
 -- Append-only audit log, written only by the lifecycle RPCs (SECURITY DEFINER,

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -875,6 +875,52 @@ COMMENT ON COLUMN "public"."spectrum_exposures"."exposure_root" IS 'Pipeline 2-t
 COMMENT ON COLUMN "public"."spectrum_exposures"."exp_group" IS 'Pipeline-computed exposure-group id (subpixel-dither), read from the canonical FITS CFEXPGRP header card. One value per group, spanning nods+detectors; a render/grouping attribute, NOT part of the unique key. Nullable (files predating the P4 stamp).';
 
 
+-- nirspec_source_review: the editable flag channel for the NIRSpec nods review
+-- loop (P6, design §4.3). One row per (observation, exposure_root, source_id) — a
+-- SOURCE-scoped grain, coarser than the spectrum_exposures render grid (which is
+-- per nod×detector), so the two flag channels live here rather than duplicating
+-- across every nod/detector row. Both channels are jsonb mirroring the local
+-- reference/nirspec/<obs>/ TOMLs 1:1, so P7's pull serializes without transform:
+--   stuck_shutters  = [1,2,3]     ordinal list   (mirrors stuck_closed_shutters.toml)
+--   bkg_overrides   = {"3":[1]}   {nod: [nods]}  (mirrors nodded_background_overrides.toml;
+--                                  keys/values are exposure-sequence numbers, not indices)
+-- Admin-only (RLS); web-editable; NOT deployed to OSN (deployments.stuck_shutters is a
+-- per-deploy snapshot, this is the live editable record). exposure_root is the 2-token
+-- root (jw07076020001_04101), same semantics as spectrum_exposures.exposure_root.
+CREATE TABLE IF NOT EXISTS "public"."nirspec_source_review" (
+    "id" integer NOT NULL,
+    "observation" "text" NOT NULL,
+    "exposure_root" "text" NOT NULL,
+    "source_id" integer NOT NULL,
+    "stuck_shutters" "jsonb",
+    "bkg_overrides" "jsonb",
+    "notes" "text",
+    "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL
+);
+
+
+ALTER TABLE "public"."nirspec_source_review" OWNER TO "postgres";
+
+
+CREATE SEQUENCE IF NOT EXISTS "public"."nirspec_source_review_id_seq"
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE "public"."nirspec_source_review_id_seq" OWNER TO "postgres";
+
+
+ALTER SEQUENCE "public"."nirspec_source_review_id_seq" OWNED BY "public"."nirspec_source_review"."id";
+
+
+COMMENT ON TABLE "public"."nirspec_source_review" IS 'Editable flag channel for the NIRSpec nods review loop (P6). One row per (observation, exposure_root, source_id); admin-only, web-editable, NOT deployed. stuck_shutters/bkg_overrides jsonb mirror the reference/nirspec/<obs>/ TOMLs 1:1 for the P7 pull-back.';
+
+
 -- storage_objects: the keystone shadow index of every object in cloud storage
 -- (epic #210, F1). Deploy writes one row per uploaded object using canonical keys
 -- from the campfire_layout contract; a backfill/reconcile pass covers historical
@@ -1386,6 +1432,8 @@ ALTER TABLE ONLY "public"."nirspec_rate_exposures" ALTER COLUMN "id" SET DEFAULT
 
 ALTER TABLE ONLY "public"."spectrum_exposures" ALTER COLUMN "id" SET DEFAULT "nextval"('"public"."spectrum_exposures_id_seq"'::"regclass");
 
+ALTER TABLE ONLY "public"."nirspec_source_review" ALTER COLUMN "id" SET DEFAULT "nextval"('"public"."nirspec_source_review_id_seq"'::"regclass");
+
 
 
 ALTER TABLE ONLY "public"."storage_objects" ALTER COLUMN "id" SET DEFAULT "nextval"('"public"."storage_objects_id_seq"'::"regclass");
@@ -1542,6 +1590,12 @@ ALTER TABLE ONLY "public"."spectrum_exposures"
 
 ALTER TABLE ONLY "public"."spectrum_exposures"
     ADD CONSTRAINT "spectrum_exposures_unique" UNIQUE ("observation", "exposure_root", "nod", "detector", "source_id");
+
+ALTER TABLE ONLY "public"."nirspec_source_review"
+    ADD CONSTRAINT "nirspec_source_review_pkey" PRIMARY KEY ("id");
+
+ALTER TABLE ONLY "public"."nirspec_source_review"
+    ADD CONSTRAINT "nirspec_source_review_unique" UNIQUE ("observation", "exposure_root", "source_id");
 
 ALTER TABLE ONLY "public"."deploy_events"
     ADD CONSTRAINT "deploy_events_pkey" PRIMARY KEY ("id");
@@ -2082,6 +2136,10 @@ GRANT ALL ON TABLE "public"."nirspec_rate_exposures" TO "service_role";
 GRANT ALL ON TABLE "public"."spectrum_exposures" TO "authenticated";
 GRANT ALL ON TABLE "public"."spectrum_exposures" TO "service_role";
 
+-- nirspec_source_review is admin-only (RLS); not granted to anon.
+GRANT ALL ON TABLE "public"."nirspec_source_review" TO "authenticated";
+GRANT ALL ON TABLE "public"."nirspec_source_review" TO "service_role";
+
 
 -- deploy_events is an admin/internal audit log (RLS admin-only); not granted to anon.
 GRANT ALL ON TABLE "public"."deploy_events" TO "authenticated";
@@ -2196,6 +2254,9 @@ GRANT ALL ON SEQUENCE "public"."nirspec_rate_exposures_id_seq" TO "service_role"
 
 GRANT ALL ON SEQUENCE "public"."spectrum_exposures_id_seq" TO "authenticated";
 GRANT ALL ON SEQUENCE "public"."spectrum_exposures_id_seq" TO "service_role";
+
+GRANT ALL ON SEQUENCE "public"."nirspec_source_review_id_seq" TO "authenticated";
+GRANT ALL ON SEQUENCE "public"."nirspec_source_review_id_seq" TO "service_role";
 
 
 GRANT ALL ON SEQUENCE "public"."storage_objects_id_seq" TO "authenticated";

--- a/web/app/admin/nirspec/nods/[source]/page.tsx
+++ b/web/app/admin/nirspec/nods/[source]/page.tsx
@@ -5,11 +5,26 @@ import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { Card } from '@/components/ui/Card';
 import { Loader2, ArrowLeft } from 'lucide-react';
-import { getNirspecNodGrid } from '@/lib/actions/nirspec-nods';
-import { buildNodGrid, decodeSource, NOD_DETECTORS } from '@/lib/nirspec-nods';
+import { getNirspecNodGrid, getNirspecSourceReviews, saveSourceReview } from '@/lib/actions/nirspec-nods';
+import {
+  buildNodGrid, decodeSource, NOD_DETECTORS,
+  nodKey, toggleStuckOrdinal, normalizeBkgOverrides,
+} from '@/lib/nirspec-nods';
 import { zscaleLimits, type StretchMode, type ColormapName } from '@/lib/fits';
 import type { SpectrumExposure } from '@/lib/types';
 import NodCell from '@/components/nirspec/NodCell';
+
+// Per-(exposure_root) editable review state, held in memory with optimistic updates.
+interface ReviewState {
+  stuck_shutters: number[];
+  bkg_overrides: Record<string, number[]>;
+}
+const EMPTY_REVIEW: ReviewState = { stuck_shutters: [], bkg_overrides: {} };
+
+/** exposure_root shared by a nod-grid row's ≤2 detector cells (nrs1/nrs2 of one nod). */
+function rowRoot(row: { cells: Record<string, SpectrumExposure | null> }): string | null {
+  return (row.cells.nrs1 ?? row.cells.nrs2)?.exposure_root ?? null;
+}
 
 function sharedRange(arrays: Float32Array[]): [number, number] | null {
   if (arrays.length === 0) return null;
@@ -82,6 +97,59 @@ function NodGridInner() {
     if (arrays.length > 0) setRange(sharedRange(arrays));
   }, [settledIds, dataById, expectedIds]);
 
+  // --- Editable flags (P6): nirspec_source_review, keyed by exposure_root ---
+  const [reviews, setReviews] = useState<Map<string, ReviewState>>(new Map());
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!decoded) return;
+    let cancelled = false;
+    getNirspecSourceReviews(decoded.observation, decoded.sourceId).then((res) => {
+      if (cancelled) return;
+      if (res.error) { setSaveError(res.error); return; }
+      const m = new Map<string, ReviewState>();
+      for (const r of res.reviews) {
+        m.set(r.exposure_root, {
+          stuck_shutters: r.stuck_shutters ?? [],
+          bkg_overrides: r.bkg_overrides ?? {},
+        });
+      }
+      setReviews(m);
+    });
+    return () => { cancelled = true; };
+  }, [decoded?.observation, decoded?.sourceId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Candidate background nods for the whole source: distinct nod sequence numbers.
+  const availableNods = useMemo(() => {
+    const s = new Set<string>();
+    for (const r of rows) s.add(nodKey(r.nod));
+    return [...s].sort((a, b) => Number(a) - Number(b));
+  }, [rows]);
+
+  // Optimistic save: update local state immediately, persist both flag channels.
+  const persist = useCallback((root: string, next: ReviewState) => {
+    if (!decoded) return;
+    setReviews((prev) => new Map(prev).set(root, next));
+    saveSourceReview(
+      decoded.observation, root, decoded.sourceId,
+      next.stuck_shutters.length ? next.stuck_shutters : null,
+      normalizeBkgOverrides(next.bkg_overrides),
+    ).then((res) => { if (res.error) setSaveError(res.error); });
+  }, [decoded?.observation, decoded?.sourceId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleToggleShutter = useCallback((root: string, ordinal: number) => {
+    const cur = reviews.get(root) ?? EMPTY_REVIEW;
+    persist(root, { ...cur, stuck_shutters: toggleStuckOrdinal(cur.stuck_shutters, ordinal) });
+  }, [reviews, persist]);
+
+  const handleBkgChange = useCallback((root: string, nk: string, list: number[] | null) => {
+    const cur = reviews.get(root) ?? EMPTY_REVIEW;
+    const bkg = { ...cur.bkg_overrides };
+    if (list === null) delete bkg[nk];
+    else bkg[nk] = list;
+    persist(root, { ...cur, bkg_overrides: bkg });
+  }, [reviews, persist]);
+
   if (loading) {
     return <div className="flex items-center justify-center py-16"><Loader2 className="w-8 h-8 animate-spin text-primary" /></div>;
   }
@@ -120,9 +188,9 @@ function NodGridInner() {
         </div>
       </div>
 
-      {error && (
+      {(error || saveError) && (
         <div className="bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-900 rounded-lg p-4 mb-4">
-          <p className="text-red-800 dark:text-red-400">{error}</p>
+          <p className="text-red-800 dark:text-red-400">{error ?? saveError}</p>
         </div>
       )}
 
@@ -131,35 +199,117 @@ function NodGridInner() {
       ) : (
         <Card className="overflow-x-auto p-3">
           <div className="min-w-fit">
-            {/* header row: detector labels */}
+            {/* header row: detector labels + flag column */}
             <div className="flex gap-2 mb-1 pl-16 text-xs font-medium text-text-secondary">
               {NOD_DETECTORS.map((d) => (
                 <div key={d} className="w-64 text-center">{d}</div>
               ))}
+              <div className="w-44 text-center">bkg override</div>
             </div>
-            {grid.map((row) => (
-              <div key={`${row.exp_group}-${row.nod}`} className="flex items-stretch gap-2 mb-2 h-32">
-                <div className="w-16 flex-shrink-0 flex items-center text-xs font-mono text-text-secondary">
-                  {multiGroup ? row.label : row.nod}
-                </div>
-                {NOD_DETECTORS.map((d) => (
-                  <div key={d} className="w-64 h-32 border border-border rounded">
-                    <NodCell
-                      exposure={row.cells[d]}
-                      range={range}
-                      stretch={stretch}
-                      colormap={colormap}
-                      bkgsub={bkgsub}
-                      onData={onData}
-                      onSettled={onSettled}
+            <p className="pl-16 mb-2 text-[10px] text-text-tertiary">
+              Click a shutter band on a cutout to toggle it stuck. Set per-nod background below.
+            </p>
+            {grid.map((row) => {
+              const root = rowRoot(row);
+              const review = (root && reviews.get(root)) || EMPTY_REVIEW;
+              const nk = nodKey(row.nod);
+              return (
+                <div key={`${row.exp_group}-${row.nod}`} className="flex items-stretch gap-2 mb-2 h-32">
+                  <div className="w-16 flex-shrink-0 flex items-center text-xs font-mono text-text-secondary">
+                    {multiGroup ? row.label : row.nod}
+                  </div>
+                  {NOD_DETECTORS.map((d) => (
+                    <div key={d} className="w-64 h-32 border border-border rounded">
+                      <NodCell
+                        exposure={row.cells[d]}
+                        range={range}
+                        stretch={stretch}
+                        colormap={colormap}
+                        bkgsub={bkgsub}
+                        onData={onData}
+                        onSettled={onSettled}
+                        stuckList={review.stuck_shutters}
+                        onToggleShutter={(ordinal) => { if (root) handleToggleShutter(root, ordinal); }}
+                      />
+                    </div>
+                  ))}
+                  <div className="w-44 h-32 border border-border rounded p-2 overflow-y-auto">
+                    <BkgOverrideControl
+                      disabled={!root}
+                      availableNods={availableNods.filter((n) => n !== nk)}
+                      value={review.bkg_overrides[nk]}
+                      onChange={(list) => { if (root) handleBkgChange(root, nk, list); }}
                     />
                   </div>
-                ))}
-              </div>
-            ))}
+                </div>
+              );
+            })}
           </div>
         </Card>
       )}
+    </div>
+  );
+}
+
+/**
+ * Per-nod background-override control. Three states, mirroring the TOML semantics:
+ *  - absent (undefined) → no override; pipeline uses its default background logic.
+ *  - explicit list [1,2] → use only those nods as background for this nod.
+ *  - empty list []       → exclude this nod entirely (CFP_BKG='excluded:override').
+ */
+function BkgOverrideControl({
+  disabled, availableNods, value, onChange,
+}: {
+  disabled: boolean;
+  availableNods: string[];
+  value: number[] | undefined;
+  onChange: (list: number[] | null) => void;
+}) {
+  const excluded = Array.isArray(value) && value.length === 0;
+  const selected = new Set(value ?? []);
+  const toggleNod = (n: number) => {
+    const next = new Set(selected);
+    if (next.has(n)) next.delete(n); else next.add(n);
+    onChange(next.size ? [...next].sort((a, b) => a - b) : null);
+  };
+  return (
+    <div className={`flex flex-col gap-1 text-[10px] ${disabled ? 'opacity-40 pointer-events-none' : ''}`}>
+      <div className="flex flex-wrap gap-1">
+        {availableNods.length === 0 && <span className="text-text-tertiary">no other nods</span>}
+        {availableNods.map((n) => {
+          const num = Number(n);
+          const on = selected.has(num) && !excluded;
+          return (
+            <button
+              key={n}
+              onClick={() => toggleNod(num)}
+              disabled={excluded}
+              className={`px-1.5 py-0.5 rounded border ${on ? 'bg-primary text-on-primary border-primary' : 'border-border text-text-secondary'} ${excluded ? 'opacity-40' : ''}`}
+              title={`Use nod ${n} as background`}
+            >
+              {n}
+            </button>
+          );
+        })}
+      </div>
+      <div className="flex gap-1">
+        <button
+          onClick={() => onChange(excluded ? null : [])}
+          className={`px-1.5 py-0.5 rounded border ${excluded ? 'bg-red-500 text-white border-red-500' : 'border-border text-text-secondary'}`}
+          title="Exclude this nod (empty background list)"
+        >
+          excl
+        </button>
+        {(value !== undefined) && (
+          <button
+            onClick={() => onChange(null)}
+            className="px-1.5 py-0.5 rounded border border-border text-text-tertiary"
+            title="Clear override (use pipeline default)"
+          >
+            clear
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/web/components/nirspec/NodCell.tsx
+++ b/web/components/nirspec/NodCell.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Loader2 } from 'lucide-react';
 import { fetchS2dCell, HduNotFoundError, paintToImageData, type S2dCell } from '@/lib/fits';
 import type { StretchMode } from '@/lib/fits';
 import type { ColormapName } from '@/lib/fits';
 import type { SpectrumExposure } from '@/lib/types';
+import { shutterOverlayRegions } from '@/lib/nirspec-shutters';
 
 interface Props {
   exposure: SpectrumExposure | null;
@@ -21,6 +22,10 @@ interface Props {
    * the page can compute the shared stretch once ALL cells have settled — not
    * only once all have succeeded (absent cells never call onData). */
   onSettled: (id: number) => void;
+  /** 1-indexed shutter ordinals flagged stuck for this cell's source (from the DB). */
+  stuckList: number[];
+  /** Toggle a shutter ordinal stuck/unstuck. The page binds (exposure_root, source_id). */
+  onToggleShutter: (ordinal: number) => void;
 }
 
 /** Median across the dispersion axis (columns) → one value per row. Mirrors the
@@ -63,7 +68,56 @@ function ProfileSvg({ data, width, height }: { data: Float32Array; width: number
   );
 }
 
-export default function NodCell({ exposure, range, stretch, colormap, bkgsub, onData, onSettled }: Props) {
+/** Clickable shutter-boundary overlay drawn over the s2d canvas. Each region is a
+ * band toggling its shutter ordinal stuck/unstuck; stuck ordinals show red + `n*`.
+ * Uses origin='lower' (row 0 at the bottom), matching the canvas + profile. */
+function ShutterOverlay({
+  regions,
+  nRows,
+  onToggle,
+}: {
+  regions: import('@/lib/nirspec-shutters').ShutterOverlayRegion[];
+  nRows: number;
+  onToggle: (ordinal: number) => void;
+}) {
+  const yFromRow = (row: number) => 100 - (row / (nRows - 1)) * 100;
+  return (
+    <svg viewBox="0 0 100 100" preserveAspectRatio="none" className="absolute inset-0 w-full h-full">
+      {regions.map((r, k) => {
+        const yTop = yFromRow(r.rowEnd);
+        const yBot = yFromRow(r.rowStart);
+        const h = Math.max(0, yBot - yTop);
+        const yMid = (yTop + yBot) / 2;
+        return (
+          <g key={`${r.ordinal}-${k}`}>
+            {k > 0 && (
+              <line x1={0} x2={100} y1={yBot} y2={yBot} stroke="gray" strokeWidth={0.5}
+                strokeDasharray="2 2" vectorEffect="non-scaling-stroke" opacity={0.6} />
+            )}
+            <rect
+              x={0} y={yTop} width={100} height={h}
+              fill={r.stuck ? 'red' : 'white'} fillOpacity={r.stuck ? 0.18 : 0.001}
+              className="cursor-pointer"
+              onClick={() => onToggle(r.ordinal)}
+            >
+              <title>{r.stuck ? `shutter ${r.ordinal} — stuck (click to clear)` : `shutter ${r.ordinal} (click to mark stuck)`}</title>
+            </rect>
+            <text
+              x={98} y={yMid} textAnchor="end" dominantBaseline="middle"
+              fontSize={6} fill={r.stuck ? '#f87171' : '#d1d5db'}
+              fontWeight={r.stuck ? 'bold' : 'normal'}
+              style={{ pointerEvents: 'none' }}
+            >
+              {r.stuck ? `${r.ordinal}*` : r.ordinal}
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+export default function NodCell({ exposure, range, stretch, colormap, bkgsub, onData, onSettled, stuckList, onToggleShutter }: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [cell, setCell] = useState<S2dCell | null>(null);
   const [state, setState] = useState<'loading' | 'ready' | 'absent' | 'error'>('loading');
@@ -107,6 +161,18 @@ export default function NodCell({ exposure, range, stretch, colormap, bkgsub, on
     ctx.putImageData(paintToImageData(cell.data, cell.width, cell.height, range[0], range[1], stretch, colormap), 0, 0);
   }, [state, cell, range, stretch, colormap]);
 
+  // Shutter-boundary overlay regions (P6). Computed from the s2d headers already
+  // captured by fetchS2dCell — matches the *_nods.pdf annotation geometry.
+  const overlay = useMemo(() => {
+    if (state !== 'ready' || !cell) return [];
+    return shutterOverlayRegions({
+      shutsta: cell.sciHeader?.getString('SHUTSTA'),
+      stuckList,
+      stkshtrs: cell.primaryHeader.getString('STKSHTRS'),
+      nRows: cell.height,
+    });
+  }, [state, cell, stuckList]);
+
   if (!exposure) {
     return <div className="flex items-center justify-center h-full text-text-tertiary text-xs">—</div>;
   }
@@ -142,6 +208,9 @@ export default function NodCell({ exposure, range, stretch, colormap, bkgsub, on
           className="w-full h-full"
           style={{ imageRendering: 'pixelated', objectFit: 'fill' }}
         />
+        {cell && overlay.length > 0 && (
+          <ShutterOverlay regions={overlay} nRows={cell.height} onToggle={onToggleShutter} />
+        )}
         {(stkshtrs || shutsta) && (
           <div className="absolute bottom-0 left-0 right-0 px-1 py-0.5 bg-black/50 text-[9px] font-mono text-white/80 truncate"
             title={`STKSHTRS=${stkshtrs ?? ''} SHUTSTA=${shutsta ?? ''}`}>

--- a/web/lib/actions/nirspec-nods.ts
+++ b/web/lib/actions/nirspec-nods.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { createClient } from '@/lib/supabase/server';
-import type { SpectrumExposure } from '@/lib/types';
+import type { SpectrumExposure, NirspecSourceReview } from '@/lib/types';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -104,5 +104,70 @@ export async function getNirspecNodGrid(
       rows: [],
       error: err instanceof Error ? err.message : 'Failed to fetch nod grid',
     };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Source-scoped flags (P6): nirspec_source_review, one row per
+// (observation, exposure_root, source_id). A nods grid spans several exposure
+// roots, so the page loads all reviews for the source and indexes by root.
+// ---------------------------------------------------------------------------
+
+export async function getNirspecSourceReviews(
+  observation: string,
+  sourceId: number,
+): Promise<{ reviews: NirspecSourceReview[]; error?: string }> {
+  try {
+    const supabase = await requireAdmin();
+    const { data, error } = await supabase
+      .from('nirspec_source_review')
+      .select('*')
+      .eq('observation', observation)
+      .eq('source_id', sourceId);
+    if (error) return { reviews: [], error: error.message };
+    return { reviews: (data ?? []) as NirspecSourceReview[] };
+  } catch (err) {
+    return {
+      reviews: [],
+      error: err instanceof Error ? err.message : 'Failed to fetch source reviews',
+    };
+  }
+}
+
+/**
+ * Upsert a source's review row by its natural key. BOTH flag channels are written
+ * on every save (the caller passes the current sibling value) so a single-channel
+ * edit can't null the other column — the upsert writes a whole row. Empty
+ * stuck-shutter lists / empty override maps are stored as SQL NULL (see the
+ * normalizeBkgOverrides / caller conventions).
+ */
+export async function saveSourceReview(
+  observation: string,
+  exposureRoot: string,
+  sourceId: number,
+  stuckShutters: number[] | null,
+  bkgOverrides: Record<string, number[]> | null,
+): Promise<{ review?: NirspecSourceReview; error?: string }> {
+  try {
+    const supabase = await requireAdmin();
+    const { data, error } = await supabase
+      .from('nirspec_source_review')
+      .upsert(
+        {
+          observation,
+          exposure_root: exposureRoot,
+          source_id: sourceId,
+          stuck_shutters: stuckShutters && stuckShutters.length ? stuckShutters : null,
+          bkg_overrides: bkgOverrides,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'observation,exposure_root,source_id' },
+      )
+      .select()
+      .single();
+    if (error) return { error: error.message };
+    return { review: data as NirspecSourceReview };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : 'Failed to save source review' };
   }
 }

--- a/web/lib/nirspec-nods.test.ts
+++ b/web/lib/nirspec-nods.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { encodeSource, decodeSource, buildNodGrid } from './nirspec-nods';
+import {
+  encodeSource, decodeSource, buildNodGrid,
+  nodKey, toggleStuckOrdinal, normalizeBkgOverrides,
+} from './nirspec-nods';
 import type { SpectrumExposure } from './types';
 
 function row(over: Partial<SpectrumExposure>): SpectrumExposure {
@@ -56,5 +59,29 @@ describe('buildNodGrid', () => {
     expect(grid[0].label).toBe('00001');
     expect(grid[0].cells.nrs1?.id).toBe(1);
     expect(grid[0].cells.nrs2).toBeNull();
+  });
+});
+
+describe('flag helpers (P6)', () => {
+  it('nodKey int-parses the zero-padded nod token (matches stage2 filename parse)', () => {
+    expect(nodKey('00003')).toBe('3');
+    expect(nodKey('00001')).toBe('1');
+    expect(nodKey('12')).toBe('12');
+  });
+
+  it('toggleStuckOrdinal adds (sorted), removes, and dedups', () => {
+    expect(toggleStuckOrdinal([1, 3], 2)).toEqual([1, 2, 3]); // add, sorted
+    expect(toggleStuckOrdinal([1, 2, 3], 2)).toEqual([1, 3]); // remove existing
+    expect(toggleStuckOrdinal([2], 2)).toEqual([]);           // toggle to empty
+    expect(toggleStuckOrdinal([], 5)).toEqual([5]);
+  });
+
+  it('normalizeBkgOverrides: empty map → null; empty list preserved (= exclude)', () => {
+    expect(normalizeBkgOverrides({})).toBeNull();
+    expect(normalizeBkgOverrides({ '3': [1] })).toEqual({ '3': [1] });
+    // empty list is meaningful ("exclude this nod") and must survive
+    expect(normalizeBkgOverrides({ '3': [] })).toEqual({ '3': [] });
+    // values + keys are sorted numerically
+    expect(normalizeBkgOverrides({ '2': [3, 1], '10': [2] })).toEqual({ '2': [1, 3], '10': [2] });
   });
 });

--- a/web/lib/nirspec-nods.ts
+++ b/web/lib/nirspec-nods.ts
@@ -67,3 +67,43 @@ export function buildNodGrid(rows: SpectrumExposure[]): NodGridRow[] {
   }
   return result;
 }
+
+// ---------------------------------------------------------------------------
+// Flag helpers (P6) — pure, shared by the page + server actions + tests.
+// ---------------------------------------------------------------------------
+
+/**
+ * The jsonb/TOML key for a nod is the exposure-SEQUENCE number (the int-parsed
+ * filename token), NOT the zero-padded token. Matches stage2.py's
+ * `int(filename.split('_')[2])` and the bkg-override TOML docstring. So the DB key
+ * for nod token '00003' is '3'.
+ */
+export function nodKey(nodToken: string): string {
+  return String(parseInt(nodToken, 10));
+}
+
+/** Toggle a 1-indexed shutter ordinal in a stuck-shutter list; returns a new sorted, deduped list. */
+export function toggleStuckOrdinal(list: number[], ordinal: number): number[] {
+  const set = new Set(list);
+  if (set.has(ordinal)) set.delete(ordinal);
+  else set.add(ordinal);
+  return [...set].sort((a, b) => a - b);
+}
+
+/**
+ * Normalize a bkg-override map for storage: an empty list `[]` for a nod is
+ * meaningful (it means "exclude this nod", distinct from an absent key) and is
+ * preserved, but a wholly-empty map collapses to `null` so the column reads as
+ * "no overrides".
+ */
+export function normalizeBkgOverrides(
+  map: Record<string, number[]>,
+): Record<string, number[]> | null {
+  const keys = Object.keys(map);
+  if (keys.length === 0) return null;
+  const out: Record<string, number[]> = {};
+  for (const k of keys.sort((a, b) => Number(a) - Number(b))) {
+    out[k] = [...map[k]!].sort((a, b) => a - b);
+  }
+  return out;
+}

--- a/web/lib/nirspec-shutters.test.ts
+++ b/web/lib/nirspec-shutters.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { computeShutterRegions, shutterOverlayRegions } from './nirspec-shutters';
+
+// Oracle values computed directly from the pipeline's _compute_shutter_regions
+// (stuck_shutters.py) — the web port must match the *_nods.pdf geometry exactly.
+describe('computeShutterRegions', () => {
+  it('matches the pipeline oracle for representative (nShutters, nRows)', () => {
+    expect(computeShutterRegions(3, 400).map((r) => [r.rowStart, r.rowEnd]))
+      .toEqual([[46, 147], [149, 252], [254, 355]]);
+    expect(computeShutterRegions(5, 400).map((r) => [r.rowStart, r.rowEnd]))
+      .toEqual([[31, 97], [99, 165], [167, 234], [236, 302], [304, 370]]);
+    expect(computeShutterRegions(1, 400).map((r) => [r.rowStart, r.rowEnd]))
+      .toEqual([[96, 305]]);
+    expect(computeShutterRegions(3, 100).map((r) => [r.rowStart, r.rowEnd]))
+      .toEqual([[12, 37], [39, 62], [64, 89]]);
+  });
+
+  it('returns one region per shutter, ordered bottom→top', () => {
+    const regions = computeShutterRegions(5, 400);
+    expect(regions).toHaveLength(5);
+    // region 0 is the bottom (lowest rows), region N-1 the top (highest rows)
+    for (let i = 1; i < regions.length; i++) {
+      expect(regions[i].rowStart).toBeGreaterThan(regions[i - 1].rowStart);
+    }
+  });
+});
+
+describe('shutterOverlayRegions', () => {
+  it('pre-reprocessing: ordinals N..1, no stuck flags without a stuck list', () => {
+    const regions = shutterOverlayRegions({ shutsta: 'xxx', stuckList: [], stkshtrs: 'N/A', nRows: 400 });
+    expect(regions.map((r) => r.ordinal)).toEqual([3, 2, 1]); // bottom→top
+    expect(regions.every((r) => !r.stuck)).toBe(true);
+  });
+
+  it('pre-reprocessing: marks the flagged ordinal stuck', () => {
+    const regions = shutterOverlayRegions({ shutsta: 'xxx', stuckList: [2], stkshtrs: 'N/A', nRows: 400 });
+    expect(regions.find((r) => r.ordinal === 2)?.stuck).toBe(true);
+    expect(regions.find((r) => r.ordinal === 1)?.stuck).toBe(false);
+  });
+
+  it('post-reprocessing: removed stuck shutter shrinks the window', () => {
+    // 2 shutters remain in SHUTSTA, ordinal 3 was removed from the metafile.
+    const regions = shutterOverlayRegions({ shutsta: 'xx', stuckList: [3], stkshtrs: 'OPEN', nRows: 400 });
+    // nOriginal=3, remaining=[1,2], window spans ordinals 2..1
+    expect(regions.map((r) => r.ordinal)).toEqual([2, 1]);
+    expect(regions).toHaveLength(2);
+  });
+
+  it('empty SHUTSTA yields no regions', () => {
+    expect(shutterOverlayRegions({ shutsta: '', stuckList: [], stkshtrs: 'N/A', nRows: 400 })).toEqual([]);
+    expect(shutterOverlayRegions({ shutsta: null, stuckList: [], stkshtrs: 'N/A', nRows: 400 })).toEqual([]);
+  });
+});

--- a/web/lib/nirspec-shutters.ts
+++ b/web/lib/nirspec-shutters.ts
@@ -1,0 +1,107 @@
+// Shutter-region geometry for the NIRSpec nods overlay (P6). A faithful port of
+// two pipeline functions so the web overlay matches the *_nods.pdf exactly:
+//   - _compute_shutter_regions  (stuck_shutters.py:_compute_shutter_regions)
+//   - _annotate_stuck_shutters  (plots.py:_annotate_stuck_shutters)
+// Pure module (no 'use server'); imported by NodCell for drawing and by tests.
+
+// JWST NIRSpec MSA slit geometry (must match stuck_shutters.py constants).
+const MSA_MARGIN = 1.05; // 0.55 (half open area) + 0.50 (padding beyond outer shutters)
+const MSA_PITCH = 1.15; // slit_frame units per shutter pitch
+const PADDING = 0.5; // padding zone beyond the outer shutters, excluded from regions
+
+/**
+ * numpy-compatible round-half-away-from-zero. NB: numpy actually rounds
+ * half-to-even; for the fractional pixel positions here an exact .5 is
+ * vanishingly unlikely, so Math.round (half-up) matches in practice. Kept as a
+ * named helper to flag the (negligible) discrepancy — the vitest oracle catches
+ * any real divergence.
+ */
+function npRound(x: number): number {
+  return Math.round(x);
+}
+
+export interface ShutterRegion {
+  rowStart: number;
+  rowEnd: number;
+}
+
+/**
+ * Pixel row boundaries for each shutter region in an s2d image. Port of
+ * `_compute_shutter_regions`. Regions are ordered from the BOTTOM of the s2d
+ * (region 0 = highest shutter_column = shutter N) to the top (region N-1 =
+ * shutter 1). The 0.50 padding beyond the outer shutters and the sub-pixel bar
+ * rows between shutters are excluded.
+ */
+export function computeShutterRegions(nShutters: number, nRows: number): ShutterRegion[] {
+  const total = (nShutters - 1) * MSA_PITCH + 2 * MSA_MARGIN;
+  const outerMarginPix = npRound((PADDING / total) * (nRows - 1));
+
+  const boundaries: number[] = [outerMarginPix];
+  for (let k = 0; k < nShutters - 1; k++) {
+    const frac = (MSA_MARGIN + (k + 0.5) * MSA_PITCH) / total;
+    boundaries.push(npRound(frac * (nRows - 1)));
+  }
+  boundaries.push(nRows - outerMarginPix);
+
+  const regions: ShutterRegion[] = [];
+  for (let i = 0; i < nShutters; i++) {
+    const start = boundaries[i]! + (i > 0 ? 1 : 0) + 1;
+    const end = boundaries[i + 1]!;
+    regions.push({ rowStart: start, rowEnd: end });
+  }
+  return regions;
+}
+
+export interface ShutterOverlayRegion extends ShutterRegion {
+  ordinal: number; // 1-indexed slitlet ordinal
+  stuck: boolean; // whether this ordinal is flagged stuck
+}
+
+export interface ShutterOverlayInput {
+  /** SHUTSTA header string from the s2d SCI extension; its length is the current shutter count. */
+  shutsta: string | null | undefined;
+  /** 1-indexed shutter ordinals flagged as stuck (from nirspec_source_review.stuck_shutters). */
+  stuckList: number[];
+  /** STKSHTRS header from the s2d PRIMARY extension ('N/A' ⇒ pre-reprocessing). */
+  stkshtrs: string | null | undefined;
+  /** Number of spatial pixels (image height). */
+  nRows: number;
+}
+
+/**
+ * Map an s2d cell's shutter geometry to labelled, clickable overlay regions. Port
+ * of `_annotate_stuck_shutters` — handles pre-reprocessing (stuck shutters still in
+ * SHUTSTA) and post-reprocessing (removed from the metafile) geometry. Returns [] if
+ * the cell has no shutters or the reprocessed window is empty.
+ */
+export function shutterOverlayRegions(input: ShutterOverlayInput): ShutterOverlayRegion[] {
+  const { shutsta, stuckList, stkshtrs, nRows } = input;
+  const nCurrent = shutsta ? shutsta.length : 0;
+  if (nCurrent < 1) return [];
+
+  // STKSHTRS distinguishes pre- vs post-reprocessing; 'N/A' (or absent) ⇒ pre.
+  const reprocessed = !!stkshtrs && stkshtrs !== 'N/A';
+
+  let nEffective: number;
+  let ordinals: number[];
+  if (!reprocessed) {
+    nEffective = nCurrent;
+    ordinals = Array.from({ length: nCurrent }, (_, k) => nCurrent - k);
+  } else {
+    const nOriginal = nCurrent + stuckList.length;
+    const stuckSet = new Set(stuckList);
+    const remaining: number[] = [];
+    for (let s = 1; s <= nOriginal; s++) if (!stuckSet.has(s)) remaining.push(s);
+    if (remaining.length === 0) return [];
+    const minRemain = remaining[0]!;
+    const maxRemain = remaining[remaining.length - 1]!;
+    nEffective = maxRemain - minRemain + 1;
+    ordinals = Array.from({ length: nEffective }, (_, k) => maxRemain - k);
+  }
+
+  const stuckSet = new Set(stuckList);
+  return computeShutterRegions(nEffective, nRows).map((region, k) => {
+    const ordinal = ordinals[k]!;
+    return { ...region, ordinal, stuck: stuckSet.has(ordinal) };
+  });
+}

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -403,6 +403,22 @@ export interface SpectrumExposure {
   updated_at: string;
 }
 
+// Source-scoped editable review flags for the NIRSpec nods loop (P6). One row per
+// (observation, exposure_root, source_id). Both jsonb channels mirror the local
+// reference/nirspec/<obs>/ TOMLs 1:1: stuck_shutters is an ordinal list [1,2,3];
+// bkg_overrides is {nod: [bkg nods]} keyed by exposure-sequence number (e.g. {"3":[1]}).
+export interface NirspecSourceReview {
+  id: number;
+  observation: string;
+  exposure_root: string;
+  source_id: number;
+  stuck_shutters: number[] | null;
+  bkg_overrides: Record<string, number[]> | null;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 // One entry in observations.pointings — a NIRSpec MSA pointing.
 export interface Pointing {
   msametid: number;


### PR DESCRIPTION
## P6 — Editable flag channel + nods flag UI

Sixth phase of the NIRSpec web review loop (`docs/design-nirspec-review-loop.md` §4.3/§5/§6). Web + Supabase only — no `pipeline/**`, so no changelog/migration-to-pipeline obligations. Admin-only and merge-inert (no public surface).

### Schema (additive, one new table)
- **`nirspec_source_review`** — one row per `(observation, exposure_root, source_id)`, UNIQUE on that triple. Two jsonb channels that mirror the local `reference/nirspec/<obs>/` TOMLs **1:1**, so P7's pull serializes without transform:
  - `stuck_shutters` = `[1,2,3]` (ordinal list, mirrors `stuck_closed_shutters.toml`)
  - `bkg_overrides` = `{"3":[1]}` (`{nod: [bkg nods]}`, keyed by exposure-sequence number, mirrors `nodded_background_overrides.toml`)
- Admin RLS, web-editable, **not** deployed to OSN. Schema files (`tables.sql`/`policies.sql`) + a hand-authored additive migration mirror the merged `nirspec_rate_exposures` idiom exactly (integer id + sequence, canonical `is_admin()` RLS, `authenticated`+`service_role` grants, no anon; sequence grants in the schema file, omitted from the migration — same as the sibling).
- Brand-new empty table with no dependents → `seed.sql` unaffected (the seed generator doesn't emit it, same precedent as `nirspec_rate_exposures`/`spectrum_exposures`).

### Web
- **`lib/nirspec-shutters.ts`** (new) — a faithful port of the pipeline shutter geometry (`stuck_shutters.py:_compute_shutter_regions` + `plots.py:_annotate_stuck_shutters`), handling pre- vs post-reprocessing (`STKSHTRS`) window logic. Pure module.
- **`NodCell`** — a clickable shutter-boundary SVG overlay over the s2d cutout. Each band toggles its ordinal stuck (red tint + `n*` label); `origin='lower'` to match the canvas + 1D profile. Header inputs (`SHUTSTA`/`STKSHTRS`) already captured by `fetchS2dCell`, no proxy change.
- **`nods/[source]` page** — loads reviews keyed by `exposure_root`, threads each source's stuck list + toggle into its cells, and adds a **per-nod background-override control** (include specific nods / exclude / clear) in a new right-hand column. Optimistic in-memory updates.
- **Server actions** — `getNirspecSourceReviews` (load) + `saveSourceReview` (upsert by natural key). Every save writes **both** flag channels so a single-channel edit can't null its sibling column. All `requireAdmin()`-gated. Consts/pure helpers live in the plain `lib/nirspec-nods.ts` (the `'use server'` module exports only async functions).

### Correctness notes
- Nod keys/values are the **exposure-sequence integers** (`"00003"` → `"3"`), matching `stage2.py`'s filename parse and the bkg-override TOML docstring.
- An **empty** bkg list `[]` (= "exclude this nod", `CFP_BKG='excluded:override'`) is preserved and kept distinct from an **absent** key (pipeline default) in both the UI and `normalizeBkgOverrides`.
- Stuck-shutter geometry is per-source, so toggling on one detector cell applies to the whole `(root, source_id)` row — matching the pipeline's per-source consumption.

### Verification
- `vitest`: 13 tests pass — geometry oracle (values cross-checked against the pipeline functions) + flag helpers.
- `tsc --noEmit` clean; `npm run build` green (86 pages; both nods routes generate).
- Pixel render + click-through validate on the Vercel preview against real deployed S2D data (can't be exercised in CI).

Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQiCGrfdaQu5cF9dbVCJNd)_