### PR TITLE
fix(nircam): make exposure prev/next actually instant — local image cache + warmth-aware swap

### DIFF
--- a/web/components/nircam/MaskEditor.tsx
+++ b/web/components/nircam/MaskEditor.tsx
@@ -27,6 +27,7 @@ import { Button } from '@/components/ui/Button';
 import type { MaskPolygon, MaskRegionsPayload } from '@/lib/types';
 import FitsCanvas, { type FitsCanvasLoad } from './FitsCanvas';
 import { STRETCH_MODES, COLORMAP_NAMES, type StretchMode, type ColormapName } from '@/lib/fits';
+import { isPngCached } from '@/lib/nircam-exposure-cache';
 
 type Mode = 'inspect' | 'draw' | 'edit';
 
@@ -127,9 +128,11 @@ export default function MaskEditor({
   const [saveError, setSaveError] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<number | null>(null);
 
-  // The PNG actually painted. We hold the current exposure's image until the
-  // *next* URL has decoded, then swap in one frame (see the swap effect below).
+  // The PNG actually painted. Swapped by the effect below: held across a warm
+  // navigation (seamless) but cleared to a loading state on a cold one, so we
+  // never show a stale exposure under the next one's metadata + mask.
   const [shownUrl, setShownUrl] = useState<string | undefined>(pngUrl);
+  const swappedOnceRef = useRef(false);
 
   // FITS render controls (only used when `fitsKey` is set). vmin/vmax drive the
   // display interval; 0/0 means "unset" so FitsCanvas keeps its on-load ZScale
@@ -194,20 +197,23 @@ export default function MaskEditor({
     setDraftVertices([]);
   }, [initialRegions, imageHeight]);
 
-  // Seamless image swap. Changing an <img> src blanks the element for a frame
-  // before the new bitmap paints — the "reload" flash on prev/next, even when
-  // the bytes are already cached. Instead we keep showing the current PNG and
-  // only swap `shownUrl` once the incoming URL has decoded — which is ~instant
-  // when it's in the retained image cache (lib/nircam-exposure-cache), so the
-  // step reads as a single seamless frame change with no blank in between.
+  // Image swap on prev/next. The initial mount already shows `pngUrl`, so skip
+  // the first run and let that image load natively. On later navigations:
+  //   - Warm (already decoded in the retained cache): keep the current frame
+  //     and swap on the ~instant decode, so the step never flashes.
+  //   - Cold: blank to a loading state immediately rather than lingering on the
+  //     previous exposure's pixels (misleading beside the new metadata + mask),
+  //     then swap once the incoming image has decoded.
   useEffect(() => {
+    if (!swappedOnceRef.current) { swappedOnceRef.current = true; return; }
     if (pngUrl === undefined) { setShownUrl(undefined); return; }
+    if (!isPngCached(pngUrl)) setShownUrl(undefined);
     let cancelled = false;
     const swap = () => { if (!cancelled) setShownUrl(pngUrl); };
     const img = new Image();
     img.decoding = 'async';
     img.src = pngUrl;
-    // Swap on decode-error too, so a bad frame never wedges us on the old one.
+    // Swap on decode-error too, so a bad frame never wedges us on a blank panel.
     img.decode().then(swap).catch(swap);
     return () => { cancelled = true; };
   }, [pngUrl]);
@@ -488,6 +494,9 @@ export default function MaskEditor({
               style={{ imageRendering: 'pixelated' }}
             />
           ) : null}
+          {/* Overlay only when an image is present — during a cold-load blank
+              there's nothing to draw masks against. */}
+          {(shownUrl || fitsKey) && (
           <svg
             ref={svgRef}
             width={imageWidth}
@@ -538,7 +547,17 @@ export default function MaskEditor({
               </g>
             )}
           </svg>
+          )}
         </div>
+
+        {/* Cold-load indicator: the incoming PNG isn't cached yet, so the panel
+            stays blank (rather than showing the previous exposure) until it's
+            fetched and decoded. */}
+        {!fitsKey && pngUrl && !shownUrl && (
+          <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+            <Loader2 className="w-8 h-8 animate-spin text-white/40" />
+          </div>
+        )}
 
         {/* Help footer */}
         <div className="absolute bottom-2 left-2 right-2 text-[11px] text-white/70 pointer-events-none font-mono">

--- a/web/components/nircam/MaskEditor.tsx
+++ b/web/components/nircam/MaskEditor.tsx
@@ -127,6 +127,10 @@ export default function MaskEditor({
   const [saveError, setSaveError] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<number | null>(null);
 
+  // The PNG actually painted. We hold the current exposure's image until the
+  // *next* URL has decoded, then swap in one frame (see the swap effect below).
+  const [shownUrl, setShownUrl] = useState<string | undefined>(pngUrl);
+
   // FITS render controls (only used when `fitsKey` is set). vmin/vmax drive the
   // display interval; 0/0 means "unset" so FitsCanvas keeps its on-load ZScale
   // until the range flows back in from `handleFitsLoad`.
@@ -189,6 +193,24 @@ export default function MaskEditor({
     setSelectedId(null);
     setDraftVertices([]);
   }, [initialRegions, imageHeight]);
+
+  // Seamless image swap. Changing an <img> src blanks the element for a frame
+  // before the new bitmap paints — the "reload" flash on prev/next, even when
+  // the bytes are already cached. Instead we keep showing the current PNG and
+  // only swap `shownUrl` once the incoming URL has decoded — which is ~instant
+  // when it's in the retained image cache (lib/nircam-exposure-cache), so the
+  // step reads as a single seamless frame change with no blank in between.
+  useEffect(() => {
+    if (pngUrl === undefined) { setShownUrl(undefined); return; }
+    let cancelled = false;
+    const swap = () => { if (!cancelled) setShownUrl(pngUrl); };
+    const img = new Image();
+    img.decoding = 'async';
+    img.src = pngUrl;
+    // Swap on decode-error too, so a bad frame never wedges us on the old one.
+    img.decode().then(swap).catch(swap);
+    return () => { cancelled = true; };
+  }, [pngUrl]);
 
   const markDirty = useCallback(() => { setDirty(true); setSavedAt(null); }, []);
 
@@ -454,10 +476,10 @@ export default function MaskEditor({
               onLoad={handleFitsLoad}
               onError={setFitsError}
             />
-          ) : pngUrl ? (
+          ) : shownUrl ? (
             /* eslint-disable-next-line @next/next/no-img-element */
             <img
-              src={pngUrl}
+              src={shownUrl}
               width={imageWidth}
               height={imageHeight}
               alt="exposure preview"

--- a/web/lib/nircam-exposure-cache.ts
+++ b/web/lib/nircam-exposure-cache.ts
@@ -77,3 +77,15 @@ export function prefetchPng(url: string | null): void {
     retainedImages.delete(oldest);
   }
 }
+
+/**
+ * True when a PNG is already fully loaded in the retained cache — i.e. it can be
+ * painted with no network wait. Callers use this to decide between a seamless
+ * swap (warm) and blanking to a loading state (cold), so the viewer never shows
+ * a stale exposure's pixels beside the next exposure's metadata.
+ */
+export function isPngCached(url: string | null): boolean {
+  if (!url) return false;
+  const img = retainedImages.get(url);
+  return !!img && img.complete && img.naturalWidth > 0;
+}

--- a/web/lib/nircam-exposure-cache.ts
+++ b/web/lib/nircam-exposure-cache.ts
@@ -27,19 +27,53 @@ export function clearExposureCache(): void {
 }
 
 /**
- * Warm browser HTTP cache for a PNG (full-res mask surface or preview) so the
- * next render of an <img src=...> is paint-instant. Returns immediately; the
- * fetch continues in the background and lands in the same cache the eventual
- * <img> will use. Re-warming an already-cached URL is a cache hit (no network),
- * so it's safe to call on every navigation.
+ * Retained decoded exposure PNGs, keyed by URL. This is the "local cache" that
+ * makes prev/next switching paint-instant.
+ *
+ * The exposure PNGs are served straight into <img> from OSN via presigned URLs
+ * (epic #261 N5) — deliberately bypassing the Next proxy other images use. That
+ * proxy is also where those images pick up a `Cache-Control` header; the OSN
+ * objects themselves carry none (the deploy upload sets only content-type). So
+ * the browser will NOT reliably keep a fetched PNG in its HTTP cache, and a
+ * throwaway `new Image()` prefetch is garbage-collected the moment it returns —
+ * both of which mean the eventual <img> just refetches ~5.7 MB from OSN (~1 s).
+ *
+ * Holding a live HTMLImageElement keeps the browser's in-memory image cache hot
+ * for that exact URL, so a later <img src=sameUrl> reuses the decoded bitmap
+ * with no network round-trip — independent of any Cache-Control header. Bounded
+ * LRU because full-res PNGs are large; the window we actively step through
+ * (a few ahead + one back + current) stays resident while older ones evict.
+ */
+const RETAINED_IMAGE_LIMIT = 12;
+const retainedImages = new Map<string, HTMLImageElement>();
+
+/**
+ * Warm + retain a PNG (full-res mask surface or preview) so the next render of
+ * an <img src=...> is paint-instant. Returns immediately; the fetch/decode
+ * continues in the background and the element is held so its bytes stay in the
+ * browser's image cache. Idempotent per URL (refreshes LRU recency), so it's
+ * safe to call on every navigation.
  */
 export function prefetchPng(url: string | null): void {
   if (!url || typeof window === 'undefined') return;
-  // new Image() triggers a normal HTTP fetch from the renderer with the
-  // browser's image cache; safer than fetch() (which can land in a different
-  // bucket depending on credentials/mode and miss when the <img> later
-  // tries to use it).
+  const existing = retainedImages.get(url);
+  if (existing) {
+    // Already warmed — bump recency so the window in view isn't evicted.
+    retainedImages.delete(url);
+    retainedImages.set(url, existing);
+    return;
+  }
   const img = new Image();
   img.decoding = 'async';
   img.src = url;
+  // Retain a reference so the fetched+decoded bytes stay resident; a later
+  // <img src=url> reuses them with no refetch. (A plain fetch() could land in
+  // a different cache bucket by credentials/mode and miss the <img>, so we use
+  // an Image element — the same request the <img> will make.)
+  retainedImages.set(url, img);
+  while (retainedImages.size > RETAINED_IMAGE_LIMIT) {
+    const oldest = retainedImages.keys().next().value;
+    if (oldest === undefined) break;
+    retainedImages.delete(oldest);
+  }
 }


### PR DESCRIPTION
## Summary

Follow-up to #312. That PR fixed the prefetch *logic* but stepping through the NIRCam exposure inspector still showed ~1 s cold loads, because the prefetched bytes had nowhere durable to live and the `<img>` re-fetched on every navigation. This makes prev/next genuinely instant and fixes the resulting UX.

## Why #312 wasn't enough

- `prefetchPng` created a throwaway `new Image()` and dropped the reference → garbage-collected.
- The exposure PNGs are served **direct-to-`<img>` from OSN via presigned URLs** (epic #261 N5), deliberately bypassing the Next proxy that stamps `Cache-Control` on the app's other images — and the OSN objects carry **no `Cache-Control`** of their own (the deploy upload sets only content-type).

So the browser wouldn't reliably keep a fetched PNG, and each MaskEditor `<img>` mount refetched ~5.7 MB from OSN → the ~1 s reload.

## Changes (3 commits)

1. **Retain prefetched PNGs in memory** (`nircam-exposure-cache.ts`). A bounded module-level LRU holds the live `HTMLImageElement`s, keeping the browser's in-memory image cache hot for those exact URLs — so a later ``'&lt;img src=sameUrl&gt;'`` reuses the decoded bitmap with **no network round-trip**, independent of any `Cache-Control` header. This is the "local cache."

2. **Decode-gated seamless swap** (`MaskEditor.tsx`). Changing an `<img>` src blanks the element for a frame before the new bitmap paints — the visible "reload." Now the editor holds the current frame and swaps only once the incoming URL has decoded (`img.decode()`), which is ~instant when warm.

3. **Blank on a cold exposure instead of showing the last one** (`MaskEditor.tsx` + `isPngCached`). Holding the previous image is only correct when the next one is warm. On a *cold* navigation, lingering on the old pixels beside the new exposure's metadata + mask polygons is misleading — so the panel now blanks to a centered loading spinner (and drops the mask overlay) until the image decodes. A new `isPngCached(url)` helper reports whether the incoming URL is already fully loaded, gating warm-swap vs cold-blank.

Net flow: **prefetch the right bytes → keep them resident in memory → swap the picture only when it's decode-ready, else show a clear loading state.**

Scope is the PNG mask-editor path. The FITS "beta" render path still has no prefetch/pixel cache (separate follow-up).

## Files

- `web/lib/nircam-exposure-cache.ts` — retained-image LRU + `isPngCached`
- `web/components/nircam/MaskEditor.tsx` — warmth-aware `shownUrl` swap + cold-load spinner

## Verification

- `tsc --noEmit`: clean
- `next lint` (changed files): clean
- `vitest`: 126/126 pass

Note: I couldn't drive the live app against OSN in a browser from the build sandbox, so this is verified by reasoning + static checks, not a measured before/after. One dev-only caveat: the "skip first swap on mount" uses a ref that React StrictMode double-invokes, so a freshly-mounted cold panel may briefly show the spinner under `npm run dev`; production builds are unaffected.

Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrRUzTctbVX7z6mPk93dUJ)_