### PR TITLE
Fix spinner 3D-flip in Firefox with quarter-turn spin keyframe

### DIFF
--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -54,18 +54,24 @@ const config: Config = {
           '0%': { opacity: '0', transform: 'scale(0.95)' },
           '100%': { opacity: '1', transform: 'scale(1)' },
         },
-        // Override Tailwind's default `spin` keyframe, which only defines a
-        // `to: rotate(360deg)` frame. With an implicit `from` (the element's
-        // underlying `none`), Firefox interpolates `none -> rotate(360deg)` via
-        // matrix decomposition instead of component-wise angle interpolation.
-        // Because rotate(360deg) decomposes to the identity matrix, Firefox's
-        // decompose/recompose of the intermediate frames leaks a 3D rotation
-        // component, making `animate-spin` flip around a vertical axis instead
-        // of spinning flat (Chrome/Safari are unaffected). Declaring both
-        // endpoints as matching rotate() functions keeps the interpolation 2D.
+        // Override Tailwind's default `spin` keyframe (a single
+        // `to: rotate(360deg)` frame). Firefox interpolates transform
+        // animations by decomposing the endpoints into rotation quaternions and
+        // slerping between them. A full turn, rotate(360deg), maps to the
+        // quaternion antipodal to the identity, so the rotation axis is
+        // undefined and Firefox slerps around an arbitrary axis (Y) — the
+        // spinner flips in/out of the page instead of spinning flat.
+        // Chrome/Safari special-case 2D rotate() and interpolate the scalar
+        // angle, so they're unaffected. Breaking the turn into quarter-turn
+        // waypoints keeps every interpolation segment an unambiguous 90deg
+        // Z-rotation, which no engine can reinterpret as a 3D flip. Applies to
+        // every `animate-spin` (all Loader2 icons + the border spinner).
         spin: {
-          from: { transform: 'rotate(0deg)' },
-          to: { transform: 'rotate(360deg)' },
+          '0%': { transform: 'rotate(0deg)' },
+          '25%': { transform: 'rotate(90deg)' },
+          '50%': { transform: 'rotate(180deg)' },
+          '75%': { transform: 'rotate(270deg)' },
+          '100%': { transform: 'rotate(360deg)' },
         },
       },
       animation: {


### PR DESCRIPTION
## Context

Follow-up to #313. That PR's merged commit only contained an earlier, ineffective attempt (a single `0deg → 360deg` interpolation), so `main` still exhibits the bug. This PR contains the actual fix.

## Problem

The loading spinner used throughout the UI (all `lucide-react` `Loader2` icons via `animate-spin`, plus the `border-b-2` div spinner in `NearbyObjects.tsx`) renders incorrectly in Firefox: instead of spinning flat, it rotates around a vertical axis (in/out of the page). Chrome and Safari are unaffected.

## Root cause

A **full 360° turn** is the trigger. As a rotation, `rotate(360deg)` equals the identity. Firefox animates transforms by decomposing each endpoint into a rotation quaternion and slerp-interpolating between them. The quaternion for a 360° turn is *antipodal* to the identity quaternion, so the rotation axis between the endpoints is mathematically undefined — Firefox's slerp picks an arbitrary axis (Y) and the spinner flips in/out of the page. Chrome/Safari special-case 2D `rotate()` and interpolate the scalar angle, so they never hit the degeneracy.

This is why the earlier single `0deg → 360deg` keyframe (from #313) didn't help: the endpoints are still identity → antipodal-identity, so the degenerate interpolation is unchanged.

## Fix

Override the shared `spin` keyframe in `web/tailwind.config.ts` with quarter-turn waypoints:

```ts
spin: {
  '0%':   { transform: 'rotate(0deg)' },
  '25%':  { transform: 'rotate(90deg)' },
  '50%':  { transform: 'rotate(180deg)' },
  '75%':  { transform: 'rotate(270deg)' },
  '100%': { transform: 'rotate(360deg)' },
},
```

Every interpolation segment is now an unambiguous 90° Z-rotation, well clear of the antipodal degeneracy, so no engine can reinterpret it as a 3D flip. The animation is visually identical (uniform continuous spin), the `.animate-spin` utility is unchanged, and the single shared keyframe covers every spinner at once.

## Verification

`node_modules` isn't present in the CI/dev container, and only Chromium (not Firefox) is available, so this fix is reasoned from the quaternion interpolation mechanism rather than observed in Firefox directly. I did compile Tailwind standalone against this config to confirm the emitted `@keyframes spin` contains the quarter-turn waypoints and that `.animate-spin` is unchanged.

**Please verify in Firefox on the preview deploy before merging.** If the spinner still flips, open devtools on a spinning `<svg>` mid-animation and check its computed `transform` — a `matrix3d(...)` value confirms the diagnosis; anything unexpected points to a different cause (browser extension, ancestor transform).

Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9rSnr2sty2RJR6qJ5yJ2m)_