### PR TITLE
fix(nircam): apply_masks no longer crashes on web-defined pixel masks

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -26,6 +26,18 @@ Release procedure: edit the `## Unreleased` section below, then run
 ## Unreleased
 
 ### Calibration
+- NIRCam `apply_masks` now reads web-defined masks instead of crashing on them.
+  Masks drawn in the web editor materialize (via `campfire deploy pull-masks`)
+  as DS9 **image**-coordinate `.reg` files, which `Regions.read` parses back as
+  `PolygonPixelRegion`s. The step called `reg.to_pixel(wcs)` unconditionally —
+  a method only sky regions have — so every web-defined mask aborted the combine
+  phase with `AttributeError: 'PolygonPixelRegion' object has no attribute
+  'to_pixel'`. Pixel regions are now rasterized directly and only sky regions
+  (legacy FK5/ICRS hand-drawn masks) are projected through the exposure WCS,
+  matching the guard the deploy-side `import-masks` already used. Regions whose
+  footprint falls entirely off the frame (`to_image` → `None`) are now skipped
+  rather than crashing on `None.astype`. Net effect: web-defined masks reach the
+  mosaic (excluding masked pixels) where they previously produced no output.
 - NIRCam manual masks now actually reach the mosaic, and uncovered pixels are
   `NaN` (epic #261, N7). The `apply_mask` step painted user region masks as DQ
   bit `1024` (`DEAD`), which `good_bits='~DO_NOT_USE'` **ignores** — so a mask

--- a/pipeline/campfire_pipeline/nircam/steps/apply_masks.py
+++ b/pipeline/campfire_pipeline/nircam/steps/apply_masks.py
@@ -35,6 +35,37 @@ from campfire_pipeline.common.io import log, atomic_save
 from campfire_pipeline.common import cfp
 
 
+def _rasterize_regions(regs, wcs, shape, reg_file=''):
+    """Union a list of DS9 regions into a 0/1 ``uint8`` mask of ``shape``.
+
+    Regions already in image/pixel coordinates (``PixelRegion`` — what
+    ``campfire deploy pull-masks`` writes, since the web canvas is
+    pixel-native) are rasterized directly; only sky regions (legacy
+    FK5/ICRS hand-drawn masks) are projected through the exposure ``wcs``
+    via ``to_pixel``. Calling ``to_pixel`` on a region that is *already*
+    pixel raises ``AttributeError`` — the crash this guards against.
+
+    A region that fails to project, or whose footprint falls entirely off
+    the frame (``to_image`` → ``None``), is skipped with a warning rather
+    than aborting the whole exposure.
+    """
+    from regions import PixelRegion
+
+    cfmask = np.zeros(shape, np.uint8)
+    for reg in regs:
+        try:
+            reg_pix = reg if isinstance(reg, PixelRegion) else reg.to_pixel(wcs)
+            mask_arr = reg_pix.to_mask(mode='center').to_image(shape)
+        except (ValueError, TypeError, AttributeError) as e:
+            log(f"Warning: skipping region in {reg_file}: {e}")
+            continue
+        if mask_arr is None:
+            # Region footprint doesn't overlap the frame — nothing to mask.
+            continue
+        cfmask |= mask_arr.astype(bool).astype(np.uint8)
+    return cfmask
+
+
 def apply_masks_step(exposure_file, field, step_config, overwrite=False,
                      status=None):
     """Apply region-file masks to a single canonical exposure.
@@ -85,19 +116,8 @@ def apply_masks_step(exposure_file, field, step_config, overwrite=False,
         # each run. It records *what* is masked; the DO_NOT_USE fuse (how the
         # mask is honored) happens on the combine working copy, so the canonical
         # SCI/DQ are never touched here.
-        cfmask = np.zeros(shape, np.uint8)
         regs = Regions.read(reg_file)
-        for reg in regs:
-            try:
-                reg_pix = reg.to_pixel(wcs)
-                mask_obj = reg_pix.to_mask(mode='center')
-                mask_arr = mask_obj.to_image(shape)
-                mask_arr = mask_arr.astype(bool)
-            except (ValueError, TypeError) as e:
-                log(f"Warning: skipping region in {reg_file}: {e}")
-                continue
-
-            cfmask |= mask_arr.astype(np.uint8)
+        cfmask = _rasterize_regions(regs, wcs, shape, reg_file=reg_file)
 
         cfmask_hdu = fits.ImageHDU(cfmask, name='CFMASK')
         atomic_save(

--- a/pipeline/tests/test_nircam_apply_masks.py
+++ b/pipeline/tests/test_nircam_apply_masks.py
@@ -1,0 +1,124 @@
+"""Tests for NIRCam ``apply_masks`` region rasterization.
+
+The web mask editor is pixel-native, so ``campfire deploy pull-masks``
+writes ``.reg`` files in DS9 ``image`` coordinates. ``Regions.read`` parses
+those back as ``PixelRegion`` objects, which have **no** ``to_pixel`` method
+— only sky regions do. ``apply_masks_step`` used to call ``reg.to_pixel(wcs)``
+unconditionally, so every web-defined mask crashed the combine phase with
+
+    AttributeError: 'PolygonPixelRegion' object has no attribute 'to_pixel'
+
+These tests pin the fix in ``_rasterize_regions``: pixel regions rasterize
+directly, sky regions still project through the WCS, and degenerate regions
+(off-frame, unprojectable) are skipped instead of aborting the exposure.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("regions")
+
+from regions import Regions
+
+from campfire_pipeline.nircam.steps.apply_masks import _rasterize_regions
+
+
+def _parse(text):
+    return Regions.parse(text, format="ds9")
+
+
+def _tan_wcs():
+    """A small TAN WCS whose reference pixel sits mid-frame."""
+    from astropy.wcs import WCS
+
+    w = WCS(naxis=2)
+    w.wcs.crpix = [5, 5]
+    w.wcs.cdelt = [-1e-4, 1e-4]
+    w.wcs.crval = [150.0, 2.0]
+    w.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+    return w
+
+
+class TestPixelRegions:
+    def test_image_coord_polygon_does_not_crash(self):
+        # This is the regression: a pull-masks-style image-coord polygon.
+        # No WCS is needed (or used) for a pixel region — pass None to prove it.
+        regs = _parse("image\npolygon(2,2,8,2,8,8,2,8)")
+        mask = _rasterize_regions(regs, wcs=None, shape=(10, 10))
+        assert mask.dtype == np.uint8
+        assert mask[5, 5] == 1          # inside the square
+        assert mask[0, 0] == 0          # outside
+        assert mask.sum() > 0
+
+    def test_union_of_two_polygons(self):
+        regs = _parse(
+            "image\n"
+            "polygon(1,1,3,1,3,3,1,3)\n"
+            "polygon(6,6,9,6,9,9,6,9)"
+        )
+        mask = _rasterize_regions(regs, wcs=None, shape=(10, 10))
+        assert mask[1, 1] == 1          # interior of the first square
+        assert mask[7, 7] == 1          # interior of the second square
+        assert mask[4, 4] == 0          # gap between the two squares
+
+    def test_offframe_region_skipped(self):
+        # to_image() returns None when the footprint misses the frame — the
+        # old code crashed on None.astype; now it's skipped, mask stays empty.
+        regs = _parse("image\npolygon(100,100,110,100,110,110,100,110)")
+        mask = _rasterize_regions(regs, wcs=None, shape=(10, 10))
+        assert mask.sum() == 0
+
+    def test_pixel_region_ignores_wcs(self):
+        # Passing a real WCS must not change a pixel region's rasterization
+        # (it must not be re-projected).
+        regs = _parse("image\npolygon(2,2,8,2,8,8,2,8)")
+        with_wcs = _rasterize_regions(_parse("image\npolygon(2,2,8,2,8,8,2,8)"),
+                                      wcs=_tan_wcs(), shape=(10, 10))
+        without_wcs = _rasterize_regions(regs, wcs=None, shape=(10, 10))
+        np.testing.assert_array_equal(with_wcs, without_wcs)
+
+
+class TestSkyRegions:
+    def test_sky_polygon_projects_through_wcs(self):
+        pytest.importorskip("astropy")
+        wcs = _tan_wcs()
+        # A small fk5 quad around the WCS reference coordinate.
+        regs = _parse(
+            "fk5\npolygon("
+            "150.0003,1.9997,149.9997,1.9997,"
+            "149.9997,2.0003,150.0003,2.0003)"
+        )
+        mask = _rasterize_regions(regs, wcs=wcs, shape=(10, 10))
+        assert mask.sum() > 0
+
+    def test_sky_region_without_wcs_is_skipped_not_crash(self):
+        # A sky region needs a WCS to project; with wcs=None the projection
+        # raises and the region is skipped rather than aborting the exposure.
+        regs = _parse(
+            "fk5\npolygon("
+            "150.0003,1.9997,149.9997,1.9997,"
+            "149.9997,2.0003,150.0003,2.0003)"
+        )
+        mask = _rasterize_regions(regs, wcs=None, shape=(10, 10))
+        assert mask.sum() == 0
+
+
+class TestMixed:
+    def test_mixed_pixel_and_sky(self):
+        pytest.importorskip("astropy")
+        wcs = _tan_wcs()
+        pix = _rasterize_regions(_parse("image\npolygon(1,1,3,1,3,3,1,3)"),
+                                 wcs=wcs, shape=(10, 10))
+        sky = _rasterize_regions(
+            _parse("fk5\npolygon(150.0003,1.9997,149.9997,1.9997,"
+                   "149.9997,2.0003,150.0003,2.0003)"),
+            wcs=wcs, shape=(10, 10))
+        # Both contribute independently; a file with both unions them.
+        both = _rasterize_regions(
+            _parse("image\npolygon(1,1,3,1,3,3,1,3)"
+                   "\nfk5;polygon(150.0003,1.9997,149.9997,1.9997,"
+                   "149.9997,2.0003,150.0003,2.0003)"),
+            wcs=wcs, shape=(10, 10))
+        np.testing.assert_array_equal(both, (pix | sky))


### PR DESCRIPTION
## Problem

NIRCam masks drawn in the web editor are stored pixel-native and materialized by `campfire deploy pull-masks` as DS9 **image**-coordinate `.reg` files. When `apply_masks_step` reads them with `Regions.read()`, they come back as `PolygonPixelRegion` objects — but the step called `reg.to_pixel(wcs)` unconditionally, and `to_pixel` exists only on **sky** regions. So every web-defined mask aborted the combine phase:

```
AttributeError: 'PolygonPixelRegion' object has no attribute 'to_pixel'
```

The deploy-side `nircam_masks.py` (`import-masks`) already guarded this with `isinstance(reg, PolygonPixelRegion)`, but the pipeline's `apply_masks` step did not.

## Fix

In `pipeline/campfire_pipeline/nircam/steps/apply_masks.py`:

- Extracted the rasterization loop into a testable `_rasterize_regions()` helper.
- Pixel regions are rasterized directly; only **sky** regions (legacy FK5/ICRS hand-drawn masks) are projected through the exposure WCS via `to_pixel` — the `isinstance(reg, PixelRegion)` guard mirroring the deploy side.
- Fixed a latent crash in the same path: a region whose footprint falls entirely off the detector makes `to_image()` return `None`, which the old code hit with `None.astype`. It's now skipped cleanly.

Net effect: web-defined masks reach the mosaic (excluding masked pixels) where they previously produced no output at all. Runs with no web masks (legacy sky-coord masks or none) are unaffected.

## Tests

Added `pipeline/tests/test_nircam_apply_masks.py` (7 tests): pixel regions (the regression), sky-region WCS projection, off-frame skip, WCS-independence of pixel regions, and mixed pixel+sky unions. All 25 mask-related tests pass.

## Changelog

Added a **Calibration** (MINOR) entry to `pipeline/CHANGELOG.md` — web-defined masks now reach the mosaic where they previously produced no output, consistent with the existing mask entry's categorization.

Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01LF7dhphxXbKyam64eE48iR)_