### PR TITLE
fix(nircam): cache presigned PNG URLs at module scope so exposure prefetch survives navigation

### DIFF
--- a/web/app/admin/nircam/[id]/page.tsx
+++ b/web/app/admin/nircam/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { Suspense, useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import React, { Suspense, useState, useEffect, useCallback, useMemo, useRef, useReducer } from 'react';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { Card } from '@/components/ui/Card';
@@ -14,7 +14,6 @@ import {
   updateExposureReview,
   saveExposureMaskRegions,
   presignExposurePngs,
-  type ExposurePngUrls,
   type ExposureNeighbors,
 } from '@/lib/actions/nircam-exposures';
 import type { NircamExposure, MaskRegionsPayload } from '@/lib/types';
@@ -26,6 +25,8 @@ import {
   getCachedExposure,
   setCachedExposure,
   prefetchPng,
+  getCachedPngUrls,
+  setCachedPngUrls,
 } from '@/lib/nircam-exposure-cache';
 
 // Eager PNG prefetch window: warm the full-res mask surface (~5.7 MB) the
@@ -71,15 +72,13 @@ function ExposureDetailPageInner() {
   // N4 (epic #261): live FITS render vs the legacy pre-generated PNG. Defaults
   // to PNG; the toggle doubles as the pixel-parity check during the rollout.
   const [viewMode, setViewMode] = useState<'png' | 'fits'>('png');
-  // Presigned OSN GET URLs (dual-read R2 fallback) for the current + windowed
-  // exposures' PNGs (epic #261, N5), keyed by exposure id. Served straight into
-  // <img> — no /api/nircam-preview proxy hop. Refreshed on navigation.
-  const [pngUrls, setPngUrls] = useState<Record<number, ExposurePngUrls>>({});
-  // Read-only mirror so the presign effect can skip ids already presigned:
-  // re-presigning mints a fresh signature, which would change the <img src> and
-  // force the browser to refetch a PNG the prefetch already cached.
-  const pngUrlsRef = useRef(pngUrls);
-  pngUrlsRef.current = pngUrls;
+  // Presigned OSN GET URLs (epic #261, N5) live in a MODULE-level cache
+  // (getCachedPngUrls) — NOT React state — because this page remounts on every
+  // prev/next, which would otherwise wipe them and force a fresh presign (new
+  // signature) on each step, flashing the spinner and missing the retained PNG.
+  // This reducer just forces a re-render when a presign lands so the pending
+  // spinner clears and the <img> picks up the freshly-cached URL.
+  const [, bumpPngUrls] = useReducer((n: number) => n + 1, 0);
   useEffect(() => {
     let cancelled = false;
     getExposureNeighbors(id, { ...navFilters, window: PREFETCH_AHEAD }).then((res) => {
@@ -167,25 +166,27 @@ function ExposureDetailPageInner() {
     // full-res mask surface the editor renders, or the preview when there's no
     // full PNG. Re-warming an already-cached URL is a browser cache hit, so the
     // only new network per step is the frontier exposure entering the window.
-    const warm = (map: Record<number, ExposurePngUrls>) => {
+    const warm = () => {
       for (const sib of win) {
-        const u = map[sib];
+        const u = getCachedPngUrls(sib);
         if (u) prefetchPng(u.full ?? u.preview);
       }
     };
-    // Only presign ids we haven't already (prefetched siblings keep their URL);
-    // when the whole window is already signed, just re-warm from what we have.
-    const batch = [id, ...win].filter((x) => pngUrlsRef.current[x] === undefined);
+    // Only presign ids not already in the module cache (a cached sibling keeps
+    // its URL); when the whole window is already signed, just re-warm.
+    const batch = [id, ...win].filter((x) => getCachedPngUrls(x) === undefined);
     if (batch.length === 0) {
-      warm(pngUrlsRef.current);
+      warm();
       return;
     }
     let cancelled = false;
     presignExposurePngs(batch).then((urls) => {
+      // Populate the module cache even if this instance unmounted mid-flight —
+      // the URLs are valid for whichever instance renders the exposure next.
+      for (const [key, u] of Object.entries(urls)) setCachedPngUrls(Number(key), u);
       if (cancelled) return;
-      const merged = { ...pngUrlsRef.current, ...urls };
-      setPngUrls(merged);
-      warm(merged);
+      bumpPngUrls();
+      warm();
     });
     return () => { cancelled = true; };
   }, [id, nav]);
@@ -291,8 +292,9 @@ function ExposureDetailPageInner() {
   }
 
   // Presigned OSN URLs for the current exposure (undefined until the presign
-  // round-trip lands; null once resolved if the exposure has no PNG).
-  const currentUrls = pngUrls[id];
+  // round-trip lands; null once resolved if the exposure has no PNG). Read from
+  // the module cache so a prefetched sibling is already resolved on arrival.
+  const currentUrls = getCachedPngUrls(id);
   const pngUrl = currentUrls?.preview ?? null;
   const fullPngUrl = currentUrls?.full ?? null;
   const pngPresignPending = currentUrls === undefined;

--- a/web/lib/nircam-exposure-cache.ts
+++ b/web/lib/nircam-exposure-cache.ts
@@ -103,16 +103,27 @@ export function isPngCached(url: string | null): boolean {
  * row + image caches, a prefetched sibling's URL survives the remount: the next
  * exposure paints from cache with no spinner and no network round-trip.
  *
- * Unbounded like the row cache (a couple of small strings per id; sessions are
- * short). URLs carry a ~1 h TTL, but a prefetched image is already fully loaded
- * and paints from the retained element even if its URL later expires.
+ * Entries carry a signed-at timestamp and expire before the presigned URL's own
+ * ~1 h TTL (PNG_PRESIGN_TTL_SECONDS in lib/actions/nircam-exposures.ts). Once
+ * stale, getCachedPngUrls treats the id as absent so the caller re-presigns a
+ * fresh URL — otherwise a long session (or an exposure whose retained image has
+ * since been LRU-evicted) could serve an expired URL straight into <img> and
+ * render a broken image with no in-session recovery. Unbounded like the row
+ * cache (a couple of small strings per id; sessions are short).
  */
-const pngUrlCache = new Map<number, ExposurePngUrls>();
+const PNG_URL_FRESH_MS = 50 * 60 * 1000; // < the 3600 s presign TTL, with buffer
+const pngUrlCache = new Map<number, { urls: ExposurePngUrls; signedAt: number }>();
 
 export function getCachedPngUrls(id: number): ExposurePngUrls | undefined {
-  return pngUrlCache.get(id);
+  const entry = pngUrlCache.get(id);
+  if (!entry) return undefined;
+  if (Date.now() - entry.signedAt > PNG_URL_FRESH_MS) {
+    pngUrlCache.delete(id);
+    return undefined;
+  }
+  return entry.urls;
 }
 
 export function setCachedPngUrls(id: number, urls: ExposurePngUrls): void {
-  pngUrlCache.set(id, urls);
+  pngUrlCache.set(id, { urls, signedAt: Date.now() });
 }

--- a/web/lib/nircam-exposure-cache.ts
+++ b/web/lib/nircam-exposure-cache.ts
@@ -11,6 +11,7 @@
  */
 
 import type { NircamExposure } from '@/lib/types';
+import type { ExposurePngUrls } from '@/lib/actions/nircam-exposures';
 
 const cache = new Map<number, NircamExposure>();
 
@@ -88,4 +89,30 @@ export function isPngCached(url: string | null): boolean {
   if (!url) return false;
   const img = retainedImages.get(url);
   return !!img && img.complete && img.naturalWidth > 0;
+}
+
+/**
+ * Presigned OSN GET URLs per exposure id.
+ *
+ * MODULE scope on purpose: the /admin/nircam/[id] page REMOUNTS on every
+ * prev/next (the App Router re-instantiates the dynamic-segment page), so
+ * holding these in React state — as the page originally did — wiped them on
+ * each step. That forced a fresh presign (a new signature) on arrival, which
+ * both flashed the presign spinner AND missed the retained-image cache keyed by
+ * that URL, so every step refetched the PNG from OSN. Cached here alongside the
+ * row + image caches, a prefetched sibling's URL survives the remount: the next
+ * exposure paints from cache with no spinner and no network round-trip.
+ *
+ * Unbounded like the row cache (a couple of small strings per id; sessions are
+ * short). URLs carry a ~1 h TTL, but a prefetched image is already fully loaded
+ * and paints from the retained element even if its URL later expires.
+ */
+const pngUrlCache = new Map<number, ExposurePngUrls>();
+
+export function getCachedPngUrls(id: number): ExposurePngUrls | undefined {
+  return pngUrlCache.get(id);
+}
+
+export function setCachedPngUrls(id: number, urls: ExposurePngUrls): void {
+  pngUrlCache.set(id, urls);
 }


### PR DESCRIPTION
## Summary

Follow-up to #312 and #315. Those made the prefetch logic correct and added an in-memory image cache + seamless swap — but stepping through the NIRCam exposure inspector was **still** loading each image cold (mask-editor box disappears → spinner → image reads out top→bottom). This finds and fixes the actual mechanism defeating all of it.

## Root cause

The `/admin/nircam/[id]` page **remounts on every prev/next navigation**, discarding all React component state. The tell was the symptom asymmetry: the metadata sidebar stayed put while only the image panel flashed.

- **Row data** survived the remount because it lives in a **module-level** cache (`getCachedExposure`) — hence the stable sidebar.
- **Presigned PNG URLs** were held in **React state** (`useState`, commented *"Refreshed on navigation"*) — so they were **wiped on every step**.

Consequences on each arrival:
1. The URL map is empty → `pngPresignPending` is true → the entire MaskEditor (toolbar included) is replaced by the presign spinner.
2. The page re-presigns from scratch, minting a **new signature**. Since the retained-image cache from #315 is keyed by URL, the new URL **misses** it, and the browser refetches ~5.7 MB from OSN (the top→bottom readout).

So the prefetch never had a chance: the previous exposure warmed the *next* one, but the warmed URL was thrown away and a different one generated on arrival.

## Fix

Move the presigned URLs into the **same module-level cache** as the rows and retained images:

- `nircam-exposure-cache.ts` — add `getCachedPngUrls` / `setCachedPngUrls` (a `Map<number, ExposurePngUrls>`), documented as module-scoped precisely because the page remounts.
- `[id]/page.tsx` — drop the `useState` URL map + ref; read/write the module cache in the prefetch effect and render. A `useReducer` bump forces a re-render when a presign lands (for the direct-entry first load). URLs are written to the cache even if the requesting instance unmounts mid-flight, since they're valid for whichever instance renders that exposure next.

Now a prefetched sibling's URL survives the remount: the next exposure resolves on arrival with **no spinner**, and its `<img>` URL matches the retained image → paints from memory with **no network round-trip**.

## Files

- `web/lib/nircam-exposure-cache.ts` — module-level presigned-URL cache
- `web/app/admin/nircam/[id]/page.tsx` — read/write module cache instead of component state

## Verification

- `tsc --noEmit`: clean
- `next lint` (changed files): clean (only the pre-existing `<img>` warning)
- `vitest`: 126/126 pass

Notes:
- Verified by reasoning + static checks; I couldn't drive the live app against OSN from the build sandbox.
- Known residual (cosmetic, not in scope here): because the page still remounts, the prev/next **position indicator** and buttons briefly reset each step (that state is still component-level). The image load is fixed. Moving the neighbors/nav into the module cache would remove that flash too — happy to follow up.

Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrRUzTctbVX7z6mPk93dUJ)_