### PR TITLE
NIRCam jhat: accept single refcat as well as refcat_dict

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -276,6 +276,15 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- **NIRCam `jhat` accepts a single `refcat` in addition to `refcat_dict`.** A
+  field that aligns every filter to the same reference catalog can now set
+  `[<field>.jhat].refcat = "<file>"` instead of repeating that filename across a
+  `[<field>.jhat.refcat_dict]` block. When both are given, `refcat_dict` entries
+  win per-filter and `refcat` is the fallback for any filter it doesn't list.
+  Resolution moved into a small `_resolve_refcat` helper (covered by
+  `tests/test_nircam_jhat_refcat.py`). Config ergonomics only — for a given
+  configuration the same catalog is passed to JHAT as before, so no change to
+  aligned WCS or pixel values.
 - **NIRSpec `stuck_closed_shutters.toml` entries now carry a `# hand` / `# web` /
   `# auto` provenance tag.** `write_stuck_shutters_toml` preserves the tag of each
   existing entry (via a new `provenance` arg) instead of collapsing it to untagged,

--- a/pipeline/campfire_pipeline/nircam/refcat/__init__.py
+++ b/pipeline/campfire_pipeline/nircam/refcat/__init__.py
@@ -13,8 +13,9 @@ Three workflows are supported via ``cfpipe nircam refcat <subcmd>``:
   compare  Sky-residual diagnostic between two catalogs.
 
 All catalogs share the same on-disk schema (ECSV with columns RA, DEC,
-mag, mag_err) so they can be fed straight into JHAT via the
-``[<field>.jhat.refcat_dict]`` mapping in ``fields.toml``.
+mag, mag_err) so they can be fed straight into JHAT via ``[<field>.jhat]``
+in ``fields.toml`` -- either ``refcat`` (one catalog for all filters) or the
+``refcat_dict`` mapping of filter name to filename.
 """
 
 from .io import (

--- a/pipeline/campfire_pipeline/nircam/steps/jhat.py
+++ b/pipeline/campfire_pipeline/nircam/steps/jhat.py
@@ -81,6 +81,40 @@ def _stamp_jhat(exposure_file, value):
     os.replace(tmp_path, exposure_file)
 
 
+def _resolve_refcat(step_config, refcat_dir, filtname):
+    """Resolve the reference-catalog path for *filtname* from *step_config*.
+
+    A single ``refcat`` string is used for every filter; a ``refcat_dict``
+    maps filter -> filename for per-filter catalogs. When both are set,
+    ``refcat_dict`` entries win per-filter and ``refcat`` is the fallback for
+    any filter it doesn't list. The chosen filename is joined onto
+    *refcat_dir*. Raises ``ValueError`` if neither is configured, or if only a
+    ``refcat_dict`` is set and it lacks an entry for *filtname*.
+    """
+    refcat_dict = step_config.get('refcat_dict')
+    refcat_single = step_config.get('refcat')
+
+    if refcat_dict is None and refcat_single is None:
+        raise ValueError(
+            "jhat config missing 'refcat'/'refcat_dict'. Define either "
+            "[<field>.jhat].refcat = \"<file>\" (one catalog for all filters) "
+            "or [<field>.jhat.refcat_dict] mapping filter names to refcat "
+            "filenames in fields.toml."
+        )
+
+    if refcat_dict is not None and filtname in refcat_dict:
+        refcat_name = refcat_dict[filtname]
+    elif refcat_single is not None:
+        refcat_name = refcat_single
+    else:
+        raise ValueError(
+            f"jhat.refcat_dict has no entry for filter '{filtname}' and no "
+            f"single 'refcat' fallback is set. Available: "
+            f"{list(refcat_dict.keys())}"
+        )
+    return os.path.join(refcat_dir, refcat_name)
+
+
 def _copy_diagnostics(scratch_subdir, diag_dir, rootname):
     """Move jhat's diagnostic PDFs and ECSV photometry tables to ``diag_dir``."""
     if not os.path.isdir(scratch_subdir):
@@ -107,9 +141,12 @@ def jhat_step(exposure_file, field, step_config, overwrite=False, status=None):
         WCS to be refined).
     field : Field
     step_config : dict
-        ``[nircam.jhat]`` (legacy ``[nircam.stage3.jhat]``). Must include a
-        ``refcat_dict`` mapping filter names to refcat filenames in
-        ``field.refcat_dir``.
+        ``[nircam.jhat]`` (legacy ``[nircam.stage3.jhat]``). Must specify the
+        reference catalog(s) in ``field.refcat_dir`` via either ``refcat`` (a
+        single filename used for every filter) or ``refcat_dict`` (a mapping of
+        filter name to refcat filename). If both are given, ``refcat_dict``
+        entries win per-filter and ``refcat`` is the fallback for any filter
+        not listed.
     overwrite : bool
     status : StepStatus, optional
         Pre-scanned CFP_* status cache.
@@ -135,19 +172,7 @@ def jhat_step(exposure_file, field, step_config, overwrite=False, status=None):
                        'jhat', status, overwrite):
         return
 
-    if 'refcat_dict' not in step_config:
-        raise ValueError(
-            "jhat config missing 'refcat_dict'. Define "
-            "[<field>.jhat.refcat_dict] in fields.toml mapping filter names "
-            "to refcat filenames."
-        )
-    refcat_dict = step_config['refcat_dict']
-    if filtname not in refcat_dict:
-        raise ValueError(
-            f"jhat.refcat_dict has no entry for filter '{filtname}'. "
-            f"Available: {list(refcat_dict.keys())}"
-        )
-    refcat = os.path.join(field.refcat_dir, refcat_dict[filtname])
+    refcat = _resolve_refcat(step_config, field.refcat_dir, filtname)
 
     log(f"Running jhat on {rootname}")
 

--- a/pipeline/fields.example.toml
+++ b/pipeline/fields.example.toml
@@ -50,9 +50,12 @@
 #       enabled = true
 #       theta_min = 25.0
 #       theta_max = 35.0
-#   [field.jhat.refcat_dict]
+#   [field.jhat]                             # single catalog for all filters
+#       refcat = "gaia_dr3.cat"
+#   [field.jhat.refcat_dict]                 # or per-filter catalogs
 #       f444w = "gaia_dr3_f444w.cat"
 #       f200w = "gaia_dr3_f200w.cat"
+#   If both are given, refcat_dict wins per-filter and refcat is the fallback.
 #
 # Pre-JHAT astrometric shifts (opt-in, declared as an array of tables):
 #   [[field.wcs_shift]]

--- a/pipeline/tests/test_nircam_jhat_refcat.py
+++ b/pipeline/tests/test_nircam_jhat_refcat.py
@@ -1,0 +1,51 @@
+"""Reference-catalog resolution for the NIRCam ``jhat`` step.
+
+``_resolve_refcat`` accepts either a single ``refcat`` string (one catalog for
+every filter) or a ``refcat_dict`` mapping filter -> filename. When both are
+given, ``refcat_dict`` entries win per-filter and ``refcat`` is the fallback.
+The heavy ``jhat`` import is lazy inside ``jhat_step``, so importing the helper
+here is cheap.
+"""
+import os
+
+import pytest
+
+from campfire_pipeline.nircam.steps.jhat import _resolve_refcat
+
+REFCAT_DIR = '/refcats'
+
+
+def test_single_refcat_applies_to_every_filter():
+    cfg = {'refcat': 'gaia_dr3.cat'}
+    for filt in ('f444w', 'f200w', 'f115w'):
+        assert _resolve_refcat(cfg, REFCAT_DIR, filt) == os.path.join(
+            REFCAT_DIR, 'gaia_dr3.cat')
+
+
+def test_refcat_dict_maps_per_filter():
+    cfg = {'refcat_dict': {'f444w': 'lw.cat', 'f200w': 'sw.cat'}}
+    assert _resolve_refcat(cfg, REFCAT_DIR, 'f444w') == os.path.join(
+        REFCAT_DIR, 'lw.cat')
+    assert _resolve_refcat(cfg, REFCAT_DIR, 'f200w') == os.path.join(
+        REFCAT_DIR, 'sw.cat')
+
+
+def test_dict_wins_per_filter_and_single_is_fallback():
+    cfg = {'refcat': 'default.cat', 'refcat_dict': {'f444w': 'lw.cat'}}
+    # Listed filter uses the dict entry.
+    assert _resolve_refcat(cfg, REFCAT_DIR, 'f444w') == os.path.join(
+        REFCAT_DIR, 'lw.cat')
+    # Unlisted filter falls back to the single refcat.
+    assert _resolve_refcat(cfg, REFCAT_DIR, 'f200w') == os.path.join(
+        REFCAT_DIR, 'default.cat')
+
+
+def test_missing_both_raises():
+    with pytest.raises(ValueError, match="missing 'refcat'/'refcat_dict'"):
+        _resolve_refcat({}, REFCAT_DIR, 'f444w')
+
+
+def test_dict_without_entry_and_no_fallback_raises():
+    cfg = {'refcat_dict': {'f444w': 'lw.cat'}}
+    with pytest.raises(ValueError, match="no entry for filter 'f200w'"):
+        _resolve_refcat(cfg, REFCAT_DIR, 'f200w')


### PR DESCRIPTION
## Summary

The NIRCam `jhat` step required a `[<field>.jhat.refcat_dict]` mapping of filter → refcat filename. Fields that align **every** filter to the same reference catalog had to repeat that one filename across a `refcat_dict` block. This PR lets such fields set a single `refcat` instead:

```toml
[my_field.jhat]
    refcat = "gaia_dr3.cat"
```

## Behavior

Refcat resolution moved into a small, testable `_resolve_refcat(step_config, refcat_dir, filtname)` helper (matching the module's existing `_`-helper style):

- **`refcat = "<file>"`** — a single catalog used for every filter.
- **`refcat_dict = { … }`** — per-filter mapping (unchanged).
- **Both set** — `refcat_dict` entries win per-filter, and `refcat` is the fallback for any filter the dict doesn't list.
- **Neither set** → clear `ValueError`; a `refcat_dict` missing the current filter with no `refcat` fallback → the same "no entry for filter" error as before.

No other wiring was needed: `get_nircam_step_config` already deep-merges `[<field>.jhat]` over the `[nircam.jhat]` defaults, so a per-field `refcat` string flows straight into `step_config`.

## Changes

- `pipeline/campfire_pipeline/nircam/steps/jhat.py` — extract `_resolve_refcat`; support the single-`refcat` form with `refcat_dict` precedence.
- `pipeline/fields.example.toml` — document both `refcat` and `refcat_dict`, including precedence.
- `pipeline/campfire_pipeline/nircam/refcat/__init__.py` — docstring mentions both options.
- `pipeline/tests/test_nircam_jhat_refcat.py` — new test covering single, dict, both-with-fallback, and both error cases.
- `pipeline/CHANGELOG.md` — one **Infrastructure** entry under `## Unreleased`.

## Scientific impact

None. This is config ergonomics only — for a given configuration the same catalog reaches JHAT as before, so aligned WCS and pixel values are unchanged. Categorized **Infrastructure** (PATCH).

## Testing

The `campfire` conda env (pytest/astropy) isn't available in the authoring environment, so `_resolve_refcat` was exercised directly across all six cases (stubbing only the module-top `astropy.io.fits` import, which the helper never touches) — all passed. The committed `tests/test_nircam_jhat_refcat.py` runs under CI / the `campfire` env.

Generated with Claude Code

https://claude.ai/code/session_01J8Q6aGUzTj2sCoQkzoVDJL

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8Q6aGUzTj2sCoQkzoVDJL)_