### PR TITLE
NIRCam resample: migrate tile selection to a --tiles CLI flag

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -276,6 +276,18 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- **NIRCam resample tile selection moved from config to a `--tiles` CLI flag.**
+  Which mosaic tiles get drizzled is a runtime choice, not a processing
+  parameter, so the undocumented `[nircam.resample].tile` config key is retired
+  in favor of `--tiles` on `cfpipe nircam {resample,combine,run,check}` (variadic,
+  e.g. `--tiles A1 A2`; default: all tiles in the field). The flag scopes the
+  resample step *only* — the exposure/visit-level combine steps (`apply_mask`,
+  `bad_pixel`, `outlier`) still run over the full field, so a tile built from a
+  subset run is bit-identical to the same tile from a whole-field run (truncating
+  outlier's cross-visit median pool would change edge pixels). `run` rejects
+  `--tiles` unless the combine phase is selected. Covered by
+  `tests/test_nircam_resample_tiles.py`. CLI ergonomics only; no change to mosaic
+  pixel values.
 - **NIRCam `jhat` accepts a single `refcat` in addition to `refcat_dict`.** A
   field that aligns every filter to the same reference catalog can now set
   `[<field>.jhat].refcat = "<file>"` instead of repeating that filename across a

--- a/pipeline/campfire_pipeline/nircam/cli.py
+++ b/pipeline/campfire_pipeline/nircam/cli.py
@@ -90,6 +90,19 @@ def processing_options(f):
     return f
 
 
+def tile_option(f):
+    """``--tiles``: runtime tile selection for the resample step.
+
+    Tile selection is a runtime parameter, not a config key — a subset only
+    limits which mosaics are drizzled; the exposure-level combine steps
+    (apply_mask, bad_pixel, outlier) still run over the full field.
+    """
+    return click.option('--tiles', multiple=True, default=None,
+                        cls=VariadicOption,
+                        help='Tile name(s) to resample '
+                             '(default: all tiles in field).')(f)
+
+
 def _setup(config_path, field_name):
     """Load config + environment + field; set up the workspace."""
     config = load_config(config_path)
@@ -144,24 +157,27 @@ def process(config, field, filters, processes, overwrite):
 @main.command()
 @common_options
 @processing_options
-def combine(config, field, filters, processes, overwrite):
+@tile_option
+def combine(config, field, filters, processes, overwrite, tiles):
     """Run the ensemble combine phase (apply_mask → resample)."""
     cfg, field_obj = _setup(config, field)
     run_combine(field_obj, cfg,
                 filters=_resolve_filters(filters, field_obj),
-                n_processes=processes, overwrite=overwrite)
+                n_processes=processes, overwrite=overwrite,
+                tiles=list(tiles) if tiles else None)
 
 
 @main.command()
 @common_options
 @processing_options
+@tile_option
 @click.option('--process', 'do_process', is_flag=True,
               help='Run the process phase.')
 @click.option('--combine', 'do_combine', is_flag=True,
               help='Run the combine phase.')
 @click.option('--all', 'do_all', is_flag=True,
               help='Run both phases.')
-def run(config, field, filters, processes, overwrite,
+def run(config, field, filters, processes, overwrite, tiles,
         do_process, do_combine, do_all):
     """Run process and/or combine in one invocation."""
     if do_all:
@@ -169,6 +185,13 @@ def run(config, field, filters, processes, overwrite,
     if not (do_process or do_combine):
         raise click.UsageError(
             "Specify --process, --combine, or --all."
+        )
+
+    tile_list = list(tiles) if tiles else None
+    if tile_list and not do_combine:
+        raise click.UsageError(
+            "--tiles scopes the resample step, which only runs in the "
+            "combine phase; pass --combine or --all."
         )
 
     cfg, field_obj = _setup(config, field)
@@ -179,7 +202,8 @@ def run(config, field, filters, processes, overwrite,
                     n_processes=processes, overwrite=overwrite)
     if do_combine:
         run_combine(field_obj, cfg, filters=filter_list,
-                    n_processes=processes, overwrite=overwrite)
+                    n_processes=processes, overwrite=overwrite,
+                    tiles=tile_list)
 
 
 # ---------------------------------------------------------------------------
@@ -200,8 +224,25 @@ def _make_step_command(step_name):
     return _cmd
 
 
+# resample is the only per-tile step, so it carries the extra --tiles option
+# and is registered explicitly below rather than through _make_step_command.
 for _step_name in STEP_NAMES:
+    if _step_name == 'resample':
+        continue
     main.add_command(_make_step_command(_step_name))
+
+
+@main.command()
+@common_options
+@processing_options
+@tile_option
+def resample(config, field, filters, processes, overwrite, tiles):
+    """Run the resample step."""
+    cfg, field_obj = _setup(config, field)
+    run_step('resample', field_obj, cfg,
+             filters=_resolve_filters(filters, field_obj),
+             n_processes=processes, overwrite=overwrite,
+             tiles=list(tiles) if tiles else None)
 
 
 # Refcat utilities: `cfpipe nircam refcat {query,extract,merge,compare}`
@@ -292,13 +333,15 @@ def expmap(config, field, filters, stage, pixel_scale, padding,
 @common_options
 @click.option('--filters', multiple=True, default=None, cls=VariadicOption,
               help='Filters to check (default: all from field).')
-def check(config, field, filters):
+@tile_option
+def check(config, field, filters, tiles):
     """Report which mosaic tiles are stale and need re-mosaicking."""
     from campfire_pipeline.nircam.manifest import get_stale_tiles
     from campfire_pipeline.config import get_nircam_step_config
 
     cfg, field_obj = _setup(config, field)
     filter_list = _resolve_filters(filters, field_obj)
+    tile_list = list(tiles) if tiles else None
 
     any_stale = False
     for filtname in filter_list:
@@ -311,7 +354,7 @@ def check(config, field, filters):
             'resample': resample_cfg,
             'files_to_skip': files_to_skip,
         }
-        results = get_stale_tiles(field_obj, filtname, wrapped)
+        results = get_stale_tiles(field_obj, filtname, wrapped, tiles=tile_list)
         if not results:
             log(f'{filtname}: no tiles configured')
             continue

--- a/pipeline/campfire_pipeline/nircam/manifest.py
+++ b/pipeline/campfire_pipeline/nircam/manifest.py
@@ -309,7 +309,7 @@ def check_config_changed(manifest_path, stage_config, pixel_scale):
     return current_hash != manifest.get('config_hash')
 
 
-def get_stale_tiles(field, filtname, stage_config):
+def get_stale_tiles(field, filtname, stage_config, tiles=None):
     """Identify tiles that need re-mosaicking.
 
     Parameters
@@ -320,6 +320,9 @@ def get_stale_tiles(field, filtname, stage_config):
         Filter name.
     stage_config : dict
         Stage-3 configuration dict.
+    tiles : str, list of str, or None
+        Tile name(s) to probe. ``None`` (the default) checks every tile in
+        the field.
 
     Returns
     -------
@@ -339,10 +342,9 @@ def get_stale_tiles(field, filtname, stage_config):
         else:
             pixel_scale = f'{int(pixel_scale * 1000)}mas'
 
-    tiles = resample_cfg.get('tile', None)
     if tiles is None:
         tiles = list(field.tiles.keys())
-    if isinstance(tiles, str):
+    elif isinstance(tiles, str):
         tiles = [tiles]
 
     files_to_skip = stage_config.get('files_to_skip', [])

--- a/pipeline/campfire_pipeline/nircam/orchestrate.py
+++ b/pipeline/campfire_pipeline/nircam/orchestrate.py
@@ -509,7 +509,7 @@ def _run_outlier_per_visit(field, cfg, filtname, n_processes, overwrite, status,
 
 
 def _run_resample(field, config, filtname, n_processes, overwrite, status,
-                  reduction_version):
+                  reduction_version, tiles=None):
     # Read the outlier-finished working copies; the mosaic itself is written to
     # the canonical filter dir (resample_step derives it from field.filter_dir).
     exposures = field.get_exposure_files(filtname, with_step='CFP_OUT',
@@ -520,7 +520,7 @@ def _run_resample(field, config, filtname, n_processes, overwrite, status,
     from campfire_pipeline.nircam.steps.resample import resample_step
     cfg = get_nircam_step_config('resample', config, field)
     resample_step(filtname, exposures, field, cfg, reduction_version,
-                  overwrite=overwrite)
+                  overwrite=overwrite, tiles=tiles)
 
 
 # Dispatch table: step name → callable that takes (field, config, filtname,
@@ -616,8 +616,18 @@ def run_process(field, config, filters=None, n_processes=1, overwrite=False):
                                 status)
 
 
-def run_combine(field, config, filters=None, n_processes=1, overwrite=False):
-    """Run all combine-phase steps in order across each filter."""
+def run_combine(field, config, filters=None, n_processes=1, overwrite=False,
+                tiles=None):
+    """Run all combine-phase steps in order across each filter.
+
+    ``tiles`` scopes the resample step *only* — the exposure/visit-level
+    ensemble steps (apply_mask, bad_pixel, outlier) always run over the full
+    exposure set for the filter. Restricting those to a tile subset would
+    truncate outlier's cross-visit median pool and bad_pixel's per-detector
+    stacks, so a tile built from a subset would not match the same tile built
+    with the whole field. They skip already-stamped exposures, so re-running
+    combine with ``--tiles`` after a full pass goes straight to resampling.
+    """
     filters = _resolve_filters(filters, field)
     reduction_version = _resolve_reduction_version(config)
     status = _scan_status(field, filters, overwrite=overwrite)
@@ -637,17 +647,19 @@ def run_combine(field, config, filters=None, n_processes=1, overwrite=False):
                 field.materialize_work(filt, status=status, overwrite=overwrite)
             elif step_name == 'resample':
                 _run_resample(field, config, filt, n_processes, overwrite,
-                              status, reduction_version)
+                              status, reduction_version, tiles=tiles)
             else:
                 _RUNNERS[step_name](field, config, filt, n_processes, overwrite,
                                     status)
 
 
 def run_step(step_name, field, config, filters=None, n_processes=1,
-             overwrite=False):
+             overwrite=False, tiles=None):
     """Run a single named step across the field's filters.
 
-    Used by the per-step CLI commands (``cfpipe nircam <step>``).
+    Used by the per-step CLI commands (``cfpipe nircam <step>``). ``tiles``
+    is only meaningful for ``resample`` (it scopes which mosaics are built)
+    and is ignored by every other step.
     """
     if step_name not in STEP_NAMES:
         raise ValueError(
@@ -670,7 +682,7 @@ def run_step(step_name, field, config, filters=None, n_processes=1,
         if step_name == 'resample':
             reduction_version = _resolve_reduction_version(config)
             _run_resample(field, config, filt, n_processes, overwrite,
-                          status, reduction_version)
+                          status, reduction_version, tiles=tiles)
         else:
             _RUNNERS[step_name](field, config, filt, n_processes, overwrite,
                                 status)

--- a/pipeline/campfire_pipeline/nircam/steps/resample.py
+++ b/pipeline/campfire_pipeline/nircam/steps/resample.py
@@ -165,7 +165,7 @@ def _drizzle_tile_via_jwst(
 
 
 def resample_step(filtname, exposure_files, field, step_config,
-                  reduction_version, overwrite=False):
+                  reduction_version, overwrite=False, tiles=None):
     """Drizzle-combine canonical exposure files into mosaic tiles.
 
     Parameters
@@ -180,6 +180,12 @@ def resample_step(filtname, exposure_files, field, step_config,
         Campfire reduction version stamped onto each mosaic primary header
         as ``CMPFRVER``.
     overwrite : bool
+    tiles : str, list of str, or None
+        Tile name(s) to drizzle. ``None`` (the default) resamples every tile
+        in the field. Tile selection is a runtime CLI parameter (``--tiles``),
+        not a config key — passing a subset only limits which mosaics are
+        built; each tile is drizzled from the same exposure set it would use
+        in a whole-field run.
     """
     from campfire_pipeline.nircam.manifest import (
         build_mosaic_name, check_config_changed, check_inputs_changed,
@@ -193,8 +199,9 @@ def resample_step(filtname, exposure_files, field, step_config,
     if mode != 'tile':
         raise NotImplementedError(f"resample mode {mode!r} not supported")
 
-    tiles = step_config.get('tile', None) or list(field.tiles.keys())
-    if isinstance(tiles, str):
+    if tiles is None:
+        tiles = list(field.tiles.keys())
+    elif isinstance(tiles, str):
         tiles = [tiles]
 
     for tile in tiles:

--- a/pipeline/tests/test_nircam_resample_tiles.py
+++ b/pipeline/tests/test_nircam_resample_tiles.py
@@ -1,0 +1,94 @@
+"""Tests for the runtime ``--tiles`` selection on the resample step.
+
+Tile selection migrated from a ``[nircam.resample].tile`` config key to a CLI
+flag (``--tiles``), since it is a runtime parameter, not a config parameter.
+The flag scopes the resample step only; it is exposed on ``resample``,
+``combine``, ``run``, and ``check``, and is absent from the exposure-level
+per-step commands.
+"""
+
+import tempfile
+import types
+
+import pytest
+from click.testing import CliRunner
+
+from campfire_pipeline.nircam import cli as nircam_cli
+import campfire_pipeline.nircam.steps.resample as resample_mod
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring
+# ---------------------------------------------------------------------------
+
+def _help(runner, command):
+    return runner.invoke(nircam_cli.main, [command, '--help']).output
+
+
+def test_resample_registered_exactly_once():
+    # Skipped in the auto-registration loop and added explicitly with --tiles;
+    # a double-registration would silently clobber one definition.
+    assert list(nircam_cli.main.commands.keys()).count('resample') == 1
+
+
+@pytest.mark.parametrize('command', ['resample', 'combine', 'run', 'check'])
+def test_tiles_flag_present(command):
+    assert '--tiles' in _help(CliRunner(), command)
+
+
+@pytest.mark.parametrize('command', ['sky', 'outlier', 'jhat', 'apply_mask'])
+def test_tiles_flag_absent_on_exposure_level_steps(command):
+    # Only resample is per-tile; the exposure/visit-level steps must not
+    # advertise a flag they ignore.
+    assert '--tiles' not in _help(CliRunner(), command)
+
+
+def test_run_rejects_tiles_without_combine_phase():
+    # --tiles scopes resample, which only runs in the combine phase.
+    res = CliRunner().invoke(
+        nircam_cli.main,
+        ['run', '--field', 'x', '--process', '--tiles', 'A1'],
+    )
+    assert res.exit_code == 2  # click.UsageError
+    assert 'combine' in res.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# resample_step tile resolution
+# ---------------------------------------------------------------------------
+
+def _visited_tiles(tiles_arg, monkeypatch):
+    """Return the tiles ``resample_step`` iterates for a given ``tiles`` arg.
+
+    Overlap selection is stubbed to return no files, so each tile logs its
+    header line and short-circuits before any WCS/drizzle work.
+    """
+    captured = []
+    monkeypatch.setattr(resample_mod, 'select_overlapping_files',
+                        lambda files, poly: [])
+    monkeypatch.setattr(resample_mod, 'log', captured.append)
+
+    field = types.SimpleNamespace(
+        name='cosmos',
+        tiles={'A1': None, 'A2': None, 'B3': None},
+        filter_dir=lambda f: tempfile.gettempdir(),
+        get_tile_corners=lambda t: [(0, 0), (0, 1), (1, 1), (1, 0)],
+    )
+    resample_mod.resample_step(
+        'f444w', ['exp1.fits'], field, {'pixel_scale': '30mas'},
+        'v1.2.3', overwrite=False, tiles=tiles_arg,
+    )
+    return [m.split(',')[0].removeprefix('resample: tile ')
+            for m in captured if m.startswith('resample: tile ')]
+
+
+def test_tiles_none_resamples_all(monkeypatch):
+    assert _visited_tiles(None, monkeypatch) == ['A1', 'A2', 'B3']
+
+
+def test_tiles_subset(monkeypatch):
+    assert _visited_tiles(['A1', 'B3'], monkeypatch) == ['A1', 'B3']
+
+
+def test_tiles_string_is_normalized(monkeypatch):
+    assert _visited_tiles('A2', monkeypatch) == ['A2']


### PR DESCRIPTION
## Summary

Which mosaic tiles get drizzled is a **runtime** choice, not a processing parameter, so this retires the undocumented `[nircam.resample].tile` config key in favor of a `--tiles` CLI flag on `cfpipe nircam {resample,combine,run,check}` (variadic, e.g. `--tiles A1 A2`; default: all tiles in the field).

## Scoping decision

`--tiles` scopes the **resample step only**. The exposure/visit-level combine steps (`apply_mask`, `bad_pixel`, `outlier`) still run over the full field. Restricting those to a tile subset would truncate `outlier`'s cross-visit median pool and `bad_pixel`'s per-detector stacks, so a tile built from a subset run would **not** be bit-identical to the same tile from a whole-field run. Those steps already skip exposures/visits that carry their CFP stamp, so re-running `combine --tiles A1` after a full pass is a near no-op up to the drizzle.

`run` rejects `--tiles` unless the combine phase is selected (`--combine` / `--all`), since resample only runs there.

## Changes

- **`steps/resample.py`** — `resample_step` gains `tiles=None`; drops the `step_config.get('tile')` read. `None` → all field tiles; a bare string is normalized to a one-element list.
- **`orchestrate.py`** — threads `tiles` through `run_combine` → `run_step` → `_run_resample` → `resample_step`, with docstrings explaining the resample-only scoping.
- **`manifest.py`** — `get_stale_tiles` takes `tiles` as a parameter instead of reading the config key, so the `check` probe honors the flag too.
- **`cli.py`** — new `tile_option` decorator; `--tiles` on `resample`, `combine`, `run`, `check`. `resample` is now registered explicitly (skipped in the auto-registration loop) as the only per-tile step. Guard on `run`.
- **`CHANGELOG.md`** — Infrastructure / PATCH entry (CLI ergonomics; no change to mosaic pixel values).

## Migration note

If anyone had `[nircam.resample].tile` set in a personal config TOML, it is now silently ignored — switch to `--tiles`. It was never in the shipped defaults, so nothing in the repo relied on it.

## Testing

New `tests/test_nircam_resample_tiles.py` (13 tests) covers the CLI wiring (flag present on the four intended commands, absent on exposure-level steps, `resample` registered exactly once, `run --process --tiles` rejected) and `resample_step` tile resolution (`None`→all, subset, string normalization). New tests + existing mosaic-naming tests pass.

Generated with Claude Code

https://claude.ai/code/session_01AiNBznMa2rq1BiomxgyfhP

---
_Generated by [Claude Code](https://claude.ai/code/session_01AiNBznMa2rq1BiomxgyfhP)_