### PR TITLE
feat(nircam): align phase foundation — CFP_ALGN key, config namespace, deps

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -276,6 +276,15 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- **NIRCam `align` phase — foundation scaffolding (no behavior change).** Registers
+  the `CFP_ALGN` provenance keyword in the `NIRCAM` CFP keyset (immediately after
+  `CFP_JHAT`, so `reset --from jhat` / `--from wcs_shift` also clears it — both mutate
+  the WCS), opens the `[<field>.align]` per-field config namespace (`known_steps`), and
+  declares the two dependencies the forthcoming adaptive astrometric align step will
+  import (`tweakwcs>=0.8`, previously only transitive via `jwst`; `tristars==0.1`, the
+  triangle/asterism catalog matcher). Nothing new runs yet — this is the pipeline-side
+  foundation for the field-level `align` phase that will replace the JHAT-based
+  `jhat`/`wcs_shift` alignment. No change to any output values.
 - **NIRCam resample tile selection moved from config to a `--tiles` CLI flag.**
   Which mosaic tiles get drizzled is a runtime choice, not a processing
   parameter, so the undocumented `[nircam.resample].tile` config key is retired

--- a/pipeline/campfire_pipeline/common/cfp.py
+++ b/pipeline/campfire_pipeline/common/cfp.py
@@ -78,6 +78,7 @@ NIRCAM = Keyset(
         'CFP_SHFT',  # pre-jhat astrometric WCS shift (opt-in, rule-driven)
         'CFP_PREV',  # per-exposure preview PNG for web admin triage
         'CFP_JHAT',  # WCS alignment
+        'CFP_ALGN',  # adaptive astrometric align (replaces jhat/wcs_shift)
         'CFP_MASK',  # user region masks
         'CFP_BPIX',  # bad pixel mask
         'CFP_OUT',   # outlier detection (per-visit ensemble)
@@ -95,6 +96,7 @@ NIRCAM = Keyset(
         'CFP_SHFT': 'campfire: pre-jhat WCS shift (dra,ddec,droll,scale)',
         'CFP_PREV': 'campfire: preview PNG rendered',
         'CFP_JHAT': 'campfire: jhat refcat used',
+        'CFP_ALGN': 'campfire: align shift/rot + solve_status',
         'CFP_MASK': 'campfire: user masks applied',
         'CFP_BPIX': 'campfire: bad pixel mask applied',
         'CFP_OUT':  'campfire: outlier detection done',

--- a/pipeline/campfire_pipeline/nircam/field.py
+++ b/pipeline/campfire_pipeline/nircam/field.py
@@ -302,7 +302,7 @@ class Field:
         known_steps = {
             'detector1', 'persistence', 'wisp', 'striping',
             'image2', 'diag_striping', 'edge', 'sky', 'variance',
-            'wcs_shift', 'jhat',
+            'wcs_shift', 'jhat', 'align',
             'apply_mask', 'bad_pixel', 'outlier', 'resample',
         }
 

--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -28,6 +28,8 @@ dependencies = [
     "sep>=1.4.1",
     "astroquery>=0.4.7",
     "pyvo>=1.5",
+    "tweakwcs>=0.8",  # NIRCam align step: JWSTWCSCorrector/align_wcs (also transitive via jwst)
+    "tristars==0.1",  # NIRCam align step: triangle/asterism matcher (unmaintained v0.1; pin exact)
 ]
 
 [project.scripts]

--- a/pipeline/tests/test_cfp.py
+++ b/pipeline/tests/test_cfp.py
@@ -37,6 +37,15 @@ def test_module_aliases_point_at_nircam():
     assert cfp.CFP_KEYS[-1] == 'CFP_OUT'
 
 
+def test_align_key_positioned_after_jhat():
+    # CFP_ALGN (adaptive astrometric align) must sit immediately after CFP_JHAT so
+    # `reset --from jhat` / `--from wcs_shift` also clears the align stamp — both
+    # mutate the WCS. Guards the clear_from reset-slice contract for the align phase.
+    keys = cfp.NIRCAM.keys
+    assert 'CFP_ALGN' in keys
+    assert keys[keys.index('CFP_JHAT') + 1] == 'CFP_ALGN'
+
+
 def test_format_defaults_to_nircam():
     out = cfp.format(CFP_DET1=None)
     val, comment = out['CFP_DET1']


### PR DESCRIPTION
## Phase 1 of the NIRCam `align` build — foundation scaffolding

First PR in the per-phase rollout of a new field-level NIRCam **`align`** phase that will replace the JHAT-based `jhat`/`wcs_shift` alignment (design + resolved decisions in `pipeline/ASTROMETRY_ALIGN_HANDOFF.md`). This PR is **pure, behavior-neutral scaffolding** — nothing new runs; it only puts the declarative hooks in place that every later phase depends on.

### What's here
- **`CFP_ALGN` provenance key** registered in the `NIRCAM` CFP keyset (`common/cfp.py`), positioned **immediately after `CFP_JHAT`** so `reset --from jhat` / `--from wcs_shift` also clears it (both mutate the WCS), with downstream `CFP_MASK`/`CFP_BPIX`/`CFP_OUT` correctly after it. `status.py` reads `CFP_KEYS` dynamically, so no scan/status change is needed.
  - Note: the key is `CFP_ALGN` (8 chars), **not** `CFP_ALIGN` (9 chars) — the latter exceeds the FITS 8-character keyword limit and fails `test_every_key_has_comment_and_fits_8char`.
- **`[<field>.align]` config namespace** opened via `field.py` `known_steps` (flows into `reserved_keys` so it isn't misread as a tile, and into `step_overrides` so it's resolvable via `get_nircam_step_config('align', …)`). Inert until `run_align` consumes it.
- **Dependency pins** in `pyproject.toml`: `tweakwcs>=0.8` (previously only transitive via `jwst`) and `tristars==0.1` (triangle/asterism matcher, decision D5; unmaintained v0.1, pinned exact). `scikit-image` — tristars' only heavy requirement — is already transitive via `jwst`/`stcal`/`drizzlepac`, so this adds no new heavy runtime dep.
- **Guard test** locking the `CFP_ALGN`-immediately-after-`CFP_JHAT` reset-slice contract.
- **CHANGELOG** entry under Unreleased → Infrastructure (PATCH; no output-value change).

### Explicitly deferred (tracked follow-ups)
The cross-package `CFP_KEYS` mirrors — `python/campfire/deploy/nircam.py::_CFP_TO_STAGE` and `web/lib/{types.ts,nircam-stages.ts}` — are **not** touched here. They only matter once align actually *stamps* files, and no test enforces lockstep with the pipeline keyset. They'll be updated in the phase that adds the solve worker, to keep this a clean pipeline-only PR.

### Verification
- `pytest pipeline/tests/test_cfp.py` → 21 passed (incl. the new adjacency guard).
- Registry smoke test: `CFP_ALGN` present, immediately after `CFP_JHAT`, ≤8 chars, has a comment.
- `pyproject.toml` parses; `tweakwcs>=0.8` + `tristars==0.1` resolve (`pip install --dry-run`).

### Scope boundary
No `association.py`, matcher, detection, `run_align`, CLI wiring, `jhat`/`wcs_shift` gating, or deploy/web mirror updates — those are later phases.

Generated with Claude Code
