### PR TITLE
feat(nircam): align phase — exposure-association layer (association.py)

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -276,6 +276,16 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- **NIRCam `align` phase — exposure-association layer.** New `nircam/association.py`
+  groups canonical exposure files into per-exposure `ExposureGroup`s keyed on the
+  exposure token (`rootname.rsplit('_',1)[0]`), pooling every detector of one dither
+  across the SW and LW filter directories (they share the token). Reuses
+  `Field.get_exposure_files` so per-filter effective-skip (field `skip` + reviewer
+  `excluded_exposures` + caller skip) is honored; classifies module/channel from the
+  detector token; is imaging-only (grism is gated upstream) and reads filenames only
+  (never opens a FITS). Standalone library module for the forthcoming `align` phase —
+  not yet wired into orchestration; covered by `tests/test_association.py`. No behavior
+  change.
 - **NIRCam `align` phase — foundation scaffolding (no behavior change).** Registers
   the `CFP_ALGN` provenance keyword in the `NIRCAM` CFP keyset (immediately after
   `CFP_JHAT`, so `reset --from jhat` / `--from wcs_shift` also clears it — both mutate

--- a/pipeline/campfire_pipeline/nircam/association.py
+++ b/pipeline/campfire_pipeline/nircam/association.py
@@ -1,0 +1,237 @@
+"""Group NIRCam canonical exposure files into per-exposure ``ExposureGroup``s.
+
+This is the association / enumeration layer for the field-level astrometric
+``align`` phase. One :class:`ExposureGroup` is one *physical* NIRCam exposure
+(one dither): every detector file that shares the exposure token
+``rootname.rsplit('_', 1)[0]`` (= filename ``parts[0]_parts[1]_parts[2]``,
+dropping the ``_<detector>`` suffix).
+
+A single NIRCam exposure images simultaneously through a short-wavelength (SW)
+filter — modules A1-A4, B1-B4 — and a long-wavelength (LW) filter —
+NRCALONG/NRCBLONG. One canonical FITS is written per detector; the SW files
+land in the SW filter's directory and the LW files in the LW filter's
+directory, but *all ten share one exposure token* (see ``list_products`` in
+``common/query.py``). So grouping pools **across all of the field's filters**
+and reunites the SW + LW halves of each dither. Groups of 10 / 5 / 2 / 1
+members are all normal (both modules / single module / LW-only / subarray); a
+one-member group is valid and later phases fall back to a per-detector solve
+for it. Detectors are **never** grouped across dithers — a different exposure
+number yields a different token.
+
+**Imaging only.** Grism/WFSS never reaches the canonical tree (dropped at
+download and at ``orchestrate._filter_imaging_uncals`` / ``steps/image2``), so
+this module needs no ``EXP_TYPE`` read and performs none — it groups purely
+from filenames and parent directories and never opens a FITS.
+
+Deliberately import-light (stdlib + ``common.io.log`` only): this layer will
+sit on the align orchestrator's hot path, so it does not import the step
+modules (``steps/bad_pixel`` etc.) that would drag in numpy / jwst / CRDS. The
+two trivial detector classifiers are re-implemented locally — an existing
+convention in this codebase (cf. ``steps/bad_pixel._detector_of``,
+``orchestrate._detector_sorted``, ``common/query._is_lw_detector``).
+"""
+
+import os
+from dataclasses import dataclass
+from typing import List, Tuple
+
+from campfire_pipeline.common.io import log
+
+
+# Canonical detector order (module-major, each module's LW after its SW).
+# Mirrors steps/bad_pixel.py SW_DETECTORS/LW_DETECTORS; re-declared here to keep
+# this module free of the step-module import chain.
+_CANONICAL_DETECTORS = (
+    'nrca1', 'nrca2', 'nrca3', 'nrca4', 'nrcalong',
+    'nrcb1', 'nrcb2', 'nrcb3', 'nrcb4', 'nrcblong',
+)
+
+
+def exposure_key(path) -> str:
+    """Exposure token for *path*: the rootname minus its ``_<detector>`` suffix.
+
+    ``'.../jw01727028001_04101_00003_nrcalong.fits'`` ->
+    ``'jw01727028001_04101_00003'``. One token identifies one physical exposure
+    (one dither) across every detector and both filter channels.
+    """
+    base = os.path.basename(path).removesuffix('.fits')
+    return base.rsplit('_', 1)[0]
+
+
+def detector_of(path) -> str:
+    """Detector token (the last ``_``-delimited field) of *path*.
+
+    Complement of :func:`exposure_key`. Mirrors ``steps/bad_pixel._detector_of``.
+    """
+    base = os.path.basename(path).removesuffix('.fits')
+    return base.rsplit('_', 1)[-1]
+
+
+def channel_of(detector) -> str:
+    """``'lw'`` for a long-wavelength detector, else ``'sw'``.
+
+    LW iff the detector token ends in ``'long'`` (``nrcalong``/``nrcblong``) or
+    ``'5'`` (the ``nrca5``/``nrcb5`` aliases). Source of truth:
+    ``common/query._is_lw_detector``.
+    """
+    d = (detector or '').lower()
+    return 'lw' if d.endswith('long') or d.endswith('5') else 'sw'
+
+
+def module_of(detector) -> str:
+    """NIRCam module ``'a'`` or ``'b'`` from a detector token (``''`` if unknown).
+
+    The module is the character after the ``nrc`` prefix: ``nrca1`` -> ``'a'``,
+    ``nrcblong`` -> ``'b'``.
+    """
+    d = (detector or '').lower()
+    if d.startswith('nrc') and len(d) > 3:
+        return d[3]
+    return ''
+
+
+@dataclass(frozen=True)
+class ExposureMember:
+    """One detector's canonical FITS within an exposure group."""
+
+    path: str          # absolute canonical (or working-copy) path
+    filter_name: str   # the filter DIRECTORY the file was found in
+    rootname: str      # basename without '.fits' (full, incl. detector)
+    detector: str      # e.g. 'nrca1' … 'nrcblong'
+
+    @property
+    def channel(self) -> str:
+        return channel_of(self.detector)
+
+    @property
+    def module(self) -> str:
+        return module_of(self.detector)
+
+    @property
+    def is_sw(self) -> bool:
+        return self.channel == 'sw'
+
+    @property
+    def is_lw(self) -> bool:
+        return self.channel == 'lw'
+
+
+@dataclass(frozen=True)
+class ExposureGroup:
+    """All detector files of one physical NIRCam exposure (one dither).
+
+    Purely structural — it describes what was found on disk. Solve-time policy
+    (e.g. falling back to a per-detector solve for a one-member group) lives in
+    the align solve phase, which reads :attr:`is_single_member`.
+    """
+
+    key: str
+    members: Tuple[ExposureMember, ...]
+
+    @property
+    def paths(self) -> Tuple[str, ...]:
+        return tuple(m.path for m in self.members)
+
+    @property
+    def n_members(self) -> int:
+        return len(self.members)
+
+    @property
+    def sw_members(self) -> Tuple[ExposureMember, ...]:
+        return tuple(m for m in self.members if m.is_sw)
+
+    @property
+    def lw_members(self) -> Tuple[ExposureMember, ...]:
+        return tuple(m for m in self.members if m.is_lw)
+
+    @property
+    def filters(self) -> frozenset:
+        return frozenset(m.filter_name for m in self.members)
+
+    @property
+    def modules(self) -> frozenset:
+        return frozenset(m.module for m in self.members if m.module)
+
+    @property
+    def detectors(self) -> Tuple[str, ...]:
+        return tuple(m.detector for m in self.members)
+
+    @property
+    def is_single_member(self) -> bool:
+        return self.n_members == 1
+
+
+def _member_sort_key(member):
+    try:
+        idx = _CANONICAL_DETECTORS.index(member.detector)
+    except ValueError:
+        idx = len(_CANONICAL_DETECTORS)  # unknown detector sorts last
+    return (idx, member.detector, member.filter_name, member.path)
+
+
+def _make_member(field, path, filter_name) -> ExposureMember:
+    """Build one member, emitting advisory (never fatal) warnings on anomalies."""
+    rootname = os.path.basename(path).removesuffix('.fits')
+    detector = detector_of(path)
+
+    if detector not in _CANONICAL_DETECTORS:
+        # Never drop science over an unrecognized token — keep it (it sorts
+        # last) and flag it. Mirrors the non-fatal stance of
+        # Field._load_excluded_exposures.
+        log(f"association: unexpected detector token '{detector}' in "
+            f"{os.path.basename(path)}; keeping it (grouped, sorted last).")
+    else:
+        det_channel = channel_of(detector)
+        if field.is_sw_filter(filter_name):
+            filt_channel = 'sw'
+        elif field.is_lw_filter(filter_name):
+            filt_channel = 'lw'
+        else:
+            filt_channel = None
+        if filt_channel is not None and det_channel != filt_channel:
+            log(f"association: {det_channel.upper()} detector '{detector}' "
+                f"found in {filt_channel.upper()} filter dir '{filter_name}' "
+                f"({os.path.basename(path)}); keeping it.")
+
+    # WFSS seam: a future mode-aware path would read EXP_TYPE here to keep grism
+    # out of imaging groups. The canonical tree is imaging-only (grism is gated
+    # upstream), so Phase 2 performs no mode read.
+    return ExposureMember(path=path, filter_name=filter_name,
+                          rootname=rootname, detector=detector)
+
+
+def build_exposure_groups(field, filters=None, *, skip=None, with_step=None,
+                          status=None, work=False) -> List[ExposureGroup]:
+    """Group a field's canonical exposure files by physical exposure.
+
+    Scans every filter in *filters* (default ``field.filters``) via
+    :meth:`Field.get_exposure_files` — so per-filter effective-skip
+    (``field.skip`` + reviewer ``excluded_exposures[filter]`` + caller *skip*)
+    is applied for free — and buckets the results by :func:`exposure_key`,
+    reuniting the SW and LW detectors of each dither.
+
+    *skip*, *with_step*, *status*, and *work* are passed through verbatim to
+    :meth:`Field.get_exposure_files` (the align phase will later pass its
+    process-completion CFP key via *with_step* plus a pre-scanned
+    ``StepStatus``). Requires ``field.setup_workspace()`` to have been called;
+    otherwise ``Field.filter_dir`` raises ``RuntimeError``, which propagates.
+
+    Returns a list of :class:`ExposureGroup`, sorted by ``key``, each with its
+    members in canonical detector order.
+    """
+    filters = list(field.filters if filters is None else filters)
+
+    buckets = {}
+    for filter_name in filters:
+        for path in field.get_exposure_files(filter_name, skip=skip,
+                                             with_step=with_step,
+                                             status=status, work=work):
+            member = _make_member(field, path, filter_name)
+            buckets.setdefault(exposure_key(path), []).append(member)
+
+    groups = [
+        ExposureGroup(key=key,
+                      members=tuple(sorted(members, key=_member_sort_key)))
+        for key, members in buckets.items()
+    ]
+    return sorted(groups, key=lambda g: g.key)

--- a/pipeline/tests/test_association.py
+++ b/pipeline/tests/test_association.py
@@ -1,0 +1,269 @@
+"""Tests for the NIRCam exposure-association layer (nircam/association.py).
+
+Covers the per-exposure grouping that the field-level ``align`` phase consumes:
+one ``ExposureGroup`` == one physical exposure (one dither), pooling every
+detector that shares the exposure token across the SW + LW filter directories.
+The module reads filenames + parent dir only, so fixtures are zero-byte files
+(mirrors test_nircam_exclusions.py) under a real, set-up ``Field``.
+"""
+
+import os
+
+import pytest
+
+from campfire_pipeline.nircam.field import Field
+from campfire_pipeline.nircam.association import (
+    ExposureGroup,
+    build_exposure_groups,
+    channel_of,
+    detector_of,
+    exposure_key,
+    module_of,
+)
+
+_TOKEN = 'jw01727028001_04101_00003'
+_TOKEN2 = 'jw01727028001_04101_00004'
+_SW = ('nrca1', 'nrca2', 'nrca3', 'nrca4', 'nrcb1', 'nrcb2', 'nrcb3', 'nrcb4')
+_LW = ('nrcalong', 'nrcblong')
+
+
+def _make_field(tmp_path, filters=('f200w', 'f444w'), **kw):
+    f = Field(name='cosmos', filters=list(filters), files=['jw01727*'],
+              tangent_point=(150.0, 2.0), tiles={}, **kw)
+    f.setup_workspace(campfire_root=str(tmp_path))
+    return f
+
+
+def _touch(field, filt, root):
+    path = os.path.join(field.filter_dir(filt), f'{root}.fits')
+    open(path, 'w').close()
+    return path
+
+
+def _dets(group):
+    return [m.detector for m in group.members]
+
+
+# --- core grouping ----------------------------------------------------------
+
+def test_multi_filter_grouping_one_token(tmp_path):
+    f = _make_field(tmp_path)
+    for det in _SW:
+        _touch(f, 'f200w', f'{_TOKEN}_{det}')
+    for det in _LW:
+        _touch(f, 'f444w', f'{_TOKEN}_{det}')
+
+    groups = build_exposure_groups(f)
+    assert len(groups) == 1
+    g = groups[0]
+    assert g.key == _TOKEN
+    assert g.n_members == 10
+    assert g.filters == frozenset({'f200w', 'f444w'})
+    assert g.modules == frozenset({'a', 'b'})
+    assert len(g.sw_members) == 8
+    assert len(g.lw_members) == 2
+    assert not g.is_single_member
+
+
+def test_two_dithers_do_not_cross_group(tmp_path):
+    f = _make_field(tmp_path)
+    for token in (_TOKEN, _TOKEN2):
+        for det in _SW:
+            _touch(f, 'f200w', f'{token}_{det}')
+        for det in _LW:
+            _touch(f, 'f444w', f'{token}_{det}')
+
+    groups = build_exposure_groups(f)
+    assert [g.key for g in groups] == [_TOKEN, _TOKEN2]
+    for g in groups:
+        assert all(exposure_key(m.path) == g.key for m in g.members)
+
+
+def test_five_member_single_module(tmp_path):
+    f = _make_field(tmp_path)
+    for det in ('nrca1', 'nrca2', 'nrca3', 'nrca4'):
+        _touch(f, 'f200w', f'{_TOKEN}_{det}')
+    _touch(f, 'f444w', f'{_TOKEN}_nrcalong')
+
+    (g,) = build_exposure_groups(f)
+    assert g.n_members == 5
+    assert g.modules == frozenset({'a'})
+    assert len(g.sw_members) == 4
+    assert len(g.lw_members) == 1
+
+
+def test_one_member_lw_only_is_single(tmp_path):
+    f = _make_field(tmp_path)
+    _touch(f, 'f444w', f'{_TOKEN}_nrcalong')
+
+    (g,) = build_exposure_groups(f)
+    assert g.n_members == 1
+    assert g.is_single_member
+    assert g.members[0].channel == 'lw'
+
+
+def test_two_member_lw_only_not_single(tmp_path):
+    f = _make_field(tmp_path)
+    for det in _LW:
+        _touch(f, 'f444w', f'{_TOKEN}_{det}')
+
+    (g,) = build_exposure_groups(f)
+    assert g.n_members == 2
+    assert not g.is_single_member
+    assert g.modules == frozenset({'a', 'b'})
+
+
+# --- effective skip ---------------------------------------------------------
+
+def test_skip_via_field_skip(tmp_path):
+    f = _make_field(tmp_path, skip=[f'{_TOKEN2}*'])
+    for token in (_TOKEN, _TOKEN2):
+        for det in _SW:
+            _touch(f, 'f200w', f'{token}_{det}')
+
+    groups = build_exposure_groups(f)
+    assert [g.key for g in groups] == [_TOKEN]
+
+
+def test_skip_via_excluded_exposures(tmp_path):
+    f = _make_field(tmp_path)
+    for det in _SW:
+        _touch(f, 'f200w', f'{_TOKEN}_{det}')
+    # Reviewer exclusion is per-filter and drops a single detector.
+    f.excluded_exposures = {'f200w': [f'{_TOKEN}_nrca1']}
+
+    (g,) = build_exposure_groups(f)
+    assert 'nrca1' not in g.detectors
+    assert g.n_members == 7
+
+
+# --- classification ---------------------------------------------------------
+
+def test_module_and_channel_tagging(tmp_path):
+    f = _make_field(tmp_path)
+    _touch(f, 'f200w', f'{_TOKEN}_nrca1')
+    _touch(f, 'f200w', f'{_TOKEN}_nrcb3')
+    _touch(f, 'f444w', f'{_TOKEN}_nrcalong')
+    _touch(f, 'f444w', f'{_TOKEN}_nrcblong')
+
+    (g,) = build_exposure_groups(f)
+    tags = {m.detector: (m.module, m.channel) for m in g.members}
+    assert tags['nrca1'] == ('a', 'sw')
+    assert tags['nrcb3'] == ('b', 'sw')
+    assert tags['nrcalong'] == ('a', 'lw')
+    assert tags['nrcblong'] == ('b', 'lw')
+
+
+def test_public_helpers():
+    p = '/x/f444w/jw01727028001_04101_00003_nrcalong.fits'
+    assert exposure_key(p) == 'jw01727028001_04101_00003'
+    assert detector_of(p) == 'nrcalong'
+    assert channel_of('nrcalong') == 'lw'
+    assert channel_of('nrca5') == 'lw'
+    assert channel_of('nrcb2') == 'sw'
+    assert module_of('nrca1') == 'a'
+    assert module_of('nrcblong') == 'b'
+    assert module_of('weird') == ''
+
+
+# --- ordering ---------------------------------------------------------------
+
+def test_deterministic_ordering(tmp_path):
+    f = _make_field(tmp_path)
+    # Create in a deliberately non-canonical order.
+    for det in ('nrcb2', 'nrca4', 'nrca1'):
+        _touch(f, 'f200w', f'{_TOKEN}_{det}')
+    _touch(f, 'f444w', f'{_TOKEN}_nrcalong')
+
+    g1 = build_exposure_groups(f)[0]
+    g2 = build_exposure_groups(f)[0]
+    assert _dets(g1) == _dets(g2)
+    # Canonical order: SW module A, then that module's LW, then module B.
+    assert _dets(g1) == ['nrca1', 'nrca4', 'nrcalong', 'nrcb2']
+
+
+# --- passthrough params -----------------------------------------------------
+
+def test_filters_arg_subsets_to_lw(tmp_path):
+    f = _make_field(tmp_path)
+    for det in _SW:
+        _touch(f, 'f200w', f'{_TOKEN}_{det}')
+    for det in _LW:
+        _touch(f, 'f444w', f'{_TOKEN}_{det}')
+
+    (g,) = build_exposure_groups(f, filters=['f444w'])
+    assert g.detectors == ('nrcalong', 'nrcblong')
+
+
+class _StatusStub:
+    """Minimal StepStatus stand-in: only ``has(path, key)`` is consulted."""
+
+    def __init__(self, keep):
+        self.keep = set(keep)
+
+    def has(self, path, key):
+        return path in self.keep
+
+
+def test_with_step_via_status_stub(tmp_path):
+    f = _make_field(tmp_path)
+    keep = []
+    for token in (_TOKEN, _TOKEN2):
+        for det in _SW:
+            p = _touch(f, 'f200w', f'{token}_{det}')
+            if token == _TOKEN:
+                keep.append(p)
+
+    groups = build_exposure_groups(f, with_step='CFP_ALGN',
+                                   status=_StatusStub(keep))
+    assert [g.key for g in groups] == [_TOKEN]
+
+
+# --- edge cases -------------------------------------------------------------
+
+def test_empty_filters_returns_empty(tmp_path):
+    f = _make_field(tmp_path)
+    assert build_exposure_groups(f, filters=[]) == []
+
+
+def test_runtime_error_if_not_setup():
+    f = Field(name='cosmos', filters=['f200w'], files=['jw01727*'],
+              tangent_point=(150.0, 2.0), tiles={})
+    with pytest.raises(RuntimeError):
+        build_exposure_groups(f)
+
+
+# --- advisory, non-fatal anomalies ------------------------------------------
+
+def test_unexpected_detector_kept_and_sorted_last(tmp_path, capsys):
+    f = _make_field(tmp_path)
+    _touch(f, 'f200w', f'{_TOKEN}_nrca1')
+    _touch(f, 'f200w', f'{_TOKEN}_nrcz9')
+
+    (g,) = build_exposure_groups(f)
+    assert 'nrcz9' in g.detectors
+    assert g.detectors[-1] == 'nrcz9'  # unknown sorts last
+    assert 'unexpected detector' in capsys.readouterr().out
+
+
+def test_channel_filter_mismatch_kept_and_warned(tmp_path, capsys):
+    f = _make_field(tmp_path)
+    # SW detector placed in the LW filter directory.
+    _touch(f, 'f444w', f'{_TOKEN}_nrca1')
+
+    (g,) = build_exposure_groups(f)
+    assert g.detectors == ('nrca1',)
+    out = capsys.readouterr().out
+    assert 'SW detector' in out and 'f444w' in out
+
+
+# --- dataclass sanity -------------------------------------------------------
+
+def test_group_is_frozen_and_hashable(tmp_path):
+    f = _make_field(tmp_path)
+    _touch(f, 'f444w', f'{_TOKEN}_nrcalong')
+    (g,) = build_exposure_groups(f)
+    assert isinstance(g, ExposureGroup)
+    with pytest.raises(Exception):
+        g.key = 'mutated'  # frozen
+    _ = {g}  # hashable (frozen dataclass of hashable fields)


### PR DESCRIPTION
## Phase 2 of the NIRCam `align` build — exposure-association layer

Second PR in the per-phase rollout of the field-level NIRCam **`align`** phase (design in `pipeline/ASTROMETRY_ALIGN_HANDOFF.md`; Phase 1 — the `CFP_ALGN` key + config + deps — merged in #322). This PR adds the **association / enumeration layer** that every later phase (matcher, solve worker, `run_align`) consumes. It's a **standalone, unit-tested library module** — nothing is wired into orchestration or the CLI yet.

### What's here
- **`nircam/association.py`** — `build_exposure_groups(field, filters=None, *, skip=None, with_step=None, status=None, work=False) -> list[ExposureGroup]`. Groups canonical exposure files into per-exposure `ExposureGroup`s keyed on the exposure token `rootname.rsplit('_',1)[0]` (= filename `parts[0]_parts[1]_parts[2]`), pooling **every detector of one dither across the SW and LW filter directories** — they share the token (verified: one MAST fileset = one exposure = up to 10 detectors sharing the exposure number, `common/query.py:491-497`). Groups of 10 / 5 / 2 / 1 members are all normal (both-modules / single-module / LW-only / subarray); a 1-member group is valid (`is_single_member`) and later phases degrade it to a per-detector solve.
  - Reuses `Field.get_exposure_files` per filter, so **per-filter effective-skip** (`field.skip` + reviewer `excluded_exposures[filter]` + caller `skip`) is honored for free.
  - `ExposureMember` / `ExposureGroup` are frozen dataclasses; `ExposureGroup` exposes `paths`, `n_members`, `sw_members`, `lw_members`, `filters`, `modules`, `detectors`, `is_single_member` — **purely structural**, no solve-policy flag.
  - **Imaging-only** (grism is gated upstream at download / `_filter_imaging_uncals` / `image2`), so it reads filenames + parent dir only and **never opens a FITS**. A one-line comment marks the WFSS seam where a future `EXP_TYPE` mode split would go, without building it.
  - **Import-light** (stdlib + `common.io.log` only) since it will sit on the align orchestrator hot path; the two trivial detector classifiers are re-implemented locally rather than importing the `steps/bad_pixel` chain (numpy/jwst/CRDS) — an existing convention (`_detector_of`, `_detector_sorted`, `_is_lw_detector`).
  - Anomalies (unknown detector token; detector/filter channel mismatch) are **advisory, never fatal** — the member is kept, matching `Field._load_excluded_exposures`.
- **`tests/test_association.py`** — 17 cases (multi-filter grouping under one token; no cross-dither grouping; 10/5/2/1-member groups; effective-skip via `field.skip` and via `excluded_exposures`; module/channel tagging; deterministic ordering; `filters=`/`with_step`+`status` passthrough; `RuntimeError` when `setup_workspace` not called; unknown-detector and channel-mismatch advisory paths; frozen/hashable).
- **CHANGELOG** entry under Unreleased → Infrastructure (PATCH).

### Verification
- `pytest pipeline/tests/test_association.py` → **17 passed**.
- No regressions: `pytest test_cfp.py test_nircam_work_tree.py test_nircam_exclusions.py` → **29 passed**.

### Scope boundary
No matcher, detection, `run_align`, CLI/orchestration wiring, `tweakwcs`/`tristars` imports, deploy/web mirror updates, or FITS reads. Those are later phases.

Generated with Claude Code
