### PR TITLE
feat(nircam): align phase — triangle/asterism matcher (TriangleMatch)

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -276,6 +276,16 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- **NIRCam `align` phase — triangle/asterism matcher.** New `nircam/align/` subpackage
+  with `TriangleMatch`, a `tweakwcs` `MatchCatalogs` subclass that matches source
+  catalogs by triangle *shape* (side ratios) — invariant to translation/rotation/scale,
+  so it recovers correspondences with no prior on the WCS offset (the regime where the
+  default 2d-histogram + nearest-neighbour matcher silently mis-aligns). Wraps
+  `tristars.match_catalog_tri` (correspondence path only; the fit stays `tweakwcs`'s
+  job). Color-free — magnitude is used only to cap each catalog to its brightest-N
+  triangle vertices, never as a match constraint. Standalone library module for the
+  forthcoming align solve — not yet wired in; covered by `tests/test_align_matcher.py`.
+  No behavior change.
 - **NIRCam `align` phase — exposure-association layer.** New `nircam/association.py`
   groups canonical exposure files into per-exposure `ExposureGroup`s keyed on the
   exposure token (`rootname.rsplit('_',1)[0]`), pooling every detector of one dither

--- a/pipeline/campfire_pipeline/nircam/align/__init__.py
+++ b/pipeline/campfire_pipeline/nircam/align/__init__.py
@@ -1,0 +1,16 @@
+"""NIRCam astrometric ``align`` subsystem.
+
+The field-level alignment algorithm that replaces the JHAT-based ``jhat`` /
+``wcs_shift`` steps: triangle-matches a pooled per-exposure source catalog to a
+Gaia-tied reference catalog and fits one shared shift+rotation per exposure via
+``tweakwcs`` (SIAF distortion fixed), freeing a per-detector shift only where
+residuals demand it. See ``pipeline/ASTROMETRY_ALIGN_HANDOFF.md``.
+
+Modules are added phase by phase; this package currently exports the matcher.
+The exposure-grouping layer lives at ``nircam/association.py`` (a general
+primitive, not align-specific).
+"""
+
+from campfire_pipeline.nircam.align.matcher import TriangleMatch
+
+__all__ = ['TriangleMatch']

--- a/pipeline/campfire_pipeline/nircam/align/matcher.py
+++ b/pipeline/campfire_pipeline/nircam/align/matcher.py
@@ -1,0 +1,126 @@
+"""Triangle/asterism catalog matcher for the NIRCam ``align`` phase.
+
+:class:`TriangleMatch` is a ``tweakwcs`` ``MatchCatalogs`` subclass that finds
+source correspondences by matching triangle *shape* (side ratios) — invariant
+to translation, rotation, and scale — so it recovers the match with **no prior
+on the WCS offset**. That is exactly the regime where ``tweakwcs``'s default
+``XYXYMatch`` (2-D histogram + nearest-neighbour) fails: once the WCS offset
+exceeds the search radius, NN grabs the wrong neighbours and the histogram peak
+lands near zero, so the fit "succeeds" with a spurious ~zero shift. Triangle
+matching demands geometric consistency, so chance can't fake a match.
+
+**Color-free.** Magnitude is dropped from the correspondence entirely; the
+``mag_col`` is used *only* to cap each catalog to its brightest-N vertices
+before triangle building (to bound the O(N^3) triangle count) — never as a
+match constraint. This is what lets the align phase feed a reference catalog
+whose magnitude zeropoint is inconsistent across build backends.
+
+Wraps ``tristars.match.match_catalog_tri`` on its correspondence-only path
+(``auto_keep=False``): the matcher returns matched index pairs; the
+sigma-clipped transform fit is ``tweakwcs``'s job (``align_wcs`` / ``fit_wcs``),
+not the matcher's.
+"""
+
+import numpy as np
+from tweakwcs.matchutils import MatchCatalogs
+
+from campfire_pipeline.common.io import log
+
+_EMPTY = (np.array([], dtype=int), np.array([], dtype=int))
+
+
+class TriangleMatch(MatchCatalogs):
+    """Match two tangent-plane catalogs by triangle shape.
+
+    Instances are passed as the ``match=`` callable to ``tweakwcs.align_wcs``.
+    ``__call__`` follows the ``MatchCatalogs`` contract: it receives the
+    reference and image catalogs (astropy ``Table``s carrying ``TPx``/``TPy``
+    tangent-plane columns, in arcsec for ``JWSTWCSCorrector``) and returns a
+    tuple ``(ref_idx, im_idx)`` — **reference indices first** — of matched rows.
+
+    Parameters
+    ----------
+    brightest : int or None
+        Cap each catalog to this many brightest vertices before building
+        triangles (bounds the triangle count). ``None`` uses every source.
+    mag_col : str
+        Column used to rank brightness for the ``brightest`` cap (smaller =
+        brighter, i.e. an AB magnitude). Used for vertex selection ONLY, never
+        as a match constraint. If absent, the cap falls back to input order.
+    size_limit : (float, float)
+        Min/max triangle side length passed to ``match_catalog_tri``. In the
+        JWST tangent plane these are **arcsec**; the default ``(5, 800)`` keeps
+        within- and cross-detector triangles for a pooled exposure. Tune on
+        real data during align validation.
+    ignore_rot, ignore_scale, ba_max, max_keep :
+        Passed straight through to ``tristars.match.match_catalog_tri``.
+    """
+
+    def __init__(self, *, brightest=150, mag_col='mag',
+                 size_limit=(5.0, 800.0), ignore_rot=True, ignore_scale=True,
+                 ba_max=0.9, max_keep=10):
+        self.brightest = brightest
+        self.mag_col = mag_col
+        self.size_limit = [float(size_limit[0]), float(size_limit[1])]
+        self.ignore_rot = ignore_rot
+        self.ignore_scale = ignore_scale
+        self.ba_max = ba_max
+        self.max_keep = max_keep
+
+    def _vertices(self, cat):
+        """Return ``(xy [N, 2] float, orig_idx [N] int)`` — the brightest-N
+        ``TPx``/``TPy`` vertices and their row indices into the ORIGINAL *cat*.
+
+        Selecting a subset means the tristars indices are into the subset, so we
+        carry ``orig_idx`` to map matched pairs back to the caller's rows.
+        """
+        for col in ('TPx', 'TPy'):
+            if col not in cat.colnames:
+                raise KeyError(
+                    f"TriangleMatch: catalog is missing the '{col}' column "
+                    f"(tangent-plane coordinates)."
+                )
+        n = len(cat)
+        order = np.arange(n)
+        if self.brightest is not None and n > self.brightest:
+            if self.mag_col in cat.colnames:
+                # smaller magnitude == brighter
+                order = np.argsort(np.asarray(cat[self.mag_col], dtype=float),
+                                   kind='stable')
+            else:
+                log(f"TriangleMatch: no '{self.mag_col}' column to rank "
+                    f"brightness; capping to the first {self.brightest} of {n} "
+                    f"sources in input order.")
+            order = order[:self.brightest]
+        tpx = np.asarray(cat['TPx'], dtype=float)[order]
+        tpy = np.asarray(cat['TPy'], dtype=float)[order]
+        return np.column_stack([tpx, tpy]), order.astype(int)
+
+    def __call__(self, refcat, imcat, tp_pscale=1.0, tp_units=None, **kwargs):
+        # tp_pscale / tp_units are part of the MatchCatalogs contract but unused
+        # here: triangle matching is scale-invariant and works directly in the
+        # tangent-plane units the correctors supply (arcsec for JWSTWCSCorrector).
+        ref_xy, ref_orig = self._vertices(refcat)
+        im_xy, im_orig = self._vertices(imcat)
+
+        # A starved exposure must yield zero matches so the solve phase falls to
+        # the NOT_ALIGNED / identity sentinel — never crash the align worker.
+        if len(ref_xy) < 3 or len(im_xy) < 3:
+            return _EMPTY
+
+        from tristars.match import match_catalog_tri
+        pair_ix = match_catalog_tri(
+            ref_xy, im_xy, auto_keep=False, maxKeep=self.max_keep,
+            size_limit=self.size_limit, ignore_rot=self.ignore_rot,
+            ignore_scale=self.ignore_scale, ba_max=self.ba_max,
+        )
+        pair_ix = np.asarray(pair_ix)
+        if pair_ix.size == 0:
+            return _EMPTY
+
+        # match_catalog_tri returns [M, 2]: column 0 indexes V1 (=refcat),
+        # column 1 indexes V2 (=imcat). Remap subset -> original rows and return
+        # reference-first, per the MatchCatalogs contract.
+        ref_idx = ref_orig[pair_ix[:, 0]]
+        im_idx = im_orig[pair_ix[:, 1]]
+        return ref_idx, im_idx

--- a/pipeline/tests/test_align_matcher.py
+++ b/pipeline/tests/test_align_matcher.py
@@ -1,0 +1,145 @@
+"""Tests for the NIRCam triangle/asterism catalog matcher (nircam/align/matcher.py).
+
+The matcher wraps ``tristars`` behind a ``tweakwcs`` ``MatchCatalogs`` interface.
+Fixtures are synthetic tangent-plane point sets (no WCS/corrector needed): a
+reference set, and an "image" set that is the reference rotated + shifted +
+jittered, with spurious extras appended. Because ``im[k]`` is built from
+``ref[k]``, the geometrically-correct match for reference row ``k`` is image row
+``k`` — so a returned pair ``(ri, ii)`` is correct iff ``ri == ii``.
+"""
+
+import numpy as np
+import pytest
+from astropy.table import Table
+
+from campfire_pipeline.nircam.align import TriangleMatch
+
+
+def _synthetic(n=40, theta_deg=0.4, shift=(2.5, -1.0), jitter=0.02,
+               n_spurious=10, seed=0):
+    """Return (ref[n,2], im[n+n_spurious,2], R, shift, n_true)."""
+    rng = np.random.default_rng(seed)
+    ref = rng.uniform(0.0, 100.0, size=(n, 2))
+    th = np.deg2rad(theta_deg)
+    R = np.array([[np.cos(th), -np.sin(th)],
+                  [np.sin(th), np.cos(th)]])
+    shift = np.asarray(shift, dtype=float)
+    im_true = ref @ R.T + shift + rng.normal(0.0, jitter, ref.shape)
+    spurious = rng.uniform(0.0, 100.0, size=(n_spurious, 2))
+    im = np.vstack([im_true, spurious])
+    return ref, im, R, shift, n
+
+
+def _tables(ref, im, mag_ref=None, mag_im=None):
+    rt = Table({'TPx': ref[:, 0], 'TPy': ref[:, 1]})
+    it = Table({'TPx': im[:, 0], 'TPy': im[:, 1]})
+    if mag_ref is not None:
+        rt['mag'] = np.asarray(mag_ref, dtype=float)
+    if mag_im is not None:
+        it['mag'] = np.asarray(mag_im, dtype=float)
+    return rt, it
+
+
+def _residuals(ref, im, R, shift, ri, ii):
+    pred = ref[ri] @ R.T + shift
+    return np.hypot(*(pred - im[ii]).T)
+
+
+# --- core recovery ----------------------------------------------------------
+
+@pytest.mark.parametrize('shift', [(2.5, -1.0), (30.0, -25.0)])
+def test_recovers_shift_and_rotation(shift):
+    # Triangle sides are translation-invariant, so even a large offset (the
+    # regime that breaks nearest-neighbour matching) is recovered.
+    ref, im, R, shift_v, n_true = _synthetic(shift=shift)
+    rt, it = _tables(ref, im)
+
+    ri, ii = TriangleMatch()(rt, it)
+    assert len(ri) == len(ii) >= 6
+
+    n_correct = int(np.sum(ri == ii))
+    assert n_correct >= 6
+    assert n_correct / len(ri) >= 0.9                      # high precision
+    assert np.all(_residuals(ref, im, R, shift_v, ri, ii)[ri == ii] < 0.2)
+
+
+def test_return_order_is_reference_first():
+    # imcat is larger than refcat (spurious extras), so a swapped return would
+    # put out-of-range / wrong indices in the first array.
+    ref, im, R, shift, n_true = _synthetic()
+    rt, it = _tables(ref, im)
+
+    ri, ii = TriangleMatch()(rt, it)
+    assert ri.max() < len(rt)          # ref indices index refcat
+    assert ii.max() < len(it)          # im indices index imcat
+    # ref rows transform onto the matched image rows (not the reverse).
+    assert np.all(_residuals(ref, im, R, shift, ri, ii)[ri == ii] < 0.2)
+
+
+def test_spurious_image_sources_excluded():
+    ref, im, R, shift, n_true = _synthetic(n_spurious=15)
+    rt, it = _tables(ref, im)
+    ri, ii = TriangleMatch()(rt, it)
+    assert np.all(ii < n_true)         # no match points at a spurious extra
+
+
+# --- graceful degradation ---------------------------------------------------
+
+def test_too_few_sources_returns_empty():
+    rt = Table({'TPx': [1.0, 2.0], 'TPy': [1.0, 3.0]})          # only 2
+    it = Table({'TPx': [1.0, 2.0, 3.0], 'TPy': [1.0, 2.0, 3.5]})
+    ri, ii = TriangleMatch()(rt, it)
+    assert len(ri) == 0 and len(ii) == 0
+
+
+def test_empty_table_returns_empty():
+    rt = Table({'TPx': [], 'TPy': []})
+    it = Table({'TPx': [1.0, 2.0, 3.0], 'TPy': [1.0, 2.0, 3.5]})
+    ri, ii = TriangleMatch()(rt, it)
+    assert len(ri) == 0 and len(ii) == 0
+
+
+def test_missing_tp_columns_raises():
+    rt = Table({'x': [1.0, 2.0, 3.0], 'y': [1.0, 2.0, 3.0]})
+    it = Table({'TPx': [1.0, 2.0, 3.0], 'TPy': [1.0, 2.0, 3.0]})
+    with pytest.raises(KeyError):
+        TriangleMatch()(rt, it)
+
+
+# --- brightest-N cap + index remapping --------------------------------------
+
+def test_brightest_cap_remaps_to_original_rows():
+    # n_true=160 > brightest=150. Rank magnitude so the SURVIVING rows are the
+    # LAST 150 (mag[k] = 159-k => row 159 brightest), not the first — proving
+    # both that the cap fires and that returned indices are original rows.
+    ref, im, R, shift, n_true = _synthetic(n=160, n_spurious=0)
+    mag = (n_true - 1) - np.arange(n_true)
+    rt, it = _tables(ref, im, mag_ref=mag, mag_im=mag)
+
+    ri, ii = TriangleMatch(brightest=150)(rt, it)
+    assert len(ri) >= 6
+    # Only rows [10, 159] survive the brightest-150 cut on both sides.
+    assert ri.min() >= 10 and ri.max() <= 159
+    # Remapping correct: original ref rows transform onto original image rows.
+    assert np.all(_residuals(ref, im, R, shift, ri, ii)[ri == ii] < 0.2)
+    assert int(np.sum(ri == ii)) >= 6
+
+
+def test_brightest_cap_without_mag_col_warns_and_matches(capsys):
+    ref, im, R, shift, n_true = _synthetic(n=200, n_spurious=0)
+    rt, it = _tables(ref, im)                       # no 'mag' column
+    ri, ii = TriangleMatch(brightest=150)(rt, it)
+    assert len(ri) >= 6
+    assert ri.max() < 150 and ii.max() < 150        # capped to first 150
+    assert "no 'mag' column" in capsys.readouterr().out
+
+
+# --- determinism ------------------------------------------------------------
+
+def test_deterministic():
+    ref, im, R, shift, n_true = _synthetic(seed=7)
+    rt, it = _tables(ref, im)
+    m = TriangleMatch()
+    r1, i1 = m(rt, it)
+    r2, i2 = m(rt, it)
+    assert np.array_equal(r1, r2) and np.array_equal(i1, i2)


### PR DESCRIPTION
## Phase 3 of the NIRCam `align` build — triangle/asterism matcher

Third PR in the per-phase rollout of the field-level NIRCam **`align`** phase (design in `pipeline/ASTROMETRY_ALIGN_HANDOFF.md`; Phase 1 `CFP_ALGN`/config/deps in #322, Phase 2 `association.py` in #323). This adds the **core algorithmic win**: a triangle/asterism matcher that recovers source correspondences with **no prior on the WCS offset** — the exact regime where `tweakwcs`'s default `XYXYMatch` (2d-histogram + nearest-neighbour) silently mis-aligns (a few-arcsec offset makes NN grab wrong neighbours and the histogram peak lands near zero). Standalone, unit-tested library module — not yet wired into orchestration.

> **Re-scope note:** I'd earlier bundled Phase 3 as "detection + matcher." They turned out fully independent (detection feeds the *solve worker*, not the matcher) with different deps and test strategies, so this PR is **matcher only** and centroid detection is the next phase.

### What's here
- **New `nircam/align/` subpackage** (mirrors `nircam/refcat/`) — the home for the align-algorithm code. `association.py` stays at `nircam/` level (a general grouping primitive).
- **`align/matcher.py` — `TriangleMatch(MatchCatalogs)`**: matches by triangle *shape* (side ratios), invariant to translation/rotation/scale. Wraps `tristars.match_catalog_tri` on its correspondence-only path (`auto_keep=False`); the sigma-clipped transform fit stays `tweakwcs`'s job (`align_wcs`/`fit_wcs`).
  - **Contract-exact** (verified against installed `tweakwcs` 0.8.12 / `tristars` 0.1 source): reads `TPx`/`TPy` (arcsec tangent plane for `JWSTWCSCorrector`); returns `(ref_idx, im_idx)` **reference-first**; `tristars` `pair_ix[:,0]`→ref, `[:,1]`→im. A prototype confirmed the return-order (`ref[ri]` transforms onto `im[ii]`, zero spurious).
  - **Color-free**: magnitude (`mag_col`) is used *only* to cap each catalog to its brightest-N triangle vertices (bounds the O(N³) triangle count) — never as a match constraint. Subset indices are remapped back to original catalog rows.
  - **Graceful**: `<3` sources (or empty) → empty match, so a starved exposure falls to the NOT_ALIGNED/identity sentinel rather than crashing the align worker. Missing `TPx`/`TPy` → `KeyError` (matches the base).
  - Works in arcsec directly (no arcsec→pixel conversion — refines the original design note, which assumed pixels).
- **`tests/test_align_matcher.py`** (10): recovery under large translation + rotation (the motivating win); reference-first return-order; spurious-source exclusion; `<3`/empty → empty; missing-`TP`-column `KeyError`; brightest-N cap with original-row remapping (+ the no-`mag`-col fallback path); determinism.
- **CHANGELOG** → Unreleased → Infrastructure (PATCH).

### Dependency note
`tristars` (added to `pyproject` in #322) was not yet in the local editable-pipeline env; it's now installed there (`--no-deps`; `scikit-image` already present via `jwst`). Heads-up: `tristars` 0.1 emits a NumPy-2.0 `DeprecationWarning` (`np.cross` on 2-D vectors) — benign today and caught by the regression test, but a reason the dep is pinned exactly (`==0.1`, unmaintained).

### Verification
- `pytest pipeline/tests/test_align_matcher.py` → **10 passed**.
- No regressions: `pytest test_association.py test_cfp.py` → **38 passed**.

### Scope boundary
No detection, solve worker, `run_align`, CLI/orchestration wiring, or `association` changes — later phases.

Generated with Claude Code
