### PR TITLE
feat(nircam): align phase — centroid-only source detection (detect.py)

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -276,6 +276,16 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- **NIRCam `align` phase — centroid-only source detection.** New
+  `nircam/align/detect.py` (`detect_star_centroids` / `detect_in_exposure`) finds
+  point-source centroids on a detector's SCI image with `photutils.DAOStarFinder` —
+  **centroids only, no aperture photometry**, so it structurally avoids JHAT's `-99.99`
+  sky-annulus sentinel (which floods the matcher with fake constant-magnitude sources
+  on CAMPFIRE's sky-subtracted frames). Returns `x, y` (0-indexed detector pixels) plus
+  a PSF-fit brightness proxy (`flux`/`mag`), masking `DO_NOT_USE` DQ and off-detector
+  pixels. WCS-free and `jwst`-free (reads SCI/ERR/DQ via `astropy.io.fits`). Standalone
+  library module for the forthcoming align solve — not yet wired in; covered by
+  `tests/test_align_detect.py`. No behavior change.
 - **NIRCam `align` phase — triangle/asterism matcher.** New `nircam/align/` subpackage
   with `TriangleMatch`, a `tweakwcs` `MatchCatalogs` subclass that matches source
   catalogs by triangle *shape* (side ratios) — invariant to translation/rotation/scale,

--- a/pipeline/campfire_pipeline/nircam/align/__init__.py
+++ b/pipeline/campfire_pipeline/nircam/align/__init__.py
@@ -6,11 +6,15 @@ Gaia-tied reference catalog and fits one shared shift+rotation per exposure via
 ``tweakwcs`` (SIAF distortion fixed), freeing a per-detector shift only where
 residuals demand it. See ``pipeline/ASTROMETRY_ALIGN_HANDOFF.md``.
 
-Modules are added phase by phase; this package currently exports the matcher.
-The exposure-grouping layer lives at ``nircam/association.py`` (a general
-primitive, not align-specific).
+Modules are added phase by phase; this package currently exports the source
+detector and the triangle matcher. The exposure-grouping layer lives at
+``nircam/association.py`` (a general primitive, not align-specific).
 """
 
+from campfire_pipeline.nircam.align.detect import (
+    detect_in_exposure,
+    detect_star_centroids,
+)
 from campfire_pipeline.nircam.align.matcher import TriangleMatch
 
-__all__ = ['TriangleMatch']
+__all__ = ['TriangleMatch', 'detect_star_centroids', 'detect_in_exposure']

--- a/pipeline/campfire_pipeline/nircam/align/detect.py
+++ b/pipeline/campfire_pipeline/nircam/align/detect.py
@@ -1,0 +1,143 @@
+"""Centroid-only point-source detection for the NIRCam ``align`` phase.
+
+Produces ``(x, y)`` star centroids plus a brightness proxy for a detector image
+— the image-side catalog that the align solve worker projects to the tangent
+plane and triangle-matches against the Gaia-tied reference catalog.
+
+**Centroids only, no aperture photometry.** JHAT's aperture annulus, run on
+CAMPFIRE's already sky-subtracted frames, averages *negative* for ~46% of
+detections and trips a ``-99.99`` sky sentinel, producing a spurious constant
+magnitude that floods the matcher (handoff §2a). A peak / PSF-fit finder
+(``photutils.DAOStarFinder``) has no sky annulus and structurally cannot hit
+that bug — its ``flux``/``mag`` come from the PSF fit, not a background-
+subtracted aperture.
+
+Coordinates are **0-indexed** detector pixels (the ``DAOStarFinder`` and gwcs
+convention — what the ``tweakwcs`` corrector's ``det_to_world`` / ``det_to_tanp``
+expect). ``mag = -2.5·log10(flux)`` (smaller = brighter) rides along **only**
+for downstream brightest-N triangle-vertex selection, never as a match
+constraint.
+
+Import-light and ``jwst``-free: detection is WCS-free (works in detector
+pixels), so it reads SCI/ERR/DQ via plain ``astropy.io.fits`` rather than a
+jwst ``ImageModel``.
+"""
+
+import warnings
+
+import numpy as np
+from astropy.io import fits
+from astropy.stats import sigma_clipped_stats
+from astropy.table import Table
+from photutils.detection import DAOStarFinder
+from photutils.utils.exceptions import NoDetectionsWarning
+
+from campfire_pipeline.common.io import log
+
+# jwst.datamodels.dqflags.pixel['DO_NOT_USE'] == 1 (bit 0). Hardcoded to keep
+# this module free of the jwst/CRDS import chain (cf. field.py's _DO_NOT_USE).
+_DO_NOT_USE = np.uint32(1)
+
+_FLOAT_COLUMNS = ('x', 'y', 'flux', 'mag', 'sharpness',
+                  'roundness1', 'roundness2', 'peak')
+
+
+def _empty_catalog():
+    cols = {c: np.array([], dtype=float) for c in _FLOAT_COLUMNS}
+    cols['npix'] = np.array([], dtype=int)
+    return Table(cols)
+
+
+def detect_star_centroids(data, *, mask=None, fwhm=2.5, nsigma=5.0,
+                          sharplo=0.2, sharphi=1.0, roundlo=-1.0, roundhi=1.0,
+                          edge=8, brightest=None, sigma=3.0, maxiters=5):
+    """Detect point-source centroids on a detector image.
+
+    Returns an astropy ``Table`` with columns ``x, y, flux, mag, sharpness,
+    roundness1, roundness2, peak, npix`` (0-indexed pixels), sorted by ``flux``
+    descending; an empty (but typed) Table when nothing is found.
+
+    Parameters
+    ----------
+    data : 2-D array
+        Detector SCI image (any residual smooth background is removed by the
+        scalar median subtraction below; DAOStarFinder's kernel suppresses the
+        rest).
+    mask : 2-D bool array, optional
+        Pixels to ignore (bad pixels, off-detector). Non-finite ``data`` pixels
+        are always added to the mask.
+    fwhm : float
+        PSF FWHM in pixels (NIRCam ≈ 2–2.5 px near native scale; tune per
+        channel when the solve worker calls this).
+    nsigma : float
+        Detection threshold in units of the sigma-clipped background RMS.
+    edge : int
+        Reject centroids within this many pixels of any border (unreliable).
+    brightest : int, optional
+        Keep only the ``brightest`` sources (by flux) after edge rejection.
+    """
+    data = np.asarray(data, dtype=float)
+    mask = np.zeros(data.shape, dtype=bool) if mask is None else np.asarray(mask, dtype=bool)
+    mask = mask | ~np.isfinite(data)
+
+    mean, median, std = sigma_clipped_stats(data, mask=mask, sigma=sigma,
+                                            maxiters=maxiters)
+    if not np.isfinite(std) or std <= 0:
+        log("detect: non-finite/zero background noise; skipping detection.")
+        return _empty_catalog()
+
+    finder = DAOStarFinder(threshold=nsigma * float(std), fwhm=fwhm,
+                           sharplo=sharplo, sharphi=sharphi,
+                           roundlo=roundlo, roundhi=roundhi)
+    with warnings.catch_warnings():
+        # A starved detector legitimately finds nothing — not worth a warning.
+        warnings.simplefilter('ignore', NoDetectionsWarning)
+        sources = finder(data - median, mask=mask)
+    if sources is None or len(sources) == 0:
+        return _empty_catalog()
+
+    x = np.asarray(sources['xcentroid'], dtype=float)
+    y = np.asarray(sources['ycentroid'], dtype=float)
+    ny, nx = data.shape
+    keep = ((x >= edge) & (x <= nx - 1 - edge) &
+            (y >= edge) & (y <= ny - 1 - edge))
+
+    out = Table({
+        'x': x[keep],
+        'y': y[keep],
+        'flux': np.asarray(sources['flux'], dtype=float)[keep],
+        'mag': np.asarray(sources['mag'], dtype=float)[keep],
+        'sharpness': np.asarray(sources['sharpness'], dtype=float)[keep],
+        'roundness1': np.asarray(sources['roundness1'], dtype=float)[keep],
+        'roundness2': np.asarray(sources['roundness2'], dtype=float)[keep],
+        'peak': np.asarray(sources['peak'], dtype=float)[keep],
+        'npix': np.asarray(sources['npix'], dtype=int)[keep],
+    })
+    if len(out) == 0:
+        return _empty_catalog()
+    out.sort('flux', reverse=True)
+    if brightest is not None and len(out) > brightest:
+        out = out[:int(brightest)]
+    return out
+
+
+def detect_in_exposure(path, *, fwhm=2.5, nsigma=5.0, **kwargs):
+    """Detect star centroids on a canonical NIRCam exposure's SCI image.
+
+    Reads SCI/ERR/DQ via ``astropy.io.fits`` (no jwst datamodel needed —
+    detection is WCS-free and works in detector pixels). Masks off-detector
+    pixels (non-finite ERR) and ``DO_NOT_USE`` DQ pixels (only that flag —
+    JUMP_DET etc. are already-corrected and kept, matching ``sky.py``). ERR/DQ
+    are read defensively (skipped if absent). Extra keyword arguments pass
+    through to :func:`detect_star_centroids`.
+    """
+    with fits.open(path, memmap=False) as hdul:
+        sci = np.asarray(hdul['SCI'].data, dtype=float)
+        mask = ~np.isfinite(sci)
+        if 'ERR' in hdul and hdul['ERR'].data is not None:
+            mask |= ~np.isfinite(np.asarray(hdul['ERR'].data, dtype=float))
+        if 'DQ' in hdul and hdul['DQ'].data is not None:
+            dq = np.asarray(hdul['DQ'].data).astype(np.uint32)
+            mask |= (dq & _DO_NOT_USE) != 0
+    return detect_star_centroids(sci, mask=mask, fwhm=fwhm, nsigma=nsigma,
+                                 **kwargs)

--- a/pipeline/tests/test_align_detect.py
+++ b/pipeline/tests/test_align_detect.py
@@ -1,0 +1,133 @@
+"""Tests for the NIRCam centroid-only source detector (nircam/align/detect.py).
+
+Fixtures inject 2-D Gaussian point sources onto Gaussian noise (mirrors the
+RNG-injection pattern in test_nircam_diag_striping.py) — no real FITS needed for
+the pure core; the wrapper test writes a minimal SCI/ERR/DQ HDUList.
+"""
+
+import numpy as np
+import pytest
+from astropy.io import fits
+from photutils.utils.exceptions import NoDetectionsWarning
+
+from campfire_pipeline.nircam.align import (
+    detect_in_exposure,
+    detect_star_centroids,
+)
+
+
+def _inject(shape, sources, rng, noise=1.0, fwhm=2.5):
+    """Gaussian sources (cx, cy, amp) added to Gaussian noise."""
+    sigma = fwhm / 2.3548
+    img = rng.normal(0.0, noise, shape).astype(float)
+    yy, xx = np.mgrid[0:shape[0], 0:shape[1]]
+    for cx, cy, amp in sources:
+        img += amp * np.exp(-((xx - cx) ** 2 + (yy - cy) ** 2) / (2 * sigma ** 2))
+    return img
+
+
+def _nearest(cat, cx, cy):
+    if len(cat) == 0:
+        return np.inf
+    return float(np.min(np.hypot(np.asarray(cat['x']) - cx,
+                                 np.asarray(cat['y']) - cy)))
+
+
+# --- pure core --------------------------------------------------------------
+
+def test_recovers_injected_sources():
+    rng = np.random.default_rng(1)
+    truth = [(30.4, 25.2, 300.0), (60.1, 70.8, 150.0), (45.0, 45.0, 500.0)]
+    img = _inject((100, 100), truth, rng)
+    cat = detect_star_centroids(img, fwhm=2.5, nsigma=5.0)
+
+    assert len(cat) >= 3
+    for cx, cy, _ in truth:
+        assert _nearest(cat, cx, cy) < 0.3
+    assert np.all(np.diff(np.asarray(cat['flux'])) <= 0)   # flux descending
+
+
+def test_mag_is_flux_proxy():
+    rng = np.random.default_rng(1)
+    img = _inject((100, 100), [(50.0, 50.0, 400.0), (30.0, 70.0, 200.0)], rng)
+    cat = detect_star_centroids(img)
+    assert len(cat) >= 2
+    assert np.allclose(np.asarray(cat['mag']),
+                       -2.5 * np.log10(np.asarray(cat['flux'])), atol=1e-6)
+
+
+def test_mask_suppresses_source():
+    rng = np.random.default_rng(1)
+    img = _inject((100, 100), [(30.0, 30.0, 400.0), (70.0, 70.0, 400.0)], rng)
+    mask = np.zeros((100, 100), dtype=bool)
+    mask[24:37, 24:37] = True                    # cover the (30, 30) source
+    cat = detect_star_centroids(img, mask=mask)
+    assert _nearest(cat, 70, 70) < 0.3
+    assert _nearest(cat, 30, 30) > 5.0
+
+
+def test_edge_rejection():
+    rng = np.random.default_rng(1)
+    img = _inject((100, 100), [(3.0, 50.0, 400.0), (50.0, 50.0, 400.0)], rng)
+    cat = detect_star_centroids(img, edge=8)
+    assert _nearest(cat, 50, 50) < 0.3
+    assert not np.any(np.asarray(cat['x']) < 8)  # within-edge source dropped
+
+
+def test_pure_noise_returns_empty_typed(recwarn):
+    rng = np.random.default_rng(2)
+    img = rng.normal(0.0, 1.0, (80, 80)).astype(float)
+    cat = detect_star_centroids(img, nsigma=50.0)
+    assert len(cat) == 0
+    assert {'x', 'y', 'flux', 'mag', 'npix'}.issubset(cat.colnames)
+    # the NoDetectionsWarning is suppressed inside the function
+    assert not any(issubclass(w.category, NoDetectionsWarning) for w in recwarn)
+
+
+def test_brightest_caps_to_n():
+    rng = np.random.default_rng(3)
+    sources = [(15 + 20 * (i % 4), 15 + 20 * (i // 4), 100.0 + 40 * i)
+               for i in range(12)]
+    img = _inject((100, 100), sources, rng)
+    cat_all = detect_star_centroids(img)
+    assert len(cat_all) >= 5
+    cat = detect_star_centroids(img, brightest=5)
+    assert len(cat) == 5
+    assert np.array_equal(np.asarray(cat['flux']),
+                          np.asarray(cat_all['flux'])[:5])   # the 5 brightest
+
+
+def test_nan_pixels_handled():
+    rng = np.random.default_rng(4)
+    img = _inject((80, 80), [(40.0, 40.0, 400.0)], rng)
+    img[0:10, 0:10] = np.nan
+    cat = detect_star_centroids(img)                 # must not crash
+    assert _nearest(cat, 40, 40) < 0.3
+
+
+# --- FITS wrapper -----------------------------------------------------------
+
+def test_detect_in_exposure_masks_dq_and_err(tmp_path):
+    rng = np.random.default_rng(5)
+    shape = (100, 100)
+    # A: DQ-flagged, B: clean, C: under an off-detector (NaN ERR) patch.
+    sci = _inject(shape, [(30.0, 30.0, 400.0),
+                          (70.0, 70.0, 400.0),
+                          (50.0, 75.0, 400.0)], rng).astype('float32')
+    err = np.ones(shape, dtype='float32')
+    err[70:81, 45:56] = np.nan                       # covers C (x=50, y=75)
+    dq = np.zeros(shape, dtype='uint32')
+    dq[24:37, 24:37] = 1                             # DO_NOT_USE over A (30, 30)
+
+    path = tmp_path / 'jw01727028001_04101_00003_nrca1.fits'
+    fits.HDUList([
+        fits.PrimaryHDU(),
+        fits.ImageHDU(sci, name='SCI'),
+        fits.ImageHDU(err, name='ERR'),
+        fits.ImageHDU(dq, name='DQ'),
+    ]).writeto(path, overwrite=True)
+
+    cat = detect_in_exposure(str(path))
+    assert _nearest(cat, 70, 70) < 0.3               # clean source detected
+    assert _nearest(cat, 30, 30) > 5.0               # DQ-masked
+    assert _nearest(cat, 50, 75) > 5.0               # ERR-masked


### PR DESCRIPTION
## Phase 4 of the NIRCam `align` build — centroid-only source detection

Fourth PR in the per-phase rollout of the field-level NIRCam **`align`** phase (design in `pipeline/ASTROMETRY_ALIGN_HANDOFF.md`; #322 `CFP_ALGN`/config/deps, #323 `association.py`, #324 `TriangleMatch`). This adds the **image-side source detection** that produces the `(x, y)` star centroids the solve worker will project to the tangent plane and hand to `TriangleMatch`. Standalone, unit-tested library module — not yet wired into orchestration.

### Why centroids only (no aperture photometry)
JHAT's aperture annulus, run on CAMPFIRE's already sky-subtracted frames, averages *negative* for ~46% of detections and trips a `-99.99` sky sentinel → a spurious constant magnitude ~19.22 that floods the matcher (the root-cause bug in handoff §2a). `photutils.DAOStarFinder` has **no sky annulus** and structurally cannot hit that bug — its `flux`/`mag` come from the PSF fit, not a background-subtracted aperture.

### What's here
- **`nircam/align/detect.py`**:
  - `detect_star_centroids(data, *, mask, fwhm, nsigma, edge, brightest, …)` (pure core): sigma-clipped `(median, std)` → `DAOStarFinder(threshold=nsigma·std, fwhm=…)` on `data − median`; renames `xcentroid/ycentroid → x/y`; edge-rejects; sorts by flux; optional brightest-N cap. Returns an astropy `Table[x, y, flux, mag, sharpness, roundness1, roundness2, peak, npix]` (**0-indexed** detector pixels — the gwcs/corrector `det_to_world` convention), empty-but-typed when nothing is found.
  - `detect_in_exposure(path, …)`: reads SCI/ERR/DQ via `astropy.io.fits`, masks off-detector (NaN ERR) + `DO_NOT_USE` DQ (only that flag — JUMP_DET etc. are already-corrected and kept, matching `sky.py`), delegates to the core.
  - `mag = -2.5·log10(flux)` (smaller = brighter) rides along **only** for downstream brightest-N triangle-vertex selection — never a match constraint.
  - **WCS-free and `jwst`-free** (detection works in detector pixels): reads via `fits.open`, hardcodes `DO_NOT_USE = 1` (== `dqflags.pixel['DO_NOT_USE']`) to avoid the jwst/CRDS import chain, as `field.py` does. `NoDetectionsWarning` on a starved detector is suppressed (expected, not an error).
- **`tests/test_align_detect.py`** (8): source recovery to <0.3 px + flux ordering; `mag` = flux proxy; caller-mask suppression; edge rejection; empty-on-noise (typed columns, no warning leak); brightest-N cap; NaN handling; the FITS wrapper masking DQ `DO_NOT_USE` + off-detector ERR.
- **CHANGELOG** → Unreleased → Infrastructure (PATCH).

### Verification (against installed photutils 2.3.0)
- `pytest pipeline/tests/test_align_detect.py` → **8 passed**.
- No regressions: `pytest test_align_matcher.py test_association.py test_cfp.py` → **48 passed**.

### Scope boundary
No solve worker, `run_align`, CLI/orchestration wiring, or tangent-plane projection (the solve worker's job). Detection produces detector-pixel `(x, y)` only.

Generated with Claude Code
