### PR TITLE
feat(nircam): align phase — per-exposure solve core (solve.py)

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -276,6 +276,19 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- **NIRCam `align` phase — per-exposure solve core.** New `nircam/align/solve.py`
+  (`solve_exposure_group`) fits ONE shared shift+rotation per exposure via
+  `tweakwcs.align_wcs` (`fitgeom='rshift'`, SIAF distortion untouched) against the
+  static Gaia-tied reference catalog: one `JWSTWCSCorrector` per detector, all sharing
+  the exposure's `group_id` (the pooling constraint made mechanical); distinct
+  per-exposure group_ids + `expand_refcat=False` keep exposures independent (no global
+  collapse). Per-detector residuals are recomputed directly (`det_to_world` vs matched
+  reference positions), and a detector whose residual exceeds tolerance gets an adaptive
+  shift-only refit against a distractor-free local reference subset (accepted only if it
+  improves). A `SUCCESS` fit that matches too few sources is rejected to a NOT_ALIGNED
+  identity fallback (reject-to-identity). Returns corrected gwcs + diagnostics per
+  detector; no FITS I/O yet. Prototype-validated (2″ offset → 0.036 mas); covered by
+  `tests/test_align_solve.py` with a CRDS-free mock gwcs. No behavior change.
 - **NIRCam `align` phase — centroid-only source detection.** New
   `nircam/align/detect.py` (`detect_star_centroids` / `detect_in_exposure`) finds
   point-source centroids on a detector's SCI image with `photutils.DAOStarFinder` —

--- a/pipeline/campfire_pipeline/nircam/align/__init__.py
+++ b/pipeline/campfire_pipeline/nircam/align/__init__.py
@@ -7,8 +7,9 @@ Gaia-tied reference catalog and fits one shared shift+rotation per exposure via
 residuals demand it. See ``pipeline/ASTROMETRY_ALIGN_HANDOFF.md``.
 
 Modules are added phase by phase; this package currently exports the source
-detector and the triangle matcher. The exposure-grouping layer lives at
-``nircam/association.py`` (a general primitive, not align-specific).
+detector, the triangle matcher, and the per-exposure solve. The
+exposure-grouping layer lives at ``nircam/association.py`` (a general primitive,
+not align-specific).
 """
 
 from campfire_pipeline.nircam.align.detect import (
@@ -16,5 +17,19 @@ from campfire_pipeline.nircam.align.detect import (
     detect_star_centroids,
 )
 from campfire_pipeline.nircam.align.matcher import TriangleMatch
+from campfire_pipeline.nircam.align.solve import (
+    DetectorInput,
+    DetectorSolution,
+    GroupSolution,
+    solve_exposure_group,
+)
 
-__all__ = ['TriangleMatch', 'detect_star_centroids', 'detect_in_exposure']
+__all__ = [
+    'TriangleMatch',
+    'detect_star_centroids',
+    'detect_in_exposure',
+    'solve_exposure_group',
+    'DetectorInput',
+    'DetectorSolution',
+    'GroupSolution',
+]

--- a/pipeline/campfire_pipeline/nircam/align/solve.py
+++ b/pipeline/campfire_pipeline/nircam/align/solve.py
@@ -1,0 +1,227 @@
+"""Per-exposure astrometric solve for the NIRCam ``align`` phase.
+
+Given, for one exposure group, each detector's gwcs + detected source catalog
+and a static Gaia-tied reference catalog, this fits ONE shared shift+rotation
+for the whole exposure via ``tweakwcs`` (SIAF distortion untouched), then — where
+a detector's residual still exceeds tolerance — frees an adaptive per-detector
+shift. It returns the corrected gwcs per detector plus solve diagnostics; it does
+no FITS I/O (the exposure reader/writer + ``CFP_ALGN`` stamp live in the
+orchestration layer).
+
+The shared solve is the mechanical expression of the pooling constraint: every
+detector of one exposure shares one ``group_id`` so a single rigid rshift is fit
+from the pooled catalog and applied to all of them. Distinct per-exposure
+``group_id``s + a static reference catalog + ``expand_refcat=False`` keep
+exposures independent (each ties to the same reference on its own); we
+deliberately do NOT use ``stcal``'s ``group_id=987654`` global collapse.
+
+Per-detector residuals are recomputed DIRECTLY (``det_to_world`` vs matched
+refcat positions), not read from ``tweakwcs``'s group-level ``fit_info`` — which
+carries no per-source residuals, only a fragile group-catalog join.
+"""
+
+import copy
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import numpy as np
+from astropy.coordinates import SkyCoord
+from tweakwcs.correctors import JWSTWCSCorrector
+from tweakwcs.imalign import align_wcs
+
+from campfire_pipeline.common.io import log
+from campfire_pipeline.nircam.align.matcher import TriangleMatch
+
+
+@dataclass
+class DetectorInput:
+    """One detector's inputs to the solve."""
+
+    detector: str      # e.g. 'nrca1'
+    wcs: object        # gwcs.WCS (this detector's current gwcs)
+    wcsinfo: dict      # {'v2_ref' (arcsec), 'v3_ref' (arcsec), 'roll_ref' (deg)}
+    catalog: object    # astropy Table with 'x','y' (0-indexed) [+ 'mag']
+
+
+@dataclass
+class DetectorSolution:
+    """The align outcome for one detector."""
+
+    detector: str
+    wcs: object              # corrected (or, when NOT_ALIGNED, original) gwcs
+    dof: str                 # 'shared' | 'shift' | 'identity'
+    residual_arcsec: float   # median matched residual after alignment (nan if none)
+    n_matched: int
+    within_tolerance: bool
+
+
+@dataclass
+class GroupSolution:
+    """The align outcome for one exposure group."""
+
+    key: str
+    status: str                          # 'SOLVED' | 'NOT_ALIGNED'
+    shift: Optional[Tuple[float, float]]  # shared (dx, dy), arcsec
+    rot_deg: Optional[float]              # shared rotation, degrees
+    rmse_arcsec: Optional[float]
+    n_matched: int                        # group-level matched-source count
+    detectors: List[DetectorSolution]
+
+
+def _has_radec(refcat):
+    return (refcat is not None and 'RA' in refcat.colnames
+            and 'DEC' in refcat.colnames)
+
+
+def _as_float(value, default=float('nan')):
+    try:
+        arr = np.asarray(value, dtype=float).ravel()
+        return float(arr[0]) if arr.size else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _match(corrector, catalog, ref_sky, match_radius):
+    """Direct residual for one detector: ``(residual_arcsec, n_matched,
+    matched_ref_idx)``.
+
+    Transform the detector's own sources through the (corrected) gwcs and
+    nearest-neighbour match them to the reference positions, keeping only
+    matches within *match_radius* arcsec. ``matched_ref_idx`` is the set of
+    reference rows those sources landed on — reused to build a distractor-free
+    local reference catalog for the adaptive per-detector refit.
+    """
+    empty = (float('nan'), 0, np.array([], dtype=int))
+    x = np.asarray(catalog['x'], dtype=float)
+    y = np.asarray(catalog['y'], dtype=float)
+    if x.size == 0:
+        return empty
+    ra, dec = corrector.det_to_world(x, y)
+    src = SkyCoord(np.asarray(ra, dtype=float), np.asarray(dec, dtype=float),
+                   unit='deg')
+    idx, d2d, _ = src.match_to_catalog_sky(ref_sky)
+    sep = d2d.arcsec
+    keep = np.isfinite(sep) & (sep <= match_radius)
+    if not np.any(keep):
+        return empty
+    return (float(np.median(sep[keep])), int(np.count_nonzero(keep)),
+            np.unique(np.asarray(idx)[keep]))
+
+
+def _not_aligned(key, detectors, wcs_getter):
+    return GroupSolution(
+        key=key, status='NOT_ALIGNED', shift=None, rot_deg=None,
+        rmse_arcsec=None, n_matched=0,
+        detectors=[DetectorSolution(name, wcs_getter(name, obj), 'identity',
+                                    float('nan'), 0, False)
+                   for name, obj in detectors],
+    )
+
+
+def solve_exposure_group(detectors, refcat, *, key='group', matcher=None,
+                         fitgeom='rshift', minobj=None, nclip=3, sigma=3.0,
+                         tolerance=0.05, adaptive=True, adaptive_min_matches=3,
+                         match_radius=0.5, min_matched=4):
+    """Solve one exposure group; return a :class:`GroupSolution`.
+
+    Parameters mirror ``tweakwcs.align_wcs`` where relevant. *tolerance* and
+    *match_radius* are in **arcsec**. With ``adaptive=True`` (the default per
+    decision D2), a detector whose residual exceeds *tolerance* gets an
+    individual shift-only refit against a distractor-free local reference
+    subset, accepted only if it has at least *adaptive_min_matches* matches and
+    measurably reduces the residual.
+
+    ``align_wcs`` reports ``status='SUCCESS'`` even for a geometrically wrong
+    fit, so we reject to NOT_ALIGNED (reject-to-identity) when fewer than
+    *min_matched* sources across the whole group land within *match_radius* of a
+    reference source after the shared fit.
+    """
+    detectors = list(detectors)
+    if not detectors:
+        return GroupSolution(key, 'NOT_ALIGNED', None, None, None, 0, [])
+
+    if not _has_radec(refcat) or len(refcat) < 3:
+        log(f"align solve[{key}]: reference catalog missing 'RA'/'DEC' or "
+            f"has <3 sources; NOT_ALIGNED (WCS preserved).")
+        return _not_aligned(key, [(d.detector, d.wcs) for d in detectors],
+                            lambda name, wcs: wcs)
+
+    if matcher is None:
+        matcher = TriangleMatch()
+
+    # One corrector per detector, ALL sharing the exposure's group_id -> one
+    # shared rigid fit for the exposure.
+    correctors = [
+        JWSTWCSCorrector(
+            d.wcs, d.wcsinfo,
+            meta={'catalog': d.catalog, 'group_id': key, 'name': d.detector},
+        )
+        for d in detectors
+    ]
+
+    align_wcs(correctors, refcat=refcat, enforce_user_order=True,
+              expand_refcat=False, minobj=minobj, match=matcher,
+              fitgeom=fitgeom, nclip=nclip, sigma=(sigma, 'rmse'))
+
+    fit_info = correctors[0].meta.get('fit_info', {})
+    if not str(fit_info.get('status', '')).startswith('SUCCESS'):
+        log(f"align solve[{key}]: shared fit "
+            f"{fit_info.get('status', 'FAILED')}; NOT_ALIGNED (WCS preserved).")
+        # set_correction only runs on success, so the WCS is untouched; return
+        # each corrector's original gwcs explicitly.
+        return _not_aligned(
+            key, [(c.meta['name'], c) for c in correctors],
+            lambda name, c: c.original_wcs)
+
+    shift = tuple(_as_float(v) for v in np.asarray(fit_info['shift']).ravel()[:2])
+    rot_deg = _as_float(fit_info.get('proper_rot', fit_info.get('rot')))
+    rmse = _as_float(fit_info.get('rmse'))
+    group_nmatched = int(fit_info.get('nmatches', 0))
+
+    ref_sky = SkyCoord(np.asarray(refcat['RA'], dtype=float),
+                       np.asarray(refcat['DEC'], dtype=float), unit='deg')
+
+    # Recompute matches directly, then reject-to-identity if the "successful"
+    # fit did not actually put sources onto the reference (a garbage match).
+    prelim = [_match(corr, d.catalog, ref_sky, match_radius)
+              for corr, d in zip(correctors, detectors)]
+    if sum(n for _, n, _ in prelim) < min_matched:
+        log(f"align solve[{key}]: shared fit matched "
+            f"{sum(n for _, n, _ in prelim)} < {min_matched} sources within "
+            f"{match_radius}\"; rejecting to NOT_ALIGNED.")
+        return _not_aligned(
+            key, [(c.meta['name'], c) for c in correctors],
+            lambda name, c: c.original_wcs)
+
+    solutions = []
+    for corr, d, (resid, nmatch, ref_idx) in zip(correctors, detectors, prelim):
+        within = bool(np.isfinite(resid) and resid <= tolerance)
+        dof, out_wcs = 'shared', corr.wcs
+
+        if (adaptive and not within and np.isfinite(resid)
+                and len(ref_idx) >= adaptive_min_matches):
+            # Refit this detector alone (shift only) against ONLY the reference
+            # sources it already matched — a distractor-free local catalog, so a
+            # single small detector cannot mismatch to a far region. Deep-copy
+            # so a rejected refit never touches the shared corrector.
+            trial = copy.deepcopy(corr)
+            trial.meta['group_id'] = f'{key}:{d.detector}'   # distinct -> solo fit
+            local_refcat = refcat[ref_idx]
+            align_wcs([trial], refcat=local_refcat, enforce_user_order=True,
+                      expand_refcat=False, minobj=None, match=matcher,
+                      fitgeom='shift', nclip=nclip, sigma=(sigma, 'rmse'))
+            tfi = trial.meta.get('fit_info', {})
+            if (str(tfi.get('status', '')).startswith('SUCCESS')
+                    and int(tfi.get('nmatches', 0)) >= adaptive_min_matches):
+                new_resid, new_n, _ = _match(trial, d.catalog, ref_sky,
+                                             match_radius)
+                if np.isfinite(new_resid) and new_resid < resid:
+                    out_wcs, dof = trial.wcs, 'shift'
+                    resid, nmatch = new_resid, new_n
+                    within = bool(resid <= tolerance)
+
+        solutions.append(DetectorSolution(d.detector, out_wcs, dof,
+                                          resid, nmatch, within))
+
+    return GroupSolution(key, 'SOLVED', shift, rot_deg, rmse,
+                         group_nmatched, solutions)

--- a/pipeline/tests/_align_gwcs.py
+++ b/pipeline/tests/_align_gwcs.py
@@ -1,0 +1,32 @@
+"""Shared test helper: a CRDS-free, datamodel-free JWST-structured gwcs builder.
+
+tweakwcs ships a mock gwcs builder in its test package, but the function name
+differs across versions (``make_mock_jwst_wcs`` in 0.8.x, ``make_mock_st_wcs``
+in 0.9.x). This wraps whichever is available so the align tests are
+version-tolerant and skip cleanly if a future tweakwcs drops the helper. Not a
+``test_`` module, so pytest does not collect it.
+
+``make_mock_wcs(v2ref=, v3ref=, roll=, crpix=, cd=, crval=)`` returns a
+``gwcs.WCS`` with a 1024x2048 bounding box (x in [-0.5, 1023.5], y in
+[-0.5, 2047.5]); keep synthetic source pixels inside it.
+"""
+
+try:
+    from tweakwcs.tests.helper_correctors import make_mock_jwst_wcs as _mk
+
+    def make_mock_wcs(**kw):
+        return _mk(**kw)
+
+    HAVE_MOCK_WCS = True
+except Exception:  # pragma: no cover - version fallback
+    try:
+        from tweakwcs.correctors import JWSTWCSCorrector as _JC
+        from tweakwcs.tests.helper_correctors import make_mock_st_wcs as _mk
+
+        def make_mock_wcs(**kw):
+            return _mk(corr_cls=_JC, **kw)
+
+        HAVE_MOCK_WCS = True
+    except Exception:  # pragma: no cover
+        make_mock_wcs = None
+        HAVE_MOCK_WCS = False

--- a/pipeline/tests/test_align_solve.py
+++ b/pipeline/tests/test_align_solve.py
@@ -1,0 +1,169 @@
+"""Tests for the NIRCam align solve core (nircam/align/solve.py).
+
+Uses a CRDS-free mock JWST gwcs (see _align_gwcs). For each detector we build a
+"truth" gwcs mapping a pixel grid to a sky patch (-> the reference catalog) and
+an "input" gwcs carrying a known injected offset; the solve must recover it.
+"""
+
+import copy
+
+import numpy as np
+import pytest
+from astropy.coordinates import SkyCoord
+from astropy.table import Table
+
+from _align_gwcs import HAVE_MOCK_WCS, make_mock_wcs
+from campfire_pipeline.nircam.align.solve import (
+    DetectorInput,
+    solve_exposure_group,
+)
+from campfire_pipeline.nircam.align.solve import _match
+
+pytestmark = pytest.mark.skipif(
+    not HAVE_MOCK_WCS, reason="tweakwcs mock-gwcs test helper unavailable")
+
+_V2, _V3, _ROLL = 120.0, 500.0, 30.0
+_BASE_RA, _BASE_DEC = 80.0, -30.0
+_COSD = np.cos(np.deg2rad(_BASE_DEC))
+
+
+def _mock(crval, roll=_ROLL):
+    return make_mock_wcs(v2ref=_V2, v3ref=_V3, roll=roll,
+                         crpix=[512, 512], cd=[[1e-5, 0], [0, 1e-5]],
+                         crval=list(crval))
+
+
+def _wcsinfo(roll=_ROLL):
+    return {'v2_ref': _V2, 'v3_ref': _V3, 'roll_ref': roll}
+
+
+def _build_group(n_det=3, n_src=40, offset=(2.0, 0.0), roll=_ROLL, seed=0,
+                 per_det_extra=None):
+    """Return (detectors, refcat) with a shared injected *offset* (arcsec).
+
+    ``per_det_extra`` maps detector index -> (dx, dy) arcsec added on top of the
+    shared offset for that detector only (to exercise the adaptive path).
+    """
+    rng = np.random.default_rng(seed)
+    per_det_extra = per_det_extra or {}
+    ref_ra, ref_dec, detectors = [], [], []
+    for i in range(n_det):
+        # each detector on its own sky patch so the pooled catalog is non-degenerate
+        crval_truth = [_BASE_RA + i * 0.02 / _COSD, _BASE_DEC]
+        wt = _mock(crval_truth, roll=roll)
+        x = rng.uniform(50, 950, n_src)
+        y = rng.uniform(50, 2000, n_src)
+        ra_t, dec_t = wt(x, y)
+        ref_ra.append(np.asarray(ra_t, float))
+        ref_dec.append(np.asarray(dec_t, float))
+
+        dx, dy = offset
+        ex, ey = per_det_extra.get(i, (0.0, 0.0))
+        crval_off = [crval_truth[0] + (dx + ex) / 3600.0 / _COSD,
+                     crval_truth[1] + (dy + ey) / 3600.0]
+        wo = _mock(crval_off, roll=roll)
+        cat = Table({'x': x, 'y': y, 'mag': rng.uniform(18, 24, n_src)})
+        detectors.append(DetectorInput(f'nrc{i}', wo, _wcsinfo(roll), cat))
+
+    refcat = Table({'RA': np.concatenate(ref_ra),
+                    'DEC': np.concatenate(ref_dec)})
+    refcat.meta['name'] = 'truth'
+    return detectors, refcat
+
+
+# --- shared solve -----------------------------------------------------------
+
+def test_recovers_shared_translation():
+    detectors, refcat = _build_group(n_det=3, offset=(2.0, 0.0))
+    sol = solve_exposure_group(detectors, refcat, key='exp')
+    assert sol.status == 'SOLVED'
+    assert len(sol.detectors) == 3
+    assert all(ds.dof == 'shared' for ds in sol.detectors)
+    assert all(ds.within_tolerance for ds in sol.detectors)
+    assert all(ds.residual_arcsec < 0.02 for ds in sol.detectors)
+    # shared shift magnitude ~ 2 arcsec
+    assert abs(np.hypot(*sol.shift) - 2.0) < 0.1
+
+
+def test_recovers_shift_and_rotation():
+    detectors, refcat = _build_group(n_det=3, offset=(1.5, -0.8), roll=45.0)
+    sol = solve_exposure_group(detectors, refcat, key='exp')
+    assert sol.status == 'SOLVED'
+    assert all(ds.within_tolerance for ds in sol.detectors)
+
+
+def test_single_detector_group():
+    detectors, refcat = _build_group(n_det=1, offset=(2.0, 0.0))
+    sol = solve_exposure_group(detectors, refcat, key='exp')
+    assert sol.status == 'SOLVED'
+    assert len(sol.detectors) == 1
+    assert sol.detectors[0].within_tolerance
+
+
+# --- adaptive per-detector shift --------------------------------------------
+
+def test_adaptive_frees_outlier_detector():
+    # 4 aligned detectors + 1 carrying an extra per-detector dec offset.
+    detectors, refcat = _build_group(
+        n_det=5, offset=(2.0, 0.0), per_det_extra={4: (0.0, 0.3)})
+    sol = solve_exposure_group(detectors, refcat, key='exp',
+                               tolerance=0.15, adaptive=True)
+    assert sol.status == 'SOLVED'
+    good = sol.detectors[:4]
+    outlier = sol.detectors[4]
+    assert all(ds.dof == 'shared' and ds.within_tolerance for ds in good)
+    assert outlier.dof == 'shift'
+    assert outlier.within_tolerance
+    assert outlier.residual_arcsec < 0.1
+
+
+def test_adaptive_off_leaves_outlier_over_tolerance():
+    detectors, refcat = _build_group(
+        n_det=5, offset=(2.0, 0.0), per_det_extra={4: (0.0, 0.3)})
+    sol = solve_exposure_group(detectors, refcat, key='exp',
+                               tolerance=0.15, adaptive=False)
+    outlier = sol.detectors[4]
+    assert outlier.dof == 'shared'
+    assert not outlier.within_tolerance
+
+
+# --- NOT_ALIGNED ------------------------------------------------------------
+
+def test_too_few_refcat_sources_not_aligned():
+    detectors, _ = _build_group(n_det=2)
+    refcat = Table({'RA': [80.0, 80.1], 'DEC': [-30.0, -30.1]})   # <3 rows
+    originals = [copy.deepcopy(d.wcs) for d in detectors]
+    sol = solve_exposure_group(detectors, refcat, key='exp')
+    assert sol.status == 'NOT_ALIGNED'
+    assert all(ds.dof == 'identity' for ds in sol.detectors)
+    # original WCS preserved (same sky for a probe pixel)
+    for ds, orig in zip(sol.detectors, originals):
+        assert ds.wcs(500, 500) == orig(500, 500)
+
+
+def test_no_geometric_match_not_aligned():
+    detectors, _ = _build_group(n_det=2, seed=1)
+    rng = np.random.default_rng(99)
+    # a reference catalog with no asterism in common with the sources
+    refcat = Table({'RA': 80.0 + rng.uniform(-0.05, 0.05, 30),
+                    'DEC': -30.0 + rng.uniform(-0.05, 0.05, 30)})
+    sol = solve_exposure_group(detectors, refcat, key='exp')
+    assert sol.status == 'NOT_ALIGNED'
+    assert all(ds.dof == 'identity' for ds in sol.detectors)
+
+
+# --- residual helper --------------------------------------------------------
+
+def test_match_measures_small_offset():
+    # a single detector offset by 0.2 arcsec, matched within a 0.5 arcsec radius
+    detectors, refcat = _build_group(n_det=1, offset=(0.2, 0.0))
+    from tweakwcs.correctors import JWSTWCSCorrector
+    d = detectors[0]
+    corr = JWSTWCSCorrector(d.wcs, d.wcsinfo,
+                            meta={'catalog': d.catalog, 'group_id': 'g',
+                                  'name': d.detector})
+    ref_sky = SkyCoord(refcat['RA'], refcat['DEC'], unit='deg')
+    resid, n, ref_idx = _match(corr, d.catalog, ref_sky, match_radius=0.5)
+    assert n >= 30
+    assert 0.15 < resid < 0.25
+    assert len(ref_idx) >= 30


### PR DESCRIPTION
## Phase 5 of the NIRCam `align` build — the per-exposure solve core

Fifth PR in the per-phase rollout (design in `pipeline/ASTROMETRY_ALIGN_HANDOFF.md`; #322 key/config/deps, #323 `association.py`, #324 `TriangleMatch`, #325 `detect.py`). This is the **algorithmic heart** — where detection + matcher + reference catalog come together into a WCS solution. It is **in-memory only** (no FITS I/O; the exposure reader/writer + `CFP_ALGN` stamp are Phase 6), so it's fully unit-testable CRDS-free.

### Prototype-validated (not paper design)
I ran the real stack in `campfire-jwst-2.0.1` (tweakwcs 0.8.12 / jwst 2.0.1): a **2″ injected offset recovers to 0.036 mas** via `align_wcs` with `TriangleMatch` + `fitgeom='rshift'`.

### What's here
- **`nircam/align/solve.py` `solve_exposure_group(detectors, refcat, …)`**: one `JWSTWCSCorrector` per detector, **all sharing the exposure's `group_id`** (the pooling constraint made mechanical) → `align_wcs` fits ONE shared shift+rotation (`fitgeom='rshift'`, SIAF distortion untouched) against the static Gaia-tied refcat. Distinct per-exposure group_ids + `expand_refcat=False` keep exposures **independent** (deliberately *not* stcal's `group_id=987654` global collapse).
- **Per-detector residuals recomputed directly** (`det_to_world` vs NN-matched reference positions) — tweakwcs's group-level `fit_info` carries no per-source residuals.
- **Adaptive per-detector shift (ON by default, decision D2)**: a detector over `tolerance` gets a shift-only refit — on a `deepcopy` so a rejected refit never touches the shared corrector, and against **only the reference sources it already matched** (a distractor-free local catalog). Accepted only if it measurably improves.
- **Reject-to-identity**: `align_wcs` reports `status='SUCCESS'` even for a geometrically wrong fit (a random refcat produced a 1123″-RMSE "success"). If too few sources land on the reference after the shared fit, the group falls back to `NOT_ALIGNED` with the original WCS preserved.
- Returns `GroupSolution` / `DetectorSolution` (corrected gwcs + `dof` ∈ {shared, shift, identity} + residual + match count + status) for Phase 6 to write back and stamp.

### Two robustness fixes the tests surfaced (worth a look)
1. **`SUCCESS` ≠ good fit** → the reject-to-identity gate above.
2. **Re-matching a single detector against the full refcat can mismatch to distractors** → the adaptive refit uses the already-matched local reference subset. Both are better for real data, not just tests.

### Testing
- CRDS-free mock JWST gwcs via a **version-tolerant** shared helper (`tests/_align_gwcs.py`) — the tweakwcs helper name differs across 0.8/0.9, so tests skip cleanly if it's ever dropped.
- `pytest test_align_solve.py` → **8 passed** (shared translation + rotation recovery; adaptive frees an outlier while others stay untouched; adaptive-off leaves it over tolerance; NOT_ALIGNED on too-few / non-matching refcat; single-detector group; direct residual helper).
- No regressions: full align + neighbor suite → **64 passed**.

### Scope boundary
No FITS/datamodel I/O, no `CFP_ALGN` stamp/sentinel, no `run_align`, no CLI/orchestration wiring, no config parsing — Phase 6+.

Generated with Claude Code
