### PR TITLE
feat(nircam): align phase — exposure I/O + CFP_ALGN stamp (apply.py)

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -276,6 +276,18 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- **NIRCam `align` phase — exposure I/O + `CFP_ALGN` stamp.** New
+  `nircam/align/apply.py` (`align_exposure_group`) is the FITS layer: it reads each
+  detector's gwcs and detects sources, runs the in-memory solve, and writes the
+  corrected gwcs back onto the canonical (`model.meta.wcs` + `update_fits_wcsinfo`,
+  re-attaching `SRCMASK`, via `atomic_save`) with a per-detector `CFP_ALGN` provenance
+  value (`dof`/residual/match-count) — or a `NOT_ALIGNED` sentinel when the exposure
+  can't be tied to the reference (WCS preserved, never retried). The original
+  (un-aligned) gwcs is stashed in a `WCS_BAK` extension so an `overwrite` re-run solves
+  from the original and never double-corrects (mirrors the `wcs_shift` contract).
+  Right-sizes the `CFP_ALGN` card comment set in the earlier scaffolding so the value +
+  comment fit one 80-char FITS card. Still not wired into any run; covered by
+  `tests/test_align_apply.py` (persistable-gwcs canonical round-trip). No behavior change.
 - **NIRCam `align` phase — per-exposure solve core.** New `nircam/align/solve.py`
   (`solve_exposure_group`) fits ONE shared shift+rotation per exposure via
   `tweakwcs.align_wcs` (`fitgeom='rshift'`, SIAF distortion untouched) against the

--- a/pipeline/campfire_pipeline/common/cfp.py
+++ b/pipeline/campfire_pipeline/common/cfp.py
@@ -96,7 +96,7 @@ NIRCAM = Keyset(
         'CFP_SHFT': 'campfire: pre-jhat WCS shift (dra,ddec,droll,scale)',
         'CFP_PREV': 'campfire: preview PNG rendered',
         'CFP_JHAT': 'campfire: jhat refcat used',
-        'CFP_ALGN': 'campfire: align shift/rot + solve_status',
+        'CFP_ALGN': 'campfire: align solve',
         'CFP_MASK': 'campfire: user masks applied',
         'CFP_BPIX': 'campfire: bad pixel mask applied',
         'CFP_OUT':  'campfire: outlier detection done',

--- a/pipeline/campfire_pipeline/nircam/align/__init__.py
+++ b/pipeline/campfire_pipeline/nircam/align/__init__.py
@@ -12,6 +12,7 @@ exposure-grouping layer lives at ``nircam/association.py`` (a general primitive,
 not align-specific).
 """
 
+from campfire_pipeline.nircam.align.apply import align_exposure_group
 from campfire_pipeline.nircam.align.detect import (
     detect_in_exposure,
     detect_star_centroids,
@@ -32,4 +33,5 @@ __all__ = [
     'DetectorInput',
     'DetectorSolution',
     'GroupSolution',
+    'align_exposure_group',
 ]

--- a/pipeline/campfire_pipeline/nircam/align/apply.py
+++ b/pipeline/campfire_pipeline/nircam/align/apply.py
@@ -134,22 +134,24 @@ def _write_solution(path, corrected_wcs, cfp_value, ImageModel,
                                         header=sm.header.copy(), name='SRCMASK')
 
     model = ImageModel(path, memmap=False)
-    # Preserve the true original: keep an existing WCS_BAK, else the current
-    # (still un-aligned) WCS becomes the baseline.
-    wcs_bak = (existing_wcs_bak if existing_wcs_bak is not None
-               else _serialize_gwcs_to_hdu(model.meta.wcs))
-    model.meta.wcs = corrected_wcs
     try:
-        update_fits_wcsinfo(model)
-    except (ValueError, RuntimeError) as e:
-        log(f"align: update_fits_wcsinfo failed on {os.path.basename(path)} "
-            f"({type(e).__name__}); FITS SIP keywords not refreshed.")
+        # Preserve the true original: keep an existing WCS_BAK, else the current
+        # (still un-aligned) WCS becomes the baseline.
+        wcs_bak = (existing_wcs_bak if existing_wcs_bak is not None
+                   else _serialize_gwcs_to_hdu(model.meta.wcs))
+        model.meta.wcs = corrected_wcs
+        try:
+            update_fits_wcsinfo(model)
+        except (ValueError, RuntimeError) as e:
+            log(f"align: update_fits_wcsinfo failed on {os.path.basename(path)} "
+                f"({type(e).__name__}); FITS SIP keywords not refreshed.")
 
-    extra_hdus = [wcs_bak] + ([srcmask_hdu] if srcmask_hdu is not None else [])
-    atomic_save(model, path,
-                header_updates=cfp.format(CFP_ALGN=cfp_value),
-                extra_hdus=extra_hdus)
-    model.close()
+        extra_hdus = [wcs_bak] + ([srcmask_hdu] if srcmask_hdu is not None else [])
+        atomic_save(model, path,
+                    header_updates=cfp.format(CFP_ALGN=cfp_value),
+                    extra_hdus=extra_hdus)
+    finally:
+        model.close()
 
 
 def align_exposure_group(members, refcat, *, key=None, config=None,

--- a/pipeline/campfire_pipeline/nircam/align/apply.py
+++ b/pipeline/campfire_pipeline/nircam/align/apply.py
@@ -1,0 +1,218 @@
+"""Align exposure I/O: read a canonical exposure group, solve, write back.
+
+This is the FITS layer of the NIRCam ``align`` phase. For one exposure group it
+reads each detector's gwcs and detects sources, runs the in-memory solve
+(:func:`campfire_pipeline.nircam.align.solve.solve_exposure_group`), and writes
+the corrected gwcs back onto each canonical with a ``CFP_ALGN`` provenance stamp
+— or a ``NOT_ALIGNED`` sentinel when the exposure can't be tied to the reference
+(WCS preserved, never retried).
+
+Idempotency: the original (un-aligned) gwcs is stashed in a ``WCS_BAK``
+extension on first apply; on ``overwrite`` the solve runs from that original, so
+re-running never composes a second correction on top of the first. Mirrors the
+``steps/wcs_shift.py`` write-back contract (the ``WCS_BAK`` helpers are
+replicated here because ``align`` supersedes and will remove ``wcs_shift``).
+
+The reference catalog and config knobs arrive already resolved — refcat
+resolution / loading and ``[<field>.align]`` parsing live in the field-level
+orchestration.
+"""
+
+import io
+import os
+import warnings
+
+import numpy as np
+from astropy.io import fits
+
+from campfire_pipeline.common import cfp
+from campfire_pipeline.common.io import atomic_save, log
+from campfire_pipeline.nircam.align.detect import detect_star_centroids
+from campfire_pipeline.nircam.align.solve import (
+    DetectorInput,
+    GroupSolution,
+    solve_exposure_group,
+)
+from campfire_pipeline.nircam.association import exposure_key
+
+WCS_BAK_EXTNAME = 'WCS_BAK'
+NOT_ALIGNED_SENTINEL = 'NOT_ALIGNED'
+
+# jwst.datamodels.dqflags.pixel['DO_NOT_USE'] == 1 (bit 0).
+_DO_NOT_USE = np.uint32(1)
+
+# Solve/detection knobs threaded from [<field>.align]; the orchestration passes
+# a resolved dict, these are the fallbacks.
+_SOLVE_KEYS = ('fitgeom', 'minobj', 'nclip', 'sigma', 'tolerance', 'adaptive',
+               'adaptive_min_matches', 'match_radius', 'min_matched')
+_DETECT_KEYS = ('fwhm', 'nsigma', 'edge', 'brightest')
+
+
+# --- WCS_BAK gwcs <-> ASDF-in-FITS (replicated from steps/wcs_shift.py) ------
+
+def _serialize_gwcs_to_hdu(wcs, name=WCS_BAK_EXTNAME):
+    import asdf
+    af = asdf.AsdfFile({'wcs': wcs})
+    buf = io.BytesIO()
+    af.write_to(buf)
+    data = np.frombuffer(buf.getvalue(), dtype=np.uint8).copy()
+    return fits.ImageHDU(data=data, name=name)
+
+
+def _deserialize_gwcs_from_hdu(hdu):
+    import asdf
+    buf = io.BytesIO(hdu.data.tobytes())
+    with asdf.open(buf, lazy_load=False) as af:
+        return af['wcs']
+
+
+def _stamp_algn(path, value):
+    """Atomically set CFP_ALGN=*value* (header only; WCS untouched)."""
+    base, ext = os.path.splitext(path)
+    tmp = f'{base}.tmp{ext}'
+    with fits.open(path) as hdul:
+        hdul[0].header['CFP_ALGN'] = (value, cfp.CFP_COMMENTS['CFP_ALGN'])
+        hdul.writeto(tmp, overwrite=True)
+    os.replace(tmp, path)
+
+
+def _format_algn_value(det):
+    # Per-detector provenance, kept short so the value + card comment fit one
+    # 80-char FITS card. The shared shift/rot is group-level (same for every
+    # detector) and is logged once per group, not stamped on each card.
+    return f'dof={det.dof} res={det.residual_arcsec:.3g} n={det.n_matched}'
+
+
+def _detect_mask(model):
+    mask = ~np.isfinite(np.asarray(model.data, dtype=float))
+    if getattr(model, 'err', None) is not None:
+        mask |= ~np.isfinite(np.asarray(model.err, dtype=float))
+    if getattr(model, 'dq', None) is not None:
+        mask |= (np.asarray(model.dq).astype(np.uint32) & _DO_NOT_USE) != 0
+    return mask
+
+
+def _load_detector(path, detector, detect_cfg, ImageModel):
+    """Open a canonical, pick the ORIGINAL gwcs (from WCS_BAK if this file was
+    aligned before), detect sources, and return a :class:`DetectorInput`."""
+    model = ImageModel(path, memmap=False)
+    try:
+        wi = model.meta.wcsinfo.instance
+        wcsinfo = {'v2_ref': wi['v2_ref'], 'v3_ref': wi['v3_ref'],
+                   'roll_ref': wi['roll_ref']}
+        orig_wcs = model.meta.wcs
+        cat = detect_star_centroids(np.asarray(model.data, dtype=float),
+                                    mask=_detect_mask(model), **detect_cfg)
+    finally:
+        model.close()
+
+    # A prior align stashed the un-aligned gwcs; solve from it so an overwrite
+    # re-run corrects the original, never the already-corrected WCS.
+    with fits.open(path, memmap=False) as hdul:
+        if WCS_BAK_EXTNAME in hdul:
+            orig_wcs = _deserialize_gwcs_from_hdu(hdul[WCS_BAK_EXTNAME])
+
+    return DetectorInput(detector=detector, wcs=orig_wcs, wcsinfo=wcsinfo,
+                         catalog=cat)
+
+
+def _write_solution(path, corrected_wcs, cfp_value, ImageModel,
+                    update_fits_wcsinfo):
+    """Write *corrected_wcs* back onto the canonical + stamp CFP_ALGN, keeping
+    SRCMASK and stashing the original gwcs in WCS_BAK."""
+    existing_wcs_bak = None
+    srcmask_hdu = None
+    with fits.open(path, memmap=False) as hdul:
+        if WCS_BAK_EXTNAME in hdul:
+            wb = hdul[WCS_BAK_EXTNAME]
+            existing_wcs_bak = fits.ImageHDU(data=wb.data.copy(),
+                                             header=wb.header.copy(),
+                                             name=WCS_BAK_EXTNAME)
+        if 'SRCMASK' in hdul:
+            sm = hdul['SRCMASK']
+            srcmask_hdu = fits.ImageHDU(data=sm.data.copy(),
+                                        header=sm.header.copy(), name='SRCMASK')
+
+    model = ImageModel(path, memmap=False)
+    # Preserve the true original: keep an existing WCS_BAK, else the current
+    # (still un-aligned) WCS becomes the baseline.
+    wcs_bak = (existing_wcs_bak if existing_wcs_bak is not None
+               else _serialize_gwcs_to_hdu(model.meta.wcs))
+    model.meta.wcs = corrected_wcs
+    try:
+        update_fits_wcsinfo(model)
+    except (ValueError, RuntimeError) as e:
+        log(f"align: update_fits_wcsinfo failed on {os.path.basename(path)} "
+            f"({type(e).__name__}); FITS SIP keywords not refreshed.")
+
+    extra_hdus = [wcs_bak] + ([srcmask_hdu] if srcmask_hdu is not None else [])
+    atomic_save(model, path,
+                header_updates=cfp.format(CFP_ALGN=cfp_value),
+                extra_hdus=extra_hdus)
+    model.close()
+
+
+def align_exposure_group(members, refcat, *, key=None, config=None,
+                         overwrite=False, status=None):
+    """Align one exposure group and write the results to its canonicals.
+
+    Parameters
+    ----------
+    members : list of association.ExposureMember
+        The detectors of one exposure (each carries ``.path``, ``.detector``).
+    refcat : astropy.table.Table
+        Static reference catalog with ``RA``/``DEC`` (deg), already loaded.
+    key : str, optional
+        Exposure key; defaults to the shared exposure token.
+    config : dict, optional
+        Resolved ``[<field>.align]`` knobs (solve + detection).
+    overwrite, status :
+        Standard step idempotency controls.
+
+    Returns
+    -------
+    GroupSolution
+        ``status`` is ``'SOLVED'`` / ``'NOT_ALIGNED'`` / ``'SKIPPED'``.
+    """
+    members = list(members)
+    if not members:
+        return GroupSolution(key or '', 'SKIPPED', None, None, None, 0, [])
+    if key is None:
+        key = exposure_key(members[0].path)
+    config = dict(config or {})
+
+    def _done(path):
+        return (status.has(path, 'CFP_ALGN') if status is not None
+                else cfp.has_step(path, 'CFP_ALGN'))
+
+    if not overwrite and all(_done(m.path) for m in members):
+        log(f"align[{key}]: all {len(members)} detectors already stamped "
+            f"CFP_ALGN; skipping.")
+        return GroupSolution(key, 'SKIPPED', None, None, None, 0, [])
+
+    solve_cfg = {k: config[k] for k in _SOLVE_KEYS if k in config}
+    detect_cfg = {k: config[k] for k in _DETECT_KEYS if k in config}
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        from jwst.datamodels import ImageModel
+        from jwst.assign_wcs.util import update_fits_wcsinfo
+
+    detectors = [_load_detector(m.path, m.detector, detect_cfg, ImageModel)
+                 for m in members]
+
+    solution = solve_exposure_group(detectors, refcat, key=key, **solve_cfg)
+
+    by_detector = {d.detector: d for d in solution.detectors}
+    for m in members:
+        det_sol = by_detector.get(m.detector)
+        if solution.status == 'SOLVED' and det_sol is not None:
+            _write_solution(m.path, det_sol.wcs,
+                            _format_algn_value(det_sol),
+                            ImageModel, update_fits_wcsinfo)
+        else:
+            _stamp_algn(m.path, NOT_ALIGNED_SENTINEL)
+
+    log(f"align[{key}]: {solution.status} "
+        f"({len(members)} detectors, n_matched={solution.n_matched})")
+    return solution

--- a/pipeline/tests/_align_gwcs.py
+++ b/pipeline/tests/_align_gwcs.py
@@ -30,3 +30,85 @@ except Exception:  # pragma: no cover - version fallback
     except Exception:  # pragma: no cover
         make_mock_wcs = None
         HAVE_MOCK_WCS = False
+
+
+# --- persistable JWST gwcs (survives the ImageModel FITS round-trip) ---------
+# The tweakwcs mock above uses a custom (untagged) V2V3ToSky model, which
+# ImageModel.save silently drops. This builder uses jwst's own asdf-tagged
+# `v23tosky` + Shift/Scale, so `model.meta.wcs` persists through save/reload —
+# required to integration-test the align I/O layer (apply.py). jwst-dependent.
+
+try:
+    import numpy as _np
+    import astropy.units as _u
+    from astropy import coordinates as _coord
+    from astropy.modeling import models as _models
+    import gwcs as _gwcs
+    from jwst.datamodels import ImageModel as _ImageModel
+    from jwst.assign_wcs.pointing import v23tosky as _v23tosky
+
+    HAVE_PERSISTABLE_WCS = True
+except Exception:  # pragma: no cover
+    HAVE_PERSISTABLE_WCS = False
+
+
+_DEF = dict(v2ref=120.0, v3ref=500.0, roll=30.0, ra_ref=80.0, dec_ref=-30.0,
+            crpix=(512.0, 512.0), scale=1e-5)
+
+
+def make_persistable_wcs(*, v2ref=120.0, v3ref=500.0, roll=30.0, ra_ref=80.0,
+                         dec_ref=-30.0, crpix=(512.0, 512.0), scale=1e-5):
+    """A JWST-structured gwcs (detector->v2v3->world) that persists through an
+    ImageModel FITS save/reload. ``scale`` is deg/pixel; the sky reference point
+    is ``(ra_ref, dec_ref)`` and the injected astrometric offset is applied by
+    shifting those (1 arcsec = ``1/3600`` deg / cos(dec) in RA)."""
+    stub = _ImageModel()
+    for k, v in [('v2_ref', v2ref), ('v3_ref', v3ref), ('roll_ref', roll),
+                 ('ra_ref', ra_ref), ('dec_ref', dec_ref),
+                 ('v3yangle', 0.0), ('vparity', -1)]:
+        setattr(stub.meta.wcsinfo, k, v)
+    det = _gwcs.coordinate_frames.Frame2D(name='detector', axes_order=(0, 1),
+                                          unit=(_u.pix, _u.pix))
+    v2v3 = _gwcs.coordinate_frames.Frame2D(name='v2v3', axes_order=(0, 1),
+                                           unit=(_u.arcsec, _u.arcsec))
+    world = _gwcs.coordinate_frames.CelestialFrame(
+        reference_frame=_coord.ICRS(), name='world')
+    det2v2v3 = ((_models.Shift(-crpix[0]) & _models.Shift(-crpix[1]))
+                | (_models.Scale(scale * 3600) & _models.Scale(scale * 3600))
+                | (_models.Shift(v2ref) & _models.Shift(v3ref)))
+    w = _gwcs.wcs.WCS([(det, det2v2v3), (v2v3, _v23tosky(stub)), (world, None)])
+    w.bounding_box = ((-0.5, 1023.5), (-0.5, 2047.5))
+    w.array_shape = (2048, 1024)
+    return w
+
+
+def build_canonical(path, sci, *, err=None, dq=None, srcmask=None,
+                    v2ref=120.0, v3ref=500.0, roll=30.0, ra_ref=80.0,
+                    dec_ref=-30.0, crpix=(512.0, 512.0), scale=1e-5):
+    """Write a canonical NIRCam exposure FITS (ImageModel: SCI/ERR/DQ + a
+    persisted gwcs, plus an optional SRCMASK). Returns the gwcs so a caller can
+    map source pixels to sky (e.g. to build the reference catalog)."""
+    from astropy.io import fits
+    from campfire_pipeline.common.io import atomic_save
+
+    ny, nx = sci.shape
+    w = make_persistable_wcs(v2ref=v2ref, v3ref=v3ref, roll=roll, ra_ref=ra_ref,
+                             dec_ref=dec_ref, crpix=crpix, scale=scale)
+    m = _ImageModel((ny, nx))
+    m.data = _np.asarray(sci, dtype='float32')
+    m.err = (_np.ones((ny, nx), 'float32') if err is None
+             else _np.asarray(err, dtype='float32'))
+    m.dq = (_np.zeros((ny, nx), 'uint32') if dq is None
+            else _np.asarray(dq, dtype='uint32'))
+    for k, v in [('v2_ref', v2ref), ('v3_ref', v3ref), ('roll_ref', roll),
+                 ('ra_ref', ra_ref), ('dec_ref', dec_ref),
+                 ('v3yangle', 0.0), ('vparity', -1)]:
+        setattr(m.meta.wcsinfo, k, v)
+    m.meta.wcs = w
+    extra = None
+    if srcmask is not None:
+        extra = [fits.ImageHDU(data=_np.asarray(srcmask, dtype='uint8'),
+                               name='SRCMASK')]
+    atomic_save(m, path, extra_hdus=extra)
+    m.close()
+    return w

--- a/pipeline/tests/test_align_apply.py
+++ b/pipeline/tests/test_align_apply.py
@@ -1,0 +1,170 @@
+"""Integration tests for the NIRCam align I/O layer (nircam/align/apply.py).
+
+Builds real canonical ImageModel FITS (persistable gwcs + injected offset + DAO-
+detectable sources + SRCMASK), runs align_exposure_group, and checks the on-disk
+contract: CFP_ALGN stamp, the corrected gwcs persisted and now maps sources onto
+the reference catalog, SRCMASK survives, NOT_ALIGNED preserves the WCS,
+idempotency, and overwrite does not double-correct.
+"""
+
+import os
+
+import numpy as np
+import pytest
+from astropy.coordinates import SkyCoord
+from astropy.io import fits
+from astropy.table import Table
+
+from _align_gwcs import HAVE_PERSISTABLE_WCS, build_canonical, make_persistable_wcs
+from campfire_pipeline.common import cfp
+from campfire_pipeline.nircam.align.apply import align_exposure_group
+from campfire_pipeline.nircam.association import ExposureMember
+
+pytestmark = pytest.mark.skipif(
+    not HAVE_PERSISTABLE_WCS, reason="jwst persistable-gwcs builder unavailable")
+
+_TOKEN = 'jw01727028001_04101_00003'
+_DETS = ['nrca1', 'nrca2', 'nrca3', 'nrca4', 'nrcb1']
+_COSD = float(np.cos(np.deg2rad(-30.0)))
+_SHAPE = (2048, 1024)
+
+
+def _inject(shape, xy, rng, noise=1.0, fwhm=2.5, amp=400.0):
+    sigma = fwhm / 2.3548
+    img = rng.normal(0.0, noise, shape).astype(float)
+    yy, xx = np.mgrid[0:shape[0], 0:shape[1]]
+    for cx, cy in zip(*xy):
+        img += amp * np.exp(-((xx - cx) ** 2 + (yy - cy) ** 2) / (2 * sigma ** 2))
+    return img
+
+
+def _make_exposure(tmp_path, n_det=2, offset=(2.0, 0.0), per_det_extra=None,
+                   seed=0, srcmask=True):
+    """Return (members, refcat, xy_by_detector)."""
+    rng = np.random.default_rng(seed)
+    per_det_extra = per_det_extra or {}
+    members, ref_ra, ref_dec, xy_by = [], [], [], {}
+    for i, det in enumerate(_DETS[:n_det]):
+        x = rng.uniform(50, 950, 40)
+        y = rng.uniform(50, 2000, 40)
+        xy_by[det] = (x, y)
+        base_ra = 80.0 + i * 0.02 / _COSD
+        truth = make_persistable_wcs(ra_ref=base_ra, dec_ref=-30.0)
+        rt, dt = truth(x, y)
+        ref_ra.append(np.asarray(rt, float))
+        ref_dec.append(np.asarray(dt, float))
+
+        dx, dy = offset
+        ex, ey = per_det_extra.get(i, (0.0, 0.0))
+        off_ra = base_ra + (dx + ex) / 3600.0 / _COSD
+        off_dec = -30.0 + (dy + ey) / 3600.0
+        sci = _inject(_SHAPE, (x, y), rng)
+        sm = None
+        if srcmask:
+            sm = np.zeros(_SHAPE, 'uint8')
+            sm[100:110, 100:110] = 1
+        path = str(tmp_path / f'{_TOKEN}_{det}.fits')
+        build_canonical(path, sci, ra_ref=off_ra, dec_ref=off_dec, srcmask=sm)
+        members.append(ExposureMember(path=path, filter_name='f200w',
+                                      rootname=f'{_TOKEN}_{det}', detector=det))
+    refcat = Table({'RA': np.concatenate(ref_ra),
+                    'DEC': np.concatenate(ref_dec)})
+    refcat.meta['name'] = 't'
+    return members, refcat, xy_by
+
+
+def _cfp_algn(path):
+    with fits.open(path) as h:
+        return h[0].header.get('CFP_ALGN', '')
+
+
+def _reload_residual(path, xy, refcat):
+    from jwst.datamodels import ImageModel
+    m = ImageModel(path, memmap=False)
+    ra, dec = m.meta.wcs(xy[0], xy[1])
+    m.close()
+    ref = SkyCoord(refcat['RA'], refcat['DEC'], unit='deg')
+    _, d2d, _ = SkyCoord(ra, dec, unit='deg').match_to_catalog_sky(ref)
+    return float(np.median(d2d.arcsec))
+
+
+# --- success ----------------------------------------------------------------
+
+def test_success_stamps_and_corrects(tmp_path):
+    members, refcat, xy = _make_exposure(tmp_path, n_det=2, offset=(2.0, 0.0))
+    sol = align_exposure_group(members, refcat, config={})
+    assert sol.status == 'SOLVED'
+    for m in members:
+        assert _cfp_algn(m.path).startswith('dof=')          # non-sentinel
+        # corrected gwcs persisted and now maps sources onto the reference
+        assert _reload_residual(m.path, xy[m.detector], refcat) < 0.05
+
+
+def test_srcmask_preserved(tmp_path):
+    members, refcat, _ = _make_exposure(tmp_path, n_det=2, srcmask=True)
+    align_exposure_group(members, refcat, config={})
+    for m in members:
+        with fits.open(m.path) as h:
+            assert 'SRCMASK' in h
+
+
+def test_wcs_bak_written(tmp_path):
+    members, refcat, _ = _make_exposure(tmp_path, n_det=1)
+    align_exposure_group(members, refcat, config={})
+    with fits.open(members[0].path) as h:
+        assert 'WCS_BAK' in h
+
+
+# --- NOT_ALIGNED ------------------------------------------------------------
+
+def test_not_aligned_preserves_wcs(tmp_path):
+    members, _, _ = _make_exposure(tmp_path, n_det=2, seed=3)
+    from jwst.datamodels import ImageModel
+    before = {}
+    for m in members:
+        mo = ImageModel(m.path, memmap=False)
+        before[m.path] = tuple(float(v) for v in mo.meta.wcs(500.0, 700.0))
+        mo.close()
+    rng = np.random.default_rng(99)
+    badref = Table({'RA': 80.0 + rng.uniform(-0.05, 0.05, 30),
+                    'DEC': -30.0 + rng.uniform(-0.05, 0.05, 30)})
+    sol = align_exposure_group(members, badref, config={})
+    assert sol.status == 'NOT_ALIGNED'
+    for m in members:
+        assert _cfp_algn(m.path) == 'NOT_ALIGNED'
+        mo = ImageModel(m.path, memmap=False)
+        after = tuple(float(v) for v in mo.meta.wcs(500.0, 700.0))
+        mo.close()
+        assert np.allclose(after, before[m.path], atol=1e-12)   # WCS untouched
+
+
+# --- idempotency / overwrite ------------------------------------------------
+
+def test_idempotent_skip(tmp_path):
+    members, refcat, _ = _make_exposure(tmp_path, n_det=2)
+    align_exposure_group(members, refcat, config={})
+    mtimes = {m.path: os.path.getmtime(m.path) for m in members}
+    sol = align_exposure_group(members, refcat, config={}, overwrite=False)
+    assert sol.status == 'SKIPPED'
+    assert all(os.path.getmtime(m.path) == mtimes[m.path] for m in members)
+
+
+def test_overwrite_does_not_double_correct(tmp_path):
+    members, refcat, xy = _make_exposure(tmp_path, n_det=2, offset=(2.0, 0.0))
+    align_exposure_group(members, refcat, config={})
+    align_exposure_group(members, refcat, config={}, overwrite=True)
+    for m in members:
+        # a double-correction would leave ~2 arcsec; a correct re-solve ~0
+        assert _reload_residual(m.path, xy[m.detector], refcat) < 0.05
+
+
+# --- adaptive end-to-end ----------------------------------------------------
+
+def test_adaptive_dof_recorded(tmp_path):
+    members, refcat, _ = _make_exposure(
+        tmp_path, n_det=5, offset=(2.0, 0.0), per_det_extra={4: (0.0, 0.3)})
+    align_exposure_group(members, refcat, config={'tolerance': 0.15})
+    # detectors 0-3 stay on the shared solution; detector 4 (nrcb1) is freed
+    for m in members[:4]:
+        assert 'dof=shared' in _cfp_algn(m.path)
+    assert 'dof=shift' in _cfp_algn(members[4].path)


### PR DESCRIPTION
## Phase 6 of the NIRCam `align` build — exposure I/O + `CFP_ALGN` stamp

Sixth PR (design in `pipeline/ASTROMETRY_ALIGN_HANDOFF.md`; #322 key/config/deps, #323 `association.py`, #324 `TriangleMatch`, #325 `detect.py`, #326 `solve.py`). This is the **FITS layer** that wires the in-memory solve to real canonical exposures. It processes one exposure group — field-level orchestration + CLI + refcat resolution + `jhat`/`wcs_shift` gating are Phase 7 (the refcat + config arrive pre-resolved, which keeps this layer testable).

### What's here
- **`nircam/align/apply.py` `align_exposure_group(members, refcat, …)`**: reads each detector's gwcs + `wcsinfo` and detects sources on the `ImageModel` arrays, runs `solve_exposure_group`, and writes the corrected gwcs back — `model.meta.wcs` + `update_fits_wcsinfo` (defensive try/except, as jwst's own tweakreg does) + re-attach `SRCMASK`, via `common.io.atomic_save` — stamping a compact per-detector **`CFP_ALGN`** value (`dof=… res=… n=…`). A `NOT_ALIGNED` group stamps a `NOT_ALIGNED` **sentinel** (WCS preserved, never retried), mirroring `jhat`'s no-overlap path.
- **Idempotency / no double-correction**: the original un-aligned gwcs is stashed in a `WCS_BAK` extension on first apply; on `overwrite` the solve runs from that original, so a re-run never composes a second correction (mirrors `steps/wcs_shift.py`; the `WCS_BAK` gwcs↔ASDF helpers are replicated here since `align` supersedes/removes `wcs_shift` in Phase 7).
- **Right-sizes the `CFP_ALGN` card comment** set in the Phase-1 scaffolding so value + comment fit one 80-char FITS card (avoids a per-detector `VerifyWarning`). The shared shift/rot is group-level — logged once, not stamped on every detector card.

### Testability solved (the make-or-break)
`ImageModel.save` silently **drops** the tweakwcs mock gwcs — its custom `V2V3ToSky` model has no ASDF tag. So `tests/_align_gwcs.py` gains a **persistable** builder using jwst's own asdf-tagged `v23tosky` + `Shift`/`Scale`, which survives the FITS round-trip (prototype: a 2″ offset recovers exactly). `test_align_apply.py` (7) builds real canonical FITS and checks the on-disk contract: success stamps `CFP_ALGN` **and** the corrected gwcs persists (reloaded sources now map onto the reference, residual ≈ 0); `SRCMASK` preserved; `WCS_BAK` written; `NOT_ALIGNED` preserves the WCS; idempotent skip; overwrite does not double-correct; adaptive `dof=shift` recorded.

### Verification
- `pytest test_align_apply.py` → **7 passed**.
- No regressions: full align + neighbor suite → **71 passed** (and the earlier `CFP_ALGN` `VerifyWarning` is gone).

### Scope boundary
No `run_align` field-level phase, CLI, `[<field>.align]` config parsing, refcat resolution, `jhat`/`wcs_shift` gating, or deploy/web mirror updates — Phase 7.

Generated with Claude Code
