### PR TITLE
feat(nircam): make the astrometric align phase runnable (run_align + CLI)

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -95,6 +95,19 @@ Release procedure: edit the `## Unreleased` section below, then run
   feature failed for fixed-slit sources.
 
 ### Algorithm
+- **NIRCam field-level astrometric `align` phase is now runnable** (`cfpipe nircam
+  align` / `run --align`), **opt-in and default-off** so existing reductions are
+  unchanged. When a field sets `[<field>.align].enabled = true` (and names its
+  Gaia-tied `campfire-refcat-v1` catalog via `[<field>.align].refcat`), a bespoke
+  field-level phase runs between `process` and `combine`: it groups all detectors of
+  each exposure across the SW+LW filter dirs, triangle-matches a pooled source catalog
+  to the reference (no prior on the offset), fits one shared shift+rotation per exposure
+  via `tweakwcs` (`fitgeom='rshift'`, SIAF distortion fixed) with an adaptive
+  per-detector shift, and writes the corrected gwcs back with a `CFP_ALGN` stamp
+  (or a `NOT_ALIGNED` sentinel). The process phase then skips `jhat`+`wcs_shift` for that
+  field — exactly one alignment path. Replaces the JHAT-based alignment for opt-in
+  fields; JHAT remains the default and coexists during validation. New `[nircam.align]`
+  config block; covered by `tests/test_align_run.py`.
 - NIRCam `combine` now honors per-exposure reviewer exclusions (epic #261, N6 /
   D10). `Field.setup_workspace` reads `reference/<field>/exposures.json`
   (materialized by `campfire deploy nircam pull` from the portal's

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -346,6 +346,28 @@
     saveplots = false
     savephottable = true
 
+[nircam.align]
+    # Adaptive astrometric alignment (replaces the JHAT-based jhat/wcs_shift).
+    # Opt-in per field: default OFF so existing reductions are unchanged. A
+    # field enables it — and names its Gaia-tied reference catalog — in
+    # fields.toml:
+    #     [<field>.align]
+    #         enabled = true
+    #         refcat  = "<file>.ecsv"   # in the field's astrom_cats dir
+    # With align enabled the process phase skips jhat + wcs_shift (exactly one
+    # alignment path per field).
+    enabled = false
+    fitgeom = "rshift"          # per-exposure shared shift + rotation (SIAF fixed)
+    tolerance = 0.05            # arcsec; free a per-detector shift above this
+    adaptive = true             # adaptive per-detector shift when over tolerance
+    adaptive_min_matches = 3
+    match_radius = 0.5          # arcsec; NN radius for per-detector residuals
+    min_matched = 4             # reject-to-identity below this many matches
+    nsigma = 5.0                # source-detection threshold (background sigma)
+    fwhm = 2.5                  # detection PSF FWHM (pixels)
+    edge = 8                    # drop detections within this many px of a border
+    brightest = 150             # cap detections per detector (triangle vertices)
+
 # --- combine phase (ensemble) ---
 
 [nircam.apply_mask]

--- a/pipeline/campfire_pipeline/nircam/cli.py
+++ b/pipeline/campfire_pipeline/nircam/cli.py
@@ -29,7 +29,7 @@ from campfire_pipeline.common import cfp as cfp_mod
 from campfire_pipeline.common.cli import VariadicOption
 from campfire_pipeline.nircam.orchestrate import (
     STEP_NAMES, ALL_STEPS, PROCESS_STEPS, COMBINE_STEPS,
-    run_process, run_combine, run_step,
+    run_process, run_align, run_combine, run_step,
 )
 from campfire_pipeline.nircam.refcat.cli import refcat as refcat_group
 
@@ -157,6 +157,21 @@ def process(config, field, filters, processes, overwrite):
 @main.command()
 @common_options
 @processing_options
+def align(config, field, filters, processes, overwrite):
+    """Run the field-level astrometric align phase (between process and combine).
+
+    Opt-in per field via [<field>.align].enabled = true in fields.toml;
+    a no-op for fields that still use jhat.
+    """
+    cfg, field_obj = _setup(config, field)
+    run_align(field_obj, cfg,
+              filters=_resolve_filters(filters, field_obj),
+              n_processes=processes, overwrite=overwrite)
+
+
+@main.command()
+@common_options
+@processing_options
 @tile_option
 def combine(config, field, filters, processes, overwrite, tiles):
     """Run the ensemble combine phase (apply_mask → resample)."""
@@ -173,18 +188,21 @@ def combine(config, field, filters, processes, overwrite, tiles):
 @tile_option
 @click.option('--process', 'do_process', is_flag=True,
               help='Run the process phase.')
+@click.option('--align', 'do_align', is_flag=True,
+              help='Run the astrometric align phase (between process and '
+                   'combine; opt-in via [<field>.align].enabled).')
 @click.option('--combine', 'do_combine', is_flag=True,
               help='Run the combine phase.')
 @click.option('--all', 'do_all', is_flag=True,
-              help='Run both phases.')
+              help='Run all phases (process, align, combine).')
 def run(config, field, filters, processes, overwrite, tiles,
-        do_process, do_combine, do_all):
-    """Run process and/or combine in one invocation."""
+        do_process, do_align, do_combine, do_all):
+    """Run process, align, and/or combine in one invocation."""
     if do_all:
-        do_process = do_combine = True
-    if not (do_process or do_combine):
+        do_process = do_align = do_combine = True
+    if not (do_process or do_align or do_combine):
         raise click.UsageError(
-            "Specify --process, --combine, or --all."
+            "Specify --process, --align, --combine, or --all."
         )
 
     tile_list = list(tiles) if tiles else None
@@ -200,6 +218,9 @@ def run(config, field, filters, processes, overwrite, tiles,
     if do_process:
         run_process(field_obj, cfg, filters=filter_list,
                     n_processes=processes, overwrite=overwrite)
+    if do_align:
+        run_align(field_obj, cfg, filters=filter_list,
+                  n_processes=processes, overwrite=overwrite)
     if do_combine:
         run_combine(field_obj, cfg, filters=filter_list,
                     n_processes=processes, overwrite=overwrite,

--- a/pipeline/campfire_pipeline/nircam/orchestrate.py
+++ b/pipeline/campfire_pipeline/nircam/orchestrate.py
@@ -596,6 +596,22 @@ def _scan_status(field, filters, overwrite=False):
     return StepStatus.scan(paths)
 
 
+def _active_process_steps(config, field):
+    """``PROCESS_STEPS`` with ``jhat``+``wcs_shift`` removed when the field has
+    opted into the astrometric ``align`` phase.
+
+    Decision D6 coexistence: a field that runs ``align``
+    (``[<field>.align].enabled = true``) must NOT also run the JHAT-based
+    ``jhat``/``wcs_shift`` steps — exactly one alignment path per field. When
+    align is off (the default), the full ``PROCESS_STEPS`` list runs unchanged.
+    """
+    align_mode = get_nircam_step_config('align', config, field).get(
+        'enabled', False)
+    if not align_mode:
+        return PROCESS_STEPS
+    return [(n, k) for n, k in PROCESS_STEPS if n not in ('wcs_shift', 'jhat')]
+
+
 def run_process(field, config, filters=None, n_processes=1, overwrite=False):
     """Run all process-phase steps in order across each filter.
 
@@ -609,11 +625,98 @@ def run_process(field, config, filters=None, n_processes=1, overwrite=False):
     log(f"=== Process phase: field={field.name}, filters={filters} ===")
     prefetch_process_references(field, filters, status=status,
                                overwrite=overwrite)
+    active_steps = _active_process_steps(config, field)
     for filt in filters:
         log(f"--- Process: {filt} ---")
-        for step_name, _ in PROCESS_STEPS:
+        for step_name, _ in active_steps:
             _RUNNERS[step_name](field, config, filt, n_processes, overwrite,
                                 status)
+
+
+def _resolve_align_refcat(align_cfg, refcat_dir):
+    """Resolve the single per-field align reference-catalog path.
+
+    Align ties a whole multi-filter exposure to ONE refcat, so — unlike jhat —
+    there is no per-filter mapping; just ``[<field>.align].refcat``.
+    """
+    name = align_cfg.get('refcat')
+    if not name:
+        raise ValueError(
+            "align config missing 'refcat'. Set [<field>.align].refcat = "
+            '"<file>" in fields.toml (a Gaia-tied campfire-refcat-v1 ECSV in '
+            "the field's astrometric-catalog directory).")
+    return os.path.join(refcat_dir, name)
+
+
+def _align_group_worker(key, members, *, refcat, config, overwrite, status):
+    """``dispatch`` worker: align one exposure group. Module-level for pickling."""
+    from campfire_pipeline.nircam.align.apply import align_exposure_group
+    return align_exposure_group(members, refcat, key=key, config=config,
+                                overwrite=overwrite, status=status)
+
+
+def run_align(field, config, filters=None, n_processes=1, overwrite=False):
+    """Field-level astrometric align phase (runs between process and combine).
+
+    Groups all detectors of each exposure across the SW+LW filter dirs, ties
+    each exposure to the field's Gaia-tied reference catalog with one shared
+    shift+rotation (plus an adaptive per-detector shift), and writes the
+    corrected gwcs back with a ``CFP_ALGN`` stamp. Opt-in per field via
+    ``[<field>.align].enabled`` — a no-op otherwise, so ``run --all`` on a
+    jhat-aligned field skips it and the process phase keeps running
+    ``jhat``/``wcs_shift`` instead (decision D6).
+    """
+    filters = _resolve_filters(filters, field)
+    align_cfg = get_nircam_step_config('align', config, field)
+    if not align_cfg.get('enabled', False):
+        log(f"align: disabled for field '{field.name}' "
+            f"(set [{field.name}.align].enabled = true to run); skipping.")
+        return
+
+    from campfire_pipeline.nircam.association import build_exposure_groups
+    from campfire_pipeline.nircam.refcat.io import read_refcat
+
+    refcat_path = _resolve_align_refcat(align_cfg, field.refcat_dir)
+    refcat = read_refcat(refcat_path)
+    log(f"=== Align phase: field={field.name}, filters={filters}, "
+        f"refcat={os.path.basename(refcat_path)} ({len(refcat)} sources) ===")
+
+    status = _scan_status(field, filters, overwrite=overwrite)
+    groups = build_exposure_groups(field, filters)
+    if not groups:
+        log("align: no exposure groups found; nothing to do.")
+        return
+
+    if overwrite:
+        pending = groups
+    else:
+        pending = [g for g in groups
+                   if not all(status.has(m.path, 'CFP_ALGN')
+                              for m in g.members)]
+        skipped = len(groups) - len(pending)
+        if skipped:
+            log(f"align: {skipped}/{len(groups)} exposures already aligned; "
+                f"skipping those")
+    if not pending:
+        return
+
+    log(f"align: solving {len(pending)} exposure(s)")
+    tasks = [(g.key, list(g.members)) for g in pending]
+    results = dispatch(_align_group_worker, tasks, n_processes=n_processes,
+                       use_starmap=True, refcat=refcat, config=align_cfg,
+                       overwrite=overwrite, status=status)
+
+    # Workers stamped CFP_ALGN on disk in child processes; sync the parent cache
+    # so a later phase in the same run sees the fresh stamps.
+    for g in pending:
+        status.mark_all([m.path for m in g.members], 'CFP_ALGN')
+
+    counts = {}
+    for r in results:
+        st = getattr(r, 'status', 'UNKNOWN')
+        counts[st] = counts.get(st, 0) + 1
+    log(f"=== Align phase done for {field.name}: "
+        f"{dict(sorted(counts.items()))} ===")
 
 
 def run_combine(field, config, filters=None, n_processes=1, overwrite=False,

--- a/pipeline/tests/test_align_run.py
+++ b/pipeline/tests/test_align_run.py
@@ -1,0 +1,125 @@
+"""Tests for the field-level align phase wiring (nircam/orchestrate.run_align).
+
+The gating test is fast (no FITS). The end-to-end tests build a real synthetic
+field — canonical exposures with a persistable gwcs + injected offset across two
+filter dirs sharing one exposure token, plus a written refcat — and run the
+phase through the same path the CLI uses.
+"""
+
+import os
+
+import numpy as np
+import pytest
+from astropy.coordinates import SkyCoord
+from astropy.io import fits
+from astropy.table import Table
+
+from _align_gwcs import HAVE_PERSISTABLE_WCS, build_canonical, make_persistable_wcs
+from campfire_pipeline.nircam.field import Field
+from campfire_pipeline.nircam.orchestrate import _active_process_steps, run_align
+from campfire_pipeline.nircam.refcat.io import write_refcat
+
+_TOKEN = 'jw01727028001_04101_00003'
+_SHAPE = (2048, 1024)
+_COSD = float(np.cos(np.deg2rad(-30.0)))
+
+
+# --- gating (fast, no FITS) -------------------------------------------------
+
+def _field(enabled, **kw):
+    return Field(name='cosmos', filters=['f200w'], files=['jw01727*'],
+                 tangent_point=(80.0, -30.0), tiles={},
+                 step_overrides={'align': {'enabled': enabled, **kw}})
+
+
+def test_active_process_steps_gates_jhat_and_wcs_shift():
+    off = [n for n, _ in _active_process_steps({}, _field(False))]
+    on = [n for n, _ in _active_process_steps({}, _field(True))]
+    # align off (default): the JHAT path runs
+    assert 'jhat' in off and 'wcs_shift' in off
+    # align on: the JHAT path is removed (exactly one alignment path)
+    assert 'jhat' not in on and 'wcs_shift' not in on
+    # everything else is untouched
+    assert 'variance' in on and 'sky' in on and 'detector1' in on
+
+
+# --- end-to-end -------------------------------------------------------------
+
+pytestmark_e2e = pytest.mark.skipif(
+    not HAVE_PERSISTABLE_WCS, reason="jwst persistable-gwcs builder unavailable")
+
+
+def _inject(shape, xy, rng, noise=1.0, fwhm=2.5, amp=400.0):
+    sigma = fwhm / 2.3548
+    img = rng.normal(0.0, noise, shape).astype(float)
+    yy, xx = np.mgrid[0:shape[0], 0:shape[1]]
+    for cx, cy in zip(*xy):
+        img += amp * np.exp(-((xx - cx) ** 2 + (yy - cy) ** 2) / (2 * sigma ** 2))
+    return img
+
+
+def _build_field(tmp_path, enabled=True):
+    """A field with one exposure: nrca1 in f200w + nrcalong in f444w (one token),
+    each carrying a 2 arcsec offset from the written reference catalog."""
+    field = Field(name='cosmos', filters=['f200w', 'f444w'], files=['jw01727*'],
+                  tangent_point=(80.0, -30.0), tiles={},
+                  step_overrides={'align': {'enabled': enabled,
+                                            'refcat': 'test.ecsv'}})
+    field.setup_workspace(campfire_root=str(tmp_path))
+    rng = np.random.default_rng(0)
+    ref_ra, ref_dec, xy_by_path = [], [], {}
+    for filt, det, base_ra in [('f200w', 'nrca1', 80.0),
+                               ('f444w', 'nrcalong', 80.05)]:
+        x = rng.uniform(50, 950, 40)
+        y = rng.uniform(50, 2000, 40)
+        truth = make_persistable_wcs(ra_ref=base_ra, dec_ref=-30.0)
+        rt, dt = truth(x, y)
+        ref_ra.append(np.asarray(rt, float))
+        ref_dec.append(np.asarray(dt, float))
+        off_ra = base_ra + 2.0 / 3600.0 / _COSD          # inject 2 arcsec
+        sci = _inject(_SHAPE, (x, y), rng)
+        path = os.path.join(field.filter_dir(filt), f'{_TOKEN}_{det}.fits')
+        build_canonical(path, sci, ra_ref=off_ra, dec_ref=-30.0)
+        xy_by_path[path] = (x, y)
+    refcat = Table({'RA': np.concatenate(ref_ra), 'DEC': np.concatenate(ref_dec)})
+    refcat['mag'] = np.zeros(len(refcat), 'float32')
+    refcat['mag_err'] = np.ones(len(refcat), 'float32')
+    write_refcat(refcat, os.path.join(field.refcat_dir, 'test.ecsv'),
+                 overwrite=True)
+    return field, refcat, xy_by_path
+
+
+@pytestmark_e2e
+def test_run_align_end_to_end(tmp_path):
+    field, refcat, xy_by_path = _build_field(tmp_path, enabled=True)
+    run_align(field, {}, filters=['f200w', 'f444w'], n_processes=1)
+
+    from jwst.datamodels import ImageModel
+    ref = SkyCoord(refcat['RA'], refcat['DEC'], unit='deg')
+    assert len(xy_by_path) == 2
+    for path, (x, y) in xy_by_path.items():
+        with fits.open(path) as h:
+            assert h[0].header.get('CFP_ALGN', '').startswith('dof=')
+        m = ImageModel(path, memmap=False)
+        ra, dec = m.meta.wcs(x, y)
+        m.close()
+        _, d2d, _ = SkyCoord(ra, dec, unit='deg').match_to_catalog_sky(ref)
+        assert float(np.median(d2d.arcsec)) < 0.05     # corrected onto refcat
+
+
+@pytestmark_e2e
+def test_run_align_disabled_is_noop(tmp_path):
+    field, _, xy_by_path = _build_field(tmp_path, enabled=False)
+    run_align(field, {}, filters=['f200w', 'f444w'], n_processes=1)
+    for path in xy_by_path:
+        with fits.open(path) as h:
+            assert 'CFP_ALGN' not in h[0].header
+
+
+@pytestmark_e2e
+def test_run_align_idempotent(tmp_path):
+    field, _, xy_by_path = _build_field(tmp_path, enabled=True)
+    run_align(field, {}, filters=['f200w', 'f444w'], n_processes=1)
+    mtimes = {p: os.path.getmtime(p) for p in xy_by_path}
+    run_align(field, {}, filters=['f200w', 'f444w'], n_processes=1)
+    assert all(os.path.getmtime(p) == mtimes[p] for p in xy_by_path)


### PR DESCRIPTION
## Phase 7 of the NIRCam `align` build — make it runnable

Seventh PR (design in `pipeline/ASTROMETRY_ALIGN_HANDOFF.md`; #322 key/config/deps → #327 the exposure I/O layer). The whole align **engine** exists and is tested; this PR **wires it into the pipeline** so `cfpipe nircam align --field <F>` (and `run --align`) actually runs it. **Opt-in per field, default-off** — existing reductions are unchanged.

### What's here
- **`orchestrate.run_align(field, config, filters, n_processes, overwrite)`** — a bespoke field-level phase between `process` and `combine` (it iterates *exposure groups* across SW+LW filter dirs, so it can't be a per-filter `PROCESS_STEPS` entry). It groups exposures (`association.build_exposure_groups`), loads the field's Gaia-tied refcat once (`_resolve_align_refcat` + `refcat.io.read_refcat`), pre-filters pending groups, and dispatches `align_exposure_group` per group (`use_starmap`, mirroring `_run_outlier_per_visit`), then `status.mark_all(..., 'CFP_ALGN')` and logs a `SOLVED`/`NOT_ALIGNED`/`SKIPPED` summary. **Self-gates** on `[<field>.align].enabled` (a no-op otherwise, so `run --all` on a JHAT field skips it).
- **D6 coexistence** — `_active_process_steps(config, field)` drops `jhat`+`wcs_shift` from `PROCESS_STEPS` when a field opts into align (exactly one alignment path). `run_process` iterates it; behavior is **identical when align is off** (the default).
- **CLI** — a bespoke `align` command (modeled on `process`) and a `--align` flag on `run` (`--all` now runs process → align → combine). `align` is kept **out of `STEP_NAMES`/`ALL_STEPS`** (no auto-registered per-filter command; no `_STEP_LABELS` KeyError); `reset --from jhat`/`--from wcs_shift` already cascade to `CFP_ALGN` via the CFP keyset order, and re-running uses `align --overwrite` (the `apply.py` WCS_BAK path).
- **Config** — a `[nircam.align]` default block (`enabled = false` + solve/detect tunables); the refcat is named per-field in `[<field>.align].refcat`.

### Testing
`tests/test_align_run.py`: gating (jhat/wcs_shift removed iff `enabled`), **end-to-end** (a real synthetic field — a 2-detector exposure across `f200w`+`f444w` sharing one exposure token, each offset 2″ from a written refcat — runs through `run_align`; every canonical ends up with a non-sentinel `CFP_ALGN` and the reloaded `meta.wcs` maps sources onto the refcat, residual ≈ 0), disabled-is-no-op, and idempotent re-run.
- `pytest test_align_run.py` → **4 passed**; full align + neighbor suite → **75 passed**, no regressions.
- `cfpipe nircam align --help` and `run --help` (now shows `--align`) verified.

### Scope boundary — tracked follow-ups
- Deploy/web `CFP_ALGN` provenance mirrors (`_CFP_TO_STAGE`, `NIRCAM_STAGES`, …) — safe to defer (deploy reads the highest post-combine stamp).
- Overlap-residual diagnostics (D3).
- `align` into `ALL_STEPS` + `reset --from align`/status column — lands with the replace PR that removes `jhat`/`wcs_shift`, after A/B validation on ≥2 real fields.

Generated with Claude Code
