### PR TITLE
NIRCam: --tiles pre-filters process/align/combine + align-vs-jhat A/B harness

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -289,6 +289,24 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- **NIRCam `--tiles` now pre-filters the exposure set for `process`/`align`/`combine`,
+  not just `resample`.** Previously `--tiles` scoped only which mosaics were drizzled;
+  every earlier step ran over the whole field, so building one tile meant processing
+  all of it. `--tiles` now restricts each phase to exposures overlapping the named
+  tile(s): `detector1` gates on the uncal `S_REGION` footprint (present before any WCS
+  is assigned), and the canonical-stage steps + `align` groups inherit the subset. The
+  overlap gate lives in `nircam/geometry.py` (`select_overlapping_by_sregion` +
+  `filter_exposures_to_tiles`, exposure-union so a straddling dither keeps its full
+  detector complement; the tile polygon is buffered ~11″ to stay a conservative
+  superset of resample's precise SCI-WCS selection; missing/blank `S_REGION` fails
+  open). This makes a single-tile reduction cheap — e.g. an `align`-vs-`jhat` A/B on one
+  COSMOS tile (`scripts/nircam_ab_astrometry.py` compares the two mosaics' extracted
+  catalogs to each other and to the reference). **Default (no `--tiles`) runs are
+  byte-identical.** A tile-scoped run restricts `outlier`/`bad_pixel` to the overlapping
+  subset, so tile-edge pixels may differ from a full-field pass — expected, since a
+  tile-scoped run is a distinct input set. *(Categorized Infrastructure because the
+  canonical full-field reduction is unchanged; noting the tile-scoped caveat.)* Covered
+  by `tests/test_tile_filter.py` + `tests/test_ab_astrometry.py`.
 - **NIRCam `align` phase — exposure I/O + `CFP_ALGN` stamp.** New
   `nircam/align/apply.py` (`align_exposure_group`) is the FITS layer: it reads each
   detector's gwcs and detects sources, runs the in-memory solve, and writes the

--- a/pipeline/campfire_pipeline/nircam/association.py
+++ b/pipeline/campfire_pipeline/nircam/association.py
@@ -53,8 +53,14 @@ def exposure_key(path) -> str:
     ``'.../jw01727028001_04101_00003_nrcalong.fits'`` ->
     ``'jw01727028001_04101_00003'``. One token identifies one physical exposure
     (one dither) across every detector and both filter channels.
+
+    Also accepts raw ``_uncal.fits`` names (``'..._nrcalong_uncal.fits'``) — the
+    trailing ``_uncal`` is stripped before the detector, so an uncal and its
+    canonical map to the same token. Canonical rootnames never carry ``_uncal``,
+    so this widening is a no-op for them (used by the ``--tiles`` exposure gate,
+    which runs at ``detector1`` on uncals).
     """
-    base = os.path.basename(path).removesuffix('.fits')
+    base = os.path.basename(path).removesuffix('.fits').removesuffix('_uncal')
     return base.rsplit('_', 1)[0]
 
 
@@ -201,7 +207,8 @@ def _make_member(field, path, filter_name) -> ExposureMember:
 
 
 def build_exposure_groups(field, filters=None, *, skip=None, with_step=None,
-                          status=None, work=False) -> List[ExposureGroup]:
+                          status=None, work=False,
+                          tiles=None) -> List[ExposureGroup]:
     """Group a field's canonical exposure files by physical exposure.
 
     Scans every filter in *filters* (default ``field.filters``) via
@@ -210,11 +217,13 @@ def build_exposure_groups(field, filters=None, *, skip=None, with_step=None,
     is applied for free — and buckets the results by :func:`exposure_key`,
     reuniting the SW and LW detectors of each dither.
 
-    *skip*, *with_step*, *status*, and *work* are passed through verbatim to
-    :meth:`Field.get_exposure_files` (the align phase will later pass its
-    process-completion CFP key via *with_step* plus a pre-scanned
-    ``StepStatus``). Requires ``field.setup_workspace()`` to have been called;
-    otherwise ``Field.filter_dir`` raises ``RuntimeError``, which propagates.
+    *skip*, *with_step*, *status*, *work*, and *tiles* are passed through
+    verbatim to :meth:`Field.get_exposure_files`. *tiles* restricts the scan to
+    exposures overlapping the named tile(s); the enumerator's exposure-union
+    gate keeps a dither's full detector complement whenever any member overlaps,
+    so pooled solves stay complete at tile edges. Requires
+    ``field.setup_workspace()`` to have been called; otherwise
+    ``Field.filter_dir`` raises ``RuntimeError``, which propagates.
 
     Returns a list of :class:`ExposureGroup`, sorted by ``key``, each with its
     members in canonical detector order.
@@ -225,7 +234,8 @@ def build_exposure_groups(field, filters=None, *, skip=None, with_step=None,
     for filter_name in filters:
         for path in field.get_exposure_files(filter_name, skip=skip,
                                              with_step=with_step,
-                                             status=status, work=work):
+                                             status=status, work=work,
+                                             tiles=tiles):
             member = _make_member(field, path, filter_name)
             buckets.setdefault(exposure_key(path), []).append(member)
 

--- a/pipeline/campfire_pipeline/nircam/cli.py
+++ b/pipeline/campfire_pipeline/nircam/cli.py
@@ -91,16 +91,18 @@ def processing_options(f):
 
 
 def tile_option(f):
-    """``--tiles``: runtime tile selection for the resample step.
+    """``--tiles``: runtime tile selection.
 
-    Tile selection is a runtime parameter, not a config key — a subset only
-    limits which mosaics are drizzled; the exposure-level combine steps
-    (apply_mask, bad_pixel, outlier) still run over the full field.
+    A runtime parameter, not a config key. On ``process``/``align``/``combine``
+    it pre-filters the exposure set to dithers overlapping the named tile(s)
+    (gated on the ``S_REGION`` footprint), so a single tile can be reduced
+    without processing the whole field; on ``resample`` it additionally scopes
+    which mosaics are drizzled. Default: all tiles / all exposures.
     """
     return click.option('--tiles', multiple=True, default=None,
                         cls=VariadicOption,
-                        help='Tile name(s) to resample '
-                             '(default: all tiles in field).')(f)
+                        help='Tile name(s) to scope the run to '
+                             '(default: all tiles / all exposures).')(f)
 
 
 def _setup(config_path, field_name):
@@ -146,27 +148,37 @@ def main():
 @main.command()
 @common_options
 @processing_options
-def process(config, field, filters, processes, overwrite):
-    """Run the per-exposure process phase (detector1 → jhat)."""
+@tile_option
+def process(config, field, filters, processes, overwrite, tiles):
+    """Run the per-exposure process phase (detector1 → jhat).
+
+    ``--tiles`` restricts the phase to exposures overlapping the named tile(s)
+    (detector1 gates on the uncal S_REGION footprint), so a single tile can be
+    reduced without processing the whole field.
+    """
     cfg, field_obj = _setup(config, field)
     run_process(field_obj, cfg,
                 filters=_resolve_filters(filters, field_obj),
-                n_processes=processes, overwrite=overwrite)
+                n_processes=processes, overwrite=overwrite,
+                tiles=list(tiles) if tiles else None)
 
 
 @main.command()
 @common_options
 @processing_options
-def align(config, field, filters, processes, overwrite):
+@tile_option
+def align(config, field, filters, processes, overwrite, tiles):
     """Run the field-level astrometric align phase (between process and combine).
 
     Opt-in per field via [<field>.align].enabled = true in fields.toml;
-    a no-op for fields that still use jhat.
+    a no-op for fields that still use jhat. ``--tiles`` restricts to exposures
+    overlapping the named tile(s).
     """
     cfg, field_obj = _setup(config, field)
     run_align(field_obj, cfg,
               filters=_resolve_filters(filters, field_obj),
-              n_processes=processes, overwrite=overwrite)
+              n_processes=processes, overwrite=overwrite,
+              tiles=list(tiles) if tiles else None)
 
 
 @main.command()
@@ -206,21 +218,18 @@ def run(config, field, filters, processes, overwrite, tiles,
         )
 
     tile_list = list(tiles) if tiles else None
-    if tile_list and not do_combine:
-        raise click.UsageError(
-            "--tiles scopes the resample step, which only runs in the "
-            "combine phase; pass --combine or --all."
-        )
 
     cfg, field_obj = _setup(config, field)
     filter_list = _resolve_filters(filters, field_obj)
 
     if do_process:
         run_process(field_obj, cfg, filters=filter_list,
-                    n_processes=processes, overwrite=overwrite)
+                    n_processes=processes, overwrite=overwrite,
+                    tiles=tile_list)
     if do_align:
         run_align(field_obj, cfg, filters=filter_list,
-                  n_processes=processes, overwrite=overwrite)
+                  n_processes=processes, overwrite=overwrite,
+                  tiles=tile_list)
     if do_combine:
         run_combine(field_obj, cfg, filters=filter_list,
                     n_processes=processes, overwrite=overwrite,

--- a/pipeline/campfire_pipeline/nircam/field.py
+++ b/pipeline/campfire_pipeline/nircam/field.py
@@ -458,13 +458,19 @@ class Field:
             log(f"Warning: could not read {path}: {e}; ignoring exclusions.")
             return {}
 
-    def get_uncal_files(self, filter_name, skip=None):
+    def get_uncal_files(self, filter_name, skip=None, tiles=None):
         """Get uncal files from PID-organized raw directories.
 
         Globs across ``$CAMPFIRE_ROOT/raw/nircam/{PID}/{filter}/`` for every PID
         derived from this field's ``files`` patterns. The field-wide ``skip``
         list (from fields.toml) is always applied; caller-passed ``skip`` adds
         to it.
+
+        ``tiles`` (optional) restricts the result to exposures overlapping the
+        named tile(s), gated on each uncal's ``S_REGION`` footprint (raw uncals
+        carry it before any WCS is assigned). This is what lets ``--tiles`` skip
+        ``detector1`` on off-tile exposures. See
+        :func:`geometry.filter_exposures_to_tiles`.
         """
         if self.raw_root is None:
             raise RuntimeError("setup_workspace() must be called first")
@@ -492,10 +498,14 @@ class Field:
                 excluded.update(glob(full_exc))
             result = [f for f in result if f not in excluded]
 
-        return sorted(result)
+        result = sorted(result)
+        if tiles:
+            from campfire_pipeline.nircam.geometry import filter_exposures_to_tiles
+            result = filter_exposures_to_tiles(self, result, tiles)
+        return result
 
     def get_exposure_files(self, filter_name, skip=None, with_step=None,
-                           status=None, work=False):
+                           status=None, work=False, tiles=None):
         """Get canonical per-exposure files from the filter's flat dir.
 
         These are the files that the process phase writes — one FITS file per
@@ -531,6 +541,12 @@ class Field:
             the per-file fits.open.
         work : bool, optional
             Enumerate the working-copy tree instead of the canonical tree.
+        tiles : str or list of str, optional
+            Restrict the result to exposures overlapping the named tile(s),
+            gated on each file's ``S_REGION`` footprint via
+            :func:`geometry.filter_exposures_to_tiles` (exposure-union: a whole
+            dither is kept when any of its detectors overlaps). ``None`` (the
+            default) applies no tile restriction.
 
         Returns
         -------
@@ -570,7 +586,11 @@ class Field:
                 from campfire_pipeline.common import cfp
                 result = [f for f in result if cfp.has_step(f, with_step)]
 
-        return sorted(result)
+        result = sorted(result)
+        if tiles:
+            from campfire_pipeline.nircam.geometry import filter_exposures_to_tiles
+            result = filter_exposures_to_tiles(self, result, tiles)
+        return result
 
     def get_exposure_path(self, rootname, filter_name, work=False):
         """Return the canonical path for a given exposure rootname.

--- a/pipeline/campfire_pipeline/nircam/geometry.py
+++ b/pipeline/campfire_pipeline/nircam/geometry.py
@@ -14,6 +14,16 @@ import numpy as np
 from astropy.io import fits
 from astropy.wcs import WCS
 from shapely.geometry import Polygon
+from shapely.ops import unary_union
+
+# Buffer (deg) applied to a tile polygon when gating whole exposures by their
+# approximate ``S_REGION`` footprint (see ``filter_exposures_to_tiles``). The
+# SDP-derived ``S_REGION`` is a guide-star-attitude footprint — good to ~1", not
+# distortion-solved — so a small dilation keeps the coarse pre-filter a
+# conservative SUPERSET of the precise per-tile selection ``resample`` still
+# does with the SCI WCS. ~11 arcsec: negligible vs a tile (arcmin-scale) but
+# comfortably above ``S_REGION``'s error.
+DEFAULT_TILE_BUFFER_DEG = 0.003
 
 
 def select_overlapping_files(exposure_files, tile_polygon, *, in_shape=(2048, 2048)):
@@ -44,3 +54,110 @@ def select_overlapping_files(exposure_files, tile_polygon, *, in_shape=(2048, 20
         if tile_polygon.intersects(file_polygon):
             selected.append(f)
     return selected
+
+
+def polygon_from_sregion(s_region):
+    """Parse an ``S_REGION`` string into a footprint ``Polygon`` (or ``None``).
+
+    Handles the standard ``'POLYGON ICRS ra1 dec1 ra2 dec2 ...'`` form (the
+    leading two tokens are the shape + frame; RA/Dec alternate thereafter, the
+    same layout ``expmap._parse_sregion`` reads). Returns ``None`` for anything
+    unparseable or with fewer than three vertices — callers treat ``None`` as
+    "footprint unknown" and fail open rather than dropping the exposure.
+    """
+    if not s_region:
+        return None
+    try:
+        parts = s_region.split()
+        ra = [float(x) for x in parts[2::2]]
+        dec = [float(x) for x in parts[3::2]]
+    except (ValueError, IndexError):
+        return None
+    if len(ra) < 3 or len(ra) != len(dec):
+        return None
+    return Polygon(zip(ra, dec))
+
+
+def read_sregion_polygon(path):
+    """Footprint ``Polygon`` from a file's ``S_REGION`` keyword, or ``None``.
+
+    Reads ``S_REGION`` from the SCI extension (falling back to the primary
+    header), mirroring ``expmap._read_metadata``. Because ``S_REGION`` is
+    written by the ground system it is present on raw ``_uncal`` files — before
+    any WCS is assigned — as well as on canonical exposures, so this is the one
+    overlap source usable at every pipeline phase. ``None`` when the keyword is
+    missing/blank or the file can't be opened.
+    """
+    try:
+        with fits.open(path, memmap=False) as hdul:
+            sci_hdr = None
+            for hdu in hdul[1:]:
+                if hdu.header.get('EXTNAME', '').upper() == 'SCI':
+                    sci_hdr = hdu.header
+                    break
+            if sci_hdr is None and len(hdul) > 1:
+                sci_hdr = hdul[1].header
+            s_region = sci_hdr.get('S_REGION') if sci_hdr is not None else None
+            if s_region is None:
+                s_region = hdul[0].header.get('S_REGION')
+    except (OSError, KeyError):
+        return None
+    return polygon_from_sregion(s_region)
+
+
+def select_overlapping_by_sregion(files, tile_polygon, *, key_fn=None):
+    """Subset of *files* whose ``S_REGION`` footprint intersects *tile_polygon*.
+
+    Unlike :func:`select_overlapping_files` (which derives the footprint from a
+    live SCI WCS, canonical-only), this uses the ``S_REGION`` keyword, so it
+    works before ``assign_wcs`` has run (raw uncals). **Fails open**: a file
+    whose footprint can't be determined is kept, never silently dropped.
+
+    With *key_fn* (e.g. :func:`association.exposure_key`), selection is by
+    GROUP — every file sharing a key is kept when *any* member of that key
+    overlaps (or is fail-open). This keeps a whole dither together when it
+    straddles a tile edge, so the align phase pools its full detector set.
+    """
+    overlaps = {}
+    for f in files:
+        poly = read_sregion_polygon(f)
+        overlaps[f] = (poly is None) or tile_polygon.intersects(poly)
+
+    if key_fn is None:
+        return [f for f in files if overlaps[f]]
+
+    keep_keys = {key_fn(f) for f in files if overlaps[f]}
+    return [f for f in files if key_fn(f) in keep_keys]
+
+
+def tiles_union_polygon(field, tiles, *, buffer_deg=DEFAULT_TILE_BUFFER_DEG):
+    """Buffered sky-polygon union of the named *tiles*.
+
+    Each tile's corners come from :meth:`Field.get_tile_corners`; the small
+    *buffer_deg* dilation keeps the ``S_REGION`` gate conservative. Propagates
+    ``get_tile_corners``'s ``ValueError`` on an unknown tile name.
+    """
+    if isinstance(tiles, str):
+        tiles = [tiles]
+    polys = [Polygon(field.get_tile_corners(t)) for t in tiles]
+    union = unary_union(polys)
+    if buffer_deg:
+        union = union.buffer(buffer_deg)
+    return union
+
+
+def filter_exposures_to_tiles(field, files, tiles, *,
+                              buffer_deg=DEFAULT_TILE_BUFFER_DEG):
+    """Restrict *files* to exposures overlapping the named *tiles*.
+
+    A no-op when *tiles* is falsy. Gates whole exposures (dithers) by their
+    approximate ``S_REGION`` footprint against the buffered tile union — so it
+    applies uniformly at every phase, including ``detector1`` on raw uncals
+    (before any WCS exists). Fail-open on unknown footprints.
+    """
+    if not tiles:
+        return files
+    from campfire_pipeline.nircam.association import exposure_key
+    tile_polygon = tiles_union_polygon(field, tiles, buffer_deg=buffer_deg)
+    return select_overlapping_by_sregion(files, tile_polygon,
+                                         key_fn=exposure_key)

--- a/pipeline/campfire_pipeline/nircam/orchestrate.py
+++ b/pipeline/campfire_pipeline/nircam/orchestrate.py
@@ -201,8 +201,9 @@ def _filter_imaging_uncals(uncals, step_name):
     return keep
 
 
-def _run_detector1(field, config, filtname, n_processes, overwrite, status):
-    uncals = field.get_uncal_files(filtname)
+def _run_detector1(field, config, filtname, n_processes, overwrite, status,
+                   tiles=None):
+    uncals = field.get_uncal_files(filtname, tiles=tiles)
     if not uncals:
         log(f"detector1: no uncal files for {filtname}")
         return
@@ -249,8 +250,9 @@ def _run_detector1(field, config, filtname, n_processes, overwrite, status):
     )
 
 
-def _run_persistence(field, config, filtname, n_processes, overwrite, status):
-    exposures = field.get_exposure_files(filtname)
+def _run_persistence(field, config, filtname, n_processes, overwrite, status,
+                     tiles=None):
+    exposures = field.get_exposure_files(filtname, tiles=tiles)
     if not exposures:
         log(f"persistence: no exposures for {filtname}")
         return
@@ -267,7 +269,7 @@ def _run_persistence(field, config, filtname, n_processes, overwrite, status):
 
 
 def _run_per_exposure(step_name, field, config, filtname,
-                      n_processes, overwrite, status):
+                      n_processes, overwrite, status, tiles=None):
     """Generic per-exposure parallel dispatch.
 
     Filters out already-stamped exposures *before* spinning up the worker
@@ -276,7 +278,7 @@ def _run_per_exposure(step_name, field, config, filtname,
     checks), so a no-op pass doesn't import the step's heavy deps at all.
     """
     module_basename, func_name, cfp_key = _PER_EXPOSURE_STEPS[step_name]
-    exposures = field.get_exposure_files(filtname)
+    exposures = field.get_exposure_files(filtname, tiles=tiles)
     if not exposures:
         log(f"{step_name}: no exposures for {filtname}")
         return
@@ -294,14 +296,15 @@ def _run_per_exposure(step_name, field, config, filtname,
     status.mark_all(pending, cfp_key)
 
 
-def _run_diag_striping(field, config, filtname, n_processes, overwrite, status):
+def _run_diag_striping(field, config, filtname, n_processes, overwrite, status,
+                       tiles=None):
     """Opt-in scattered-light diagonal striping. Disabled unless a field
     sets ``[field.diag_striping].enabled = true``."""
     cfg = get_nircam_step_config('diag_striping', config, field)
     if not cfg.get('enabled', False):
         log(f"diag_striping: disabled by config; skipping {filtname}")
         return
-    exposures = field.get_exposure_files(filtname)
+    exposures = field.get_exposure_files(filtname, tiles=tiles)
     if not exposures:
         log(f"diag_striping: no exposures for {filtname}")
         return
@@ -317,14 +320,15 @@ def _run_diag_striping(field, config, filtname, n_processes, overwrite, status):
     status.mark_all(pending, 'CFP_DIAG')
 
 
-def _run_wcs_shift(field, config, filtname, n_processes, overwrite, status):
+def _run_wcs_shift(field, config, filtname, n_processes, overwrite, status,
+                   tiles=None):
     """Opt-in pre-JHAT astrometric shift. No-op unless ``[[<field>.wcs_shift]]``
     rules are defined in fields.toml."""
     rules = field.wcs_shift_rules
     if not rules:
         log(f"wcs_shift: no rules; skipping {filtname}")
         return
-    exposures = field.get_exposure_files(filtname)
+    exposures = field.get_exposure_files(filtname, tiles=tiles)
     if not exposures:
         log(f"wcs_shift: no exposures for {filtname}")
         return
@@ -357,9 +361,10 @@ def _run_wcs_shift(field, config, filtname, n_processes, overwrite, status):
     status.mark_all(pending, 'CFP_SHFT')
 
 
-def _run_bad_pixel(field, config, filtname, n_processes, overwrite, status):
+def _run_bad_pixel(field, config, filtname, n_processes, overwrite, status,
+                   tiles=None):
     # Combine phase: operate on the working copies, never the frozen canonical.
-    exposures = field.get_exposure_files(filtname, work=True)
+    exposures = field.get_exposure_files(filtname, work=True, tiles=tiles)
     if not exposures:
         log(f"bad_pixel: no exposures for {filtname}")
         return
@@ -391,7 +396,8 @@ def _run_bad_pixel(field, config, filtname, n_processes, overwrite, status):
     status.mark_all(pending, 'CFP_BPIX')
 
 
-def _run_outlier(field, config, filtname, n_processes, overwrite, status):
+def _run_outlier(field, config, filtname, n_processes, overwrite, status,
+                 tiles=None):
     cfg = get_nircam_step_config('outlier', config, field)
     implementation = cfg.get('implementation', 'jwst')
     if implementation not in ('jwst', 'campfire'):
@@ -400,11 +406,11 @@ def _run_outlier(field, config, filtname, n_processes, overwrite, status):
             f"expected 'jwst' or 'campfire'"
         )
     _run_outlier_per_visit(field, cfg, filtname, n_processes, overwrite, status,
-                           implementation=implementation)
+                           implementation=implementation, tiles=tiles)
 
 
 def _run_outlier_per_visit(field, cfg, filtname, n_processes, overwrite, status,
-                           implementation='jwst'):
+                           implementation='jwst', tiles=None):
     """Per-visit outlier dispatcher.
 
     Both implementations share the same orchestration (visit grouping,
@@ -440,7 +446,7 @@ def _run_outlier_per_visit(field, cfg, filtname, n_processes, overwrite, status,
     )
 
     # Combine phase: operate on the working copies, never the frozen canonical.
-    exposures = field.get_exposure_files(filtname, work=True)
+    exposures = field.get_exposure_files(filtname, work=True, tiles=tiles)
     if not exposures:
         log(f"outlier: no exposures for {filtname}")
         return
@@ -512,8 +518,11 @@ def _run_resample(field, config, filtname, n_processes, overwrite, status,
                   reduction_version, tiles=None):
     # Read the outlier-finished working copies; the mosaic itself is written to
     # the canonical filter dir (resample_step derives it from field.filter_dir).
+    # ``tiles`` both coarse-filters the input here and tells resample_step which
+    # tiles to drizzle (its own precise per-tile SCI-WCS selection narrows
+    # further within this set).
     exposures = field.get_exposure_files(filtname, with_step='CFP_OUT',
-                                         status=status, work=True)
+                                         status=status, work=True, tiles=tiles)
     if not exposures:
         log(f"resample: no CFP_OUT-stamped exposures for {filtname}")
         return
@@ -612,12 +621,18 @@ def _active_process_steps(config, field):
     return [(n, k) for n, k in PROCESS_STEPS if n not in ('wcs_shift', 'jhat')]
 
 
-def run_process(field, config, filters=None, n_processes=1, overwrite=False):
+def run_process(field, config, filters=None, n_processes=1, overwrite=False,
+                tiles=None):
     """Run all process-phase steps in order across each filter.
 
     Per-exposure steps run in parallel via ``dispatch``; the per-filter
     persistence step runs serially since it operates over the whole filter
     set at once.
+
+    ``tiles`` restricts the phase to exposures overlapping the named tile(s) —
+    ``detector1`` gates on the uncal ``S_REGION`` footprint, and every later
+    step inherits the resulting canonical subset — so a single tile can be
+    reduced without processing the whole field. ``None`` processes everything.
     """
     from campfire_pipeline.nircam.prefetch import prefetch_process_references
     filters = _resolve_filters(filters, field)
@@ -630,7 +645,7 @@ def run_process(field, config, filters=None, n_processes=1, overwrite=False):
         log(f"--- Process: {filt} ---")
         for step_name, _ in active_steps:
             _RUNNERS[step_name](field, config, filt, n_processes, overwrite,
-                                status)
+                                status, tiles=tiles)
 
 
 def _resolve_align_refcat(align_cfg, refcat_dir):
@@ -655,7 +670,8 @@ def _align_group_worker(key, members, *, refcat, config, overwrite, status):
                                 overwrite=overwrite, status=status)
 
 
-def run_align(field, config, filters=None, n_processes=1, overwrite=False):
+def run_align(field, config, filters=None, n_processes=1, overwrite=False,
+              tiles=None):
     """Field-level astrometric align phase (runs between process and combine).
 
     Groups all detectors of each exposure across the SW+LW filter dirs, ties
@@ -665,6 +681,9 @@ def run_align(field, config, filters=None, n_processes=1, overwrite=False):
     ``[<field>.align].enabled`` — a no-op otherwise, so ``run --all`` on a
     jhat-aligned field skips it and the process phase keeps running
     ``jhat``/``wcs_shift`` instead (decision D6).
+
+    ``tiles`` restricts to exposure groups overlapping the named tile(s)
+    (exposure-union, so each solved dither keeps its full detector complement).
     """
     filters = _resolve_filters(filters, field)
     align_cfg = get_nircam_step_config('align', config, field)
@@ -682,7 +701,7 @@ def run_align(field, config, filters=None, n_processes=1, overwrite=False):
         f"refcat={os.path.basename(refcat_path)} ({len(refcat)} sources) ===")
 
     status = _scan_status(field, filters, overwrite=overwrite)
-    groups = build_exposure_groups(field, filters)
+    groups = build_exposure_groups(field, filters, tiles=tiles)
     if not groups:
         log("align: no exposure groups found; nothing to do.")
         return
@@ -723,13 +742,16 @@ def run_combine(field, config, filters=None, n_processes=1, overwrite=False,
                 tiles=None):
     """Run all combine-phase steps in order across each filter.
 
-    ``tiles`` scopes the resample step *only* — the exposure/visit-level
-    ensemble steps (apply_mask, bad_pixel, outlier) always run over the full
-    exposure set for the filter. Restricting those to a tile subset would
-    truncate outlier's cross-visit median pool and bad_pixel's per-detector
-    stacks, so a tile built from a subset would not match the same tile built
-    with the whole field. They skip already-stamped exposures, so re-running
-    combine with ``--tiles`` after a full pass goes straight to resampling.
+    ``tiles`` scopes the *whole* combine phase to exposures overlapping the
+    named tile(s): apply_mask, bad_pixel, outlier, and resample all see only
+    the overlapping subset. This is what lets a single tile be combined without
+    touching the rest of the field (e.g. an A/B reduction), and it pairs with a
+    tile-scoped ``run_process``/``run_align`` that only ever produced the subset
+    canonicals. **Caveat:** restricting the ensemble steps truncates outlier's
+    cross-visit median pool and bad_pixel's per-detector stacks, so a
+    tile-scoped mosaic may differ at tile boundaries from the same tile built
+    with the whole field — a tile-scoped run is a distinct input set by design.
+    ``None`` (the default) runs the full field and is unchanged.
     """
     filters = _resolve_filters(filters, field)
     reduction_version = _resolve_reduction_version(config)
@@ -746,14 +768,14 @@ def run_combine(field, config, filters=None, n_processes=1, overwrite=False,
                 # mutate (copy canonical -> work where stale, fuse CFMASK ->
                 # DO_NOT_USE) and rescan them into the status cache.
                 _RUNNERS[step_name](field, config, filt, n_processes,
-                                    overwrite, status)
+                                    overwrite, status, tiles=tiles)
                 field.materialize_work(filt, status=status, overwrite=overwrite)
             elif step_name == 'resample':
                 _run_resample(field, config, filt, n_processes, overwrite,
                               status, reduction_version, tiles=tiles)
             else:
                 _RUNNERS[step_name](field, config, filt, n_processes, overwrite,
-                                    status)
+                                    status, tiles=tiles)
 
 
 def run_step(step_name, field, config, filters=None, n_processes=1,
@@ -761,8 +783,10 @@ def run_step(step_name, field, config, filters=None, n_processes=1,
     """Run a single named step across the field's filters.
 
     Used by the per-step CLI commands (``cfpipe nircam <step>``). ``tiles``
-    is only meaningful for ``resample`` (it scopes which mosaics are built)
-    and is ignored by every other step.
+    restricts the step to exposures overlapping the named tile(s); for
+    ``resample`` it additionally scopes which mosaics are built. The per-step
+    CLI commands other than ``resample`` don't expose ``--tiles``, so they pass
+    ``None`` and run over the full field.
     """
     if step_name not in STEP_NAMES:
         raise ValueError(
@@ -788,4 +812,4 @@ def run_step(step_name, field, config, filters=None, n_processes=1,
                           status, reduction_version, tiles=tiles)
         else:
             _RUNNERS[step_name](field, config, filt, n_processes, overwrite,
-                                status)
+                                status, tiles=tiles)

--- a/pipeline/tests/test_ab_astrometry.py
+++ b/pipeline/tests/test_ab_astrometry.py
@@ -1,0 +1,76 @@
+"""Tests for the A/B astrometry driver (scripts/nircam_ab_astrometry.py).
+
+Exercises the pure ``run_ab`` core (the three-way comparison over in-memory
+catalogs) with a synthetic reference and two arms carrying known injected
+offsets, so it needs no mosaics or SEP extraction. The mosaic→catalog half is
+already covered by the refcat extract tests.
+"""
+
+import importlib.util
+import os
+
+import astropy.units as u
+import numpy as np
+import pytest
+from astropy.table import Table
+
+_SCRIPT = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    'scripts', 'nircam_ab_astrometry.py',
+)
+
+
+@pytest.fixture(scope='module')
+def ab():
+    spec = importlib.util.spec_from_file_location('nircam_ab_astrometry', _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _grid(n=5, ra0=150.0, dec0=2.1, step=0.002):
+    ra, dec = np.meshgrid(np.arange(n) * step + ra0,
+                          np.arange(n) * step + dec0)
+    return Table({'RA': ra.ravel(), 'DEC': dec.ravel(),
+                  'mag': np.full(ra.size, 22.0),
+                  'mag_err': np.full(ra.size, 0.1)})
+
+
+def _offset_dec(cat, mas):
+    out = cat.copy()
+    out['DEC'] = out['DEC'] + mas / 3.6e6  # mas → deg
+    return out
+
+
+def test_run_ab_recovers_injected_offsets(ab):
+    cat_ref = _grid()
+    cat_jhat = _offset_dec(cat_ref, 100.0)   # +100 mas in Dec vs reference
+    cat_align = _offset_dec(cat_ref, 20.0)    # +20 mas in Dec vs reference
+
+    result = ab.run_ab(cat_jhat, cat_align, cat_ref,
+                       match_radius=0.5 * u.arcsec)
+
+    assert set(result) == {'jhat_vs_align', 'jhat_vs_ref', 'align_vs_ref'}
+    for r in result.values():
+        assert r['n_matched'] == len(cat_ref)
+        for k in ('dra_stats', 'ddec_stats', 'sep_stats'):
+            assert set(r[k]) == {'mean', 'median', 'mad'}
+
+    # Absolute Dec residuals recover the injections; align is the tighter arm.
+    assert result['jhat_vs_ref']['ddec_stats']['median'] == pytest.approx(100.0,
+                                                                          abs=1)
+    assert result['align_vs_ref']['ddec_stats']['median'] == pytest.approx(20.0,
+                                                                           abs=1)
+    # Method-to-method: jhat is +80 mas in Dec relative to align.
+    assert result['jhat_vs_align']['ddec_stats']['median'] == pytest.approx(80.0,
+                                                                            abs=1)
+
+
+def test_summarize_strips_arrays(ab):
+    cat_ref = _grid()
+    result = ab.run_ab(cat_ref, cat_ref, cat_ref)
+    summary = ab.summarize(result)
+    for pairing in result:
+        keys = set(summary[pairing])
+        assert 'dra_mas' not in keys and 'sep_mas' not in keys
+        assert {'n_matched', 'dra_stats', 'ddec_stats', 'sep_stats'} <= keys

--- a/pipeline/tests/test_tile_filter.py
+++ b/pipeline/tests/test_tile_filter.py
@@ -1,0 +1,225 @@
+"""Tests for the ``--tiles`` exposure pre-filter (Phase 8).
+
+Covers the ``S_REGION``-based coarse overlap gate that lets ``process`` /
+``align`` / ``combine`` reduce a single tile without touching the rest of the
+field:
+
+- ``geometry`` primitives: ``polygon_from_sregion``, ``read_sregion_polygon``,
+  ``select_overlapping_by_sregion`` (per-file + exposure-union + fail-open),
+  ``tiles_union_polygon`` (buffer + unknown-tile error), ``filter_exposures_to_tiles``.
+- ``Field.get_exposure_files(tiles=)`` / ``Field.get_uncal_files(tiles=)`` and
+  ``build_exposure_groups(tiles=)`` end-to-end on real FITS carrying ``S_REGION``.
+- CLI wiring: ``--tiles`` on ``process``/``align`` and the relaxed ``run`` guard.
+
+Everything here is pure (astropy FITS + shapely) — no CRDS / jwst / assign_wcs.
+"""
+
+import os
+
+import numpy as np
+import pytest
+from astropy.io import fits
+from shapely.geometry import Point, Polygon
+
+from campfire_pipeline.nircam import geometry as g
+from campfire_pipeline.nircam.association import build_exposure_groups, exposure_key
+from campfire_pipeline.nircam.field import Field
+
+# Tile A4 (test): a small square 150.0..150.2 / 2.0..2.2 (deg), explicit corners.
+_A4_CORNERS = [[150.0, 2.0], [150.2, 2.0], [150.2, 2.2], [150.0, 2.2]]
+# An S_REGION footprint fully inside A4, and one far away.
+_SR_IN = 'POLYGON ICRS 150.05 2.05 150.06 2.05 150.06 2.06 150.05 2.06'
+_SR_OUT = 'POLYGON ICRS 151.00 3.00 151.01 3.00 151.01 3.01 151.00 3.01'
+
+_TOKEN = 'jw01727028001_04101_00003'
+
+
+def _write_fits(path, s_region=None, on_primary=False):
+    """A minimal 2-HDU FITS (Primary + SCI) with an optional S_REGION."""
+    prim = fits.PrimaryHDU()
+    sci = fits.ImageHDU(data=np.zeros((2, 2), dtype='f4'), name='SCI')
+    if s_region is not None:
+        (prim.header if on_primary else sci.header)['S_REGION'] = s_region
+    fits.HDUList([prim, sci]).writeto(path, overwrite=True)
+    return path
+
+
+def _make_field(tmp_path, filters=('f200w', 'f444w'), tiles=None):
+    f = Field(name='cosmos', filters=list(filters), files=['jw01727*'],
+              tangent_point=(150.1, 2.1),
+              tiles=tiles if tiles is not None else {'A4': {'corners': _A4_CORNERS}})
+    f.setup_workspace(campfire_root=str(tmp_path))
+    return f
+
+
+# --- polygon_from_sregion ---------------------------------------------------
+
+def test_polygon_from_sregion_valid():
+    poly = g.polygon_from_sregion(_SR_IN)
+    assert isinstance(poly, Polygon) and poly.area > 0
+
+
+@pytest.mark.parametrize('s', ['', None, 'POLYGON ICRS 150.0',
+                               'POLYGON ICRS 150.0 2.0 150.1 2.0',  # 2 verts
+                               'garbage tokens here x y'])
+def test_polygon_from_sregion_bad_returns_none(s):
+    assert g.polygon_from_sregion(s) is None
+
+
+# --- read_sregion_polygon ---------------------------------------------------
+
+def test_read_sregion_polygon_sci_and_primary(tmp_path):
+    p_sci = _write_fits(str(tmp_path / 'sci.fits'), _SR_IN)
+    p_prim = _write_fits(str(tmp_path / 'prim.fits'), _SR_IN, on_primary=True)
+    assert g.read_sregion_polygon(p_sci) is not None
+    assert g.read_sregion_polygon(p_prim) is not None
+
+
+def test_read_sregion_polygon_missing_and_unreadable(tmp_path):
+    p_none = _write_fits(str(tmp_path / 'nosr.fits'), s_region=None)
+    assert g.read_sregion_polygon(p_none) is None
+    # An empty / non-FITS file → OSError → None (fail-open signal).
+    bad = tmp_path / 'empty.fits'
+    bad.write_text('')
+    assert g.read_sregion_polygon(str(bad)) is None
+
+
+# --- select_overlapping_by_sregion ------------------------------------------
+
+def _polys_map(mapping):
+    """Patch read_sregion_polygon to a dict keyed by basename."""
+    def _read(path):
+        return mapping[os.path.basename(path)]
+    return _read
+
+
+def test_select_overlapping_per_file(monkeypatch):
+    tile = Polygon([(150.0, 2.0), (150.2, 2.0), (150.2, 2.2), (150.0, 2.2)])
+    inside = g.polygon_from_sregion(_SR_IN)
+    outside = g.polygon_from_sregion(_SR_OUT)
+    monkeypatch.setattr(g, 'read_sregion_polygon', _polys_map({
+        'in.fits': inside, 'out.fits': outside, 'noneknown.fits': None,
+    }))
+    files = ['in.fits', 'out.fits', 'noneknown.fits']
+    # per-file: keep the overlapping one + the fail-open (None) one.
+    assert g.select_overlapping_by_sregion(files, tile) == ['in.fits',
+                                                            'noneknown.fits']
+
+
+def test_select_overlapping_exposure_union(monkeypatch):
+    tile = Polygon([(150.0, 2.0), (150.2, 2.0), (150.2, 2.2), (150.0, 2.2)])
+    inside = g.polygon_from_sregion(_SR_IN)
+    outside = g.polygon_from_sregion(_SR_OUT)
+    # jw1 has one in-tile detector + one out; jw2 fully out; jw3 fail-open.
+    monkeypatch.setattr(g, 'read_sregion_polygon', _polys_map({
+        'jw1_nrca1.fits': inside, 'jw1_nrca2.fits': outside,
+        'jw2_nrca1.fits': outside, 'jw3_nrca1.fits': None,
+    }))
+    files = ['jw1_nrca1.fits', 'jw1_nrca2.fits', 'jw2_nrca1.fits',
+             'jw3_nrca1.fits']
+    sel = g.select_overlapping_by_sregion(files, tile, key_fn=exposure_key)
+    # union: both jw1 detectors kept (dither straddles the edge), jw3 fail-open,
+    # jw2 dropped.
+    assert set(sel) == {'jw1_nrca1.fits', 'jw1_nrca2.fits', 'jw3_nrca1.fits'}
+
+
+# --- tiles_union_polygon ----------------------------------------------------
+
+def test_tiles_union_polygon_buffer(tmp_path):
+    f = _make_field(tmp_path)
+    raw = Polygon(f.get_tile_corners('A4'))
+    buffered = g.tiles_union_polygon(f, ['A4'], buffer_deg=0.01)
+    just_outside = Point(150.0 - 0.005, 2.1)  # 0.005 deg left of the edge
+    assert not raw.contains(just_outside)
+    assert buffered.contains(just_outside)
+
+
+def test_tiles_union_polygon_unknown_tile(tmp_path):
+    f = _make_field(tmp_path)
+    with pytest.raises(ValueError):
+        g.tiles_union_polygon(f, ['ZZ'])
+
+
+def test_tiles_union_polygon_accepts_string(tmp_path):
+    f = _make_field(tmp_path)
+    assert g.tiles_union_polygon(f, 'A4').area > 0
+
+
+# --- Field enumerators + build_exposure_groups ------------------------------
+
+def test_get_exposure_files_tiles(tmp_path):
+    f = _make_field(tmp_path)
+    # Two SW detectors of one dither (one on-tile, one off) + a fully-off dither.
+    on = _write_fits(os.path.join(f.filter_dir('f200w'),
+                                  f'{_TOKEN}_nrca1.fits'), _SR_IN)
+    edge = _write_fits(os.path.join(f.filter_dir('f200w'),
+                                    f'{_TOKEN}_nrca2.fits'), _SR_OUT)
+    _write_fits(os.path.join(f.filter_dir('f200w'),
+                             'jw01727028001_04101_00099_nrca1.fits'), _SR_OUT)
+
+    kept = f.get_exposure_files('f200w', tiles=['A4'])
+    # Exposure-union: both detectors of the on-tile dither survive; the
+    # fully-off dither is dropped.
+    assert set(kept) == {on, edge}
+    # No tiles → everything.
+    assert len(f.get_exposure_files('f200w')) == 3
+
+
+def test_get_uncal_files_tiles(tmp_path):
+    f = _make_field(tmp_path)
+    raw_dir = os.path.join(f.raw_root, '1727', 'f200w')
+    os.makedirs(raw_dir, exist_ok=True)
+    on = _write_fits(os.path.join(raw_dir, f'{_TOKEN}_nrca1_uncal.fits'), _SR_IN)
+    _write_fits(os.path.join(raw_dir,
+                             'jw01727028001_04101_00099_nrca1_uncal.fits'),
+                _SR_OUT)
+    kept = f.get_uncal_files('f200w', tiles=['A4'])
+    assert kept == [on]
+    assert len(f.get_uncal_files('f200w')) == 2
+
+
+def test_build_exposure_groups_tiles(tmp_path):
+    f = _make_field(tmp_path)
+    for det in ('nrca1', 'nrca2', 'nrca3', 'nrca4'):
+        _write_fits(os.path.join(f.filter_dir('f200w'),
+                                 f'{_TOKEN}_{det}.fits'), _SR_IN)
+    _write_fits(os.path.join(f.filter_dir('f444w'),
+                             f'{_TOKEN}_nrcalong.fits'), _SR_IN)
+    # A second dither entirely off-tile.
+    _write_fits(os.path.join(f.filter_dir('f200w'),
+                             'jw01727028001_04101_00099_nrca1.fits'), _SR_OUT)
+
+    groups = build_exposure_groups(f, tiles=['A4'])
+    assert [gr.key for gr in groups] == [_TOKEN]
+    assert groups[0].n_members == 5
+
+
+# --- CLI wiring -------------------------------------------------------------
+
+def test_cli_process_align_have_tiles():
+    from click.testing import CliRunner
+    from campfire_pipeline.nircam.cli import main
+    runner = CliRunner()
+    for cmd in ('process', 'align'):
+        out = runner.invoke(main, [cmd, '--help'])
+        assert out.exit_code == 0
+        assert '--tiles' in out.output
+
+
+def test_cli_run_tiles_allowed_with_process(monkeypatch):
+    from click.testing import CliRunner
+    import campfire_pipeline.nircam.cli as cli
+
+    calls = {}
+    monkeypatch.setattr(cli, '_setup', lambda c, f: ({}, object()))
+    monkeypatch.setattr(cli, '_resolve_filters', lambda flt, fo: ['f200w'])
+    monkeypatch.setattr(cli, 'run_process',
+                        lambda *a, **k: calls.setdefault('tiles', k.get('tiles')))
+    monkeypatch.setattr(cli, 'run_align', lambda *a, **k: None)
+    monkeypatch.setattr(cli, 'run_combine', lambda *a, **k: None)
+
+    out = CliRunner().invoke(
+        cli.main, ['run', '--field', 'cosmos', '--process', '--tiles', 'A4'])
+    # The old "only combine" guard is gone; --tiles reaches run_process.
+    assert out.exit_code == 0, out.output
+    assert calls['tiles'] == ['A4']

--- a/scripts/nircam_ab_astrometry.py
+++ b/scripts/nircam_ab_astrometry.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python
+"""A/B astrometry comparison for NIRCam mosaics: ``jhat`` vs ``align``.
+
+Given a JHAT-aligned mosaic and an ``align``-aligned mosaic for the same
+field/filter/tile, this extracts a comparable source catalog from each and
+cross-matches them (a) to each other and (b) to an absolute reference catalog
+(for COSMOS that is ``cosmos2025_v1_refcat.ecsv`` — the very ECSV both methods
+tie to). It reports ΔRA/ΔDec/separation in milliarcseconds (mean/median/MAD)
+and writes 2D-histogram QA figures, so you can read off *which method achieves
+the tighter tie to the reference* and *how much the two methods disagree*.
+
+This is a thin orchestrator over existing pipeline building blocks:
+``refcat.extract.extract_from_mosaic`` (mosaic → RA/DEC/mag catalog via SEP),
+``refcat.io.read_refcat`` (loads + column-canonicalizes the reference), and
+``refcat.compare.compare_catalogs`` / ``plot_comparison`` (the mas-residual
+comparator + figure).
+
+Example
+-------
+    python scripts/nircam_ab_astrometry.py \\
+        --ref  $CAMPFIRE_ROOT/reference/nircam/cosmos/astrom_cats/cosmos2025_v1_refcat.ecsv \\
+        --out  $CAMPFIRE_ROOT/products/nircam/ab_astrometry_A4 \\
+        --case f200w .../cosmos/f200w/mosaic_nircam_f200w_cosmos_30mas_A4_i2d.fits \\
+                     .../cosmos_align/f200w/mosaic_nircam_f200w_cosmos_align_30mas_A4_i2d.fits \\
+        --case f356w .../cosmos/f356w/mosaic_nircam_f356w_cosmos_30mas_A4_i2d.fits \\
+                     .../cosmos_align/f356w/mosaic_nircam_f356w_cosmos_align_30mas_A4_i2d.fits
+
+Produces, in ``--out``: ``<filter>_{jhat_vs_align,jhat_vs_ref,align_vs_ref}.png``
+and a machine-readable ``ab_astrometry_summary.json``.
+"""
+
+import argparse
+import json
+import os
+
+import astropy.units as u
+
+# Which pairings to compute, and their display labels (a, b).
+_PAIRINGS = {
+    'jhat_vs_align': ('jhat', 'align'),
+    'jhat_vs_ref': ('jhat', 'ref'),
+    'align_vs_ref': ('align', 'ref'),
+}
+
+
+def run_ab(cat_jhat, cat_align, cat_ref, *, match_radius=0.5 * u.arcsec):
+    """Three-way astrometric comparison of the two arms and the reference.
+
+    ``cat_jhat`` / ``cat_align`` / ``cat_ref`` are tables with ``RA``/``DEC``
+    (deg). Returns ``{pairing: compare_catalogs(...) dict}`` for
+    ``jhat_vs_align``, ``jhat_vs_ref``, ``align_vs_ref`` — pure and in-memory,
+    so it is unit-testable without any mosaics.
+    """
+    from campfire_pipeline.nircam.refcat.compare import compare_catalogs
+    return {
+        'jhat_vs_align': compare_catalogs(cat_jhat, cat_align,
+                                          match_radius=match_radius),
+        'jhat_vs_ref': compare_catalogs(cat_jhat, cat_ref,
+                                        match_radius=match_radius),
+        'align_vs_ref': compare_catalogs(cat_align, cat_ref,
+                                         match_radius=match_radius),
+    }
+
+
+def summarize(result):
+    """Strip the big per-pair arrays, keeping counts + stats for JSON output."""
+    out = {}
+    for pairing, r in result.items():
+        out[pairing] = {
+            'n_matched': r['n_matched'],
+            'n_a': r['n_a'],
+            'n_b': r['n_b'],
+            'match_radius_arcsec': r['match_radius_arcsec'],
+            'dra_stats': r['dra_stats'],
+            'ddec_stats': r['ddec_stats'],
+            'sep_stats': r['sep_stats'],
+        }
+    return out
+
+
+def _fmt(stats, key):
+    return f"{stats[key]:7.1f}" if stats else "     --"
+
+
+def print_case(filt, result):
+    """Print the headline A/B table for one filter to stdout."""
+    print(f"\n=== {filt} ===  (residuals in mas; abs = vs reference catalog)")
+    print(f"  {'arm':<6} {'N':>5}  {'med|sep|':>8}  "
+          f"{'med dRA':>8}  {'med dDec':>8}  {'MAD dRA':>8}  {'MAD dDec':>8}")
+    for arm, pairing in (('jhat', 'jhat_vs_ref'), ('align', 'align_vs_ref')):
+        r = result[pairing]
+        print(f"  {arm:<6} {r['n_matched']:>5}  "
+              f"{_fmt(r['sep_stats'], 'median')}  "
+              f"{_fmt(r['dra_stats'], 'median')}  "
+              f"{_fmt(r['ddec_stats'], 'median')}  "
+              f"{_fmt(r['dra_stats'], 'mad')}  "
+              f"{_fmt(r['ddec_stats'], 'mad')}")
+    ja = result['jhat_vs_align']
+    js = ja['sep_stats']
+    print(f"  jhat<->align: N={ja['n_matched']}  "
+          f"med|sep|={_fmt(js, 'median')} mas  "
+          f"med(dRA)={_fmt(ja['dra_stats'], 'median')}  "
+          f"med(dDec)={_fmt(ja['ddec_stats'], 'median')}")
+
+
+def _extract(mosaic_path, **kw):
+    from campfire_pipeline.nircam.refcat.extract import extract_from_mosaic
+    table, _info = extract_from_mosaic(mosaic_path, **kw)
+    return table
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description="A/B astrometry: jhat vs align mosaics, cross-matched to "
+                    "each other and to an absolute reference catalog.")
+    ap.add_argument('--ref', required=True,
+                    help="Absolute reference catalog ECSV (e.g. "
+                         "cosmos2025_v1_refcat.ecsv). Loaded via read_refcat, "
+                         "so aliased RA/Dec column names are accepted.")
+    ap.add_argument('--out', required=True,
+                    help="Output directory for QA figures + summary JSON.")
+    ap.add_argument('--case', nargs=3, action='append', required=True,
+                    metavar=('FILTER', 'JHAT_MOSAIC', 'ALIGN_MOSAIC'),
+                    help="A (filter, jhat mosaic, align mosaic) triple. "
+                         "Repeatable, one per filter.")
+    ap.add_argument('--match-radius', type=float, default=0.5,
+                    help="Cross-match radius in arcsec (default 0.5).")
+    ap.add_argument('--snr-min', type=float, default=10.0,
+                    help="Lower SNR cut for source extraction (default 10).")
+    ap.add_argument('--mag-min', type=float, default=None,
+                    help="Optional bright AB-mag cut for extracted sources.")
+    ap.add_argument('--mag-max', type=float, default=None,
+                    help="Optional faint AB-mag cut for extracted sources.")
+    args = ap.parse_args(argv)
+
+    from campfire_pipeline.nircam.refcat.compare import plot_comparison
+    from campfire_pipeline.nircam.refcat.io import read_refcat
+
+    os.makedirs(args.out, exist_ok=True)
+    cat_ref = read_refcat(args.ref)
+    match_radius = args.match_radius * u.arcsec
+    mag_range = None
+    if args.mag_min is not None or args.mag_max is not None:
+        mag_range = (args.mag_min if args.mag_min is not None else -99.0,
+                     args.mag_max if args.mag_max is not None else 99.0)
+    extract_kw = dict(snr_min=args.snr_min, mag_range=mag_range)
+
+    combined = {}
+    for filt, jhat_mosaic, align_mosaic in args.case:
+        cat_jhat = _extract(jhat_mosaic, **extract_kw)
+        cat_align = _extract(align_mosaic, **extract_kw)
+        result = run_ab(cat_jhat, cat_align, cat_ref, match_radius=match_radius)
+
+        for pairing, (name_a, name_b) in _PAIRINGS.items():
+            plot_comparison(
+                result[pairing],
+                name_a=f"{name_a} {filt}", name_b=name_b,
+                save_path=os.path.join(args.out, f"{filt}_{pairing}.png"))
+
+        combined[filt] = summarize(result)
+        print_case(filt, result)
+
+    summary_path = os.path.join(args.out, 'ab_astrometry_summary.json')
+    with open(summary_path, 'w') as fh:
+        json.dump(combined, fh, indent=2)
+    print(f"\nWrote {summary_path} and QA figures to {args.out}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## `--tiles` exposure pre-filter + `align`-vs-`jhat` A/B harness

Sets up a **proper A/B validation** of the new NIRCam `align` phase against legacy `jhat` on one COSMOS tile — decision D6's empirical gate before `align` can replace `jhat`. The blocker was cost: producing an align-arm A4 mosaic today means running `process → align → combine` over the *entire* COSMOS field, twice (once per arm). This PR fixes that and adds the comparison tooling.

### 1. `--tiles` now pre-filters `process` / `align` / `combine` (not just `resample`)
`--tiles` previously scoped only which mosaics `resample` drizzled; every earlier step ran over the full field. Now it restricts each phase to exposures overlapping the named tile(s), so a single tile can be reduced without touching the rest of the field.

- **The pre-WCS problem, solved with `S_REGION`.** `process` starts at `detector1` on raw `_uncal` files, which have no assigned WCS — so `geometry.select_overlapping_files` (SCI-WCS-based) can't gate them. But NIRCam uncals already carry the SDP footprint polygon `S_REGION` (the same keyword `expmap.py` already parses). New `nircam/geometry.py` helpers gate on it: `polygon_from_sregion`, `read_sregion_polygon`, `select_overlapping_by_sregion`, `tiles_union_polygon`, `filter_exposures_to_tiles`. No `pysiaf`, no assign_wcs, no CRDS.
- **Conservative + safe:** exposure-union semantics (a dither straddling a tile edge keeps its full detector complement, so `align` pooling stays complete); the tile polygon is buffered ~11″ so the coarse gate is a superset of resample's precise per-tile SCI-WCS selection; missing/blank `S_REGION` **fails open** (kept, never silently dropped).
- **Threaded** through `Field.get_uncal_files`/`get_exposure_files`, `build_exposure_groups`, every `_run_*` runner, and `run_process`/`run_align`/`run_combine`/`run_step`; `--tiles` added to the `process` and `align` CLI commands and the `run` guard relaxed.

**Default (no `--tiles`) runs are byte-identical.** A tile-scoped run restricts `outlier`/`bad_pixel` to the overlapping subset, so tile-edge pixels may differ from a full-field pass — expected, since a tile-scoped run is a distinct input set. Categorized **Infrastructure** (the canonical full-field reduction is unchanged); the caveat is noted in the changelog.

### 2. A/B comparison driver — `scripts/nircam_ab_astrometry.py`
A thin orchestrator over existing refcat tooling (`extract_from_mosaic` + `read_refcat` + `compare_catalogs`/`plot_comparison`). Per filter it extracts a comparable catalog from the jhat and align mosaics and cross-matches them (a) to each other and (b) to the absolute reference — for COSMOS that's `cosmos2025_v1_refcat.ecsv`, the very ECSV both methods tie to — reporting ΔRA/ΔDec/sep in mas (median/MAD) + 2D-histogram QA figures. The pure `run_ab(cat_jhat, cat_align, cat_ref)` core is unit-tested.

### Run recipe (on the reduction machine, collision-free)
Both arms run the **same** `--tiles A4` subset in isolated field trees so the only difference is the alignment method:
```
# fields.toml: keep [cosmos] (jhat); add [cosmos_align] (same files/tile) with
#   [cosmos_align.align] enabled=true, refcat="cosmos2025_v1_refcat.ecsv"
cfpipe nircam run --all --field cosmos       --filters f200w f356w --tiles A4 -p N   # jhat arm
cfpipe nircam run --all --field cosmos_align --filters f200w f356w --tiles A4 -p N   # align arm
python scripts/nircam_ab_astrometry.py --ref .../cosmos2025_v1_refcat.ecsv --out .../ab_A4 \
  --case f200w <cosmos jhat i2d> <cosmos_align i2d>  --case f356w <...> <...>
```

### Testing
- `tests/test_tile_filter.py` — geometry primitives (parse/read/overlap/union/buffer/fail-open), `Field.get_exposure_files`/`get_uncal_files(tiles=)`, `build_exposure_groups(tiles=)`, CLI wiring (`--tiles` on process/align, relaxed `run` guard). Pure FITS + shapely, no CRDS/jwst.
- `tests/test_ab_astrometry.py` — `run_ab` recovers injected offsets on synthetic catalogs.
- **66 passed** (new + regressions: association, align_run/apply, cfp, nircam_exclusions); real CLI `--help` for `process`/`align`/`run` all show `--tiles`.

### Scope boundary (tracked follow-ups)
Deploy/web `CFP_ALGN` provenance mirrors; overlap-residual diagnostics (D3); the `align`-replaces-`jhat` PR — all land *after* this A/B validates on ≥2 fields.

Generated with Claude Code
