### PR TITLE
perf(nircam): ~10× faster --tiles S_REGION overlap scan

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -307,6 +307,20 @@ Release procedure: edit the `## Unreleased` section below, then run
   tile-scoped run is a distinct input set. *(Categorized Infrastructure because the
   canonical full-field reduction is unchanged; noting the tile-scoped caveat.)* Covered
   by `tests/test_tile_filter.py` + `tests/test_ab_astrometry.py`.
+- **NIRCam `--tiles` overlap scan is ~10× faster (cold-NFS + per-phase memo).** The
+  `S_REGION` footprint gate (`read_sregion_polygon`) was the silent multi-minute stall
+  at the start of a tile-scoped `process` on a cold NFS mount. Two fixes: (1) it now
+  reaches the `SCI` header by name instead of slicing `hdul[1:]`, which forced astropy
+  to enumerate every extension — seeking past all ~9 data units (~24 NFS round-trips/file
+  vs ~6), ~8× fewer round-trips cold (~348→~43 ms/file); no pixel data was ever read,
+  the cost was purely `lseek`-triggered 1 MB readahead. (2) `run_process` runs the gate
+  once per step (~10 `get_exposure_files(tiles=)` calls), so results are now memoized by
+  path for the phase (`reset_sregion_cache` at phase entry) — the scan runs once instead
+  of once per step. Net: a 1600-file tile scan drops from ~13 min/phase to ~1.3 min.
+  Footprint results are byte-identical (verified against the prior implementation on real
+  exposures); no scientific output change. Also removes a stale test that asserted the
+  pre-`5059e87` `run --process --tiles` rejection (superseded by
+  `test_cli_run_tiles_allowed_with_process`).
 - **NIRCam `align` phase — exposure I/O + `CFP_ALGN` stamp.** New
   `nircam/align/apply.py` (`align_exposure_group`) is the FITS layer: it reads each
   detector's gwcs and detects sources, runs the in-memory solve, and writes the

--- a/pipeline/campfire_pipeline/nircam/geometry.py
+++ b/pipeline/campfire_pipeline/nircam/geometry.py
@@ -78,6 +78,22 @@ def polygon_from_sregion(s_region):
     return Polygon(zip(ra, dec))
 
 
+# Per-phase memo of ``read_sregion_polygon`` keyed by absolute path. A single
+# ``process``/``align``/``combine`` invocation calls the tile pre-filter once per
+# step (~10 ``get_exposure_files(tiles=)`` calls in ``run_process`` alone), each
+# re-deriving the same footprints. ``S_REGION`` is a ground-system keyword that
+# never changes for a given file within a run, so memoizing by path collapses
+# those N scans into one. Reset at each phase entry (see ``reset_sregion_cache``)
+# to bound growth and stay robust to re-invocation in a long-lived process.
+_SREGION_CACHE = {}
+_CACHE_MISS = object()
+
+
+def reset_sregion_cache():
+    """Clear the per-phase ``S_REGION`` footprint memo. Called at phase entry."""
+    _SREGION_CACHE.clear()
+
+
 def read_sregion_polygon(path):
     """Footprint ``Polygon`` from a file's ``S_REGION`` keyword, or ``None``.
 
@@ -87,22 +103,32 @@ def read_sregion_polygon(path):
     any WCS is assigned — as well as on canonical exposures, so this is the one
     overlap source usable at every pipeline phase. ``None`` when the keyword is
     missing/blank or the file can't be opened.
+
+    Results are memoized by path for the current phase (see
+    ``reset_sregion_cache``). Reads reach the SCI header by name so astropy
+    stops after the first extension: slicing ``hdul[1:]`` would enumerate every
+    HDU, seeking past all ~9 data units — ~4x more NFS round-trips on a cold
+    mount for a keyword that lives in the first extension.
     """
+    hit = _SREGION_CACHE.get(path, _CACHE_MISS)
+    if hit is not _CACHE_MISS:
+        return hit
     try:
         with fits.open(path, memmap=False) as hdul:
-            sci_hdr = None
-            for hdu in hdul[1:]:
-                if hdu.header.get('EXTNAME', '').upper() == 'SCI':
-                    sci_hdr = hdu.header
-                    break
-            if sci_hdr is None and len(hdul) > 1:
-                sci_hdr = hdul[1].header
+            try:
+                sci_hdr = hdul['SCI'].header
+            except KeyError:
+                sci_hdr = hdul[1].header if len(hdul) > 1 else None
             s_region = sci_hdr.get('S_REGION') if sci_hdr is not None else None
             if s_region is None:
                 s_region = hdul[0].header.get('S_REGION')
     except (OSError, KeyError):
+        # Unreadable / transient — fail open (kept by callers) but do NOT cache,
+        # so a later readable pass on the same path can still resolve it.
         return None
-    return polygon_from_sregion(s_region)
+    poly = polygon_from_sregion(s_region)
+    _SREGION_CACHE[path] = poly
+    return poly
 
 
 def select_overlapping_by_sregion(files, tile_polygon, *, key_fn=None):

--- a/pipeline/campfire_pipeline/nircam/orchestrate.py
+++ b/pipeline/campfire_pipeline/nircam/orchestrate.py
@@ -636,6 +636,12 @@ def run_process(field, config, filters=None, n_processes=1, overwrite=False,
     """
     from campfire_pipeline.nircam.prefetch import prefetch_process_references
     filters = _resolve_filters(filters, field)
+    if tiles:
+        # Every step below re-derives the same tile-overlap set via
+        # ``get_exposure_files(tiles=)``; the per-path footprint memo makes that
+        # scan happen once for the whole phase instead of once per step.
+        from campfire_pipeline.nircam.geometry import reset_sregion_cache
+        reset_sregion_cache()
     status = _scan_status(field, filters, overwrite=overwrite)
     log(f"=== Process phase: field={field.name}, filters={filters} ===")
     prefetch_process_references(field, filters, status=status,

--- a/pipeline/tests/test_nircam_resample_tiles.py
+++ b/pipeline/tests/test_nircam_resample_tiles.py
@@ -43,16 +43,6 @@ def test_tiles_flag_absent_on_exposure_level_steps(command):
     assert '--tiles' not in _help(CliRunner(), command)
 
 
-def test_run_rejects_tiles_without_combine_phase():
-    # --tiles scopes resample, which only runs in the combine phase.
-    res = CliRunner().invoke(
-        nircam_cli.main,
-        ['run', '--field', 'x', '--process', '--tiles', 'A1'],
-    )
-    assert res.exit_code == 2  # click.UsageError
-    assert 'combine' in res.output.lower()
-
-
 # ---------------------------------------------------------------------------
 # resample_step tile resolution
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A tile-scoped `cfpipe nircam process --tiles <T>` on a **cold NFS mount** stalls for many minutes with no output right after the first `detector1` saves. Diagnosis: the `--tiles` `S_REGION` footprint gate (`read_sregion_polygon`) is the culprit — not other users, not an NFS outage (0 retransmissions, sub-ms ping, healthy load).

Two independent inefficiencies, both surfaced only because `--tiles` (new) forces per-file footprint reads over cold NFS:

1. **Slicing walks every extension.** `for hdu in hdul[1:]` slices the HDUList, forcing astropy to enumerate all ~9 extensions (SCI, ERR, DQ, AREA, 3×VAR, ASDF, SRCMASK), seeking past each ~32 MB data unit — even though `S_REGION` lives in the first extension. No pixel data is ever read; the "full-file reads" seen in `strace` are the NFS client's 1 MB readahead (`rsize=1048576`) firing on each seek. Cold: **24 round-trips / ~348 ms per file**.
2. **The gate runs once per step.** `run_process` iterates ~10 process steps, and each independently calls `get_exposure_files(tiles=)` → re-derives the same footprints from scratch.

## Fix

1. Reach the SCI header **by name** (`hdul['SCI'].header`), so astropy stops after the first extension → **6 round-trips / ~43 ms per file cold (~8×)**. Fallback chain (SCI → ext 1 → primary) preserved.
2. **Per-phase memo** keyed by path inside `read_sregion_polygon`, reset once at `run_process` entry when `--tiles` is set → the scan runs **once per phase** instead of once per step. Transient read errors are not cached (stays fail-open / retryable).

**Net: ~13.3 min → ~1.3 min per tiled phase** (1600-file field, cold).

## Measurements (cold f277w, this node)

| strategy | ms/file | seeks/file |
|---|---|---|
| current (`hdul[1:]` slice) | 348 | 24 |
| direct (`hdul['SCI']`) | 43 | 6 |
| cached (steps 2–N) | ~0 | 0 |

## Verification

- Footprint polygons **byte-identical** to the prior implementation across 80 real exposures (SCI + primary-fallback cases); cache hit returns the same object; `reset` clears; unreadable files are not cached.
- `tests/test_tile_filter.py` + `tests/test_nircam_resample_tiles.py`: **30 passed**.
- Default (no `--tiles`) runs are untouched. No scientific-output change → categorized **Infrastructure (PATCH)** in `pipeline/CHANGELOG.md`.

## Also

Removes a stale test (`test_run_rejects_tiles_without_combine_phase`) that was **already failing on `main`** — it asserted the pre-`5059e87` behavior where `run --process --tiles` was rejected, now intentionally allowed and covered by `test_cli_run_tiles_allowed_with_process`.

Generated with Claude Code