### PR TITLE
feat(nircam): align S1–S3a — footprint refcat, robust refine, quality detection, NOT_ALIGNED quarantine

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -139,7 +139,10 @@ Release procedure: edit the `## Unreleased` section below, then run
       (raw WCS preserved) and quarantined from combine by `Field.materialize_work`
       (the single ensemble gate; the outlier pre-scan now also re-runs a visit
       whose membership shrank, so surviving frames don't reuse CR masks computed
-      with the dropped exposure). `run_align` reports every failure in a loud
+      with the dropped exposure). For an align-enabled field, combine likewise
+      quarantines exposures carrying **no** `CFP_ALGN` at all (align enabled but
+      never solved them → raw WCS), each surfaced with its own fix rather than
+      silently drizzled. `run_align` reports every failure in a loud
       end-of-command banner (failed files + how to fix) and **re-attempts**
       `NOT_ALIGNED` exposures on a normal re-run (no `--overwrite`), while
       already-solved exposures are skipped. `--include-unaligned` forces

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -108,70 +108,48 @@ Release procedure: edit the `## Unreleased` section below, then run
   field — exactly one alignment path. Replaces the JHAT-based alignment for opt-in
   fields; JHAT remains the default and coexists during validation. New `[nircam.align]`
   config block; covered by `tests/test_align_run.py`.
-- NIRCam `align` triangle matcher no longer starves multi-detector exposures of
-  their non-first detector. `tweakwcs.WCSGroupCatalog.create_group_catalog`
-  rebuilds the pooled image catalog keeping only `x/y/RA/DEC/id` — it drops the
-  `mag`/`flux` column `detect.py` attaches — so `TriangleMatch`'s brightest-N
-  vertex cap could not rank the image side and fell back to the first N rows *in
-  input order*. Because the per-detector catalogs are vstacked head-to-tail,
-  that consumed one detector's whole block (e.g. all 150 of detector 0) and left
-  the rest with zero triangle vertices, collapsing the pooled shared-fit geometry
-  to a single detector. The cap now subsamples evenly across the pooled catalog
-  when the ranking column is absent, so every detector contributes vertices (each
-  block stays flux-sorted, so the brighter sources within it are still favored).
-  The reference side, which keeps its `mag`, is unchanged. Changes which sources
-  match (and thus the fitted WCS) for opt-in `align` fields; the reference-catalog
-  `weight` column is deliberately *not* used to carry brightness, since tweakwcs
-  would fold it into the least-squares fit. Covered by `tests/test_align_matcher.py`.
-- **NIRCam `align` shared solve now footprint-clips the refcat and rests the fit
-  on an all-source refine, not the triangle cap.** Previously the full field
-  refcat (e.g. ~550k rows for COSMOS) reached the matcher, so the brightest-N
-  vertex cap kept the globally brightest sources — nearly all off-frame — and that
-  same cap gated the final fit (~17–30 pairs). The solve now (1) clips the refcat
-  to the exposure's detector-union footprint plus a `ref_border_arcmin` margin
-  (default 0.5′), projected through a local gnomonic tangent plane
-  (`align/footprint.py`); (2) runs `TriangleMatch` as a bounded **bootstrap** only
-  (renamed `brightest` → `bootstrap_max`); then (3) refines with an all-source,
-  one-to-one `tweakwcs.XYXYMatch` pass (`fitgeom='rshift'`, σ-clip, up to
-  `refine_niter` iterations, no 2-D-histogram re-acquisition) so the fitted WCS
-  rests on every matched source, not the capped vertices. Per-detector residuals
-  and the reject-to-identity gate now use mutual-nearest-neighbour (one-to-one)
-  matching, so counts no longer pile several detections onto one reference. The
-  translation-invariant matcher (not `XYXYMatch`) still drives the adaptive
-  per-detector refit, so a detector off by up to `match_radius` is still
-  recoverable. Changes which sources match — and thus the fitted WCS — for opt-in
-  `align` fields. `align/{footprint,solve,matcher}.py`, new `[nircam.align]` knobs
-  (`ref_border_arcmin`, `bootstrap_max`, `refine_searchrad/tolerance/niter`);
-  covered by `tests/test_align_{footprint,solve}.py`.
-- **NIRCam `align` detection is quality-selected, not count-capped.** `detect.py`
-  adds a peak-SNR floor (`snr_min`) and an (uncalibrated) DAO-magnitude range trim
-  (`objmag_lim`), and masks `SATURATED` + `NO_LIN_CORR` DQ (not only `DO_NOT_USE`)
-  so a saturated or nonlinearity-uncorrected core can't seed a false centroid or a
-  corrupt flux. The align path drops the fixed `brightest` count cap (the
-  vertex cap moved to the bootstrap), so the full quality-cut catalog reaches the
-  refine. Detection PSF FWHM is now **per filter** (`psf_fwhm_by_filter`, keyed off
-  each member's filter, falling back to the scalar `fwhm`) instead of one value
-  across F070W→F480M. Changes which sources are detected for opt-in `align` fields.
-  `align/{detect,apply}.py`, config; covered by `tests/test_align_detect.py`.
-- **NIRCam `combine` quarantines `NOT_ALIGNED` exposures for align-enabled
-  fields.** An exposure the align phase could not tie to the reference is stamped
-  `CFP_ALGN = NOT_ALIGNED` with its raw WCS preserved; drizzling it doubles sources
-  and defeats CR rejection. `Field.materialize_work` — the single gate into the
-  combine working tree that every ensemble step reads — now drops such exposures
-  (and deletes any stale working copy), so they enter neither the drizzle nor the
-  outlier / bad-pixel pools. A new `--include-unaligned` flag on `cfpipe nircam
-  combine` / `run` overrides. Pre-existing issue (JHAT shares it) and usually
-  ≲0.5″, but now closed for align fields. New `cfp.step_value` accessor;
-  `field.py`, `orchestrate.py`, `cli.py`; covered by `tests/test_nircam_work_tree.py`
-  and `tests/test_cfp.py`. Because dropping data from a stack must never be a
-  silent, automatic decision, `run_align` now (a) **loudly reports** every
-  `NOT_ALIGNED` exposure at the *end* of the command — a banner with the failed
-  exposure files and the levers to fix it (retune `[<field>.align]` + re-run, or
-  `combine --include-unaligned`) — and (b) **re-attempts** `NOT_ALIGNED`
-  exposures on a normal re-run (no `--overwrite` needed), so retuning parameters
-  and re-running just works, while already-solved exposures are still skipped.
-  The `NOT_ALIGNED` sentinel is now centralized as `cfp.NOT_ALIGNED`. Covered by
-  `tests/test_align_run.py` and `tests/test_align_apply.py`.
+- **NIRCam field-level `align` phase — matcher / solve / detection / combine
+  hardening (S1–S3a).** Opt-in and default-off, so no existing (JHAT) reduction
+  changes; for align-enabled fields it changes which sources match and thus the
+  fitted WCS. One PR, four parts:
+    - *Refcat footprint + all-source refine.* The full field refcat (~550k rows
+      for COSMOS) used to reach the matcher, so the brightest-N vertex cap kept
+      globally-brightest, mostly off-frame sources — and that same cap gated the
+      final fit (~17–30 pairs). The shared solve now clips the refcat to the
+      exposure's detector-union footprint + `ref_border_arcmin` margin (default
+      0.5′, local gnomonic tangent plane, `align/footprint.py`), runs
+      `TriangleMatch` as a bounded **bootstrap** only (`brightest` →
+      `bootstrap_max`), then refines on **all** sources with a one-to-one
+      `tweakwcs.XYXYMatch` pass (`fitgeom='rshift'`, σ-clip, `refine_niter`, no
+      2-D-histogram re-acquisition) — the fit rests on every matched source, not
+      the capped vertices. Per-detector residuals and the reject gate use
+      mutual-NN (one-to-one) matching; the translation-invariant matcher still
+      drives the adaptive per-detector refit (recovers offsets up to
+      `match_radius`). Also folds in the earlier pooled-catalog starvation fix
+      (the `create_group_catalog` `mag`-strip bug): the bootstrap cap spreads
+      vertices evenly across the pooled catalog when the ranking column is absent.
+    - *Quality-selected detection.* `detect.py` adds a peak-SNR floor (`snr_min`)
+      and an (uncalibrated) DAO-magnitude range trim (`objmag_lim`), masks
+      `SATURATED` + `NO_LIN_CORR` DQ (not only `DO_NOT_USE`), keys the detection
+      PSF FWHM per filter (`psf_fwhm_by_filter`, F070W→F480M), and drops the fixed
+      `brightest` count cap so the whole quality-cut catalog reaches the refine.
+    - *`NOT_ALIGNED` is never silent.* An exposure the solve can't tie to the
+      reference — **or any solver/refine/detection exception, which now degrades
+      instead of crashing the align worker** — is stamped `CFP_ALGN = NOT_ALIGNED`
+      (raw WCS preserved) and quarantined from combine by `Field.materialize_work`
+      (the single ensemble gate; the outlier pre-scan now also re-runs a visit
+      whose membership shrank, so surviving frames don't reuse CR masks computed
+      with the dropped exposure). `run_align` reports every failure in a loud
+      end-of-command banner (failed files + how to fix) and **re-attempts**
+      `NOT_ALIGNED` exposures on a normal re-run (no `--overwrite`), while
+      already-solved exposures are skipped. `--include-unaligned` forces
+      inclusion. Sentinel centralized as `cfp.NOT_ALIGNED`; new `cfp.step_value`.
+  New `[nircam.align]` knobs (`ref_border_arcmin`, `bootstrap_max`,
+  `refine_searchrad`/`refine_tolerance`/`refine_niter`, `snr_min`,
+  `psf_fwhm_by_filter`); `brightest` removed. Touches
+  `align/{footprint,solve,matcher,detect,apply}.py`, `field.py`, `orchestrate.py`,
+  `cli.py`, `common/cfp.py`; covered by `tests/test_align_*`,
+  `tests/test_nircam_work_tree.py`, `tests/test_cfp.py`.
 - NIRCam `combine` now honors per-exposure reviewer exclusions (epic #261, N6 /
   D10). `Field.setup_workspace` reads `reference/<field>/exposures.json`
   (materialized by `campfire deploy nircam pull` from the portal's

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -123,6 +123,47 @@ Release procedure: edit the `## Unreleased` section below, then run
   match (and thus the fitted WCS) for opt-in `align` fields; the reference-catalog
   `weight` column is deliberately *not* used to carry brightness, since tweakwcs
   would fold it into the least-squares fit. Covered by `tests/test_align_matcher.py`.
+- **NIRCam `align` shared solve now footprint-clips the refcat and rests the fit
+  on an all-source refine, not the triangle cap.** Previously the full field
+  refcat (e.g. ~550k rows for COSMOS) reached the matcher, so the brightest-N
+  vertex cap kept the globally brightest sources — nearly all off-frame — and that
+  same cap gated the final fit (~17–30 pairs). The solve now (1) clips the refcat
+  to the exposure's detector-union footprint plus a `ref_border_arcmin` margin
+  (default 0.5′), projected through a local gnomonic tangent plane
+  (`align/footprint.py`); (2) runs `TriangleMatch` as a bounded **bootstrap** only
+  (renamed `brightest` → `bootstrap_max`); then (3) refines with an all-source,
+  one-to-one `tweakwcs.XYXYMatch` pass (`fitgeom='rshift'`, σ-clip, up to
+  `refine_niter` iterations, no 2-D-histogram re-acquisition) so the fitted WCS
+  rests on every matched source, not the capped vertices. Per-detector residuals
+  and the reject-to-identity gate now use mutual-nearest-neighbour (one-to-one)
+  matching, so counts no longer pile several detections onto one reference. The
+  translation-invariant matcher (not `XYXYMatch`) still drives the adaptive
+  per-detector refit, so a detector off by up to `match_radius` is still
+  recoverable. Changes which sources match — and thus the fitted WCS — for opt-in
+  `align` fields. `align/{footprint,solve,matcher}.py`, new `[nircam.align]` knobs
+  (`ref_border_arcmin`, `bootstrap_max`, `refine_searchrad/tolerance/niter`);
+  covered by `tests/test_align_{footprint,solve}.py`.
+- **NIRCam `align` detection is quality-selected, not count-capped.** `detect.py`
+  adds a peak-SNR floor (`snr_min`) and an (uncalibrated) DAO-magnitude range trim
+  (`objmag_lim`), and masks `SATURATED` + `NO_LIN_CORR` DQ (not only `DO_NOT_USE`)
+  so a saturated or nonlinearity-uncorrected core can't seed a false centroid or a
+  corrupt flux. The align path drops the fixed `brightest` count cap (the
+  vertex cap moved to the bootstrap), so the full quality-cut catalog reaches the
+  refine. Detection PSF FWHM is now **per filter** (`psf_fwhm_by_filter`, keyed off
+  each member's filter, falling back to the scalar `fwhm`) instead of one value
+  across F070W→F480M. Changes which sources are detected for opt-in `align` fields.
+  `align/{detect,apply}.py`, config; covered by `tests/test_align_detect.py`.
+- **NIRCam `combine` quarantines `NOT_ALIGNED` exposures for align-enabled
+  fields.** An exposure the align phase could not tie to the reference is stamped
+  `CFP_ALGN = NOT_ALIGNED` with its raw WCS preserved; drizzling it doubles sources
+  and defeats CR rejection. `Field.materialize_work` — the single gate into the
+  combine working tree that every ensemble step reads — now drops such exposures
+  (and deletes any stale working copy), so they enter neither the drizzle nor the
+  outlier / bad-pixel pools. A new `--include-unaligned` flag on `cfpipe nircam
+  combine` / `run` overrides. Pre-existing issue (JHAT shares it) and usually
+  ≲0.5″, but now closed for align fields. New `cfp.step_value` accessor;
+  `field.py`, `orchestrate.py`, `cli.py`; covered by `tests/test_nircam_work_tree.py`
+  and `tests/test_cfp.py`.
 - NIRCam `combine` now honors per-exposure reviewer exclusions (epic #261, N6 /
   D10). `Field.setup_workspace` reads `reference/<field>/exposures.json`
   (materialized by `campfire deploy nircam pull` from the portal's

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -163,7 +163,15 @@ Release procedure: edit the `## Unreleased` section below, then run
   combine` / `run` overrides. Pre-existing issue (JHAT shares it) and usually
   ≲0.5″, but now closed for align fields. New `cfp.step_value` accessor;
   `field.py`, `orchestrate.py`, `cli.py`; covered by `tests/test_nircam_work_tree.py`
-  and `tests/test_cfp.py`.
+  and `tests/test_cfp.py`. Because dropping data from a stack must never be a
+  silent, automatic decision, `run_align` now (a) **loudly reports** every
+  `NOT_ALIGNED` exposure at the *end* of the command — a banner with the failed
+  exposure files and the levers to fix it (retune `[<field>.align]` + re-run, or
+  `combine --include-unaligned`) — and (b) **re-attempts** `NOT_ALIGNED`
+  exposures on a normal re-run (no `--overwrite` needed), so retuning parameters
+  and re-running just works, while already-solved exposures are still skipped.
+  The `NOT_ALIGNED` sentinel is now centralized as `cfp.NOT_ALIGNED`. Covered by
+  `tests/test_align_run.py` and `tests/test_align_apply.py`.
 - NIRCam `combine` now honors per-exposure reviewer exclusions (epic #261, N6 /
   D10). `Field.setup_workspace` reads `reference/<field>/exposures.json`
   (materialized by `campfire deploy nircam pull` from the portal's

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -108,6 +108,21 @@ Release procedure: edit the `## Unreleased` section below, then run
   field — exactly one alignment path. Replaces the JHAT-based alignment for opt-in
   fields; JHAT remains the default and coexists during validation. New `[nircam.align]`
   config block; covered by `tests/test_align_run.py`.
+- NIRCam `align` triangle matcher no longer starves multi-detector exposures of
+  their non-first detector. `tweakwcs.WCSGroupCatalog.create_group_catalog`
+  rebuilds the pooled image catalog keeping only `x/y/RA/DEC/id` — it drops the
+  `mag`/`flux` column `detect.py` attaches — so `TriangleMatch`'s brightest-N
+  vertex cap could not rank the image side and fell back to the first N rows *in
+  input order*. Because the per-detector catalogs are vstacked head-to-tail,
+  that consumed one detector's whole block (e.g. all 150 of detector 0) and left
+  the rest with zero triangle vertices, collapsing the pooled shared-fit geometry
+  to a single detector. The cap now subsamples evenly across the pooled catalog
+  when the ranking column is absent, so every detector contributes vertices (each
+  block stays flux-sorted, so the brighter sources within it are still favored).
+  The reference side, which keeps its `mag`, is unchanged. Changes which sources
+  match (and thus the fitted WCS) for opt-in `align` fields; the reference-catalog
+  `weight` column is deliberately *not* used to carry brightness, since tweakwcs
+  would fold it into the least-squares fit. Covered by `tests/test_align_matcher.py`.
 - NIRCam `combine` now honors per-exposure reviewer exclusions (epic #261, N6 /
   D10). `Field.setup_workspace` reads `reference/<field>/exposures.json`
   (materialized by `campfire deploy nircam pull` from the portal's

--- a/pipeline/campfire_pipeline/common/cfp.py
+++ b/pipeline/campfire_pipeline/common/cfp.py
@@ -172,6 +172,21 @@ def has_step(path_or_header, key, *, keyset=NIRCAM):
         return key in hdul[0].header
 
 
+def step_value(path_or_header, key, *, keyset=NIRCAM):
+    """Return the recorded value of ``key`` on a canonical file/header, or None.
+
+    Like :func:`has_step`, but returns the card's value rather than just its
+    presence — used to tell a ``NOT_ALIGNED`` sentinel apart from a real align
+    solution when the combine phase quarantines un-aligned exposures. Accepts a
+    path or an already-open ``fits.Header``.
+    """
+    keyset.validate(key)
+    if isinstance(path_or_header, fits.Header):
+        return path_or_header.get(key)
+    with fits.open(path_or_header, memmap=False) as hdul:
+        return hdul[0].header.get(key)
+
+
 def should_skip(exposure_file, key, rootname, step_name, status, overwrite,
                 *, keyset=NIRCAM):
     """Skip-check shared across per-exposure/per-source step modules.

--- a/pipeline/campfire_pipeline/common/cfp.py
+++ b/pipeline/campfire_pipeline/common/cfp.py
@@ -137,6 +137,13 @@ def iso_now():
     return datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
 
 
+# Sentinel the NIRCam align phase writes to CFP_ALGN when it cannot tie an
+# exposure to the reference catalog (its WCS is preserved). Distinct from a real
+# solution value (``dof=... res=... n=...``); read via :func:`step_value`. The
+# combine phase quarantines these exposures, and an align re-run re-attempts them.
+NOT_ALIGNED = 'NOT_ALIGNED'
+
+
 def format(*, keyset=NIRCAM, **updates):
     """Validate CFP keyword updates and pair them with their comments.
 

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -362,11 +362,39 @@
     adaptive = true             # adaptive per-detector shift when over tolerance
     adaptive_min_matches = 3
     match_radius = 0.5          # arcsec; NN radius for per-detector residuals
-    min_matched = 4             # reject-to-identity below this many matches
-    nsigma = 5.0                # source-detection threshold (background sigma)
-    fwhm = 2.5                  # detection PSF FWHM (pixels)
+    min_matched = 4             # reject-to-identity below this many 1-to-1 matches
+    # Shared fit: footprint-clip the refcat, then bootstrap (triangle matcher,
+    # capped) -> all-source robust refine (XYXYMatch). The cap bounds only the
+    # bootstrap; the fit rests on the uncapped refine.
+    ref_border_arcmin = 0.5     # refcat footprint margin (sized for acquisition
+                                # pointing error); arcmin
+    bootstrap_max = 150         # brightest-N vertex cap, triangle BOOTSTRAP only
+    refine_searchrad = 2.0      # arcsec; XYXYMatch search radius (refine passes)
+    refine_tolerance = 0.5      # arcsec; XYXYMatch match tolerance (refine passes)
+    refine_niter = 3            # max refine match->fit iterations (converges early)
+    # Detection quality selection (per detector, no count cap):
+    nsigma = 5.0                # detection threshold (convolved background sigma)
+    snr_min = 5.0               # drop detections below this peak SNR (peak/bkg-rms)
+    fwhm = 2.5                  # fallback detection PSF FWHM (px); per-filter
+                                # override below
     edge = 8                    # drop detections within this many px of a border
-    brightest = 150             # cap detections per detector (triangle vertices)
+
+    # Per-filter detection PSF FWHM (detector pixels). NIRCam's PSF core runs
+    # from ~F070W to ~F480M, so one fwhm is wrong across the SW+LW channels; the
+    # align worker keys detection off each member's filter, falling back to the
+    # scalar `fwhm` above for any filter not listed. Values ≈ PSF-core FWHM /
+    # pixel-scale — approximate; tune per field on real data.
+    [nircam.align.psf_fwhm_by_filter]
+        f070w = 1.5
+        f090w = 1.6
+        f115w = 1.7
+        f150w = 1.8
+        f200w = 2.1
+        f277w = 1.6
+        f356w = 1.9
+        f410m = 2.1
+        f444w = 2.3
+        f480m = 2.6
 
 # --- combine phase (ensemble) ---
 

--- a/pipeline/campfire_pipeline/nircam/align/DESIGN.md
+++ b/pipeline/campfire_pipeline/nircam/align/DESIGN.md
@@ -370,9 +370,43 @@ Layer-3 calibration signal, not per-exposure freedom.
 
 ---
 
-## 13. Versioning / changelog
+## 13. Staged rollout (PR plan)
+
+Sequenced so that **nothing waits on the empirical question that isn't blocked by it.**
+Align is opt-in/default-off, so every stage has a small blast radius and each carries
+its own `## Unreleased` changelog entry. Stages 1–3 are improvements to the *current
+pooled* solve and can land (and be validated on real data) before the architecture
+pivot; the pieces they build (footprint filter, robust refine, quality detection) are
+reused by the joint solve, not thrown away.
+
+```
+S1 ─┐
+S2 ─┼─► S4 (Layer 1 joint attitude) ─► S5 (measure) ─► S6 (Layer 2) ─► S7 (Layer 3)
+S3 ─┘
+(S1/S2/S3 independent, any order/parallel; S4 needs S1; S6 needs S4 + S5's verdict)
+```
+
+| # | PR | Scope / files | Ships alone? | Depends on | Changelog |
+|---|----|---------------|--------------|-----------|-----------|
+| **S1** | **Refcat footprint + robust refine** | Footprint-clip the refcat to the exposure/detector union + border (GWCS bboxes, spherical polygons); density-matched **bootstrap-only** cap; specified `XYXYMatch` all-source robust refine (immutable baseline, 1-to-1 rematch, σ-clip, convergence). Slots into the *current* pooled solve. `matcher.py`, `solve.py`, new refcat-footprint helper, tests | yes | — | Algorithm |
+| **S2** | **Detection quality selection** | SNR/sharpness/roundness + magnitude-range cuts, per-filter PSF `fwhm`, DQ saturation/nonlinearity masking; drop the `brightest` count cap. `detect.py`, config, tests | yes | — | Algorithm |
+| **S3a** | **`NOT_ALIGNED` combine quarantine** | Exclude reject-to-identity exposures from combine for align-enabled fields; explicit `--include-unaligned`. combine path, tests | yes | — | Algorithm |
+| **S3b** | **Refcat epoch/PM contract** | Schema gains `source_id/ref_epoch/pmra/pmdec/parallax` + errors; `apply_space_motion` to exposure mid-time before clip/projection; stationary-vs-star handling. `refcat/{io,query}.py`, tests | yes | — | Calibration |
+| **S3c** | **Dependency closure + mode gating** | Resolve physical-exposure membership across **all** field filters before the write scope; tile selection on the cross-filter union; `EXP_TYPE`/aperture/subarray gating; real SW∩LW overlap. `orchestrate.py`, `association.py`, tests | yes | — | Infrastructure |
+| **S4** | **Layer 1 — hierarchical joint attitude** | Replace pooled `solve_exposure_group` with the single-attitude joint fit (all detectors, precision-weighted), reusing S1's footprint+refine; conditioning-based acceptance (condition #, unique matches, held-out residual); **generation ID** + solution-ID provenance. `solve.py`, `apply.py`, `orchestrate.py`, tests | yes (Layer-1-only, shared-attitude default) | S1 (S2/S3 recommended) | Algorithm |
+| **S5** | **Data validation** *(measurement, not a PR)* | On the A4 harness + regimes in §11: unique 1-to-1 SW∩LW matches & radial leverage per detector, A↔B closure, shared-attitude residual vector fields. Decides whether Layer 2 is justified | — | S4 | — |
+| **S6** | **Layer 2 — gated per-detector shifts** | Shift-only per-detector residual, accepted only on the §7.4 gate. *Only if S5 shows real per-detector structure.* `solve.py`, config, tests | yes | S4 + S5 verdict | Algorithm |
+| **S7** | **Layer 3 + structured provenance** *(later)* | Cross-exposure per-detector/A↔B offset estimation → SIAF-residual/distortion term; full transactional solution records + staleness. Out of first scope | yes | S6 | Calibration/Infra |
+
+**Guidance.** Land S1–S3 first (biggest correctness wins, reusable pieces, real-data
+feedback early). S4 is the pivot but ships as *Layer-1-only* — shared-attitude-first is
+the safe default. Do **not** build S6 before S5's measurement justifies per-detector
+freedom. If S5 shows only noise, stop at S4 and defer any structure to S7 calibration.
+
+## 14. Versioning / changelog
 
 **Algorithm** change (alters which sources match → the fitted WCS) → MINOR. Opt-in and
-default-off, so no existing (JHAT) reduction changes. One `## Unreleased` → Algorithm
-entry before the PR opens. The `NOT_ALIGNED`-quarantine and refcat-epoch items are
-correctness fixes that may warrant their own entries.
+default-off, so no existing (JHAT) reduction changes. Each stage above carries its own
+`## Unreleased` entry in the category shown. The refcat epoch/PM change (S3b) is
+**Calibration** (it moves reference positions → the fitted WCS); the dependency/mode
+closure (S3c) is **Infrastructure**.

--- a/pipeline/campfire_pipeline/nircam/align/DESIGN.md
+++ b/pipeline/campfire_pipeline/nircam/align/DESIGN.md
@@ -1,349 +1,378 @@
-# NIRCam `align` — two-stage LW-anchor design
+# NIRCam `align` — hierarchical joint-solve design
 
 **Status:** proposal, not yet built. Targets the NIRCam field-level astrometric
-`align` phase (`campfire_pipeline/nircam/align/`). Written for an independent
-design review — the goal is to catch footguns *before* implementation.
+`align` phase (`campfire_pipeline/nircam/align/`). Written for implementation and
+review.
 
-**Scope of the change:** a rework of the **solve** and **orchestration** layers
-(`solve.py`, `apply.py`, `orchestrate.run_align`) plus additive changes to
-`detect.py` and the refcat handling. The `association.py` layer already exposes
-everything the new structure needs (`sw_members`, `lw_members`, `modules`,
-`is_single_member`). The blind matcher (`matcher.py`, `tristars`) is reused.
+**Supersedes** the earlier *serial LW-anchor cascade* proposal (see §4 — it was
+considered and rejected after an adversarial review). **Scope of the change:** the
+**solve** and **orchestration** layers (`solve.py`, `apply.py`,
+`orchestrate.run_align`), the refcat schema/handling, additive detection changes,
+and a combine-side quarantine. The blind matcher (`matcher.py`, `tristars`) is
+reused but reframed honestly (§6).
 
 ---
 
 ## 1. Where this sits in the align PR series
 
-The align phase is a ground-up replacement for the JHAT-based `jhat` / `wcs_shift`
-alignment, built as a stack of small PRs and shipped **opt-in, default-off**
-(`[<field>.align].enabled = true`). When a field opts in, the process phase skips
-`jhat` + `wcs_shift` — exactly one alignment path per field — and JHAT remains the
-default while align is validated.
+The align phase replaces the JHAT-based `jhat` / `wcs_shift` alignment and ships
+**opt-in, default-off** (`[<field>.align].enabled = true`). When a field opts in the
+process phase skips `jhat` + `wcs_shift` — exactly one alignment path per field — and
+JHAT stays the default while align is validated.
 
 | PR | Branch | What it added |
 |----|--------|---------------|
-| #322 | `nircam-align-foundation` | `CFP_ALGN` provenance key, `[nircam.align]` config namespace, deps |
-| #323 | `nircam-align-association` | exposure-association layer (`association.py`: `ExposureGroup`, SW/LW/module helpers) |
-| #324 | `nircam-align-matcher` | `TriangleMatch` — `tristars` blind triangle/asterism matcher |
-| #325 | `nircam-align-detect` | centroid-only source detection (`detect.py`, DAOStarFinder) |
+| #322 | `nircam-align-foundation` | `CFP_ALGN` key, `[nircam.align]` config, deps |
+| #323 | `nircam-align-association` | exposure-association (`association.py`: `ExposureGroup`, SW/LW/module helpers) |
+| #324 | `nircam-align-matcher` | `TriangleMatch` — `tristars` triangle matcher |
+| #325 | `nircam-align-detect` | centroid-only detection (`detect.py`, DAOStarFinder) |
 | #326 | `nircam-align-solve` | per-exposure solve core (`solve.py`) |
-| #327 | `nircam-align-apply` | exposure I/O + `CFP_ALGN` stamp + `WCS_BAK` (`apply.py`) |
-| #328 | `nircam-align-run` | `run_align` + CLI (`cfpipe nircam align` / `run --align`) |
-| #329 | `nircam-tiles-prefilter` | `--tiles` pre-filters process/align/combine; A/B astrometry harness |
-| *(this branch)* | `cfpipe-nircam-import-error-d6034o` | fix: matcher spreads vertex cap across pooled detectors (unmerged) |
+| #327 | `nircam-align-apply` | exposure I/O + `CFP_ALGN` + `WCS_BAK` (`apply.py`) |
+| #328 | `nircam-align-run` | `run_align` + CLI |
+| #329 | `nircam-tiles-prefilter` | `--tiles` pre-filter; A/B astrometry harness |
+| *(this branch)* | `cfpipe-nircam-import-error-d6034o` | matcher spread fix (unmerged) + this doc |
 
-This document proposes the **next** step on that arc: replacing the single pooled
-whole-focal-plane solve with an automatic two-stage, per-module, LW-anchored solve.
-It supersedes the pooled `solve_exposure_group` design from #326.
-
----
-
-## 2. What exists today (the pooled design)
-
-For each physical exposure (one dither), `run_align` builds an `ExposureGroup` of
-**every detector on disk across all filter directories** — up to 8 SW (nrca1–4,
-nrcb1–4) + 2 LW (nrcalong, nrcblong) — and solves it as one unit:
-
-1. Detect centroids per detector (DAOStarFinder), capped to the brightest 150.
-2. Give every detector a `JWSTWCSCorrector` sharing one `group_id`, so `tweakwcs`
-   pools all sources into one group catalog and fits **one shared shift+rotation**
-   (`fitgeom='rshift'`) against the field reference catalog, matched by
-   `TriangleMatch`.
-3. Recompute per-detector residuals; for any detector over `tolerance`, an
-   **adaptive** shift-only refit against the ref sources it already matched.
-4. Write the corrected gwcs + `CFP_ALGN` stamp; original gwcs stashed in `WCS_BAK`;
-   reject-to-identity (`NOT_ALIGNED`) below `min_matched`.
-
-### Problems found (the motivation for this rework)
-
-- **The reference catalog is never footprint-filtered.** The full field refcat
-  (e.g. 550,005 sources for COSMOS) reaches the matcher; `TriangleMatch` then caps
-  it to the 150 *globally* brightest — almost all outside the exposure footprint.
-  Verified in both `campfire_pipeline` and `tweakwcs`: `run_align` passes the whole
-  table, and `tweakwcs.RefCatalog.calc_tanp_xy` / `align_to_ref` project and match
-  every row with no spatial cut.
-- **The brightest-N cap is a triangle-count bound applied in the wrong place.**
-  `tristars.parse_triangles` enumerates every `C(N,3)` triangle globally, so the cap
-  is required for tractability — but it was allowed to bound the **final fit**, not
-  just the blind bootstrap. In practice the shared solution rests on ~17–30 matched
-  pairs.
-- **The cap silently starved multi-detector pools.** `tweakwcs` strips the `mag`
-  column when it builds the pooled group catalog, so the cap fell back to "first N in
-  input order" and consumed one detector's whole block. (Fixed on this branch by an
-  even spread; the rework removes the need.)
-- **The SW/LW pooling rationale was wrong.** See §4.
-
-### The consensus this rework adopts
-
-grizli (`align_drizzled_image`), JHAT (`st_wcs_align`), and tweakwcs (`XYXYMatch`)
-all use the same shape: **spatially restrict the reference → coarse/blind bootstrap
-on a bounded bright subset → nearest-neighbour refine on _all_ inliers.** grizli —
-whose author, Gabe Brammer, also wrote the `tristars` library CAMPFIRE calls — caps
-its `tristars` bootstrap to ~200 "to avoid triangle-matching combinatorics," then
-runs `NITER` NN refinement on everything. The cap belongs on the bootstrap, never on
-the fit. The pooled design had the capped bootstrap and no refine stage.
+This document proposes the next step: replace the single pooled whole-focal-plane
+solve with a **hierarchical joint solve** — one shared exposure attitude plus gated
+per-detector residual shifts — carrying the matcher/refcat repairs everyone agrees on.
 
 ---
 
-## 3. Corrected physics: what actually constrains the solution
+## 2. What exists today (the pooled solve) and why it needs work
 
-The uncertainty on the fitted rotation is roughly
+For each exposure, `run_align` groups every detector on disk across filter dirs (≤8
+SW + 2 LW) and fits **one shared shift+rotation** via `tweakwcs` against the field
+refcat, matched by `TriangleMatch`, then an adaptive per-detector shift for stragglers.
 
-```
-σ_θ  ≈  σ_centroid / (√N · R)
-```
+Defects found:
 
-where `N` is the number of matched sources and `R` is their spatial spread about the
-fit center. Two consequences drive the whole design:
+- **Refcat never footprint-filtered.** The full field refcat (e.g. 550k rows for
+  COSMOS) reaches the matcher and is capped to the 150 *globally* brightest, almost
+  all outside the frame (verified in `campfire_pipeline` + `tweakwcs`).
+- **The brightest-N cap bounded the fit, not just the bootstrap.** `tristars`
+  enumerates every `C(N,3)` triangle, so a cap is needed — but it was allowed to gate
+  the final fit; the solution rests on ~17–30 pairs.
+- **Pooled-catalog starvation** (the `mag`-strip bug; fixed on this branch by an even
+  spread, and made moot by the redesign).
+- **Weak acceptance.** `_match` uses `SkyCoord.match_to_catalog_sky` (solve.py:102),
+  which is **not one-to-one** — `n_matched` can count several detections onto one
+  reference, so `n_match`+RMSE is a soft gate.
 
-- **SW and LW image the same field of view.** A module's four SW detectors tile the
-  same sky as that module's one LW detector, so `R` is *identical* between channels.
-  There is no "SW has a wider baseline." (An earlier version of this design claimed
-  SW pins rotation — that was wrong.)
-- **With `R` equal, the better anchor is whichever channel yields more clean
-  matches**, and in deep extragalactic fields that is **LW**: more sensitive to the
-  red population, *contiguous* (one detector per module — no inter-chip gaps that
-  drop sources), and only 2 SIAF placements to trust vs 8. SW's one edge is sharper
-  per-source centroids (PSF ~2× smaller in arcsec), which does not overcome LW's
-  advantage in `N` and cleanliness for the anchor role.
-
-**Design consequence:** anchor on LW; treat each SW detector as a differential
-refinement tied to LW. Rotation is a large-scale quantity best measured from the
-dense LW solution over the module FOV, not re-derived from one small, undersampled
-SW chip against a sparse external catalog.
+These are **matcher/refcat defects, not proof that pooling is wrong** — a key point
+from review (§4).
 
 ---
 
-## 4. Final decisions
+## 3. Corrected physics: what constrains the solution
 
-The pooled single-solve is replaced by an **automatic two-stage, per-module,
-LW-anchored** solve.
+Rotation uncertainty for a rigid fit is roughly
 
-- **D1 — Modules A and B are solved independently.** Each module's LW detector
-  anchors that module's SW detectors. Rationale (from heavy JHAT use): a single LW
-  detector aligns to an external reference catalog robustly on its own. What is hard
-  is aligning an *individual SW detector* to a sparse external catalog — that would
-  need a dense reference derived from LW imaging, which is exactly why SW is tied to
-  LW instead. Keeping A and B independent also absorbs any real module-to-module
-  placement offset that SIAF misses.
+```
+σ_θ  ≈  σ_centroid / (√N · R)          (R = spatial spread of matched sources)
+```
 
-- **D2 — Each SW detector gets a full alignment (shift *and* rotation) tied to LW.**
-  Not shift-only. The enabling condition is that SW's reference is the **dense,
-  co-observed LW source catalog** (see §5), which supplies enough references across a
-  single SW chip to constrain rotation — the regime JHAT operates in routinely.
+- **SW and LW image the same field of view**, so `R` is the same between channels —
+  there is no "SW wide baseline" (an earlier draft claimed this; it was wrong).
+- **The exposure attitude is a single 3-parameter quantity** (Δx, Δy, roll θ) shared
+  by all 10 detectors — one spacecraft pointing. It is best estimated from **all**
+  usable sources across both modules and both channels at once (maximal `N`, full `R`).
+- **A single small detector is a poor place to fit rotation.** One SW detector spans
+  ~half the module's linear extent; a handful of clustered matches gives a
+  well-fit-looking but badly-conditioned θ.
+- **SIAF placement residuals are stable in time.** They belong in a calibration layer
+  estimated across many exposures, not re-fit (degenerate with attitude) every exposure.
 
-- **Two-stage, automatic.** The pipeline runs the LW anchor when LW canonicals exist
-  and the SW tie when SW canonicals exist *and* the module's LW anchor is already
-  solved. No manual sequencing; the phase discovers what is runnable. This also
-  resolves the partial-processing case (§7).
+These four facts drive the architecture: solve the attitude **jointly and globally**,
+demote per-detector freedom to **gated shifts**, and push persistent detector offsets
+into a **calibration** layer.
 
 ---
 
-## 5. Detailed design
+## 4. Rejected alternative: the serial LW-anchor cascade
 
-### 5.1 Per-module hierarchy
+An intermediate proposal solved modules A/B independently, anchored each on its LW
+detector to the external refcat, then aligned each SW detector (full shift+rotation)
+to the LW-derived catalog. An adversarial review (GPT/Codex) plus source cross-checks
+retired it. Recorded here so it isn't re-proposed:
 
-Work is organized per `(exposure, module)`. `association.ExposureGroup` already
-splits members by `.module` and `.channel`, so a module unit is
-`{lw: <1 LW member>, sw: [<≤4 SW members>]}`.
+- **A and B share one attitude** — independent per-module rotations discard the
+  strongest roll constraint (the A–B baseline) and permit mosaic shear across the
+  module gap. A module offset is a *calibration* term, not per-exposure attitude.
+- **Per-SW-detector rotation is under-conditioned** — half the lever arm, few
+  cross-band common sources, and an acceptance gate (`n_match`+RMSE, non-one-to-one)
+  too weak to catch a wrong-but-low-RMSE θ.
+- **"LW is the better anchor" is field-dependent** — false for blue/stellar fields,
+  narrow/medium LW filters (F430M/F460M/F466N/F470N/F480M), nebulous star-forming
+  regions, and dropout fields where SW∩LW is tiny.
+- **"SW→LW guarantees mutual registration" is false** — cross-band centroids shift
+  (galaxy color gradients, blends splitting, emission-line-only objects), so the
+  serial fit propagates LW centroid bias coherently into all four SW detectors.
+- **Serial state is brittle** — channel ordering, LW-final/SW-stale coupling,
+  `--filters`/`--tiles` selection deciding astrometry, mixed-generation crashes.
+
+The joint solve below keeps the *good* parts (footprint filter, bootstrap-only cap,
+all-source robust refine) and drops the cascade.
+
+---
+
+## 5. Architecture: hierarchical joint solve
 
 ```
-exposure (one dither)
-├── module A
-│   ├── LW: nrcalong        ← anchor (Stage 1)
-│   └── SW: nrca1..4        ← each tied to A's LW (Stage 2)
-└── module B
-    ├── LW: nrcblong        ← anchor (Stage 1)
-    └── SW: nrcb1..4        ← each tied to B's LW (Stage 2)
+per exposure (one dither — every detector on disk, both modules, SW + LW)
+        │
+        ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│ PREP  (per detector)                                                   │
+│  • detect sources: SNR / sharpness / roundness + magnitude-range cuts, │
+│    per-filter PSF fwhm, saturation & nonlinearity masked from DQ       │
+│  • project pixels → v2/v3 (SIAF) → common tangent plane (arcsec)       │
+│  • footprint-filter refcat to the exposure's detector-union + border,  │
+│    epoch/proper-motion propagated to the exposure mid-time             │
+└──────────────────────────────────────────────────────────────────────┘
+        │
+        ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│ LAYER 1 — shared exposure attitude   (Δx, Δy, roll θ : 3 params)       │
+│   bootstrap  : tristars — hypothesis generator, scale+roll CONSTRAINED │
+│                (uses the pipeline WCS as the prior; see §6)             │
+│        ↓ coarse (Δx, Δy, θ)                                            │
+│   refine     : ALL unique 1-to-1 matches, robust (RANSAC / σ-clip),    │
+│                iterate match→fit to convergence                        │
+│   → ONE attitude for all detectors, weighted by centroid precision;    │
+│     whichever channel is informative drives it (no hard LW/SW anchor)  │
+└──────────────────────────────────────────────────────────────────────┘
+        │
+        ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│ LAYER 2 — per-detector SHIFT residuals   (SIAF placement, shift-only)  │
+│   each detector: 1-to-1 NN to refcat around the Layer-1 WCS,           │
+│   accept a shift ONLY if gated: normal-matrix condition number,        │
+│   unique-match count, radial coverage, held-out residual improves.     │
+│   NO per-detector rotation per exposure.                               │
+└──────────────────────────────────────────────────────────────────────┘
+        │
+        ▼
+   quality gate ─► ACCEPTED : write corrected gwcs + CFP_ALGN + WCS_BAK
+        │          REJECTED : NOT_ALIGNED  →  QUARANTINED from combine (§9.1)
+        ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│ LAYER 3 — persistent calibration  (offline / cross-exposure, later)    │
+│   pool Layer-2 residual vector fields over many dithers → stable       │
+│   per-detector & A↔B-module offsets → SIAF-residual/distortion term,   │
+│   rather than per-exposure freedom.                                    │
+└──────────────────────────────────────────────────────────────────────┘
 ```
 
-### 5.2 Stage 1 — LW anchor (per module → absolute frame)
+**One-line summary:** *fit the exposure attitude once from everything; correct
+per-detector placement with gated shifts; learn the stable offsets as calibration.*
 
-Reference = the field's Gaia-tied `campfire-refcat-v1`, **footprint-filtered** to the
-LW detector's sky footprint + `ref_border_arcmin` (default **0.5′**).
+---
 
-1. Detect sources in the LW detector — quality cuts, not a count cap (§5.4).
-2. **Bootstrap:** `TriangleMatch` (`tristars`) — rotation-invariant, no offset prior
-   — on a density-matched bright subset (cap = `bootstrap_max`, default 150). Yields
-   a coarse shift+rotation.
-3. **Refine:** `tweakwcs.XYXYMatch` (2-D offset-histogram → NN within tolerance) on
-   the *full* LW catalog vs the footprint-filtered refcat, `fitgeom='rshift'`, looped
-   `refine_niter` (default 3) with sigma-clipping. The LW WCS is now absolutely
-   registered.
-4. Write the LW canonical (corrected gwcs, `CFP_ALGN`, `WCS_BAK`) or reject-to-identity.
+## 6. The matcher, described honestly
 
-The LW anchor is **final** once written; it is never re-solved when SW arrives.
+Cross-checking `tristars 0.1` corrected our understanding: with `TriangleMatch`'s
+defaults `ignore_scale=True, ignore_rot=True`, the hash uses **absolute side lengths**
+(scale *constrained*) and the **longest-edge position angle** (rotation *constrained*).
+So it is **translation-invariant only** — it assumes both catalogs are already at the
+same scale and roll, which for JWST they are (assign_wcs gives scale and roll to
+≪1°). tristars' own docs warn the fully scale/rotation-free mode "doesn't work well."
 
-### 5.3 Stage 2 — SW tied to LW (per detector → differential)
+Implications:
 
-Reference = the **LW-derived source catalog**: sources detected in the *aligned* LW
-image of the same exposure+module, at their now-registered sky positions. Dense,
-co-observed, and already tied to the absolute frame through Stage 1.
+- The matcher is **not** "blind / rotation-invariant / no offset prior" — it *relies
+  on the pipeline WCS prior*. The `matcher.py` and old-doc language saying otherwise is
+  wrong and should be corrected (a one-line docstring fix can land now).
+- Because we *have* a roll+scale prior, exotic rotation-invariance is unnecessary; the
+  bootstrap's job is only to seed Layer 1.
+- `tristars` with `auto_keep=False` returns vertices from a few top triangle-hash
+  pairs — **not** RANSAC, **not** one-to-one, **not** inlier-validated. Treat it as a
+  **hypothesis generator only**: never trust raw top-triangle pairs as matches. Layer-1
+  refine (robust, all unique matches) is what earns trust.
+- If a mode with large roll error is ever supported, `ignore_rot` must go `False`
+  (true invariance, less robust) — an explicit, tested decision, not a silent default.
 
-For each SW detector in the module:
+---
 
-1. Starting WCS = SW's own gwcs with the module's LW shift+rotation applied (SIAF
-   places SW relative to LW, so this lands the SW frame within ~the SIAF residual —
-   sub-arcsec, near-zero residual rotation).
-2. Detect SW sources (same quality cuts).
-3. **Refine directly to the LW catalog:** `XYXYMatch`, `fitgeom='rshift'` (full
-   shift+rotation per D2), looped with sigma-clipping. Because the start WCS is
-   already close, no blind bootstrap is normally needed; a `tristars` bootstrap is a
-   fallback if the SW↔LW residual is too large to match.
-4. Write the SW canonical (`CFP_ALGN`, `WCS_BAK`) or reject-to-identity.
+## 7. Detailed design
 
-Tying SW to LW (rather than independently to the external refcat) is deliberate:
-SW and LW were co-observed, so they share sources with no epoch/proper-motion
-mismatch, and — critically for downstream **multiband aperture photometry** — it
-**guarantees SW/LW are mutually registered**. Two independent refcat solves would
-each carry their own residual and could leave a small SW–LW relative offset.
+### 7.1 Detection (`detect.py`) — quality selection, not a count cap
 
-### 5.4 Detection quality cuts (replaces the count cap)
+Return the full quality-cut catalog; the only cap left is `bootstrap_max` on the
+triangle stage. Cuts (configurable; DAOStarFinder emits the needed columns):
 
-`detect.py` returns the *full* quality-cut catalog; the only cap left is
-`bootstrap_max` on the triangle stage. Cuts (JHAT-style, all configurable; DAOStarFinder
-already emits the needed columns):
+- `snr_min`; `sharpness_lim`; `roundness1_lim`; `objmag_lim=(bright,faint)` magnitude
+  **range** (drops saturated-bright and low-SNR-faint).
+- **Per-filter PSF `fwhm`** — a single `fwhm=2.5` is wrong across F070W→F480M; key
+  DAOStarFinder off the filter's PSF. (Note `flux`/`mag` here are a kernel matched-
+  filter estimate, adequate only for *ranking* the bootstrap subset — not photometry.)
+- **Saturation/nonlinearity masked from DQ + ramp**, not inferred from a mag cut
+  (saturation corrupts the measured flux).
+- The old `brightest` count cap is **removed**.
 
-- `snr_min` — SNR floor.
-- `sharpness_lim`, `roundness1_lim` — reject cosmics / streaks / extended sources.
-- `objmag_lim = (bright, faint)` — a magnitude **range** dropping *saturated bright*
-  as well as low-SNR faint sources.
-- `brightest` (the old per-detector count cap) is **removed**.
+### 7.2 Reference catalog — footprint + epoch (the two real gaps)
 
-The same cuts apply to the LW-derived reference catalog built in Stage 2, so SW never
-aligns to LW noise/false-positives.
+- **Schema** grows an epoch/motion contract: `source_id, ref_epoch, pmra, pmdec,
+  parallax` (where available) + uncertainties, alongside `RA, DEC, mag, mag_err`.
+  Distinguish stationary extragalactic anchors from stars; for survey-derived galaxy
+  positions record the effective coadd epoch.
+- **Propagate to the exposure mid-time** (`apply_space_motion`) **before** footprint
+  clipping and projection. Today's schema (`RA/DEC/mag/mag_err`) silently assumes zero
+  motion — fine for a pure-galaxy anchor, wrong for stars or mixed HSC/LS/Gaia rows.
+- **Footprint clip** to the exposure's detector-union sky polygon + `ref_border_arcmin`
+  (default 0.5′), using actual GWCS bounding boxes and spherical polygons. Because the
+  footprint derives from the (possibly offset) input WCS, the border **is** an implicit
+  pointing prior: size it for the max supported acquisition error and fail
+  `outside-acquisition-bound` distinctly from `source-starved`.
 
-### 5.5 Provenance & reporting
+### 7.3 Layer 1 — shared attitude
 
-`CFP_ALGN` distinguishes the two solution types and records per-stage accounting so a
-run *shows* what drove each fit:
+Bootstrap (`tristars`, §6) → coarse (Δx, Δy, θ). Refine with `tweakwcs.XYXYMatch`
+against the footprint-filtered refcat, but specified exactly to avoid footguns:
+**immutable baseline corrector, transformed catalogs each iteration, one-to-one
+rematch, robust refit (`fitgeom='rshift'`, σ-clip), convergence test, one final WCS
+application.** Do *not* re-run the 2-D histogram acquisition once a good transform
+exists (it composes corrections); rebuild fresh correctors per outer iteration.
+Attitude is fit from all detectors sharing one `group_id`, weighted by centroid
+precision.
 
-- LW: `role=lw-anchor dof=rshift n_ref=… n_match=… rmse=…`
-- SW: `role=sw→lw dof=rshift n_match=… rmse=… (or fallback=refcat)`
-- Rejected: `NOT_ALIGNED` (WCS preserved) with the reason.
+### 7.4 Layer 2 — gated per-detector shifts
 
-Log lines report, per module: LW n_detected/n_matched/rmse, and per SW detector
-dof/n_matched/rmse/accepted.
+For each detector: one-to-one NN to the refcat around the Layer-1 WCS; propose a
+shift-only correction; **accept only if gated** on normal-matrix condition number,
+unique-match count, radial coverage, and a held-out residual that actually improves.
+No per-detector rotation. Rejected detectors keep the Layer-1 attitude
+(`dof=attitude`).
 
-### 5.6 Config (`[nircam.align]`)
+### 7.5 Layer 3 — persistent calibration (later)
+
+Aggregate Layer-2 residual vector fields across many dithers to estimate stable
+per-detector and A↔B-module offsets; fold into a SIAF-residual/distortion term. Out
+of scope for the first build, but the parametrization above is chosen so it can be
+added without rework.
+
+### 7.6 Acceptance & provenance
+
+- **Acceptance** never rests on `n_match`+RMSE alone (they hide the non-one-to-one
+  and conditioning problems). Use unique matches, condition number, predicted edge
+  displacement, radial coverage, held-out residuals; reject-to-identity otherwise.
+- **Provenance**: a short **solution ID** in the `CFP_ALGN` card, backed by a
+  structured per-exposure/module record — refcat content hash + epoch, source counts
+  at every cut, transform + covariance, residual quantiles/vector diagnostics, and
+  code/CRDS/config baseline + parent generation. (Full record is phaseable; the card
+  ID + counts + rmse land first.)
+
+### 7.7 Config (`[nircam.align]`)
 
 | Knob | Default | Controls | Status |
 |------|---------|----------|--------|
-| `ref_border_arcmin` | `0.5` | Sky margin around a detector footprint for refcat clipping | new |
+| `ref_border_arcmin` | `0.5` | Footprint margin (sized for acquisition error) | new |
 | `snr_min` | — | Detection SNR floor | new |
-| `sharpness_lim` | `(lo, hi)` | DAOStarFinder sharpness window | new |
-| `roundness1_lim` | `(-0.75, 0.75)` | Roundness window | new |
+| `sharpness_lim` / `roundness1_lim` | windows | DAOStarFinder shape cuts | new |
 | `objmag_lim` | `(bright, faint)` | Detection magnitude range | new |
-| `bootstrap_max` | `150` | Density-matched vertex cap for the triangle bootstrap **only** | changed |
-| `refine_searchrad` | arcsec | `XYXYMatch` 2-D histogram search radius | new |
-| `refine_tolerance` | arcsec | NN match tolerance after the coarse shift | new |
-| `refine_niter` | `3` | match→fit iterations in the refine loop | new |
-| `sw_to_lw` | `true` | Tie SW to the LW-derived catalog (vs external refcat fallback) | new |
-| `brightest` | — | **removed** — detection is no longer count-capped | changed |
+| `psf_fwhm_by_filter` | table | Per-filter detection PSF FWHM | new |
+| `bootstrap_max` | `150` | Density-matched vertex cap — **bootstrap only** | changed |
+| `refine_searchrad` / `refine_tolerance` / `refine_niter` | arcsec / arcsec / `3` | Layer-1 refine | new |
+| `detector_shift` | `gated` | Layer-2: `off` / `gated` | new |
+| `brightest` | — | **removed** | changed |
 
 ---
 
-## 6. What stays the same
+## 8. What stays the same
 
-- The `association.py` exposure model (already module/channel-aware).
-- `tristars` `TriangleMatch` as the blind bootstrap.
-- `tweakwcs` correctors and the tangent-plane machinery.
-- `CFP_ALGN` + `WCS_BAK` provenance and the reject-to-identity contract.
-- Opt-in, default-off; process phase skips `jhat`/`wcs_shift` for align fields.
-- `--tiles` pre-filtering and multiprocessing dispatch.
+`association.py` (already module/channel-aware); `tristars` bootstrap; `tweakwcs`
+correctors + tangent-plane machinery; `CFP_ALGN` + `WCS_BAK` + reject-to-identity;
+opt-in/default-off; `--tiles` and multiprocessing dispatch; the matcher spread-fix.
 
 ---
 
-## 7. Partial processing (LW done, SW not — the "Point 0" case)
+## 9. Correctness gaps to close (independent of the layering)
 
-Because filters are processed independently, LW canonicals for an exposure often
-exist before SW canonicals (or vice versa). The two-stage split handles this by
-**temporal decoupling**:
+### 9.1 `NOT_ALIGNED` must be quarantined from combine
 
-- **LW present, SW absent** → run Stage 1. The LW anchor is written and is final.
-- **SW present, LW anchor already solved** → run Stage 2 against the stored LW
-  solution + LW-derived reference. LW is *not* re-solved.
-- **SW present, LW anchor not yet solved** → SW is deferred (nothing to anchor to)
-  unless the no-LW fallback (§8) is enabled.
+Confirmed: combine enumerates canonicals unconditionally with no `CFP_ALGN` check, so
+a reject-to-identity exposure drizzles with its raw WCS (doubled sources, CR-rejection
+failure). Pre-existing (JHAT shares it) and usually ≲0.5″ for JWST, but real. For
+align-enabled fields, exclude `NOT_ALIGNED` from combine (or require an accepted
+alignment), with an explicit `--include-unaligned` opt-in — never implicit inclusion.
 
-Contrast with the pooled design, where an LW-only group aligns on LW, then SW's later
-arrival re-forms a 10-detector group and re-solves — silently mutating an LW WCS that
-may already be deployed. The anchor design makes the LW solution monotonic.
+### 9.2 Cross-filter / tile dependency closure
 
----
+`run_align` builds associations only from the *selected* filters, so `--filters f200w`
+can't see its paired F444W, and per-filter tile selection can split a physical
+exposure at a tile edge. Resolve the physical-exposure membership across **all** field
+filters before applying the write scope; select tiles on the cross-filter exposure
+union; log any out-of-selection file read as input.
 
-## 8. Fallbacks / graceful degradation
+### 9.3 Observing-mode gating
 
-- **No LW filter processed for the field/selection at all** → fall back to
-  SW-direct-to-refcat (the pooled/per-detector external solve). Must remain a
-  supported path so SW-only reductions still align.
-- **LW detector too source-starved to anchor** → widen `ref_border`, or fall back to
-  a pooled-LW (A+B shared) anchor for the exposure. Quality-gated.
-- **SW↔LW too few common sources** (blue SW filter on a red field) → fall back to
-  SW→external-refcat using the LW-derived starting WCS.
-- **A single SW detector source-starved** → fall back to shift-only, or inherit the
-  module's LW solution unchanged (`dof=inherited`), rather than fitting a poorly
-  constrained rotation.
-- **Single-member / missing-detector groups** → existing per-detector fallback.
+Grouping by filename doesn't validate `EXP_TYPE`, aperture, or subarray, or compute
+real SW∩LW overlap. Define supported modes; unsupported (subarray/coronagraph/TSO/dead
+detector) stop or take a separately-validated path rather than falling through generic
+per-detector logic.
 
----
+### 9.4 State & staleness
 
-## 9. Open questions & footguns for review
-
-1. **Per-SW-detector rotation robustness.** D2 fits full shift+rotation per SW
-   detector (~1.1′, undersampled). Is the dense LW reference reliably enough to
-   constrain θ per chip across real fields? What is the minimum matched-source count
-   below which we must drop to shift-only or inherit? Is there a risk of a plausible
-   but wrong per-detector rotation passing the quality gate?
-2. **A/B independence vs downstream mosaic.** Solving modules A and B independently
-   can leave a small relative A↔B rotation/shift. Does `combine`/resample assume a
-   single consistent per-exposure frame anywhere? Is per-module independence safe end
-   to end, or should A/B share rotation and differ only in shift?
-3. **SW inherits LW's absolute error.** Every SW detector in a module is tied to the
-   same LW solution, so LW's residual to the sky is a *correlated* error across all
-   its SW detectors. Intended (registration > absolute), but confirm it doesn't bias
-   downstream absolute astrometry beyond spec.
-4. **Astrometric color terms.** SW centroids matched to LW centroids of the same
-   object assume no color-dependent centroid offset. Negligible at this precision?
-5. **LW-derived reference quality.** False positives / blends in LW detection would
-   inject bad references for SW. Are the §5.4 cuts sufficient on the reference side?
-6. **State & idempotency.** SW Stage 2 depends on the LW canonical's corrected WCS +
-   `WCS_BAK`. Re-running align with `--overwrite`: does SW re-derive from the LW
-   canonical correctly? If LW is *re-aligned* later, SW becomes stale — do we detect
-   and re-run SW, or is LW-final enforced?
-7. **Interaction with `--tiles` (#329).** Tile pre-filtering selects exposure groups
-   overlapping a tile. Ensure both the LW anchor and its SW leaves for a tile are
-   selected together, or that Stage 2 can find the LW anchor even if tile filtering
-   dropped it.
-8. **Frozen-canonical / `nircam_work` model (#261 N7).** Align writes the *canonical*
-   WCS (with `WCS_BAK`). Confirm Stage 2 reads the aligned LW canonical's corrected
-   WCS, and that the working-copy materialization in `combine` picks up both channels'
-   updated WCS.
-9. **Reference frame consistency.** LW anchors to the external refcat; SW anchors to
-   LW. Confirm both express the same tangent-plane/units so the composed transform is
-   exact.
+A single FITS keyword can't encode a dependency graph. Even in the joint solve, an
+exposure re-solved when more channels/filters arrive (or after `--overwrite`, a new
+refcat, or new CRDS) needs a **generation ID + content hash**; children/derived
+products mark **stale** when a parent changes; write a module/exposure solution
+transactionally with `PENDING/ACCEPTED/REJECTED/STALE` states. Phaseable, but the
+generation ID should exist from the first build.
 
 ---
 
-## 10. Affected files (implementation sketch)
+## 10. Partial processing (LW present, SW not — etc.)
 
-- `orchestrate.py::run_align` — discover module units; drive Stage 1 then Stage 2;
-  footprint-filter the refcat per unit; enforce LW-before-SW ordering + fallbacks.
-- `solve.py` — replace `solve_exposure_group` (pooled) with `solve_lw_anchor` and
-  `solve_sw_to_lw`; add the `XYXYMatch` refine loop; keep `tristars` bootstrap.
-- `apply.py` — build the LW-derived reference from an aligned LW canonical; SW
-  starting-WCS construction from the module LW solution; extend `CFP_ALGN` provenance.
-- `detect.py` — add SNR/sharpness/roundness/mag-range cuts; drop the `brightest` cap.
-- `matcher.py` — density-matched bootstrap subset (the even-spread fix stays as the
-  fallback for any pooled/rank-less catalog).
-- refcat helpers — footprint clip to a detector footprint + margin.
-- config defaults + tests (`tests/test_align_*`).
+The joint solve removes the serial LW→SW coupling, but partial data still matters:
+solve the attitude from whatever usable detectors are present, stamp its **generation**
+(§9.4), and re-solve when more arrive if the new data would change it (staleness-
+gated), rather than silently leaving a mixed-generation exposure. An exposure with too
+few usable detectors/sources rejects to identity and is quarantined (§9.1).
 
 ---
 
-## 11. Versioning / changelog
+## 11. Open questions — validate on real data before committing parametrization
 
-Per repo policy this is an **Algorithm** change (it alters which sources match and
-therefore the fitted WCS) → MINOR. The align phase is opt-in and default-off, so no
-existing (JHAT) reduction changes. One `## Unreleased` → Algorithm entry covers the
-rework before the PR opens.
+The layer *structure* is settled; the *parametrization* (how much per-detector
+freedom) is an empirical question. **Shared-attitude-first is the safe default;**
+enable Layer-2 shifts only where the data support them. Before finalizing, measure on
+the `cosmos_align` A4 harness and a spread of regimes:
+
+1. **Unique 1-to-1 matches and weighted radial leverage per detector**, after real
+   quality/saturation/blend/morphology cuts — the quantity that decides whether any
+   per-detector freedom is justified.
+2. **A↔B closure** and **shared-attitude residual vector fields** — do residuals show
+   real per-detector/module structure, or just noise?
+3. Regimes: COSMOS/CEERS broad-band pairs; an F070W/F090W field; a crowded stellar
+   field; a nebulous star-forming field; a narrow/medium LW pairing; tile-edge and
+   missing-detector cases.
+
+If residuals are noise, ship Layer 1 only. If they show stable structure, that's a
+Layer-3 calibration signal, not per-exposure freedom.
+
+---
+
+## 12. Affected files (implementation sketch)
+
+- `orchestrate.py::run_align` — cross-filter exposure membership + tile union; drive
+  Layer 1 → Layer 2; generation stamping; NOT_ALIGNED quarantine hand-off.
+- `solve.py` — replace pooled `solve_exposure_group` with a joint attitude fit +
+  gated per-detector shift; robust one-to-one refine; conditioning-based acceptance.
+- `apply.py` — extend `CFP_ALGN` provenance (solution ID + counts + rmse); structured
+  record hook.
+- `detect.py` — SNR/shape/mag-range cuts, per-filter PSF fwhm, DQ saturation masking;
+  drop `brightest`.
+- `matcher.py` — correct the invariance docstring now; density-matched bootstrap subset
+  (spread fix stays as fallback).
+- `refcat/{io,query}.py` — epoch/PM schema + `apply_space_motion`.
+- combine path — `NOT_ALIGNED` exclusion + `--include-unaligned`.
+- config defaults + `tests/test_align_*`.
+
+---
+
+## 13. Versioning / changelog
+
+**Algorithm** change (alters which sources match → the fitted WCS) → MINOR. Opt-in and
+default-off, so no existing (JHAT) reduction changes. One `## Unreleased` → Algorithm
+entry before the PR opens. The `NOT_ALIGNED`-quarantine and refcat-epoch items are
+correctness fixes that may warrant their own entries.

--- a/pipeline/campfire_pipeline/nircam/align/DESIGN.md
+++ b/pipeline/campfire_pipeline/nircam/align/DESIGN.md
@@ -1,0 +1,349 @@
+# NIRCam `align` — two-stage LW-anchor design
+
+**Status:** proposal, not yet built. Targets the NIRCam field-level astrometric
+`align` phase (`campfire_pipeline/nircam/align/`). Written for an independent
+design review — the goal is to catch footguns *before* implementation.
+
+**Scope of the change:** a rework of the **solve** and **orchestration** layers
+(`solve.py`, `apply.py`, `orchestrate.run_align`) plus additive changes to
+`detect.py` and the refcat handling. The `association.py` layer already exposes
+everything the new structure needs (`sw_members`, `lw_members`, `modules`,
+`is_single_member`). The blind matcher (`matcher.py`, `tristars`) is reused.
+
+---
+
+## 1. Where this sits in the align PR series
+
+The align phase is a ground-up replacement for the JHAT-based `jhat` / `wcs_shift`
+alignment, built as a stack of small PRs and shipped **opt-in, default-off**
+(`[<field>.align].enabled = true`). When a field opts in, the process phase skips
+`jhat` + `wcs_shift` — exactly one alignment path per field — and JHAT remains the
+default while align is validated.
+
+| PR | Branch | What it added |
+|----|--------|---------------|
+| #322 | `nircam-align-foundation` | `CFP_ALGN` provenance key, `[nircam.align]` config namespace, deps |
+| #323 | `nircam-align-association` | exposure-association layer (`association.py`: `ExposureGroup`, SW/LW/module helpers) |
+| #324 | `nircam-align-matcher` | `TriangleMatch` — `tristars` blind triangle/asterism matcher |
+| #325 | `nircam-align-detect` | centroid-only source detection (`detect.py`, DAOStarFinder) |
+| #326 | `nircam-align-solve` | per-exposure solve core (`solve.py`) |
+| #327 | `nircam-align-apply` | exposure I/O + `CFP_ALGN` stamp + `WCS_BAK` (`apply.py`) |
+| #328 | `nircam-align-run` | `run_align` + CLI (`cfpipe nircam align` / `run --align`) |
+| #329 | `nircam-tiles-prefilter` | `--tiles` pre-filters process/align/combine; A/B astrometry harness |
+| *(this branch)* | `cfpipe-nircam-import-error-d6034o` | fix: matcher spreads vertex cap across pooled detectors (unmerged) |
+
+This document proposes the **next** step on that arc: replacing the single pooled
+whole-focal-plane solve with an automatic two-stage, per-module, LW-anchored solve.
+It supersedes the pooled `solve_exposure_group` design from #326.
+
+---
+
+## 2. What exists today (the pooled design)
+
+For each physical exposure (one dither), `run_align` builds an `ExposureGroup` of
+**every detector on disk across all filter directories** — up to 8 SW (nrca1–4,
+nrcb1–4) + 2 LW (nrcalong, nrcblong) — and solves it as one unit:
+
+1. Detect centroids per detector (DAOStarFinder), capped to the brightest 150.
+2. Give every detector a `JWSTWCSCorrector` sharing one `group_id`, so `tweakwcs`
+   pools all sources into one group catalog and fits **one shared shift+rotation**
+   (`fitgeom='rshift'`) against the field reference catalog, matched by
+   `TriangleMatch`.
+3. Recompute per-detector residuals; for any detector over `tolerance`, an
+   **adaptive** shift-only refit against the ref sources it already matched.
+4. Write the corrected gwcs + `CFP_ALGN` stamp; original gwcs stashed in `WCS_BAK`;
+   reject-to-identity (`NOT_ALIGNED`) below `min_matched`.
+
+### Problems found (the motivation for this rework)
+
+- **The reference catalog is never footprint-filtered.** The full field refcat
+  (e.g. 550,005 sources for COSMOS) reaches the matcher; `TriangleMatch` then caps
+  it to the 150 *globally* brightest — almost all outside the exposure footprint.
+  Verified in both `campfire_pipeline` and `tweakwcs`: `run_align` passes the whole
+  table, and `tweakwcs.RefCatalog.calc_tanp_xy` / `align_to_ref` project and match
+  every row with no spatial cut.
+- **The brightest-N cap is a triangle-count bound applied in the wrong place.**
+  `tristars.parse_triangles` enumerates every `C(N,3)` triangle globally, so the cap
+  is required for tractability — but it was allowed to bound the **final fit**, not
+  just the blind bootstrap. In practice the shared solution rests on ~17–30 matched
+  pairs.
+- **The cap silently starved multi-detector pools.** `tweakwcs` strips the `mag`
+  column when it builds the pooled group catalog, so the cap fell back to "first N in
+  input order" and consumed one detector's whole block. (Fixed on this branch by an
+  even spread; the rework removes the need.)
+- **The SW/LW pooling rationale was wrong.** See §4.
+
+### The consensus this rework adopts
+
+grizli (`align_drizzled_image`), JHAT (`st_wcs_align`), and tweakwcs (`XYXYMatch`)
+all use the same shape: **spatially restrict the reference → coarse/blind bootstrap
+on a bounded bright subset → nearest-neighbour refine on _all_ inliers.** grizli —
+whose author, Gabe Brammer, also wrote the `tristars` library CAMPFIRE calls — caps
+its `tristars` bootstrap to ~200 "to avoid triangle-matching combinatorics," then
+runs `NITER` NN refinement on everything. The cap belongs on the bootstrap, never on
+the fit. The pooled design had the capped bootstrap and no refine stage.
+
+---
+
+## 3. Corrected physics: what actually constrains the solution
+
+The uncertainty on the fitted rotation is roughly
+
+```
+σ_θ  ≈  σ_centroid / (√N · R)
+```
+
+where `N` is the number of matched sources and `R` is their spatial spread about the
+fit center. Two consequences drive the whole design:
+
+- **SW and LW image the same field of view.** A module's four SW detectors tile the
+  same sky as that module's one LW detector, so `R` is *identical* between channels.
+  There is no "SW has a wider baseline." (An earlier version of this design claimed
+  SW pins rotation — that was wrong.)
+- **With `R` equal, the better anchor is whichever channel yields more clean
+  matches**, and in deep extragalactic fields that is **LW**: more sensitive to the
+  red population, *contiguous* (one detector per module — no inter-chip gaps that
+  drop sources), and only 2 SIAF placements to trust vs 8. SW's one edge is sharper
+  per-source centroids (PSF ~2× smaller in arcsec), which does not overcome LW's
+  advantage in `N` and cleanliness for the anchor role.
+
+**Design consequence:** anchor on LW; treat each SW detector as a differential
+refinement tied to LW. Rotation is a large-scale quantity best measured from the
+dense LW solution over the module FOV, not re-derived from one small, undersampled
+SW chip against a sparse external catalog.
+
+---
+
+## 4. Final decisions
+
+The pooled single-solve is replaced by an **automatic two-stage, per-module,
+LW-anchored** solve.
+
+- **D1 — Modules A and B are solved independently.** Each module's LW detector
+  anchors that module's SW detectors. Rationale (from heavy JHAT use): a single LW
+  detector aligns to an external reference catalog robustly on its own. What is hard
+  is aligning an *individual SW detector* to a sparse external catalog — that would
+  need a dense reference derived from LW imaging, which is exactly why SW is tied to
+  LW instead. Keeping A and B independent also absorbs any real module-to-module
+  placement offset that SIAF misses.
+
+- **D2 — Each SW detector gets a full alignment (shift *and* rotation) tied to LW.**
+  Not shift-only. The enabling condition is that SW's reference is the **dense,
+  co-observed LW source catalog** (see §5), which supplies enough references across a
+  single SW chip to constrain rotation — the regime JHAT operates in routinely.
+
+- **Two-stage, automatic.** The pipeline runs the LW anchor when LW canonicals exist
+  and the SW tie when SW canonicals exist *and* the module's LW anchor is already
+  solved. No manual sequencing; the phase discovers what is runnable. This also
+  resolves the partial-processing case (§7).
+
+---
+
+## 5. Detailed design
+
+### 5.1 Per-module hierarchy
+
+Work is organized per `(exposure, module)`. `association.ExposureGroup` already
+splits members by `.module` and `.channel`, so a module unit is
+`{lw: <1 LW member>, sw: [<≤4 SW members>]}`.
+
+```
+exposure (one dither)
+├── module A
+│   ├── LW: nrcalong        ← anchor (Stage 1)
+│   └── SW: nrca1..4        ← each tied to A's LW (Stage 2)
+└── module B
+    ├── LW: nrcblong        ← anchor (Stage 1)
+    └── SW: nrcb1..4        ← each tied to B's LW (Stage 2)
+```
+
+### 5.2 Stage 1 — LW anchor (per module → absolute frame)
+
+Reference = the field's Gaia-tied `campfire-refcat-v1`, **footprint-filtered** to the
+LW detector's sky footprint + `ref_border_arcmin` (default **0.5′**).
+
+1. Detect sources in the LW detector — quality cuts, not a count cap (§5.4).
+2. **Bootstrap:** `TriangleMatch` (`tristars`) — rotation-invariant, no offset prior
+   — on a density-matched bright subset (cap = `bootstrap_max`, default 150). Yields
+   a coarse shift+rotation.
+3. **Refine:** `tweakwcs.XYXYMatch` (2-D offset-histogram → NN within tolerance) on
+   the *full* LW catalog vs the footprint-filtered refcat, `fitgeom='rshift'`, looped
+   `refine_niter` (default 3) with sigma-clipping. The LW WCS is now absolutely
+   registered.
+4. Write the LW canonical (corrected gwcs, `CFP_ALGN`, `WCS_BAK`) or reject-to-identity.
+
+The LW anchor is **final** once written; it is never re-solved when SW arrives.
+
+### 5.3 Stage 2 — SW tied to LW (per detector → differential)
+
+Reference = the **LW-derived source catalog**: sources detected in the *aligned* LW
+image of the same exposure+module, at their now-registered sky positions. Dense,
+co-observed, and already tied to the absolute frame through Stage 1.
+
+For each SW detector in the module:
+
+1. Starting WCS = SW's own gwcs with the module's LW shift+rotation applied (SIAF
+   places SW relative to LW, so this lands the SW frame within ~the SIAF residual —
+   sub-arcsec, near-zero residual rotation).
+2. Detect SW sources (same quality cuts).
+3. **Refine directly to the LW catalog:** `XYXYMatch`, `fitgeom='rshift'` (full
+   shift+rotation per D2), looped with sigma-clipping. Because the start WCS is
+   already close, no blind bootstrap is normally needed; a `tristars` bootstrap is a
+   fallback if the SW↔LW residual is too large to match.
+4. Write the SW canonical (`CFP_ALGN`, `WCS_BAK`) or reject-to-identity.
+
+Tying SW to LW (rather than independently to the external refcat) is deliberate:
+SW and LW were co-observed, so they share sources with no epoch/proper-motion
+mismatch, and — critically for downstream **multiband aperture photometry** — it
+**guarantees SW/LW are mutually registered**. Two independent refcat solves would
+each carry their own residual and could leave a small SW–LW relative offset.
+
+### 5.4 Detection quality cuts (replaces the count cap)
+
+`detect.py` returns the *full* quality-cut catalog; the only cap left is
+`bootstrap_max` on the triangle stage. Cuts (JHAT-style, all configurable; DAOStarFinder
+already emits the needed columns):
+
+- `snr_min` — SNR floor.
+- `sharpness_lim`, `roundness1_lim` — reject cosmics / streaks / extended sources.
+- `objmag_lim = (bright, faint)` — a magnitude **range** dropping *saturated bright*
+  as well as low-SNR faint sources.
+- `brightest` (the old per-detector count cap) is **removed**.
+
+The same cuts apply to the LW-derived reference catalog built in Stage 2, so SW never
+aligns to LW noise/false-positives.
+
+### 5.5 Provenance & reporting
+
+`CFP_ALGN` distinguishes the two solution types and records per-stage accounting so a
+run *shows* what drove each fit:
+
+- LW: `role=lw-anchor dof=rshift n_ref=… n_match=… rmse=…`
+- SW: `role=sw→lw dof=rshift n_match=… rmse=… (or fallback=refcat)`
+- Rejected: `NOT_ALIGNED` (WCS preserved) with the reason.
+
+Log lines report, per module: LW n_detected/n_matched/rmse, and per SW detector
+dof/n_matched/rmse/accepted.
+
+### 5.6 Config (`[nircam.align]`)
+
+| Knob | Default | Controls | Status |
+|------|---------|----------|--------|
+| `ref_border_arcmin` | `0.5` | Sky margin around a detector footprint for refcat clipping | new |
+| `snr_min` | — | Detection SNR floor | new |
+| `sharpness_lim` | `(lo, hi)` | DAOStarFinder sharpness window | new |
+| `roundness1_lim` | `(-0.75, 0.75)` | Roundness window | new |
+| `objmag_lim` | `(bright, faint)` | Detection magnitude range | new |
+| `bootstrap_max` | `150` | Density-matched vertex cap for the triangle bootstrap **only** | changed |
+| `refine_searchrad` | arcsec | `XYXYMatch` 2-D histogram search radius | new |
+| `refine_tolerance` | arcsec | NN match tolerance after the coarse shift | new |
+| `refine_niter` | `3` | match→fit iterations in the refine loop | new |
+| `sw_to_lw` | `true` | Tie SW to the LW-derived catalog (vs external refcat fallback) | new |
+| `brightest` | — | **removed** — detection is no longer count-capped | changed |
+
+---
+
+## 6. What stays the same
+
+- The `association.py` exposure model (already module/channel-aware).
+- `tristars` `TriangleMatch` as the blind bootstrap.
+- `tweakwcs` correctors and the tangent-plane machinery.
+- `CFP_ALGN` + `WCS_BAK` provenance and the reject-to-identity contract.
+- Opt-in, default-off; process phase skips `jhat`/`wcs_shift` for align fields.
+- `--tiles` pre-filtering and multiprocessing dispatch.
+
+---
+
+## 7. Partial processing (LW done, SW not — the "Point 0" case)
+
+Because filters are processed independently, LW canonicals for an exposure often
+exist before SW canonicals (or vice versa). The two-stage split handles this by
+**temporal decoupling**:
+
+- **LW present, SW absent** → run Stage 1. The LW anchor is written and is final.
+- **SW present, LW anchor already solved** → run Stage 2 against the stored LW
+  solution + LW-derived reference. LW is *not* re-solved.
+- **SW present, LW anchor not yet solved** → SW is deferred (nothing to anchor to)
+  unless the no-LW fallback (§8) is enabled.
+
+Contrast with the pooled design, where an LW-only group aligns on LW, then SW's later
+arrival re-forms a 10-detector group and re-solves — silently mutating an LW WCS that
+may already be deployed. The anchor design makes the LW solution monotonic.
+
+---
+
+## 8. Fallbacks / graceful degradation
+
+- **No LW filter processed for the field/selection at all** → fall back to
+  SW-direct-to-refcat (the pooled/per-detector external solve). Must remain a
+  supported path so SW-only reductions still align.
+- **LW detector too source-starved to anchor** → widen `ref_border`, or fall back to
+  a pooled-LW (A+B shared) anchor for the exposure. Quality-gated.
+- **SW↔LW too few common sources** (blue SW filter on a red field) → fall back to
+  SW→external-refcat using the LW-derived starting WCS.
+- **A single SW detector source-starved** → fall back to shift-only, or inherit the
+  module's LW solution unchanged (`dof=inherited`), rather than fitting a poorly
+  constrained rotation.
+- **Single-member / missing-detector groups** → existing per-detector fallback.
+
+---
+
+## 9. Open questions & footguns for review
+
+1. **Per-SW-detector rotation robustness.** D2 fits full shift+rotation per SW
+   detector (~1.1′, undersampled). Is the dense LW reference reliably enough to
+   constrain θ per chip across real fields? What is the minimum matched-source count
+   below which we must drop to shift-only or inherit? Is there a risk of a plausible
+   but wrong per-detector rotation passing the quality gate?
+2. **A/B independence vs downstream mosaic.** Solving modules A and B independently
+   can leave a small relative A↔B rotation/shift. Does `combine`/resample assume a
+   single consistent per-exposure frame anywhere? Is per-module independence safe end
+   to end, or should A/B share rotation and differ only in shift?
+3. **SW inherits LW's absolute error.** Every SW detector in a module is tied to the
+   same LW solution, so LW's residual to the sky is a *correlated* error across all
+   its SW detectors. Intended (registration > absolute), but confirm it doesn't bias
+   downstream absolute astrometry beyond spec.
+4. **Astrometric color terms.** SW centroids matched to LW centroids of the same
+   object assume no color-dependent centroid offset. Negligible at this precision?
+5. **LW-derived reference quality.** False positives / blends in LW detection would
+   inject bad references for SW. Are the §5.4 cuts sufficient on the reference side?
+6. **State & idempotency.** SW Stage 2 depends on the LW canonical's corrected WCS +
+   `WCS_BAK`. Re-running align with `--overwrite`: does SW re-derive from the LW
+   canonical correctly? If LW is *re-aligned* later, SW becomes stale — do we detect
+   and re-run SW, or is LW-final enforced?
+7. **Interaction with `--tiles` (#329).** Tile pre-filtering selects exposure groups
+   overlapping a tile. Ensure both the LW anchor and its SW leaves for a tile are
+   selected together, or that Stage 2 can find the LW anchor even if tile filtering
+   dropped it.
+8. **Frozen-canonical / `nircam_work` model (#261 N7).** Align writes the *canonical*
+   WCS (with `WCS_BAK`). Confirm Stage 2 reads the aligned LW canonical's corrected
+   WCS, and that the working-copy materialization in `combine` picks up both channels'
+   updated WCS.
+9. **Reference frame consistency.** LW anchors to the external refcat; SW anchors to
+   LW. Confirm both express the same tangent-plane/units so the composed transform is
+   exact.
+
+---
+
+## 10. Affected files (implementation sketch)
+
+- `orchestrate.py::run_align` — discover module units; drive Stage 1 then Stage 2;
+  footprint-filter the refcat per unit; enforce LW-before-SW ordering + fallbacks.
+- `solve.py` — replace `solve_exposure_group` (pooled) with `solve_lw_anchor` and
+  `solve_sw_to_lw`; add the `XYXYMatch` refine loop; keep `tristars` bootstrap.
+- `apply.py` — build the LW-derived reference from an aligned LW canonical; SW
+  starting-WCS construction from the module LW solution; extend `CFP_ALGN` provenance.
+- `detect.py` — add SNR/sharpness/roundness/mag-range cuts; drop the `brightest` cap.
+- `matcher.py` — density-matched bootstrap subset (the even-spread fix stays as the
+  fallback for any pooled/rank-less catalog).
+- refcat helpers — footprint clip to a detector footprint + margin.
+- config defaults + tests (`tests/test_align_*`).
+
+---
+
+## 11. Versioning / changelog
+
+Per repo policy this is an **Algorithm** change (it alters which sources match and
+therefore the fitted WCS) → MINOR. The align phase is opt-in and default-off, so no
+existing (JHAT) reduction changes. One `## Unreleased` → Algorithm entry covers the
+rework before the PR opens.

--- a/pipeline/campfire_pipeline/nircam/align/apply.py
+++ b/pipeline/campfire_pipeline/nircam/align/apply.py
@@ -39,7 +39,7 @@ from campfire_pipeline.nircam.align.solve import (
 from campfire_pipeline.nircam.association import exposure_key
 
 WCS_BAK_EXTNAME = 'WCS_BAK'
-NOT_ALIGNED_SENTINEL = 'NOT_ALIGNED'
+NOT_ALIGNED_SENTINEL = cfp.NOT_ALIGNED
 
 # Solve/detection knobs threaded from [<field>.align]; the orchestration passes
 # a resolved dict, these are the fallbacks. Per-filter PSF FWHM
@@ -190,13 +190,18 @@ def align_exposure_group(members, refcat, *, key=None, config=None,
         key = exposure_key(members[0].path)
     config = dict(config or {})
 
-    def _done(path):
-        return (status.has(path, 'CFP_ALGN') if status is not None
-                else cfp.has_step(path, 'CFP_ALGN'))
+    def _aligned_ok(path):
+        # A detector counts as done only if it carries a *completed, non-rejected*
+        # alignment. A NOT_ALIGNED exposure is re-attempted on a normal re-run
+        # (no --overwrite) so the user can retune [<field>.align] params and try
+        # again without force-re-solving everything that already succeeded.
+        stamped = (status.has(path, 'CFP_ALGN') if status is not None
+                   else cfp.has_step(path, 'CFP_ALGN'))
+        return stamped and cfp.step_value(path, 'CFP_ALGN') != NOT_ALIGNED_SENTINEL
 
-    if not overwrite and all(_done(m.path) for m in members):
-        log(f"align[{key}]: all {len(members)} detectors already stamped "
-            f"CFP_ALGN; skipping.")
+    if not overwrite and all(_aligned_ok(m.path) for m in members):
+        log(f"align[{key}]: all {len(members)} detectors already aligned; "
+            f"skipping (use --overwrite to re-solve).")
         return GroupSolution(key, 'SKIPPED', None, None, None, 0, [])
 
     solve_cfg = {k: config[k] for k in _SOLVE_KEYS if k in config}

--- a/pipeline/campfire_pipeline/nircam/align/apply.py
+++ b/pipeline/campfire_pipeline/nircam/align/apply.py
@@ -219,15 +219,29 @@ def align_exposure_group(members, refcat, *, key=None, config=None,
         from jwst.datamodels import ImageModel
         from jwst.assign_wcs.util import update_fits_wcsinfo
 
-    detectors = []
-    for m in members:
-        member_cfg = dict(detect_cfg)
-        member_cfg['fwhm'] = psf_by_filter.get(m.filter_name.lower(),
-                                               default_fwhm)
-        detectors.append(_load_detector(m.path, m.detector, member_cfg,
-                                        ImageModel))
-
-    solution = solve_exposure_group(detectors, refcat, key=key, **solve_cfg)
+    # Reading + solving one exposure must never abort a whole field's align. Any
+    # unexpected failure (a corrupt canonical, an unforeseen solver error the
+    # in-solve guards missed) degrades this exposure to NOT_ALIGNED — surfaced
+    # loudly by run_align and quarantined from combine — rather than crashing.
+    try:
+        detectors = []
+        for m in members:
+            member_cfg = dict(detect_cfg)
+            member_cfg['fwhm'] = psf_by_filter.get(m.filter_name.lower(),
+                                                   default_fwhm)
+            detectors.append(_load_detector(m.path, m.detector, member_cfg,
+                                            ImageModel))
+        solution = solve_exposure_group(detectors, refcat, key=key, **solve_cfg)
+    except Exception as e:  # noqa: BLE001 — one bad exposure must not abort the field
+        log(f"align[{key}]: FAILED — {type(e).__name__}: {e}; "
+            f"stamping NOT_ALIGNED (WCS preserved, excluded from combine).")
+        for m in members:
+            try:
+                _stamp_algn(m.path, NOT_ALIGNED_SENTINEL)
+            except Exception as se:  # noqa: BLE001 — best-effort stamp
+                log(f"align[{key}]: could not stamp NOT_ALIGNED on "
+                    f"{os.path.basename(m.path)} ({type(se).__name__}).")
+        return GroupSolution(key, 'NOT_ALIGNED', None, None, None, 0, [])
 
     by_detector = {d.detector: d for d in solution.detectors}
     for m in members:

--- a/pipeline/campfire_pipeline/nircam/align/apply.py
+++ b/pipeline/campfire_pipeline/nircam/align/apply.py
@@ -27,7 +27,10 @@ from astropy.io import fits
 
 from campfire_pipeline.common import cfp
 from campfire_pipeline.common.io import atomic_save, log
-from campfire_pipeline.nircam.align.detect import detect_star_centroids
+from campfire_pipeline.nircam.align.detect import (
+    DETECT_DQ_BITS,
+    detect_star_centroids,
+)
 from campfire_pipeline.nircam.align.solve import (
     DetectorInput,
     GroupSolution,
@@ -38,14 +41,18 @@ from campfire_pipeline.nircam.association import exposure_key
 WCS_BAK_EXTNAME = 'WCS_BAK'
 NOT_ALIGNED_SENTINEL = 'NOT_ALIGNED'
 
-# jwst.datamodels.dqflags.pixel['DO_NOT_USE'] == 1 (bit 0).
-_DO_NOT_USE = np.uint32(1)
-
 # Solve/detection knobs threaded from [<field>.align]; the orchestration passes
-# a resolved dict, these are the fallbacks.
+# a resolved dict, these are the fallbacks. Per-filter PSF FWHM
+# (``psf_fwhm_by_filter``) is resolved per member below, not passed through
+# these keys. ``bootstrap_max`` and the ``refine_*`` knobs are solve keys (the
+# triangle-vertex cap moved to the bootstrap; detection is no longer count-
+# capped, so ``brightest`` is gone from the align path).
 _SOLVE_KEYS = ('fitgeom', 'minobj', 'nclip', 'sigma', 'tolerance', 'adaptive',
-               'adaptive_min_matches', 'match_radius', 'min_matched')
-_DETECT_KEYS = ('fwhm', 'nsigma', 'edge', 'brightest')
+               'adaptive_min_matches', 'match_radius', 'min_matched',
+               'ref_border_arcmin', 'bootstrap_max', 'refine_searchrad',
+               'refine_tolerance', 'refine_niter')
+_DETECT_KEYS = ('fwhm', 'nsigma', 'edge', 'snr_min', 'objmag_lim',
+                'sharplo', 'sharphi', 'roundlo', 'roundhi')
 
 
 # --- WCS_BAK gwcs <-> ASDF-in-FITS (replicated from steps/wcs_shift.py) ------
@@ -88,7 +95,7 @@ def _detect_mask(model):
     if getattr(model, 'err', None) is not None:
         mask |= ~np.isfinite(np.asarray(model.err, dtype=float))
     if getattr(model, 'dq', None) is not None:
-        mask |= (np.asarray(model.dq).astype(np.uint32) & _DO_NOT_USE) != 0
+        mask |= (np.asarray(model.dq).astype(np.uint32) & DETECT_DQ_BITS) != 0
     return mask
 
 
@@ -195,13 +202,25 @@ def align_exposure_group(members, refcat, *, key=None, config=None,
     solve_cfg = {k: config[k] for k in _SOLVE_KEYS if k in config}
     detect_cfg = {k: config[k] for k in _DETECT_KEYS if k in config}
 
+    # Per-filter detection PSF FWHM: NIRCam's core width runs from ~F070W to
+    # ~F480M, so a single fwhm is wrong across the exposure's SW+LW channels.
+    # Key it off each member's filter, falling back to the scalar `fwhm`.
+    psf_by_filter = {str(k).lower(): float(v)
+                     for k, v in (config.get('psf_fwhm_by_filter') or {}).items()}
+    default_fwhm = detect_cfg.get('fwhm', 2.5)
+
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
         from jwst.datamodels import ImageModel
         from jwst.assign_wcs.util import update_fits_wcsinfo
 
-    detectors = [_load_detector(m.path, m.detector, detect_cfg, ImageModel)
-                 for m in members]
+    detectors = []
+    for m in members:
+        member_cfg = dict(detect_cfg)
+        member_cfg['fwhm'] = psf_by_filter.get(m.filter_name.lower(),
+                                               default_fwhm)
+        detectors.append(_load_detector(m.path, m.detector, member_cfg,
+                                        ImageModel))
 
     solution = solve_exposure_group(detectors, refcat, key=key, **solve_cfg)
 

--- a/pipeline/campfire_pipeline/nircam/align/detect.py
+++ b/pipeline/campfire_pipeline/nircam/align/detect.py
@@ -15,7 +15,7 @@ subtracted aperture.
 Coordinates are **0-indexed** detector pixels (the ``DAOStarFinder`` and gwcs
 convention — what the ``tweakwcs`` corrector's ``det_to_world`` / ``det_to_tanp``
 expect). ``mag = -2.5·log10(flux)`` (smaller = brighter) rides along **only**
-for downstream brightest-N triangle-vertex selection, never as a match
+to rank the bootstrap triangle-vertex cap (``matcher.py``), never as a match
 constraint.
 
 Import-light and ``jwst``-free: detection is WCS-free (works in detector
@@ -34,9 +34,16 @@ from photutils.utils.exceptions import NoDetectionsWarning
 
 from campfire_pipeline.common.io import log
 
-# jwst.datamodels.dqflags.pixel['DO_NOT_USE'] == 1 (bit 0). Hardcoded to keep
-# this module free of the jwst/CRDS import chain (cf. field.py's _DO_NOT_USE).
+# jwst.datamodels.dqflags.pixel bit values, hardcoded to keep this module free
+# of the jwst/CRDS import chain (cf. field.py's _DO_NOT_USE). Centroiding must
+# skip pixels that are unusable (DO_NOT_USE), saturated (a saturated core
+# corrupts both the centroid and the kernel flux), or lack a valid nonlinearity
+# correction (NO_LIN_CORR) — the latter two are exactly the bright-star failure
+# modes a magnitude cut can't catch because the measured flux is already wrong.
 _DO_NOT_USE = np.uint32(1)
+_SATURATED = np.uint32(2)
+_NO_LIN_CORR = np.uint32(1 << 20)          # 1048576
+DETECT_DQ_BITS = _DO_NOT_USE | _SATURATED | _NO_LIN_CORR
 
 _FLOAT_COLUMNS = ('x', 'y', 'flux', 'mag', 'sharpness',
                   'roundness1', 'roundness2', 'peak')
@@ -50,7 +57,8 @@ def _empty_catalog():
 
 def detect_star_centroids(data, *, mask=None, fwhm=2.5, nsigma=5.0,
                           sharplo=0.2, sharphi=1.0, roundlo=-1.0, roundhi=1.0,
-                          edge=8, brightest=None, sigma=3.0, maxiters=5):
+                          edge=8, snr_min=None, objmag_lim=None, brightest=None,
+                          sigma=3.0, maxiters=5):
     """Detect point-source centroids on a detector image.
 
     Returns an astropy ``Table`` with columns ``x, y, flux, mag, sharpness,
@@ -67,14 +75,29 @@ def detect_star_centroids(data, *, mask=None, fwhm=2.5, nsigma=5.0,
         Pixels to ignore (bad pixels, off-detector). Non-finite ``data`` pixels
         are always added to the mask.
     fwhm : float
-        PSF FWHM in pixels (NIRCam ≈ 2–2.5 px near native scale; tune per
-        channel when the solve worker calls this).
+        PSF FWHM in pixels. NIRCam's PSF core is filter-dependent (F070W→F480M),
+        so the align worker keys this off the exposure's filter
+        (``psf_fwhm_by_filter``) rather than using one value.
     nsigma : float
         Detection threshold in units of the sigma-clipped background RMS.
     edge : int
         Reject centroids within this many pixels of any border (unreliable).
+    snr_min : float, optional
+        Drop detections below this peak SNR (``peak / background_rms``). Raises
+        the effective floor above the kernel ``nsigma`` threshold; a matched-
+        filter detection can trip ``nsigma`` on a noise peak whose real SNR is
+        marginal.
+    objmag_lim : (float, float), optional
+        Keep only ``bright <= mag <= faint``. ``mag = -2.5·log10(flux)`` is the
+        DAOStarFinder kernel estimate — **uncalibrated** (no zeropoint), so this
+        is a coarse per-run trim (drop the saturated-bright and the faint junk),
+        not a physical magnitude cut; prefer ``snr_min`` + DQ saturation masking
+        for physically meaningful cuts.
     brightest : int, optional
-        Keep only the ``brightest`` sources (by flux) after edge rejection.
+        Keep only the ``brightest`` sources (by flux) after all cuts. The align
+        path leaves this unset — the triangle-vertex cap is applied later, on
+        the bootstrap only (see ``matcher.py``) — so the full quality-selected
+        catalog reaches the all-source refine.
     """
     data = np.asarray(data, dtype=float)
     mask = np.zeros(data.shape, dtype=bool) if mask is None else np.asarray(mask, dtype=bool)
@@ -115,6 +138,20 @@ def detect_star_centroids(data, *, mask=None, fwhm=2.5, nsigma=5.0,
     })
     if len(out) == 0:
         return _empty_catalog()
+
+    # Quality cuts. sharpness/roundness are already applied inside DAOStarFinder;
+    # snr_min and objmag_lim trim what the kernel threshold alone can't.
+    quality = np.ones(len(out), dtype=bool)
+    if snr_min is not None:
+        quality &= (np.asarray(out['peak'], dtype=float) / std) >= float(snr_min)
+    if objmag_lim is not None:
+        bright, faint = float(objmag_lim[0]), float(objmag_lim[1])
+        mag = np.asarray(out['mag'], dtype=float)
+        quality &= np.isfinite(mag) & (mag >= bright) & (mag <= faint)
+    out = out[quality]
+    if len(out) == 0:
+        return _empty_catalog()
+
     out.sort('flux', reverse=True)
     if brightest is not None and len(out) > brightest:
         out = out[:int(brightest)]
@@ -126,10 +163,11 @@ def detect_in_exposure(path, *, fwhm=2.5, nsigma=5.0, **kwargs):
 
     Reads SCI/ERR/DQ via ``astropy.io.fits`` (no jwst datamodel needed —
     detection is WCS-free and works in detector pixels). Masks off-detector
-    pixels (non-finite ERR) and ``DO_NOT_USE`` DQ pixels (only that flag —
-    JUMP_DET etc. are already-corrected and kept, matching ``sky.py``). ERR/DQ
-    are read defensively (skipped if absent). Extra keyword arguments pass
-    through to :func:`detect_star_centroids`.
+    pixels (non-finite ERR) and the ``DETECT_DQ_BITS`` DQ pixels (DO_NOT_USE +
+    SATURATED + NO_LIN_CORR — unusable, saturated, or nonlinearity-uncorrected;
+    JUMP_DET etc. are already-corrected and kept). ERR/DQ are read defensively
+    (skipped if absent). Extra keyword arguments pass through to
+    :func:`detect_star_centroids`.
     """
     with fits.open(path, memmap=False) as hdul:
         sci = np.asarray(hdul['SCI'].data, dtype=float)
@@ -138,6 +176,6 @@ def detect_in_exposure(path, *, fwhm=2.5, nsigma=5.0, **kwargs):
             mask |= ~np.isfinite(np.asarray(hdul['ERR'].data, dtype=float))
         if 'DQ' in hdul and hdul['DQ'].data is not None:
             dq = np.asarray(hdul['DQ'].data).astype(np.uint32)
-            mask |= (dq & _DO_NOT_USE) != 0
+            mask |= (dq & DETECT_DQ_BITS) != 0
     return detect_star_centroids(sci, mask=mask, fwhm=fwhm, nsigma=nsigma,
                                  **kwargs)

--- a/pipeline/campfire_pipeline/nircam/align/footprint.py
+++ b/pipeline/campfire_pipeline/nircam/align/footprint.py
@@ -1,0 +1,208 @@
+"""Footprint-clip the reference catalog to one exposure's sky coverage.
+
+The field reference catalog is field-wide (e.g. ~550k rows for COSMOS), but a
+single NIRCam exposure covers only its ~10' detector union. Feeding the whole
+catalog to the matcher forces the brightest-N vertex cap to pick globally
+brightest sources — almost all of them off-frame — so the triangle bootstrap
+sees essentially no real correspondences. Clipping the refcat to the exposure's
+footprint (plus a border sized for the acquisition-pointing error) is what makes
+the in-frame sources the ones the cap keeps.
+
+Geometry is done in a local **gnomonic tangent plane** (arcsec) about the mean
+exposure pointing, not in raw RA/Dec: the border buffer is then an isotropic
+true-angle margin, and the projection is immune to the RA wrap / cos(dec)
+stretch / pole degeneracies that bite a naive RA/Dec polygon. Over NIRCam's
+~10' field the tangent-plane distortion is negligible.
+
+The clip is deliberately a **superset** of the true footprint — the border
+means we keep a ring of just-outside sources — because the border doubles as an
+implicit pointing prior: the footprint derives from the (possibly offset) input
+WCS, so it must be grown by the largest acquisition error we expect to recover.
+Over-inclusion is harmless (the robust refine rejects the extras); under-
+inclusion would starve the solve.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from campfire_pipeline.common.io import log
+
+_ARCSEC_PER_DEG = 3600.0
+# NIRCam detectors are all 2048^2; the corner sampling grid falls back to this
+# when a gwcs carries no bounding box.
+_DEFAULT_SHAPE = (2048, 2048)
+
+
+@dataclass
+class FootprintClip:
+    """Result of :func:`clip_refcat_to_exposure`."""
+
+    table: object          # the clipped refcat (astropy Table)
+    n_total: int           # rows in the input refcat
+    n_kept: int            # rows inside footprint + border
+    clipped: bool          # False when the clip failed open (table == input)
+
+    @property
+    def starved(self) -> bool:
+        """True when the clip succeeded but left too few rows to bootstrap."""
+        return self.clipped and self.n_kept < 3
+
+
+def _detector_corner_sky(wcs, in_shape=_DEFAULT_SHAPE):
+    """Return ``(ra[deg], dec[deg])`` sampled around one detector's boundary.
+
+    Samples the four corners plus the four edge midpoints of the detector's
+    pixel grid (its gwcs ``bounding_box`` if set, else a full ``in_shape``
+    frame) and transforms them through the gwcs. Eight boundary points capture
+    the (small) edge curvature from distortion better than corners alone, at
+    negligible cost.
+    """
+    (x0, x1), (y0, y1) = _pixel_extent(wcs, in_shape)
+    xm, ym = 0.5 * (x0 + x1), 0.5 * (y0 + y1)
+    xs = np.array([x0, xm, x1, x1, x1, xm, x0, x0], dtype=float)
+    ys = np.array([y0, y0, y0, ym, y1, y1, y1, ym], dtype=float)
+    ra, dec = wcs(xs, ys)
+    ra = np.asarray(ra, dtype=float)
+    dec = np.asarray(dec, dtype=float)
+    good = np.isfinite(ra) & np.isfinite(dec)
+    return ra[good], dec[good]
+
+
+def _pixel_extent(wcs, in_shape):
+    """``((x0, x1), (y0, y1))`` pixel bounds for *wcs* (bounding_box or frame)."""
+    bb = getattr(wcs, 'bounding_box', None)
+    try:
+        # gwcs bounding_box is ((x_lo, x_hi), (y_lo, y_hi)); tolerate the
+        # ModelBoundingBox wrapper by indexing.
+        (x0, x1), (y0, y1) = bb[0], bb[1]
+        return (float(x0), float(x1)), (float(y0), float(y1))
+    except (TypeError, ValueError, IndexError):
+        nx, ny = in_shape
+        return (0.0, float(nx - 1)), (0.0, float(ny - 1))
+
+
+def _gnomonic(ra_deg, dec_deg, ra0_deg, dec0_deg):
+    """Gnomonic (TAN) projection to tangent-plane ``(xi, eta)`` in **arcsec**.
+
+    Standard tangent-plane projection about ``(ra0, dec0)``. Points on the far
+    hemisphere (``cos c <= 0``) map to NaN — they are never part of a NIRCam
+    footprint, and NaN simply fails the downstream containment test.
+    """
+    ra = np.radians(np.asarray(ra_deg, dtype=float))
+    dec = np.radians(np.asarray(dec_deg, dtype=float))
+    ra0 = np.radians(float(ra0_deg))
+    dec0 = np.radians(float(dec0_deg))
+    dra = ra - ra0
+    sin_dec, cos_dec = np.sin(dec), np.cos(dec)
+    sin_dec0, cos_dec0 = np.sin(dec0), np.cos(dec0)
+    cos_c = sin_dec0 * sin_dec + cos_dec0 * cos_dec * np.cos(dra)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        xi = cos_dec * np.sin(dra) / cos_c
+        eta = (cos_dec0 * sin_dec - sin_dec0 * cos_dec * np.cos(dra)) / cos_c
+    bad = ~np.isfinite(cos_c) | (cos_c <= 0)
+    xi = np.where(bad, np.nan, xi)
+    eta = np.where(bad, np.nan, eta)
+    scale = np.degrees(1.0) * _ARCSEC_PER_DEG
+    return xi * scale, eta * scale
+
+
+def _tangent_center(ra_deg, dec_deg):
+    """Mean pointing of a set of sky points, via unit-vector averaging.
+
+    Averaging unit vectors (rather than raw RA/Dec) keeps the center correct
+    across the RA=0/360 seam and near the pole.
+    """
+    ra = np.radians(np.asarray(ra_deg, dtype=float))
+    dec = np.radians(np.asarray(dec_deg, dtype=float))
+    x = np.mean(np.cos(dec) * np.cos(ra))
+    y = np.mean(np.cos(dec) * np.sin(ra))
+    z = np.mean(np.sin(dec))
+    ra0 = np.degrees(np.arctan2(y, x)) % 360.0
+    dec0 = np.degrees(np.arctan2(z, np.hypot(x, y)))
+    return ra0, dec0
+
+
+def clip_refcat_to_exposure(refcat, detector_wcses, *, border_arcmin=0.5,
+                            in_shape=_DEFAULT_SHAPE):
+    """Clip *refcat* to the sky footprint of one exposure's detectors.
+
+    Parameters
+    ----------
+    refcat : astropy.table.Table
+        Field reference catalog with ``RA``/``DEC`` columns (degrees, ICRS).
+    detector_wcses : iterable of gwcs.WCS
+        One gwcs per detector in the exposure group (their union defines the
+        footprint).
+    border_arcmin : float
+        Isotropic true-angle margin added around the detector union, sized for
+        the maximum acquisition-pointing error to be recovered.
+    in_shape : (int, int)
+        Pixel frame used when a gwcs has no bounding box (NIRCam: 2048x2048).
+
+    Returns
+    -------
+    FootprintClip
+        ``.table`` is the clipped catalog (or, when the clip can't be built,
+        the untouched input — fail-open, with ``.clipped == False``).
+    """
+    from shapely.geometry import Polygon
+    from shapely.ops import unary_union
+    try:                                   # shapely >= 2.0
+        from shapely import contains_xy as _contains_xy
+    except ImportError:                    # shapely 1.7–1.x
+        from shapely.vectorized import contains as _contains_xy
+
+    n_total = len(refcat)
+    wcses = [w for w in detector_wcses if w is not None]
+    if n_total == 0 or not wcses:
+        return FootprintClip(refcat, n_total, n_total, clipped=False)
+
+    if 'RA' not in refcat.colnames or 'DEC' not in refcat.colnames:
+        log("footprint: refcat has no RA/DEC; skipping clip (fail-open).")
+        return FootprintClip(refcat, n_total, n_total, clipped=False)
+
+    # Detector boundary points -> a single tangent center for the exposure.
+    det_sky = [_detector_corner_sky(w, in_shape) for w in wcses]
+    det_sky = [(ra, dec) for ra, dec in det_sky if ra.size >= 3]
+    if not det_sky:
+        log("footprint: no usable detector WCS footprints; skipping clip "
+            "(fail-open).")
+        return FootprintClip(refcat, n_total, n_total, clipped=False)
+
+    all_ra = np.concatenate([ra for ra, _ in det_sky])
+    all_dec = np.concatenate([dec for _, dec in det_sky])
+    ra0, dec0 = _tangent_center(all_ra, all_dec)
+
+    # Union of the per-detector quads in the tangent plane, buffered by border.
+    quads = []
+    for ra, dec in det_sky:
+        xi, eta = _gnomonic(ra, dec, ra0, dec0)
+        pts = np.column_stack([xi, eta])
+        pts = pts[np.all(np.isfinite(pts), axis=1)]
+        if len(pts) >= 3:
+            quads.append(Polygon(pts).convex_hull)
+    if not quads:
+        log("footprint: detector footprints degenerate; skipping clip.")
+        return FootprintClip(refcat, n_total, n_total, clipped=False)
+
+    border_arcsec = float(border_arcmin) * 60.0
+    footprint = unary_union(quads).buffer(border_arcsec)
+
+    # Project the refcat once; cheap tangent-plane bbox pre-filter, then an
+    # exact polygon test only on the survivors.
+    ref_xi, ref_eta = _gnomonic(refcat['RA'], refcat['DEC'], ra0, dec0)
+    minx, miny, maxx, maxy = footprint.bounds
+    in_box = (np.isfinite(ref_xi) & np.isfinite(ref_eta)
+              & (ref_xi >= minx) & (ref_xi <= maxx)
+              & (ref_eta >= miny) & (ref_eta <= maxy))
+
+    keep = np.zeros(n_total, dtype=bool)
+    box_idx = np.flatnonzero(in_box)
+    if box_idx.size:
+        inside = _contains_xy(footprint, ref_xi[box_idx], ref_eta[box_idx])
+        keep[box_idx] = np.asarray(inside, dtype=bool)
+
+    clipped_table = refcat[keep]
+    n_kept = int(keep.sum())
+    return FootprintClip(clipped_table, n_total, n_kept, clipped=True)

--- a/pipeline/campfire_pipeline/nircam/align/matcher.py
+++ b/pipeline/campfire_pipeline/nircam/align/matcher.py
@@ -21,11 +21,20 @@ plausible pairs in a dense or contaminated field. Trust comes from the
 downstream robust, all-source refine (the sigma-clipped ``align_wcs`` fit), not
 from these raw pairs.
 
+**Bootstrap only.** This matcher *seeds* the solve; it does not decide the fit.
+``bootstrap_max`` caps each catalog to its brightest-N vertices before triangle
+building (to bound the O(N^3) triangle count), so the triangle stage rests on a
+small vertex set by design — the downstream all-source robust refine
+(``tweakwcs.XYXYMatch`` over every detected source; see ``solve.py``) is what the
+fitted WCS actually rests on. Capping the *bootstrap* is correct; the cap never
+reaches the final fit.
+
 **Color-free.** Magnitude is dropped from the correspondence entirely; the
-``mag_col`` is used *only* to cap each catalog to its brightest-N vertices
-before triangle building (to bound the O(N^3) triangle count) — never as a
-match constraint. This is what lets the align phase feed a reference catalog
-whose magnitude zeropoint is inconsistent across build backends.
+``mag_col`` is used *only* to rank the ``bootstrap_max`` cap (brightest first) —
+never as a match constraint. This is what lets the align phase feed a reference
+catalog whose magnitude zeropoint is inconsistent across build backends. Capping
+both catalogs to the same ``bootstrap_max`` also density-matches the two vertex
+sets, so the triangle hash isn't swamped by whichever side is denser.
 
 Wraps ``tristars.match.match_catalog_tri`` on its correspondence-only path
 (``auto_keep=False``): the matcher returns matched index pairs; the
@@ -57,13 +66,15 @@ class TriangleMatch(MatchCatalogs):
 
     Parameters
     ----------
-    brightest : int or None
+    bootstrap_max : int or None
         Cap each catalog to this many brightest vertices before building
-        triangles (bounds the triangle count). ``None`` uses every source.
+        triangles (bounds the triangle count). Bounds the **bootstrap** only —
+        the fit rests on the all-source refine, not on these vertices. ``None``
+        uses every source.
     mag_col : str
-        Column used to rank brightness for the ``brightest`` cap (smaller =
+        Column used to rank brightness for the ``bootstrap_max`` cap (smaller =
         brighter, i.e. an AB magnitude). Used for vertex selection ONLY, never
-        as a match constraint. If absent, the cap falls back to input order.
+        as a match constraint. If absent, the cap falls back to an even spread.
     size_limit : (float, float)
         Min/max triangle side length passed to ``match_catalog_tri``. In the
         JWST tangent plane these are **arcsec**; the default ``(5, 800)`` keeps
@@ -77,10 +88,10 @@ class TriangleMatch(MatchCatalogs):
         defaults (both ``True``) assume the JWST WCS already fixes scale and roll.
     """
 
-    def __init__(self, *, brightest=150, mag_col='mag',
+    def __init__(self, *, bootstrap_max=150, mag_col='mag',
                  size_limit=(5.0, 800.0), ignore_rot=True, ignore_scale=True,
                  ba_max=0.9, max_keep=10):
-        self.brightest = brightest
+        self.bootstrap_max = bootstrap_max
         self.mag_col = mag_col
         self.size_limit = [float(size_limit[0]), float(size_limit[1])]
         self.ignore_rot = ignore_rot
@@ -103,11 +114,11 @@ class TriangleMatch(MatchCatalogs):
                 )
         n = len(cat)
         order = np.arange(n)
-        if self.brightest is not None and n > self.brightest:
+        if self.bootstrap_max is not None and n > self.bootstrap_max:
             if self.mag_col in cat.colnames:
                 # smaller magnitude == brighter
                 order = np.argsort(np.asarray(cat[self.mag_col], dtype=float),
-                                   kind='stable')[:self.brightest]
+                                   kind='stable')[:self.bootstrap_max]
             else:
                 # tweakwcs' create_group_catalog rebuilds the pooled image
                 # catalog from scratch — only x/y/RA/DEC/id (+ its own
@@ -120,7 +131,7 @@ class TriangleMatch(MatchCatalogs):
                 # pooled detector contributes vertices, and since each block is
                 # already flux-sorted the brighter sources within it are kept.
                 order = np.unique(
-                    np.linspace(0, n - 1, self.brightest).round().astype(int))
+                    np.linspace(0, n - 1, self.bootstrap_max).round().astype(int))
                 self._warn_unranked(n)
         tpx = np.asarray(cat['TPx'], dtype=float)[order]
         tpy = np.asarray(cat['TPy'], dtype=float)[order]
@@ -140,8 +151,8 @@ class TriangleMatch(MatchCatalogs):
         _UNRANKED_WARNED = True
         log(f"TriangleMatch: no '{self.mag_col}' column to rank brightness "
             f"(expected for the tweakwcs-pooled image catalog, which drops it); "
-            f"spreading the brightest-{self.brightest} vertex cap evenly across "
-            f"the {n} pooled sources. Logged once per process.")
+            f"spreading the bootstrap-{self.bootstrap_max} vertex cap evenly "
+            f"across the {n} pooled sources. Logged once per process.")
 
     def __call__(self, refcat, imcat, tp_pscale=1.0, tp_units=None, **kwargs):
         # tp_pscale / tp_units are part of the MatchCatalogs contract but unused

--- a/pipeline/campfire_pipeline/nircam/align/matcher.py
+++ b/pipeline/campfire_pipeline/nircam/align/matcher.py
@@ -1,13 +1,25 @@
 """Triangle/asterism catalog matcher for the NIRCam ``align`` phase.
 
 :class:`TriangleMatch` is a ``tweakwcs`` ``MatchCatalogs`` subclass that finds
-source correspondences by matching triangle *shape* (side ratios) — invariant
-to translation, rotation, and scale — so it recovers the match with **no prior
-on the WCS offset**. That is exactly the regime where ``tweakwcs``'s default
-``XYXYMatch`` (2-D histogram + nearest-neighbour) fails: once the WCS offset
-exceeds the search radius, NN grabs the wrong neighbours and the histogram peak
-lands near zero, so the fit "succeeds" with a spurious ~zero shift. Triangle
-matching demands geometric consistency, so chance can't fake a match.
+source correspondences by matching triangle geometry via ``tristars``. The
+``tristars`` invariance flags are counter-intuitive: with the defaults used here
+(``ignore_scale=True``, ``ignore_rot=True``) the hash keys on the triangles'
+**absolute side lengths** (scale is *constrained*) and the **longest-edge
+position angle** (rotation is *constrained*). So this matcher is
+**translation-invariant only** — it assumes both catalogs already share a scale
+and roll, which holds for JWST because ``assign_wcs`` fixes the pixel scale and
+gives the roll to ≪1°. It is therefore *not* blind to rotation: it leans on the
+pipeline WCS as a prior, which is fine here because we have one. (``tristars``
+itself warns the fully scale/rotation-free mode "doesn't work well.") Set
+``ignore_rot=False`` only to recover a large roll blindly — a deliberate, tested
+choice, never the default.
+
+On the correspondence-only path (``auto_keep=False``) ``tristars`` returns the
+vertices of a few top triangle-hash pairs: a **hypothesis generator**, not
+RANSAC, not one-to-one, and not inlier-validated — chance triangles can supply
+plausible pairs in a dense or contaminated field. Trust comes from the
+downstream robust, all-source refine (the sigma-clipped ``align_wcs`` fit), not
+from these raw pairs.
 
 **Color-free.** Magnitude is dropped from the correspondence entirely; the
 ``mag_col`` is used *only* to cap each catalog to its brightest-N vertices
@@ -58,7 +70,11 @@ class TriangleMatch(MatchCatalogs):
         within- and cross-detector triangles for a pooled exposure. Tune on
         real data during align validation.
     ignore_rot, ignore_scale, ba_max, max_keep :
-        Passed straight through to ``tristars.match.match_catalog_tri``.
+        Passed straight through to ``tristars.match.match_catalog_tri``. The
+        ``tristars`` sense is inverted from the names: ``ignore_scale=True`` keys
+        on absolute side lengths (scale *constrained*) and ``ignore_rot=True``
+        adds the longest-edge position angle (rotation *constrained*). The
+        defaults (both ``True``) assume the JWST WCS already fixes scale and roll.
     """
 
     def __init__(self, *, brightest=150, mag_col='mag',

--- a/pipeline/campfire_pipeline/nircam/align/matcher.py
+++ b/pipeline/campfire_pipeline/nircam/align/matcher.py
@@ -28,6 +28,11 @@ from campfire_pipeline.common.io import log
 
 _EMPTY = (np.array([], dtype=int), np.array([], dtype=int))
 
+# Warn at most once per process that the image side reached us without a
+# brightness column: it is expected (see _vertices) and would otherwise print
+# once per exposure, flooding a field's align log with identical lines.
+_UNRANKED_WARNED = False
+
 
 class TriangleMatch(MatchCatalogs):
     """Match two tangent-plane catalogs by triangle shape.
@@ -86,15 +91,41 @@ class TriangleMatch(MatchCatalogs):
             if self.mag_col in cat.colnames:
                 # smaller magnitude == brighter
                 order = np.argsort(np.asarray(cat[self.mag_col], dtype=float),
-                                   kind='stable')
+                                   kind='stable')[:self.brightest]
             else:
-                log(f"TriangleMatch: no '{self.mag_col}' column to rank "
-                    f"brightness; capping to the first {self.brightest} of {n} "
-                    f"sources in input order.")
-            order = order[:self.brightest]
+                # tweakwcs' create_group_catalog rebuilds the pooled image
+                # catalog from scratch — only x/y/RA/DEC/id (+ its own
+                # bookkeeping) survive, every brightness column is dropped — so
+                # the image side arrives here unrankable. The per-detector
+                # catalogs were vstacked head-to-tail, so slicing the first N
+                # would consume one detector's whole block and starve the rest,
+                # collapsing the pooled multi-detector geometry to a single
+                # detector. Subsample evenly across the catalog instead: every
+                # pooled detector contributes vertices, and since each block is
+                # already flux-sorted the brighter sources within it are kept.
+                order = np.unique(
+                    np.linspace(0, n - 1, self.brightest).round().astype(int))
+                self._warn_unranked(n)
         tpx = np.asarray(cat['TPx'], dtype=float)[order]
         tpy = np.asarray(cat['TPy'], dtype=float)[order]
         return np.column_stack([tpx, tpy]), order.astype(int)
+
+    def _warn_unranked(self, n):
+        """Note (once per process) that a catalog reached us without a
+        brightness column, so the vertex cap fell back to an even spread.
+
+        This is the normal path for the tweakwcs-pooled *image* catalog — not a
+        misconfigured reference catalog — so the message says so and is emitted
+        only once to avoid one identical line per exposure.
+        """
+        global _UNRANKED_WARNED
+        if _UNRANKED_WARNED:
+            return
+        _UNRANKED_WARNED = True
+        log(f"TriangleMatch: no '{self.mag_col}' column to rank brightness "
+            f"(expected for the tweakwcs-pooled image catalog, which drops it); "
+            f"spreading the brightest-{self.brightest} vertex cap evenly across "
+            f"the {n} pooled sources. Logged once per process.")
 
     def __call__(self, refcat, imcat, tp_pscale=1.0, tp_units=None, **kwargs):
         # tp_pscale / tp_units are part of the MatchCatalogs contract but unused

--- a/pipeline/campfire_pipeline/nircam/align/solve.py
+++ b/pipeline/campfire_pipeline/nircam/align/solve.py
@@ -237,10 +237,19 @@ def solve_exposure_group(detectors, refcat, *, key='group', matcher=None,
 
     wcs_by_det = {d.detector: d.wcs for d in detectors}
 
-    # 2. Bootstrap: coarse shared shift+rotation from the triangle matcher.
-    correctors, fit_info = _shared_fit(
-        detectors, wcs_by_det, refcat, matcher, key=key, fitgeom=fitgeom,
-        minobj=minobj, nclip=nclip, sigma=sigma)
+    # 2. Bootstrap: coarse shared shift+rotation from the triangle matcher. A
+    #    matcher/align_wcs *exception* (e.g. tweakwcs source confusion on a
+    #    crowded field) must degrade to NOT_ALIGNED, never crash the worker — the
+    #    exposure is then surfaced loudly and quarantined, not silently dropped.
+    try:
+        correctors, fit_info = _shared_fit(
+            detectors, wcs_by_det, refcat, matcher, key=key, fitgeom=fitgeom,
+            minobj=minobj, nclip=nclip, sigma=sigma)
+    except Exception as e:  # noqa: BLE001 — worker robustness; degrade gracefully
+        log(f"align solve[{key}]: bootstrap raised {type(e).__name__}: {e}; "
+            f"NOT_ALIGNED (WCS preserved).")
+        return _not_aligned(key, [(d.detector, d.wcs) for d in detectors],
+                            lambda name, wcs: wcs)
     if not _succeeded(fit_info):
         log(f"align solve[{key}]: bootstrap fit "
             f"{fit_info.get('status', 'FAILED')}; NOT_ALIGNED (WCS preserved).")
@@ -260,9 +269,16 @@ def solve_exposure_group(detectors, refcat, *, key='group', matcher=None,
     for _ in range(max(0, int(refine_niter))):
         refine_match = XYXYMatch(use2dhist=False, searchrad=refine_searchrad,
                                  tolerance=refine_tolerance)
-        r_correctors, r_info = _shared_fit(
-            detectors, wcs_by_det, refcat, refine_match, key=key,
-            fitgeom=fitgeom, minobj=minobj, nclip=nclip, sigma=sigma)
+        try:
+            r_correctors, r_info = _shared_fit(
+                detectors, wcs_by_det, refcat, refine_match, key=key,
+                fitgeom=fitgeom, minobj=minobj, nclip=nclip, sigma=sigma)
+        except Exception as e:  # noqa: BLE001 — XYXYMatch can raise on crowded
+            # fields (source confusion). A refine crash must not lose a good
+            # bootstrap solution; keep the last good transform and stop refining.
+            log(f"align solve[{key}]: refine pass raised {type(e).__name__}: "
+                f"{e}; keeping the last good transform.")
+            break
         if not _succeeded(r_info):
             break  # keep the last good (bootstrap or prior refine) transform
         wcs_by_det = {c.meta['name']: c.wcs for c in r_correctors}
@@ -308,10 +324,15 @@ def solve_exposure_group(detectors, refcat, *, key='group', matcher=None,
             # refine_tolerance could not re-pair sources it can't already see. The
             # local refcat is distractor-free, so the triangle matcher recovers the
             # correspondence at any offset, then a shift-only fit removes it.
-            align_wcs([trial], refcat=local_refcat, enforce_user_order=True,
-                      expand_refcat=False, minobj=None, match=matcher,
-                      fitgeom='shift', nclip=nclip, sigma=(sigma, 'rmse'))
-            tfi = trial.meta.get('fit_info', {})
+            try:
+                align_wcs([trial], refcat=local_refcat, enforce_user_order=True,
+                          expand_refcat=False, minobj=None, match=matcher,
+                          fitgeom='shift', nclip=nclip, sigma=(sigma, 'rmse'))
+                tfi = trial.meta.get('fit_info', {})
+            except Exception as e:  # noqa: BLE001 — keep the shared solution
+                log(f"align solve[{key}]: adaptive refit for {d.detector} raised "
+                    f"{type(e).__name__}: {e}; keeping the shared solution.")
+                tfi = {}
             if (_succeeded(tfi)
                     and int(tfi.get('nmatches', 0)) >= adaptive_min_matches):
                 new_resid, new_n, _ = _match(trial, d.catalog, ref_sky,

--- a/pipeline/campfire_pipeline/nircam/align/solve.py
+++ b/pipeline/campfire_pipeline/nircam/align/solve.py
@@ -8,6 +8,20 @@ shift. It returns the corrected gwcs per detector plus solve diagnostics; it doe
 no FITS I/O (the exposure reader/writer + ``CFP_ALGN`` stamp live in the
 orchestration layer).
 
+**Bootstrap → refine.** The shared fit runs in two stages so the triangle cap
+never gates the solution:
+
+1. *Footprint-clip* the field refcat to this exposure's detector union + border,
+   so the matcher's brightest-N cap keeps in-frame sources (``footprint.py``).
+2. *Bootstrap* — ``TriangleMatch`` (``tristars``) recovers a coarse shared
+   shift+rotation from a bounded triangle set. This is only a **seed** (§ matcher
+   docstring); it is translation-invariant and leans on the pipeline WCS prior.
+3. *Refine* — with the coarse transform applied, iterate ``tweakwcs.XYXYMatch``
+   (one-to-one nearest-neighbour over **all** detected sources, no 2-D histogram
+   re-acquisition) with a robust ``rshift`` refit, rebuilding fresh correctors
+   from the current best WCS each pass, until the correction converges. The
+   fitted WCS rests on this all-source refine, not on the capped bootstrap.
+
 The shared solve is the mechanical expression of the pooling constraint: every
 detector of one exposure shares one ``group_id`` so a single rigid rshift is fit
 from the pooled catalog and applied to all of them. Distinct per-exposure
@@ -16,8 +30,9 @@ exposures independent (each ties to the same reference on its own); we
 deliberately do NOT use ``stcal``'s ``group_id=987654`` global collapse.
 
 Per-detector residuals are recomputed DIRECTLY (``det_to_world`` vs matched
-refcat positions), not read from ``tweakwcs``'s group-level ``fit_info`` — which
-carries no per-source residuals, only a fragile group-catalog join.
+refcat positions) with **one-to-one** (mutual nearest-neighbour) matching, not
+read from ``tweakwcs``'s group-level ``fit_info`` — which carries no per-source
+residuals, only a fragile group-catalog join, and whose match is not one-to-one.
 """
 
 import copy
@@ -28,9 +43,15 @@ import numpy as np
 from astropy.coordinates import SkyCoord
 from tweakwcs.correctors import JWSTWCSCorrector
 from tweakwcs.imalign import align_wcs
+from tweakwcs.matchutils import XYXYMatch
 
 from campfire_pipeline.common.io import log
+from campfire_pipeline.nircam.align.footprint import clip_refcat_to_exposure
 from campfire_pipeline.nircam.align.matcher import TriangleMatch
+
+# A refine pass that moves the shared WCS by less than this (arcsec) has
+# converged — well below a NIRCam pixel (31 mas SW / 63 mas LW).
+_REFINE_CONVERGE_ARCSEC = 0.01
 
 
 @dataclass
@@ -82,30 +103,38 @@ def _as_float(value, default=float('nan')):
 
 
 def _match(corrector, catalog, ref_sky, match_radius):
-    """Direct residual for one detector: ``(residual_arcsec, n_matched,
+    """One-to-one residual for one detector: ``(residual_arcsec, n_matched,
     matched_ref_idx)``.
 
-    Transform the detector's own sources through the (corrected) gwcs and
-    nearest-neighbour match them to the reference positions, keeping only
-    matches within *match_radius* arcsec. ``matched_ref_idx`` is the set of
+    Transform the detector's own sources through the (corrected) gwcs and match
+    them to the reference positions by **mutual nearest neighbour** — a source
+    and a reference pair up only if each is the other's closest — keeping pairs
+    within *match_radius* arcsec. Mutual matching makes the count honest: unlike
+    a plain ``match_to_catalog_sky`` (many sources can pile onto one reference),
+    each reference is used at most once. ``matched_ref_idx`` is the set of
     reference rows those sources landed on — reused to build a distractor-free
     local reference catalog for the adaptive per-detector refit.
     """
     empty = (float('nan'), 0, np.array([], dtype=int))
     x = np.asarray(catalog['x'], dtype=float)
     y = np.asarray(catalog['y'], dtype=float)
-    if x.size == 0:
+    if x.size == 0 or len(ref_sky) == 0:
         return empty
     ra, dec = corrector.det_to_world(x, y)
     src = SkyCoord(np.asarray(ra, dtype=float), np.asarray(dec, dtype=float),
                    unit='deg')
-    idx, d2d, _ = src.match_to_catalog_sky(ref_sky)
+    # source -> nearest reference, and reference -> nearest source; keep only
+    # pairs that agree (mutual NN), within the match radius.
+    s2r, d2d, _ = src.match_to_catalog_sky(ref_sky)
+    r2s, _, _ = ref_sky.match_to_catalog_sky(src)
     sep = d2d.arcsec
-    keep = np.isfinite(sep) & (sep <= match_radius)
+    src_ix = np.arange(src.size)
+    mutual = r2s[s2r] == src_ix
+    keep = mutual & np.isfinite(sep) & (sep <= match_radius)
     if not np.any(keep):
         return empty
     return (float(np.median(sep[keep])), int(np.count_nonzero(keep)),
-            np.unique(np.asarray(idx)[keep]))
+            np.unique(np.asarray(s2r)[keep]))
 
 
 def _not_aligned(key, detectors, wcs_getter):
@@ -118,23 +147,58 @@ def _not_aligned(key, detectors, wcs_getter):
     )
 
 
+def _shared_fit(detectors, wcs_by_det, refcat, match, *, key, fitgeom, minobj,
+                nclip, sigma):
+    """Fit one shared correction over the pooled group and return
+    ``(correctors, fit_info)``.
+
+    Builds a fresh corrector per detector from *wcs_by_det* (so each call starts
+    from the current best WCS as an immutable baseline), all sharing *key* as
+    ``group_id`` — one pooled rigid fit. ``align_wcs`` mutates the correctors in
+    place on success, so the caller reads the corrected WCS back off them.
+    """
+    correctors = [
+        JWSTWCSCorrector(
+            wcs_by_det[d.detector], d.wcsinfo,
+            meta={'catalog': d.catalog, 'group_id': key, 'name': d.detector},
+        )
+        for d in detectors
+    ]
+    align_wcs(correctors, refcat=refcat, enforce_user_order=True,
+              expand_refcat=False, minobj=minobj, match=match,
+              fitgeom=fitgeom, nclip=nclip, sigma=(sigma, 'rmse'))
+    return correctors, correctors[0].meta.get('fit_info', {})
+
+
+def _succeeded(fit_info):
+    return str(fit_info.get('status', '')).startswith('SUCCESS')
+
+
 def solve_exposure_group(detectors, refcat, *, key='group', matcher=None,
                          fitgeom='rshift', minobj=None, nclip=3, sigma=3.0,
                          tolerance=0.05, adaptive=True, adaptive_min_matches=3,
-                         match_radius=0.5, min_matched=4):
+                         match_radius=0.5, min_matched=4, ref_border_arcmin=0.5,
+                         bootstrap_max=150, refine_searchrad=2.0,
+                         refine_tolerance=0.5, refine_niter=3):
     """Solve one exposure group; return a :class:`GroupSolution`.
 
-    Parameters mirror ``tweakwcs.align_wcs`` where relevant. *tolerance* and
-    *match_radius* are in **arcsec**. With ``adaptive=True`` (the default per
-    decision D2), a detector whose residual exceeds *tolerance* gets an
-    individual shift-only refit against a distractor-free local reference
-    subset, accepted only if it has at least *adaptive_min_matches* matches and
-    measurably reduces the residual.
+    Parameters mirror ``tweakwcs.align_wcs`` where relevant. *tolerance*,
+    *match_radius*, *ref_border_arcmin*'s buffer, and the ``refine_*`` radii are
+    angular (arcsec, except *ref_border_arcmin* in arcmin). The shared fit runs
+    as a **bootstrap** (``TriangleMatch``, capped at *bootstrap_max* vertices)
+    followed by an all-source **refine** (``XYXYMatch``, up to *refine_niter*
+    one-to-one passes within *refine_searchrad*/*refine_tolerance*), so the
+    triangle cap bounds only the seed, never the final fit.
+
+    With ``adaptive=True`` (decision D2), a detector whose residual exceeds
+    *tolerance* gets an individual shift-only refit against a distractor-free
+    local reference subset, accepted only if it has at least
+    *adaptive_min_matches* matches and measurably reduces the residual.
 
     ``align_wcs`` reports ``status='SUCCESS'`` even for a geometrically wrong
     fit, so we reject to NOT_ALIGNED (reject-to-identity) when fewer than
-    *min_matched* sources across the whole group land within *match_radius* of a
-    reference source after the shared fit.
+    *min_matched* sources across the whole group match one-to-one within
+    *match_radius* of a reference source after the fit.
     """
     detectors = list(detectors)
     if not detectors:
@@ -146,29 +210,40 @@ def solve_exposure_group(detectors, refcat, *, key='group', matcher=None,
         return _not_aligned(key, [(d.detector, d.wcs) for d in detectors],
                             lambda name, wcs: wcs)
 
+    # 1. Footprint-clip the field refcat to this exposure's coverage + border,
+    #    so the bootstrap cap keeps in-frame sources rather than the globally
+    #    brightest (nearly all off-frame). Fail-open (keep the full refcat) on
+    #    any geometry error — a per-exposure worker must never crash the field.
+    try:
+        clip = clip_refcat_to_exposure(refcat, [d.wcs for d in detectors],
+                                       border_arcmin=ref_border_arcmin)
+        if clip.clipped:
+            log(f"align solve[{key}]: refcat footprint clip "
+                f"{clip.n_kept}/{clip.n_total} sources "
+                f"(border {ref_border_arcmin:.2f}').")
+        refcat = clip.table
+    except Exception as e:  # noqa: BLE001 — worker robustness; fail open
+        log(f"align solve[{key}]: footprint clip failed ({type(e).__name__}: "
+            f"{e}); using the full refcat.")
+    if len(refcat) < 3:
+        log(f"align solve[{key}]: only {len(refcat)} refcat sources inside the "
+            f"exposure footprint; NOT_ALIGNED (source-starved / "
+            f"outside-acquisition-bound).")
+        return _not_aligned(key, [(d.detector, d.wcs) for d in detectors],
+                            lambda name, wcs: wcs)
+
     if matcher is None:
-        matcher = TriangleMatch()
+        matcher = TriangleMatch(bootstrap_max=bootstrap_max)
 
-    # One corrector per detector, ALL sharing the exposure's group_id -> one
-    # shared rigid fit for the exposure.
-    correctors = [
-        JWSTWCSCorrector(
-            d.wcs, d.wcsinfo,
-            meta={'catalog': d.catalog, 'group_id': key, 'name': d.detector},
-        )
-        for d in detectors
-    ]
+    wcs_by_det = {d.detector: d.wcs for d in detectors}
 
-    align_wcs(correctors, refcat=refcat, enforce_user_order=True,
-              expand_refcat=False, minobj=minobj, match=matcher,
-              fitgeom=fitgeom, nclip=nclip, sigma=(sigma, 'rmse'))
-
-    fit_info = correctors[0].meta.get('fit_info', {})
-    if not str(fit_info.get('status', '')).startswith('SUCCESS'):
-        log(f"align solve[{key}]: shared fit "
+    # 2. Bootstrap: coarse shared shift+rotation from the triangle matcher.
+    correctors, fit_info = _shared_fit(
+        detectors, wcs_by_det, refcat, matcher, key=key, fitgeom=fitgeom,
+        minobj=minobj, nclip=nclip, sigma=sigma)
+    if not _succeeded(fit_info):
+        log(f"align solve[{key}]: bootstrap fit "
             f"{fit_info.get('status', 'FAILED')}; NOT_ALIGNED (WCS preserved).")
-        # set_correction only runs on success, so the WCS is untouched; return
-        # each corrector's original gwcs explicitly.
         return _not_aligned(
             key, [(c.meta['name'], c) for c in correctors],
             lambda name, c: c.original_wcs)
@@ -176,19 +251,39 @@ def solve_exposure_group(detectors, refcat, *, key='group', matcher=None,
     shift = tuple(_as_float(v) for v in np.asarray(fit_info['shift']).ravel()[:2])
     rot_deg = _as_float(fit_info.get('proper_rot', fit_info.get('rot')))
     rmse = _as_float(fit_info.get('rmse'))
-    group_nmatched = int(fit_info.get('nmatches', 0))
+    wcs_by_det = {c.meta['name']: c.wcs for c in correctors}
+
+    # 3. Refine: all-source one-to-one XYXYMatch, robust rshift, iterated to
+    #    convergence. No 2-D histogram re-acquisition (the bootstrap already
+    #    seeded the offset); each pass rebuilds correctors from the current best
+    #    WCS so the fitted delta stays small and well-conditioned.
+    for _ in range(max(0, int(refine_niter))):
+        refine_match = XYXYMatch(use2dhist=False, searchrad=refine_searchrad,
+                                 tolerance=refine_tolerance)
+        r_correctors, r_info = _shared_fit(
+            detectors, wcs_by_det, refcat, refine_match, key=key,
+            fitgeom=fitgeom, minobj=minobj, nclip=nclip, sigma=sigma)
+        if not _succeeded(r_info):
+            break  # keep the last good (bootstrap or prior refine) transform
+        wcs_by_det = {c.meta['name']: c.wcs for c in r_correctors}
+        correctors = r_correctors
+        rmse = _as_float(r_info.get('rmse'))
+        delta = np.asarray(r_info['shift'], dtype=float).ravel()[:2]
+        if float(np.hypot(*delta)) < _REFINE_CONVERGE_ARCSEC:
+            break
 
     ref_sky = SkyCoord(np.asarray(refcat['RA'], dtype=float),
                        np.asarray(refcat['DEC'], dtype=float), unit='deg')
 
-    # Recompute matches directly, then reject-to-identity if the "successful"
-    # fit did not actually put sources onto the reference (a garbage match).
+    # Recompute matches directly (one-to-one), then reject-to-identity if the
+    # "successful" fit did not actually put sources onto the reference.
     prelim = [_match(corr, d.catalog, ref_sky, match_radius)
               for corr, d in zip(correctors, detectors)]
-    if sum(n for _, n, _ in prelim) < min_matched:
-        log(f"align solve[{key}]: shared fit matched "
-            f"{sum(n for _, n, _ in prelim)} < {min_matched} sources within "
-            f"{match_radius}\"; rejecting to NOT_ALIGNED.")
+    group_nmatched = sum(n for _, n, _ in prelim)
+    if group_nmatched < min_matched:
+        log(f"align solve[{key}]: fit matched {group_nmatched} < {min_matched} "
+            f"sources one-to-one within {match_radius}\"; rejecting to "
+            f"NOT_ALIGNED.")
         return _not_aligned(
             key, [(c.meta['name'], c) for c in correctors],
             lambda name, c: c.original_wcs)
@@ -207,11 +302,17 @@ def solve_exposure_group(detectors, refcat, *, key='group', matcher=None,
             trial = copy.deepcopy(corr)
             trial.meta['group_id'] = f'{key}:{d.detector}'   # distinct -> solo fit
             local_refcat = refcat[ref_idx]
+            # Use the translation-invariant bootstrap matcher here, NOT XYXYMatch:
+            # this detector is out of tolerance precisely because its residual is
+            # large (up to match_radius), and a nearest-neighbour matcher capped at
+            # refine_tolerance could not re-pair sources it can't already see. The
+            # local refcat is distractor-free, so the triangle matcher recovers the
+            # correspondence at any offset, then a shift-only fit removes it.
             align_wcs([trial], refcat=local_refcat, enforce_user_order=True,
                       expand_refcat=False, minobj=None, match=matcher,
                       fitgeom='shift', nclip=nclip, sigma=(sigma, 'rmse'))
             tfi = trial.meta.get('fit_info', {})
-            if (str(tfi.get('status', '')).startswith('SUCCESS')
+            if (_succeeded(tfi)
                     and int(tfi.get('nmatches', 0)) >= adaptive_min_matches):
                 new_resid, new_n, _ = _match(trial, d.catalog, ref_sky,
                                              match_radius)

--- a/pipeline/campfire_pipeline/nircam/cli.py
+++ b/pipeline/campfire_pipeline/nircam/cli.py
@@ -185,13 +185,18 @@ def align(config, field, filters, processes, overwrite, tiles):
 @common_options
 @processing_options
 @tile_option
-def combine(config, field, filters, processes, overwrite, tiles):
+@click.option('--include-unaligned', is_flag=True,
+              help='Include exposures the align phase left NOT_ALIGNED in the '
+                   'combine (default: quarantine them for align-enabled fields).')
+def combine(config, field, filters, processes, overwrite, tiles,
+            include_unaligned):
     """Run the ensemble combine phase (apply_mask → resample)."""
     cfg, field_obj = _setup(config, field)
     run_combine(field_obj, cfg,
                 filters=_resolve_filters(filters, field_obj),
                 n_processes=processes, overwrite=overwrite,
-                tiles=list(tiles) if tiles else None)
+                tiles=list(tiles) if tiles else None,
+                include_unaligned=include_unaligned)
 
 
 @main.command()
@@ -207,8 +212,11 @@ def combine(config, field, filters, processes, overwrite, tiles):
               help='Run the combine phase.')
 @click.option('--all', 'do_all', is_flag=True,
               help='Run all phases (process, align, combine).')
+@click.option('--include-unaligned', is_flag=True,
+              help='Include NOT_ALIGNED exposures in the combine (default: '
+                   'quarantine them for align-enabled fields).')
 def run(config, field, filters, processes, overwrite, tiles,
-        do_process, do_align, do_combine, do_all):
+        do_process, do_align, do_combine, do_all, include_unaligned):
     """Run process, align, and/or combine in one invocation."""
     if do_all:
         do_process = do_align = do_combine = True
@@ -233,7 +241,7 @@ def run(config, field, filters, processes, overwrite, tiles,
     if do_combine:
         run_combine(field_obj, cfg, filters=filter_list,
                     n_processes=processes, overwrite=overwrite,
-                    tiles=tile_list)
+                    tiles=tile_list, include_unaligned=include_unaligned)
 
 
 # ---------------------------------------------------------------------------

--- a/pipeline/campfire_pipeline/nircam/field.py
+++ b/pipeline/campfire_pipeline/nircam/field.py
@@ -76,12 +76,6 @@ def _expand_braces(pattern):
 # top, would lock CRDS into serverless mode before setup_environment runs).
 _DO_NOT_USE = np.uint32(1)
 
-# CFP_ALGN value the align phase stamps on an exposure it could not tie to the
-# reference (WCS preserved, never retried). Mirrors
-# ``nircam.align.apply.NOT_ALIGNED_SENTINEL`` — duplicated as a literal to keep
-# field.py off align's heavy import chain (align.apply -> solve -> tweakwcs).
-_NOT_ALIGNED_SENTINEL = 'NOT_ALIGNED'
-
 
 def _prime_work_copy(path):
     """Prime a freshly-copied combine working copy for the ensemble steps.
@@ -685,7 +679,7 @@ class Field:
 
         kept, dropped = [], 0
         for src in canon:
-            if cfp.step_value(src, 'CFP_ALGN') == _NOT_ALIGNED_SENTINEL:
+            if cfp.step_value(src, 'CFP_ALGN') == cfp.NOT_ALIGNED:
                 dropped += 1
                 dst = os.path.join(work_dir, os.path.basename(src))
                 if os.path.exists(dst):

--- a/pipeline/campfire_pipeline/nircam/field.py
+++ b/pipeline/campfire_pipeline/nircam/field.py
@@ -76,6 +76,12 @@ def _expand_braces(pattern):
 # top, would lock CRDS into serverless mode before setup_environment runs).
 _DO_NOT_USE = np.uint32(1)
 
+# CFP_ALGN value the align phase stamps on an exposure it could not tie to the
+# reference (WCS preserved, never retried). Mirrors
+# ``nircam.align.apply.NOT_ALIGNED_SENTINEL`` — duplicated as a literal to keep
+# field.py off align's heavy import chain (align.apply -> solve -> tweakwcs).
+_NOT_ALIGNED_SENTINEL = 'NOT_ALIGNED'
+
 
 def _prime_work_copy(path):
     """Prime a freshly-copied combine working copy for the ensemble steps.
@@ -602,7 +608,8 @@ class Field:
         return os.path.join(self.filter_dir(filter_name, work=work),
                             f'{rootname}.fits')
 
-    def materialize_work(self, filter_name, status=None, overwrite=False):
+    def materialize_work(self, filter_name, status=None, overwrite=False,
+                         exclude_not_aligned=False):
         """Refresh the combine working copies for a filter; return their paths.
 
         The combine phase must not mutate the canonical per-exposure FITS (those
@@ -628,12 +635,20 @@ class Field:
 
         If a ``StepStatus`` is passed, the working paths are rescanned into it so
         the combine steps' skip checks reflect the working tree's current state.
+
+        With ``exclude_not_aligned`` (set by the combine phase for align-enabled
+        fields), reject-to-identity exposures (``CFP_ALGN = NOT_ALIGNED``) are
+        quarantined from the working tree so they never drizzle or pollute the
+        ensemble — this is the single gate into the tree every combine step reads.
         """
         import shutil
 
         canon = self.get_exposure_files(filter_name)          # frozen process outputs
         work_dir = self.filter_dir(filter_name, work=True)
         os.makedirs(work_dir, exist_ok=True)
+
+        if exclude_not_aligned:
+            canon = self._quarantine_not_aligned(canon, work_dir)
 
         work_paths = []
         for src in canon:
@@ -654,6 +669,33 @@ class Field:
         if status is not None:
             status.rescan(work_paths)
         return sorted(work_paths)
+
+    def _quarantine_not_aligned(self, canon, work_dir):
+        """Drop reject-to-identity exposures from the combine input.
+
+        For an align-enabled field an exposure the align phase could not tie to
+        the reference is stamped ``CFP_ALGN = NOT_ALIGNED`` with its raw WCS
+        preserved; drizzling it doubles sources and defeats CR rejection. We
+        exclude it here — the one gate into the working tree — and delete any
+        stale working copy left from a run before it became NOT_ALIGNED, so a
+        lingering copy can't sneak into the work-tree glob the ensemble steps
+        enumerate. Returns the kept canonical paths.
+        """
+        from campfire_pipeline.common import cfp
+
+        kept, dropped = [], 0
+        for src in canon:
+            if cfp.step_value(src, 'CFP_ALGN') == _NOT_ALIGNED_SENTINEL:
+                dropped += 1
+                dst = os.path.join(work_dir, os.path.basename(src))
+                if os.path.exists(dst):
+                    os.remove(dst)
+            else:
+                kept.append(src)
+        if dropped:
+            log(f"combine: quarantined {dropped} NOT_ALIGNED exposure(s) from "
+                f"the ensemble (use --include-unaligned to override).")
+        return kept
 
     def get_tile_wcs(self, tile_name, pixel_scale='30mas'):
         """Get WCS parameters for a tile at the requested pixel scale.

--- a/pipeline/campfire_pipeline/nircam/field.py
+++ b/pipeline/campfire_pipeline/nircam/field.py
@@ -631,9 +631,11 @@ class Field:
         the combine steps' skip checks reflect the working tree's current state.
 
         With ``exclude_not_aligned`` (set by the combine phase for align-enabled
-        fields), reject-to-identity exposures (``CFP_ALGN = NOT_ALIGNED``) are
+        fields), exposures without a completed alignment — both ``CFP_ALGN =
+        NOT_ALIGNED`` rejects and exposures with no ``CFP_ALGN`` at all — are
         quarantined from the working tree so they never drizzle or pollute the
-        ensemble — this is the single gate into the tree every combine step reads.
+        ensemble with a raw WCS. This is the single gate into the tree every
+        combine step reads (see :meth:`_quarantine_not_aligned`).
         """
         import shutil
 
@@ -665,30 +667,51 @@ class Field:
         return sorted(work_paths)
 
     def _quarantine_not_aligned(self, canon, work_dir):
-        """Drop reject-to-identity exposures from the combine input.
+        """Drop exposures without a completed alignment from the combine input.
 
-        For an align-enabled field an exposure the align phase could not tie to
-        the reference is stamped ``CFP_ALGN = NOT_ALIGNED`` with its raw WCS
-        preserved; drizzling it doubles sources and defeats CR rejection. We
-        exclude it here — the one gate into the working tree — and delete any
-        stale working copy left from a run before it became NOT_ALIGNED, so a
-        lingering copy can't sneak into the work-tree glob the ensemble steps
-        enumerate. Returns the kept canonical paths.
+        For an align-enabled field, only exposures carrying a real align
+        solution (``CFP_ALGN`` set to a ``dof=…`` value) may enter the ensemble.
+        Two failure modes are excluded — both would otherwise drizzle with a raw
+        (unaligned) WCS, doubling sources and defeating CR rejection — and each
+        is surfaced with its own fix, because silently omitting data is never
+        acceptable:
+
+        * ``CFP_ALGN = NOT_ALIGNED`` — the align phase tried and could not tie
+          the exposure to the reference. Retune ``[<field>.align]`` and re-run
+          ``cfpipe nircam align`` (NOT_ALIGNED exposures are re-attempted), or
+          force it in with ``combine --include-unaligned``.
+        * **no ``CFP_ALGN`` at all** — align has not solved this exposure (it was
+          never run, was run over a different filter/tile subset, or its worker
+          died). Since an align-enabled field skips ``jhat``/``wcs_shift``, this
+          exposure has *no* astrometric correction. Run ``cfpipe nircam align``.
+
+        This is the one gate into the working tree; we also delete any stale
+        working copy so a lingering copy can't sneak into the work-tree glob the
+        ensemble steps enumerate. Returns the kept canonical paths.
         """
         from campfire_pipeline.common import cfp
 
-        kept, dropped = [], 0
+        kept, rejected, unstamped = [], [], []
         for src in canon:
-            if cfp.step_value(src, 'CFP_ALGN') == cfp.NOT_ALIGNED:
-                dropped += 1
-                dst = os.path.join(work_dir, os.path.basename(src))
-                if os.path.exists(dst):
-                    os.remove(dst)
-            else:
-                kept.append(src)
-        if dropped:
-            log(f"combine: quarantined {dropped} NOT_ALIGNED exposure(s) from "
-                f"the ensemble (use --include-unaligned to override).")
+            value = cfp.step_value(src, 'CFP_ALGN')
+            if value is not None and value != cfp.NOT_ALIGNED:
+                kept.append(src)                      # a real align solution
+                continue
+            (rejected if value == cfp.NOT_ALIGNED else unstamped).append(src)
+            dst = os.path.join(work_dir, os.path.basename(src))
+            if os.path.exists(dst):
+                os.remove(dst)
+
+        if rejected:
+            log(f"combine: quarantined {len(rejected)} NOT_ALIGNED exposure(s) "
+                f"from the ensemble — failed alignment. Retune [<field>.align] "
+                f"and re-run `cfpipe nircam align`, or `combine "
+                f"--include-unaligned`.")
+        if unstamped:
+            log(f"combine: quarantined {len(unstamped)} exposure(s) with NO "
+                f"alignment stamp — align is enabled but has not solved them "
+                f"(raw WCS). Run `cfpipe nircam align`, or `combine "
+                f"--include-unaligned`.")
         return kept
 
     def get_tile_wcs(self, tile_name, pixel_scale='30mas'):

--- a/pipeline/campfire_pipeline/nircam/orchestrate.py
+++ b/pipeline/campfire_pipeline/nircam/orchestrate.py
@@ -739,7 +739,7 @@ def run_align(field, config, filters=None, n_processes=1, overwrite=False,
 
 
 def run_combine(field, config, filters=None, n_processes=1, overwrite=False,
-                tiles=None):
+                tiles=None, include_unaligned=False):
     """Run all combine-phase steps in order across each filter.
 
     ``tiles`` scopes the *whole* combine phase to exposures overlapping the
@@ -757,6 +757,12 @@ def run_combine(field, config, filters=None, n_processes=1, overwrite=False,
     reduction_version = _resolve_reduction_version(config)
     status = _scan_status(field, filters, overwrite=overwrite)
 
+    # For an align-enabled field, quarantine NOT_ALIGNED exposures from the
+    # ensemble (they'd drizzle with a raw WCS). --include-unaligned overrides.
+    align_enabled = get_nircam_step_config('align', config, field).get(
+        'enabled', False)
+    exclude_not_aligned = align_enabled and not include_unaligned
+
     log(f"=== Combine phase: field={field.name}, filters={filters} ===")
     for filt in filters:
         log(f"--- Combine: {filt} ---")
@@ -769,7 +775,8 @@ def run_combine(field, config, filters=None, n_processes=1, overwrite=False,
                 # DO_NOT_USE) and rescan them into the status cache.
                 _RUNNERS[step_name](field, config, filt, n_processes,
                                     overwrite, status, tiles=tiles)
-                field.materialize_work(filt, status=status, overwrite=overwrite)
+                field.materialize_work(filt, status=status, overwrite=overwrite,
+                                       exclude_not_aligned=exclude_not_aligned)
             elif step_name == 'resample':
                 _run_resample(field, config, filt, n_processes, overwrite,
                               status, reduction_version, tiles=tiles)
@@ -801,11 +808,18 @@ def run_step(step_name, field, config, filters=None, n_processes=1,
         prefetch_process_references(field, filters, status=status,
                                     overwrite=overwrite)
 
+    # A standalone ensemble step honours the same NOT_ALIGNED quarantine as the
+    # full combine phase for align-enabled fields (no --include-unaligned escape
+    # hatch on the per-step CLI — the full `combine` command is where you opt in).
+    exclude_not_aligned = get_nircam_step_config('align', config, field).get(
+        'enabled', False)
+
     for filt in filters:
         # A standalone combine ensemble step needs the working copies present
         # and primed (canonical -> work, CFMASK -> DO_NOT_USE) before it runs.
         if step_name in _COMBINE_WORK_STEPS:
-            field.materialize_work(filt, status=status, overwrite=overwrite)
+            field.materialize_work(filt, status=status, overwrite=overwrite,
+                                   exclude_not_aligned=exclude_not_aligned)
         if step_name == 'resample':
             reduction_version = _resolve_reduction_version(config)
             _run_resample(field, config, filt, n_processes, overwrite,

--- a/pipeline/campfire_pipeline/nircam/orchestrate.py
+++ b/pipeline/campfire_pipeline/nircam/orchestrate.py
@@ -20,6 +20,7 @@ from importlib import import_module
 
 from astropy.io import fits
 
+from campfire_pipeline.common import cfp
 from campfire_pipeline.common.io import log
 from campfire_pipeline.common.parallel import dispatch
 from campfire_pipeline.config import get_nircam_step_config
@@ -670,6 +671,39 @@ def _align_group_worker(key, members, *, refcat, config, overwrite, status):
                                 overwrite=overwrite, status=status)
 
 
+def _warn_not_aligned(field, failed_groups):
+    """Loudly report exposures that failed alignment, and how to resolve them.
+
+    Excluding data from the mosaic is never an automatic decision — a NOT_ALIGNED
+    exposure is quarantined from every future combine (its raw WCS would double
+    sources). Surface the full list at the end of the command and hand the user
+    the two levers: retune + re-run (re-attempted automatically), or force-include.
+    """
+    bar = '!' * 72
+    log('')
+    log(bar)
+    log(f"align: WARNING — {len(failed_groups)} exposure(s) FAILED alignment "
+        f"(CFP_ALGN = {cfp.NOT_ALIGNED}).")
+    log("These are EXCLUDED from all future mosaics by default (the combine")
+    log("quarantine). Omitting data is not automatic — review and resolve first:")
+    log('')
+    for g in failed_groups:
+        log(f"  {g.key}  ({g.n_members} detector(s)):")
+        for m in g.members:
+            log(f"      {m.path}")
+    log('')
+    log("To retry: retune [<field>.align] in fields.toml (e.g. widen "
+        "ref_border_arcmin,")
+    log("  lower snr_min, raise match_radius / refine_searchrad), then re-run")
+    log("  `cfpipe nircam align` — NOT_ALIGNED exposures are re-attempted "
+        "automatically")
+    log("  (no --overwrite needed; already-aligned exposures are left alone).")
+    log("To include them as-is (raw WCS, not recommended): "
+        "`cfpipe nircam combine --include-unaligned`.")
+    log(bar)
+    log('')
+
+
 def run_align(field, config, filters=None, n_processes=1, overwrite=False,
               tiles=None):
     """Field-level astrometric align phase (runs between process and combine).
@@ -709,13 +743,29 @@ def run_align(field, config, filters=None, n_processes=1, overwrite=False,
     if overwrite:
         pending = groups
     else:
-        pending = [g for g in groups
-                   if not all(status.has(m.path, 'CFP_ALGN')
-                              for m in g.members)]
+        # A group is "done" (skippable) only if every detector carries a
+        # completed, non-rejected alignment. NOT_ALIGNED exposures are
+        # re-attempted on a normal re-run — the user may have retuned
+        # [<field>.align] params and wants another try without force-re-solving
+        # everything that already succeeded. Groups are homogeneous (a whole
+        # exposure solves or rejects together), so one stamped member classifies
+        # a fully-stamped group.
+        pending, retry = [], 0
+        for g in groups:
+            stamped = all(status.has(m.path, 'CFP_ALGN') for m in g.members)
+            if stamped and (cfp.step_value(g.members[0].path, 'CFP_ALGN')
+                            != cfp.NOT_ALIGNED):
+                continue                        # already solved -> skip
+            pending.append(g)
+            if stamped:
+                retry += 1                      # stamped but NOT_ALIGNED -> retry
         skipped = len(groups) - len(pending)
         if skipped:
             log(f"align: {skipped}/{len(groups)} exposures already aligned; "
-                f"skipping those")
+                f"skipping those (--overwrite to re-solve)")
+        if retry:
+            log(f"align: re-attempting {retry} previously NOT_ALIGNED "
+                f"exposure(s)")
     if not pending:
         return
 
@@ -736,6 +786,16 @@ def run_align(field, config, filters=None, n_processes=1, overwrite=False,
         counts[st] = counts.get(st, 0) + 1
     log(f"=== Align phase done for {field.name}: "
         f"{dict(sorted(counts.items()))} ===")
+
+    # Failing to align an exposure quietly drops it from every future mosaic
+    # (the combine quarantine). That must never be silent: surface it loudly at
+    # the end of the command and hand the user the tools to resolve it.
+    pending_by_key = {g.key: g for g in pending}
+    failed = [pending_by_key[r.key] for r in results
+              if r is not None and getattr(r, 'status', None) == 'NOT_ALIGNED'
+              and getattr(r, 'key', None) in pending_by_key]
+    if failed:
+        _warn_not_aligned(field, failed)
 
 
 def run_combine(field, config, filters=None, n_processes=1, overwrite=False,

--- a/pipeline/campfire_pipeline/nircam/orchestrate.py
+++ b/pipeline/campfire_pipeline/nircam/orchestrate.py
@@ -140,6 +140,24 @@ def _group_by_visit(exposure_files):
     return visits
 
 
+def _visit_membership_matches(manifest, visit, visit_files):
+    """True iff an outlier *manifest* recorded exactly the current *visit_files*
+    as this visit's own inputs.
+
+    Catches a member dropped from the visit (a NOT_ALIGNED quarantine, a new
+    skip/exclusion, a tile re-scope) that the per-file hash check alone would
+    miss — the survivors' hashes still match the larger manifest, so outlier
+    would be skipped and resample would reuse CR masks computed with the
+    now-absent exposure still pooled. A manifest input belongs to this visit iff
+    its filename's leading ``jw...`` token is the visit; cross-visit overlap
+    inputs (a different token) are excluded here and validated by
+    ``outlier_step``'s full input-set check on the slow path.
+    """
+    manifest_this_visit = {inp['filename'] for inp in manifest.get('inputs', [])
+                           if inp['filename'].split('_')[0] == visit}
+    return manifest_this_visit == {os.path.basename(f) for f in visit_files}
+
+
 def _read_sregions(exposure_files):
     """Return S_REGION header strings parallel to ``exposure_files``."""
     sregions = []
@@ -470,10 +488,12 @@ def _run_outlier_per_visit(field, cfg, filtname, n_processes, overwrite, status,
         manifest = load_manifest(manifest_path)
         if manifest is None:
             return False
+        # A member dropped from this visit (e.g. a NOT_ALIGNED quarantine) must
+        # force outlier to re-run, else resample reuses CR masks computed with
+        # the now-absent exposure still pooled (see _visit_membership_matches).
+        if not _visit_membership_matches(manifest, visit, visit_files):
+            return False
         # Check that visit_files (a subset of all_inputs) hashes still match.
-        # Cross-visit overlaps are validated inside outlier_step on the slow
-        # path; here we only confirm the visit's own files are unchanged so
-        # we can cheaply skip the obvious no-op case.
         old_hashes = {
             inp['filename']: inp['file_hash']
             for inp in manifest['inputs']

--- a/pipeline/tests/test_align_apply.py
+++ b/pipeline/tests/test_align_apply.py
@@ -149,6 +149,20 @@ def test_idempotent_skip(tmp_path):
     assert all(os.path.getmtime(m.path) == mtimes[m.path] for m in members)
 
 
+def test_not_aligned_reattempted_without_overwrite(tmp_path):
+    # A rejected exposure is re-attempted on a normal re-run (no --overwrite) —
+    # unlike a solved one, which is skipped — so the user can retune params and
+    # try again without force-re-solving everything that already succeeded.
+    members, _, _ = _make_exposure(tmp_path, n_det=2, seed=3)
+    rng = np.random.default_rng(99)
+    badref = Table({'RA': 80.0 + rng.uniform(-0.05, 0.05, 30),
+                    'DEC': -30.0 + rng.uniform(-0.05, 0.05, 30)})
+    assert align_exposure_group(members, badref, config={}).status == 'NOT_ALIGNED'
+    # Re-run without overwrite: re-attempted (fails again here), NOT skipped.
+    sol2 = align_exposure_group(members, badref, config={}, overwrite=False)
+    assert sol2.status == 'NOT_ALIGNED'
+
+
 def test_overwrite_does_not_double_correct(tmp_path):
     members, refcat, xy = _make_exposure(tmp_path, n_det=2, offset=(2.0, 0.0))
     align_exposure_group(members, refcat, config={})

--- a/pipeline/tests/test_align_apply.py
+++ b/pipeline/tests/test_align_apply.py
@@ -161,9 +161,15 @@ def test_overwrite_does_not_double_correct(tmp_path):
 # --- adaptive end-to-end ----------------------------------------------------
 
 def test_adaptive_dof_recorded(tmp_path):
+    # Detector 4 carries a 0.6" per-detector offset — large enough that the
+    # all-source shared refine sigma-clips it (rather than tilting the whole
+    # exposure to absorb it), so its residual survives above tolerance and the
+    # adaptive shift-only refit frees it. match_radius=0.8 keeps its sources
+    # matchable at that offset.
     members, refcat, _ = _make_exposure(
-        tmp_path, n_det=5, offset=(2.0, 0.0), per_det_extra={4: (0.0, 0.3)})
-    align_exposure_group(members, refcat, config={'tolerance': 0.15})
+        tmp_path, n_det=5, offset=(2.0, 0.0), per_det_extra={4: (0.0, 0.6)})
+    align_exposure_group(members, refcat,
+                         config={'tolerance': 0.15, 'match_radius': 0.8})
     # detectors 0-3 stay on the shared solution; detector 4 (nrcb1) is freed
     for m in members[:4]:
         assert 'dof=shared' in _cfp_algn(m.path)

--- a/pipeline/tests/test_align_apply.py
+++ b/pipeline/tests/test_align_apply.py
@@ -163,6 +163,20 @@ def test_not_aligned_reattempted_without_overwrite(tmp_path):
     assert sol2.status == 'NOT_ALIGNED'
 
 
+def test_worker_survives_solve_crash(tmp_path, monkeypatch):
+    # An unexpected solver error on one exposure must degrade it to NOT_ALIGNED
+    # (surfaced + quarantined), never abort the whole field's align worker.
+    members, refcat, _ = _make_exposure(tmp_path, n_det=2)
+    import campfire_pipeline.nircam.align.apply as _a
+    monkeypatch.setattr(_a, 'solve_exposure_group',
+                        lambda *a, **k: (_ for _ in ()).throw(
+                            RuntimeError("unexpected solver error")))
+    sol = align_exposure_group(members, refcat, config={}, overwrite=True)
+    assert sol.status == 'NOT_ALIGNED'
+    for m in members:
+        assert _cfp_algn(m.path) == 'NOT_ALIGNED'
+
+
 def test_overwrite_does_not_double_correct(tmp_path):
     members, refcat, xy = _make_exposure(tmp_path, n_det=2, offset=(2.0, 0.0))
     align_exposure_group(members, refcat, config={})

--- a/pipeline/tests/test_align_detect.py
+++ b/pipeline/tests/test_align_detect.py
@@ -105,6 +105,63 @@ def test_nan_pixels_handled():
     assert _nearest(cat, 40, 40) < 0.3
 
 
+# --- quality cuts (S2) ------------------------------------------------------
+
+def test_snr_min_drops_low_peak_sources():
+    # peak SNR ≈ amp / background_rms (rms ~ 1 here). snr_min drops the faint
+    # source (~15σ) but keeps the bright one (~400σ), even though nsigma found both.
+    rng = np.random.default_rng(6)
+    img = _inject((100, 100), [(30.0, 30.0, 400.0), (70.0, 70.0, 15.0)], rng)
+    base = detect_star_centroids(img, nsigma=4.0)
+    assert _nearest(base, 30, 30) < 0.3 and _nearest(base, 70, 70) < 0.6
+    cut = detect_star_centroids(img, nsigma=4.0, snr_min=40.0)
+    assert _nearest(cut, 30, 30) < 0.3               # bright kept
+    assert _nearest(cut, 70, 70) > 5.0               # faint dropped
+
+
+def test_objmag_lim_keeps_only_range():
+    # objmag_lim trims a magnitude window (uncalibrated DAO mag). Derive the
+    # limits from the actual catalog so the test doesn't hard-code kernel flux.
+    rng = np.random.default_rng(7)
+    img = _inject((120, 120),
+                  [(30.0, 30.0, 600.0), (60.0, 60.0, 120.0), (90.0, 90.0, 25.0)],
+                  rng)
+    full = detect_star_centroids(img, nsigma=4.0)
+    assert len(full) >= 3
+    # DAOStarFinder can emit a negative-flux detection (mag = nan); rank on the
+    # finite mags. objmag_lim itself drops the nan-mag rows (isfinite gate).
+    mags = np.sort(np.asarray(full['mag']))
+    mags = mags[np.isfinite(mags)]
+    lo, hi = mags[0] + 0.01, mags[-1] - 0.01         # exclude the extremes
+    cut = detect_star_centroids(img, nsigma=4.0, objmag_lim=(lo, hi))
+    assert 0 < len(cut) < len(full)
+    cm = np.asarray(cut['mag'])
+    assert np.all(np.isfinite(cm) & (cm >= lo) & (cm <= hi))
+
+
+def test_detect_in_exposure_masks_saturated_dq(tmp_path):
+    # A SATURATED pixel (DQ bit 1) is masked even without DO_NOT_USE — a
+    # saturated core corrupts the centroid/flux the mag cut can't catch.
+    rng = np.random.default_rng(8)
+    shape = (100, 100)
+    sci = _inject(shape, [(30.0, 30.0, 400.0), (70.0, 70.0, 400.0)],
+                  rng).astype('float32')
+    err = np.ones(shape, dtype='float32')
+    dq = np.zeros(shape, dtype='uint32')
+    dq[24:37, 24:37] = 2                             # SATURATED, no DO_NOT_USE
+    path = tmp_path / 'jw01727028001_04101_00003_nrca1.fits'
+    fits.HDUList([
+        fits.PrimaryHDU(),
+        fits.ImageHDU(sci, name='SCI'),
+        fits.ImageHDU(err, name='ERR'),
+        fits.ImageHDU(dq, name='DQ'),
+    ]).writeto(path, overwrite=True)
+
+    cat = detect_in_exposure(str(path))
+    assert _nearest(cat, 70, 70) < 0.3               # clean source detected
+    assert _nearest(cat, 30, 30) > 5.0               # saturated source masked
+
+
 # --- FITS wrapper -----------------------------------------------------------
 
 def test_detect_in_exposure_masks_dq_and_err(tmp_path):

--- a/pipeline/tests/test_align_footprint.py
+++ b/pipeline/tests/test_align_footprint.py
@@ -1,0 +1,87 @@
+"""Tests for the refcat footprint clip (nircam/align/footprint.py).
+
+The tangent-plane helpers are pure numpy; the clip itself uses shapely + a
+CRDS-free mock gwcs (``_align_gwcs``) to build a detector footprint and check
+that in-frame reference sources are kept and far decoys dropped.
+"""
+
+import numpy as np
+import pytest
+from astropy.table import Table, vstack
+
+from _align_gwcs import HAVE_MOCK_WCS, make_mock_wcs
+from campfire_pipeline.nircam.align import footprint as fp
+from campfire_pipeline.nircam.align.footprint import clip_refcat_to_exposure
+
+
+# --- tangent-plane helpers (numpy only) -------------------------------------
+
+def test_gnomonic_center_and_axes():
+    ra0, dec0 = 150.0, 2.3
+    xi, eta = fp._gnomonic(np.array([ra0]), np.array([dec0]), ra0, dec0)
+    assert abs(xi[0]) < 1e-6 and abs(eta[0]) < 1e-6
+    # xi is +east (arcsec), eta is +north (arcsec)
+    dra = 10.0 / 3600.0 / np.cos(np.radians(dec0))
+    xi, eta = fp._gnomonic(np.array([ra0 + dra, ra0]),
+                           np.array([dec0, dec0 + 30.0 / 3600.0]), ra0, dec0)
+    assert abs(xi[0] - 10.0) < 0.01 and abs(eta[0]) < 0.01
+    assert abs(xi[1]) < 0.01 and abs(eta[1] - 30.0) < 0.01
+
+
+def test_gnomonic_far_hemisphere_is_nan():
+    xi, eta = fp._gnomonic(np.array([270.0]), np.array([0.0]), 90.0, 0.0)
+    assert not np.isfinite(xi[0]) and not np.isfinite(eta[0])
+
+
+def test_tangent_center_is_wrap_safe():
+    # points straddling the RA=0/360 seam -> center near 0/360, not ~180
+    ra0, dec0 = fp._tangent_center(np.array([359.9, 0.1, 0.0]),
+                                   np.array([1.0, 1.0, 1.1]))
+    assert min(ra0, 360.0 - ra0) < 0.2
+    assert abs(dec0 - 1.03) < 0.1
+
+
+# --- fail-open --------------------------------------------------------------
+
+def test_clip_fail_open_without_radec():
+    refcat = Table({'x': [1.0, 2.0, 3.0], 'y': [1.0, 2.0, 3.0]})
+    clip = clip_refcat_to_exposure(refcat, [object()], border_arcmin=0.5)
+    assert clip.clipped is False and clip.n_kept == 3
+
+
+def test_clip_fail_open_without_wcs():
+    refcat = Table({'RA': [150.0, 150.1], 'DEC': [2.0, 2.1]})
+    clip = clip_refcat_to_exposure(refcat, [], border_arcmin=0.5)
+    assert clip.clipped is False and clip.n_kept == 2
+
+
+# --- clip (shapely + mock gwcs) ---------------------------------------------
+
+@pytest.mark.skipif(not HAVE_MOCK_WCS, reason="tweakwcs mock-gwcs helper unavailable")
+def test_clip_keeps_in_footprint_drops_decoys():
+    wcs = make_mock_wcs(v2ref=120.0, v3ref=500.0, roll=0.0, crpix=[512, 512],
+                        cd=[[1e-5, 0], [0, 1e-5]], crval=[150.0, 2.0])
+    # In-footprint sources: a pixel grid mapped to sky through the detector WCS.
+    # The mock detector is 1024x2048, so stay inside that extent (x<1024).
+    gx, gy = np.meshgrid(np.linspace(50, 1000, 12), np.linspace(50, 2000, 12))
+    ra_in, dec_in = wcs(gx.ravel(), gy.ravel())
+    ra_in = np.asarray(ra_in, float)
+    dec_in = np.asarray(dec_in, float)
+    # Decoys ~1 degree away — outside the footprint + border.
+    decoy = Table({'RA': ra_in[:50] + 1.0, 'DEC': dec_in[:50] + 1.0})
+    refcat = vstack([Table({'RA': ra_in, 'DEC': dec_in}), decoy])
+
+    clip = clip_refcat_to_exposure(refcat, [wcs], border_arcmin=0.5)
+    assert clip.clipped is True
+    assert clip.n_total == len(refcat)
+    assert clip.n_kept == len(ra_in)                 # every in-frame kept, decoys gone
+    assert np.all(np.asarray(clip.table['RA']) < 150.5)
+
+
+@pytest.mark.skipif(not HAVE_MOCK_WCS, reason="tweakwcs mock-gwcs helper unavailable")
+def test_clip_starved_when_nothing_in_footprint():
+    wcs = make_mock_wcs(v2ref=120.0, v3ref=500.0, roll=0.0, crpix=[512, 512],
+                        cd=[[1e-5, 0], [0, 1e-5]], crval=[150.0, 2.0])
+    far = Table({'RA': [150.0 + 2.0, 150.0 + 2.1], 'DEC': [2.0 + 2.0, 2.0 + 2.1]})
+    clip = clip_refcat_to_exposure(far, [wcs], border_arcmin=0.5)
+    assert clip.clipped is True and clip.n_kept == 0 and clip.starved is True

--- a/pipeline/tests/test_align_matcher.py
+++ b/pipeline/tests/test_align_matcher.py
@@ -125,12 +125,25 @@ def test_brightest_cap_remaps_to_original_rows():
     assert int(np.sum(ri == ii)) >= 6
 
 
-def test_brightest_cap_without_mag_col_warns_and_matches(capsys):
+def test_brightest_cap_without_mag_col_spreads_and_matches(capsys):
+    # tweakwcs' create_group_catalog strips every brightness column from the
+    # pooled image catalog, so the cap can't rank by magnitude. It must then
+    # spread the surviving vertices EVENLY across the whole catalog rather than
+    # slice a contiguous head: a multi-detector pooled catalog is vstacked
+    # head-to-tail, so a head-slice would keep only the first detector's block
+    # and starve the rest (collapsing the pooled geometry to one detector).
+    import campfire_pipeline.nircam.align.matcher as _m
+    _m._UNRANKED_WARNED = False                     # warn-once is per-process
     ref, im, R, shift, n_true = _synthetic(n=200, n_spurious=0)
-    rt, it = _tables(ref, im)                       # no 'mag' column
+    rt, it = _tables(ref, im)                       # no 'mag' column either side
     ri, ii = TriangleMatch(brightest=150)(rt, it)
     assert len(ri) >= 6
-    assert ri.max() < 150 and ii.max() < 150        # capped to first 150
+    # Vertices are drawn from across the full [0, 200) range, not confined to
+    # the first 150 — the old head-slice would cap both maxima below 150.
+    assert ri.max() >= 150 and ii.max() >= 150
+    # Remapping still lands original ref rows on their original image rows.
+    assert int(np.sum(ri == ii)) >= 6
+    assert np.all(_residuals(ref, im, R, shift, ri, ii)[ri == ii] < 0.2)
     assert "no 'mag' column" in capsys.readouterr().out
 
 

--- a/pipeline/tests/test_align_matcher.py
+++ b/pipeline/tests/test_align_matcher.py
@@ -106,17 +106,17 @@ def test_missing_tp_columns_raises():
         TriangleMatch()(rt, it)
 
 
-# --- brightest-N cap + index remapping --------------------------------------
+# --- bootstrap-N cap + index remapping --------------------------------------
 
-def test_brightest_cap_remaps_to_original_rows():
-    # n_true=160 > brightest=150. Rank magnitude so the SURVIVING rows are the
-    # LAST 150 (mag[k] = 159-k => row 159 brightest), not the first — proving
-    # both that the cap fires and that returned indices are original rows.
+def test_bootstrap_cap_remaps_to_original_rows():
+    # n_true=160 > bootstrap_max=150. Rank magnitude so the SURVIVING rows are
+    # the LAST 150 (mag[k] = 159-k => row 159 brightest), not the first —
+    # proving both that the cap fires and that returned indices are original rows.
     ref, im, R, shift, n_true = _synthetic(n=160, n_spurious=0)
     mag = (n_true - 1) - np.arange(n_true)
     rt, it = _tables(ref, im, mag_ref=mag, mag_im=mag)
 
-    ri, ii = TriangleMatch(brightest=150)(rt, it)
+    ri, ii = TriangleMatch(bootstrap_max=150)(rt, it)
     assert len(ri) >= 6
     # Only rows [10, 159] survive the brightest-150 cut on both sides.
     assert ri.min() >= 10 and ri.max() <= 159
@@ -125,7 +125,7 @@ def test_brightest_cap_remaps_to_original_rows():
     assert int(np.sum(ri == ii)) >= 6
 
 
-def test_brightest_cap_without_mag_col_spreads_and_matches(capsys):
+def test_bootstrap_cap_without_mag_col_spreads_and_matches(capsys):
     # tweakwcs' create_group_catalog strips every brightness column from the
     # pooled image catalog, so the cap can't rank by magnitude. It must then
     # spread the surviving vertices EVENLY across the whole catalog rather than
@@ -136,7 +136,7 @@ def test_brightest_cap_without_mag_col_spreads_and_matches(capsys):
     _m._UNRANKED_WARNED = False                     # warn-once is per-process
     ref, im, R, shift, n_true = _synthetic(n=200, n_spurious=0)
     rt, it = _tables(ref, im)                       # no 'mag' column either side
-    ri, ii = TriangleMatch(brightest=150)(rt, it)
+    ri, ii = TriangleMatch(bootstrap_max=150)(rt, it)
     assert len(ri) >= 6
     # Vertices are drawn from across the full [0, 200) range, not confined to
     # the first 150 — the old head-slice would cap both maxima below 150.

--- a/pipeline/tests/test_align_run.py
+++ b/pipeline/tests/test_align_run.py
@@ -32,6 +32,26 @@ def _field(enabled, **kw):
                  step_overrides={'align': {'enabled': enabled, **kw}})
 
 
+def test_visit_membership_detects_dropped_member():
+    # The cheap outlier pre-scan must re-run a visit whose membership changed
+    # (e.g. a NOT_ALIGNED quarantine dropped an exposure) — otherwise resample
+    # reuses CR masks computed with the now-absent exposure still pooled.
+    from campfire_pipeline.nircam.orchestrate import _visit_membership_matches
+    manifest = {'inputs': [
+        {'filename': 'jw001_001_001_nrca1.fits'},
+        {'filename': 'jw001_001_002_nrca1.fits'},
+        {'filename': 'jw002_001_001_nrca1.fits'},     # cross-visit overlap
+    ]}
+    all_members = ['/w/jw001_001_001_nrca1.fits', '/w/jw001_001_002_nrca1.fits']
+    assert _visit_membership_matches(manifest, 'jw001', all_members)  # unchanged
+    # a member dropped (quarantined) -> mismatch -> force re-run
+    assert not _visit_membership_matches(manifest, 'jw001',
+                                         all_members[:1])
+    # a member added -> mismatch too
+    assert not _visit_membership_matches(
+        manifest, 'jw001', all_members + ['/w/jw001_001_003_nrca1.fits'])
+
+
 def test_active_process_steps_gates_jhat_and_wcs_shift():
     off = [n for n, _ in _active_process_steps({}, _field(False))]
     on = [n for n, _ in _active_process_steps({}, _field(True))]

--- a/pipeline/tests/test_align_run.py
+++ b/pipeline/tests/test_align_run.py
@@ -123,3 +123,29 @@ def test_run_align_idempotent(tmp_path):
     mtimes = {p: os.path.getmtime(p) for p in xy_by_path}
     run_align(field, {}, filters=['f200w', 'f444w'], n_processes=1)
     assert all(os.path.getmtime(p) == mtimes[p] for p in xy_by_path)
+
+
+@pytestmark_e2e
+def test_run_align_warns_and_reattempts_not_aligned(tmp_path, capsys):
+    field, _, xy_by_path = _build_field(tmp_path, enabled=True)
+    # Clobber the refcat with too few sources -> every exposure rejects to
+    # NOT_ALIGNED (the solve's <3-source guard).
+    tiny = Table({'RA': [80.0, 80.001], 'DEC': [-30.0, -30.001]})
+    tiny['mag'] = np.zeros(2, 'float32')
+    tiny['mag_err'] = np.ones(2, 'float32')
+    write_refcat(tiny, os.path.join(field.refcat_dir, 'test.ecsv'), overwrite=True)
+
+    run_align(field, {}, filters=['f200w', 'f444w'], n_processes=1)
+    out1 = capsys.readouterr().out
+    for path in xy_by_path:
+        with fits.open(path) as h:
+            assert h[0].header.get('CFP_ALGN') == 'NOT_ALIGNED'
+    assert 'FAILED alignment' in out1                 # loud end-of-command warning
+    assert _TOKEN in out1                              # lists the failed exposure
+
+    # Re-run WITHOUT --overwrite: the NOT_ALIGNED exposure is re-attempted (the
+    # user may have retuned params), not silently skipped, and warned about again.
+    run_align(field, {}, filters=['f200w', 'f444w'], n_processes=1)
+    out2 = capsys.readouterr().out
+    assert 're-attempting' in out2
+    assert 'FAILED alignment' in out2

--- a/pipeline/tests/test_align_solve.py
+++ b/pipeline/tests/test_align_solve.py
@@ -152,6 +152,25 @@ def test_no_geometric_match_not_aligned():
     assert all(ds.dof == 'identity' for ds in sol.detectors)
 
 
+# --- footprint clip ---------------------------------------------------------
+
+def test_footprint_clip_survives_refcat_decoys():
+    # refcat = in-frame truth + a large pile of far (~1 deg) decoys. Without the
+    # footprint clip the bootstrap cap would keep mostly decoys and starve; with
+    # it, only the in-frame sources reach the matcher and the solve succeeds.
+    from astropy.table import vstack
+    detectors, refcat = _build_group(n_det=2, offset=(2.0, 0.0))
+    rng = np.random.default_rng(11)
+    decoy = Table({'RA': _BASE_RA + 1.0 + rng.uniform(-0.05, 0.05, 500),
+                   'DEC': _BASE_DEC + 1.0 + rng.uniform(-0.05, 0.05, 500)})
+    big = vstack([refcat, decoy], metadata_conflicts='silent')
+
+    sol = solve_exposure_group(detectors, big, key='exp', bootstrap_max=150)
+    assert sol.status == 'SOLVED'
+    assert all(ds.within_tolerance for ds in sol.detectors)
+    assert abs(np.hypot(*sol.shift) - 2.0) < 0.1
+
+
 # --- residual helper --------------------------------------------------------
 
 def test_match_measures_small_offset():

--- a/pipeline/tests/test_align_solve.py
+++ b/pipeline/tests/test_align_solve.py
@@ -171,6 +171,29 @@ def test_footprint_clip_survives_refcat_decoys():
     assert abs(np.hypot(*sol.shift) - 2.0) < 0.1
 
 
+# --- robustness: exceptions never crash the worker --------------------------
+
+def test_refine_exception_keeps_bootstrap(monkeypatch):
+    # A crowded field can make XYXYMatch raise (source confusion). The refine
+    # crash must be swallowed and the good bootstrap solution retained, not
+    # propagated out of the solve (which would abort the align worker).
+    from tweakwcs.matchutils import MatchCatalogs
+    import campfire_pipeline.nircam.align.solve as _s
+
+    class _BoomMatch(MatchCatalogs):
+        def __init__(self, *a, **k):
+            pass
+
+        def __call__(self, refcat, imcat, **k):
+            raise RuntimeError("simulated source confusion")
+
+    monkeypatch.setattr(_s, 'XYXYMatch', _BoomMatch)
+    detectors, refcat = _build_group(n_det=2, offset=(2.0, 0.0))
+    sol = solve_exposure_group(detectors, refcat, key='exp')
+    assert sol.status == 'SOLVED'                       # bootstrap survived
+    assert abs(np.hypot(*sol.shift) - 2.0) < 0.1
+
+
 # --- residual helper --------------------------------------------------------
 
 def test_match_measures_small_offset():

--- a/pipeline/tests/test_cfp.py
+++ b/pipeline/tests/test_cfp.py
@@ -128,6 +128,24 @@ def test_has_step_accepts_header_object():
     assert cfp.has_step(hdr, 'CFP_BKG', keyset=cfp.NIRSPEC) is True
 
 
+def test_step_value_returns_card_value(tmp_path):
+    # step_value returns the recorded VALUE (unlike has_step's presence-only) —
+    # the combine quarantine reads it to tell NOT_ALIGNED apart from a solution.
+    path = _write_header(tmp_path / 'a.fits', CFP_ALGN='NOT_ALIGNED')
+    assert cfp.step_value(path, 'CFP_ALGN') == 'NOT_ALIGNED'
+    # absent key -> None
+    assert cfp.step_value(path, 'CFP_MASK') is None
+    # accepts a Header too
+    hdr = fits.Header()
+    hdr['CFP_ALGN'] = 'dof=shared res=0.01 n=30'
+    assert cfp.step_value(hdr, 'CFP_ALGN') == 'dof=shared res=0.01 n=30'
+
+
+def test_step_value_rejects_unknown_key():
+    with pytest.raises(ValueError):
+        cfp.step_value(fits.Header(), 'CFP_CAL', keyset=cfp.NIRCAM)
+
+
 def test_has_step_rejects_unknown_key():
     with pytest.raises(ValueError):
         cfp.has_step(fits.Header(), 'CFP_CAL', keyset=cfp.NIRCAM)

--- a/pipeline/tests/test_nircam_work_tree.py
+++ b/pipeline/tests/test_nircam_work_tree.py
@@ -124,27 +124,34 @@ def _stamp_algn(path, value):
 
 
 def test_materialize_quarantines_not_aligned(tmp_path):
-    # An align-enabled combine must keep NOT_ALIGNED exposures out of the working
-    # tree (they'd drizzle with a raw WCS). exclude_not_aligned is the gate.
+    # An align-enabled combine only admits exposures with a completed alignment.
+    # BOTH failure modes are dropped (they'd drizzle with a raw WCS): a
+    # CFP_ALGN=NOT_ALIGNED reject, and an exposure with no CFP_ALGN stamp at all
+    # (align never solved it). Only the dof=... solution survives.
     f = _make_field(tmp_path)
     d = f.filter_dir('f444w')
     solved = os.path.join(d, f'{_ROOT}.fits')
     rej_root = 'jw01727028001_04101_00004_nrcalong'
+    unstamped_root = 'jw01727028001_04101_00005_nrcalong'
     rejected = os.path.join(d, f'{rej_root}.fits')
+    unstamped = os.path.join(d, f'{unstamped_root}.fits')
     _write_canonical(solved, stamps=())
     _write_canonical(rejected, stamps=())
+    _write_canonical(unstamped, stamps=())            # no CFP_ALGN written
     _stamp_algn(solved, 'dof=shared res=0.01 n=30')
     _stamp_algn(rejected, 'NOT_ALIGNED')
 
-    # Default: no quarantine -> both exposures materialized.
+    # Default: no quarantine -> all three exposures materialized.
     both = f.materialize_work('f444w', overwrite=True)
-    assert len(both) == 2
+    assert len(both) == 3
 
-    # With the quarantine, the NOT_ALIGNED exposure is dropped AND its stale work
-    # copy (left by the call above) is removed, so the ensemble glob can't see it.
+    # With the quarantine, only the solved exposure survives; the rejected and
+    # unstamped ones are dropped AND their stale work copies removed, so the
+    # ensemble glob can't see them.
     kept = f.materialize_work('f444w', overwrite=True, exclude_not_aligned=True)
     assert len(kept) == 1
     assert os.path.basename(kept[0]) == f'{_ROOT}.fits'
     work_dir = f.filter_dir('f444w', work=True)
     assert not os.path.exists(os.path.join(work_dir, f'{rej_root}.fits'))
+    assert not os.path.exists(os.path.join(work_dir, f'{unstamped_root}.fits'))
     assert os.path.exists(os.path.join(work_dir, f'{_ROOT}.fits'))

--- a/pipeline/tests/test_nircam_work_tree.py
+++ b/pipeline/tests/test_nircam_work_tree.py
@@ -115,3 +115,36 @@ def test_materialize_is_incremental(tmp_path):
     f.materialize_work('f444w')
     with fits.open(wp) as hdul:
         assert 'CFP_OUT' not in hdul[0].header
+
+
+def _stamp_algn(path, value):
+    with fits.open(path, mode='update') as hdul:
+        hdul[0].header['CFP_ALGN'] = value
+        hdul.flush()
+
+
+def test_materialize_quarantines_not_aligned(tmp_path):
+    # An align-enabled combine must keep NOT_ALIGNED exposures out of the working
+    # tree (they'd drizzle with a raw WCS). exclude_not_aligned is the gate.
+    f = _make_field(tmp_path)
+    d = f.filter_dir('f444w')
+    solved = os.path.join(d, f'{_ROOT}.fits')
+    rej_root = 'jw01727028001_04101_00004_nrcalong'
+    rejected = os.path.join(d, f'{rej_root}.fits')
+    _write_canonical(solved, stamps=())
+    _write_canonical(rejected, stamps=())
+    _stamp_algn(solved, 'dof=shared res=0.01 n=30')
+    _stamp_algn(rejected, 'NOT_ALIGNED')
+
+    # Default: no quarantine -> both exposures materialized.
+    both = f.materialize_work('f444w', overwrite=True)
+    assert len(both) == 2
+
+    # With the quarantine, the NOT_ALIGNED exposure is dropped AND its stale work
+    # copy (left by the call above) is removed, so the ensemble glob can't see it.
+    kept = f.materialize_work('f444w', overwrite=True, exclude_not_aligned=True)
+    assert len(kept) == 1
+    assert os.path.basename(kept[0]) == f'{_ROOT}.fits'
+    work_dir = f.filter_dir('f444w', work=True)
+    assert not os.path.exists(os.path.join(work_dir, f'{rej_root}.fits'))
+    assert os.path.exists(os.path.join(work_dir, f'{_ROOT}.fits'))


### PR DESCRIPTION
## Summary

Advances the opt-in NIRCam astrometric `align` phase with the first three stages of the [align design doc](../blob/claude/cfpipe-nircam-import-error-d6034o/pipeline/campfire_pipeline/nircam/align/DESIGN.md)'s staged rollout (S1–S3a). All three are **Algorithm**-category and **default-off** — a field must set `[<field>.align].enabled = true`, so existing JHAT reductions are untouched. S3b (refcat epoch/PM) and S3c (dependency closure + mode gating) are deferred to their own PRs.

This branch also carries the design doc itself (the pivot to a hierarchical joint solve) and the earlier `matcher` fixes (vertex-cap spread + a corrected invariance docstring) it builds on.

## S1 — refcat footprint + bootstrap-only cap + all-source refine
The full field refcat (~550k rows for COSMOS) used to reach the matcher, so the brightest-N vertex cap kept the *globally* brightest sources — nearly all off-frame — and that same cap gated the final fit (~17–30 pairs).

- **`align/footprint.py`** (new): clips the refcat to the exposure's detector-union footprint + `ref_border_arcmin` margin (default 0.5′), projected through a local gnomonic tangent plane (RA-wrap / cos(dec) / pole-safe), with a shapely convex hull + buffer. Fails open on any geometry error.
- **`solve.py`**: the shared solve is now **bootstrap** (`TriangleMatch`, capped at `bootstrap_max`) → **all-source one-to-one `XYXYMatch` refine** (`fitgeom='rshift'`, σ-clip, up to `refine_niter` passes, no 2-D-histogram re-acquisition). The vertex cap bounds only the bootstrap seed; the fitted WCS rests on every matched source. Per-detector residuals and the reject-to-identity gate now use mutual-nearest-neighbour (1-to-1) matching, so counts stop piling several detections onto one reference. The translation-invariant matcher (not `XYXYMatch`) still drives the adaptive per-detector refit, so a detector off by up to `match_radius` remains recoverable.
- **`matcher.py`**: `brightest` → `bootstrap_max`, reframed and documented as bootstrap-only.

## S2 — detection quality selection
- **`detect.py`**: adds a peak-SNR floor (`snr_min`), an (uncalibrated) DAO-magnitude range trim (`objmag_lim`), and masks `SATURATED` + `NO_LIN_CORR` DQ (not just `DO_NOT_USE`) so a saturated / nonlinearity-uncorrected core can't seed a false centroid or corrupt flux. The align path drops the fixed `brightest` count cap so the full quality-cut catalog reaches the refine.
- **`apply.py`**: detection PSF FWHM is now **per filter** (`psf_fwhm_by_filter`, keyed off each member's filter, falling back to the scalar `fwhm`) instead of one value across F070W→F480M; wider DQ mask.

## S3a — NOT_ALIGNED combine quarantine
An exposure the align phase can't tie to the reference is stamped `CFP_ALGN = NOT_ALIGNED` with its raw WCS preserved; drizzling it doubles sources and defeats CR rejection.
- **`Field.materialize_work`** — the single gate into the combine working tree that every ensemble step reads — now drops such exposures (and removes any stale working copy), so they enter neither the drizzle nor the outlier / bad-pixel pools.
- New `--include-unaligned` flag on `cfpipe nircam combine` / `run` overrides. New `cfp.step_value` accessor; `orchestrate.py` / `cli.py` wiring.

## Config & changelog
New `[nircam.align]` knobs (`ref_border_arcmin`, `bootstrap_max`, `refine_searchrad/tolerance/niter`, `snr_min`, `psf_fwhm_by_filter`); `brightest` removed. Three categorized bullets added under `## Unreleased` in `pipeline/CHANGELOG.md` (all **Algorithm** → MINOR at release).

## Testing
Ran the align-related suites against the real libraries (`tweakwcs`, `tristars`, `shapely`, `photutils`, `jwst`) — **93 passing**. New/updated coverage: `test_align_footprint.py` (new), `test_align_solve.py` (bootstrap→refine + footprint decoy), `test_align_detect.py` (SNR / mag-range / saturation-DQ cuts), `test_align_matcher.py` (`bootstrap_max` rename), `test_nircam_work_tree.py` + `test_cfp.py` (quarantine + `step_value`).

Notably, the real-geometry apply test caught a bug where I'd swapped the *adaptive* refit to `XYXYMatch` (which capped offset recovery at `refine_tolerance`); reverted to the translation-invariant matcher and verified via an offset sweep that a 0.6–0.8″ per-detector offset recovers to ~0.001″.

Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01BVjMLjYjEQYPZqsFFh1bzv)_