### PR TITLE
Add epoch (exposure subset) mosaics for NIRCam

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -95,6 +95,21 @@ Release procedure: edit the `## Unreleased` section below, then run
   feature failed for fixed-slit sources.
 
 ### Algorithm
+- **NIRCam epoch mosaics** — `cfpipe nircam combine`/`resample`/`run`/`check` take
+  a new `--epoch <name>` flag that builds a mosaic from a *subset* of a field's
+  exposures (e.g. one program or one observing season), **additive and default-off**
+  so a run without `--epoch` is byte-for-byte unchanged. Epochs are defined per
+  field in fields.toml under `[<field>.epochs.<name>]` by an optional `files` glob
+  list and/or an inclusive `date_range` (matched against `DATE-OBS`); the subset
+  scopes the *whole* combine phase (apply_mask → bad_pixel → outlier → resample,
+  like `--tiles`), so the epoch mosaic is a distinct reduction from only those
+  exposures. The epoch name is appended as a trailing filename segment
+  (`mosaic_nircam_<filter>_<field>_<scale>_<tile>_<epoch>_i2d.fits`), stamped as
+  `CFEPOCH` in the mosaic header, and recorded in the manifest; deploy indexes
+  epoch mosaics on the portal as a new `epoch` axis (`nircam_images.epoch`, `''` =
+  full field) alongside full-field mosaics. Category is Algorithm (new science
+  product / naming), though it's arguably Infrastructure since it changes no
+  existing output.
 - **NIRCam field-level astrometric `align` phase is now runnable** (`cfpipe nircam
   align` / `run --align`), **opt-in and default-off** so existing reductions are
   unchanged. When a field sets `[<field>.align].enabled = true` (and names its

--- a/pipeline/campfire_pipeline/nircam/cli.py
+++ b/pipeline/campfire_pipeline/nircam/cli.py
@@ -105,6 +105,22 @@ def tile_option(f):
                              '(default: all tiles / all exposures).')(f)
 
 
+def epoch_option(f):
+    """``--epoch``: runtime epoch selection.
+
+    A runtime parameter, not a config key. Selects one named epoch from
+    fields.toml (``[<field>.epochs.<name>]``) — a subset of the field's
+    exposures, defined by file globs and/or a date range. It scopes the whole
+    combine phase (apply_mask → resample) to that subset, mirroring ``--tiles``,
+    and adds the epoch name as a trailing segment on the mosaic filename
+    (``mosaic_nircam_<filter>_<field>_<scale>_<tile>_<epoch>``). Default: the
+    full field (no epoch segment).
+    """
+    return click.option('--epoch', default=None,
+                        help='Epoch name from fields.toml (subset of exposures; '
+                             'adds a filename segment). Default: full field.')(f)
+
+
 def _setup(config_path, field_name):
     """Load config + environment + field; set up the workspace."""
     config = load_config(config_path)
@@ -185,19 +201,26 @@ def align(config, field, filters, processes, overwrite, tiles):
 @common_options
 @processing_options
 @tile_option
-def combine(config, field, filters, processes, overwrite, tiles):
-    """Run the ensemble combine phase (apply_mask → resample)."""
+@epoch_option
+def combine(config, field, filters, processes, overwrite, tiles, epoch):
+    """Run the ensemble combine phase (apply_mask → resample).
+
+    ``--epoch`` scopes the whole phase to one named epoch's exposure subset and
+    labels the mosaics with the epoch name.
+    """
     cfg, field_obj = _setup(config, field)
     run_combine(field_obj, cfg,
                 filters=_resolve_filters(filters, field_obj),
                 n_processes=processes, overwrite=overwrite,
-                tiles=list(tiles) if tiles else None)
+                tiles=list(tiles) if tiles else None,
+                epoch=epoch)
 
 
 @main.command()
 @common_options
 @processing_options
 @tile_option
+@epoch_option
 @click.option('--process', 'do_process', is_flag=True,
               help='Run the process phase.')
 @click.option('--align', 'do_align', is_flag=True,
@@ -207,9 +230,13 @@ def combine(config, field, filters, processes, overwrite, tiles):
               help='Run the combine phase.')
 @click.option('--all', 'do_all', is_flag=True,
               help='Run all phases (process, align, combine).')
-def run(config, field, filters, processes, overwrite, tiles,
+def run(config, field, filters, processes, overwrite, tiles, epoch,
         do_process, do_align, do_combine, do_all):
-    """Run process, align, and/or combine in one invocation."""
+    """Run process, align, and/or combine in one invocation.
+
+    ``--epoch`` applies only to the combine phase (process/align produce the
+    shared canonical exposures every epoch draws from).
+    """
     if do_all:
         do_process = do_align = do_combine = True
     if not (do_process or do_align or do_combine):
@@ -233,7 +260,7 @@ def run(config, field, filters, processes, overwrite, tiles,
     if do_combine:
         run_combine(field_obj, cfg, filters=filter_list,
                     n_processes=processes, overwrite=overwrite,
-                    tiles=tile_list)
+                    tiles=tile_list, epoch=epoch)
 
 
 # ---------------------------------------------------------------------------
@@ -266,13 +293,19 @@ for _step_name in STEP_NAMES:
 @common_options
 @processing_options
 @tile_option
-def resample(config, field, filters, processes, overwrite, tiles):
-    """Run the resample step."""
+@epoch_option
+def resample(config, field, filters, processes, overwrite, tiles, epoch):
+    """Run the resample step.
+
+    ``--epoch`` restricts the drizzle inputs to the named epoch's exposure
+    subset and labels the mosaics with the epoch name.
+    """
     cfg, field_obj = _setup(config, field)
     run_step('resample', field_obj, cfg,
              filters=_resolve_filters(filters, field_obj),
              n_processes=processes, overwrite=overwrite,
-             tiles=list(tiles) if tiles else None)
+             tiles=list(tiles) if tiles else None,
+             epoch=epoch)
 
 
 # Refcat utilities: `cfpipe nircam refcat {query,extract,merge,compare}`
@@ -364,8 +397,13 @@ def expmap(config, field, filters, stage, pixel_scale, padding,
 @click.option('--filters', multiple=True, default=None, cls=VariadicOption,
               help='Filters to check (default: all from field).')
 @tile_option
-def check(config, field, filters, tiles):
-    """Report which mosaic tiles are stale and need re-mosaicking."""
+@epoch_option
+def check(config, field, filters, tiles, epoch):
+    """Report which mosaic tiles are stale and need re-mosaicking.
+
+    ``--epoch`` reports staleness for the named epoch's mosaics (matching what
+    ``combine``/``resample --epoch`` would build) instead of the full field.
+    """
     from campfire_pipeline.nircam.manifest import get_stale_tiles
     from campfire_pipeline.config import get_nircam_step_config
 
@@ -384,7 +422,8 @@ def check(config, field, filters, tiles):
             'resample': resample_cfg,
             'files_to_skip': files_to_skip,
         }
-        results = get_stale_tiles(field_obj, filtname, wrapped, tiles=tile_list)
+        results = get_stale_tiles(field_obj, filtname, wrapped, tiles=tile_list,
+                                  epoch=epoch)
         if not results:
             log(f'{filtname}: no tiles configured')
             continue

--- a/pipeline/campfire_pipeline/nircam/field.py
+++ b/pipeline/campfire_pipeline/nircam/field.py
@@ -13,7 +13,9 @@ import json
 import os
 import re
 from glob import glob
+from datetime import date
 from dataclasses import dataclass, field
+from fnmatch import fnmatch
 from typing import List, Optional
 
 import toml
@@ -69,6 +71,41 @@ def _expand_braces(pattern):
     for opt in options:
         result.extend(_expand_braces(prefix + opt + suffix))
     return result
+
+
+# Cache of path → observation date (or None) so a date-range epoch doesn't
+# reopen the same FITS header on every combine step. Mirrors the S_REGION cache
+# in geometry.py; a miss (unreadable / missing keyword) is cached as None so a
+# later readable pass can still resolve it — matching the S_REGION fail-open.
+_DATE_OBS_CACHE = {}
+
+
+def _read_date_obs(path):
+    """Observation date of an exposure as a ``datetime.date``, or ``None``.
+
+    Reads ``DATE-OBS`` (``YYYY-MM-DD``) from the primary header, falling back to
+    the date part of ``DATE-BEG`` (``YYYY-MM-DDThh:mm:ss``). Returns ``None`` for
+    an unreadable file or a missing/malformed keyword; callers fail open (keep
+    the file) so a bad header never silently drops an exposure.
+    """
+    if path in _DATE_OBS_CACHE:
+        return _DATE_OBS_CACHE[path]
+    d = None
+    try:
+        with fits.open(path, memmap=False) as hdul:
+            hdr = hdul[0].header
+            raw = hdr.get('DATE-OBS') or hdr.get('DATE-BEG')
+        if raw:
+            try:
+                d = date.fromisoformat(str(raw)[:10])
+            except ValueError:
+                d = None
+    except (OSError, KeyError):
+        # Unreadable / transient — fail open (kept by callers) but do NOT cache,
+        # so a later readable pass on the same path can still resolve it.
+        return None
+    _DATE_OBS_CACHE[path] = d
+    return d
 
 
 # DO_NOT_USE == 1 (jwst.datamodels.dqflags.pixel['DO_NOT_USE']). Hardcoded so
@@ -197,6 +234,92 @@ def _parse_wcs_shift_rules(field_name, raw, field_filters):
     return rules
 
 
+_EPOCH_ALLOWED = {'files', 'date_range'}
+
+
+def _parse_epochs(field_name, raw):
+    """Normalize the ``[<field>.epochs.<name>]`` tables into a dict.
+
+    Each epoch names a *subset* of the field's exposures, defined by an optional
+    ``files`` glob list (same ``jwNNNNN`` validation + brace expansion as the
+    field's ``files``/``skip``) and/or an optional ``date_range = [start, end]``
+    (inclusive ISO dates matched against each exposure's ``DATE-OBS``). At least
+    one of the two must be present. The epoch name becomes an extra segment on
+    the mosaic filename (see :func:`manifest.build_mosaic_name`).
+
+    Returns
+    -------
+    dict
+        ``{name: {'files': [globs] | None, 'date_range': (start, end) | None}}``.
+        Empty dict when ``raw`` is None or empty.
+    """
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"Field '{field_name}': [{field_name}.epochs] must be a table of "
+            f"named epochs, got {type(raw).__name__}"
+        )
+
+    epochs = {}
+    for name, entry in raw.items():
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"Field '{field_name}': epoch '{name}' must be a table"
+            )
+        unknown = set(entry) - _EPOCH_ALLOWED
+        if unknown:
+            raise ValueError(
+                f"Field '{field_name}': epoch '{name}' has unknown keys "
+                f"{sorted(unknown)}. Allowed: {sorted(_EPOCH_ALLOWED)}"
+            )
+
+        files = entry.get('files')
+        if files is not None:
+            if isinstance(files, str):
+                files = [files]
+            files = [p for raw_p in files for p in _expand_braces(raw_p)]
+            files = list(np.unique(files))
+            bad = [p for p in files if _extract_pid(p) is None]
+            if bad:
+                raise ValueError(
+                    f"Field '{field_name}': epoch '{name}' `files` patterns "
+                    f"must start with 'jwNNNNN' (5-digit PID). Offending: {bad}"
+                )
+
+        date_range = entry.get('date_range')
+        if date_range is not None:
+            if (not isinstance(date_range, (list, tuple))
+                    or len(date_range) != 2):
+                raise ValueError(
+                    f"Field '{field_name}': epoch '{name}' `date_range` must be "
+                    f"a two-element [start, end] list of ISO dates"
+                )
+            try:
+                start = date.fromisoformat(str(date_range[0]))
+                end = date.fromisoformat(str(date_range[1]))
+            except ValueError as e:
+                raise ValueError(
+                    f"Field '{field_name}': epoch '{name}' `date_range` values "
+                    f"must be ISO dates (YYYY-MM-DD): {e}"
+                )
+            if start > end:
+                raise ValueError(
+                    f"Field '{field_name}': epoch '{name}' `date_range` start "
+                    f"{start} is after end {end}"
+                )
+            date_range = (start, end)
+
+        if files is None and date_range is None:
+            raise ValueError(
+                f"Field '{field_name}': epoch '{name}' must define at least one "
+                f"of `files` or `date_range`"
+            )
+
+        epochs[name] = {'files': files, 'date_range': date_range}
+    return epochs
+
+
 @dataclass
 class Field:
     name: str
@@ -211,6 +334,9 @@ class Field:
     # Each entry: {files: [globs], filters: [filtnames] | None,
     #              delta_ra, delta_dec, delta_roll, scale}.
     wcs_shift_rules: List[dict] = field(default_factory=list)
+    # Parsed [<field>.epochs.<name>] tables (combine-time exposure subsets).
+    # {name: {files: [globs] | None, date_range: (start, end) | None}}.
+    epochs: dict = field(default_factory=dict)
 
     # Populated by setup_workspace()
     campfire_root: Optional[str] = None
@@ -311,7 +437,8 @@ class Field:
         # provides at least one `<scale>mas` subsection with `crpix`+`naxis`
         # — in the latter case corners are derived on demand from the WCS.
         tiles = {}
-        reserved_keys = ({'filters', 'files', 'skip', 'tangent_point', 'rgb'} | known_steps)
+        reserved_keys = ({'filters', 'files', 'skip', 'tangent_point', 'rgb',
+                          'epochs'} | known_steps)
         for key, value in fc.items():
             if key in reserved_keys:
                 continue
@@ -340,6 +467,9 @@ class Field:
         wcs_shift_rules = _parse_wcs_shift_rules(name, fc.get('wcs_shift'),
                                                  filters)
 
+        # Parse [<field>.epochs.<name>] tables (combine-time exposure subsets).
+        epochs = _parse_epochs(name, fc.get('epochs'))
+
         return cls(
             name=name,
             filters=filters,
@@ -350,6 +480,7 @@ class Field:
             skip=skip_patterns,
             rgb=rgb_cfg,
             wcs_shift_rules=wcs_shift_rules,
+            epochs=epochs,
         )
 
     @property
@@ -458,7 +589,45 @@ class Field:
             log(f"Warning: could not read {path}: {e}; ignoring exclusions.")
             return {}
 
-    def get_uncal_files(self, filter_name, skip=None, tiles=None):
+    def filter_files_to_epoch(self, files, epoch):
+        """Restrict *files* to the named epoch's exposure subset.
+
+        A no-op when *epoch* is falsy. An epoch is defined in fields.toml by an
+        optional ``files`` glob list and/or an optional ``date_range`` — both are
+        applied as an AND. File globs are matched against each path's basename
+        (so this works on both the canonical and combine working-copy trees);
+        the date range is matched against ``DATE-OBS`` (fail-open: a file whose
+        date can't be read is kept). Raises ``ValueError`` for an unknown epoch.
+        """
+        if not epoch:
+            return files
+        if epoch not in self.epochs:
+            raise ValueError(
+                f"Field '{self.name}': unknown epoch '{epoch}'. "
+                f"Available: {sorted(self.epochs)}"
+            )
+        edef = self.epochs[epoch]
+        result = list(files)
+
+        globs = edef.get('files')
+        if globs:
+            result = [f for f in result
+                      if any(fnmatch(os.path.basename(f), pat + '*')
+                             for pat in globs)]
+
+        date_range = edef.get('date_range')
+        if date_range:
+            start, end = date_range
+            kept = []
+            for f in result:
+                d = _read_date_obs(f)
+                if d is None or start <= d <= end:  # fail open on unknown date
+                    kept.append(f)
+            result = kept
+
+        return result
+
+    def get_uncal_files(self, filter_name, skip=None, tiles=None, epoch=None):
         """Get uncal files from PID-organized raw directories.
 
         Globs across ``$CAMPFIRE_ROOT/raw/nircam/{PID}/{filter}/`` for every PID
@@ -502,10 +671,12 @@ class Field:
         if tiles:
             from campfire_pipeline.nircam.geometry import filter_exposures_to_tiles
             result = filter_exposures_to_tiles(self, result, tiles)
+        if epoch:
+            result = self.filter_files_to_epoch(result, epoch)
         return result
 
     def get_exposure_files(self, filter_name, skip=None, with_step=None,
-                           status=None, work=False, tiles=None):
+                           status=None, work=False, tiles=None, epoch=None):
         """Get canonical per-exposure files from the filter's flat dir.
 
         These are the files that the process phase writes — one FITS file per
@@ -547,6 +718,10 @@ class Field:
             :func:`geometry.filter_exposures_to_tiles` (exposure-union: a whole
             dither is kept when any of its detectors overlaps). ``None`` (the
             default) applies no tile restriction.
+        epoch : str, optional
+            Restrict the result to the named epoch's exposure subset (see
+            :meth:`filter_files_to_epoch`). ``None`` (the default) applies no
+            epoch restriction. Composes with ``tiles`` as an AND.
 
         Returns
         -------
@@ -590,6 +765,8 @@ class Field:
         if tiles:
             from campfire_pipeline.nircam.geometry import filter_exposures_to_tiles
             result = filter_exposures_to_tiles(self, result, tiles)
+        if epoch:
+            result = self.filter_files_to_epoch(result, epoch)
         return result
 
     def get_exposure_path(self, rootname, filter_name, work=False):

--- a/pipeline/campfire_pipeline/nircam/manifest.py
+++ b/pipeline/campfire_pipeline/nircam/manifest.py
@@ -99,20 +99,29 @@ def input_entry(filepath, extra=None):
 DEFAULT_MOSAIC_NAME = 'mosaic_nircam_[filter]_[field_name]_[pixel_scale]_[tile]'
 
 
-def build_mosaic_name(filtname, field_name, pixel_scale, tile, template=None):
+def build_mosaic_name(filtname, field_name, pixel_scale, tile, epoch=None,
+                      template=None):
     """Version-free mosaic basename (without ``_i2d.fits``).
 
     Expands the ``[filter]`` / ``[field_name]`` / ``[pixel_scale]`` / ``[tile]``
     placeholders. A ``template`` override (from ``resample.mosaic_name`` config)
     may omit some placeholders but must NOT reintroduce ``[version]`` — that axis
     is retired (D3).
+
+    ``epoch`` (optional) appends a trailing ``_<epoch>`` segment, marking a
+    mosaic built from an exposure subset (fields.toml ``[<field>.epochs.<name>]``).
+    An empty/None epoch yields today's version-free full-field name unchanged, so
+    normal mosaics and their deploy identity stay byte-for-byte compatible.
     """
     tmpl = template or DEFAULT_MOSAIC_NAME
-    return (tmpl
+    name = (tmpl
             .replace('[filter]', filtname)
             .replace('[field_name]', field_name)
             .replace('[pixel_scale]', pixel_scale)
             .replace('[tile]', tile))
+    if epoch:
+        name = f'{name}_{epoch}'
+    return name
 
 
 # ---------------------------------------------------------------------------
@@ -120,7 +129,7 @@ def build_mosaic_name(filtname, field_name, pixel_scale, tile, template=None):
 # ---------------------------------------------------------------------------
 
 def create_manifest(mosaic_name, field, filtname, tile, pixel_scale,
-                    input_files, stage_config):
+                    input_files, stage_config, epoch=None):
     """Build a manifest dict for a completed mosaic tile.
 
     Parameters
@@ -139,6 +148,9 @@ def create_manifest(mosaic_name, field, filtname, tile, pixel_scale,
         Paths to the CRF files that were drizzled into this tile.
     stage_config : dict
         Stage-3 configuration dict.
+    epoch : str, optional
+        Epoch name for a subset mosaic, or ``None``/``''`` for the full field.
+        Recorded verbatim (empty string when absent) so deploy can key on it.
 
     Returns
     -------
@@ -178,6 +190,7 @@ def create_manifest(mosaic_name, field, filtname, tile, pixel_scale,
         'filter': filtname,
         'tile': tile,
         'pixel_scale': pixel_scale,
+        'epoch': epoch or '',
         'created_at': datetime.now(timezone.utc).isoformat(),
         'pipeline_version': pipeline_version,
         'config_hash': config_hash,
@@ -309,7 +322,7 @@ def check_config_changed(manifest_path, stage_config, pixel_scale):
     return current_hash != manifest.get('config_hash')
 
 
-def get_stale_tiles(field, filtname, stage_config, tiles=None):
+def get_stale_tiles(field, filtname, stage_config, tiles=None, epoch=None):
     """Identify tiles that need re-mosaicking.
 
     Parameters
@@ -323,6 +336,10 @@ def get_stale_tiles(field, filtname, stage_config, tiles=None):
     tiles : str, list of str, or None
         Tile name(s) to probe. ``None`` (the default) checks every tile in
         the field.
+    epoch : str, optional
+        Probe the named epoch's mosaics (subset inputs + epoch-labelled
+        manifest name), matching what ``resample --epoch`` builds. ``None``
+        (the default) checks the full-field mosaics.
 
     Returns
     -------
@@ -357,12 +374,13 @@ def get_stale_tiles(field, filtname, stage_config, tiles=None):
         skip=files_to_skip if files_to_skip else None,
         with_step='CFP_OUT',
         work=True,
+        epoch=epoch,
     )
 
     results = []
     for tile in tiles:
         mosaic_name = build_mosaic_name(
-            filtname, field.name, pixel_scale, tile,
+            filtname, field.name, pixel_scale, tile, epoch=epoch,
             template=resample_cfg.get('mosaic_name'),
         )
 

--- a/pipeline/campfire_pipeline/nircam/orchestrate.py
+++ b/pipeline/campfire_pipeline/nircam/orchestrate.py
@@ -269,16 +269,19 @@ def _run_persistence(field, config, filtname, n_processes, overwrite, status,
 
 
 def _run_per_exposure(step_name, field, config, filtname,
-                      n_processes, overwrite, status, tiles=None):
+                      n_processes, overwrite, status, tiles=None, epoch=None):
     """Generic per-exposure parallel dispatch.
 
     Filters out already-stamped exposures *before* spinning up the worker
     pool — a no-op pass on a finished field skips the Pool entirely. The
     step's worker callable is imported lazily here (after the early-out
     checks), so a no-op pass doesn't import the step's heavy deps at all.
+
+    ``epoch`` restricts to the named epoch's exposure subset (used by the
+    combine-phase ``apply_mask`` step); process-phase steps pass ``None``.
     """
     module_basename, func_name, cfp_key = _PER_EXPOSURE_STEPS[step_name]
-    exposures = field.get_exposure_files(filtname, tiles=tiles)
+    exposures = field.get_exposure_files(filtname, tiles=tiles, epoch=epoch)
     if not exposures:
         log(f"{step_name}: no exposures for {filtname}")
         return
@@ -362,9 +365,10 @@ def _run_wcs_shift(field, config, filtname, n_processes, overwrite, status,
 
 
 def _run_bad_pixel(field, config, filtname, n_processes, overwrite, status,
-                   tiles=None):
+                   tiles=None, epoch=None):
     # Combine phase: operate on the working copies, never the frozen canonical.
-    exposures = field.get_exposure_files(filtname, work=True, tiles=tiles)
+    exposures = field.get_exposure_files(filtname, work=True, tiles=tiles,
+                                         epoch=epoch)
     if not exposures:
         log(f"bad_pixel: no exposures for {filtname}")
         return
@@ -397,7 +401,7 @@ def _run_bad_pixel(field, config, filtname, n_processes, overwrite, status,
 
 
 def _run_outlier(field, config, filtname, n_processes, overwrite, status,
-                 tiles=None):
+                 tiles=None, epoch=None):
     cfg = get_nircam_step_config('outlier', config, field)
     implementation = cfg.get('implementation', 'jwst')
     if implementation not in ('jwst', 'campfire'):
@@ -406,11 +410,12 @@ def _run_outlier(field, config, filtname, n_processes, overwrite, status,
             f"expected 'jwst' or 'campfire'"
         )
     _run_outlier_per_visit(field, cfg, filtname, n_processes, overwrite, status,
-                           implementation=implementation, tiles=tiles)
+                           implementation=implementation, tiles=tiles,
+                           epoch=epoch)
 
 
 def _run_outlier_per_visit(field, cfg, filtname, n_processes, overwrite, status,
-                           implementation='jwst', tiles=None):
+                           implementation='jwst', tiles=None, epoch=None):
     """Per-visit outlier dispatcher.
 
     Both implementations share the same orchestration (visit grouping,
@@ -446,7 +451,8 @@ def _run_outlier_per_visit(field, cfg, filtname, n_processes, overwrite, status,
     )
 
     # Combine phase: operate on the working copies, never the frozen canonical.
-    exposures = field.get_exposure_files(filtname, work=True, tiles=tiles)
+    exposures = field.get_exposure_files(filtname, work=True, tiles=tiles,
+                                         epoch=epoch)
     if not exposures:
         log(f"outlier: no exposures for {filtname}")
         return
@@ -515,21 +521,23 @@ def _run_outlier_per_visit(field, cfg, filtname, n_processes, overwrite, status,
 
 
 def _run_resample(field, config, filtname, n_processes, overwrite, status,
-                  reduction_version, tiles=None):
+                  reduction_version, tiles=None, epoch=None):
     # Read the outlier-finished working copies; the mosaic itself is written to
     # the canonical filter dir (resample_step derives it from field.filter_dir).
     # ``tiles`` both coarse-filters the input here and tells resample_step which
     # tiles to drizzle (its own precise per-tile SCI-WCS selection narrows
-    # further within this set).
+    # further within this set). ``epoch`` subsets the drizzle inputs to the
+    # named epoch and labels the mosaics with the epoch name.
     exposures = field.get_exposure_files(filtname, with_step='CFP_OUT',
-                                         status=status, work=True, tiles=tiles)
+                                         status=status, work=True, tiles=tiles,
+                                         epoch=epoch)
     if not exposures:
         log(f"resample: no CFP_OUT-stamped exposures for {filtname}")
         return
     from campfire_pipeline.nircam.steps.resample import resample_step
     cfg = get_nircam_step_config('resample', config, field)
     resample_step(filtname, exposures, field, cfg, reduction_version,
-                  overwrite=overwrite, tiles=tiles)
+                  overwrite=overwrite, tiles=tiles, epoch=epoch)
 
 
 # Dispatch table: step name → callable that takes (field, config, filtname,
@@ -745,7 +753,7 @@ def run_align(field, config, filters=None, n_processes=1, overwrite=False,
 
 
 def run_combine(field, config, filters=None, n_processes=1, overwrite=False,
-                tiles=None):
+                tiles=None, epoch=None):
     """Run all combine-phase steps in order across each filter.
 
     ``tiles`` scopes the *whole* combine phase to exposures overlapping the
@@ -758,12 +766,20 @@ def run_combine(field, config, filters=None, n_processes=1, overwrite=False,
     tile-scoped mosaic may differ at tile boundaries from the same tile built
     with the whole field — a tile-scoped run is a distinct input set by design.
     ``None`` (the default) runs the full field and is unchanged.
+
+    ``epoch`` scopes the whole combine phase to one named epoch's exposure
+    subset (fields.toml ``[<field>.epochs.<name>]``) in the same way ``tiles``
+    does, and the resulting mosaics carry the epoch name as a trailing filename
+    segment. The same ensemble-truncation caveat applies: an epoch mosaic is
+    reduced from only the epoch's exposures by design. ``None`` (the default)
+    uses the full field with no epoch segment.
     """
     filters = _resolve_filters(filters, field)
     reduction_version = _resolve_reduction_version(config)
     status = _scan_status(field, filters, overwrite=overwrite)
 
-    log(f"=== Combine phase: field={field.name}, filters={filters} ===")
+    log(f"=== Combine phase: field={field.name}, filters={filters}"
+        f"{f', epoch={epoch}' if epoch else ''} ===")
     for filt in filters:
         log(f"--- Combine: {filt} ---")
         for step_name, _ in COMBINE_STEPS:
@@ -774,25 +790,28 @@ def run_combine(field, config, filters=None, n_processes=1, overwrite=False,
                 # mutate (copy canonical -> work where stale, fuse CFMASK ->
                 # DO_NOT_USE) and rescan them into the status cache.
                 _RUNNERS[step_name](field, config, filt, n_processes,
-                                    overwrite, status, tiles=tiles)
+                                    overwrite, status, tiles=tiles, epoch=epoch)
                 field.materialize_work(filt, status=status, overwrite=overwrite)
             elif step_name == 'resample':
                 _run_resample(field, config, filt, n_processes, overwrite,
-                              status, reduction_version, tiles=tiles)
+                              status, reduction_version, tiles=tiles,
+                              epoch=epoch)
             else:
                 _RUNNERS[step_name](field, config, filt, n_processes, overwrite,
-                                    status, tiles=tiles)
+                                    status, tiles=tiles, epoch=epoch)
 
 
 def run_step(step_name, field, config, filters=None, n_processes=1,
-             overwrite=False, tiles=None):
+             overwrite=False, tiles=None, epoch=None):
     """Run a single named step across the field's filters.
 
     Used by the per-step CLI commands (``cfpipe nircam <step>``). ``tiles``
     restricts the step to exposures overlapping the named tile(s); for
     ``resample`` it additionally scopes which mosaics are built. The per-step
     CLI commands other than ``resample`` don't expose ``--tiles``, so they pass
-    ``None`` and run over the full field.
+    ``None`` and run over the full field. ``epoch`` is only meaningful for
+    ``resample`` (the only per-step command exposing ``--epoch``): it subsets
+    the drizzle inputs and labels the mosaics.
     """
     if step_name not in STEP_NAMES:
         raise ValueError(
@@ -815,7 +834,7 @@ def run_step(step_name, field, config, filters=None, n_processes=1,
         if step_name == 'resample':
             reduction_version = _resolve_reduction_version(config)
             _run_resample(field, config, filt, n_processes, overwrite,
-                          status, reduction_version, tiles=tiles)
+                          status, reduction_version, tiles=tiles, epoch=epoch)
         else:
             _RUNNERS[step_name](field, config, filt, n_processes, overwrite,
                                 status, tiles=tiles)

--- a/pipeline/campfire_pipeline/nircam/steps/resample.py
+++ b/pipeline/campfire_pipeline/nircam/steps/resample.py
@@ -165,14 +165,16 @@ def _drizzle_tile_via_jwst(
 
 
 def resample_step(filtname, exposure_files, field, step_config,
-                  reduction_version, overwrite=False, tiles=None):
+                  reduction_version, overwrite=False, tiles=None, epoch=None):
     """Drizzle-combine canonical exposure files into mosaic tiles.
 
     Parameters
     ----------
     filtname : str
     exposure_files : list of str
-        Canonical exposure paths (``CFP_OUT`` already stamped).
+        Canonical exposure paths (``CFP_OUT`` already stamped). When ``epoch``
+        is set these have already been narrowed to the epoch's subset by the
+        caller (see :meth:`Field.get_exposure_files`).
     field : Field
     step_config : dict
         ``[nircam.resample]`` (legacy ``[nircam.stage3.resample]``).
@@ -186,6 +188,11 @@ def resample_step(filtname, exposure_files, field, step_config,
         not a config key — passing a subset only limits which mosaics are
         built; each tile is drizzled from the same exposure set it would use
         in a whole-field run.
+    epoch : str, optional
+        Epoch name (fields.toml ``[<field>.epochs.<name>]``) for a subset
+        mosaic. Appended as a trailing filename segment and recorded in the
+        manifest. ``None`` (the default) builds the full-field mosaics with no
+        epoch segment.
     """
     from campfire_pipeline.nircam.manifest import (
         build_mosaic_name, check_config_changed, check_inputs_changed,
@@ -208,7 +215,7 @@ def resample_step(filtname, exposure_files, field, step_config,
         log(f"resample: tile {tile}, {filtname}, {pixel_scale_str}")
 
         mosaic_name = build_mosaic_name(
-            filtname, field.name, pixel_scale_str, tile,
+            filtname, field.name, pixel_scale_str, tile, epoch=epoch,
             template=step_config.get('mosaic_name'),
         )
         mosaic_outdir = field.filter_dir(filtname)
@@ -277,9 +284,18 @@ def resample_step(filtname, exposure_files, field, step_config,
                 reduction_version=reduction_version,
             )
 
+            # Stamp epoch provenance onto the drizzled i2d (both drizzle
+            # implementations already stamp CMPFRVER/CMPFRTIM). Empty for a
+            # full-field mosaic so normal outputs are unaffected.
+            if epoch:
+                with fits.open(mosaic_file, mode='update') as hdul:
+                    hdul[0].header['CFEPOCH'] = (
+                        epoch, 'CAMPFIRE epoch (exposure subset) name',
+                    )
+
             manifest = create_manifest(
                 mosaic_name, field, filtname, tile, pixel_scale_str,
-                selected, {'resample': step_config},
+                selected, {'resample': step_config}, epoch=epoch,
             )
             write_manifest(manifest, manifest_path)
 

--- a/pipeline/fields.example.toml
+++ b/pipeline/fields.example.toml
@@ -41,6 +41,23 @@
 #           crpix = [x, y]
 #           naxis = [nx, ny]
 #
+# Epochs: named exposure subsets, built into their own mosaics at combine time
+# (cfpipe nircam combine/resample --epoch <name>). An epoch selects a subset of
+# the field's exposures by file globs and/or a DATE-OBS range, and scopes the
+# whole combine phase to that subset (like --tiles), so the epoch mosaic is a
+# distinct reduction from only those exposures. The epoch name becomes a trailing
+# segment on the mosaic filename:
+#     mosaic_nircam_<filter>_<field>_<scale>_<tile>_<epoch>_i2d.fits
+# Omitting --epoch builds the full-field mosaics with no epoch segment (the
+# default; unchanged). Epochs nest under the field in an `epochs` table:
+#   [field.epochs.<name>]
+#       files      = ['jw05893*']            # optional: subset of the field's globs
+#                                            # (same jwNNNNN + brace-list syntax).
+#       date_range = ['2023-11-01', '2024-02-01']  # optional: inclusive ISO dates
+#                                            # matched against each exposure's DATE-OBS.
+#   At least one of `files` / `date_range` is required; if both are given a file
+#   must satisfy BOTH (AND). Epoch names are free-form (e.g. CW, PRIMER, Y1).
+#
 # Per-field per-step overrides use a flat layout matching the
 # canonical-exposure config namespace in config_default.toml:
 #   [field.striping]
@@ -106,6 +123,16 @@
         [example_cosmos.A2.60mas]
             crpix = [-2845, 11545]
             naxis = [9600, 12455]
+
+    # Epoch mosaics — subsets of this field's exposures. `CW` keeps only the
+    # Cosmos Web program (PID 5893); `y1` additionally restricts to the first
+    # observing season by DATE-OBS. Build with e.g.
+    #   cfpipe nircam combine --field example_cosmos --epoch CW
+    [example_cosmos.epochs.CW]
+        files = ['jw05893*']
+    [example_cosmos.epochs.y1]
+        files = ['jw01727*']
+        date_range = ['2023-11-01', '2024-05-01']
 
     [example_cosmos.rgb]
         noisesig = 2.0

--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -780,11 +780,14 @@ def discover_mosaics(dirs, field, filters):
     """Discover deployable mosaic products via their manifests.
 
     Each ``mosaic_*_manifest.json`` (written by the resample step) carries the
-    authoritative ``(mosaic_name, filter, tile, pixel_scale)`` — read from the
-    manifest rather than parsed from the filename, so a multi-underscore field
-    name can't break a positional split. Returns one dict per existing mosaic
-    file: ``{path, filter, tile, pixel_scale, extension, storage_key}`` under the
-    version-free canonical key (epic #261, N2 / D3).
+    authoritative ``(mosaic_name, filter, tile, pixel_scale, epoch)`` — read from
+    the manifest rather than parsed from the filename, so a multi-underscore
+    field name can't break a positional split. Returns one dict per existing
+    mosaic file:
+    ``{path, filter, tile, pixel_scale, epoch, extension, storage_key}`` under
+    the version-free canonical key (epic #261, N2 / D3). ``epoch`` is ``''`` for
+    a full-field mosaic and the epoch name for a subset mosaic; it rides in the
+    filename so the storage key is unique without any layout change.
     """
     import json
     products = dirs['products']
@@ -803,6 +806,7 @@ def discover_mosaics(dirs, field, filters):
             pixel_scale = m.get('pixel_scale')
             mfilter = m.get('filter') or filtname
             mfield = m.get('field') or field
+            epoch = m.get('epoch') or ''
             if not (base and tile and pixel_scale):
                 continue
             # Skip stale pre-N2 versioned / `_latest_` manifests: only the
@@ -811,10 +815,15 @@ def discover_mosaics(dirs, field, filters):
             # disk after re-combine; without this guard that stale slot would
             # both re-upload a version-bearing key to OSN AND collide with the
             # version-free row on the nircam_images (field,tile,filter,scale,
-            # extension) conflict key, crashing the batch upsert. Reconstruct the
-            # expected name deploy-side (deploy must not import the pipeline) —
-            # the same version-free contract rgb._find_mosaic enforces.
-            if base != f'mosaic_nircam_{mfilter}_{mfield}_{pixel_scale}_{tile}':
+            # extension,epoch) conflict key, crashing the batch upsert. Reconstruct
+            # the expected name deploy-side (deploy must not import the pipeline) —
+            # the same version-free contract rgb._find_mosaic enforces. An epoch
+            # mosaic appends a trailing ``_<epoch>`` segment (see
+            # manifest.build_mosaic_name), so fold it into the expected name.
+            expected = f'mosaic_nircam_{mfilter}_{mfield}_{pixel_scale}_{tile}'
+            if epoch:
+                expected += f'_{epoch}'
+            if base != expected:
                 continue
             for suffix, ext in _MOSAIC_EXTENSIONS:
                 fpath = filter_dir / f'{base}{suffix}'
@@ -824,7 +833,8 @@ def discover_mosaics(dirs, field, filters):
                                   fpath.name, scheme=KeyScheme.CANONICAL)
                 out.append({
                     'path': fpath, 'filter': mfilter, 'tile': tile,
-                    'pixel_scale': pixel_scale, 'extension': ext, 'storage_key': key,
+                    'pixel_scale': pixel_scale, 'epoch': epoch,
+                    'extension': ext, 'storage_key': key,
                 })
     return out
 
@@ -892,6 +902,7 @@ def _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
     img_rows = [{
         'field': field, 'tile': m['tile'], 'filter': m['filter'],
         'pixel_scale': m['pixel_scale'], 'extension': m['extension'],
+        'epoch': m.get('epoch', ''),
         'file_path': m['storage_key'], 'file_size': m['size'],
         'deploy_status': img_status, 'deployment_id': deployment_id,
     } for m in mosaics if m['storage_key'] in indexable]
@@ -927,12 +938,13 @@ def _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
 
 
 def _upsert_nircam_images(client, rows, batch_size=500):
-    """Upsert nircam_images rows keyed on (field, tile, filter, pixel_scale, extension)."""
+    """Upsert nircam_images rows keyed on
+    (field, tile, filter, pixel_scale, extension, epoch)."""
     if not rows:
         return 0
     for i in range(0, len(rows), batch_size):
         batch = rows[i:i + batch_size]
         client.table('nircam_images').upsert(
-            batch, on_conflict='field,tile,filter,pixel_scale,extension',
+            batch, on_conflict='field,tile,filter,pixel_scale,extension,epoch',
         ).execute()
     return len(rows)

--- a/supabase/migrations/20260706000000_nircam_images_add_epoch.sql
+++ b/supabase/migrations/20260706000000_nircam_images_add_epoch.sql
@@ -1,0 +1,26 @@
+-- Add the mosaic `epoch` axis (subset mosaics: fields.toml [<field>.epochs.<name>]).
+--
+-- An epoch names a subset of a field's exposures built into its own mosaic
+-- (e.g. epoch 'CW' = Cosmos Web only), selected at combine time via
+-- `cfpipe nircam combine --epoch <name>` and stamped as a trailing filename
+-- segment. The full-field mosaic keeps epoch = ''.
+--
+-- `epoch` is added to the version-free UNIQUE so a subset mosaic gets its own
+-- row instead of colliding with the full-field mosaic of the same
+-- (field, tile, filter, pixel_scale, extension). It is NOT NULL DEFAULT ''
+-- (never NULL) because Postgres treats NULLs as distinct in a UNIQUE index,
+-- which would defeat dedup of full-field mosaics. Widening the key with a
+-- column that defaults to '' cannot create duplicate rows, so unlike the
+-- version-retirement migration no row-collapse is needed. The seed has no
+-- nircam_images rows, so no seed change is needed.
+
+alter table "public"."nircam_images"
+  add column "epoch" text not null default '';
+
+alter table "public"."nircam_images" drop constraint "nircam_images_unique";
+
+create unique index nircam_images_unique
+  on public.nircam_images using btree (field, tile, filter, pixel_scale, extension, epoch);
+
+alter table "public"."nircam_images"
+  add constraint "nircam_images_unique" unique using index "nircam_images_unique";

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -690,9 +690,13 @@ CREATE TABLE IF NOT EXISTS "public"."programs" (
 ALTER TABLE "public"."programs" OWNER TO "postgres";
 
 
--- One logical mosaic per (field, tile, filter, pixel_scale, extension). The
--- `version` axis is retired (epic #261, N2 / D3): the pipeline emits a single
--- canonical mosaic name per slot and re-combine overwrites it in place.
+-- One logical mosaic per (field, tile, filter, pixel_scale, extension, epoch).
+-- The `version` axis is retired (epic #261, N2 / D3): the pipeline emits a
+-- single canonical mosaic name per slot and re-combine overwrites it in place.
+-- `epoch` names an exposure subset (fields.toml [<field>.epochs.<name>]) built
+-- into its own mosaic; `''` is the full-field mosaic. It is NOT NULL DEFAULT ''
+-- (never NULL) so the unique constraint still dedups full-field mosaics —
+-- Postgres treats NULLs as distinct, which would defeat the upsert.
 CREATE TABLE IF NOT EXISTS "public"."nircam_images" (
     "id" integer NOT NULL,
     "field" "text" NOT NULL,
@@ -700,6 +704,7 @@ CREATE TABLE IF NOT EXISTS "public"."nircam_images" (
     "filter" "text" NOT NULL,
     "pixel_scale" "text" NOT NULL,
     "extension" "text" NOT NULL,
+    "epoch" "text" NOT NULL DEFAULT '',
     "file_path" "text" NOT NULL,
     "created_at" timestamp without time zone DEFAULT "now"(),
     "file_size" bigint,
@@ -1568,9 +1573,11 @@ ALTER TABLE ONLY "public"."nircam_images"
 
 -- Single version-free uniqueness (epic #261, N2 / D3). The former redundant
 -- twin `nircam_images_field_tile_filter_pixel_scale_version_extensi_key` is
--- dropped alongside the `version` axis.
+-- dropped alongside the `version` axis. `epoch` ('' = full field) is part of the
+-- key so a subset mosaic gets its own row instead of colliding with the
+-- full-field mosaic of the same (field, tile, filter, pixel_scale, extension).
 ALTER TABLE ONLY "public"."nircam_images"
-    ADD CONSTRAINT "nircam_images_unique" UNIQUE ("field", "tile", "filter", "pixel_scale", "extension");
+    ADD CONSTRAINT "nircam_images_unique" UNIQUE ("field", "tile", "filter", "pixel_scale", "extension", "epoch");
 
 
 ALTER TABLE ONLY "public"."nircam_exposures"

--- a/web/app/nircam/page.tsx
+++ b/web/app/nircam/page.tsx
@@ -26,6 +26,7 @@ export default function NircamPage() {
   const [availableFilters, setAvailableFilters] = useState<string[]>([]);
   const [availablePixelScales, setAvailablePixelScales] = useState<string[]>([]);
   const [availableExtensions, setAvailableExtensions] = useState<string[]>([]);
+  const [availableEpochs, setAvailableEpochs] = useState<string[]>([]);
 
   // Fetch data
   const fetchData = useCallback(async () => {
@@ -53,6 +54,7 @@ export default function NircamPage() {
         setAvailableFilters(filterOptionsResult.filters);
         setAvailablePixelScales(filterOptionsResult.pixel_scales);
         setAvailableExtensions(filterOptionsResult.extensions);
+        setAvailableEpochs(filterOptionsResult.epochs);
       }
     } catch (err) {
       setError('Failed to fetch data');
@@ -142,6 +144,7 @@ export default function NircamPage() {
           availableFilters={availableFilters}
           availablePixelScales={availablePixelScales}
           availableExtensions={availableExtensions}
+          availableEpochs={availableEpochs}
         />
       </div>
 

--- a/web/components/nircam/NircamFilterBar.tsx
+++ b/web/components/nircam/NircamFilterBar.tsx
@@ -10,6 +10,7 @@ export interface NircamFilterOptions {
   filters: string[];
   pixel_scales: string[];
   extensions: string[];
+  epochs: string[];
 }
 
 export const DEFAULT_NIRCAM_FILTERS: NircamFilterOptions = {
@@ -18,7 +19,11 @@ export const DEFAULT_NIRCAM_FILTERS: NircamFilterOptions = {
   filters: [],
   pixel_scales: [],
   extensions: [],
+  epochs: [],
 };
+
+// Label for a raw epoch value: '' (the full-field mosaic) reads as "Full field".
+const epochLabel = (e: string) => (e === '' ? 'Full field' : e);
 
 interface NircamFilterBarProps {
   filterState: NircamFilterOptions;
@@ -28,6 +33,7 @@ interface NircamFilterBarProps {
   availableFilters: string[];
   availablePixelScales: string[];
   availableExtensions: string[];
+  availableEpochs: string[];
   className?: string;
 }
 
@@ -39,6 +45,7 @@ export const NircamFilterBar: React.FC<NircamFilterBarProps> = ({
   availableFilters,
   availablePixelScales,
   availableExtensions,
+  availableEpochs,
   className = '',
 }) => {
   const updateFilter = <K extends keyof NircamFilterOptions>(
@@ -74,13 +81,23 @@ export const NircamFilterBar: React.FC<NircamFilterBarProps> = ({
     label: e.toUpperCase(),
   }));
 
+  const epochOptions: FilterOption[] = availableEpochs.map((e) => ({
+    value: e,
+    label: epochLabel(e),
+  }));
+
+  // Only surface the Epoch facet when the data actually has a named epoch
+  // (something other than the full-field ''); otherwise it's noise.
+  const hasEpochFacet = availableEpochs.some((e) => e !== '');
+
   // Check if any filters are active
   const hasActiveFilters =
     filterState.fields.length > 0 ||
     filterState.tiles.length > 0 ||
     filterState.filters.length > 0 ||
     filterState.pixel_scales.length > 0 ||
-    filterState.extensions.length > 0;
+    filterState.extensions.length > 0 ||
+    filterState.epochs.length > 0;
 
   const handleClearAll = () => {
     onFiltersChange(DEFAULT_NIRCAM_FILTERS);
@@ -132,6 +149,16 @@ export const NircamFilterBar: React.FC<NircamFilterBarProps> = ({
           selected={filterState.extensions}
           onChange={(selected) => updateFilter('extensions', selected as string[])}
         />
+
+        {/* Epoch filter (only when named epochs exist) */}
+        {hasEpochFacet && (
+          <FilterChip
+            label="Epoch"
+            options={epochOptions}
+            selected={filterState.epochs}
+            onChange={(selected) => updateFilter('epochs', selected as string[])}
+          />
+        )}
 
         {/* Clear all button */}
         {hasActiveFilters && (

--- a/web/components/nircam/NircamTable.tsx
+++ b/web/components/nircam/NircamTable.tsx
@@ -129,6 +129,9 @@ export const NircamTable: React.FC<NircamTableProps> = ({
       if (filters.extensions.length > 0 && !filters.extensions.includes(image.extension)) {
         return false;
       }
+      if (filters.epochs.length > 0 && !filters.epochs.includes(image.epoch ?? '')) {
+        return false;
+      }
       return true;
     });
   }, [images, filters]);
@@ -230,6 +233,24 @@ export const NircamTable: React.FC<NircamTableProps> = ({
           if (bIdx === -1) return -1;
           return aIdx - bIdx;
         },
+      },
+      {
+        accessorKey: 'epoch',
+        header: ({ column }) => (
+          <SortableHeader column={column}>Epoch</SortableHeader>
+        ),
+        cell: ({ row }) => {
+          const epoch = row.original.epoch ?? '';
+          return epoch === '' ? (
+            <span className="text-sm text-text-secondary">Full field</span>
+          ) : (
+            <span className="inline-flex items-center rounded border border-border px-1.5 py-0.5 text-xs font-mono font-medium bg-surface-2 text-text-primary">
+              {epoch}
+            </span>
+          );
+        },
+        sortingFn: (rowA, rowB) =>
+          (rowA.original.epoch ?? '').localeCompare(rowB.original.epoch ?? ''),
       },
       {
         accessorKey: 'file_size',

--- a/web/lib/actions/nircam.ts
+++ b/web/lib/actions/nircam.ts
@@ -16,6 +16,7 @@ export interface NircamFilterOptionsResult {
   filters: string[];
   pixel_scales: string[];
   extensions: string[];
+  epochs: string[];  // exposure-subset names ('' = full field)
   error?: string;
 }
 
@@ -88,17 +89,18 @@ export async function getNircamFilterOptions(): Promise<NircamFilterOptionsResul
       filters: [],
       pixel_scales: [],
       extensions: [],
+      epochs: [],
     };
   }
 
   try {
     const { data: images, error } = await paginateQuery<{
       field: string; tile: string; filter: string;
-      pixel_scale: string; extension: string;
+      pixel_scale: string; extension: string; epoch: string | null;
     }>(
       () => supabase
         .from('nircam_images')
-        .select('field, tile, filter, pixel_scale, extension')
+        .select('field, tile, filter, pixel_scale, extension, epoch')
         .order('field')
         .order('filter')
         .order('tile'),
@@ -112,6 +114,7 @@ export async function getNircamFilterOptions(): Promise<NircamFilterOptionsResul
         filters: [],
         pixel_scales: [],
         extensions: [],
+        epochs: [],
         error: error.message,
       };
     }
@@ -119,6 +122,9 @@ export async function getNircamFilterOptions(): Promise<NircamFilterOptionsResul
     const fields = [...new Set(images.map(i => i.field))].sort();
     const filters = [...new Set(images.map(i => i.filter))].sort();
     const pixel_scales = [...new Set(images.map(i => i.pixel_scale))].sort();
+    // Epoch '' = full-field mosaic; keep it (sorts first) so the "Full field"
+    // option is always available alongside any named subset epochs.
+    const epochs = [...new Set(images.map(i => i.epoch ?? ''))].sort();
     const extensions = [...new Set(images.map(i => i.extension))].sort((a, b) => {
       // Sort extensions by priority: sci > err > rms > srcmask
       const order = ['sci', 'err', 'rms', 'srcmask'];
@@ -154,6 +160,7 @@ export async function getNircamFilterOptions(): Promise<NircamFilterOptionsResul
       filters,
       pixel_scales,
       extensions,
+      epochs,
     };
   } catch (err) {
     console.error('Unexpected error fetching NIRCam filter options:', err);
@@ -163,6 +170,7 @@ export async function getNircamFilterOptions(): Promise<NircamFilterOptionsResul
       filters: [],
       pixel_scales: [],
       extensions: [],
+      epochs: [],
       error: 'An unexpected error occurred',
     };
   }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -284,6 +284,7 @@ export interface NircamImage {
   filter: string;
   pixel_scale: string;
   extension: string;  // sci, err, rms, srcmask
+  epoch?: string;     // exposure-subset name ('' = full field)
   file_path: string;
   file_size?: number; // in bytes, if available
 }


### PR DESCRIPTION
## Summary

Adds support for building NIRCam mosaics from exposure subsets ("epochs") — e.g., one program or one observing season — via a new `--epoch <name>` flag on `combine`, `resample`, `run`, and `check` commands. Epochs are defined per field in `fields.toml` under `[<field>.epochs.<name>]` by optional `files` glob patterns and/or an inclusive `date_range` (matched against `DATE-OBS`). The epoch name is appended as a trailing filename segment and indexed as a new `epoch` axis in the portal database.

This is **additive and default-off**: a run without `--epoch` produces byte-for-byte identical output to before.

## Key Changes

**Pipeline (`pipeline/campfire_pipeline/nircam/`)**
- `field.py`:
  - Added `_read_date_obs()` to extract observation dates from FITS headers (`DATE-OBS` or `DATE-BEG`), with caching to avoid re-reading the same file across combine steps
  - Added `_parse_epochs()` to parse and validate `[<field>.epochs.<name>]` tables from fields.toml (files globs + date ranges)
  - Added `Field.epochs` dataclass field and `Field.filter_files_to_epoch()` method to restrict file lists to an epoch's subset
  - Updated `Field.get_uncal_files()` and `Field.get_exposure_files()` to accept optional `epoch` parameter
  
- `cli.py`:
  - Added `epoch_option()` decorator for `--epoch` flag
  - Updated `combine`, `resample`, `run`, and `check` commands to accept and pass through `--epoch`
  
- `orchestrate.py`:
  - Threaded `epoch` parameter through all combine-phase step dispatchers (`_run_per_exposure`, `_run_bad_pixel`, `_run_outlier`, `_run_resample`)
  
- `manifest.py`:
  - Updated `build_mosaic_name()` to append `_<epoch>` segment when epoch is provided
  - Updated `create_manifest()` to record epoch in manifest JSON
  
- `steps/resample.py`:
  - Updated `resample_step()` to accept `epoch` parameter and stamp `CFEPOCH` header keyword in output mosaics

**Database (`supabase/`)**
- Added `epoch` column (NOT NULL DEFAULT '') to `nircam_images` table
- Updated unique constraint to include `epoch` so subset mosaics get their own rows
- Generated migration `20260706000000_nircam_images_add_epoch.sql`

**Web Portal (`web/`)**
- Updated `NircamFilterOptions` interface to include `epochs` array
- Added epoch filter UI in `NircamFilterBar.tsx` (only shown when named epochs exist; full-field mosaics labeled "Full field")
- Updated `NircamTable.tsx` to display and filter by epoch
- Updated `nircam.ts` server action to fetch and aggregate epoch values from database
- Updated `NircamImage` type to include optional `epoch` field

**Documentation**
- Updated `fields.example.toml` with epoch configuration examples
- Updated `CHANGELOG.md` with Algorithm category entry describing the feature

## Implementation Details

- **Fail-open date reading**: Files whose `DATE-OBS` cannot be read are kept (not dropped) when filtering by date range, matching the existing S_REGION cache behavior in geometry.py
- **Caching**: Observation dates are cached per path to avoid re-opening FITS headers on every combine step; cache misses (unreadable files) are cached as `None` so a later readable pass can still resolve them
- **Backward compatibility**: Empty/None epoch yields the same version-free mosaic name as before, so existing mosaics and their deploy identity remain unchanged
- **Composition**: Epoch filtering composes with `--tiles` as an AND (both restrictions apply)
- **Manifest recording**: Epoch is recorded in mosaic manifests as `''` (empty string) for full-field mosaics and the epoch

https://claude.ai/code/session_01AMkNgWhxwkJ8eXsWurqJvN