### PR TITLE
feat(nircam): align S3b/S3c — refcat epoch/proper-motion + cross-filter closure + mode gating

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -26,6 +26,20 @@ Release procedure: edit the `## Unreleased` section below, then run
 ## Unreleased
 
 ### Calibration
+- **NIRCam `align` refcat gains an epoch / proper-motion contract** and
+  propagates reference positions to each exposure's mid-time. The refcat schema
+  grows optional columns — `source_id, ref_epoch, pmra, pmdec, parallax` (+
+  `pmra_err`/`pmdec_err`) — alongside the required `RA/DEC/mag/mag_err`;
+  `query_gaia` now populates them (Gaia DR3), while galaxy backends (LS/HSC) omit
+  them. When a refcat carries proper motions, the align worker moves each star to
+  the exposure mid-time (`EXPMID`) via `astropy` `apply_space_motion` **before**
+  the footprint clip and match (`refcat/motion.py`), so a fast Gaia star is
+  matched where it actually was, not where the catalog recorded it years earlier.
+  **Fully backward-compatible**: a catalog without the columns — or a row with a
+  non-finite proper motion — is treated as stationary (the prior zero-motion
+  behavior), so today's galaxy-anchored refcats are a strict no-op. This changes
+  the fitted WCS only when a motion-bearing catalog is used. `refcat/{io,query,
+  motion}.py`, `align/apply.py`; covered by `tests/test_refcat_motion.py`.
 - NIRCam `apply_masks` now reads web-defined masks instead of crashing on them.
   Masks drawn in the web editor materialize (via `campfire deploy pull-masks`)
   as DS9 **image**-coordinate `.reg` files, which `Regions.read` parses back as
@@ -334,6 +348,25 @@ Release procedure: edit the `## Unreleased` section below, then run
   never affected.
 
 ### Infrastructure
+- **NIRCam `align` closes the cross-filter dependency and gates observing mode.**
+  Two correctness fixes to the align orchestration (opt-in, default-off):
+    - *Cross-filter closure.* `run_align` now pools each physical exposure across
+      **all** field filters, even when `--filters`/`--tiles` selects a subset — so
+      `align --filters f200w` still sees its paired F444W (LW) complement for the
+      shared solve, and a tile gate can't split a dither at a tile edge. The
+      selection then just chooses **which** exposures to process; each is solved
+      and its corrected gwcs written across its full SW+LW complement (one
+      attitude corrects the whole dither), so `--filters f200w` now also stamps
+      the paired f444w canonicals — a deliberate behavior change that keeps an
+      exposure from ending up half-aligned. Status is scanned over all filters to
+      match.
+    - *Observing-mode gating.* Align now reads `EXP_TYPE`/`SUBARRAY` per exposure
+      and **hard-stops** with a clear, listed error if any exposure in scope is in
+      an unsupported mode (subarray / coronagraph / TSO / WFSS), rather than
+      silently feeding it through generic full-frame-imaging logic. The user must
+      exclude it (fields.toml `skip` / reviewer exclusions) or select a supported
+      subset. Missing metadata is treated leniently. `orchestrate.py`,
+      `association.py`; covered by `tests/test_align_run.py`, `test_association.py`.
 - **NIRCam `--tiles` now pre-filters the exposure set for `process`/`align`/`combine`,
   not just `resample`.** Previously `--tiles` scoped only which mosaics were drizzled;
   every earlier step ran over the whole field, so building one tile meant processing

--- a/pipeline/campfire_pipeline/nircam/align/apply.py
+++ b/pipeline/campfire_pipeline/nircam/align/apply.py
@@ -90,6 +90,52 @@ def _format_algn_value(det):
     return f'dof={det.dof} res={det.residual_arcsec:.3g} n={det.n_matched}'
 
 
+def _exposure_mid_mjd(path):
+    """Exposure mid-time as MJD from the primary header, or ``None``.
+
+    Prefers ``EXPMID`` / ``MJD-AVG``; falls back to the mean of
+    ``EXPSTART``/``EXPEND``. Read cheaply from the primary header (all detectors
+    of one exposure share the same time), used to propagate refcat proper
+    motions to the epoch the shutter was actually open.
+    """
+    with fits.open(path, memmap=False) as hdul:
+        h = hdul[0].header
+        for card in ('EXPMID', 'MJD-AVG'):
+            if h.get(card) is not None:
+                return float(h[card])
+        start, end = h.get('EXPSTART'), h.get('EXPEND')
+        if start is not None and end is not None:
+            return 0.5 * (float(start) + float(end))
+    return None
+
+
+def _propagate_refcat(refcat, path, key):
+    """Return *refcat* with positions moved to this exposure's mid-time.
+
+    A no-op for a stationary (galaxy) refcat with no proper-motion columns.
+    Fails open — aligns against catalog positions rather than rejecting the
+    exposure — if the epoch can't be read or propagation errors.
+    """
+    from campfire_pipeline.nircam.refcat.io import has_proper_motion
+
+    if not has_proper_motion(refcat):
+        return refcat
+    try:
+        epoch = _exposure_mid_mjd(path)
+        if epoch is None:
+            log(f"align[{key}]: no exposure mid-time in header; using catalog "
+                f"positions (no proper-motion propagation).")
+            return refcat
+        from campfire_pipeline.nircam.refcat.motion import propagate_to_epoch
+        out = propagate_to_epoch(refcat, epoch)
+        log(f"align[{key}]: propagated refcat proper motions to MJD {epoch:.4f}.")
+        return out
+    except Exception as e:  # noqa: BLE001 — align without propagation, don't reject
+        log(f"align[{key}]: refcat epoch propagation failed "
+            f"({type(e).__name__}: {e}); using catalog positions.")
+        return refcat
+
+
 def _detect_mask(model):
     mask = ~np.isfinite(np.asarray(model.data, dtype=float))
     if getattr(model, 'err', None) is not None:
@@ -231,6 +277,7 @@ def align_exposure_group(members, refcat, *, key=None, config=None,
                                                    default_fwhm)
             detectors.append(_load_detector(m.path, m.detector, member_cfg,
                                             ImageModel))
+        refcat = _propagate_refcat(refcat, members[0].path, key)
         solution = solve_exposure_group(detectors, refcat, key=key, **solve_cfg)
     except Exception as e:  # noqa: BLE001 — one bad exposure must not abort the field
         log(f"align[{key}]: FAILED — {type(e).__name__}: {e}; "

--- a/pipeline/campfire_pipeline/nircam/association.py
+++ b/pipeline/campfire_pipeline/nircam/association.py
@@ -206,6 +206,39 @@ def _make_member(field, path, filter_name) -> ExposureMember:
                           rootname=rootname, detector=detector)
 
 
+# Observing mode the align phase supports: full-frame direct imaging. Subarray,
+# coronagraphic, TSO, and grism/WFSS exposures need separately-validated paths
+# and must not fall through the generic per-detector imaging solve.
+_SUPPORTED_EXP_TYPE = 'NRC_IMAGE'
+
+
+def unsupported_mode_reason(path):
+    """Short reason string if *path*'s observing mode is unsupported, else None.
+
+    Reads the primary header only (``EXP_TYPE``, ``SUBARRAY``) — this is the one
+    place the association layer opens a FITS, called by ``run_align`` to gate a
+    physical exposure, not on the filename-only grouping path. Align supports
+    full-frame ``NRC_IMAGE``; a coronagraph / TSO / WFSS ``EXP_TYPE`` or a
+    non-``FULL`` ``SUBARRAY`` is rejected. Missing metadata is treated leniently
+    (returns None) — a header that doesn't declare a mode is not assumed bad.
+    """
+    from astropy.io import fits
+
+    try:
+        with fits.open(path, memmap=False) as hdul:
+            header = hdul[0].header
+            exp_type = str(header.get('EXP_TYPE', '') or '').upper()
+            subarray = str(header.get('SUBARRAY', '') or '').upper()
+    except (OSError, IndexError) as e:
+        return f"unreadable header ({type(e).__name__})"
+    if exp_type and exp_type != _SUPPORTED_EXP_TYPE:
+        return (f"EXP_TYPE={exp_type} (align supports full-frame "
+                f"{_SUPPORTED_EXP_TYPE} only)")
+    if subarray and subarray != 'FULL':
+        return f"SUBARRAY={subarray} (align supports SUBARRAY=FULL only)"
+    return None
+
+
 def build_exposure_groups(field, filters=None, *, skip=None, with_step=None,
                           status=None, work=False,
                           tiles=None) -> List[ExposureGroup]:

--- a/pipeline/campfire_pipeline/nircam/orchestrate.py
+++ b/pipeline/campfire_pipeline/nircam/orchestrate.py
@@ -752,7 +752,9 @@ def run_align(field, config, filters=None, n_processes=1, overwrite=False,
             f"(set [{field.name}.align].enabled = true to run); skipping.")
         return
 
-    from campfire_pipeline.nircam.association import build_exposure_groups
+    from campfire_pipeline.nircam.association import (
+        build_exposure_groups, unsupported_mode_reason,
+    )
     from campfire_pipeline.nircam.refcat.io import read_refcat
 
     refcat_path = _resolve_align_refcat(align_cfg, field.refcat_dir)
@@ -760,11 +762,45 @@ def run_align(field, config, filters=None, n_processes=1, overwrite=False,
     log(f"=== Align phase: field={field.name}, filters={filters}, "
         f"refcat={os.path.basename(refcat_path)} ({len(refcat)} sources) ===")
 
-    status = _scan_status(field, filters, overwrite=overwrite)
-    groups = build_exposure_groups(field, filters, tiles=tiles)
+    # Cross-filter dependency closure (§9.2): pool the FULL physical exposure —
+    # every detector across ALL field filters — even when a filter subset is
+    # requested, so a `--filters f200w` solve still sees its paired LW (F444W)
+    # complement and the tile gate can't split a dither at a tile edge. Status is
+    # scanned over all filters too, since a solved exposure is written across its
+    # whole SW+LW complement (one attitude corrects every detector).
+    all_filters = list(field.filters)
+    status = _scan_status(field, all_filters, overwrite=overwrite)
+    groups = build_exposure_groups(field, all_filters, tiles=tiles)
     if not groups:
         log("align: no exposure groups found; nothing to do.")
         return
+
+    # Restrict the processed set to exposures with a member in the selected
+    # filters; each is then solved and written across its full complement.
+    if set(filters) != set(all_filters):
+        n_all = len(groups)
+        groups = [g for g in groups if g.filters & set(filters)]
+        log(f"align: --filters {filters} selects {len(groups)}/{n_all} "
+            f"exposure(s); each is solved and written across its full SW+LW "
+            f"complement.")
+        if not groups:
+            log("align: no exposures match the selected filters/tiles.")
+            return
+
+    # Observing-mode gating (§9.3): stop before solving if any exposure in scope
+    # is in an unsupported mode (subarray / coronagraph / TSO / WFSS). These need
+    # a separately-validated path, so the user must exclude them explicitly
+    # rather than have align silently feed them through generic imaging logic.
+    unsupported = [(g, r) for g in groups
+                   for r in (unsupported_mode_reason(g.members[0].path),) if r]
+    if unsupported:
+        listing = "\n".join(f"  {g.key}: {reason}" for g, reason in unsupported)
+        raise RuntimeError(
+            f"align: {len(unsupported)} exposure(s) are in an observing mode the "
+            f"align phase does not support:\n{listing}\n\n"
+            f"Exclude them (fields.toml [{field.name}].skip, or the reviewer "
+            f"excluded_exposures list) and re-run, or select a supported subset "
+            f"with --filters / --tiles.")
 
     if overwrite:
         pending = groups

--- a/pipeline/campfire_pipeline/nircam/refcat/io.py
+++ b/pipeline/campfire_pipeline/nircam/refcat/io.py
@@ -9,7 +9,23 @@ what ``jhat.align_wcs`` expects via its ``refcat_*col`` knobs):
     mag      float32   AB magnitude in some band
     mag_err  float32   1-sigma magnitude error
 
-Optional columns: ``source`` (str, set by ``merge`` to record provenance
+Optional **epoch / proper-motion** columns (the align phase propagates positions
+to each exposure's mid-time when they are present — see ``refcat/motion.py``):
+
+    source_id  int      catalog identifier (e.g. Gaia source_id)
+    ref_epoch  float64  epoch of RA/DEC as a Julian year (e.g. 2016.0 for Gaia DR3)
+    pmra       float64  proper motion in RA*cos(dec), mas/yr (Gaia ``pmra`` sense)
+    pmdec      float64  proper motion in Dec, mas/yr
+    parallax   float64  mas (optional; carried for provenance)
+    pmra_err   float64  1-sigma pmra error, mas/yr
+    pmdec_err  float64  1-sigma pmdec error, mas/yr
+
+These are optional and additive: a pure-galaxy anchor catalog omits them and is
+treated as stationary (zero motion), exactly the pre-existing behavior. A row
+with non-finite ``pmra``/``pmdec`` is likewise left stationary, so a mixed
+star+galaxy catalog is handled per-row.
+
+Other optional columns: ``source`` (str, set by ``merge`` to record provenance
 per-row), plus any backend-specific extras the user wants to keep.
 
 Provenance for the catalog as a whole lives in ``Table.meta`` (which ECSV
@@ -34,6 +50,23 @@ from astropy.table import Table
 
 SCHEMA_VERSION = "campfire-refcat-v1"
 REFCAT_COLUMNS = ("RA", "DEC", "mag", "mag_err")
+
+# Optional epoch / proper-motion contract (additive; a catalog without them is
+# treated as stationary). ``ref_epoch`` + ``pmra`` + ``pmdec`` are the minimum
+# needed to propagate a position to an observation epoch.
+MOTION_COLUMNS = ("source_id", "ref_epoch", "pmra", "pmdec", "parallax",
+                  "pmra_err", "pmdec_err")
+_MOTION_REQUIRED = ("ref_epoch", "pmra", "pmdec")
+
+
+def has_proper_motion(table):
+    """True iff *table* carries what's needed to propagate positions to an epoch.
+
+    Requires ``ref_epoch``, ``pmra``, and ``pmdec``; ``parallax``/``source_id``/
+    errors are optional provenance. A catalog missing any of the three is
+    stationary (the pre-existing zero-motion behavior).
+    """
+    return all(c in table.colnames for c in _MOTION_REQUIRED)
 
 
 def make_meta(field, source, params=None, notes=None):
@@ -114,6 +147,15 @@ _COLUMN_ALIASES = {
                 "phot_rp_mean_mag_error",
                 "magerr_g", "magerr_r", "magerr_i", "magerr_z",
                 "MAGERR_AUTO", "MAGERR_APER"),
+    # Epoch / proper-motion — Gaia's native names are already canonical; alias
+    # the ``_error`` -> ``_err`` and a few common variants for external dumps.
+    "source_id": ("SOURCE_ID", "gaia_source_id"),
+    "ref_epoch": ("REF_EPOCH", "epoch"),
+    "pmra": ("pm_ra_cosdec",),
+    "pmdec": ("pm_dec",),
+    "parallax": ("plx",),
+    "pmra_err": ("pmra_error",),
+    "pmdec_err": ("pmdec_error",),
 }
 
 

--- a/pipeline/campfire_pipeline/nircam/refcat/motion.py
+++ b/pipeline/campfire_pipeline/nircam/refcat/motion.py
@@ -1,0 +1,66 @@
+"""Propagate reference-catalog positions to an exposure epoch.
+
+When a refcat carries proper motions (see :func:`io.has_proper_motion`), the
+align phase moves each star's position from the catalog epoch (``ref_epoch``) to
+the exposure mid-time *before* it footprint-clips and matches — so a fast-moving
+Gaia star lands where it actually was when the shutter was open, not where the
+catalog recorded it years earlier. Galaxies (and any row without a finite proper
+motion) are left where they are, so a stationary extragalactic anchor catalog is
+a strict no-op.
+"""
+
+import warnings
+
+import numpy as np
+
+from campfire_pipeline.nircam.refcat.io import has_proper_motion
+
+
+def propagate_to_epoch(refcat, epoch_mjd):
+    """Return a copy of *refcat* with RA/DEC propagated to ``epoch_mjd`` (MJD).
+
+    A no-op that returns the input unchanged when the catalog has no
+    proper-motion columns, or when no row carries a finite non-zero proper
+    motion — so a stationary galaxy anchor pays nothing. Only rows with finite
+    ``pmra``/``pmdec``/``ref_epoch`` are moved; every other row keeps its catalog
+    position (a mixed star+galaxy catalog is handled per-row).
+    """
+    if not has_proper_motion(refcat):
+        return refcat
+
+    ra = np.asarray(refcat['RA'], dtype=float)
+    dec = np.asarray(refcat['DEC'], dtype=float)
+    pmra = np.asarray(refcat['pmra'], dtype=float)
+    pmdec = np.asarray(refcat['pmdec'], dtype=float)
+    ref_epoch = np.asarray(refcat['ref_epoch'], dtype=float)
+
+    movable = (np.isfinite(pmra) & np.isfinite(pmdec) & np.isfinite(ref_epoch)
+               & ((pmra != 0.0) | (pmdec != 0.0)))
+    if not movable.any():
+        return refcat
+
+    from astropy.time import Time
+    import astropy.units as u
+    from astropy.coordinates import SkyCoord
+
+    src = SkyCoord(
+        ra=ra[movable] * u.deg, dec=dec[movable] * u.deg,
+        pm_ra_cosdec=pmra[movable] * u.mas / u.yr,
+        pm_dec=pmdec[movable] * u.mas / u.yr,
+        obstime=Time(ref_epoch[movable], format='jyear'),
+    )
+    with warnings.catch_warnings():
+        # apply_space_motion warns when a coord has no distance (we don't feed
+        # parallax as a distance); linear proper-motion propagation is exactly
+        # the astrometric correction we want, so the warning is expected noise.
+        warnings.simplefilter('ignore')
+        moved = src.apply_space_motion(
+            new_obstime=Time(float(epoch_mjd), format='mjd'))
+
+    out = refcat.copy()
+    new_ra, new_dec = ra.copy(), dec.copy()
+    new_ra[movable] = np.asarray(moved.ra.deg, dtype=float)
+    new_dec[movable] = np.asarray(moved.dec.deg, dtype=float)
+    out['RA'] = new_ra
+    out['DEC'] = new_dec
+    return out

--- a/pipeline/campfire_pipeline/nircam/refcat/query.py
+++ b/pipeline/campfire_pipeline/nircam/refcat/query.py
@@ -31,6 +31,18 @@ from campfire_pipeline.common.io import log
 SUPPORTED_BACKENDS = ("gaia", "ls_dr10", "hsc_ssp")
 
 
+def _float_col(result, name):
+    """Return column *name* as a float ndarray, masked entries -> NaN.
+
+    Query backends return masked tables; a masked value cast straight to float
+    yields the fill sentinel (garbage), not NaN — which would make a NULL proper
+    motion look like a real one. Fill masked entries with NaN first.
+    """
+    col = result[name]
+    filled = col.filled(np.nan) if hasattr(col, "filled") else col
+    return np.asarray(filled, dtype=float)
+
+
 def query(backend, center, radius_deg, **kwargs):
     """Dispatch to a named backend. ``center`` is ``(ra_deg, dec_deg)``."""
     if backend == "gaia":
@@ -85,7 +97,9 @@ def query_gaia(center, radius_deg, *, mag_band="G", mag_max=None,
 
     ra, dec = center
     adql = f"""
-        SELECT ra, dec, {mag_col}, {flux_col}, {flux_err_col}
+        SELECT source_id, ra, dec, ref_epoch, pmra, pmdec, parallax,
+               pmra_error, pmdec_error,
+               {mag_col}, {flux_col}, {flux_err_col}
         FROM gaiadr3.gaia_source
         WHERE 1 = CONTAINS(
             POINT('ICRS', ra, dec),
@@ -99,17 +113,27 @@ def query_gaia(center, radius_deg, *, mag_band="G", mag_max=None,
         job = Gaia.launch_job_async(adql)
         result = job.get_results()
 
-    flux = np.asarray(result[flux_col], dtype=float)
-    flux_err = np.asarray(result[flux_err_col], dtype=float)
-    mag = np.asarray(result[mag_col], dtype=float)
+    flux = _float_col(result, flux_col)
+    flux_err = _float_col(result, flux_err_col)
+    mag = _float_col(result, mag_col)
     with np.errstate(divide="ignore", invalid="ignore"):
         snr = np.where(flux_err > 0, flux / flux_err, np.nan)
         mag_err = 2.5 / np.log(10) / snr
 
     keep = np.isfinite(mag) & np.isfinite(mag_err) & (mag_err > 0)
+    # Proper-motion columns feed the align phase's epoch propagation. Gaia leaves
+    # them NULL for sources without a 5-parameter solution; NULL -> NaN so those
+    # rows are treated as stationary (see refcat.motion.propagate_to_epoch).
     out = Table({
-        "RA": np.asarray(result["ra"], dtype=float)[keep],
-        "DEC": np.asarray(result["dec"], dtype=float)[keep],
+        "source_id": np.asarray(result["source_id"])[keep],
+        "RA": _float_col(result, "ra")[keep],
+        "DEC": _float_col(result, "dec")[keep],
+        "ref_epoch": _float_col(result, "ref_epoch")[keep],
+        "pmra": _float_col(result, "pmra")[keep],
+        "pmdec": _float_col(result, "pmdec")[keep],
+        "parallax": _float_col(result, "parallax")[keep],
+        "pmra_err": _float_col(result, "pmra_error")[keep],
+        "pmdec_err": _float_col(result, "pmdec_error")[keep],
         "mag": mag[keep],
         "mag_err": mag_err[keep],
     })

--- a/pipeline/tests/test_align_run.py
+++ b/pipeline/tests/test_align_run.py
@@ -169,3 +169,33 @@ def test_run_align_warns_and_reattempts_not_aligned(tmp_path, capsys):
     out2 = capsys.readouterr().out
     assert 're-attempting' in out2
     assert 'FAILED alignment' in out2
+
+
+@pytestmark_e2e
+def test_run_align_cross_filter_closure_writes_all_members(tmp_path):
+    # Cross-filter dependency closure: aligning with --filters f200w still pools
+    # and WRITES the paired f444w (LW) member — one attitude corrects the whole
+    # dither, so both canonicals get a real (dof=...) CFP_ALGN stamp.
+    field, _, xy_by_path = _build_field(tmp_path, enabled=True)
+    run_align(field, {}, filters=['f200w'], n_processes=1)
+    assert len(xy_by_path) == 2                        # one f200w + one f444w member
+    for path in xy_by_path:
+        with fits.open(path) as h:
+            assert h[0].header.get('CFP_ALGN', '').startswith('dof=')
+
+
+@pytestmark_e2e
+def test_run_align_hardstops_unsupported_mode(tmp_path):
+    # An exposure in an unsupported observing mode must stop the whole align run
+    # (the user has to exclude it explicitly), not fall through generic logic.
+    field, _, xy_by_path = _build_field(tmp_path, enabled=True)
+    for path in xy_by_path:
+        with fits.open(path, mode='update') as h:
+            h[0].header['EXP_TYPE'] = 'NRC_CORON'
+            h.flush()
+    with pytest.raises(RuntimeError, match='observing mode'):
+        run_align(field, {}, filters=['f200w', 'f444w'], n_processes=1)
+    # nothing was aligned
+    for path in xy_by_path:
+        with fits.open(path) as h:
+            assert 'CFP_ALGN' not in h[0].header

--- a/pipeline/tests/test_association.py
+++ b/pipeline/tests/test_association.py
@@ -19,6 +19,7 @@ from campfire_pipeline.nircam.association import (
     detector_of,
     exposure_key,
     module_of,
+    unsupported_mode_reason,
 )
 
 _TOKEN = 'jw01727028001_04101_00003'
@@ -267,3 +268,29 @@ def test_group_is_frozen_and_hashable(tmp_path):
     with pytest.raises(Exception):
         g.key = 'mutated'  # frozen
     _ = {g}  # hashable (frozen dataclass of hashable fields)
+
+
+# --- observing-mode gating --------------------------------------------------
+
+def _write_header_fits(path, **cards):
+    from astropy.io import fits
+    hdu = fits.PrimaryHDU()
+    for k, v in cards.items():
+        hdu.header[k] = v
+    fits.HDUList([hdu, fits.ImageHDU(name='SCI')]).writeto(path, overwrite=True)
+    return str(path)
+
+
+def test_unsupported_mode_reason(tmp_path):
+    # Supported: full-frame direct imaging.
+    ok = _write_header_fits(tmp_path / 'ok.fits',
+                            EXP_TYPE='NRC_IMAGE', SUBARRAY='FULL')
+    assert unsupported_mode_reason(ok) is None
+    # Missing metadata is lenient (not assumed bad).
+    assert unsupported_mode_reason(_write_header_fits(tmp_path / 'bare.fits')) is None
+    # Unsupported EXP_TYPE (coronagraph) and non-FULL subarray are rejected.
+    coron = _write_header_fits(tmp_path / 'coron.fits', EXP_TYPE='NRC_CORON')
+    assert 'NRC_CORON' in unsupported_mode_reason(coron)
+    sub = _write_header_fits(tmp_path / 'sub.fits',
+                             EXP_TYPE='NRC_IMAGE', SUBARRAY='SUB320')
+    assert 'SUB320' in unsupported_mode_reason(sub)

--- a/pipeline/tests/test_refcat_motion.py
+++ b/pipeline/tests/test_refcat_motion.py
@@ -1,0 +1,87 @@
+"""Tests for the refcat epoch/proper-motion contract (refcat/io + refcat/motion).
+
+Pure astropy — no jwst/tweakwcs. Covers the optional motion schema (detection,
+round-trip, alias canonicalization) and the epoch propagation (a star moves, a
+galaxy and a motion-less catalog do not).
+"""
+
+import numpy as np
+from astropy.table import Table
+
+from campfire_pipeline.nircam.refcat.io import (
+    has_proper_motion,
+    read_refcat,
+    write_refcat,
+)
+from campfire_pipeline.nircam.refcat.motion import propagate_to_epoch
+
+
+def _pm_table():
+    """A refcat with a fast star (row 0) and a motion-less galaxy (row 1)."""
+    return Table({
+        'RA': [150.0, 150.5], 'DEC': [2.0, 2.0],
+        'mag': np.array([18.0, 20.0], 'float32'),
+        'mag_err': np.array([0.01, 0.02], 'float32'),
+        'source_id': [1, 2], 'ref_epoch': [2016.0, 2016.0],
+        'pmra': [3600.0, np.nan], 'pmdec': [0.0, np.nan],   # 3600 mas/yr = 3.6"/yr
+        'parallax': [1.0, np.nan],
+        'pmra_err': [0.1, np.nan], 'pmdec_err': [0.1, np.nan],
+    })
+
+
+def _plain_table():
+    return Table({'RA': [1.0], 'DEC': [2.0],
+                  'mag': np.array([18.0], 'float32'),
+                  'mag_err': np.array([0.01], 'float32')})
+
+
+# --- schema -----------------------------------------------------------------
+
+def test_has_proper_motion():
+    assert has_proper_motion(_pm_table())
+    assert not has_proper_motion(_plain_table())
+    t = _pm_table()
+    t.remove_column('pmdec')                        # missing one required column
+    assert not has_proper_motion(t)
+
+
+def test_write_read_roundtrip_preserves_motion(tmp_path):
+    p = str(tmp_path / 'rc.ecsv')
+    write_refcat(_pm_table(), p, overwrite=True)
+    back = read_refcat(p)
+    for c in ('source_id', 'ref_epoch', 'pmra', 'pmdec', 'parallax'):
+        assert c in back.colnames
+    assert has_proper_motion(back)
+
+
+def test_read_canonicalizes_motion_aliases(tmp_path):
+    # An external Gaia dump using pmra_error/pmdec_error / SOURCE_ID.
+    t = Table({'RA': [150.0], 'DEC': [2.0],
+               'mag': np.array([18.0], 'float32'),
+               'mag_err': np.array([0.01], 'float32'),
+               'ref_epoch': [2016.0], 'pmra': [10.0], 'pmdec': [5.0],
+               'pmra_error': [0.1], 'pmdec_error': [0.1], 'SOURCE_ID': [42]})
+    p = str(tmp_path / 'ext.ecsv')
+    t.write(p, format='ascii.ecsv', overwrite=True)
+    back = read_refcat(p)
+    assert {'pmra_err', 'pmdec_err', 'source_id'}.issubset(back.colnames)
+    assert has_proper_motion(back)
+
+
+# --- propagation ------------------------------------------------------------
+
+def test_propagate_moves_star_keeps_galaxy():
+    t = _pm_table()
+    out = propagate_to_epoch(t, 60000.0)            # MJD 60000 ~ jyear 2023.15
+    # star: 3.6"/yr over ~7.15 yr ~ 25.7" in RA*cos(dec)
+    dra = (out['RA'][0] - t['RA'][0]) * 3600.0 * np.cos(np.radians(2.0))
+    assert 24.0 < dra < 27.0
+    # galaxy (NaN proper motion) is left exactly where it was
+    assert out['RA'][1] == t['RA'][1] and out['DEC'][1] == t['DEC'][1]
+    # input is not mutated
+    assert t['RA'][0] == 150.0
+
+
+def test_propagate_noop_without_motion():
+    t = _plain_table()
+    assert propagate_to_epoch(t, 60000.0) is t      # same object, no work done


### PR DESCRIPTION
## Summary

The last two staged pieces of the align design's rollout (S3b, S3c), following the merged S1–S3a (#334). Both are **opt-in / default-off** (a field must set `[<field>.align].enabled = true`). They're independent and different categories, so they land as two changelog entries.

## S3b — refcat epoch / proper-motion contract *(Calibration)*
Reference positions are now propagated to each exposure's mid-time, so a fast-moving Gaia star is matched where it actually was — not where the catalog recorded it years earlier.

- **`refcat/io.py`** — optional motion columns (`source_id, ref_epoch, pmra, pmdec, parallax` + `pmra_err`/`pmdec_err`) alongside the required `RA/DEC/mag/mag_err`; `has_proper_motion()`; alias canonicalization for external dumps (`pmra_error`→`pmra_err`, `SOURCE_ID`→`source_id`, …).
- **`refcat/query.py`** — `query_gaia` selects/populates the PM columns (Gaia `NULL` → `NaN`); LS/HSC backends unchanged (galaxies → stationary).
- **`refcat/motion.py`** — `propagate_to_epoch(refcat, mjd)` moves star positions via `astropy` `apply_space_motion`; galaxies and any `NaN`-PM row stay put (per-row).
- **`align/apply.py`** — reads the exposure mid-time (`EXPMID`) and propagates the refcat **before** the footprint clip/solve, only when the refcat carries motion; fails open to catalog positions otherwise.

**Fully backward-compatible**: today's galaxy-anchored refcats have no motion columns, so this is a strict no-op — it changes the fitted WCS only when a motion-bearing catalog is used.

## S3c — cross-filter dependency closure + mode gating *(Infrastructure)*
- **Cross-filter closure** — `run_align` now pools each physical exposure across **all** field filters even under `--filters`/`--tiles`, so `align --filters f200w` still sees its paired F444W (LW) complement for the shared solve, and a tile gate can't split a dither at a tile edge. The selection chooses *which* exposures to process; each is solved and its corrected gwcs written across its **full SW+LW complement**. **Behavior change (confirmed):** `--filters f200w` now also stamps the paired f444w canonicals — one attitude corrects the whole dither, so an exposure never ends up half-aligned.
- **Mode gating** — align reads `EXP_TYPE`/`SUBARRAY` per exposure and **hard-stops** with a clear, listed error if any exposure in scope is in an unsupported mode (subarray / coronagraph / TSO / WFSS), rather than silently feeding it through generic full-frame-imaging logic. The user must exclude it (fields.toml `skip` / reviewer exclusions) or select a supported subset. Missing metadata is treated leniently.

## Testing
Ran against the real libraries (`tweakwcs`, `tristars`, `shapely`, `photutils`, `jwst`, `astropy`) — full align/refcat suite green. New coverage: `test_refcat_motion.py` (schema, round-trip, alias canonicalization, star-moves/galaxy-stays propagation), `test_association.py::test_unsupported_mode_reason`, and `test_align_run.py` (cross-filter closure writes all members; unsupported-mode hard-stop).

This completes the S1–S3 staged rollout; the remaining design stages (S4 Layer-1 joint attitude → S5 measurement → S6/S7) are the hierarchical-joint-solve architecture, gated on real-data validation.

Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01BVjMLjYjEQYPZqsFFh1bzv)_