### PR TITLE
feat(nircam): present exposure maps as fiducial, drop "canonical" from filename

### DIFF
--- a/layout/conformance/layout_golden.json
+++ b/layout/conformance/layout_golden.json
@@ -114,10 +114,10 @@
     {
       "product_type": "nircam_expmap",
       "scope": {"field": "cosmos", "filt": "f444w"},
-      "filename": "expmap_cosmos_f444w_canonical.fits",
-      "relpath": "products/nircam/cosmos/f444w/expmap_cosmos_f444w_canonical.fits",
+      "filename": "expmap_cosmos_f444w.fits",
+      "relpath": "products/nircam/cosmos/f444w/expmap_cosmos_f444w.fits",
       "key_legacy": null,
-      "key_canonical": "data/products/nircam/cosmos/f444w/expmap_cosmos_f444w_canonical.fits",
+      "key_canonical": "data/products/nircam/cosmos/f444w/expmap_cosmos_f444w.fits",
       "bucket": "data",
       "tree_class": "cloud-backed-product"
     },

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -26,6 +26,17 @@ Release procedure: edit the `## Unreleased` section below, then run
 ## Unreleased
 
 ### Infrastructure
+- NIRCam exposure maps: the fiducial (`canonical`-stage) per-filter map is now
+  written with an **undecorated filename** — `expmap_<field>_<filter>.fits`
+  (previously `expmap_<field>_<filter>_canonical.fits`) — so it presents to users
+  simply as *the* exposure map rather than one stage among several. The
+  reducer-only `uncal` quick-look keeps its explicit `_uncal` suffix (and its
+  matching PDF / `footprints.reg` follow the same rule), so the two never collide.
+  The FITS `STAGE` header keyword is unchanged (kept as provenance). `cfpipe nircam
+  expmap` and its `--stage` options are otherwise unchanged. Deploy ships only the
+  fiducial map (the `_uncal`/legacy `_canonical` variants are skipped) and it is now
+  surfaced for download on the web NIRCam page. Pure output-file naming change with
+  no effect on pixel values (`nircam/expmap.py`).
 - NIRCam wisp templates are now fetched from a public HTTPS host into
   `$CAMPFIRE_ROOT/cache/wisps/` against a checksummed manifest shipped with the
   package (`data/wisp_manifest.toml`), instead of being manually copied into the

--- a/pipeline/campfire_pipeline/nircam/expmap.py
+++ b/pipeline/campfire_pipeline/nircam/expmap.py
@@ -14,11 +14,14 @@ pixel-registered for direct stacking/comparison. No tile dependency —
 works on fields without a ``[tiles]`` block, suitable for full-field
 diagnostics.
 
-Outputs (per invocation, rooted at ``{products_dir}`` = ``products/nircam/<field>/``):
+Outputs (per invocation, rooted at ``{products_dir}`` = ``products/nircam/<field>/``).
+The fiducial ``canonical`` map is undecorated — to a user it is simply *the*
+exposure map — while the reducer-only ``uncal`` quick-look keeps an explicit
+``_uncal`` suffix (shown below as ``[_uncal]``):
 
-    <filter>/expmap_{field}_{filter}_{stage}.fits   float32, ``BUNIT='s'``, WCS in header
-    <filter>/expmap_{field}_{filter}_{stage}.pdf    diagnostic with RA/Dec gridlines + colorbar
-    footprints_{stage}.reg                          ds9 fk5 polygons across all filters
+    <filter>/expmap_{field}_{filter}[_uncal].fits   float32, ``BUNIT='s'``, WCS in header
+    <filter>/expmap_{field}_{filter}[_uncal].pdf    diagnostic with RA/Dec gridlines + colorbar
+    footprints[_uncal].reg                          ds9 fk5 polygons across all filters
 
 The per-filter FITS sits in the canonical filter directory alongside the
 mosaics/exposures so the deployed coverage map carries a real filter in the
@@ -390,16 +393,32 @@ def _collect_metas(field, filter_name, stage, *,
     return metas
 
 
+def _expmap_stem(field_name, filter_name, stage):
+    """Filename stem for a per-filter expmap.
+
+    The ``canonical`` map is the fiducial, deployable coverage map and carries no
+    stage decoration (``expmap_<field>_<filter>``) — to a user it is simply *the*
+    exposure map, the default rather than one option among several. The ``uncal``
+    map is a reducer-only quick-look and keeps an explicit ``_uncal`` suffix so it
+    never collides with the fiducial map and the deploy step can pick up only the
+    undecorated one.
+    """
+    stem = f'expmap_{field_name}_{filter_name}'
+    if stage != 'canonical':
+        stem += f'_{stage}'
+    return stem
+
+
 def _expmap_paths(base_dir, field_name, filter_name, stage):
-    """Canonical per-filter FITS + PDF paths.
+    """Per-filter FITS + PDF paths.
 
     Expmaps live in the filter directory alongside the mosaics/exposures
-    (``<base_dir>/<filter>/expmap_<field>_<filter>_<stage>.{fits,pdf}``) so the
-    deployed FITS carries a real filter in the registry — same key shape as every
-    other per-filter NIRCam product. ``base_dir`` is the per-field products dir.
+    (``<base_dir>/<filter>/``) so the deployed FITS carries a real filter in the
+    registry — same key shape as every other per-filter NIRCam product.
+    ``base_dir`` is the per-field products dir.
     """
-    d = os.path.join(base_dir, filter_name)
-    base = os.path.join(d, f'expmap_{field_name}_{filter_name}_{stage}')
+    base = os.path.join(base_dir, filter_name,
+                        _expmap_stem(field_name, filter_name, stage))
     return base + '.fits', base + '.pdf'
 
 
@@ -488,7 +507,7 @@ def run_expmap(
         Sky padding in arcsec around the union footprint.
     out_dir
         Base products directory. Per-filter FITS + PDFs land in
-        ``<out_dir>/<filter>/``; the combined ``footprints_<stage>.reg`` and the
+        ``<out_dir>/<filter>/``; the combined footprints ``.reg`` and the
         metadata cache land at its root. Defaults to ``field.products_dir``
         (``products/nircam/<field>/``).
     n_processes
@@ -582,7 +601,10 @@ def run_expmap(
     reg_metas = [(name, metas)
                  for name, metas, *_ in results if metas]
     if reg_metas:
-        reg_path = os.path.join(out_dir, f'footprints_{stage}.reg')
+        # Fiducial canonical footprints are undecorated (footprints.reg); the
+        # uncal quick-look keeps its stage suffix so the two don't overwrite.
+        reg_name = 'footprints.reg' if stage == 'canonical' else f'footprints_{stage}.reg'
+        reg_path = os.path.join(out_dir, reg_name)
         _write_region_file(reg_path, reg_metas)
         n_poly = sum(len(m) for _, m in reg_metas)
         log(f'wrote {os.path.basename(reg_path)} '

--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -357,14 +357,25 @@ def build_fits_upload_tasks(field, exposures):
     return tasks
 
 
+# Stage-decorated expmap variants that are NOT deployed. The fiducial coverage map
+# is the undecorated ``expmap_<field>_<filter>.fits``; ``_uncal`` is a reducer-only
+# raw quick-look, and ``_canonical`` is the pre-rename legacy name for what is now
+# the undecorated fiducial (a stale copy may still sit on a reducer's disk). Deploy
+# ships only the fiducial map so users download a single, unqualified exposure map.
+_EXPMAP_NONFIDUCIAL_SUFFIXES = ('_uncal.fits', '_canonical.fits')
+
+
 def discover_expmap_tasks(dirs, field, filters):
-    """Build canonical-key OSN upload tasks for any per-filter expmap coverage files.
+    """Build canonical-key OSN upload tasks for the per-filter fiducial expmap files.
 
     Expmaps are per-``(field, filter)`` coverage maps written into the canonical
     filter directory (``products/nircam/<field>/<filter>/expmap_*.fits``),
-    alongside the mosaics/exposures. They are produced at combine time, so a
-    process-only field may have none yet — deploy is idempotent and picks them up
-    on a later run. Returns a list of ``UploadTask`` (empty if none found).
+    alongside the mosaics/exposures. Only the **fiducial** map
+    (``expmap_<field>_<filter>.fits``, no stage suffix) is deployed; the reducer-only
+    ``_uncal`` quick-look (and any pre-rename ``_canonical`` leftover) is skipped so a
+    user downloads a single, unqualified exposure map. They are produced at combine
+    time, so a process-only field may have none yet — deploy is idempotent and picks
+    them up on a later run. Returns a list of ``UploadTask`` (empty if none found).
     """
     products = dirs['products']
     tasks = []
@@ -373,6 +384,8 @@ def discover_expmap_tasks(dirs, field, filters):
         if not filter_dir.exists():
             continue
         for path in sorted(filter_dir.glob('expmap_*.fits')):
+            if path.name.endswith(_EXPMAP_NONFIDUCIAL_SUFFIXES):
+                continue
             key = storage_key('nircam_expmap', Scope(field=field, filt=filtname),
                               path.name, scheme=KeyScheme.CANONICAL)
             tasks.append(UploadTask(local_path=path, r2_key=key,

--- a/python/tests/test_nircam_deploy.py
+++ b/python/tests/test_nircam_deploy.py
@@ -114,19 +114,34 @@ def test_build_fits_upload_tasks_refuses_combine_stamped(tmp_path):
         nc.build_fits_upload_tasks("cosmos", exposures)
 
 
-def test_discover_expmap_tasks_canonical_keys(tmp_path):
-    # Expmaps now live in the canonical per-filter dir (alongside mosaics), keyed
-    # off an ``expmap_`` filename prefix so they carry a real filter.
+def test_discover_expmap_tasks_deploys_only_fiducial(tmp_path):
+    # Expmaps live in the canonical per-filter dir (alongside mosaics), keyed off an
+    # ``expmap_`` filename prefix so they carry a real filter. Only the fiducial map
+    # (undecorated ``expmap_<field>_<filter>.fits``) deploys.
     products = tmp_path / "products" / "nircam" / "cosmos"
     (products / "f444w").mkdir(parents=True)
-    (products / "f444w" / "expmap_cosmos_f444w_canonical.fits").write_bytes(b"\x00")
+    (products / "f444w" / "expmap_cosmos_f444w.fits").write_bytes(b"\x00")
     # A non-expmap FITS in the same dir must not be picked up by the expmap glob.
     (products / "f444w" / "jw01_00001_nrcalong.fits").write_bytes(b"\x00")
     dirs = {"products": products}
     tasks = nc.discover_expmap_tasks(dirs, "cosmos", ["f444w"])
     assert len(tasks) == 1
     assert tasks[0].r2_key == \
-        "data/products/nircam/cosmos/f444w/expmap_cosmos_f444w_canonical.fits"
+        "data/products/nircam/cosmos/f444w/expmap_cosmos_f444w.fits"
+
+
+def test_discover_expmap_tasks_excludes_nonfiducial_stages(tmp_path):
+    # The reducer-only ``_uncal`` quick-look and any pre-rename ``_canonical``
+    # leftover must NOT deploy — only the undecorated fiducial map ships.
+    products = tmp_path / "products" / "nircam" / "cosmos"
+    (products / "f444w").mkdir(parents=True)
+    (products / "f444w" / "expmap_cosmos_f444w.fits").write_bytes(b"\x00")
+    (products / "f444w" / "expmap_cosmos_f444w_uncal.fits").write_bytes(b"\x00")
+    (products / "f444w" / "expmap_cosmos_f444w_canonical.fits").write_bytes(b"\x00")
+    dirs = {"products": products}
+    tasks = nc.discover_expmap_tasks(dirs, "cosmos", ["f444w"])
+    assert [t.r2_key for t in tasks] == \
+        ["data/products/nircam/cosmos/f444w/expmap_cosmos_f444w.fits"]
 
 
 def test_discover_expmap_tasks_empty_when_absent(tmp_path):
@@ -164,7 +179,7 @@ def test_row_sci_dq_hash_none_by_default():
     # An expmap (and every non-exposure product) carries no science digest, but
     # does carry its per-filter scope column now that it lives in the filter dir.
     row = reg.row_for_key(
-        "data/products/nircam/cosmos/f444w/expmap_cosmos_f444w_canonical.fits",
+        "data/products/nircam/cosmos/f444w/expmap_cosmos_f444w.fits",
         backend="osn", content_hash="sha256:" + "a" * 64, size_bytes=1,
         content_type="application/fits")
     assert row["product_type"] == "nircam_expmap"

--- a/web/app/nircam/page.tsx
+++ b/web/app/nircam/page.tsx
@@ -1,20 +1,22 @@
 'use client';
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import Link from 'next/link';
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
 import { NircamTable } from '@/components/nircam/NircamTable';
+import { NircamExpmapTable } from '@/components/nircam/NircamExpmapTable';
 import { NircamFilterBar, NircamFilterOptions, DEFAULT_NIRCAM_FILTERS } from '@/components/nircam/NircamFilterBar';
 import { CurlScriptGenerator } from '@/components/nircam/CurlScriptGenerator';
-import { getNircamImages, getNircamFilterOptions } from '@/lib/actions/nircam';
-import type { NircamImage } from '@/lib/types';
-import { LogIn, Loader2, ImageIcon } from 'lucide-react';
+import { getNircamImages, getNircamFilterOptions, getNircamExpmaps } from '@/lib/actions/nircam';
+import type { NircamImage, NircamExpmap } from '@/lib/types';
+import { LogIn, Loader2, ImageIcon, Layers } from 'lucide-react';
 import { useAuth } from '@/lib/contexts/AuthContext';
 
 export default function NircamPage() {
   const { user, loading: authLoading } = useAuth();
 
   const [images, setImages] = useState<NircamImage[]>([]);
+  const [expmaps, setExpmaps] = useState<NircamExpmap[]>([]);
   const [filters, setFilters] = useState<NircamFilterOptions>(DEFAULT_NIRCAM_FILTERS);
   const [selectedImages, setSelectedImages] = useState<NircamImage[]>([]);
   const [loading, setLoading] = useState(true);
@@ -36,9 +38,10 @@ export default function NircamPage() {
     setError(null);
 
     try {
-      // Fetch images and filter options in parallel
-      const [imagesResult, filterOptionsResult] = await Promise.all([
+      // Fetch images, expmaps, and filter options in parallel
+      const [imagesResult, expmapsResult, filterOptionsResult] = await Promise.all([
         getNircamImages(),
+        getNircamExpmaps(),
         getNircamFilterOptions(),
       ]);
 
@@ -47,6 +50,10 @@ export default function NircamPage() {
       } else {
         setImages(imagesResult.images);
       }
+
+      // Expmaps are a secondary product; a fetch error there shouldn't blank the
+      // whole page — just leave the section empty (it renders nothing when empty).
+      setExpmaps(expmapsResult.error ? [] : expmapsResult.expmaps);
 
       if (!filterOptionsResult.error) {
         setAvailableFields(filterOptionsResult.fields);
@@ -76,6 +83,16 @@ export default function NircamPage() {
   const handleSelectionChange = (selected: NircamImage[]) => {
     setSelectedImages(selected);
   };
+
+  // Expmaps share the field + filter axes with mosaics, so honor those two
+  // filter-bar selections here too (tile/scale/extension/epoch don't apply).
+  const filteredExpmaps = useMemo(() => {
+    return expmaps.filter((e) => {
+      if (filters.fields.length > 0 && !filters.fields.includes(e.field)) return false;
+      if (filters.filters.length > 0 && !filters.filters.includes(e.filter)) return false;
+      return true;
+    });
+  }, [expmaps, filters.fields, filters.filters]);
 
   // Show login prompt if not authenticated
   if (!authLoading && !user) {
@@ -195,6 +212,21 @@ export default function NircamPage() {
               filters={filters}
               onSelectionChange={handleSelectionChange}
             />
+          )}
+
+          {/* Exposure maps — per-(field, filter) coverage maps (seconds of
+              exposure per pixel), one fiducial map per field/filter. */}
+          {filteredExpmaps.length > 0 && (
+            <div className="mt-10">
+              <div className="flex items-center gap-2 mb-2">
+                <Layers className="w-5 h-5 text-primary" />
+                <h2 className="text-lg font-semibold text-text-primary">Exposure maps</h2>
+              </div>
+              <p className="text-text-secondary text-sm mb-4">
+                Per-filter exposure-time coverage maps (pixel values in seconds).
+              </p>
+              <NircamExpmapTable expmaps={filteredExpmaps} />
+            </div>
           )}
         </>
       )}

--- a/web/components/nircam/NircamExpmapTable.tsx
+++ b/web/components/nircam/NircamExpmapTable.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Download } from 'lucide-react';
+import type { NircamExpmap } from '@/lib/types';
+import { Card } from '@/components/ui/Card';
+import { generateNircamExpmapDownloadUrls } from '@/lib/actions/download';
+
+interface NircamExpmapTableProps {
+  expmaps: NircamExpmap[];
+}
+
+// Format a byte count for display (mirrors NircamTable).
+const formatFileSize = (bytes: number | undefined): string => {
+  if (!bytes) return '-';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
+};
+
+// Per-row download: authorizes + presigns the expmap key server-side, then
+// navigates the browser to the credential-free proxy URL to start the download.
+const DownloadCell: React.FC<{ expmap: NircamExpmap }> = ({ expmap }) => {
+  const [busy, setBusy] = useState(false);
+
+  const handleDownload = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const { urls } = await generateNircamExpmapDownloadUrls([expmap.storage_key]);
+      const proxyUrl = urls[expmap.storage_key];
+      if (proxyUrl) {
+        const link = document.createElement('a');
+        link.href = proxyUrl;
+        link.download = expmap.storage_key.split('/').pop() || expmap.storage_key;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+      }
+    } catch (err) {
+      console.error('Failed to start NIRCam expmap download:', err);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleDownload}
+      disabled={busy}
+      className="inline-flex items-center gap-1.5 text-sm text-primary hover:text-primary-hover hover:underline disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      <Download className="w-4 h-4" />
+      <span>{busy ? 'Preparing…' : 'Download'}</span>
+    </button>
+  );
+};
+
+export const NircamExpmapTable: React.FC<NircamExpmapTableProps> = ({ expmaps }) => {
+  if (expmaps.length === 0) return null;
+
+  return (
+    <Card className="overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="w-full">
+          <thead className="bg-table-header border-b border-border">
+            <tr>
+              {['Field', 'Filter', 'Size', 'Download'].map((h) => (
+                <th
+                  key={h}
+                  className="px-4 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider"
+                >
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="bg-card divide-y divide-border">
+            {expmaps.map((expmap) => (
+              <tr
+                key={expmap.storage_key}
+                className="hover:bg-card-hover transition-colors"
+              >
+                <td className="px-4 py-3 whitespace-nowrap">
+                  <span className="text-sm font-medium text-text-primary uppercase">
+                    {expmap.field}
+                  </span>
+                </td>
+                <td className="px-4 py-3 whitespace-nowrap">
+                  <span className="text-sm font-mono text-text-primary uppercase">
+                    {expmap.filter}
+                  </span>
+                </td>
+                <td className="px-4 py-3 whitespace-nowrap">
+                  <span className="text-sm text-text-secondary">
+                    {formatFileSize(expmap.file_size)}
+                  </span>
+                </td>
+                <td className="px-4 py-3 whitespace-nowrap">
+                  <DownloadCell expmap={expmap} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Card>
+  );
+};

--- a/web/lib/actions/download.ts
+++ b/web/lib/actions/download.ts
@@ -549,6 +549,63 @@ export async function generateNircamMosaicDownloadUrls(
 }
 
 /**
+ * Authorize NIRCam exposure-map downloads and return ready-to-fetch Worker proxy
+ * URLs, keyed by canonical storage key.
+ *
+ * Same trust model as `generateNircamMosaicDownloadUrls`: client-supplied keys are
+ * never trusted. The authorized set is re-derived server-side from `storage_objects`
+ * (product_type `nircam_expmap`, active) under the caller's RLS session, so
+ * `select_storage_objects_by_access` returns only published (or, for admins, all)
+ * rows — a draft/revoked or forged key is simply never presigned. Each authorized
+ * key is presigned against its home backend (dual-read: OSN or R2) and HMAC-signed
+ * so the credential-free proxy Worker only fetches URLs we authorized.
+ */
+export async function generateNircamExpmapDownloadUrls(
+  storageKeys: string[]
+): Promise<{ urls: Record<string, string>; error: string | null }> {
+  try {
+    if (!JWT_SECRET) {
+      return { urls: {}, error: 'Server configuration error: JWT secret not set' };
+    }
+    if (storageKeys.length === 0) {
+      return { urls: {}, error: null };
+    }
+
+    const supabase = await createClient();
+    const { data: rows, error: queryError } = await supabase
+      .from('storage_objects')
+      .select('storage_key')
+      .eq('product_type', 'nircam_expmap')
+      .eq('status', 'active')
+      .in('storage_key', storageKeys);
+
+    if (queryError) {
+      console.error('Error authorizing NIRCam expmap download:', queryError);
+      return { urls: {}, error: 'Failed to authorize download' };
+    }
+
+    const authorizedKeys = [...new Set((rows || []).map((r) => r.storage_key as string))];
+    if (authorizedKeys.length === 0) {
+      return { urls: {}, error: null };
+    }
+
+    const signed = await generateDownloadUrls(authorizedKeys, PRESIGN_TTL_SECONDS);
+    const urls: Record<string, string> = {};
+    await Promise.all(
+      authorizedKeys.map(async (key, i) => {
+        const sig = await signUrlSignature(signed[i], JWT_SECRET);
+        urls[key] = `${WORKER_URL}/proxy?url=${encodeURIComponent(signed[i])}&sig=${sig}`;
+      })
+    );
+
+    return { urls, error: null };
+  } catch (error) {
+    console.error('Error generating NIRCam expmap download URLs:', error);
+    return { urls: {}, error: 'Failed to generate download URLs' };
+  }
+}
+
+/**
  * HMAC-SHA256(secret, url), base64url-encoded — the per-URL signature the proxy
  * Worker verifies. Web Crypto API (same primitive both ends).
  */

--- a/web/lib/actions/nircam.ts
+++ b/web/lib/actions/nircam.ts
@@ -2,10 +2,16 @@
 
 import { createClient } from '@/lib/supabase/server';
 import { paginateQuery } from '@/lib/supabase/paginate';
-import type { NircamImage } from '@/lib/types';
+import type { NircamImage, NircamExpmap } from '@/lib/types';
 
 export interface NircamImagesResult {
   images: NircamImage[];
+  error?: string;
+  isAuthenticated: boolean;
+}
+
+export interface NircamExpmapsResult {
+  expmaps: NircamExpmap[];
   error?: string;
   isAuthenticated: boolean;
 }
@@ -69,6 +75,58 @@ export async function getNircamImages(): Promise<NircamImagesResult> {
       error: 'An unexpected error occurred',
       isAuthenticated: true,
     };
+  }
+}
+
+/**
+ * Fetch the per-(field, filter) exposure-coverage maps a user may see.
+ *
+ * Expmaps are registered in `storage_objects` (product_type `nircam_expmap`) and
+ * their visibility rides the owning field deployment via RLS: a published field
+ * deployment is public to everyone, drafts stay admin-only. We simply select
+ * active rows and let `select_storage_objects_by_access` do the gating — no
+ * bespoke access logic here, mirroring how mosaics rely on `nircam_images` RLS.
+ */
+export async function getNircamExpmaps(): Promise<NircamExpmapsResult> {
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) {
+    return { expmaps: [], isAuthenticated: false };
+  }
+
+  try {
+    const { data, error } = await paginateQuery<{
+      field: string; filter: string | null; storage_key: string;
+      size_bytes: number | null;
+    }>(
+      () => supabase
+        .from('storage_objects')
+        .select('field, filter, storage_key, size_bytes')
+        .eq('product_type', 'nircam_expmap')
+        .eq('status', 'active')
+        .order('field', { ascending: true })
+        .order('filter', { ascending: true }),
+    );
+
+    if (error) {
+      console.error('Error fetching NIRCam expmaps:', error);
+      return { expmaps: [], error: error.message, isAuthenticated: true };
+    }
+
+    const expmaps: NircamExpmap[] = data
+      .filter((r) => r.filter)  // per-filter product; skip any unscoped row
+      .map((r) => ({
+        field: r.field,
+        filter: r.filter as string,
+        storage_key: r.storage_key,
+        file_size: r.size_bytes ?? undefined,
+      }));
+
+    return { expmaps, isAuthenticated: true };
+  } catch (err) {
+    console.error('Unexpected error fetching NIRCam expmaps:', err);
+    return { expmaps: [], error: 'An unexpected error occurred', isAuthenticated: true };
   }
 }
 

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -289,6 +289,16 @@ export interface NircamImage {
   file_size?: number; // in bytes, if available
 }
 
+// A per-(field, filter) exposure-coverage map (product_type 'nircam_expmap',
+// sourced from the storage_objects registry). Unlike mosaics there is one
+// fiducial map per field/filter — no tile/scale/extension axes.
+export interface NircamExpmap {
+  field: string;
+  filter: string;
+  storage_key: string;
+  file_size?: number; // size_bytes from the registry, if available
+}
+
 // NIRCam pipeline step names. Matches campfire_pipeline.common.cfp.CFP_KEYS
 // order: 'uncal' means raw exists but no canonical file yet; each subsequent
 // value is the name of the highest-completed step (process phase →


### PR DESCRIPTION
## Motivation

To a user, the deployed NIRCam exposure map should be simply *the* exposure map — the default, not one stage among several. This strips the user-facing "canonical" term from exposure-map science data and gives the maps a real download surface.

While exploring, I confirmed "canonical" appears almost entirely as an **internal** data-model term ("canonical exposure", `KeyScheme.CANONICAL`) with **zero** user-facing web strings — so I deliberately left the internal term alone (renaming it would be a large, risky churn with no user benefit). The one place it leaked into deployed science data was the expmap filename suffix, which this PR fixes.

## Findings that motivated the change

- **Which stage deployed?** Both, if present — `discover_expmap_tasks` globbed `expmap_*.fits`, matching `_uncal` *and* `_canonical` with no stage filter.
- **Were they downloadable?** They reached OSN + the `storage_objects` registry and became public once the field deployment published, but **no user-facing surface listed them** — only the admin Storage registry page. Mosaics download via `nircam_images`; expmaps were in neither that table nor any UI.

## What changed

**Pipeline** (`nircam/expmap.py`)
- The fiducial (canonical-stage) per-filter map is now written undecorated as `expmap_<field>_<filter>.fits` (was `..._canonical.fits`); its PDF and the combined `footprints.reg` follow the same rule.
- The reducer-only `uncal` quick-look keeps an explicit `_uncal` suffix so the two never collide.
- The FITS `STAGE` header keyword is kept as provenance; `cfpipe nircam expmap` and its `--stage` options are otherwise unchanged. Pure output-file naming change, no effect on pixel values.

**Deploy** (`python/campfire/deploy/nircam.py`)
- `discover_expmap_tasks` now ships only the fiducial map, skipping the `_uncal` quick-look and any pre-rename `_canonical` leftover.

**Web**
- `getNircamExpmaps()` lists published `nircam_expmap` objects from the `storage_objects` registry — visibility rides the field deployment via RLS, exactly like mosaics.
- `generateNircamExpmapDownloadUrls()` authorizes + presigns downloads the same way mosaic downloads work (re-derive authorized keys server-side under RLS, HMAC-signed proxy URL).
- New "Exposure maps" table on `/nircam` surfaces them for download and honors the existing field/filter filters.

**Also**: updated the layout golden fixture, deploy tests (including a new test that non-fiducial stages are excluded from deploy), and a pipeline `CHANGELOG` Infrastructure (PATCH) entry.

## Testing

- Python deploy tests: **17/17 pass**.
- Layout conformance: Python **30** + TS **93** pass with the updated golden fixture.
- Web: `tsc --noEmit` clean, lint clean on changed files, `npm run build` exits 0.

## Notes for reviewers

- **Reducers must re-run `cfpipe nircam expmap`** to produce the new undecorated name; a stale `..._canonical.fits` on disk is now intentionally skipped by deploy.
- The `STAGE='canonical'` FITS header value is kept as provenance metadata (not surfaced in any filename or UI).

Generated with Claude Code

https://claude.ai/code/session_01VBpbC8R95DdJTs8AfJjggA

---
_Generated by [Claude Code](https://claude.ai/code/session_01VBpbC8R95DdJTs8AfJjggA)_