### PR TITLE
Extract ZIP download logic into shared utility

### DIFF
--- a/web/components/spectra/DownloadButtons.tsx
+++ b/web/components/spectra/DownloadButtons.tsx
@@ -4,6 +4,8 @@ import React, { useState } from 'react';
 import { Button } from '@/components/ui/Button';
 import { Download, Loader2 } from 'lucide-react';
 import type { Spectrum } from '@/lib/types';
+import { generateObjectFitsDownloadUrls } from '@/lib/actions/download';
+import { downloadFilesAsZip } from '@/lib/utils/zip-download';
 
 interface DownloadButtonsProps {
   spectra: Spectrum[];
@@ -20,42 +22,39 @@ export const DownloadButtons: React.FC<DownloadButtonsProps> = ({ spectra, targe
 
     setDownloading(true);
     setError(null);
+    setBatchProgress(null);
 
     try {
       const allPaths = spectra.map(s => s.fits_path);
 
-      // Batch into chunks of 10 (API limit)
-      const BATCH_SIZE = 10;
-      const batches: string[][] = [];
-      for (let i = 0; i < allPaths.length; i += BATCH_SIZE) {
-        batches.push(allPaths.slice(i, i + BATCH_SIZE));
+      // Authorize all of this object's spectra server-side (RLS) and get
+      // ready-to-fetch proxy URLs, then bundle them into a single ZIP in the
+      // browser. Fetching cross-origin presigned URLs through the proxy (which
+      // supplies CORS) and zipping is the only reliable way to deliver multiple
+      // files — sequential per-file anchor downloads get popup-blocked after the
+      // first, so only one file ever saved.
+      const result = await generateObjectFitsDownloadUrls(allPaths, targetId);
+
+      if (result.error || !result.files) {
+        setError(result.error || 'Failed to generate download URLs');
+        return;
       }
 
-      for (let batchIdx = 0; batchIdx < batches.length; batchIdx++) {
-        if (batches.length > 1) {
-          setError(null); // Clear between batches
-          setBatchProgress(`Batch ${batchIdx + 1}/${batches.length}`);
-        }
+      const { files, zipFilename } = result;
+      setBatchProgress(`0/${files.length}`);
 
-        const response = await fetch('/api/download', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ paths: batches[batchIdx], context: 'object_detail' }),
-        });
+      const res = await downloadFilesAsZip(
+        files,
+        zipFilename || `${targetId}_spectra.zip`,
+        (done, total) => setBatchProgress(`${done}/${total}`),
+      );
 
-        if (!response.ok) {
-          const data = await response.json();
-          throw new Error(data.error || 'Failed to generate download URLs');
-        }
-
-        const { urls } = await response.json();
-
-        // Download each file
-        for (const [path, url] of Object.entries(urls)) {
-          const filename = path.split('/').pop() || `${targetId}.fits`;
-          await downloadFile(url as string, filename);
-          await new Promise(resolve => setTimeout(resolve, 300));
-        }
+      if (!res.ok) {
+        setError(res.error || 'Download failed');
+        return;
+      }
+      if (res.failed.length > 0) {
+        setError(`${res.failed.length} file(s) failed to download`);
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Download failed');

--- a/web/components/spectra/DownloadTableButtons.tsx
+++ b/web/components/spectra/DownloadTableButtons.tsx
@@ -5,6 +5,7 @@ import { Download, FileText, Package, Loader2, ChevronDown } from 'lucide-react'
 import { generateCSV, generateCsvFilename, generateFitsDownloadUrl } from '@/lib/actions/download';
 import type { SortColumn, SortDirection, ViewMode } from '@/lib/actions/spectra-types';
 import { FITS_DOWNLOAD_FILE_LIMIT } from '@/lib/actions/spectra-types';
+import { downloadFilesAsZip } from '@/lib/utils/zip-download';
 import { AdvancedFilterOptions } from './SpectraFilterBar';
 
 interface DownloadDropdownProps {
@@ -99,73 +100,19 @@ export const DownloadDropdown: React.FC<DownloadDropdownProps> = ({
       const { files, zipFilename } = result;
       setFitsProgress({ done: 0, total: files.length });
 
-      // Fetch files in parallel with concurrency limit
-      const CONCURRENCY = 6;
-      const fileData: { filename: string; data: Uint8Array }[] = [];
-      const errors: string[] = [];
-      let completed = 0;
-      const queue = [...files];
+      // Fetch each file through the proxy and bundle into a single ZIP client-side.
+      const res = await downloadFilesAsZip(
+        files,
+        zipFilename || 'campfire_download.zip',
+        (done, total) => setFitsProgress({ done, total }),
+      );
 
-      async function fetchWorker() {
-        while (queue.length > 0) {
-          const file = queue.shift()!;
-          try {
-            // proxyUrl is a ready-to-fetch Worker link (?url=<presigned>&sig=<hmac>);
-            // the Worker supplies CORS so the browser can read the bytes to zip them.
-            const resp = await fetch(file.proxyUrl);
-            if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-            const buf = await resp.arrayBuffer();
-            fileData.push({ filename: file.filename, data: new Uint8Array(buf) });
-          } catch {
-            errors.push(file.filename);
-          }
-          completed++;
-          setFitsProgress({ done: completed, total: files.length });
-        }
-      }
-
-      await Promise.all(Array.from({ length: CONCURRENCY }, () => fetchWorker()));
-
-      if (fileData.length === 0) {
-        setError('All file downloads failed');
+      if (!res.ok) {
+        setError(res.error || 'Failed to download FITS files');
         return;
       }
-
-      // Build ZIP in browser
-      const { zipSync } = await import('fflate');
-
-      // Deduplicate filenames
-      const zipInput: Record<string, [Uint8Array, { level: 0 }]> = {};
-      const seenNames = new Set<string>();
-      for (const { filename, data } of fileData) {
-        let name = filename;
-        if (seenNames.has(name)) {
-          const dot = name.lastIndexOf('.');
-          const base = dot > 0 ? name.substring(0, dot) : name;
-          const ext = dot > 0 ? name.substring(dot) : '';
-          let counter = 2;
-          while (seenNames.has(`${base}_${counter}${ext}`)) counter++;
-          name = `${base}_${counter}${ext}`;
-        }
-        seenNames.add(name);
-        zipInput[name] = [data, { level: 0 }];
-      }
-
-      const zipped = zipSync(zipInput);
-
-      // Trigger browser download
-      const blob = new Blob([zipped.buffer as ArrayBuffer], { type: 'application/zip' });
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = zipFilename || 'campfire_download.zip';
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      URL.revokeObjectURL(url);
-
-      if (errors.length > 0) {
-        setError(`${errors.length} file(s) failed to download`);
+      if (res.failed.length > 0) {
+        setError(`${res.failed.length} file(s) failed to download`);
       }
     } catch (err) {
       console.error('FITS download error:', err);

--- a/web/lib/actions/download.ts
+++ b/web/lib/actions/download.ts
@@ -515,6 +515,17 @@ export async function generateObjectFitsDownloadUrls(
       return { files: null, zipFilename: null, error: 'No FITS files provided' };
     }
 
+    // Enforce the same cap the results-table ZIP path uses. A real object never
+    // has this many spectra, but this action is a POST endpoint any authenticated
+    // client can call directly, so bound the request server-side before the DB
+    // query / presign / oversized in-browser ZIP.
+    if (fitsPaths.length > FITS_DOWNLOAD_FILE_LIMIT) {
+      return {
+        files: null, zipFilename: null,
+        error: `Too many files requested (${fitsPaths.length.toLocaleString()}); the ${FITS_DOWNLOAD_FILE_LIMIT}-file ZIP limit applies here too.`,
+      };
+    }
+
     const supabase = await createClient();
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) {
@@ -522,10 +533,12 @@ export async function generateObjectFitsDownloadUrls(
     }
 
     // Re-derive the authorized key set under the caller's RLS session. Never
-    // presign a client-supplied path the DB won't return for this user.
+    // presign a client-supplied path the DB won't return for this user. Pull
+    // target_id too so download tracking records the real member targets (a
+    // merged object spans several) rather than the display object id.
     const { data: rows, error: queryError } = await supabase
       .from('spectra')
-      .select('fits_path')
+      .select('fits_path, target_id')
       .in('fits_path', fitsPaths);
 
     if (queryError) {
@@ -553,12 +566,14 @@ export async function generateObjectFitsDownloadUrls(
 
     const zipFilename = `${targetId}_spectra.zip`;
 
-    // Track object-detail bulk download (fire-and-forget)
+    // Track object-detail bulk download (fire-and-forget). Log the actual member
+    // target ids of the downloaded spectra — a merged object fans out to several.
+    const targetIds = [...new Set((rows || []).map((r) => r.target_id as string).filter(Boolean))];
     trackDownload({
       userId: user.id,
       downloadType: 'fits_object',
-      targetIds: [targetId],
-      targetCount: 1,
+      targetIds: targetIds.length > 0 ? targetIds : [targetId],
+      targetCount: targetIds.length || 1,
       fileCount: files.length,
     });
 

--- a/web/lib/actions/download.ts
+++ b/web/lib/actions/download.ts
@@ -487,6 +487,89 @@ export async function generateFitsDownloadUrl(
 }
 
 /**
+ * Authorize a single object's spectra for bulk download and return ready-to-fetch
+ * Worker proxy URLs plus a ZIP filename.
+ *
+ * Client-supplied paths are never trusted: the authorized set is re-derived
+ * server-side by querying `spectra` under the caller's RLS session, so a path the
+ * user can't see (private program, forged) is simply never presigned. Each
+ * authorized key is presigned against its home backend (dual-read: R2 or OSN) and
+ * HMAC-signed so the credential-free proxy Worker only fetches URLs we authorized.
+ * The browser fetches each proxy URL (which supplies CORS) and zips the results
+ * client-side — the same path the results-table bulk download uses.
+ */
+export async function generateObjectFitsDownloadUrls(
+  fitsPaths: string[],
+  targetId: string,
+): Promise<{
+  files: DownloadFile[] | null;
+  zipFilename: string | null;
+  error: string | null;
+}> {
+  try {
+    if (!JWT_SECRET) {
+      return { files: null, zipFilename: null, error: 'Server configuration error: JWT secret not set' };
+    }
+
+    if (!fitsPaths || fitsPaths.length === 0) {
+      return { files: null, zipFilename: null, error: 'No FITS files provided' };
+    }
+
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      return { files: null, zipFilename: null, error: 'Not authenticated' };
+    }
+
+    // Re-derive the authorized key set under the caller's RLS session. Never
+    // presign a client-supplied path the DB won't return for this user.
+    const { data: rows, error: queryError } = await supabase
+      .from('spectra')
+      .select('fits_path')
+      .in('fits_path', fitsPaths);
+
+    if (queryError) {
+      console.error('Error authorizing object FITS download:', queryError);
+      return { files: null, zipFilename: null, error: 'Failed to authorize download' };
+    }
+
+    const keys = [...new Set((rows || []).map((r) => r.fits_path as string))];
+    if (keys.length === 0) {
+      return { files: null, zipFilename: null, error: 'No FITS files found or access denied' };
+    }
+
+    const filenames = keys.map((k) => k.split('/').pop() || k);
+
+    // Presign each authorized key against its home backend (dual-read), then
+    // HMAC-sign the presigned URL so the proxy only fetches URLs we authorized.
+    const urls = await generateDownloadUrls(keys, PRESIGN_TTL_SECONDS);
+    const files: DownloadFile[] = await Promise.all(
+      urls.map(async (signedUrl, i) => {
+        const sig = await signUrlSignature(signedUrl, JWT_SECRET);
+        const proxyUrl = `${WORKER_URL}/proxy?url=${encodeURIComponent(signedUrl)}&sig=${sig}`;
+        return { proxyUrl, filename: filenames[i] };
+      })
+    );
+
+    const zipFilename = `${targetId}_spectra.zip`;
+
+    // Track object-detail bulk download (fire-and-forget)
+    trackDownload({
+      userId: user.id,
+      downloadType: 'fits_object',
+      targetIds: [targetId],
+      targetCount: 1,
+      fileCount: files.length,
+    });
+
+    return { files, zipFilename, error: null };
+  } catch (error) {
+    console.error('Error generating object FITS download URLs:', error);
+    return { files: null, zipFilename: null, error: 'Failed to generate download URLs' };
+  }
+}
+
+/**
  * Authorize NIRCam mosaic downloads and return ready-to-fetch Worker proxy URLs,
  * keyed by canonical storage key (file_path).
  *

--- a/web/lib/utils/zip-download.ts
+++ b/web/lib/utils/zip-download.ts
@@ -1,0 +1,116 @@
+// Shared client-side helper: fetch a set of authorized proxy URLs, bundle them
+// into a single ZIP in the browser, and trigger a download.
+//
+// Both bulk download surfaces use this — the results-table "FITS ZIP" button
+// (DownloadTableButtons) and the object-detail "Download All" button
+// (DownloadButtons). Each file is fetched through the credential-free download
+// Worker (which supplies CORS so the browser can read the bytes), then zipped
+// with fflate at store level (FITS are already dense, so compression buys almost
+// nothing and costs CPU/memory).
+
+/** A ready-to-fetch Worker proxy link plus the name it should take in the ZIP. */
+export interface ProxyFile {
+  proxyUrl: string;
+  filename: string;
+}
+
+export interface ZipDownloadResult {
+  /** True if at least one file was fetched and a ZIP was produced/downloaded. */
+  ok: boolean;
+  /** Filenames that failed to fetch (present even when ok is true — a partial ZIP). */
+  failed: string[];
+  /** Set only when nothing could be fetched; carries the first failure's cause
+   *  (e.g. "HTTP 403" for a rejected signature, "Failed to fetch" for an
+   *  unreachable/blocked Worker) so the UI can show an actionable message. */
+  error?: string;
+}
+
+/**
+ * Fetch every file through the download proxy, ZIP them client-side, and start a
+ * browser download of the single archive.
+ *
+ * @param files       proxy URLs + target filenames
+ * @param zipFilename name for the downloaded archive
+ * @param onProgress  called after each file settles (done, total)
+ * @param concurrency max simultaneous fetches (default 6)
+ */
+export async function downloadFilesAsZip(
+  files: ProxyFile[],
+  zipFilename: string,
+  onProgress?: (done: number, total: number) => void,
+  concurrency = 6,
+): Promise<ZipDownloadResult> {
+  const fileData: { filename: string; data: Uint8Array }[] = [];
+  const failed: string[] = [];
+  let firstError: string | null = null;
+  let completed = 0;
+  const queue = [...files];
+
+  async function fetchWorker() {
+    while (queue.length > 0) {
+      const file = queue.shift()!;
+      try {
+        // proxyUrl is a ready-to-fetch Worker link (?url=<presigned>&sig=<hmac>);
+        // the Worker supplies CORS so the browser can read the bytes to zip them.
+        const resp = await fetch(file.proxyUrl);
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const buf = await resp.arrayBuffer();
+        fileData.push({ filename: file.filename, data: new Uint8Array(buf) });
+      } catch (err) {
+        failed.push(file.filename);
+        if (!firstError) firstError = err instanceof Error ? err.message : String(err);
+      }
+      completed++;
+      onProgress?.(completed, files.length);
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.max(1, concurrency) }, () => fetchWorker()));
+
+  if (fileData.length === 0) {
+    // Every fetch failed — surface the first cause so a config/auth problem is
+    // diagnosable instead of collapsing into a generic "download failed".
+    return {
+      ok: false,
+      failed,
+      error: `All ${files.length} file(s) failed to download${firstError ? ` (${firstError})` : ''}`,
+    };
+  }
+
+  // Build ZIP in browser (lazy-load fflate to keep it out of the initial bundle).
+  const { zipSync } = await import('fflate');
+
+  // Deduplicate filenames so same-named FITS from different observations don't
+  // clobber each other in the archive.
+  const zipInput: Record<string, [Uint8Array, { level: 0 }]> = {};
+  const seenNames = new Set<string>();
+  for (const { filename, data } of fileData) {
+    let name = filename;
+    if (seenNames.has(name)) {
+      const dot = name.lastIndexOf('.');
+      const base = dot > 0 ? name.substring(0, dot) : name;
+      const ext = dot > 0 ? name.substring(dot) : '';
+      let counter = 2;
+      while (seenNames.has(`${base}_${counter}${ext}`)) counter++;
+      name = `${base}_${counter}${ext}`;
+    }
+    seenNames.add(name);
+    zipInput[name] = [data, { level: 0 }];
+  }
+
+  const zipped = zipSync(zipInput);
+
+  // fflate returns a fresh, exact-size Uint8Array, so its backing buffer is the
+  // whole ZIP. The cast satisfies the DOM lib's ArrayBuffer-only BlobPart typing.
+  const blob = new Blob([zipped.buffer as ArrayBuffer], { type: 'application/zip' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = zipFilename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+
+  return { ok: true, failed };
+}


### PR DESCRIPTION
## Summary
Refactors the client-side ZIP download functionality into a reusable utility module to eliminate code duplication between the results-table bulk download and object-detail download features. Also adds server-side authorization for object-detail FITS downloads via RLS.

## Key Changes

- **New utility module** (`web/lib/utils/zip-download.ts`):
  - Extracted `downloadFilesAsZip()` function that handles fetching files through proxy URLs, bundling them into a ZIP client-side, and triggering browser download
  - Supports configurable concurrency (default 6) and progress callbacks
  - Handles filename deduplication to prevent collisions in the archive
  - Returns detailed result with success status, failed files, and error messages
  - Uses lazy-loaded `fflate` to keep it out of the initial bundle

- **Server-side authorization** (`web/lib/actions/download.ts`):
  - Added `generateObjectFitsDownloadUrls()` function to authorize object spectra downloads
  - Re-derives authorized file set server-side via RLS query (never trusts client-supplied paths)
  - Presigns each authorized key against its home backend (dual-read: R2 or OSN)
  - HMAC-signs presigned URLs so the credential-free proxy Worker only fetches authorized URLs
  - Tracks download analytics for object-detail bulk downloads

- **Updated components**:
  - `DownloadTableButtons.tsx`: Replaced inline ZIP logic with call to `downloadFilesAsZip()` utility
  - `DownloadButtons.tsx`: Replaced sequential per-file downloads with server-authorized bulk download using the shared utility

## Implementation Details

- Both download surfaces now use the same code path: authorize server-side, fetch through proxy (which supplies CORS), zip client-side
- Filename deduplication appends `_2`, `_3`, etc. to same-named files to prevent clobbering in the archive
- ZIP compression is disabled (`level: 0`) since FITS files are already dense
- Progress tracking updated to show file-by-file completion rather than batch progress
- Error handling distinguishes between partial failures (some files downloaded) and total failures (all files failed)

https://claude.ai/code/session_01SLktBeYb2tQ9YzjBLYRsdP