### PR TITLE
fix(web): make a missing download-worker JWT_SECRET diagnosable, not an opaque 500

### DIFF
--- a/web/lib/utils/zip-download.ts
+++ b/web/lib/utils/zip-download.ts
@@ -53,7 +53,12 @@ export async function downloadFilesAsZip(
         // proxyUrl is a ready-to-fetch Worker link (?url=<presigned>&sig=<hmac>);
         // the Worker supplies CORS so the browser can read the bytes to zip them.
         const resp = await fetch(file.proxyUrl);
-        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        if (!resp.ok) {
+          // Include the proxy's own message (e.g. "Proxy misconfigured: …") so a
+          // config/auth failure is legible instead of a bare status code.
+          const detail = await resp.text().catch(() => '');
+          throw new Error(detail ? `HTTP ${resp.status}: ${detail.slice(0, 200)}` : `HTTP ${resp.status}`);
+        }
         const buf = await resp.arrayBuffer();
         fileData.push({ filename: file.filename, data: new Uint8Array(buf) });
       } catch (err) {

--- a/web/workers/download-worker/src/index.ts
+++ b/web/workers/download-worker/src/index.ts
@@ -34,6 +34,13 @@ export default {
     }
 
     try {
+      // Fail loudly on a misconfigured proxy. Without the shared secret,
+      // verifyUrlSignature's HMAC importKey gets a zero-length key and throws a
+      // DataError, which would otherwise surface as an opaque 500 on every file.
+      if (!env.JWT_SECRET) {
+        return corsError('Proxy misconfigured: JWT_SECRET is not set', 503, request, env);
+      }
+
       const target = url.searchParams.get('url');
       const sig = url.searchParams.get('sig');
       if (!target || !sig) {


### PR DESCRIPTION
Follow-up to #351 (merged). That PR fixed the object-detail "Download All" and added the object-download server action; this one lands the diagnostic hardening that missed the merge window.

## Context

The bulk "FITS ZIP" outage was traced to the `campfire-download` Worker returning **HTTP 500 on every file** while the server side presigned all files correctly. Root cause: the Worker's `JWT_SECRET` was unset. `verifyUrlSignature` calls `crypto.subtle.importKey('raw', encode(secret), {HMAC, SHA-256}, …)`, and a zero-length key makes WebCrypto throw `DataError` — which the handler's catch-all turned into a bare 500, indistinguishable from a real upstream failure. (A *wrong* secret verifies-false and returns 403; a *missing* one throws → 500.)

The operational fix is setting the secret (`wrangler secret put JWT_SECRET`, matching Vercel's `WORKER_JWT_SECRET`). This PR does not change that — it makes the misconfiguration self-explanatory next time.

## Changes

- **Worker** (`download-worker/src/index.ts`): guard for a missing `JWT_SECRET` up front and return an explicit `503 "Proxy misconfigured: JWT_SECRET is not set"` instead of letting the empty-key `importKey` throw into a 500. (Takes effect on `wrangler deploy`.)
- **Client** (`lib/utils/zip-download.ts`): include the proxy's response body in the per-file error, so the UI shows the real cause (e.g. the 503 message) rather than just `HTTP 500`.

## Verification

- `npm run build` compiles + type-checks clean.
- `vitest` 135/135 pass.

No behavior change once the Worker secret is set; this is purely failure legibility.

Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLktBeYb2tQ9YzjBLYRsdP)_