### PR TITLE
fix(worker): repair download proxy (redirect mode) + auto-deploy it in CI

### DIFF
--- a/.github/workflows/download-worker.yml
+++ b/.github/workflows/download-worker.yml
@@ -1,0 +1,77 @@
+name: Download worker
+
+# Test and deploy the credential-free download proxy Worker.
+#
+# The Worker is NOT covered by the Vercel (web) or Supabase deploy
+# integrations, so it previously shipped only via a manual `wrangler deploy`.
+# A merged fix could therefore sit undeployed (as happened with the
+# redirect:'error' outage). This workflow closes that gap: worker tests run on
+# every PR that touches it, and a merge to main test-gates then deploys it.
+#
+# Required repository secret:
+#   CLOUDFLARE_API_TOKEN — scoped to "Edit Cloudflare Workers" on the account in
+#   wrangler.toml. The Worker's JWT_SECRET is a Worker secret set once via
+#   `wrangler secret put` and is preserved across deploys — it is NOT needed here.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "web/workers/download-worker/**"
+      - ".github/workflows/download-worker.yml"
+  pull_request:
+    paths:
+      - "web/workers/download-worker/**"
+      - ".github/workflows/download-worker.yml"
+
+# Cancel superseded runs on the same ref to save Actions minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      # vitest lives in the web workspace; the worker's test script runs from there.
+      - name: Install web dependencies
+        run: npm ci
+        working-directory: web
+
+      - name: Run worker tests
+        run: npx vitest run workers/download-worker/src
+        working-directory: web
+
+  deploy:
+    # Only after a merge to main, and only if the worker tests pass.
+    if: github.event_name == 'push'
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Deploy to Cloudflare
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          workingDirectory: web/workers/download-worker
+          command: deploy

--- a/web/workers/download-worker/src/index.ts
+++ b/web/workers/download-worker/src/index.ts
@@ -60,9 +60,14 @@ export default {
         return corsError(`Target not allowed: ${check.reason}`, 403, request, env);
       }
 
-      // redirect: 'error' — an allowlisted host must not be able to bounce us
-      // to an arbitrary host after the allowlist check.
-      const upstream = await fetch(target, { redirect: 'error' });
+      // Never follow redirects: an allowlisted host must not be able to bounce
+      // us to an arbitrary host after the allowlist check. The Workers runtime
+      // does not implement redirect: 'error' (it throws a TypeError), so request
+      // 'manual' and reject any redirect ourselves — same guarantee, edge-safe.
+      const upstream = await fetch(target, { redirect: 'manual' });
+      if (upstream.type === 'opaqueredirect' || (upstream.status >= 300 && upstream.status < 400)) {
+        return corsError(`Upstream redirect refused (${upstream.status})`, 502, request, env);
+      }
       if (!upstream.ok || !upstream.body) {
         return corsError(`Upstream fetch failed (${upstream.status})`, 502, request, env);
       }

--- a/web/workers/download-worker/src/proxy.test.ts
+++ b/web/workers/download-worker/src/proxy.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { isAllowedFetchUrl } from './index';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import worker, { isAllowedFetchUrl } from './index';
 import { verifyUrlSignature } from './auth';
 
 const ALLOWED = 'uaz1.osn.mghpcc.org,abc123.r2.cloudflarestorage.com';
@@ -66,5 +66,51 @@ describe('verifyUrlSignature', () => {
 
   it('rejects a malformed signature', async () => {
     expect(await verifyUrlSignature(URL_, 'not-base64!!', SECRET)).toBe(false);
+  });
+});
+
+describe('proxy handler upstream fetch', () => {
+  const SECRET = 'test-shared-secret';
+  const ORIGIN = 'https://campfire.hollisakins.com';
+  const TARGET =
+    'https://uaz1.osn.mghpcc.org/campfire-jwst/data/products/nirspec/obs/x_spec.fits?X-Amz-Signature=deadbeef';
+
+  const ENV = {
+    JWT_SECRET: SECRET,
+    ALLOWED_ORIGINS: ORIGIN,
+    ALLOWED_FETCH_HOSTS: 'uaz1.osn.mghpcc.org',
+  };
+
+  async function proxyRequest(): Promise<Request> {
+    const sig = await sign(TARGET, SECRET);
+    const u = `https://worker.example/proxy?url=${encodeURIComponent(TARGET)}&sig=${sig}`;
+    return new Request(u, { headers: { Origin: ORIGIN } });
+  }
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('streams a 200 upstream and never requests redirect:"error" (Workers has no such mode)', async () => {
+    const seen: (RequestInit | undefined)[] = [];
+    vi.stubGlobal('fetch', async (_input: unknown, init?: RequestInit) => {
+      seen.push(init);
+      return new Response('FITSDATA', { status: 200, headers: { 'Content-Type': 'application/octet-stream' } });
+    });
+
+    const res = await worker.fetch(await proxyRequest(), ENV);
+
+    expect(res.status).toBe(200);
+    // The regression: redirect:'error' throws a TypeError at the edge → 500 on every file.
+    expect(seen[0]?.redirect).not.toBe('error');
+    expect(seen[0]?.redirect).toBe('manual');
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(ORIGIN);
+  });
+
+  it('refuses an upstream redirect instead of following it (allowlist-escape guard)', async () => {
+    vi.stubGlobal('fetch', async () =>
+      new Response(null, { status: 302, headers: { Location: 'https://evil.example/x' } }));
+
+    const res = await worker.fetch(await proxyRequest(), ENV);
+
+    expect(res.status).toBe(502);
   });
 });

--- a/web/workers/download-worker/wrangler.toml
+++ b/web/workers/download-worker/wrangler.toml
@@ -1,6 +1,11 @@
 name = "campfire-download"
 main = "src/index.ts"
 compatibility_date = "2025-06-01"
+# Cloudflare account that homes this Worker. Kept here (not a CI secret) because
+# it is not sensitive and is already published in DEPLOYMENT_GUIDE.md and the R2
+# host below; this lets `wrangler deploy` run unattended in CI with only an API
+# token. JWT_SECRET stays a Worker secret and is preserved across deploys.
+account_id = "2d136e3d61aca8a4ae08a2ea760f6d23"
 
 # No R2 binding: the Worker fetches presigned URLs (R2 or OSN) that Vercel mints,
 # so it holds no object-store credentials and works for either backend. This is


### PR DESCRIPTION
Fixes the bulk **FITS ZIP** download outage and stops it (or any future worker fix) from silently sitting undeployed.

## Root cause

The download proxy Worker called `fetch(target, { redirect: 'error' })` as SSRF hardening. The Cloudflare Workers runtime **does not implement `redirect: 'error'`** — it throws `TypeError: Invalid redirect value…` on every request, which the handler's catch-all turned into **HTTP 500 for every file**.

Confirmed via `wrangler tail`: signatures verified and the `JWT_SECRET` was fine (execution reached the upstream `fetch`), so it was never the secret — it was this line. It slipped through because `redirect: 'error'` *is* valid in Node/undici and there was no handler-level test.

## Changes

**`web/workers/download-worker/src/index.ts`** — `redirect: 'manual'`, and reject any `3xx` / `opaqueredirect` ourselves. Same guarantee (an allowlisted host can't bounce us to an arbitrary host), edge-compatible.

**`web/workers/download-worker/src/proxy.test.ts`** — handler-level tests (stubbed `fetch`) asserting the proxy streams a 200 upstream, **never** passes `redirect:'error'`, and refuses an upstream redirect. Closes the coverage gap that let this ship.

**`.github/workflows/download-worker.yml`** — the Worker isn't covered by the Vercel/Supabase deploy integrations, so it only shipped via a manual `wrangler deploy`. New workflow: run worker tests on PRs touching `web/workers/download-worker/**`, and on merge to `main` re-test then `wrangler deploy`.

**`web/workers/download-worker/wrangler.toml`** — pin `account_id` (already public in the repo) so CI needs only a `CLOUDFLARE_API_TOKEN` secret. `JWT_SECRET` stays a Worker secret, preserved across deploys.

## Deploying this

Requires the repo secret **`CLOUDFLARE_API_TOKEN`** (Edit Cloudflare Workers scope). Because the deploy job triggers on a merge that touches the worker, **merging this PR test-gates and auto-deploys the redirect fix** — resolving the outage and installing the automation in one step.

## Verification

- `vitest` 137/137 pass (incl. the 2 new handler tests).
- Workflow YAML validated; first live Actions run is the real proof.

Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLktBeYb2tQ9YzjBLYRsdP)_