### PR TITLE
FitsGL Phase 1 — packaging: wire fitsgl deps (python + web)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,15 @@ Supporting: `supabase/` (migrations), `scripts/` (one-off utilities)
 
 **Editable install order** (in the `campfire` conda env): `pip install -e ./layout && pip install -e ./pipeline && pip install -e ./python` — `campfire-layout` must precede the two packages that depend on it.
 
+**FitsGL co-development** (epic #337): the `campfire[fitsgl]` extra depends on [FitsGL](https://github.com/hollisakins/fitsgl)'s `fitsgl-py` producer, which isn't on PyPI and lives in that repo's `fitsgl-py/` subdirectory. The extra pins a git dependency as the reproducible fallback (`pip install -e "./python[fitsgl]"`), but the dev convention is to check `fitsgl` out **as a sibling of this repo** and install it editable *before* the base client, so local FitsGL edits stay live and pip never fetches from git:
+
+```bash
+pip install -e ../fitsgl/fitsgl-py[deploy]   # sibling checkout, editable
+pip install -e ./python                      # base client leaves fitsgl untouched
+```
+
+The web side consumes FitsGL as the published npm package `@fitsgl/core` (a plain version range in `web/package.json`); use `npm link` against a local `fitsgl-core` checkout only when co-editing. See `python/README.md` and `docs/design-fitsgl-integration.md` §4.
+
 ## Pipeline
 
 ### Running

--- a/python/README.md
+++ b/python/README.md
@@ -23,6 +23,43 @@ pip install -e ".[all]"
 To install straight from GitHub without cloning the repo, see
 [Getting Started](https://campfire.hollisakins.com/docs/api/getting-started).
 
+### FitsGL producer (`campfire[fitsgl]`)
+
+The `fitsgl` extra pulls in [FitsGL](https://github.com/hollisakins/fitsgl)'s
+`fitsgl-py` producer, used by the map/cutout tile-pyramid deploy path (epic #337).
+FitsGL isn't on PyPI and lives in the repo's `fitsgl-py/` subdirectory, so the
+extra pins a git dependency as the reproducible fallback:
+
+```bash
+# Reproducible / standalone (pulls fitsgl-py from git):
+pip install -e ".[fitsgl]"
+```
+
+**Local co-development (recommended when editing FitsGL too):** check both repos
+out side by side and install `fitsgl-py` editable *first*, then the base client —
+pip then treats the `fitsgl` requirement as already satisfied and never fetches
+from git, so your local edits stay live:
+
+```
+parent/
+├── campfire/          # this repo
+└── fitsgl/            # https://github.com/hollisakins/fitsgl
+    └── fitsgl-py/
+```
+
+```bash
+pip install -e ../fitsgl/fitsgl-py[deploy]   # editable, from the sibling checkout
+pip install -e .                             # base client (leaves fitsgl untouched)
+```
+
+Confirm the library imports resolve:
+
+```python
+from fitsgl.build import build_dataset
+from fitsgl.build_pyramid import build_pyramid
+from fitsgl.deploy import deploy_dataset
+```
+
 ## Authentication
 
 ```bash

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -62,6 +62,18 @@ plotting = [
 specutils = [
     "specutils>=1.13",
 ]
+fitsgl = [
+    # FitsGL producer (build + deploy the FITS tile-pyramid datasets that back
+    # the map/cutout service — epic #337). Not on PyPI and lives in the
+    # `fitsgl-py` subdirectory of a separate repo, so this extra pins the git
+    # dependency as the reproducible fallback. For local co-development, install
+    # the package editable from a side-by-side checkout FIRST, then the base
+    # client (which leaves this URL untriggered):
+    #     pip install -e ../fitsgl/fitsgl-py[deploy]
+    #     pip install -e .
+    # See python/README.md and AGENTS.md for the convention.
+    "fitsgl[deploy] @ git+https://github.com/hollisakins/fitsgl@main#subdirectory=fitsgl-py",
+]
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",

--- a/python/tests/test_fitsgl_packaging.py
+++ b/python/tests/test_fitsgl_packaging.py
@@ -1,0 +1,34 @@
+"""FitsGL packaging smoke test (epic #337, Phase 1 / #338).
+
+The `campfire[fitsgl]` extra wires in FitsGL's `fitsgl-py` producer as a library.
+FitsGL isn't on PyPI, so it's only importable when the extra (or a side-by-side
+editable checkout) is installed — the test skips otherwise. When it *is* present,
+it pins the exact public entrypoints CAMPFIRE calls as a library so a breaking
+rename in FitsGL surfaces here rather than deep in a deploy run.
+"""
+
+import importlib
+
+import pytest
+
+fitsgl = pytest.importorskip(
+    "fitsgl",
+    reason="FitsGL not installed — run `pip install -e .[fitsgl]` "
+    "(or an editable side-by-side `fitsgl-py` checkout) to exercise this.",
+)
+
+
+# (module, attribute) pairs CAMPFIRE consumes; see docs/design-fitsgl-integration.md §4.
+LIBRARY_ENTRYPOINTS = [
+    ("fitsgl.build", "build_dataset"),
+    ("fitsgl.build_pyramid", "build_pyramid"),
+    ("fitsgl.deploy", "deploy_dataset"),
+]
+
+
+@pytest.mark.parametrize("module_name, attr", LIBRARY_ENTRYPOINTS)
+def test_library_entrypoint_is_callable(module_name, attr):
+    module = importlib.import_module(module_name)
+    obj = getattr(module, attr, None)
+    assert obj is not None, f"{module_name}.{attr} is missing"
+    assert callable(obj), f"{module_name}.{attr} is not callable"

--- a/web/app/prototype/fitsgl/page.tsx
+++ b/web/app/prototype/fitsgl/page.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+/**
+ * FitsGL packaging demo (epic #337, Phase 1 / #338).
+ *
+ * A throwaway harness that proves `@fitsgl/core`'s `<FitsViewer>` builds and
+ * renders inside a Next.js page — the web half of the packaging milestone. Paste
+ * a band `manifest.json` URL from a locally-served dataset (`fitsgl serve`) or,
+ * later, a deployed `campfire-tiles` prefix, and load it. This is not the
+ * production map (that arrives in Phase 4); it deliberately carries no overlays.
+ */
+
+import dynamic from 'next/dynamic';
+import { useState } from 'react';
+
+// WebGL2 + real DOM only — mirror the Leaflet map's dynamic ssr:false import.
+const FitsGLViewerDemo = dynamic(
+  () => import('@/components/fits/FitsGLViewerDemo').then((m) => m.FitsGLViewerDemo),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex items-center justify-center h-[600px] rounded-lg border border-border bg-surface-2">
+        <div className="text-text-secondary">Loading viewer…</div>
+      </div>
+    ),
+  }
+);
+
+export default function FitsGLDemoPage() {
+  const [input, setInput] = useState('');
+  const [manifestUrl, setManifestUrl] = useState<string | null>(null);
+
+  return (
+    <div className="space-y-6 max-w-4xl">
+      <div>
+        <h1 className="text-2xl font-bold text-text-primary">FitsGL viewer demo</h1>
+        <p className="mt-2 text-text-secondary">
+          Phase 1 packaging check (epic #337): render a served FitsGL dataset with{' '}
+          <code className="px-1 py-0.5 bg-surface-2 rounded text-xs">@fitsgl/core</code>{' '}
+          inside a Next page. Serve a dataset locally with{' '}
+          <code className="px-1 py-0.5 bg-surface-2 rounded text-xs">fitsgl serve</code>{' '}
+          and paste one band&apos;s{' '}
+          <code className="px-1 py-0.5 bg-surface-2 rounded text-xs">manifest.json</code>{' '}
+          URL below.
+        </p>
+      </div>
+
+      <form
+        className="flex gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          setManifestUrl(input.trim() || null);
+        }}
+      >
+        <input
+          type="url"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="http://localhost:8000/demo/band/manifest.json"
+          className="flex-1 px-3 h-10 rounded-lg border border-border bg-card text-sm text-text-primary placeholder:text-text-tertiary"
+        />
+        <button
+          type="submit"
+          className="px-4 h-10 rounded-lg bg-primary text-on-primary text-sm font-medium hover:bg-primary-hover transition-colors disabled:opacity-50"
+          disabled={!input.trim()}
+        >
+          Load
+        </button>
+      </form>
+
+      {manifestUrl ? (
+        <FitsGLViewerDemo manifestUrl={manifestUrl} />
+      ) : (
+        <div className="flex items-center justify-center h-[600px] rounded-lg border border-dashed border-border bg-surface-2 text-text-secondary text-sm">
+          Enter a manifest URL to render a dataset.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/app/prototype/layout.tsx
+++ b/web/app/prototype/layout.tsx
@@ -30,6 +30,7 @@ export default function PrototypeLayout({
   const navItems = [
     { href: '/prototype', label: 'Overview' },
     { href: '/prototype/overflow-panel', label: 'Live Demo' },
+    { href: '/prototype/fitsgl', label: 'FitsGL Viewer' },
   ];
 
   return (

--- a/web/components/fits/FitsGLViewerDemo.tsx
+++ b/web/components/fits/FitsGLViewerDemo.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+/**
+ * Throwaway `<FitsViewer>` harness (epic #337, Phase 1 / #338).
+ *
+ * The single job of this component is to prove that `@fitsgl/core`'s React tier
+ * mounts, resolves its decode worker, and paints a served FitsGL dataset inside a
+ * Next.js page — the packaging milestone, ahead of the real map swap (Phase 4).
+ * It is NOT the production map: no object markers, no shutter overlay, no field
+ * chrome. Point it at a `manifest.json` from a locally-served dataset
+ * (`fitsgl serve`) or, later, a deployed `campfire-tiles` prefix.
+ *
+ * Loaded via `next/dynamic` with `ssr: false` (see the page) — the viewer needs
+ * WebGL2 + a real DOM, exactly like the Leaflet map's `MapViewerWrapper`.
+ */
+
+import { useMemo, useState } from 'react';
+import { FitsViewer } from '@fitsgl/core/react';
+import type { ViewerConfig } from '@fitsgl/core';
+import { makeFitsglWorker } from '@/lib/fits/fitsglWorker';
+
+/** A minimal single-band config pointing at one band manifest URL. */
+function singleBandConfig(manifestUrl: string): ViewerConfig {
+  return {
+    bands: [{ name: 'demo', tiles: [manifestUrl] }],
+    view: { mode: 'single', band: 'demo' },
+  };
+}
+
+export function FitsGLViewerDemo({ manifestUrl }: { manifestUrl: string }) {
+  const [error, setError] = useState<string | null>(null);
+  const [ready, setReady] = useState(false);
+
+  // Rebuild the config (and reset status) whenever the target manifest changes.
+  const config = useMemo(() => {
+    setError(null);
+    setReady(false);
+    return singleBandConfig(manifestUrl);
+  }, [manifestUrl]);
+
+  return (
+    <div className="relative w-full h-[600px] rounded-lg overflow-hidden border border-border bg-black">
+      <FitsViewer
+        config={config}
+        tileOptions={{ workerFactory: makeFitsglWorker }}
+        className="absolute inset-0"
+        onReady={() => setReady(true)}
+        onError={(e) => setError(e instanceof Error ? e.message : String(e))}
+      />
+      <div className="absolute top-2 left-2 px-2 py-1 rounded bg-black/60 text-xs font-mono text-white/80 pointer-events-none">
+        {error ? `error: ${error}` : ready ? 'ready' : 'loading…'}
+      </div>
+    </div>
+  );
+}
+
+export default FitsGLViewerDemo;

--- a/web/lib/fits/fitsglWorker.ts
+++ b/web/lib/fits/fitsglWorker.ts
@@ -1,0 +1,34 @@
+/**
+ * FitsGL decode-worker shim for Next.js (epic #337, Phase 1 / #338).
+ *
+ * `@fitsgl/core` offloads the CPU-bound RICE/GZIP tile decode onto a pool of Web
+ * Workers. Its built-in factory uses the Vite idiom
+ * `new Worker(new URL('../worker.js', import.meta.url), { type: 'module' })`,
+ * which Next's bundler doesn't wire up the same way — so we supply our own
+ * `workerFactory` via `tileOptions` (see `FitsGLViewerDemo`). webpack 5 (the
+ * `next build` bundler) recognises the `new Worker(new URL(<specifier>,
+ * import.meta.url))` form and emits `@fitsgl/core/worker` as its own chunk; the
+ * worker module self-attaches the decode message handler when it detects a
+ * worker scope, so importing it as the entry is all that's required.
+ *
+ * The alternative — `tileOptions={{ useWorker: false }}` — runs decode inline on
+ * the main thread and needs no worker chunk at all; keep it as the fallback if a
+ * bundler ever chokes on the worker emission.
+ */
+import type { WorkerLike } from '@fitsgl/core';
+
+/**
+ * Construct one FitsGL tile-decode Web Worker.
+ *
+ * `WorkerLike` is the library's intentionally-minimal structural view of a worker
+ * (`postMessage` / `terminate` / an `onmessage` taking `{ data }`). A real DOM
+ * `Worker` is exactly what it models and is what the pool drives at runtime, but
+ * it doesn't type-assign under strict variance — `Worker.onmessage` receives a
+ * full `MessageEvent`, a supertype of `{ data: unknown }` — so we cast.
+ */
+export function makeFitsglWorker(): WorkerLike {
+  const worker = new Worker(new URL('@fitsgl/core/worker', import.meta.url), {
+    type: 'module',
+  });
+  return worker as unknown as WorkerLike;
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.932.0",
         "@aws-sdk/s3-request-presigner": "^3.932.0",
+        "@fitsgl/core": "^0.1.0",
         "@supabase/ssr": "^0.7.0",
         "@supabase/supabase-js": "^2.81.1",
         "@tanstack/react-query": "^5.90.12",
@@ -2099,6 +2100,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fitsgl/core": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@fitsgl/core/-/core-0.1.0.tgz",
+      "integrity": "sha512-tzHb39LIKpYvknmMZFcy6Q+tXPOOcc1O/m34E3Kn9MmdCWAWvx5lwM1aGACMFLpZAECXdHBMa+gnq2dBcbXwbw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.932.0",
     "@aws-sdk/s3-request-presigner": "^3.932.0",
+    "@fitsgl/core": "^0.1.0",
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.81.1",
     "@tanstack/react-query": "^5.90.12",


### PR DESCRIPTION
Closes #338. Part of the FitsGL integration epic (#337). Design: `docs/design-fitsgl-integration.md` §4.

Packaging unblock so later phases can build/deploy pyramids (#339/#340) and render the map (#341). No build/deploy CLI or map swap here — just dependency wiring, docs, and a proof-of-render harness.

## Python (`python/`)
- Add a `campfire[fitsgl]` optional extra pinning `fitsgl[deploy]` as a **git dependency** (`@main#subdirectory=fitsgl-py`) — the reproducible fallback. FitsGL isn't on PyPI and lives in the repo's `fitsgl-py/` subdirectory, so this mirrors the existing `campfire-layout` non-PyPI treatment.
- Document the **side-by-side editable dev convention** in `python/README.md` and `AGENTS.md`: install the sibling `fitsgl-py` editable *first*, then the base client, so pip never fetches from git and local FitsGL edits stay live.
- Add `tests/test_fitsgl_packaging.py` — an import-smoke test pinning the library entrypoints CAMPFIRE calls (`fitsgl.build.build_dataset`, `fitsgl.build_pyramid.build_pyramid`, `fitsgl.deploy.deploy_dataset`). Skips cleanly when FitsGL isn't installed.

## Web (`web/`)
- Add `@fitsgl/core@^0.1.0` (published npm package) as a normal dependency — no git URL, no build hook.
- Add a **Next.js decode-worker shim** (`lib/fits/fitsglWorker.ts` → `makeFitsglWorker`): supplies `tileOptions.workerFactory` importing `@fitsgl/core/worker`, emitted as a webpack worker chunk via the `new Worker(new URL(..., import.meta.url))` form (the library's default Vite worker idiom doesn't wire up under Next's bundler).
- Add a throwaway `<FitsViewer>` harness at **`/prototype/fitsgl`** (`components/fits/FitsGLViewerDemo.tsx` + page), loaded via dynamic `ssr:false` like the Leaflet map. Paste a served `manifest.json` URL to render a dataset. Deliberately no overlays — that's Phase 4/4b.

## Verification
- `npm run build` compiles with `@fitsgl/core` resolved and the worker chunk emitted; `/prototype/fitsgl` builds as a static page. (Local build needs placeholder Supabase env vars for the prerender step — unrelated to this change; those exist on Vercel.)
- The packaging test skips cleanly without FitsGL installed.
- The `WorkerLike` cast in the shim is deliberate: the DOM `Worker` is what that minimal type models at runtime but doesn't type-assign under strict `onmessage` variance.

## Notes
- The `fitsgl` extra pins `@main` since FitsGL has no tagged release yet — worth pinning to a commit/tag once it cuts one.
- No `pipeline/**` changes, so no `pipeline/CHANGELOG.md` entry is required.

Generated with Claude Code

https://claude.ai/code/session_0191rcHHzqkn36cC13wukgxJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0191rcHHzqkn36cC13wukgxJ)_