### PR TITLE
FitsGL Phase 2 — `campfire fitsgl build` (fiducial composite, no reproject)

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -29,6 +29,15 @@ Release procedure: edit the `## Unreleased` section below, then run
 ## Unreleased
 
 ### Infrastructure
+- NIRCam fields gain an optional field-level `fiducial_tiles = ["A1", "A2", …]`
+  declaration in `fields.toml` — the subset of a field's tiles that share a
+  tangent point + rotation and span the field, forming the FitsGL field-composite
+  map view (epic #337). `Field.load` parses and validates the names against the
+  declared tiles, and a new `Field.fiducial_tile_set()` returns the set (honoring a
+  per-tile `fiducial = true` fallback) after asserting the tiles co-grid (shared
+  `crval`/rotation), so an off-grid tile mistakenly included fails fast. Additive
+  and opt-in — fields without the key are unchanged; no effect on pixel values
+  (`nircam/field.py`).
 - Install docs: `pip install` instructions now pull the unpublished
   `campfire-layout` sibling package from the monorepo alongside the pipeline, so
   a fresh `pip install "git+…#subdirectory=pipeline"` (and `conda env create`)

--- a/pipeline/campfire_pipeline/nircam/field.py
+++ b/pipeline/campfire_pipeline/nircam/field.py
@@ -337,6 +337,11 @@ class Field:
     # Parsed [<field>.epochs.<name>] tables (combine-time exposure subsets).
     # {name: {files: [globs] | None, date_range: (start, end) | None}}.
     epochs: dict = field(default_factory=dict)
+    # Field-level `fiducial_tiles = [...]`: the subset of tiles (sharing a tangent
+    # point + rotation, spanning the field) that forms the field-composite map view
+    # (FitsGL, epic #337). Empty when undeclared; `fiducial_tile_set()` also honors
+    # a per-tile `fiducial = true` fallback.
+    fiducial_tiles: List[str] = field(default_factory=list)
 
     # Populated by setup_workspace()
     campfire_root: Optional[str] = None
@@ -438,7 +443,7 @@ class Field:
         # — in the latter case corners are derived on demand from the WCS.
         tiles = {}
         reserved_keys = ({'filters', 'files', 'skip', 'tangent_point', 'rgb',
-                          'epochs'} | known_steps)
+                          'epochs', 'fiducial_tiles'} | known_steps)
         for key, value in fc.items():
             if key in reserved_keys:
                 continue
@@ -470,6 +475,25 @@ class Field:
         # Parse [<field>.epochs.<name>] tables (combine-time exposure subsets).
         epochs = _parse_epochs(name, fc.get('epochs'))
 
+        # Field-level fiducial tile set (FitsGL field-composite view, epic #337).
+        # A list of already-declared tile names; validated against `tiles` so a
+        # typo surfaces here rather than as an empty composite downstream.
+        raw_fiducial = fc.get('fiducial_tiles', [])
+        if isinstance(raw_fiducial, str):
+            raw_fiducial = [raw_fiducial]
+        if not (isinstance(raw_fiducial, list)
+                and all(isinstance(t, str) for t in raw_fiducial)):
+            raise ValueError(
+                f"Field '{name}': `fiducial_tiles` must be a list of tile-name "
+                f"strings, got {raw_fiducial!r}"
+            )
+        unknown = [t for t in raw_fiducial if t not in tiles]
+        if unknown:
+            raise ValueError(
+                f"Field '{name}': `fiducial_tiles` references undeclared tile(s) "
+                f"{unknown}. Declared tiles: {list(tiles.keys())}"
+            )
+
         return cls(
             name=name,
             filters=filters,
@@ -481,6 +505,7 @@ class Field:
             rgb=rgb_cfg,
             wcs_shift_rules=wcs_shift_rules,
             epochs=epochs,
+            fiducial_tiles=list(raw_fiducial),
         )
 
     @property
@@ -973,6 +998,45 @@ class Field:
             f"Tile '{tile_name}' on field '{self.name}' has no "
             f"`<scale>mas` subsection with `crpix` and `naxis`."
         )
+
+    def fiducial_tile_set(self, pixel_scale='30mas'):
+        """Ordered tile names forming the field-composite fiducial set (epic #337).
+
+        The field-level ``fiducial_tiles = [...]`` declaration wins; absent that,
+        any tile carrying a per-tile ``fiducial = true`` flag is included (in
+        declaration order). Returns ``[]`` when neither is declared — the caller
+        (``campfire fitsgl build``) decides whether that is an error.
+
+        The set must co-grid to composite in FitsGL, so a set of two or more tiles
+        is validated to share one tangent point (``crval``) and rotation; a
+        mismatch (e.g. an off-grid PRIMER tile mistakenly included) raises
+        ``ValueError``. Only the pipeline can see tile WCS, so the check lives
+        here rather than in the deploy client.
+        """
+        if self.fiducial_tiles:
+            names = list(self.fiducial_tiles)
+        else:
+            names = [name for name, t in self.tiles.items()
+                     if isinstance(t, dict) and t.get('fiducial') is True]
+        if len(names) <= 1:
+            return names
+
+        ref_crval = ref_rot = None
+        for tname in names:
+            _crpix, crval, _shape, rotation = self.get_tile_wcs(tname, pixel_scale)
+            if ref_crval is None:
+                ref_crval, ref_rot = crval, rotation
+                continue
+            if not (np.allclose(crval, ref_crval, atol=1e-6)
+                    and np.isclose(rotation, ref_rot, atol=1e-6)):
+                raise ValueError(
+                    f"Field '{self.name}': fiducial tiles must share a tangent "
+                    f"point and rotation to co-grid, but '{tname}' has "
+                    f"crval={crval}, rotation={rotation} vs {ref_crval}, {ref_rot}. "
+                    f"Off-grid tiles (e.g. PRIMER) need a standalone per-tile "
+                    f"dataset, not the composite."
+                )
+        return names
 
     def get_tile_corners(self, tile_name):
         """Get sky corners for a tile.

--- a/pipeline/tests/test_field_fiducial.py
+++ b/pipeline/tests/test_field_fiducial.py
@@ -1,0 +1,158 @@
+"""Tests for the field-level ``fiducial_tiles`` declaration (epic #337, Phase 2).
+
+Covers ``Field.load`` parsing/validation of ``fiducial_tiles`` in ``fields.toml``
+and ``Field.fiducial_tile_set()`` (field-level list, per-tile ``fiducial = true``
+fallback, and the co-grid WCS-consistency guard). Pure config parsing — no
+CRDS/jwst.
+"""
+
+import textwrap
+
+import pytest
+
+from campfire_pipeline.nircam.field import Field
+
+
+def _write_fields_toml(tmp_path, body):
+    """Write a fields.toml with the given [cosmos]-section body, return its path."""
+    path = tmp_path / "fields.toml"
+    path.write_text(textwrap.dedent(body))
+    return str(path)
+
+
+# A co-gridded pair: both tiles inherit the field tangent point (no per-tile
+# `tangent_point`), share rotation 0, and declare a 30mas WCS subsection — so
+# they pass the co-grid check. A third tile sits on a different tangent point.
+_COGRID_FIELD = """
+    [cosmos]
+    filters = ["f200w", "f444w"]
+    files = ["jw01727*"]
+    tangent_point = [150.1, 2.1]
+    fiducial_tiles = ["A1", "B2"]
+
+    [cosmos.A1]
+    "30mas" = { crpix = [1000, 1000], naxis = [2000, 2000] }
+
+    [cosmos.B2]
+    "30mas" = { crpix = [3000, 1000], naxis = [2000, 2000] }
+
+    [cosmos.PRIMER]
+    tangent_point = [151.5, 2.9]
+    "30mas" = { crpix = [1000, 1000], naxis = [2000, 2000] }
+"""
+
+
+def test_fiducial_tiles_parsed(tmp_path):
+    ff = _write_fields_toml(tmp_path, _COGRID_FIELD)
+    field = Field.load("cosmos", fields_file=ff)
+    assert field.fiducial_tiles == ["A1", "B2"]
+
+
+def test_fiducial_tiles_string_is_coerced(tmp_path):
+    ff = _write_fields_toml(tmp_path, """
+        [cosmos]
+        filters = ["f200w"]
+        files = ["jw01727*"]
+        tangent_point = [150.1, 2.1]
+        fiducial_tiles = "A1"
+
+        [cosmos.A1]
+        "30mas" = { crpix = [1000, 1000], naxis = [2000, 2000] }
+    """)
+    field = Field.load("cosmos", fields_file=ff)
+    assert field.fiducial_tiles == ["A1"]
+
+
+def test_fiducial_tiles_unknown_raises(tmp_path):
+    ff = _write_fields_toml(tmp_path, """
+        [cosmos]
+        filters = ["f200w"]
+        files = ["jw01727*"]
+        tangent_point = [150.1, 2.1]
+        fiducial_tiles = ["A1", "NOPE"]
+
+        [cosmos.A1]
+        "30mas" = { crpix = [1000, 1000], naxis = [2000, 2000] }
+    """)
+    with pytest.raises(ValueError, match="undeclared tile"):
+        Field.load("cosmos", fields_file=ff)
+
+
+def test_fiducial_tiles_bad_type_raises(tmp_path):
+    ff = _write_fields_toml(tmp_path, """
+        [cosmos]
+        filters = ["f200w"]
+        files = ["jw01727*"]
+        tangent_point = [150.1, 2.1]
+        fiducial_tiles = [1, 2]
+
+        [cosmos.A1]
+        "30mas" = { crpix = [1000, 1000], naxis = [2000, 2000] }
+    """)
+    with pytest.raises(ValueError, match="list of tile-name"):
+        Field.load("cosmos", fields_file=ff)
+
+
+def test_fiducial_tile_set_returns_declared_order(tmp_path):
+    ff = _write_fields_toml(tmp_path, _COGRID_FIELD)
+    field = Field.load("cosmos", fields_file=ff)
+    assert field.fiducial_tile_set() == ["A1", "B2"]
+
+
+def test_fiducial_tile_set_per_tile_fallback(tmp_path):
+    """No field-level list → tiles flagged `fiducial = true` are collected."""
+    ff = _write_fields_toml(tmp_path, """
+        [cosmos]
+        filters = ["f200w"]
+        files = ["jw01727*"]
+        tangent_point = [150.1, 2.1]
+
+        [cosmos.A1]
+        fiducial = true
+        "30mas" = { crpix = [1000, 1000], naxis = [2000, 2000] }
+
+        [cosmos.B2]
+        fiducial = true
+        "30mas" = { crpix = [3000, 1000], naxis = [2000, 2000] }
+
+        [cosmos.C3]
+        "30mas" = { crpix = [5000, 1000], naxis = [2000, 2000] }
+    """)
+    field = Field.load("cosmos", fields_file=ff)
+    assert field.fiducial_tiles == []  # nothing at the field level
+    assert set(field.fiducial_tile_set()) == {"A1", "B2"}  # per-tile flags
+
+
+def test_fiducial_tile_set_empty_when_undeclared(tmp_path):
+    ff = _write_fields_toml(tmp_path, """
+        [cosmos]
+        filters = ["f200w"]
+        files = ["jw01727*"]
+        tangent_point = [150.1, 2.1]
+
+        [cosmos.A1]
+        "30mas" = { crpix = [1000, 1000], naxis = [2000, 2000] }
+    """)
+    field = Field.load("cosmos", fields_file=ff)
+    assert field.fiducial_tile_set() == []
+
+
+def test_fiducial_tile_set_wcs_mismatch_raises(tmp_path):
+    """An off-grid tile (different tangent point) breaks the co-grid guard."""
+    ff = _write_fields_toml(tmp_path, """
+        [cosmos]
+        filters = ["f200w"]
+        files = ["jw01727*"]
+        tangent_point = [150.1, 2.1]
+        fiducial_tiles = ["A1", "PRIMER"]
+
+        [cosmos.A1]
+        "30mas" = { crpix = [1000, 1000], naxis = [2000, 2000] }
+
+        [cosmos.PRIMER]
+        tangent_point = [151.5, 2.9]
+        "30mas" = { crpix = [1000, 1000], naxis = [2000, 2000] }
+    """)
+    field = Field.load("cosmos", fields_file=ff)
+    with pytest.raises(ValueError, match="share a tangent"):
+        field.fiducial_tile_set()

--- a/python/campfire/cli.py
+++ b/python/campfire/cli.py
@@ -165,6 +165,21 @@ def _register_deploy_group():
             sys.exit(1)
 
 
+def _register_fitsgl_group():
+    """Register the fitsgl subgroup lazily (epic #337). The group itself needs no
+    producer deps — it imports FitsGL only inside `build` — so registration rarely
+    fails; the stub guards a genuinely broken/absent subpackage."""
+    try:
+        from campfire.fitsgl.cli import fitsgl_group
+        cli.add_command(fitsgl_group, name='fitsgl')
+    except ImportError:
+        @cli.command('fitsgl', hidden=False)
+        def fitsgl_stub():
+            """Build & deploy FitsGL tile-pyramid datasets. (Requires: pip install campfire[fitsgl])"""
+            click.echo("FitsGL dependencies not installed. Run: pip install campfire[fitsgl]")
+            sys.exit(1)
+
+
 # ---------------------------------------------------------------------------
 # Authentication commands
 # ---------------------------------------------------------------------------
@@ -915,6 +930,7 @@ def download(obs_filter, program_filter, field_filter, grating_filter, filter_fi
 def main():
     """Entry point for the CLI."""
     _register_deploy_group()
+    _register_fitsgl_group()
     cli()
 
 

--- a/python/campfire/fitsgl/__init__.py
+++ b/python/campfire/fitsgl/__init__.py
@@ -1,0 +1,6 @@
+"""FitsGL producer integration for CAMPFIRE (epic #337).
+
+Builds (and, in later phases, deploys) FitsGL FITS tile-pyramid datasets for the
+map/cutout service. Requires the ``campfire[fitsgl]`` extra for the actual build;
+the pure config-generation layer in :mod:`campfire.fitsgl.build` imports no FitsGL.
+"""

--- a/python/campfire/fitsgl/build.py
+++ b/python/campfire/fitsgl/build.py
@@ -1,0 +1,352 @@
+"""Build a FitsGL tile-pyramid dataset for a NIRCam field (epic #337, Phase 2).
+
+`campfire fitsgl build` gathers a field's native (rotated) mosaics — **no
+reprojection** — generates a `fitsgl.toml` programmatically, and calls the FitsGL
+producer (`fitsgl.build.build_dataset`) as a library. Two shapes:
+
+- **fiducial composite** (default): each filter becomes one FitsGL band whose input
+  is the LIST of that filter's fiducial-tile mosaics (the SP8 pre-tiled path);
+  `[build].shared_grid` co-grids the filters so they RGB-composite.
+- **single tile** (`--tile`): each filter band's input is that one tile's mosaic —
+  the only path for off-grid tiles (e.g. PRIMER) that can't join the composite.
+
+The module is split into a **pure** layer (`select_mosaics` / `group_bands` /
+`derive_viewer` / `build_fitsgl_toml` — no FitsGL, unit-testable in CI) and an
+**orchestration** layer (`run_build`) that defers the `import fitsgl` so the base
+client stays lean and the extra's absence surfaces as a pointed install hint.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+import click
+import toml
+
+# Prefer the split single-HDU SCI image; fall back to the combined i2d cube
+# (FitsGL's build_pyramid auto-selects the first 2D image HDU, so a multi-extension
+# _i2d.fits resolves to SCI too). Other extensions (err/wht/srcmask) are not images
+# FitsGL should tile.
+_EXTENSION_PREFERENCE = ('sci', 'i2d')
+
+# Default display knobs (mirrored into fitsgl.toml [build]/[viewer]).
+_QUANTIZE_LEVEL = 8      # RICE Q=8 — ~0.03% lossy display pyramid (design §7)
+_TILE_SIZE = 256
+
+
+# ---------------------------------------------------------------------------
+# Pure layer (no fitsgl import; unit-tested without real data)
+# ---------------------------------------------------------------------------
+
+def select_mosaics(dirs, field, filters, *, pixel_scale, tiles=None):
+    """Discover the mosaics to feed FitsGL for a field at one pixel scale.
+
+    Wraps :func:`campfire.deploy.nircam.discover_mosaics` and keeps one mosaic per
+    (filter, tile): those matching ``pixel_scale`` (the string form, e.g.
+    ``'30mas'``) and — when ``tiles`` is given — whose tile is in that set. Within a
+    (filter, tile) the science image is chosen by :data:`_EXTENSION_PREFERENCE`
+    (``sci`` then ``i2d``). Returns a list of ``{path, filter, tile, pixel_scale,
+    extension}`` dicts.
+    """
+    from campfire.deploy.nircam import discover_mosaics
+
+    tileset = set(tiles) if tiles is not None else None
+    best: dict[tuple[str, str], dict] = {}
+    for m in discover_mosaics(dirs, field, filters):
+        if m['pixel_scale'] != pixel_scale:
+            continue
+        if tileset is not None and m['tile'] not in tileset:
+            continue
+        if m['extension'] not in _EXTENSION_PREFERENCE:
+            continue
+        key = (m['filter'], m['tile'])
+        incumbent = best.get(key)
+        if incumbent is None or _extension_rank(m['extension']) < _extension_rank(
+            incumbent['extension']
+        ):
+            best[key] = m
+    return list(best.values())
+
+
+def _extension_rank(ext: str) -> int:
+    """Lower is preferred; unknown extensions sort last."""
+    try:
+        return _EXTENSION_PREFERENCE.index(ext)
+    except ValueError:
+        return len(_EXTENSION_PREFERENCE)
+
+
+def group_bands(mosaics, *, single_tile):
+    """Group selected mosaics into FitsGL bands keyed by filter.
+
+    Composite ⇒ each filter's value is the LIST of its tile mosaic paths (sorted by
+    tile, so band inputs are deterministic). Single-tile ⇒ each filter's value is
+    its one mosaic path. Filters with no surviving mosaic are simply absent.
+    Returns an ordered dict filter → (Path | list[Path]), filters sorted blue→red.
+    """
+    by_filter: dict[str, list] = {}
+    for m in mosaics:
+        by_filter.setdefault(m['filter'], []).append(m)
+
+    bands: dict[str, object] = {}
+    for filt in sorted(by_filter, key=_filter_wavelength):
+        entries = sorted(by_filter[filt], key=lambda m: str(m['tile']))
+        paths = [Path(m['path']) for m in entries]
+        if single_tile:
+            # A single-tile build should have exactly one mosaic per filter; if a
+            # filter somehow has more, keep the first (deterministic) rather than
+            # silently building a bogus multi-input band.
+            bands[filt] = paths[0]
+        else:
+            bands[filt] = paths
+    return bands
+
+
+def derive_viewer(rgb_channels, band_filters):
+    """Derive the fitsgl.toml ``[viewer]`` default from CAMPFIRE's RGB config.
+
+    ``rgb_channels`` maps filter → (r, g, b) color weights (from
+    ``get_rgb_configs``), or ``None`` when no imaging config is available.
+    ``band_filters`` is the list of filters that became bands. When ≥3 of the RGB
+    config's filters are present, the default is an RGB view with ``stretch =
+    "trilogy"`` and r/g/b assigned to the filter carrying the most weight in each
+    channel (mirroring the roles, not the exact trilogy normalization — the live
+    viewer restretches). Otherwise a single-band view on the reddest present filter.
+    Every filter is a band regardless; this only sets the initial view.
+    """
+    usable = [f for f in band_filters if rgb_channels and f in rgb_channels]
+    if len(usable) >= 3:
+        pick = lambda ch: max(usable, key=lambda f: rgb_channels[f][ch])
+        return {
+            'default': 'rgb',
+            'r': pick(0),
+            'g': pick(1),
+            'b': pick(2),
+            'stretch': 'trilogy',
+        }
+    if not band_filters:
+        return {'default': 'single', 'stretch': 'asinh'}
+    return {
+        'default': 'single',
+        'band': _reddest(band_filters),
+        'stretch': 'asinh',
+        'colormap': 'gray',
+        'north_up': False,
+    }
+
+
+def build_fitsgl_toml(field, *, bands, viewer, pixel_scale, single_tile, tile=None):
+    """Assemble the fitsgl.toml structure (a plain dict) for a field/tile build.
+
+    Band ``input`` paths are made **absolute**, so FitsGL's "resolve relative to the
+    toml dir" behavior is a no-op and the toml can live anywhere. Dataset name is
+    ``<field>`` for the composite and ``<field>__<tile>`` for a single tile (a
+    stable R2-prefix/dir identity). Catalog is deferred (a later phase); the seam is
+    left as a comment. Returns the dict; the caller serializes it with ``toml``.
+    """
+    name = f"{field}__{tile}" if single_tile else field
+    scope = f"tile {tile}" if single_tile else "fiducial composite"
+    band_tables = []
+    for filt, inp in bands.items():
+        if isinstance(inp, (list, tuple)):
+            value = [str(Path(p).resolve()) for p in inp]
+        else:
+            value = str(Path(inp).resolve())
+        band_tables.append({'name': filt, 'label': filt.upper(), 'input': value})
+
+    return {
+        'dataset': {
+            'name': name,
+            'title': f"{field} ({scope}, {pixel_scale})",
+            # catalog: deferred to a later phase (NIRSpec export → catalog.csv).
+            'bands': band_tables,
+        },
+        'build': {
+            'quantize_level': _QUANTIZE_LEVEL,
+            'tile_size': _TILE_SIZE,
+            'shared_grid': True,
+        },
+        'viewer': viewer,
+    }
+
+
+_WAVELEN_RE = re.compile(r'f(\d{3,4})[wmn]', re.IGNORECASE)
+
+
+def _filter_wavelength(name: str) -> tuple:
+    """Sort key: approximate central wavelength (nm) from a JWST filter name.
+
+    ``f150w`` → 1500, ``f444w`` → 4440. Unparseable names sort last, then
+    alphabetically, so order is always deterministic.
+    """
+    m = _WAVELEN_RE.search(name or '')
+    if not m:
+        return (1, 0.0, name or '')
+    digits = m.group(1)
+    # f150w -> 150 -> 1.50 µm; f0900 style would be 4 digits already in nm*10.
+    val = int(digits) * (10 if len(digits) == 3 else 1)
+    return (0, val, name)
+
+
+def _reddest(band_filters):
+    """The longest-wavelength filter present (the default single-band view)."""
+    return max(band_filters, key=_filter_wavelength)
+
+
+# ---------------------------------------------------------------------------
+# Orchestration (imports the deploy primitives + defers `import fitsgl`)
+# ---------------------------------------------------------------------------
+
+def resolve_fitsgl_dir(out_dir=None) -> Path:
+    """Resolve the local dataset output root: ``--out-dir`` or ``$CAMPFIRE_ROOT/fitsgl``."""
+    if out_dir:
+        return Path(out_dir)
+    root = os.environ.get('CAMPFIRE_ROOT')
+    if root:
+        return Path(root) / 'fitsgl'
+    click.echo("Error: no output directory. Use --out-dir <path> or set $CAMPFIRE_ROOT.")
+    sys.exit(1)
+
+
+def resolve_fiducial_tiles(field, *, pixel_scale='30mas'):
+    """The field's fiducial tile set (composite build), via the pipeline when present.
+
+    Prefers ``campfire_pipeline.nircam.field.Field`` (reuses the co-grid WCS
+    validation in ``fiducial_tile_set``); falls back to a direct read of
+    ``$CAMPFIRE_ROOT/config/fields.toml`` ``[<field>].fiducial_tiles`` when the
+    pipeline isn't installed (deploy machines needn't carry it). Returns ``[]`` when
+    undeclared; the caller errors with guidance.
+    """
+    try:
+        from campfire_pipeline.nircam.field import Field
+    except ImportError:
+        return _fiducial_tiles_from_toml(field)
+    return Field.load(field).fiducial_tile_set(pixel_scale=pixel_scale)
+
+
+def _fiducial_tiles_from_toml(field):
+    """Fallback: read ``[<field>].fiducial_tiles`` straight from fields.toml (no WCS check)."""
+    try:
+        import tomllib
+    except ModuleNotFoundError:  # pragma: no cover - py<3.11
+        import tomli as tomllib  # type: ignore
+    root = os.environ.get('CAMPFIRE_ROOT')
+    if not root:
+        return []
+    path = Path(root) / 'config' / 'fields.toml'
+    if not path.is_file():
+        return []
+    with path.open('rb') as f:
+        data = tomllib.load(f)
+    raw = (data.get(field) or {}).get('fiducial_tiles', [])
+    if isinstance(raw, str):
+        raw = [raw]
+    return list(raw) if isinstance(raw, list) else []
+
+
+def _load_rgb_channels(field):
+    """Filter → (r,g,b) color weights from imaging.toml, or ``None`` if unavailable.
+
+    Best-effort: any missing config / parse error yields ``None`` so the build
+    proceeds with a single-band default view rather than failing.
+    """
+    try:
+        from campfire.deploy.config import resolve_imaging_config
+        from campfire.deploy.tiles_engine import get_rgb_configs, load_imaging_config
+
+        path = resolve_imaging_config()
+        if path is None:
+            return None
+        rgbs = get_rgb_configs(load_imaging_config(path), fields=[field])
+        if not rgbs:
+            return None
+        return {
+            filt: tuple(float(x) for x in info['color'])
+            for filt, info in rgbs[0].filter_channels.items()
+        }
+    except Exception:
+        return None
+
+
+def run_build(field, *, pixel_scale='30mas', tile=None, processes=None,
+              overwrite=False, out_dir=None):
+    """Build one field's FitsGL dataset and return its directory.
+
+    Composite (``tile=None``) uses the field's fiducial set; ``tile`` builds a
+    single-tile standalone dataset. Writes a generated ``fitsgl.toml`` next to the
+    output, then calls FitsGL's ``build_dataset``. ``overwrite=False`` keeps
+    FitsGL's resumable per-band reuse (a re-run skips finished bands); pass
+    ``overwrite=True`` after a mosaic's pixels change, since reuse keys on a band's
+    presence, not its input content.
+    """
+    from campfire.deploy.nircam import _discover_filters, _resolve_nircam_dirs
+
+    dirs = _resolve_nircam_dirs(field)
+    if not dirs['products'].exists():
+        click.echo(f"Error: no reduced products for field '{field}' at {dirs['products']}.")
+        sys.exit(1)
+    filters = _discover_filters(dirs)
+    if not filters:
+        click.echo(f"Error: no filter products found under {dirs['products']}.")
+        sys.exit(1)
+
+    single_tile = tile is not None
+    if single_tile:
+        tileset = [tile]
+    else:
+        tileset = resolve_fiducial_tiles(field, pixel_scale=pixel_scale)
+        if not tileset:
+            click.echo(
+                f"Error: field '{field}' declares no fiducial tiles. Add "
+                f"`fiducial_tiles = [...]` under [{field}] in fields.toml, or build a "
+                f"single tile with --tile <name>."
+            )
+            sys.exit(1)
+
+    mosaics = select_mosaics(dirs, field, filters, pixel_scale=pixel_scale, tiles=tileset)
+    bands = group_bands(mosaics, single_tile=single_tile)
+    if not bands:
+        click.echo(
+            f"Error: no {pixel_scale} mosaics found for "
+            f"{'tile ' + tile if single_tile else 'fiducial tiles ' + ', '.join(tileset)}. "
+            f"Reduce/combine them first, or pick another --pixel-scale."
+        )
+        sys.exit(1)
+
+    n_inputs = sum(len(v) if isinstance(v, list) else 1 for v in bands.values())
+    click.echo(
+        f"Building FitsGL {'tile ' + tile if single_tile else 'composite'} for "
+        f"'{field}' at {pixel_scale}: {len(bands)} band(s) / {n_inputs} mosaic(s)."
+    )
+
+    viewer = derive_viewer(_load_rgb_channels(field), list(bands))
+    toml_dict = build_fitsgl_toml(
+        field, bands=bands, viewer=viewer, pixel_scale=pixel_scale,
+        single_tile=single_tile, tile=tile,
+    )
+
+    out_root = resolve_fitsgl_dir(out_dir)
+    out_root.mkdir(parents=True, exist_ok=True)
+    toml_path = out_root / f"{toml_dict['dataset']['name']}.toml"
+    toml_path.write_text(toml.dumps(toml_dict))
+
+    try:
+        from fitsgl.build import build_dataset
+        from fitsgl.config import load_config
+    except ImportError:
+        click.echo("FitsGL producer not installed. Run: pip install campfire[fitsgl]")
+        sys.exit(1)
+
+    cfg = load_config(toml_path)
+    result = build_dataset(
+        cfg, out_root=out_root, processes=processes, verify=True,
+        with_site=True, overwrite=overwrite,
+        on_progress=lambda msg: click.echo(f"  {msg}"),
+    )
+    click.echo(f"\n✓ Built {result.dataset_dir}")
+    click.echo(f"  Serve it:  fitsgl serve {result.dataset_dir}")
+    click.echo(f"  Then open /prototype/fitsgl and paste a band manifest.json URL.")
+    return result.dataset_dir

--- a/python/campfire/fitsgl/build.py
+++ b/python/campfire/fitsgl/build.py
@@ -45,17 +45,23 @@ def select_mosaics(dirs, field, filters, *, pixel_scale, tiles=None):
     """Discover the mosaics to feed FitsGL for a field at one pixel scale.
 
     Wraps :func:`campfire.deploy.nircam.discover_mosaics` and keeps one mosaic per
-    (filter, tile): those matching ``pixel_scale`` (the string form, e.g.
-    ``'30mas'``) and — when ``tiles`` is given — whose tile is in that set. Within a
-    (filter, tile) the science image is chosen by :data:`_EXTENSION_PREFERENCE`
-    (``sci`` then ``i2d``). Returns a list of ``{path, filter, tile, pixel_scale,
-    extension}`` dicts.
+    (filter, tile): full-field mosaics matching ``pixel_scale`` (the string form,
+    e.g. ``'30mas'``) and — when ``tiles`` is given — whose tile is in that set.
+    Within a (filter, tile) the science image is chosen by
+    :data:`_EXTENSION_PREFERENCE` (``sci`` then ``i2d``). Returns a list of
+    ``{path, filter, tile, pixel_scale, extension}`` dicts.
     """
     from campfire.deploy.nircam import discover_mosaics
 
     tileset = set(tiles) if tiles is not None else None
     best: dict[tuple[str, str], dict] = {}
     for m in discover_mosaics(dirs, field, filters):
+        # Skip epoch subset mosaics (`cfpipe nircam combine --epoch`): they share a
+        # (filter, tile) with the full-field mosaic but cover only part of it, so
+        # they'd yield an incomplete map. `epoch == ''` is the full-field mosaic —
+        # the only input the map pyramid should ever use.
+        if m.get('epoch'):
+            continue
         if m['pixel_scale'] != pixel_scale:
             continue
         if tileset is not None and m['tile'] not in tileset:

--- a/python/campfire/fitsgl/cli.py
+++ b/python/campfire/fitsgl/cli.py
@@ -1,0 +1,49 @@
+"""Click CLI for `campfire fitsgl` (epic #337).
+
+Registered lazily by ``campfire.cli`` (like ``deploy``) so the base client never
+imports the FitsGL producer. Phase 2 ships ``build``; ``deploy`` follows in Phase 3.
+
+Usage:
+    campfire fitsgl build --field cosmos
+    campfire fitsgl build --field cosmos --pixel-scale 30mas
+    campfire fitsgl build --field cosmos --tile PRIMER      # single-tile / off-grid
+"""
+
+import click
+
+from campfire.fitsgl import build as _build
+
+
+@click.group()
+def fitsgl_group():
+    """Build & deploy FitsGL tile-pyramid datasets for the map/cutout service."""
+    pass
+
+
+@fitsgl_group.command('build')
+@click.option('--field', required=True, help='NIRCam field name (e.g. cosmos).')
+@click.option('--tile', default=None,
+              help='Build a single-tile standalone dataset instead of the fiducial '
+                   'composite (the only path for off-grid tiles like PRIMER).')
+@click.option('--pixel-scale', default='30mas', show_default=True,
+              help='Mosaic pixel scale to build. All bands must share it to co-grid.')
+@click.option('--processes', type=int, default=None,
+              help='Per-level worker pool size (default: auto, one per level up to CPU count).')
+@click.option('--out-dir', default=None,
+              help='Dataset output root (default: $CAMPFIRE_ROOT/fitsgl).')
+@click.option('--overwrite', is_flag=True,
+              help='Rebuild every band from scratch. Pass this after a mosaic\'s '
+                   'pixels change (band reuse keys on presence, not content) or after '
+                   'changing a [build] knob.')
+def build_cmd(field, tile, pixel_scale, processes, out_dir, overwrite):
+    """Build a field's FitsGL dataset from native (rotated) mosaics — no reproject.
+
+    The default builds the fiducial composite (each filter is one band; the filters
+    co-grid so they RGB-composite). CAMPFIRE generates the fitsgl.toml; you never
+    edit it. The display pyramid is RICE Q=8 (~0.03% lossy) — for photometry read
+    the raw lossless mosaic, not the pyramid.
+    """
+    _build.run_build(
+        field, pixel_scale=pixel_scale, tile=tile, processes=processes,
+        overwrite=overwrite, out_dir=out_dir,
+    )

--- a/python/tests/test_fitsgl_build.py
+++ b/python/tests/test_fitsgl_build.py
@@ -92,15 +92,25 @@ def test_derive_viewer_empty_bands():
 
 # --- select_mosaics / group_bands (real discover_mosaics on a fake tree) -----
 
-def _write_mosaic(products, field, filt, tile, scale, exts):
-    """Create a version-free mosaic slot (manifest + given extension files)."""
+def _write_mosaic(products, field, filt, tile, scale, exts, epoch=""):
+    """Create a version-free mosaic slot (manifest + given extension files).
+
+    ``epoch`` non-empty writes a subset epoch mosaic (``..._<epoch>``, as
+    ``cfpipe nircam combine --epoch`` produces), which `discover_mosaics`
+    reconstructs from the manifest's ``epoch`` field.
+    """
     fdir = products / filt
     fdir.mkdir(parents=True, exist_ok=True)
     base = f"mosaic_nircam_{filt}_{field}_{scale}_{tile}"
-    (fdir / f"{base}_manifest.json").write_text(json.dumps({
+    if epoch:
+        base += f"_{epoch}"
+    manifest = {
         "mosaic_name": base, "field": field, "filter": filt,
         "tile": tile, "pixel_scale": scale,
-    }))
+    }
+    if epoch:
+        manifest["epoch"] = epoch
+    (fdir / f"{base}_manifest.json").write_text(json.dumps(manifest))
     for suffix in exts:
         (fdir / f"{base}{suffix}").write_bytes(b"\x00")
 
@@ -118,6 +128,10 @@ def _fake_field(tmp_path):
     _write_mosaic(products, "cosmos", "f444w", "PRIMER", "30mas", ("_i2d.fits",))
     # a coarser scale that must be filtered out
     _write_mosaic(products, "cosmos", "f444w", "A1", "60mas", ("_i2d.fits",))
+    # an epoch subset of f444w/A1: same (filter, tile) as the full-field mosaic,
+    # sorts BEFORE it (`A1_CW_manifest` < `A1_manifest`), so absent an epoch filter
+    # it would win the (filter, tile) slot and yield an incomplete map.
+    _write_mosaic(products, "cosmos", "f444w", "A1", "30mas", ("_sci.fits",), epoch="CW")
     return {"products": products}
 
 
@@ -133,6 +147,17 @@ def test_select_mosaics_filters_scale_and_tiles(tmp_path):
     ext = {(m["filter"], m["tile"]): m["extension"] for m in picked}
     assert ext[("f444w", "A1")] == "sci"
     assert ext[("f444w", "B2")] == "i2d"
+
+
+def test_select_mosaics_skips_epoch_subsets(tmp_path):
+    dirs = _fake_field(tmp_path)
+    picked = select_mosaics(dirs, "cosmos", ["f150w", "f444w"],
+                            pixel_scale="30mas", tiles={"A1", "B2"})
+    # the epoch mosaic must not appear at all, and the f444w/A1 slot must be the
+    # full-field mosaic (no `_CW`) despite the epoch mosaic sorting first
+    assert all("_CW" not in str(m["path"]) for m in picked)
+    a1_f444 = next(m for m in picked if m["filter"] == "f444w" and m["tile"] == "A1")
+    assert a1_f444["path"].name == "mosaic_nircam_f444w_cosmos_30mas_A1_sci.fits"
 
 
 def test_group_bands_composite_lists_per_filter(tmp_path):

--- a/python/tests/test_fitsgl_build.py
+++ b/python/tests/test_fitsgl_build.py
@@ -1,0 +1,154 @@
+"""Tests for `campfire fitsgl build`'s pure config-generation layer (epic #337).
+
+Exercises the fitsgl-free functions in ``campfire.fitsgl.build`` — mosaic
+selection, band grouping, RGB-viewer derivation, and fitsgl.toml assembly — so CI
+covers the logic without the FitsGL producer installed or any real NIRCam data.
+The producer-import contract lives in ``test_fitsgl_packaging.py``.
+"""
+
+import json
+
+import toml
+
+from campfire.fitsgl.build import (
+    build_fitsgl_toml,
+    derive_viewer,
+    group_bands,
+    select_mosaics,
+)
+
+
+# --- build_fitsgl_toml ------------------------------------------------------
+
+def test_build_fitsgl_toml_composite_inputs_are_lists(tmp_path):
+    a, b, c = tmp_path / "a.fits", tmp_path / "b.fits", tmp_path / "c.fits"
+    for p in (a, b, c):
+        p.write_bytes(b"\x00")
+    bands = {"f150w": [a, b], "f444w": [c]}
+    viewer = {"default": "single", "band": "f444w", "stretch": "asinh"}
+
+    d = build_fitsgl_toml("cosmos", bands=bands, viewer=viewer,
+                          pixel_scale="30mas", single_tile=False)
+
+    assert d["dataset"]["name"] == "cosmos"
+    assert d["build"]["shared_grid"] is True
+    assert d["build"]["quantize_level"] == 8
+    by_name = {b["name"]: b for b in d["dataset"]["bands"]}
+    assert isinstance(by_name["f150w"]["input"], list) and len(by_name["f150w"]["input"]) == 2
+    assert isinstance(by_name["f444w"]["input"], list) and len(by_name["f444w"]["input"]) == 1
+    assert by_name["f150w"]["label"] == "F150W"
+    # paths are absolutized so the toml can live anywhere
+    assert all(p.startswith("/") for p in by_name["f150w"]["input"])
+
+
+def test_build_fitsgl_toml_single_tile_input_is_str(tmp_path):
+    x = tmp_path / "x.fits"
+    x.write_bytes(b"\x00")
+    d = build_fitsgl_toml("cosmos", bands={"f444w": x}, viewer={"default": "single"},
+                          pixel_scale="30mas", single_tile=True, tile="PRIMER")
+    assert d["dataset"]["name"] == "cosmos__PRIMER"
+    assert isinstance(d["dataset"]["bands"][0]["input"], str)
+
+
+def test_build_fitsgl_toml_serializes_as_array_of_tables(tmp_path):
+    a = tmp_path / "a.fits"
+    a.write_bytes(b"\x00")
+    d = build_fitsgl_toml("cosmos", bands={"f444w": [a]},
+                          viewer={"default": "single", "band": "f444w"},
+                          pixel_scale="30mas", single_tile=False)
+    # round-trips through the toml serializer FitsGL will parse
+    reparsed = toml.loads(toml.dumps(d))
+    assert reparsed["dataset"]["bands"][0]["name"] == "f444w"
+    assert reparsed["build"]["shared_grid"] is True
+
+
+# --- derive_viewer ----------------------------------------------------------
+
+def test_derive_viewer_rgb_from_color_weights():
+    rgb = {"f444w": (1.0, 0.0, 0.0), "f277w": (0.0, 1.0, 0.0), "f150w": (0.0, 0.0, 1.0)}
+    v = derive_viewer(rgb, ["f150w", "f277w", "f444w"])
+    assert v["default"] == "rgb"
+    assert v["r"] == "f444w" and v["g"] == "f277w" and v["b"] == "f150w"
+    assert v["stretch"] == "trilogy"
+
+
+def test_derive_viewer_single_band_fallback_without_rgb():
+    v = derive_viewer(None, ["f150w", "f444w"])
+    assert v["default"] == "single"
+    assert v["band"] == "f444w"  # reddest present
+    assert v["stretch"] == "asinh"
+
+
+def test_derive_viewer_single_when_fewer_than_three_rgb_filters():
+    rgb = {"f444w": (1.0, 0.0, 0.0), "f150w": (0.0, 0.0, 1.0)}
+    v = derive_viewer(rgb, ["f150w", "f444w"])
+    assert v["default"] == "single"
+
+
+def test_derive_viewer_empty_bands():
+    v = derive_viewer(None, [])
+    assert v["default"] == "single" and "band" not in v
+
+
+# --- select_mosaics / group_bands (real discover_mosaics on a fake tree) -----
+
+def _write_mosaic(products, field, filt, tile, scale, exts):
+    """Create a version-free mosaic slot (manifest + given extension files)."""
+    fdir = products / filt
+    fdir.mkdir(parents=True, exist_ok=True)
+    base = f"mosaic_nircam_{filt}_{field}_{scale}_{tile}"
+    (fdir / f"{base}_manifest.json").write_text(json.dumps({
+        "mosaic_name": base, "field": field, "filter": filt,
+        "tile": tile, "pixel_scale": scale,
+    }))
+    for suffix in exts:
+        (fdir / f"{base}{suffix}").write_bytes(b"\x00")
+
+
+def _fake_field(tmp_path):
+    """A cosmos products tree: A1/B2 at 30mas (fiducial), PRIMER + a 60mas slot."""
+    products = tmp_path / "products" / "nircam" / "cosmos"
+    # A1: sci + i2d present (extension preference should pick sci)
+    _write_mosaic(products, "cosmos", "f444w", "A1", "30mas", ("_sci.fits", "_i2d.fits"))
+    _write_mosaic(products, "cosmos", "f150w", "A1", "30mas", ("_sci.fits",))
+    # B2: only i2d present (fallback)
+    _write_mosaic(products, "cosmos", "f444w", "B2", "30mas", ("_i2d.fits",))
+    _write_mosaic(products, "cosmos", "f150w", "B2", "30mas", ("_sci.fits",))
+    # PRIMER: off-grid, not in the fiducial set
+    _write_mosaic(products, "cosmos", "f444w", "PRIMER", "30mas", ("_i2d.fits",))
+    # a coarser scale that must be filtered out
+    _write_mosaic(products, "cosmos", "f444w", "A1", "60mas", ("_i2d.fits",))
+    return {"products": products}
+
+
+def test_select_mosaics_filters_scale_and_tiles(tmp_path):
+    dirs = _fake_field(tmp_path)
+    picked = select_mosaics(dirs, "cosmos", ["f150w", "f444w"],
+                            pixel_scale="30mas", tiles={"A1", "B2"})
+    # PRIMER and the 60mas slot are excluded
+    assert {(m["filter"], m["tile"]) for m in picked} == {
+        ("f444w", "A1"), ("f444w", "B2"), ("f150w", "A1"), ("f150w", "B2"),
+    }
+    # extension preference: sci wins for A1/f444w (both present); i2d for B2/f444w
+    ext = {(m["filter"], m["tile"]): m["extension"] for m in picked}
+    assert ext[("f444w", "A1")] == "sci"
+    assert ext[("f444w", "B2")] == "i2d"
+
+
+def test_group_bands_composite_lists_per_filter(tmp_path):
+    dirs = _fake_field(tmp_path)
+    picked = select_mosaics(dirs, "cosmos", ["f150w", "f444w"],
+                            pixel_scale="30mas", tiles={"A1", "B2"})
+    bands = group_bands(picked, single_tile=False)
+    assert set(bands) == {"f150w", "f444w"}
+    assert all(isinstance(v, list) and len(v) == 2 for v in bands.values())
+    # blue→red band ordering
+    assert list(bands) == ["f150w", "f444w"]
+
+
+def test_group_bands_single_tile_scalar_path(tmp_path):
+    dirs = _fake_field(tmp_path)
+    picked = select_mosaics(dirs, "cosmos", ["f444w"], pixel_scale="30mas", tiles={"A1"})
+    bands = group_bands(picked, single_tile=True)
+    assert set(bands) == {"f444w"}
+    assert not isinstance(bands["f444w"], list)  # single path, not a list


### PR DESCRIPTION
Closes #339. Part of the FitsGL epic #337 (design `docs/design-fitsgl-integration.md` §5, §5a, §10). Follows Phase 1 (#338, merged in #356).

Builds a FitsGL tile-pyramid dataset for a NIRCam field directly from the **native (rotated) mosaics — no reprojection**. FitsGL displays rotated pixels and toggles `north_up` in-view, so the slowest current map stage (reproject-to-north) is dropped. CAMPFIRE generates the `fitsgl.toml` programmatically and calls FitsGL as a library; scientists never hand-edit toml.

## What's here

### Pipeline — `fields.toml` fiducial declaration (Infrastructure)
`pipeline/campfire_pipeline/nircam/field.py`
- `Field` gains an optional field-level `fiducial_tiles = ["A1", ...]`, parsed and validated against the field's declared tiles in `Field.load` (bare string coerced to a one-element list; unknown tile names raise a pointed `ValueError`).
- New `Field.fiducial_tile_set(pixel_scale='30mas')` returns the fiducial set — declared list first, else a per-tile `fiducial = true` fallback — and **asserts the tiles co-grid** (shared tangent point `crval` + rotation via the existing tile-WCS accessor). Only the pipeline can see tile WCS, so this catches a mis-declared off-grid tile before it reaches FitsGL's co-grid step.
- `pipeline/CHANGELOG.md`: one **Infrastructure** entry under `## Unreleased` (declaration + accessor; no change to scientific output).

### Python — `campfire fitsgl build`
New `python/campfire/fitsgl/` subpackage, lazily registered in `campfire/cli.py` exactly like `deploy` so the base client never imports the FitsGL producer.
- `--field <f>` builds the **fiducial composite**: each filter is one FitsGL band; its `input` is the list of that filter's fiducial-tile mosaics (the SP8 pre-tiled path). `[build].shared_grid = true` co-grids the filters (NaN-padding) so they RGB-composite.
- `--tile <t>` builds a **single-tile standalone** dataset — the only path for off-grid tiles like PRIMER.
- Split into a **pure, fitsgl-free layer** (`select_mosaics` / `group_bands` / `derive_viewer` / `build_fitsgl_toml`) that's unit-testable in CI without the producer, and an **orchestration layer** (`run_build`) that defers `import fitsgl` and prints a `pip install campfire[fitsgl]` hint on ImportError.
- Reuses deploy's `discover_mosaics`; prefers `_sci.fits` and falls back to `_i2d.fits` per (filter, tile) — FitsGL auto-selects the first 2D image HDU, so a multi-extension `_i2d.fits` resolves to SCI too.
- `[viewer]` RGB roles + stretch are mirrored from deploy's `get_rgb_configs` when available (else a single-band default view of the reddest filter); every filter is always a band regardless.

## Deferred (design-consistent)
- **Catalog / NIRSpec markers**: the fitsgl schema makes `catalog` optional, there's no local NIRSpec-catalog export primitive (map markers come from a Supabase RPC), and it isn't needed for the "Done when". Left as a one-line seam.
- **Viewer fidelity is partial**: `[viewer]` exposes stretch + r/g/b roles but not the trilogy tunables (`noisesig`/`noiselum`/`satpercent`) that `RGBConfig` carries; the *default* view is representative and the live viewer restretches. Possible future FitsGL request.

## Testing
- **21 unit tests, green** with no real data and no `fitsgl` installed: `pipeline/tests/test_field_fiducial.py` (8 — parse/coerce/validate, declared order, per-tile fallback, WCS-mismatch raises) and `python/tests/test_fitsgl_build.py` (10 — toml assembly, viewer derivation, scale/tile/extension selection). The producer-import contract stays in `test_fitsgl_packaging.py`.
- **Real end-to-end** against the actual FitsGL producer (installed from the Phase-1 git extra) with synthetic mosaics: both `--tile` (single) and the **multi-tile fiducial composite** produced valid datasets — `fitsgl.json` + per-band `manifest.json` + `.fits.fz` supertiles + the vendored viewer. The composite exercised the co-grid precondition (FitsGL rejects tiles that don't share `CRVAL`), which is exactly what the pipeline-side WCS check guards.

The remaining step is the operator's local browser render — `campfire fitsgl build --field <f>` → `fitsgl serve $CAMPFIRE_ROOT/fitsgl/<f>` → the Phase-1 `/prototype/fitsgl` page — which needs real reduced mosaics.

Generated with Claude Code

https://claude.ai/code/session_0191rcHHzqkn36cC13wukgxJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0191rcHHzqkn36cC13wukgxJ)_