### PR TITLE
Parallelize file hashing and add PNG dedup to NIRCam deploy

### DIFF
--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -37,13 +37,16 @@ import hashlib
 import os
 import sys
 from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
 
 from astropy.io import fits
+from tqdm import tqdm
 
 from campfire_layout import KeyScheme, Scope, storage_key
 from campfire.deploy.r2 import UploadTask, upload_files_parallel
+from campfire.deploy.registry import default_hash_workers
 from campfire.deploy.supabase import (
     claim_deploy_scope, deploy_event_metadata, get_deploy_scope_version,
     get_supabase_client, get_user_id_from_token, insert_deployment, log_deploy_event,
@@ -125,6 +128,51 @@ def _sci_dq_hash(path):
     except Exception:
         return None
     return f'sha256:{h.hexdigest()}' if hashed_any else None
+
+
+def _compute_sci_dq_hashes(fits_tasks, *, max_workers=None):
+    """Return ``{r2_key: sci_dq_hash}`` for *fits_tasks*, hashed in parallel.
+
+    Computing the SCI+DQ+CFMASK digest for every candidate exposure is the
+    dominant cost *before* any upload starts — each :func:`_sci_dq_hash` reads
+    tens of MB off disk, and a field carries hundreds of exposures. Serially
+    this is the long pause before the first byte uploads. The reads are
+    I/O-bound and overlap across threads, so a pool cuts it to a fraction of the
+    serial time. A per-file read failure records ``None`` (never dedup on it),
+    matching the serial behaviour.
+    """
+    if not fits_tasks:
+        return {}
+    workers = max(1, min(max_workers or default_hash_workers(), len(fits_tasks)))
+    out: dict[str, str | None] = {}
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        futures = {ex.submit(_sci_dq_hash, t.local_path): t.r2_key for t in fits_tasks}
+        with tqdm(total=len(futures), desc='Hashing exposures', unit='file') as pbar:
+            for fut in as_completed(futures):
+                key = futures[fut]
+                try:
+                    out[key] = fut.result()
+                except Exception:
+                    out[key] = None
+                pbar.update(1)
+    return out
+
+
+def _upload_workers():
+    """Parallel upload streams for NIRCam OSN uploads.
+
+    Overridable via ``CAMPFIRE_DEPLOY_UPLOAD_WORKERS``. Defaults to 16 (up from
+    the shared upload helper's 12): NIRCam ships many ~20-40 MB exposure/PNG
+    files whose upload is network-bound, so extra concurrent streams help fill
+    the uplink. Clamped to a sane range.
+    """
+    raw = os.environ.get('CAMPFIRE_DEPLOY_UPLOAD_WORKERS')
+    if raw:
+        try:
+            return max(1, min(64, int(raw)))
+        except ValueError:
+            pass
+    return 16
 
 
 # ---------------------------------------------------------------------------
@@ -568,8 +616,8 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
         return
 
     from campfire.deploy.registry import (
-        build_registry_rows, fetch_active_sci_dq_hashes,
-        set_active_deployment, upsert_storage_objects,
+        build_registry_rows, fetch_active_content_hashes, fetch_active_sci_dq_hashes,
+        hash_files_parallel, set_active_deployment, upsert_storage_objects,
     )
 
     client = get_supabase_client(config)
@@ -598,7 +646,8 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
     # Compare each exposure's local sha256(SCI+DQ) to the digest already stored in
     # the registry; skip the upload when the science is unchanged (a pipeline
     # re-save with fresh header timestamps shifts the whole-file hash but not this).
-    local_sci_dq = {t.r2_key: _sci_dq_hash(t.local_path) for t in fits_tasks}
+    # Hashed in parallel — this is the dominant "pause before uploading" cost.
+    local_sci_dq = _compute_sci_dq_hashes(fits_tasks)
     existing_sci_dq = fetch_active_sci_dq_hashes(client, [t.r2_key for t in fits_tasks])
     fits_to_upload = [
         t for t in fits_tasks
@@ -610,13 +659,14 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
         print(f"\nSkipping {n_skipped} unchanged exposure(s) (SCI+DQ hash match)")
 
     # --- Upload canonical FITS + expmaps to OSN ----------------------------
+    upload_workers = _upload_workers()
     n_failed = 0
     osn_tasks = fits_to_upload + expmap_tasks
     osn_uploaded: set[str] = set()
     if osn_tasks:
         print(f"\nUploading {len(osn_tasks)} canonical FITS/expmap(s) to OSN...")
         success, failed, failures = upload_files_parallel(
-            config, osn_tasks, desc='OSN uploads',
+            config, osn_tasks, desc='OSN uploads', max_workers=upload_workers,
             succeeded_out=osn_uploaded, backend=_CANONICAL_BACKEND)
         n_failed += failed
         print(f"  Uploaded: {success}, Failed: {failed}")
@@ -624,17 +674,35 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
             print(f"  Error: {msg}")
 
     # --- Upload preview PNGs to OSN (canonical keys, epic #261 N5) ----------
+    # Content-hash dedup (mirrors the FITS/mosaic paths): every deploy previously
+    # re-uploaded *all* preview + native-res PNGs, which dominates a re-deploy's
+    # upload time. Skip the ones whose bytes are unchanged; the nircam_exposures
+    # png_path columns are set from the task keys regardless of upload, so a
+    # skipped PNG stays correctly referenced.
     png_upload_list = [t[0] for t in png_tasks]
+    existing_png = fetch_active_content_hashes(client, [t.r2_key for t in png_upload_list])
+    png_hashes = hash_files_parallel([t.local_path for t in png_upload_list])
+    local_png = {t.r2_key: png_hashes.get(t.local_path, (None, 0))[0] for t in png_upload_list}
+    png_to_upload = [
+        t for t in png_upload_list
+        if not (local_png.get(t.r2_key)
+                and existing_png.get(t.r2_key) == local_png[t.r2_key])
+    ]
+    n_png_skipped = len(png_upload_list) - len(png_to_upload)
     png_uploaded: set[str] = set()
-    if png_upload_list:
-        print("\nUploading preview PNGs to OSN...")
+    if png_to_upload:
+        if n_png_skipped:
+            print(f"\nSkipping {n_png_skipped} unchanged preview PNG(s) (content-hash match)")
+        print("Uploading preview PNGs to OSN...")
         success, failed, failures = upload_files_parallel(
-            config, png_upload_list, desc='Uploading PNGs',
+            config, png_to_upload, desc='Uploading PNGs', max_workers=upload_workers,
             succeeded_out=png_uploaded, backend=_CANONICAL_BACKEND)
         n_failed += failed
         print(f"  Uploaded: {success}, Failed: {failed}")
         for msg in failures:
             print(f"  Error: {msg}")
+    elif n_png_skipped:
+        print(f"\nSkipping {n_png_skipped} unchanged preview PNG(s) (content-hash match)")
 
     print("\nUpserting exposures to Supabase...")
     _upsert_exposures(client, records)
@@ -650,27 +718,33 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
         reg_rows = build_registry_rows(
             osn_tasks, backend=_CANONICAL_BACKEND, deployment_id=deployment_id,
             uploaded_by=user_id, cfpipe_version=cfpipe_version,
-            succeeded_keys=osn_uploaded, sci_dq_hashes=local_sci_dq)
+            succeeded_keys=osn_uploaded, sci_dq_hashes=local_sci_dq,
+            max_workers=upload_workers)
         n_reg += upsert_storage_objects(client, reg_rows)
     if png_uploaded:
         reg_rows = build_registry_rows(
-            png_upload_list, backend=_CANONICAL_BACKEND, cfpipe_version=cfpipe_version,
-            deployment_id=deployment_id, uploaded_by=user_id, succeeded_keys=png_uploaded)
+            png_to_upload, backend=_CANONICAL_BACKEND, cfpipe_version=cfpipe_version,
+            deployment_id=deployment_id, uploaded_by=user_id, succeeded_keys=png_uploaded,
+            max_workers=upload_workers)
         n_reg += upsert_storage_objects(client, reg_rows)
     if n_reg:
         print(f"  Registered {n_reg} storage object(s)")
 
-    # Re-point dedup-skipped exposures (unchanged bytes, not re-registered) to this
+    # Re-point dedup-skipped objects (unchanged bytes, not re-registered) to this
     # deployment so a PUBLISHED re-deploy flips the whole field consistently. NOT on
     # a --draft re-deploy: draft is staging — leave already-published unchanged
     # objects on their published deployment (only the new/changed ones stage as
-    # draft), else the whole live field goes dark.
-    skipped_keys = ([t.r2_key for t in fits_tasks if t.r2_key not in osn_uploaded]
-                    if (deployment_id and not draft) else [])
+    # draft), else the whole live field goes dark. Covers both the canonical FITS
+    # and the now-deduped preview PNGs.
+    if deployment_id and not draft:
+        skipped_keys = [t.r2_key for t in fits_tasks if t.r2_key not in osn_uploaded]
+        skipped_keys += [t.r2_key for t in png_upload_list if t.r2_key not in png_uploaded]
+    else:
+        skipped_keys = []
     if skipped_keys:
         n_moved = set_active_deployment(client, skipped_keys, deployment_id)
         if n_moved:
-            print(f"  Re-pointed {n_moved} unchanged exposure(s) to deployment #{deployment_id}")
+            print(f"  Re-pointed {n_moved} unchanged object(s) to deployment #{deployment_id}")
 
     # --- Mosaics: deploy under the same field deployment (epic #261, N2) ----
     _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
@@ -865,7 +939,7 @@ def _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
     rides the deployment (published => public to everyone).
     """
     from campfire.deploy.registry import (
-        fetch_active_content_hashes, hash_file, row_for_key,
+        fetch_active_content_hashes, hash_files_parallel, row_for_key,
         set_active_deployment, upsert_storage_objects,
     )
     mosaics = discover_mosaics(dirs, field, filters)
@@ -874,10 +948,12 @@ def _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
     print(f"\nMosaics: {len(mosaics)} product(s)")
 
     # Whole-file content-hash dedup: skip re-uploading a byte-identical mosaic.
+    # Mosaics are multi-GB, so hash them in parallel rather than one at a time.
     existing = fetch_active_content_hashes(client, [m['storage_key'] for m in mosaics])
+    mosaic_hashes = hash_files_parallel([m['path'] for m in mosaics])
     upload_tasks = []
     for m in mosaics:
-        local_hash, local_size = hash_file(m['path'])
+        local_hash, local_size = mosaic_hashes[m['path']]
         m['content_hash'] = local_hash
         m['size'] = local_size
         if existing.get(m['storage_key']) != local_hash:
@@ -892,7 +968,7 @@ def _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
     if upload_tasks:
         print(f"  Uploading {len(upload_tasks)} mosaic file(s) to OSN...")
         success, failed, failures = upload_files_parallel(
-            config, upload_tasks, desc='OSN mosaic uploads',
+            config, upload_tasks, desc='OSN mosaic uploads', max_workers=_upload_workers(),
             succeeded_out=uploaded, backend=_CANONICAL_BACKEND)
         print(f"    Uploaded: {success}, Failed: {failed}")
         for msg in failures:

--- a/python/campfire/deploy/registry.py
+++ b/python/campfire/deploy/registry.py
@@ -78,6 +78,41 @@ def hash_file(path: Path) -> tuple[str, int]:
     return f"sha256:{h.hexdigest()}", size
 
 
+def default_hash_workers() -> int:
+    """Thread count for parallel local-file hashing.
+
+    Whole-file (and NIRCam SCI+DQ) hashing of a field's worth of exposures is
+    I/O-bound — the reads overlap well across threads, so a small pool cuts the
+    serial hash time to a fraction. Sized off the CPU count and capped so we
+    don't thrash a spinning disk with too many concurrent large reads.
+    """
+    return min(16, (os.cpu_count() or 4) * 2)
+
+
+def hash_files_parallel(
+    paths: Iterable[Path], *, max_workers: Optional[int] = None,
+) -> dict[Path, tuple[str, int]]:
+    """Hash many local files concurrently → ``{path: ('sha256:<hex>', size)}``.
+
+    Order-independent (callers key by path). De-duplicates repeated paths so a
+    file is hashed once. Falls back to a serial loop for a single file.
+    """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    unique = list({Path(p) for p in paths})
+    if not unique:
+        return {}
+    workers = max(1, min(max_workers or default_hash_workers(), len(unique)))
+    if workers == 1:
+        return {p: hash_file(p) for p in unique}
+    out: dict[Path, tuple[str, int]] = {}
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        futures = {ex.submit(hash_file, p): p for p in unique}
+        for fut in as_completed(futures):
+            out[futures[fut]] = fut.result()
+    return out
+
+
 def normalize_sha256(file_hash: str | None) -> str | None:
     """Coerce a stored file hash to a single ``'sha256:<hex>'`` content_hash token.
 
@@ -231,6 +266,7 @@ def build_registry_rows(
     cfpipe_version: Optional[str] = None,
     succeeded_keys: Optional[set[str]] = None,
     sci_dq_hashes: Optional[dict[str, str]] = None,
+    max_workers: Optional[int] = None,
 ) -> list[dict]:
     """Build ``storage_objects`` rows for the objects an upload actually landed.
 
@@ -238,20 +274,30 @@ def build_registry_rows(
     all, if ``succeeded_keys`` is None), hashes the local file and maps the key
     to a row via :func:`row_for_key`. Tiles and non-cloud products are skipped.
 
+    The whole-file hashing runs across a thread pool (``max_workers``, default
+    :func:`default_hash_workers`) — for a field's worth of exposures this
+    registration read is I/O-bound and was a serial bottleneck after upload.
+
     ``sci_dq_hashes`` optionally supplies a precomputed ``sha256:<hex>`` science-only
     digest per storage key (NIRCam exposures, epic #261) — the ``content_hash`` is
     still the whole-file sha256, but ``sci_dq_hash`` carries the science-only digest
     that change-detection compares against.
     """
     sci_dq_hashes = sci_dq_hashes or {}
-    rows: list[dict] = []
+    selected: list[tuple[UploadTask, Path]] = []
     for task in tasks:
         if succeeded_keys is not None and task.r2_key not in succeeded_keys:
             continue
         local = Path(task.local_path)
         if not local.exists():
             continue
-        content_hash, size_bytes = hash_file(local)
+        selected.append((task, local))
+
+    hashed = hash_files_parallel((local for _, local in selected), max_workers=max_workers)
+
+    rows: list[dict] = []
+    for task, local in selected:
+        content_hash, size_bytes = hashed[local]
         row = row_for_key(
             task.r2_key,
             backend=backend,

--- a/python/tests/test_nircam_deploy.py
+++ b/python/tests/test_nircam_deploy.py
@@ -274,3 +274,28 @@ def test_discover_mosaics_multiunderscore_field(tmp_path):
     assert found[0]["tile"] == "t2"
     assert found[0]["storage_key"].endswith(
         "ember_egs_p1/f356w/mosaic_nircam_f356w_ember_egs_p1_30mas_t2_i2d.fits")
+
+
+# --- parallel sci_dq hashing + upload-worker tuning (deploy speed) -----------
+
+def test_compute_sci_dq_hashes_matches_serial(tmp_path):
+    sci = np.arange(16, dtype="float32").reshape(4, 4)
+    dq = np.zeros((4, 4), dtype="int32")
+    tasks = []
+    for i in range(5):
+        p = _make_exposure(tmp_path / f"jw_{i}.fits", sci + i, dq)
+        tasks.append(UploadTask(local_path=p, r2_key=f"k{i}", content_type="application/fits"))
+    serial = {t.r2_key: nc._sci_dq_hash(t.local_path) for t in tasks}
+    assert nc._compute_sci_dq_hashes(tasks) == serial
+    assert nc._compute_sci_dq_hashes([]) == {}
+
+
+def test_upload_workers_env_override(monkeypatch):
+    monkeypatch.delenv("CAMPFIRE_DEPLOY_UPLOAD_WORKERS", raising=False)
+    assert nc._upload_workers() == 16
+    monkeypatch.setenv("CAMPFIRE_DEPLOY_UPLOAD_WORKERS", "24")
+    assert nc._upload_workers() == 24
+    monkeypatch.setenv("CAMPFIRE_DEPLOY_UPLOAD_WORKERS", "0")
+    assert nc._upload_workers() == 1            # clamped to >= 1
+    monkeypatch.setenv("CAMPFIRE_DEPLOY_UPLOAD_WORKERS", "not-a-number")
+    assert nc._upload_workers() == 16           # falls back to default

--- a/python/tests/test_registry.py
+++ b/python/tests/test_registry.py
@@ -255,3 +255,23 @@ def test_reconcile_matches_legacy_pointer_to_canonical_registry_key():
     rep3 = reg.compute_reconcile([legacy, other], [canonical])
     assert rep3.missing == {other}
     assert not rep3.covered
+
+
+# --- parallel hashing (deploy speed, no behaviour change) --------------------
+
+def test_hash_files_parallel_matches_serial(tmp_path):
+    paths = []
+    for i in range(6):
+        p = tmp_path / f"f{i}.bin"
+        p.write_bytes(bytes([i]) * (1000 * (i + 1)))
+        paths.append(p)
+    serial = {p: reg.hash_file(p) for p in paths}
+    parallel = reg.hash_files_parallel(paths, max_workers=4)
+    assert parallel == serial
+    # de-duplicates repeated paths and hashes each once
+    assert reg.hash_files_parallel([paths[0], paths[0]]) == {paths[0]: serial[paths[0]]}
+    assert reg.hash_files_parallel([]) == {}
+
+
+def test_default_hash_workers_positive():
+    assert reg.default_hash_workers() >= 1


### PR DESCRIPTION
## Summary

Optimize NIRCam deployment performance by parallelizing file hashing operations and adding content-hash deduplication for preview PNGs, reducing redundant uploads and the "pause before uploading" bottleneck.

## Key Changes

- **Parallel SCI+DQ hashing**: Added `_compute_sci_dq_hashes()` to hash exposure science+DQ digests concurrently using a thread pool, reducing the dominant pre-upload cost from serial to fractional time
- **Parallel file hashing in registry**: Extracted `hash_files_parallel()` and `default_hash_workers()` utilities to the registry module for reuse across deployment paths (exposures, mosaics, PNGs)
- **PNG content-hash deduplication**: Implemented dedup logic for preview PNGs mirroring the existing FITS/mosaic approach—skip re-uploading byte-identical PNGs while keeping registry references correct
- **Configurable upload concurrency**: Added `_upload_workers()` function (default 16, up from shared helper's 12) with `CAMPFIRE_DEPLOY_UPLOAD_WORKERS` environment override to tune network-bound upload streams
- **Registry refactoring**: Updated `build_registry_rows()` to hash files in parallel via thread pool rather than serially, and pass `max_workers` through the call chain
- **Mosaic hashing optimization**: Switched mosaic hashing from serial `hash_file()` calls to `hash_files_parallel()` for multi-GB files

## Implementation Details

- I/O-bound hashing operations use thread pools (not processes) to overlap disk reads across threads
- Thread count capped at `min(16, cpu_count * 2)` to avoid thrashing spinning disks with too many concurrent large reads
- Deduplication gracefully handles failures: per-file read errors record `None` (never dedup on them), matching serial behavior
- PNG dedup skips unchanged files but still registers them correctly in the deployment, maintaining referential integrity
- Skipped objects (both FITS and PNGs) are re-pointed to the current deployment on published (non-draft) re-deploys for consistent field state
- Tests verify parallel hashing matches serial results and environment variable override behavior

https://claude.ai/code/session_01Lx5iBibN6kL4B5KDagQjRf