### PR TITLE
Render SNR instead of raw SCI in NIRCam preview PNGs

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -38,7 +38,11 @@ Release procedure: edit the `## Unreleased` section below, then run
   surfacing the pixels that actually warrant a hand mask rather than every
   bright-but-already-downweighted artifact. Quick-look only; no change to FITS
   pixel values, DQ, or the `_preview.png`/`_full.png` filenames the web mask
-  editor consumes (`nircam/steps/preview.py`, `data/config_default.toml`).
+  editor consumes. Existing reductions upgrade automatically: `CFP_PREV` now
+  records a render-format marker (`snr`) and the skip check requires it, so a
+  normal `cfpipe nircam process` re-renders exposures whose stamp predates this
+  change without needing `--overwrite` (`nircam/steps/preview.py`,
+  `data/config_default.toml`).
 - NIRCam fields gain an optional field-level `fiducial_tiles = ["A1", "A2", …]`
   declaration in `fields.toml` — the subset of a field's tiles that share a
   tangent point + rotation and span the field, forming the FitsGL field-composite

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -29,6 +29,17 @@ Release procedure: edit the `## Unreleased` section below, then run
 ## Unreleased
 
 ### Infrastructure
+- NIRCam per-exposure triage previews (`{rootname}_preview.png` /
+  `{rootname}_full.png`) now render per-pixel **SNR** (`SCI/ERR`) instead of raw
+  SCI, with a fixed σ-unit stretch (`[nircam.preview].snr_vmin`/`snr_vmax`,
+  defaults `-2`/`10`). The `jump` step drops snowball/cosmic-ray groups from the
+  ramp fit, inflating `VAR_RNOISE`→`ERR` on those pixels, so an SNR view sinks a
+  correctly error-weighted snowball back into the noise floor while leaving
+  residuals the error model under-weights visibly significant — surfacing the
+  pixels that actually warrant a hand mask rather than every bright-but-already-
+  downweighted artifact. Quick-look only; no change to FITS pixel values, DQ, or
+  the `_preview.png`/`_full.png` filenames the web mask editor consumes
+  (`nircam/steps/preview.py`, `data/config_default.toml`).
 - NIRCam fields gain an optional field-level `fiducial_tiles = ["A1", "A2", …]`
   declaration in `fields.toml` — the subset of a field's tiles that share a
   tangent point + rotation and span the field, forming the FitsGL field-composite

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -31,15 +31,14 @@ Release procedure: edit the `## Unreleased` section below, then run
 ### Infrastructure
 - NIRCam per-exposure triage previews (`{rootname}_preview.png` /
   `{rootname}_full.png`) now render per-pixel **SNR** (`SCI/ERR`) instead of raw
-  SCI, with a fixed σ-unit stretch (`[nircam.preview].snr_vmin`/`snr_vmax`,
-  defaults `-2`/`10`). The `jump` step drops snowball/cosmic-ray groups from the
-  ramp fit, inflating `VAR_RNOISE`→`ERR` on those pixels, so an SNR view sinks a
-  correctly error-weighted snowball back into the noise floor while leaving
-  residuals the error model under-weights visibly significant — surfacing the
-  pixels that actually warrant a hand mask rather than every bright-but-already-
-  downweighted artifact. Quick-look only; no change to FITS pixel values, DQ, or
-  the `_preview.png`/`_full.png` filenames the web mask editor consumes
-  (`nircam/steps/preview.py`, `data/config_default.toml`).
+  SCI (still ZScale-stretched). The `jump` step drops snowball/cosmic-ray groups
+  from the ramp fit, inflating `VAR_RNOISE`→`ERR` on those pixels, so an SNR view
+  sinks a correctly error-weighted snowball back into the noise floor while
+  leaving residuals the error model under-weights visibly significant —
+  surfacing the pixels that actually warrant a hand mask rather than every
+  bright-but-already-downweighted artifact. Quick-look only; no change to FITS
+  pixel values, DQ, or the `_preview.png`/`_full.png` filenames the web mask
+  editor consumes (`nircam/steps/preview.py`, `data/config_default.toml`).
 - NIRCam fields gain an optional field-level `fiducial_tiles = ["A1", "A2", …]`
   declaration in `fields.toml` — the subset of a field's tiles that share a
   tangent point + rotation and span the field, forming the FitsGL field-composite

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -305,10 +305,19 @@
 
 [nircam.preview]
     # Per-exposure quick-look PNG for the web admin triage UI. Read-only:
-    # downsamples SCI to ``max_dim`` long-axis pixels, ZScale-stretches,
-    # writes ``{rootname}_preview.png`` next to the canonical FITS.
+    # renders per-pixel SNR (SCI/ERR) — not raw SCI — downsampled to
+    # ``max_dim`` long-axis pixels, and writes ``{rootname}_preview.png``
+    # (thumbnail) + ``{rootname}_full.png`` (mask-editor canvas) next to the
+    # canonical FITS. SNR keeps the reviewer's eye on residuals the error
+    # model under-weights (real mask candidates) rather than on snowballs the
+    # jump step has already error-inflated and down-weighted.
     max_dim = 1024
     cmap = "Greys"
+    # Fixed SNR stretch (σ units). The noise floor is ~N(0,1); sources and
+    # under-weighted snowball residuals sit above it. Lower ``snr_vmax`` to
+    # make marginal residuals pop; raise it to keep bright source morphology.
+    snr_vmin = -2.0
+    snr_vmax = 10.0
 
 [nircam.jhat]
     verbose = true

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -306,18 +306,14 @@
 [nircam.preview]
     # Per-exposure quick-look PNG for the web admin triage UI. Read-only:
     # renders per-pixel SNR (SCI/ERR) — not raw SCI — downsampled to
-    # ``max_dim`` long-axis pixels, and writes ``{rootname}_preview.png``
-    # (thumbnail) + ``{rootname}_full.png`` (mask-editor canvas) next to the
-    # canonical FITS. SNR keeps the reviewer's eye on residuals the error
-    # model under-weights (real mask candidates) rather than on snowballs the
-    # jump step has already error-inflated and down-weighted.
+    # ``max_dim`` long-axis pixels, ZScale-stretches, and writes
+    # ``{rootname}_preview.png`` (thumbnail) + ``{rootname}_full.png``
+    # (mask-editor canvas) next to the canonical FITS. SNR keeps the reviewer's
+    # eye on residuals the error model under-weights (real mask candidates)
+    # rather than on snowballs the jump step has already error-inflated and
+    # down-weighted.
     max_dim = 1024
     cmap = "Greys"
-    # Fixed SNR stretch (σ units). The noise floor is ~N(0,1); sources and
-    # under-weighted snowball residuals sit above it. Lower ``snr_vmax`` to
-    # make marginal residuals pop; raise it to keep bright source morphology.
-    snr_vmin = -2.0
-    snr_vmax = 10.0
 
 [nircam.jhat]
     verbose = true

--- a/pipeline/campfire_pipeline/nircam/steps/preview.py
+++ b/pipeline/campfire_pipeline/nircam/steps/preview.py
@@ -30,7 +30,12 @@ pixels they are deciding to keep or drop without alignment-related warps
 hiding artifacts.
 
 Read-only with respect to pixel data — no SCI/DQ/ERR mutation. Stamps
-``CFP_PREV`` with an ISO timestamp.
+``CFP_PREV`` with the render-format marker ``snr`` (not a bare timestamp).
+The skip check requires that marker, so a canonical file carrying an *old*
+``CFP_PREV`` value (an ISO timestamp from the pre-SNR raw-SCI renderer) is
+treated as stale and re-rendered on the next ``process`` run — no
+``--overwrite`` needed. Bumping this marker is how a future preview-format
+change forces regeneration.
 """
 
 import os
@@ -41,6 +46,12 @@ from campfire_pipeline.common.io import log, atomic_save
 from campfire_pipeline.common import cfp
 from campfire_pipeline.nircam.steps._plots import _block_reduce, _zscale_limits
 
+# Render-format marker stamped into ``CFP_PREV``. The skip check requires it, so
+# a canonical file whose ``CFP_PREV`` predates the SNR renderer (a bare ISO
+# timestamp) is regenerated rather than served stale. Bump this on any future
+# preview-format change to force a one-time regeneration.
+_PREVIEW_KIND = 'snr'
+
 
 def preview_step(exposure_file, field, step_config, overwrite=False,
                  status=None):
@@ -50,12 +61,22 @@ def preview_step(exposure_file, field, step_config, overwrite=False,
     thumb_path = os.path.join(out_dir, f'{rootname}_preview.png')
     full_path = os.path.join(out_dir, f'{rootname}_full.png')
 
-    # Both the header stamp and *both* PNGs must exist for a skip — if either
-    # was deleted out-of-band, regenerate.
-    if (os.path.exists(thumb_path) and os.path.exists(full_path)
-            and cfp.should_skip(exposure_file, 'CFP_PREV', rootname,
-                                'preview', status, overwrite)):
-        return
+    # Skip only when NOT overwriting, *both* PNGs exist (regenerate if either was
+    # deleted out-of-band), and the recorded CFP_PREV marks the current render
+    # format. A pre-SNR stamp (ISO timestamp) fails the marker test and falls
+    # through to re-render, so upgrading and re-running `process` replaces stale
+    # raw-SCI previews without `--overwrite`. The status cache only tracks key
+    # *presence*, so the one value read happens solely on genuine re-runs (both
+    # PNGs already present), not on fresh exposures.
+    if not overwrite and os.path.exists(thumb_path) and os.path.exists(full_path):
+        has_prev = (status.has(exposure_file, 'CFP_PREV') if status is not None
+                    else cfp.has_step(exposure_file, 'CFP_PREV'))
+        if has_prev and str(
+                cfp.step_value(exposure_file, 'CFP_PREV')).startswith(
+                    _PREVIEW_KIND):
+            log(f"Skipping preview on {rootname}: CFP_PREV ({_PREVIEW_KIND}) "
+                f"already set")
+            return
 
     log(f"Rendering SNR preview for {rootname}")
 
@@ -82,7 +103,7 @@ def preview_step(exposure_file, field, step_config, overwrite=False,
 
         atomic_save(
             model, exposure_file,
-            header_updates=cfp.format(CFP_PREV=None),
+            header_updates=cfp.format(CFP_PREV=_PREVIEW_KIND),
         )
 
     h_d, w_d = snr_d.shape

--- a/pipeline/campfire_pipeline/nircam/steps/preview.py
+++ b/pipeline/campfire_pipeline/nircam/steps/preview.py
@@ -18,11 +18,10 @@ reviewer's eye is drawn to what actually warrants a hand mask, not to every
 bright-but-already-downweighted artifact. See the module change in
 ``pipeline/CHANGELOG.md``.
 
-Both PNGs use the same **fixed** SNR stretch (``snr_vmin``/``snr_vmax`` from
-``[nircam.preview]``) so contrast is in absolute σ units and comparable across
-exposures, and both are ``origin='lower'`` so PNG row 0 corresponds to
-``data[H-1, :]`` — the polygon editor's canvas inverts ``y`` accordingly when
-round-tripping to DS9 ``image`` coords.
+Both PNGs use the same ZScale stretch computed on the downsampled SNR map (so
+the editor and the thumbnail look identical), and both are ``origin='lower'`` so
+PNG row 0 corresponds to ``data[H-1, :]`` — the polygon editor's canvas inverts
+``y`` accordingly when round-tripping to DS9 ``image`` coords.
 
 Runs as the penultimate process step, just before ``jhat``: the preview
 captures the data state after all per-exposure SCI mutations (wisp, 1/f,
@@ -40,7 +39,7 @@ import numpy as np
 
 from campfire_pipeline.common.io import log, atomic_save
 from campfire_pipeline.common import cfp
-from campfire_pipeline.nircam.steps._plots import _block_reduce
+from campfire_pipeline.nircam.steps._plots import _block_reduce, _zscale_limits
 
 
 def preview_step(exposure_file, field, step_config, overwrite=False,
@@ -64,21 +63,19 @@ def preview_step(exposure_file, field, step_config, overwrite=False,
 
     max_dim = int(step_config.get('max_dim', 1024))
     cmap = step_config.get('cmap', 'Greys')
-    # Fixed stretch in σ units so snowball residuals read at their true
-    # significance and contrast is comparable across exposures.
-    vmin = float(step_config.get('snr_vmin', -2.0))
-    vmax = float(step_config.get('snr_vmax', 10.0))
 
     with ImageModel(exposure_file) as model:
         snr = _snr_map(np.asarray(model.data, dtype=np.float64),
                        np.asarray(model.err, dtype=np.float64))
 
-        # Full-res render is the mask-editor canvas; the thumbnail is a
-        # block-mean downsample of the same SNR map. Both share the fixed
-        # stretch so the editor and the table thumbnail look identical.
+        # ZScale is computed on the downsampled SNR map (fast, robust) and
+        # reused for the full-res render so both PNGs share contrast. The
+        # full-res render is the mask-editor canvas; the thumbnail is a
+        # block-mean downsample of the same SNR map.
         long_axis = max(snr.shape)
         block_size = max(1, int(np.ceil(long_axis / max_dim)))
         snr_d = _block_reduce(snr, block_size)
+        vmin, vmax = _zscale_limits(snr_d)
 
         _atomic_imsave(thumb_path, snr_d, cmap=cmap, vmin=vmin, vmax=vmax)
         _atomic_imsave(full_path,  snr,   cmap=cmap, vmin=vmin, vmax=vmax)

--- a/pipeline/campfire_pipeline/nircam/steps/preview.py
+++ b/pipeline/campfire_pipeline/nircam/steps/preview.py
@@ -1,18 +1,28 @@
 """
 preview: render per-exposure quick-look PNGs for web admin triage.
 
-Per-exposure step. Reads SCI from the canonical exposure and writes two PNGs
-next to the canonical FITS file:
+Per-exposure step. Renders **per-pixel SNR** (``SCI / ERR``) — not raw SCI —
+and writes two PNGs next to the canonical FITS file:
 
   * ``{rootname}_preview.png`` — downsampled (long-axis ``max_dim``) for the
     admin table thumbnail
   * ``{rootname}_full.png`` — native-resolution, used as the canvas for the
     in-browser polygon mask editor
 
-Both use the same ZScale stretch computed on the downsampled array (so the
-editor and the thumbnail look identical), and both are ``origin='lower'`` so
-PNG row 0 corresponds to ``data[H-1, :]`` — the polygon editor's canvas
-inverts ``y`` accordingly when round-tripping to DS9 ``image`` coords.
+SNR (rather than SCI) is deliberate: the ``jump`` step drops snowball/cosmic-ray
+groups from the ramp fit, which inflates ``VAR_RNOISE`` → ``ERR`` on the
+affected pixels. In an SNR render a snowball that the pipeline has already
+error-weighted correctly sinks back into the ~N(0,1) noise floor, while a
+residual the error model *under*-weights stays visibly significant — so the
+reviewer's eye is drawn to what actually warrants a hand mask, not to every
+bright-but-already-downweighted artifact. See the module change in
+``pipeline/CHANGELOG.md``.
+
+Both PNGs use the same **fixed** SNR stretch (``snr_vmin``/``snr_vmax`` from
+``[nircam.preview]``) so contrast is in absolute σ units and comparable across
+exposures, and both are ``origin='lower'`` so PNG row 0 corresponds to
+``data[H-1, :]`` — the polygon editor's canvas inverts ``y`` accordingly when
+round-tripping to DS9 ``image`` coords.
 
 Runs as the penultimate process step, just before ``jhat``: the preview
 captures the data state after all per-exposure SCI mutations (wisp, 1/f,
@@ -30,12 +40,12 @@ import numpy as np
 
 from campfire_pipeline.common.io import log, atomic_save
 from campfire_pipeline.common import cfp
-from campfire_pipeline.nircam.steps._plots import _block_reduce, _zscale_limits
+from campfire_pipeline.nircam.steps._plots import _block_reduce
 
 
 def preview_step(exposure_file, field, step_config, overwrite=False,
                  status=None):
-    """Render thumbnail + native-res preview PNGs for a single exposure."""
+    """Render thumbnail + native-res SNR preview PNGs for a single exposure."""
     rootname = os.path.basename(exposure_file).removesuffix('.fits')
     out_dir = os.path.dirname(exposure_file)
     thumb_path = os.path.join(out_dir, f'{rootname}_preview.png')
@@ -48,36 +58,53 @@ def preview_step(exposure_file, field, step_config, overwrite=False,
                                 'preview', status, overwrite)):
         return
 
-    log(f"Rendering preview for {rootname}")
+    log(f"Rendering SNR preview for {rootname}")
 
-    import matplotlib.pyplot as plt
     from jwst.datamodels import ImageModel
 
     max_dim = int(step_config.get('max_dim', 1024))
     cmap = step_config.get('cmap', 'Greys')
+    # Fixed stretch in σ units so snowball residuals read at their true
+    # significance and contrast is comparable across exposures.
+    vmin = float(step_config.get('snr_vmin', -2.0))
+    vmax = float(step_config.get('snr_vmax', 10.0))
 
     with ImageModel(exposure_file) as model:
-        sci = np.asarray(model.data)
+        snr = _snr_map(np.asarray(model.data, dtype=np.float64),
+                       np.asarray(model.err, dtype=np.float64))
 
-        # ZScale is computed on the downsampled array (fast, robust) and
-        # then reused for the full-res render so both PNGs share contrast.
-        long_axis = max(sci.shape)
+        # Full-res render is the mask-editor canvas; the thumbnail is a
+        # block-mean downsample of the same SNR map. Both share the fixed
+        # stretch so the editor and the table thumbnail look identical.
+        long_axis = max(snr.shape)
         block_size = max(1, int(np.ceil(long_axis / max_dim)))
-        sci_d = _block_reduce(sci, block_size)
-        vmin, vmax = _zscale_limits(sci_d)
+        snr_d = _block_reduce(snr, block_size)
 
-        _atomic_imsave(thumb_path, sci_d, cmap=cmap, vmin=vmin, vmax=vmax)
-        _atomic_imsave(full_path,  sci,    cmap=cmap, vmin=vmin, vmax=vmax)
+        _atomic_imsave(thumb_path, snr_d, cmap=cmap, vmin=vmin, vmax=vmax)
+        _atomic_imsave(full_path,  snr,   cmap=cmap, vmin=vmin, vmax=vmax)
 
         atomic_save(
             model, exposure_file,
             header_updates=cfp.format(CFP_PREV=None),
         )
 
-    h_d, w_d = sci_d.shape
-    h_f, w_f = sci.shape
-    log(f"Preview written: {os.path.basename(thumb_path)} ({w_d}×{h_d}), "
+    h_d, w_d = snr_d.shape
+    h_f, w_f = snr.shape
+    log(f"SNR preview written: {os.path.basename(thumb_path)} ({w_d}×{h_d}), "
         f"{os.path.basename(full_path)} ({w_f}×{h_f})")
+
+
+def _snr_map(sci, err):
+    """Per-pixel SNR = SCI / ERR, with non-finite / zero-ERR pixels set to 0.
+
+    ERR is zero or non-finite on masked / zero-coverage pixels (and can be
+    ``inf`` where the background step sets a degenerate variance); dividing
+    those through would poison the render, so they collapse to 0 — the noise
+    floor — which keeps the mask-editor canvas fully filled.
+    """
+    with np.errstate(divide='ignore', invalid='ignore'):
+        snr = sci / err
+    return np.where(np.isfinite(snr), snr, 0.0)
 
 
 def _atomic_imsave(out_path, arr, *, cmap, vmin, vmax):


### PR DESCRIPTION
## Summary
Changes the NIRCam per-exposure preview PNG rendering to display per-pixel SNR (SCI/ERR) instead of raw SCI values. This improves triage by visually de-emphasizing snowballs and cosmic rays that the pipeline has already error-weighted and downweighted, while keeping residuals that are under-weighted by the error model visibly significant.

## Key Changes
- **preview.py**: Modified `preview_step()` to compute SNR maps from SCI and ERR arrays before rendering
  - Added `_snr_map()` helper function that safely computes SCI/ERR, collapsing non-finite and zero-ERR pixels to 0
  - Updated ZScale stretch computation to operate on SNR data instead of raw SCI
  - Both thumbnail and full-resolution PNGs now render the same SNR map with shared contrast limits
  - Updated docstrings and log messages to reflect SNR rendering

- **config_default.toml**: Updated `[nircam.preview]` section documentation to explain SNR rendering rationale and clarify that both `_preview.png` (thumbnail) and `_full.png` (mask-editor canvas) are generated

- **CHANGELOG.md**: Added infrastructure note documenting the SNR rendering change, its motivation (jump step error inflation), and impact (quick-look only; no FITS changes)

## Implementation Details
- SNR computation uses `np.errstate` to safely handle division by zero and non-finite values
- Non-finite SNR values (from masked pixels, zero coverage, or degenerate variance) are set to 0 to keep the canvas fully filled
- The downsampled SNR map is used for ZScale limit computation (fast and robust), then reused for both thumbnail and full-resolution renders to ensure consistent contrast
- No changes to FITS pixel values, DQ arrays, or output filenames

https://claude.ai/code/session_01WcGsYChfJNxAEttYGCnMcw