### PR TITLE
FitsGL Phase 3 — backend + tracking (`campfire fitsgl deploy`, `fitsgl_datasets`)

### DIFF
--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -764,6 +764,16 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
             items=len(records), draft=draft,
             fits_uploaded=len(osn_uploaded), fits_skipped=n_skipped))
 
+    # If the field's FitsGL map pyramid is missing or its mosaics changed, print a
+    # suggested `campfire fitsgl build/deploy` — a hint only, never an auto-build
+    # (pyramid builds are expensive; epic #337, Phase 3). Best-effort + fully guarded
+    # so a missing fitsgl extra / dataset table never touches the deploy result.
+    try:
+        from campfire.fitsgl.deploy import suggest_fitsgl_rebuild
+        suggest_fitsgl_rebuild(client, field)
+    except Exception:
+        pass
+
 
 def _upsert_exposures(client, records, batch_size=500):
     """Upsert exposure records, preserving web-triage fields for existing rows.

--- a/python/campfire/fitsgl/__init__.py
+++ b/python/campfire/fitsgl/__init__.py
@@ -1,6 +1,9 @@
 """FitsGL producer integration for CAMPFIRE (epic #337).
 
-Builds (and, in later phases, deploys) FitsGL FITS tile-pyramid datasets for the
-map/cutout service. Requires the ``campfire[fitsgl]`` extra for the actual build;
-the pure config-generation layer in :mod:`campfire.fitsgl.build` imports no FitsGL.
+Builds and deploys FitsGL FITS tile-pyramid datasets for the map/cutout service:
+:mod:`campfire.fitsgl.build` (Phase 2) generates a ``fitsgl.toml`` and calls the
+producer's ``build_dataset``; :mod:`campfire.fitsgl.deploy` (Phase 3) pushes a built
+dataset to the campfire-tiles bucket and upserts a ``fitsgl_datasets`` row. Both
+require the ``campfire[fitsgl]`` extra for the FitsGL calls; their pure layers
+(config generation, prefix/row/source-hash assembly) import no FitsGL.
 """

--- a/python/campfire/fitsgl/build.py
+++ b/python/campfire/fitsgl/build.py
@@ -48,8 +48,10 @@ def select_mosaics(dirs, field, filters, *, pixel_scale, tiles=None):
     (filter, tile): full-field mosaics matching ``pixel_scale`` (the string form,
     e.g. ``'30mas'``) and — when ``tiles`` is given — whose tile is in that set.
     Within a (filter, tile) the science image is chosen by
-    :data:`_EXTENSION_PREFERENCE` (``sci`` then ``i2d``). Returns a list of
-    ``{path, filter, tile, pixel_scale, extension}`` dicts.
+    :data:`_EXTENSION_PREFERENCE` (``sci`` then ``i2d``). Returns the underlying
+    ``discover_mosaics`` dicts unchanged — ``{path, filter, tile, pixel_scale, epoch,
+    extension, storage_key}`` (``storage_key`` is consumed by the deploy source-hash
+    path, so keep it on the passthrough).
     """
     from campfire.deploy.nircam import discover_mosaics
 

--- a/python/campfire/fitsgl/cli.py
+++ b/python/campfire/fitsgl/cli.py
@@ -1,13 +1,16 @@
 """Click CLI for `campfire fitsgl` (epic #337).
 
 Registered lazily by ``campfire.cli`` (like ``deploy``) so the base client never
-imports the FitsGL producer. Phase 2 ships ``build``; ``deploy`` follows in Phase 3.
+imports the FitsGL producer. Phase 2 ships ``build``; Phase 3 adds ``deploy``.
 
 Usage:
-    campfire fitsgl build --field cosmos
-    campfire fitsgl build --field cosmos --pixel-scale 30mas
-    campfire fitsgl build --field cosmos --tile PRIMER      # single-tile / off-grid
+    campfire fitsgl build  --field cosmos
+    campfire fitsgl build  --field cosmos --tile PRIMER      # single-tile / off-grid
+    campfire fitsgl deploy --field cosmos                    # composite → campfire-tiles
+    campfire fitsgl deploy --field cosmos --tile PRIMER      # single tile
 """
+
+import os
 
 import click
 
@@ -46,4 +49,53 @@ def build_cmd(field, tile, pixel_scale, processes, out_dir, overwrite):
     _build.run_build(
         field, pixel_scale=pixel_scale, tile=tile, processes=processes,
         overwrite=overwrite, out_dir=out_dir,
+    )
+
+
+@fitsgl_group.command('deploy')
+@click.option('--field', required=True, help='NIRCam field name (e.g. cosmos).')
+@click.option('--tile', default=None,
+              help='Deploy a single-tile standalone dataset instead of the composite.')
+@click.option('--pixel-scale', default='30mas', show_default=True,
+              help='Pixel scale of the built dataset (recorded on the fitsgl_datasets row).')
+@click.option('--viewer-origin', default='*', show_default=True,
+              help='CORS Allow-Origin set on the tiles bucket. Default "*" (public, '
+                   'derived data; also covers preview deploys with dynamic origins).')
+@click.option('--out-dir', default=None,
+              help='Dataset output root (default: $CAMPFIRE_ROOT/fitsgl).')
+@click.option('--dry-run', is_flag=True,
+              help='Show FitsGL\'s upload/delete/purge plan without writing anything.')
+@click.option('--config', 'config_path', default=None,
+              help='Deploy config TOML (default: $CAMPFIRE_ROOT/config/config.toml).')
+@click.option('--local', is_flag=True,
+              help='Use local Supabase (127.0.0.1:54321) + local CAMPFIRE_S3_TILES_* creds.')
+@click.option('--service-role', 'service_role', is_flag=True,
+              help='Authenticate to Supabase with a service-role key and use local '
+                   'CAMPFIRE_S3_TILES_* creds (unattended / CI). Equivalent to '
+                   'CAMPFIRE_DEPLOY_MODE=service-role.')
+def deploy_cmd(field, tile, pixel_scale, viewer_origin, out_dir, dry_run,
+               config_path, local, service_role):
+    """Deploy a built FitsGL dataset to campfire-tiles + upsert its fitsgl_datasets row.
+
+    In the default `login` mode the CLI fetches the R2 tiles credentials from an
+    admin-gated web endpoint (you must `campfire login` as an admin) and hands them to
+    FitsGL. The dataset row's visibility derives from the backing mosaics'
+    deploy_status, so deploying against draft mosaics surfaces nothing publicly until
+    they publish. Re-deploy of unchanged data is an incremental no-op.
+    """
+    from campfire.deploy.cli import _gate_admin
+    from campfire.deploy.config import load_config
+    from campfire.deploy.supabase import get_supabase_client
+    from campfire.fitsgl import deploy as _deploy
+
+    if service_role:
+        os.environ['CAMPFIRE_DEPLOY_MODE'] = 'service-role'
+    config = load_config(config_path, local=local, service_role=service_role)
+    if not local:
+        _gate_admin(config)  # no-ops under service-role / local (they bypass RLS)
+    client = get_supabase_client(config)
+
+    _deploy.run_deploy(
+        field, config=config, client=client, tile=tile, pixel_scale=pixel_scale,
+        viewer_origin=viewer_origin, dry_run=dry_run, out_dir=out_dir,
     )

--- a/python/campfire/fitsgl/deploy.py
+++ b/python/campfire/fitsgl/deploy.py
@@ -1,0 +1,377 @@
+"""Deploy a FitsGL tile-pyramid dataset to the campfire-tiles bucket (epic #337, Phase 3).
+
+`campfire fitsgl deploy` takes a dataset built by `campfire fitsgl build`, pushes it to
+R2 under a per-field/tile prefix via FitsGL's ``deploy_dataset`` (called as a library),
+and upserts a thin ``fitsgl_datasets`` row the web map reads. That row carries no
+lifecycle column of its own — its public visibility DERIVES from the backing mosaics'
+``nircam_images.deploy_status`` (RLS), so a deploy against still-draft mosaics never
+surfaces a public manifest.
+
+Credentials, per Supabase auth mode:
+
+* ``login`` (default) — the admin machine holds no tiles keys, so the CLI fetches them
+  from the admin-gated web endpoint (``/deploy/tiles-credentials``) and constructs
+  FitsGL's boto3 ``R2Target`` itself. FitsGL's deploy GETs the prior ledger, DELETEs
+  orphaned supertiles, and calls ``put_bucket_cors`` — operations a presigned PutObject
+  URL cannot express, which is why this can't ride the ``/deploy/presign`` path. Bounded
+  relaxation of #250: tiles bucket only (public, derived data), never the ``data`` bucket.
+* ``service-role`` / ``local`` — read local ``CAMPFIRE_S3_TILES_*`` via ``resolve_backend``.
+
+Split like ``build.py``: a **pure** layer (prefix / DeployConfig-kwargs / dataset-row /
+source-hash assembly — no fitsgl, no network, unit-testable) and an **orchestration**
+layer (``run_deploy``) that defers the ``import fitsgl`` behind the ``campfire[fitsgl]``
+extra.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import click
+
+# The tiles-bucket key namespace for FitsGL datasets. Disjoint from the PNG tile
+# keyspace (``<field>/<filter>/<z>/<x>/<y>.png`` — campfire-layout's ``tile`` product)
+# because everything here lives under a ``fitsgl/`` root that no field name collides
+# with, so FitsGL's prefix-scoped ledger diff/delete never touches the PNG pyramid.
+# Composite and per-tile datasets are sibling prefixes (neither an ancestor of the
+# other), so a per-tile ledger delete can't reach the composite's objects.
+_FITSGL_ROOT = 'fitsgl'
+_SCHEMA_VERSION = 1
+
+
+# ---------------------------------------------------------------------------
+# Pure layer (no fitsgl import, no network; unit-tested without real data)
+# ---------------------------------------------------------------------------
+
+def dataset_prefix(field, tile=None):
+    """R2 key prefix for a field's fiducial composite (``tile=None``) or one tile."""
+    if tile is not None:
+        return f"{_FITSGL_ROOT}/{field}/tile/{tile}"
+    return f"{_FITSGL_ROOT}/{field}/composite"
+
+
+def dataset_name(field, tile=None):
+    """Local dataset dir name ``campfire fitsgl build`` wrote (mirrors build_fitsgl_toml)."""
+    return f"{field}__{tile}" if tile is not None else field
+
+
+def build_deploy_config(creds, prefix, *, viewer_origin='*'):
+    """DeployConfig kwargs for FitsGL, from resolved tiles creds + a dataset prefix.
+
+    ``public_url`` is ``<public_url_base>/<prefix>`` — FitsGL uploads an object to key
+    ``<prefix>/<path>`` and serves it at ``<public_url>/<path>`` (the workspace invariant
+    ``public_url == base/prefix``), so the two must be composed this way or the edge-purge
+    URLs drift from the uploaded keys. ``zone_id`` (optional) enables the Cloudflare edge
+    purge on re-deploy; without it (and ``CLOUDFLARE_API_TOKEN``) the purge is skipped.
+    Raises if the tiles backend has no ``public_url_base``.
+    """
+    base = creds.get('public_url_base')
+    if not base:
+        raise ValueError(
+            "tiles storage has no public_url_base — set CAMPFIRE_S3_TILES_PUBLIC_URL_BASE "
+            "(the CDN origin serving the tiles bucket) so the viewer can fetch the pyramid."
+        )
+    public_url = f"{base.rstrip('/')}/{prefix}"
+    return {
+        'bucket': creds['bucket'],
+        'endpoint': creds['endpoint'],
+        'public_url': public_url,
+        'prefix': prefix,
+        'viewer_origin': viewer_origin,
+        'zone_id': creds.get('cf_zone_id') or os.environ.get('CLOUDFLARE_ZONE_ID'),
+    }
+
+
+def fitsgl_json_url(public_url):
+    """The ``fitsgl.json`` URL the web viewer points ``<FitsViewer>`` at."""
+    return f"{public_url.rstrip('/')}/fitsgl.json"
+
+
+def compute_source_hashes(mosaics, hash_by_key):
+    """Nested ``{tile: {filter: 'sha256:..'}}`` of the mosaics a dataset was built from.
+
+    ``mosaics`` are ``select_mosaics()`` dicts (``tile`` / ``filter`` / ``storage_key``);
+    ``hash_by_key`` maps ``storage_key -> content_hash``. Mosaics with no known hash are
+    skipped (the caller decides whether that is fatal). Deterministic given its inputs.
+    """
+    out: dict[str, dict[str, str]] = {}
+    for m in mosaics:
+        h = hash_by_key.get(m['storage_key'])
+        if h:
+            out.setdefault(m['tile'], {})[m['filter']] = h
+    return out
+
+
+def dataset_row(*, field, tile, prefix, pixel_scale, fitsgl_json, bands, tiles,
+                source_hashes, is_default):
+    """Assemble the ``fitsgl_datasets`` upsert row (conflict target = ``prefix``)."""
+    return {
+        'prefix': prefix,
+        'field': field,
+        'kind': 'tile' if tile is not None else 'field',
+        'tile': tile,
+        'tiles': sorted(tiles),
+        'pixel_scale': pixel_scale,
+        'fitsgl_json_url': fitsgl_json,
+        'bands': list(bands),
+        'source_hashes': source_hashes,
+        'is_default': is_default,
+        'schema_version': _SCHEMA_VERSION,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Credentials + source hashes (touch the registry / web API)
+# ---------------------------------------------------------------------------
+
+def resolve_tiles_creds(config):
+    """Resolve tiles-bucket creds as a plain dict, per the resolved auth mode.
+
+    ``login`` (default): fetch from the admin-gated web endpoint (no local keys assumed).
+    ``service_role`` / ``local``: read local ``CAMPFIRE_S3_TILES_*`` via ``resolve_backend``.
+    Returns ``{endpoint, region, bucket, access_key_id, secret_access_key,
+    force_path_style, public_url_base}``.
+    """
+    mode = config.get('supabase', {}).get('_auth_mode', 'login')
+    if mode == 'login':
+        return fetch_tiles_credentials(config)
+    from campfire.deploy.backend import resolve_backend
+    b = resolve_backend(config, 'tiles')
+    return {
+        'endpoint': b.endpoint, 'region': b.region, 'bucket': b.bucket,
+        'access_key_id': b.access_key_id, 'secret_access_key': b.secret_access_key,
+        'force_path_style': b.force_path_style, 'public_url_base': b.public_url_base,
+    }
+
+
+def fetch_tiles_credentials(config):
+    """GET the R2 tiles creds from the admin-gated web endpoint (login mode)."""
+    import requests
+    from campfire.api.session import resolve_base_url
+    from campfire.auth.tokens import TokenManager
+
+    base_url = resolve_base_url()
+    tm = TokenManager(base_url=base_url)
+    if not tm.is_oauth():
+        raise RuntimeError(
+            "not logged in — run `campfire login` (or use --service-role with "
+            "CAMPFIRE_S3_TILES_* for unattended deploys)."
+        )
+    token = tm.get_valid_token()
+    if not token:
+        raise RuntimeError("login session expired — run `campfire login`.")
+    resp = requests.get(
+        f"{base_url}/deploy/tiles-credentials",
+        headers={'Authorization': f'Bearer {token}'}, timeout=30,
+    )
+    if resp.status_code == 403:
+        raise RuntimeError("tiles credentials require admin access.")
+    if resp.status_code == 404:
+        raise RuntimeError(
+            "tiles-credentials endpoint not found — the web app may predate Phase 3; "
+            "use --service-role with CAMPFIRE_S3_TILES_* instead."
+        )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def resolve_source_hashes(client, mosaics, *, local_fallback=True):
+    """Content-hash the mosaics a dataset is built from (registry first).
+
+    Prefers ``storage_objects.content_hash`` (what the last mosaic deploy recorded, and
+    what the deploy hook compares against) so multi-GB files aren't re-hashed. With
+    ``local_fallback=True`` (the deploy path) it hashes any not-yet-registered mosaic
+    locally so the recorded hashes are complete; with ``local_fallback=False`` (the
+    deploy-staleness hook, which must stay cheap on the hot path) it returns only the
+    registry-known hashes and lets the caller detect the gap. Returns
+    ``compute_source_hashes(...)``.
+    """
+    from campfire.deploy.registry import fetch_active_content_hashes, hash_files_parallel
+    keys = [m['storage_key'] for m in mosaics]
+    by_key = dict(fetch_active_content_hashes(client, keys)) if keys else {}
+    if local_fallback:
+        missing = [m for m in mosaics if m['storage_key'] not in by_key]
+        if missing:
+            local = hash_files_parallel([m['path'] for m in missing])
+            for m in missing:
+                by_key[m['storage_key']] = local[m['path']][0]
+    return compute_source_hashes(mosaics, by_key)
+
+
+def _hash_count(source_hashes):
+    """Number of ``(tile, filter)`` leaf hashes in a nested source_hashes dict."""
+    return sum(len(v) for v in source_hashes.values())
+
+
+def _select_dataset_mosaics(field, *, tile, pixel_scale):
+    """The mosaics backing a dataset — the same selection ``build`` fed to FitsGL.
+
+    Returns ``(mosaics, tiles, bands)``: ``select_mosaics`` dicts (each carrying a
+    ``storage_key``), the tile set, and the filter (band) list in build's blue→red
+    order. Empty ``mosaics`` means the source mosaics aren't on this machine, the
+    fiducial set is undeclared, or the fiducial/scale changed since build — the caller
+    decides whether that's fatal (``run_deploy``) or a skip (the staleness hook). Tile
+    resolution is guarded so a broken/removed fields.toml declaration degrades to "no
+    mosaics" rather than a traceback.
+    """
+    from campfire.deploy.nircam import _discover_filters, _resolve_nircam_dirs
+    from campfire.fitsgl.build import (
+        group_bands, resolve_fiducial_tiles, select_mosaics,
+    )
+    dirs = _resolve_nircam_dirs(field)
+    filters = _discover_filters(dirs) if dirs['products'].exists() else []
+    if tile is not None:
+        tiles = [tile]
+    else:
+        try:
+            tiles = resolve_fiducial_tiles(field, pixel_scale=pixel_scale)
+        except Exception:
+            tiles = []
+    mosaics = (select_mosaics(dirs, field, filters, pixel_scale=pixel_scale, tiles=tiles)
+               if filters and tiles else [])
+    bands = list(group_bands(mosaics, single_tile=(tile is not None)))
+    return mosaics, list(tiles), bands
+
+
+# ---------------------------------------------------------------------------
+# Orchestration (imports the registry + defers `import fitsgl`)
+# ---------------------------------------------------------------------------
+
+def run_deploy(field, *, config, client, tile=None, pixel_scale='30mas',
+               viewer_origin='*', dry_run=False, out_dir=None):
+    """Deploy one built FitsGL dataset to R2 and upsert its ``fitsgl_datasets`` row.
+
+    Requires the dataset to have been built (``campfire fitsgl build``) and — to record
+    ``source_hashes`` for the deploy-staleness hook — the backing mosaics to be present on
+    this machine (the build+deploy-on-one-machine workflow). ``dry_run`` prints FitsGL's
+    upload/delete/purge plan and writes nothing (no row).
+    """
+    from campfire.fitsgl.build import resolve_fitsgl_dir
+
+    out_root = resolve_fitsgl_dir(out_dir)
+    name = dataset_name(field, tile)
+    dataset_dir = out_root / name
+    if not (dataset_dir / 'fitsgl.json').is_file():
+        scope = f" --tile {tile}" if tile is not None else ""
+        click.echo(
+            f"Error: no built dataset at {dataset_dir}. Run "
+            f"`campfire fitsgl build --field {field}{scope}` first."
+        )
+        sys.exit(1)
+
+    mosaics, tiles, bands = _select_dataset_mosaics(field, tile=tile, pixel_scale=pixel_scale)
+    if not mosaics:
+        scope = f"tile {tile}" if tile is not None else f"fiducial tiles of '{field}'"
+        click.echo(
+            f"Error: no {pixel_scale} mosaics found for {scope} on this machine. Deploy "
+            f"from the same machine that built the dataset (source_hashes are read from "
+            f"the mosaics), or rebuild after fixing the fiducial/pixel-scale."
+        )
+        sys.exit(1)
+
+    source_hashes = resolve_source_hashes(client, mosaics)
+    prefix = dataset_prefix(field, tile)
+
+    # One dataset per prefix (a field has one composite at one chosen scale — design
+    # §5). Re-deploying at a different scale is a deliberate replace, but warn so it's
+    # never a silent surprise: the row is overwritten and FitsGL re-tiles the pyramid.
+    existing = (client.table('fitsgl_datasets').select('pixel_scale')
+                .eq('prefix', prefix).limit(1).execute())
+    if existing.data and existing.data[0]['pixel_scale'] != pixel_scale:
+        click.echo(f"  ⚠  replacing the existing {existing.data[0]['pixel_scale']} dataset "
+                   f"at this prefix with {pixel_scale} (its pyramid will be re-tiled).")
+
+    creds = resolve_tiles_creds(config)
+    dc_kwargs = build_deploy_config(creds, prefix, viewer_origin=viewer_origin)
+    json_url = fitsgl_json_url(dc_kwargs['public_url'])
+
+    scope = f"tile {tile}" if tile is not None else "fiducial composite"
+    click.echo(
+        f"Deploying FitsGL {scope} for '{field}' ({len(bands)} band(s)) "
+        f"→ {creds['bucket']}/{prefix}"
+    )
+
+    try:
+        from fitsgl.deploy import CloudflarePurge, DeployConfig, R2Target, deploy_dataset
+    except ImportError:
+        click.echo("FitsGL producer not installed. Run: pip install campfire[fitsgl]")
+        sys.exit(1)
+
+    deploy_cfg = DeployConfig(**dc_kwargs)
+    target = R2Target(
+        bucket=creds['bucket'], endpoint=creds['endpoint'],
+        access_key=creds['access_key_id'], secret_key=creds['secret_access_key'],
+        region=creds.get('region', 'auto'),
+    )
+    # Optional edge purge: supertile filenames are geometry-derived (not content-hashed),
+    # so a changed mosaic re-uses a filename and its edge copy must be evicted. Needs
+    # CLOUDFLARE_API_TOKEN + a zone id; absent them the purge is skipped (changed tiles
+    # serve stale until max-age) — first deploys are unaffected (nothing cached yet).
+    purger = CloudflarePurge.from_config(deploy_cfg)
+
+    result = deploy_dataset(
+        dataset_dir, deploy_cfg, target, purger=purger, dry_run=dry_run,
+        on_progress=lambda msg: click.echo(f"  {msg}"),
+    )
+
+    if dry_run:
+        click.echo("Dry run — no changes made, no fitsgl_datasets row written.")
+        return result
+
+    row = dataset_row(
+        field=field, tile=tile, prefix=prefix, pixel_scale=pixel_scale,
+        fitsgl_json=json_url, bands=bands, tiles=tiles,
+        source_hashes=source_hashes, is_default=(tile is None),
+    )
+    client.table('fitsgl_datasets').upsert(row, on_conflict='prefix').execute()
+    click.echo(f"\n✓ Deployed {name}: {len(result.uploaded)} uploaded, "
+               f"{len(result.deleted)} removed")
+    click.echo(f"  Viewer manifest: {json_url}")
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Deploy-staleness hook (called from campfire deploy after a mosaic deploy)
+# ---------------------------------------------------------------------------
+
+def suggest_fitsgl_rebuild(client, field, *, default_pixel_scale='30mas'):
+    """Print a suggested ``campfire fitsgl`` command when the field's composite is stale.
+
+    Best-effort and side-effect-free: compares the field's fiducial mosaics' current
+    content hashes to the stored ``fitsgl_datasets`` composite row and prints a hint if
+    the dataset is missing or its inputs changed. Never raises into the deploy — any
+    error (no fiducial declaration, no dataset table, etc.) just skips the suggestion.
+    Suggests; never auto-builds (pyramid builds are expensive).
+
+    Stays cheap on the deploy hot path: it uses the stored composite's ``pixel_scale``
+    (so a non-30mas composite isn't perpetually reported stale) and reads hashes
+    registry-only (no multi-GB re-hash) — if any fiducial mosaic isn't registered yet
+    it can't confirm freshness and simply skips rather than false-suggesting.
+    """
+    try:
+        resp = (client.table('fitsgl_datasets')
+                .select('source_hashes,pixel_scale')
+                .eq('field', field).eq('kind', 'field').limit(1).execute())
+        stored_row = resp.data[0] if resp.data else None
+        pixel_scale = stored_row['pixel_scale'] if stored_row else default_pixel_scale
+
+        mosaics, _tiles, _bands = _select_dataset_mosaics(field, tile=None, pixel_scale=pixel_scale)
+        if not mosaics:
+            return  # no fiducial declaration / no mosaics → nothing to suggest
+        current = resolve_source_hashes(client, mosaics, local_fallback=False)
+        if _hash_count(current) < len(mosaics):
+            return  # some fiducial mosaic unregistered → can't confirm; don't nag
+
+        stored = stored_row['source_hashes'] if stored_row else None
+        if stored == current:
+            return  # up to date
+        if stored is None:
+            click.echo(f"\n💡 No FitsGL map dataset for '{field}'. To enable the FitsGL map:")
+        else:
+            click.echo(f"\n💡 FitsGL map dataset for '{field}' is stale (mosaics changed). Rebuild:")
+        click.echo(f"     campfire fitsgl build --field {field}")
+        click.echo(f"     campfire fitsgl deploy --field {field}")
+    except Exception:
+        return

--- a/python/tests/test_fitsgl_deploy.py
+++ b/python/tests/test_fitsgl_deploy.py
@@ -1,0 +1,146 @@
+"""Tests for `campfire fitsgl deploy`'s pure layer (epic #337, Phase 3).
+
+Exercises the fitsgl-free, network-free functions in ``campfire.fitsgl.deploy`` —
+prefix/name derivation, DeployConfig-kwargs assembly (the public_url == base/prefix
+invariant), source-hash nesting, and the fitsgl_datasets row — so CI covers the logic
+without the FitsGL producer installed, a live bucket, or Supabase.
+"""
+
+import os
+
+import pytest
+
+from campfire.fitsgl.deploy import (
+    _hash_count,
+    build_deploy_config,
+    compute_source_hashes,
+    dataset_name,
+    dataset_prefix,
+    dataset_row,
+    fitsgl_json_url,
+)
+
+
+# --- prefix / name ----------------------------------------------------------
+
+def test_dataset_prefix_composite_and_tile():
+    assert dataset_prefix("cosmos") == "fitsgl/cosmos/composite"
+    assert dataset_prefix("cosmos", tile="PRIMER") == "fitsgl/cosmos/tile/PRIMER"
+
+
+def test_prefixes_are_disjoint_from_png_tile_keyspace():
+    # PNG tiles are `<field>/<filter>/<z>/<x>/<y>.png`; FitsGL lives under `fitsgl/`,
+    # and composite is never an ancestor of a tile prefix (sibling paths).
+    comp = dataset_prefix("cosmos")
+    tile = dataset_prefix("cosmos", tile="A1")
+    assert comp.startswith("fitsgl/") and tile.startswith("fitsgl/")
+    assert not tile.startswith(comp + "/") and not comp.startswith(tile + "/")
+
+
+def test_dataset_name_matches_build_naming():
+    assert dataset_name("cosmos") == "cosmos"
+    assert dataset_name("cosmos", tile="PRIMER") == "cosmos__PRIMER"
+
+
+# --- build_deploy_config ----------------------------------------------------
+
+def test_build_deploy_config_public_url_is_base_slash_prefix():
+    creds = {"bucket": "campfire-tiles", "endpoint": "https://r2.example.com",
+             "public_url_base": "https://tiles.campfire.example/"}
+    dc = build_deploy_config(creds, "fitsgl/cosmos/composite")
+    # trailing slash on base is normalized; prefix appended
+    assert dc["public_url"] == "https://tiles.campfire.example/fitsgl/cosmos/composite"
+    assert dc["prefix"] == "fitsgl/cosmos/composite"
+    assert dc["bucket"] == "campfire-tiles"
+    assert dc["viewer_origin"] == "*"
+
+
+def test_build_deploy_config_requires_public_url_base():
+    with pytest.raises(ValueError, match="public_url_base"):
+        build_deploy_config({"bucket": "b", "endpoint": "e"}, "fitsgl/cosmos/composite")
+
+
+def test_build_deploy_config_zone_id_from_creds_then_env(monkeypatch):
+    base = {"bucket": "b", "endpoint": "e", "public_url_base": "https://t/"}
+    monkeypatch.delenv("CLOUDFLARE_ZONE_ID", raising=False)
+    # creds win
+    dc = build_deploy_config({**base, "cf_zone_id": "zone-from-creds"}, "p")
+    assert dc["zone_id"] == "zone-from-creds"
+    # env fallback
+    monkeypatch.setenv("CLOUDFLARE_ZONE_ID", "zone-from-env")
+    assert build_deploy_config(base, "p")["zone_id"] == "zone-from-env"
+    # neither → None (purge skipped downstream)
+    monkeypatch.delenv("CLOUDFLARE_ZONE_ID", raising=False)
+    assert build_deploy_config(base, "p")["zone_id"] is None
+
+
+def test_fitsgl_json_url_appends_manifest():
+    assert fitsgl_json_url("https://t/fitsgl/cosmos/composite") == \
+        "https://t/fitsgl/cosmos/composite/fitsgl.json"
+
+
+# --- compute_source_hashes --------------------------------------------------
+
+def test_compute_source_hashes_nests_by_tile_then_filter():
+    mosaics = [
+        {"tile": "A1", "filter": "f444w", "storage_key": "k1"},
+        {"tile": "A1", "filter": "f150w", "storage_key": "k2"},
+        {"tile": "B2", "filter": "f444w", "storage_key": "k3"},
+    ]
+    by_key = {"k1": "sha256:aaa", "k2": "sha256:bbb", "k3": "sha256:ccc"}
+    out = compute_source_hashes(mosaics, by_key)
+    assert out == {
+        "A1": {"f444w": "sha256:aaa", "f150w": "sha256:bbb"},
+        "B2": {"f444w": "sha256:ccc"},
+    }
+
+
+def test_compute_source_hashes_skips_unknown_keys():
+    mosaics = [{"tile": "A1", "filter": "f444w", "storage_key": "missing"}]
+    assert compute_source_hashes(mosaics, {}) == {}
+
+
+def test_hash_count_counts_leaf_hashes():
+    # the staleness hook uses this to detect an incomplete (registry-only) resolve
+    assert _hash_count({}) == 0
+    assert _hash_count({"A1": {"f444w": "sha256:x"}}) == 1
+    assert _hash_count({"A1": {"f444w": "sha256:x", "f150w": "sha256:y"},
+                        "B2": {"f444w": "sha256:z"}}) == 3
+
+
+# --- dataset_row ------------------------------------------------------------
+
+def test_dataset_row_composite_is_default_field_kind():
+    row = dataset_row(
+        field="cosmos", tile=None, prefix="fitsgl/cosmos/composite",
+        pixel_scale="30mas", fitsgl_json="https://t/.../fitsgl.json",
+        bands=["f150w", "f444w"], tiles=["B2", "A1"],
+        source_hashes={"A1": {"f444w": "sha256:x"}}, is_default=True,
+    )
+    assert row["kind"] == "field"
+    assert row["tile"] is None
+    assert row["is_default"] is True
+    assert row["tiles"] == ["A1", "B2"]  # sorted
+    assert row["bands"] == ["f150w", "f444w"]
+    assert row["schema_version"] == 1
+    assert row["prefix"] == "fitsgl/cosmos/composite"
+
+
+def test_dataset_row_single_tile_is_tile_kind_not_default():
+    row = dataset_row(
+        field="cosmos", tile="PRIMER", prefix="fitsgl/cosmos/tile/PRIMER",
+        pixel_scale="30mas", fitsgl_json="https://t/.../fitsgl.json",
+        bands=["f444w"], tiles=["PRIMER"], source_hashes={}, is_default=False,
+    )
+    assert row["kind"] == "tile"
+    assert row["tile"] == "PRIMER"
+    assert row["is_default"] is False
+
+
+# --- import contract --------------------------------------------------------
+
+def test_pure_layer_imports_without_fitsgl():
+    # The module must import (and its pure helpers run) without the FitsGL producer.
+    import importlib
+    mod = importlib.import_module("campfire.fitsgl.deploy")
+    assert hasattr(mod, "run_deploy") and hasattr(mod, "suggest_fitsgl_rebuild")

--- a/supabase/migrations/20260710150358_add_fitsgl_datasets.sql
+++ b/supabase/migrations/20260710150358_add_fitsgl_datasets.sql
@@ -1,0 +1,132 @@
+-- FitsGL tile-pyramid dataset registry (epic #337, Phase 3).
+--
+-- NOTE: `supabase db diff` also emitted spurious drop/recreate statements for
+-- mv_filter_options, mv_programs_overview, nircam_reduction_progress, and
+-- spectrum_flag_summary — the known migra limitation with (materialized) views
+-- (AGENTS.md: "Materialized views ... are not tracked by the diff engine"). They
+-- are unchanged here, and the recreate even omitted the matviews' unique indexes,
+-- so those statements were removed. This migration only adds fitsgl_datasets.
+
+  create table "public"."fitsgl_datasets" (
+    "prefix" text not null,
+    "field" text not null,
+    "kind" text not null,
+    "tile" text,
+    "tiles" text[] not null,
+    "pixel_scale" text not null,
+    "fitsgl_json_url" text not null,
+    "bands" text[] not null,
+    "source_hashes" jsonb not null,
+    "is_default" boolean not null default false,
+    "schema_version" integer not null default 1,
+    "deployed_at" timestamp with time zone not null default now()
+      );
+
+
+alter table "public"."fitsgl_datasets" enable row level security;
+
+CREATE UNIQUE INDEX fitsgl_datasets_pkey ON public.fitsgl_datasets USING btree (prefix);
+
+CREATE INDEX idx_fitsgl_datasets_field ON public.fitsgl_datasets USING btree (field);
+
+CREATE UNIQUE INDEX uq_fitsgl_datasets_field_default ON public.fitsgl_datasets USING btree (field) WHERE (is_default = true);
+
+alter table "public"."fitsgl_datasets" add constraint "fitsgl_datasets_pkey" PRIMARY KEY using index "fitsgl_datasets_pkey";
+
+alter table "public"."fitsgl_datasets" add constraint "fitsgl_datasets_kind_check" CHECK ((kind = ANY (ARRAY['field'::text, 'tile'::text]))) not valid;
+
+alter table "public"."fitsgl_datasets" validate constraint "fitsgl_datasets_kind_check";
+
+-- Visibility helper: a FitsGL dataset is public iff every backing mosaic is
+-- published (a mixed published+draft composite must stay hidden). SECURITY DEFINER
+-- so it sees the draft nircam_images rows a non-admin's RLS would otherwise hide.
+CREATE OR REPLACE FUNCTION public.fitsgl_dataset_is_public(
+  p_field text, p_tiles text[], p_bands text[], p_pixel_scale text
+) RETURNS boolean
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM nircam_images ni
+    WHERE ni.field = p_field AND ni.tile = ANY (p_tiles)
+      AND ni.filter = ANY (p_bands) AND ni.pixel_scale = p_pixel_scale
+      AND ni.epoch = '' AND ni.deploy_status = 'published'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM nircam_images ni
+    WHERE ni.field = p_field AND ni.tile = ANY (p_tiles)
+      AND ni.filter = ANY (p_bands) AND ni.pixel_scale = p_pixel_scale
+      AND ni.epoch = '' AND ni.deploy_status <> 'published'
+  );
+$$;
+
+grant execute on function public.fitsgl_dataset_is_public(text, text[], text[], text) to "authenticated";
+
+grant delete on table "public"."fitsgl_datasets" to "anon";
+
+grant insert on table "public"."fitsgl_datasets" to "anon";
+
+grant references on table "public"."fitsgl_datasets" to "anon";
+
+grant select on table "public"."fitsgl_datasets" to "anon";
+
+grant trigger on table "public"."fitsgl_datasets" to "anon";
+
+grant truncate on table "public"."fitsgl_datasets" to "anon";
+
+grant update on table "public"."fitsgl_datasets" to "anon";
+
+grant delete on table "public"."fitsgl_datasets" to "authenticated";
+
+grant insert on table "public"."fitsgl_datasets" to "authenticated";
+
+grant references on table "public"."fitsgl_datasets" to "authenticated";
+
+grant select on table "public"."fitsgl_datasets" to "authenticated";
+
+grant trigger on table "public"."fitsgl_datasets" to "authenticated";
+
+grant truncate on table "public"."fitsgl_datasets" to "authenticated";
+
+grant update on table "public"."fitsgl_datasets" to "authenticated";
+
+grant delete on table "public"."fitsgl_datasets" to "service_role";
+
+grant insert on table "public"."fitsgl_datasets" to "service_role";
+
+grant references on table "public"."fitsgl_datasets" to "service_role";
+
+grant select on table "public"."fitsgl_datasets" to "service_role";
+
+grant trigger on table "public"."fitsgl_datasets" to "service_role";
+
+grant truncate on table "public"."fitsgl_datasets" to "service_role";
+
+grant update on table "public"."fitsgl_datasets" to "service_role";
+
+
+  create policy "admin_fitsgl_datasets_all"
+  on "public"."fitsgl_datasets"
+  as permissive
+  for all
+  to authenticated
+using (( SELECT public.is_admin() AS is_admin))
+with check (( SELECT public.is_admin() AS is_admin));
+
+
+
+  create policy "authenticated_select_fitsgl_datasets"
+  on "public"."fitsgl_datasets"
+  as permissive
+  for select
+  to authenticated
+using ((( SELECT public.is_admin() AS is_admin) OR public.fitsgl_dataset_is_public(field, tiles, bands, pixel_scale)));
+
+
+
+  create policy "service_role_fitsgl_datasets_all"
+  on "public"."fitsgl_datasets"
+  as permissive
+  for all
+  to service_role
+using (true)
+with check (true);

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -97,6 +97,35 @@ $$;
 GRANT EXECUTE ON FUNCTION public.accessible_program_slugs() TO authenticated;
 
 
+-- Whether a FitsGL dataset (epic #337, Phase 3) is public: every backing mosaic it
+-- was built from is published. The pyramid in the public tiles bucket is built from
+-- ALL of the dataset's on-disk mosaics, so a composite that mixes published + draft
+-- mosaics must stay hidden until they ALL publish (a plain EXISTS-any-published would
+-- leak the draft imagery). SECURITY DEFINER so it sees draft nircam_images rows the
+-- caller's own RLS would hide — otherwise the "NOT EXISTS unpublished" check can never
+-- fire for a non-admin. Requires ≥1 backing mosaic present AND none unpublished.
+CREATE OR REPLACE FUNCTION public.fitsgl_dataset_is_public(
+  p_field text, p_tiles text[], p_bands text[], p_pixel_scale text
+) RETURNS boolean
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM nircam_images ni
+    WHERE ni.field = p_field AND ni.tile = ANY (p_tiles)
+      AND ni.filter = ANY (p_bands) AND ni.pixel_scale = p_pixel_scale
+      AND ni.epoch = '' AND ni.deploy_status = 'published'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM nircam_images ni
+    WHERE ni.field = p_field AND ni.tile = ANY (p_tiles)
+      AND ni.filter = ANY (p_bands) AND ni.pixel_scale = p_pixel_scale
+      AND ni.epoch = '' AND ni.deploy_status <> 'published'
+  );
+$$;
+
+GRANT EXECUTE ON FUNCTION public.fitsgl_dataset_is_public(text, text[], text[], text) TO authenticated;
+
+
 -- =============================================================================
 -- object_scoped_aggregates
 -- =============================================================================

--- a/supabase/schemas/indexes.sql
+++ b/supabase/schemas/indexes.sql
@@ -579,5 +579,18 @@ CREATE INDEX IF NOT EXISTS idx_programs_is_public_slug
     ON public.programs USING btree (is_public, slug) WHERE (is_public = true);
 
 
+-- =============================================================================
+-- fitsgl_datasets (epic #337, Phase 3)
+-- =============================================================================
+
+-- Map query: fetch a field's datasets (then pick the default composite).
+CREATE INDEX IF NOT EXISTS idx_fitsgl_datasets_field
+    ON public.fitsgl_datasets USING btree (field);
+
+-- At most one default (fiducial composite) dataset per field.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_fitsgl_datasets_field_default
+    ON public.fitsgl_datasets USING btree (field) WHERE (is_default = true);
+
+
 -- NOTE: Materialized view indexes (mv_programs_overview, mv_filter_options)
 -- are defined in views.sql alongside the view definitions.

--- a/supabase/schemas/policies.sql
+++ b/supabase/schemas/policies.sql
@@ -889,6 +889,44 @@ CREATE POLICY "Service role has full access to map layers"
 
 
 -- =============================================================================
+-- fitsgl_datasets (epic #337, Phase 3)
+-- =============================================================================
+
+ALTER TABLE fitsgl_datasets ENABLE ROW LEVEL SECURITY;
+
+-- Visibility DERIVES from the backing mosaics — the table carries no
+-- deploy_status of its own. A dataset is public iff EVERY nircam_images mosaic it
+-- was built from (same field, one of its `tiles`, one of its `bands`, same
+-- pixel_scale, full-field epoch) is published — the pyramid in the public tiles
+-- bucket is built from all of them, so a composite mixing published + draft mosaics
+-- must stay hidden until they all publish. The all-published check lives in the
+-- SECURITY DEFINER fitsgl_dataset_is_public() so it can see the draft rows a
+-- non-admin's own RLS would hide (mirrors how the PNG map only shows deliberately-
+-- published tiles). Admins see every dataset.
+DROP POLICY IF EXISTS "authenticated_select_fitsgl_datasets" ON fitsgl_datasets;
+CREATE POLICY "authenticated_select_fitsgl_datasets"
+  ON fitsgl_datasets FOR SELECT TO authenticated
+  USING (
+    (SELECT public.is_admin())
+    OR public.fitsgl_dataset_is_public(field, tiles, bands, pixel_scale)
+  );
+
+-- Admins have full access (login-mode deploy CLI upserts through RLS).
+DROP POLICY IF EXISTS "admin_fitsgl_datasets_all" ON fitsgl_datasets;
+CREATE POLICY "admin_fitsgl_datasets_all"
+  ON fitsgl_datasets FOR ALL TO authenticated
+  USING ((SELECT public.is_admin()))
+  WITH CHECK ((SELECT public.is_admin()));
+
+-- Service role has full access (service-role / local deploy mode).
+DROP POLICY IF EXISTS "service_role_fitsgl_datasets_all" ON fitsgl_datasets;
+CREATE POLICY "service_role_fitsgl_datasets_all"
+  ON fitsgl_datasets FOR ALL TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+
+-- =============================================================================
 -- slit_regions
 -- =============================================================================
 

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -276,6 +276,37 @@ ALTER SEQUENCE "public"."map_layers_id_seq" OWNED BY "public"."map_layers"."id";
 
 
 
+-- FitsGL tile-pyramid datasets (epic #337, Phase 3). One row per *scoped* dataset
+-- deployed to the campfire-tiles bucket: a field's fiducial composite
+-- (kind='field') or a single standalone tile (kind='tile') — NOT one per
+-- nircam_images extension. Thin pointer table the map viewer reads; the pyramid
+-- itself (per-band manifest.json + .fits.fz supertiles + fitsgl.json) lives under
+-- `prefix` in R2. `bands`/`tiles` record what the dataset spans; `source_hashes`
+-- maps each backing mosaic (tile→filter→sha256, from storage_objects.content_hash)
+-- so a rebuild can skip byte-identical inputs. Deliberately carries NO
+-- deploy_status/deployment_id: public visibility DERIVES from the backing
+-- nircam_images (RLS in policies.sql), so a deploy against draft mosaics never
+-- exposes a manifest.
+CREATE TABLE IF NOT EXISTS "public"."fitsgl_datasets" (
+    "prefix" "text" NOT NULL,
+    "field" "text" NOT NULL,
+    "kind" "text" NOT NULL CONSTRAINT "fitsgl_datasets_kind_check" CHECK (("kind" = ANY (ARRAY['field'::"text", 'tile'::"text"]))),
+    "tile" "text",
+    "tiles" "text"[] NOT NULL,
+    "pixel_scale" "text" NOT NULL,
+    "fitsgl_json_url" "text" NOT NULL,
+    "bands" "text"[] NOT NULL,
+    "source_hashes" "jsonb" NOT NULL,
+    "is_default" boolean DEFAULT false NOT NULL,
+    "schema_version" integer DEFAULT 1 NOT NULL,
+    "deployed_at" timestamp with time zone DEFAULT "now"() NOT NULL
+);
+
+
+ALTER TABLE "public"."fitsgl_datasets" OWNER TO "postgres";
+
+
+
 CREATE TABLE IF NOT EXISTS "public"."spectra" (
     "id" integer NOT NULL,
     "grating" "text" NOT NULL,
@@ -1566,6 +1597,11 @@ ALTER TABLE ONLY "public"."map_layers"
 
 
 
+ALTER TABLE ONLY "public"."fitsgl_datasets"
+    ADD CONSTRAINT "fitsgl_datasets_pkey" PRIMARY KEY ("prefix");
+
+
+
 ALTER TABLE ONLY "public"."nircam_images"
     ADD CONSTRAINT "nircam_images_pkey" PRIMARY KEY ("id");
 
@@ -2068,6 +2104,12 @@ GRANT ALL ON TABLE "public"."flag_definitions" TO "service_role";
 GRANT ALL ON TABLE "public"."map_layers" TO "anon";
 GRANT ALL ON TABLE "public"."map_layers" TO "authenticated";
 GRANT ALL ON TABLE "public"."map_layers" TO "service_role";
+
+
+
+GRANT ALL ON TABLE "public"."fitsgl_datasets" TO "anon";
+GRANT ALL ON TABLE "public"."fitsgl_datasets" TO "authenticated";
+GRANT ALL ON TABLE "public"."fitsgl_datasets" TO "service_role";
 
 
 

--- a/web/app/api/v1/deploy/tiles-credentials/route.ts
+++ b/web/app/api/v1/deploy/tiles-credentials/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { validateAuth } from '@/lib/api-auth';
+import { isAdminUser } from '@/lib/api-helpers';
+import { resolveBackend } from '@/lib/storage';
+
+/**
+ * GET /api/v1/deploy/tiles-credentials
+ *
+ * Return the R2 **tiles**-bucket credentials to a logged-in admin so the
+ * `campfire fitsgl deploy` CLI can construct FitsGL's boto3 `R2Target`
+ * (epic #337, Phase 3). FitsGL's deploy needs a real S3 client — it GETs the
+ * prior `deploy-manifest.json` ledger, DELETEs orphaned supertiles, and calls
+ * PutBucketCors — operations a presigned PutObject URL cannot express, so it
+ * cannot ride the `/deploy/presign` path.
+ *
+ * Bounded relaxation of issue #250: this places raw tiles-bucket write keys on
+ * the admin machine (in memory). Acceptable ONLY because the tiles bucket is
+ * public, derived data and tile deletion already needs direct `r2_tiles` creds.
+ * Do NOT add a data-bucket equivalent.
+ *
+ * Response (snake_case to mirror the Python BackendConfig the CLI feeds FitsGL):
+ * {
+ *   endpoint, region, bucket, access_key_id, secret_access_key,
+ *   force_path_style, public_url_base
+ * }
+ */
+export async function GET(request: NextRequest) {
+  try {
+    // Authenticate (API key sk_* or JWT access token).
+    const userId = await validateAuth(request);
+    if (!userId) {
+      return NextResponse.json(
+        { error: 'unauthorized', error_description: 'Valid authentication required' },
+        { status: 401 }
+      );
+    }
+
+    // Admin-only (same gate as /deploy/presign — reuses the shared helper so the
+    // three deploy routes can't drift on access control).
+    if (!(await isAdminUser(userId))) {
+      return NextResponse.json(
+        { error: 'forbidden', error_description: 'Admin access required for deployment' },
+        { status: 403 }
+      );
+    }
+
+    // Resolve the tiles-bucket backend from the server's S3_TILES_* env.
+    let b;
+    try {
+      b = resolveBackend('tiles');
+    } catch {
+      return NextResponse.json(
+        { error: 'server_error', error_description: 'Tiles storage credentials not configured' },
+        { status: 500 }
+      );
+    }
+
+    // Never let a proxy or the browser cache credentials.
+    return NextResponse.json(
+      {
+        endpoint: b.endpoint,
+        region: b.region,
+        bucket: b.bucket,
+        access_key_id: b.accessKeyId,
+        secret_access_key: b.secretAccessKey,
+        force_path_style: b.forcePathStyle,
+        public_url_base: b.publicUrlBase ?? null,
+      },
+      { headers: { 'Cache-Control': 'no-store' } }
+    );
+  } catch (error) {
+    console.error('Error in GET /api/v1/deploy/tiles-credentials:', error);
+    return NextResponse.json(
+      { error: 'server_error', error_description: 'Failed to resolve tiles credentials' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
Closes #340. Part of the FitsGL integration epic (#337). Design: `docs/design-fitsgl-integration.md` §6, §10. Follows Phase 1 (#356) and Phase 2 (#357).

Deploys a built FitsGL dataset to the `campfire-tiles` bucket and tracks it, so the map viewer (Phase 4) has a per-field dataset to point at. No map swap or cutout service here — just deploy + tracking + the login-mode creds path.

## DB — `fitsgl_datasets` (`supabase/`)
- New thin **`fitsgl_datasets`** table: one row per *scoped* dataset (`kind='field'` fiducial composite or `kind='tile'` standalone), `prefix` PK, `bands[]`, `tiles[]`, `pixel_scale`, `fitsgl_json_url`, `source_hashes jsonb`, `is_default`, `schema_version`, `deployed_at`. No lifecycle column of its own.
- **Visibility derives from the backing mosaics.** A dataset is visible to non-admins only when **every** `nircam_images` mosaic it was built from is `published` — enforced by the SECURITY DEFINER `fitsgl_dataset_is_public(field, tiles[], bands[], pixel_scale)` ("≥1 published AND none unpublished"). It must be SECURITY DEFINER: a plain RLS `EXISTS` can't enforce *all-published*, because the non-admin's own `nircam_images` RLS hides the draft rows from the subquery — which would **leak** a mixed published+draft composite (whose public pyramid contains the draft imagery). Admins see every dataset. Mirrors the `authenticated_select_nircam` gate.
- Migration is a cleaned `supabase db diff` output: the spurious matview drop/recreate (the documented migra limitation — it even omits the matviews' unique indexes) was removed, keeping only the `fitsgl_datasets` changes.

## Web — admin-gated tiles creds (`web/`)
- New **`GET /api/v1/deploy/tiles-credentials`**: returns the R2 *tiles*-bucket credentials to a logged-in admin so `campfire fitsgl deploy` can construct FitsGL's boto3 `R2Target`. FitsGL's deploy GETs the prior ledger, DELETEs orphaned supertiles, and calls PutBucketCors — operations presigned PutObject URLs can't express, so it can't ride `/deploy/presign`. Reuses `validateAuth` + the shared `isAdminUser` gate; `Cache-Control: no-store` on the secret-bearing response.
- **Bounded relaxation of #250:** raw tiles-bucket write keys reach the admin machine (in memory) — acceptable because the tiles bucket is public, derived data and tile-delete already needs direct `r2_tiles` creds. **Not** extended to the `data` bucket.

## Python — `campfire fitsgl deploy` + hook
- New `python/campfire/fitsgl/deploy.py` + `campfire fitsgl deploy --field <f> [--tile <t>]`. Pushes the built dataset to `fitsgl/<field>/composite` (or `.../tile/<t>`) — a key namespace **disjoint from the PNG tile keyspace** — via FitsGL's `deploy_dataset` (library call), then upserts the `fitsgl_datasets` row.
- **Creds by auth mode:** `login` (default) fetches from the new endpoint (no local tiles keys assumed); `service-role`/`local` read `CAMPFIRE_S3_TILES_*` via `resolve_backend`. `DeployConfig.public_url` is composed as `base/prefix` (FitsGL's serve-vs-upload invariant).
- **`source_hashes`** recorded from `storage_objects.content_hash` (registry-first — multi-GB mosaics aren't re-hashed). Optional Cloudflare edge purge when `CLOUDFLARE_API_TOKEN` + a zone id are present (supertile filenames are geometry-derived, so a changed tile re-uses its filename and its edge copy must be evicted); absent them the purge is skipped (first deploys are unaffected).
- **Deploy hook** in `deploy_nircam`: best-effort, fully guarded, prints a suggested `campfire fitsgl build/deploy` when the field's composite is missing/stale — **suggest, never auto-build** (pyramid builds are expensive). Stays cheap on the deploy hot path (registry-only hash reads; uses the stored composite's `pixel_scale` so a non-30mas composite isn't perpetually flagged stale).
- Split into a **pure, fitsgl-free layer** (prefix / DeployConfig-kwargs / row / source-hash assembly, unit-tested in CI) and an **orchestration layer** that defers `import fitsgl` behind the `campfire[fitsgl]` extra.

## Testing / verification
- **13 new unit tests** (`test_fitsgl_deploy.py`) — prefix/name, `public_url == base/prefix`, source-hash nesting, dataset row, import-without-fitsgl. Full targeted suite: **121 passed**.
- `supabase db reset` + seed apply clean; `supabase db diff` shows **no fitsgl drift** (only the pre-existing matview noise).
- **RLS derivation verified end-to-end** (psql, seed users): non-admin sees a dataset only when all backing mosaics are published — mixed published+draft → hidden, all-published → visible, draft/revoked → hidden, admin → always.
- `npm run build` compiles with the new route in the manifest.

## Reviewed
High-effort multi-agent code review (line-by-line + removed-behavior/cross-file + cleanup/conventions, with verification). One real bug caught and fixed: the RLS originally used `EXISTS(any published)`, leaking mixed composites — now enforces all-published via the SECURITY DEFINER helper (verified above). Also applied: reuse `isAdminUser`, hot-path re-hash avoidance, stored-`pixel_scale` staleness comparison.

No `pipeline/**` changes (only `python/`, `web/`, `supabase/`), so no `pipeline/CHANGELOG.md` entry is required.

## Follow-ups (not in this PR)
- One-time Cloudflare setup on the tiles domain: a Cache Rule for `.fits.fz` + confirm CORS (`fitsgl verify --origin <web origin>` flags the Cache Rule's absence).
- Phase 4 (#341) reads `fitsgl_datasets` to swap the map to `<FitsViewer>`.

Generated with Claude Code