### PR TITLE
feat(map): FitsGL "cloud DS9" map surface — Phase 4/4.5 (#341)

### DIFF
--- a/docs/design-fitsgl-map-ux.md
+++ b/docs/design-fitsgl-map-ux.md
@@ -1,0 +1,210 @@
+# Design — FitsGL Map UX ("Phase 4.5")
+
+**Status:** Design agreed with Hollis 2026-07-10; ready to build. This is a scoped
+expansion of Phase 4 (#341) beyond the render+markers MVP — the full CAMPFIRE map
+control surface, "cloud DS9" in CAMPFIRE aesthetics.
+
+**Parent:** epic #337 (FitsGL integration). Companion to `docs/design-fitsgl-integration.md`.
+
+**Wireframes** (open in a browser — self-contained HTML):
+- `docs/wireframes/map-ux-refined.html` — **the target layout**.
+- `docs/wireframes/map-ux-rgb-and-filters.html` — Display-panel RGB mode + the Filters slide-over.
+- `docs/wireframes/map-ux-floating-pole.html`, `…-docked-pole.html` — the two poles we compared (floating won).
+
+---
+
+## 1. Where we are
+
+Phase 4 landed a **minimal** FitsGL map surface on branch `feat/fitsgl-phase4-map`
+(2 commits, not pushed): `web/components/map/FitsGLMapSurface.tsx` renders a deployed
+pyramid in `<FitsViewer>` with object markers, a tiny control panel, cursor readout,
+context menu, and URL sync; `MapViewer` dispatches per field (FitsGL if a `kind='field'`
+`fitsgl_datasets` row exists, else Leaflet; `?engine=leaflet` forces Leaflet).
+
+**Render-validated** against `rj0911/f444w/venus` (built with `campfire fitsgl build`,
+served with `fitsgl serve`, local `fitsgl_datasets` row, admin login): imagery renders,
+auto-stretch, native rotation, cursor RA/Dec, URL sync all confirmed.
+
+This doc supersedes that MVP's chrome: `FitsGLMapSurface` grows into the full UI below.
+The MVP commits stay as intermediate history; it all lands as the Phase 4 PR (we can
+optionally ship the MVP first if we want an incremental cut — TBD).
+
+---
+
+## 2. Layout & principles
+
+**The map is the hero.** Full-bleed `<FitsViewer>`; all chrome is **glass/blur panels
+floating over it** (the aesthetic Hollis liked from the MVP mini-panel). Avoid the
+FitsExplorer trap where four fixed edges + the CAMPFIRE header box the imagery into a
+shrinking center well.
+
+**Layout (from `map-ux-refined.html`):**
+- **Band rail** — top-center glass pill. Merges the **field selector** + band chips
+  (+ RGB entry). Shown only when a field has >1 band. No "FitsGL" badge.
+- **Left tool rail** — docked flush-left glass column, split into *modal tools*
+  (pan / ruler / fit) above a divider and *panel launchers* (Display / Layers / Filters /
+  coord-search / export) below. **Collapsible** via a `‹` edge arrow.
+- **Right control dock** — docked flush-right glass column holding the **Display** and
+  **Layers** panels. **Collapsible** via a `›` edge arrow (map goes fully edge-to-edge
+  when collapsed).
+- **Status pill** — bottom-center glass pill.
+- **NIRSpec Filters** — a **distinct full-height slide-over** (not a docked panel),
+  because it's a different mode (querying the catalog vs. adjusting the view).
+
+Principles: minimal nesting, minimal labels (icon tool rail + tooltips), progressive
+disclosure (only the slim spine is always visible; panels collapse), group by function.
+
+---
+
+## 3. Locked design decisions (Hollis, 2026-07-10)
+
+1. **No `Single | RGB` toggle.** Mode is implicit from band selection. RGB channel
+   assignment lives **in the band rail** (single chip → single mode; an `RGB` affordance
+   → three R/G/B band-pickers + a "rainbow" auto-assign). The Display panel is *only*
+   stretch + histogram + colormap.
+2. **Field selector merged into the band rail**; drop the FitsGL badge.
+3. **Colormap = a dropdown** (not a swatch row).
+4. **North-up = always on, not exposed.** `config.northUp: true` always; no control.
+   (Reverses the MVP's native-rotation default.)
+5. **No object quality legend** ("secure/probable/…") in the Layers panel. Marker colors
+   still apply; just no legend.
+6. **Keep the FitsExplorer-style histogram fine-adjust** in the Display panel — rebuilt
+   in CAMPFIRE chrome over the band's precomputed histogram.
+7. **Reuse the existing NIRSpec filters** (`AdvancedFiltersPanel` slide-over + its RPCs).
+   Visual refresh to glass only — do **not** rebuild the filter system.
+8. **Keep the existing dual RA/Dec readout** (sexagesimal + decimal) and the **right-click
+   context menu** — both are the already-reused `CoordinateOverlay` / `MapContextMenu`.
+
+---
+
+## 4. Component spec
+
+### Band rail (top-center pill)
+- `[<field> ▾] | [F090W][F115W]…[F444W]  [RGB]`. Field `<select>` merged in.
+- Single mode: click a band chip → `config.view = {mode:'single', band}`.
+- RGB mode: `RGB` toggle flips the rail to three channel pickers (R/G/B → band dropdowns)
+  + a **Rainbow** button (auto-assign blue→red by `pivotUm`). `config.view = {mode:'rgb', r,g,b}`.
+  Default interaction chosen by us; iterate on sight. Cross-grid bands greyed via
+  `isBandSelectableForRgb`.
+- Hidden entirely when the field has a single band.
+
+### Display panel (docked-right, collapsible)
+- **Stretch mode** chips: asinh / log / sqrt / linear / zscale (+ trilogy in RGB).
+- **Histogram fine-adjust** (FitsExplorer-style): draw the band's `stats.histogram`
+  (128 bins, `lo`/`hi`) with **draggable black/white handles**; live-drives the stretch.
+- **Colormap dropdown** (gray / viridis / magma / … ).
+- No north-up control (forced true).
+
+### Layers panel (docked-right, collapsible)
+- Toggles: **NIRSpec objects**, **MSA shutters** (Phase 4b), **Graticule (RA/Dec)**.
+- No quality legend.
+
+### Left tool rail (collapsible)
+- Modal tools: **pan** (default), **ruler/measure**, **fit-to-image**.
+- Panel launchers: **Display**, **Layers**, **Filters** (opens the slide-over),
+  **coord search**, **export PNG**.
+
+### Status pill (bottom-center)
+- Dual **RA/Dec** (sexagesimal + decimal), **zoom**, **pixel value** (per active band),
+  **band · stretch**. Grows to show separation/PA when the ruler tool is active.
+
+### NIRSpec Filters slide-over
+- The existing `AdvancedFiltersPanel`, restyled to the glass system. Same logic/RPCs.
+
+### Context menu (reuse)
+- The existing `MapContextMenu` (copy coords / copy link / search spectra near here),
+  fed by the last cursor sky position (already wired in the MVP).
+
+---
+
+## 5. FitsGL ↔ CAMPFIRE division
+
+**None of this needs a FitsGL change.** Everything is CAMPFIRE chrome driving the
+existing engine via `config`, the ref handle, `getViewer()` (the `CoreViewer` escape
+hatch), and the pure `explorer-state` helpers. Reuse the pure logic
+(`deriveViewerConfig`, `defaultExplorerState`, `bandRailModel`, `rainbowAction`,
+`trilogyComposite`, `isBandSelectableForRgb`, `canComposite`) rather than reinventing the
+decision layer; rebuild only the React shell + styling.
+
+| Feature | Where | API |
+|---|---|---|
+| Band single/RGB | CAMPFIRE → FitsGL | `config.view`; `deriveViewerConfig(bands, state)` |
+| Rainbow / trilogy weights | CAMPFIRE → FitsGL | `rainbowAction`, `trilogyComposite` (pure) |
+| Stretch mode | CAMPFIRE → FitsGL | `getViewer().setStretchMode()` |
+| Black/white + histogram drag | CAMPFIRE → FitsGL | `getViewer().setStretch()` / `setChannelStretch()`; data = `band.stats.histogram` |
+| zscale preset | CAMPFIRE → FitsGL | `band.stats.zscale` → `setStretch(z1,z2)` |
+| Colormap | CAMPFIRE → FitsGL | `getViewer().setColormap()` (or `config.view.colormap`) |
+| North-up (forced) | CAMPFIRE → FitsGL | `config.northUp: true` |
+| Graticule | CAMPFIRE → FitsGL | via `getViewer()` — **confirm setter name** (exists in the engine / FitsExplorer) |
+| Ruler / fit / export | CAMPFIRE → FitsGL | `handle.setTool()` (ruler exists), `fitToImage()`, `exportPNG()` |
+| Object markers | CAMPFIRE | `handle.setMarkers()` (done) + `get_field_object_markers` |
+| Cursor RA/Dec, URL sync | CAMPFIRE | `onCursor`/`onFrame` + `pixToSky` (done) |
+| Right-click menu | CAMPFIRE | `MapContextMenu` (done) |
+| Shutters | FitsGL primitive (shipped 0.2.0) + CAMPFIRE geometry | region overlay handle — **Phase 4b** |
+| NIRSpec filters | CAMPFIRE | existing `AdvancedFiltersPanel` + RPCs |
+
+**Two seams to confirm during build** (both exist in the engine — question is only the
+exact call from a bare `<FitsViewer>` vs. FitsExplorer's own shell): the **graticule**
+toggle and instantiating the **ruler** `PointerTool`. If either isn't cleanly reachable
+via `handle`/`getViewer()`, it's a small ergonomic addition to the FitsGL React handle
+(cross-repo, low-friction since we own it) — flag early, don't discover mid-build.
+
+---
+
+## 6. Verified data dependencies
+
+The dataset `campfire fitsgl build` emits **already carries everything the UI needs** —
+no producer change required (verified on `rj0911__venus/fitsgl.json`):
+- per-band `stats.histogram` (128 bins + `lo`/`hi`) → the fine-adjust histogram,
+- per-band `stats.zscale` → the zscale preset,
+- per-band `stats.trilogy` + `pivotUm` → the trilogy rainbow blue→red ordering.
+
+---
+
+## 7. Build sequencing (one branch: `feat/fitsgl-phase4-map`)
+
+1. **Band rail** — merge field select + band chips + RGB channel mode → `config.view`.
+2. **Display panel** (docked, collapsible) — stretch chips + histogram fine-adjust +
+   colormap dropdown; north-up forced true.
+3. **Layers panel** — objects / shutters / graticule toggles (no legend).
+4. **Tool rail** — modal tools + launchers + collapse arrows (`setTool`, `exportPNG`,
+   `fitToImage`); dock/rail collapse behavior.
+5. **Status pill** — dual RA/Dec + zoom + pixel value, bottom-center.
+6. **Filters slide-over** — reuse `AdvancedFiltersPanel`, restyle to glass.
+7. **(Phase 4b, separate)** — MSA shutters via the region primitive (#342).
+
+Verify each chunk against the live `rj0911` render (`fitsgl serve` + local
+`fitsgl_datasets` row + admin login on the worktree dev server). Suggested start:
+**1–2** (band rail + Display panel), the core interactive surface.
+
+---
+
+## 8. Open items / defaults chosen
+
+- **RGB entry interaction** — defaulted (RGB toggle → 3 pickers + rainbow); iterate on sight.
+- **MVP-first vs. one PR** — TBD whether to ship the render+markers MVP as an incremental
+  cut before the full UX, or land it all as one Phase 4 PR.
+- **Narrow-screen behavior** — auto-collapse the rail/dock on small viewports (later).
+- **Tool-rail icon set** — finalize icons during build.
+- **Zoom URL param** — FitsGL zoom (float px/native) vs. Leaflet's int; a field is one
+  engine so `z` is engine-scoped (acceptable; documented in the MVP).
+
+---
+
+## 9. References
+
+- MVP: `web/components/map/FitsGLMapSurface.tsx`, dispatch in `MapViewer.tsx`,
+  data layer in `web/lib/actions/map.ts` (`getFitsglDatasets`, `FitsglDataset`).
+- Reusable pure logic: `@fitsgl/core/react` — `explorer-state` exports
+  (`deriveViewerConfig`, `defaultExplorerState`, `bandRailModel`, `rainbowAction`,
+  `trilogyComposite`, `isBandSelectableForRgb`, `canComposite`).
+- Viewer API: `<FitsViewer>` props + `FitsViewerHandle` (`@fitsgl/core/react`),
+  `getViewer()` → `CoreViewer` (`getWcs`, `setStretch*`, `setColormap`, `setNorthUp`, …),
+  WCS helpers `pixToSky`/`skyToPix` (`@fitsgl/core`).
+- Existing CAMPFIRE pieces to reuse: `CoordinateOverlay`, `MapContextMenu`,
+  `AdvancedFiltersPanel`, `observation-colors.ts`, `MARKER_QUALITY_COLORS` (`lib/types.ts`).
+- Local render-test recipe: `campfire fitsgl build --field rj0911 --tile venus` →
+  `fitsgl serve $CAMPFIRE_ROOT/fitsgl/rj0911__venus -p 8765` → insert a `kind='field'`
+  `fitsgl_datasets` row pointing at `http://localhost:8765/fitsgl.json` → dev server on
+  a spare port → admin login → `/map?field=rj0911`. (Headless WebGL2 needs
+  `--use-angle=swiftshader --enable-unsafe-swiftshader`.)

--- a/docs/wireframes/map-ux-docked-pole.html
+++ b/docs/wireframes/map-ux-docked-pole.html
@@ -1,0 +1,93 @@
+<!doctype html><html><head><meta charset="utf-8"><style>
+:root{
+  --bg:#080a0f; --glass:rgba(20,25,34,.9); --bd:rgba(255,255,255,.09);
+  --tx:#e7eaf0; --tx2:#9aa3b2; --tx3:#69707e; --acc:#f5a524; --accbg:rgba(245,165,36,.16);
+}
+*{box-sizing:border-box;margin:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Inter,sans-serif}
+body{background:var(--bg);color:var(--tx);overflow:hidden}
+.mono{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.hdr{height:52px;display:flex;align-items:center;gap:26px;padding:0 22px;background:rgba(8,10,15,.95);
+  border-bottom:1px solid var(--bd);z-index:5}
+.logo{font-weight:800;letter-spacing:.3px;display:flex;align-items:center;gap:9px;font-size:15px}
+.nav{display:flex;gap:20px;color:var(--tx2);font-size:13.5px}.nav .on{color:var(--tx);border-bottom:2px solid var(--acc);padding-bottom:15px}
+.spacer{flex:1}.who{color:var(--tx2);font-size:13px;display:flex;gap:16px}
+/* fixed regions */
+.wrap{position:absolute;inset:52px 0 0 0}
+.bandrail{height:44px;display:flex;align-items:center;gap:4px;padding:0 14px;background:var(--glass);
+  border-bottom:1px solid var(--bd)}
+.b{padding:6px 10px;border-radius:8px;font-size:12px;color:var(--tx2)}
+.b.on{background:var(--accbg);color:var(--acc);box-shadow:inset 0 0 0 1px rgba(245,165,36,.4)}
+.b.rgb{color:var(--tx);margin-left:6px;border-left:1px solid var(--bd);padding-left:14px}
+.mid{position:absolute;inset:44px 0 34px 0;display:flex}
+.toolrail{width:50px;background:var(--glass);border-right:1px solid var(--bd);display:flex;flex-direction:column;
+  align-items:center;gap:3px;padding:8px 0}
+.t{width:38px;height:38px;display:flex;align-items:center;justify-content:center;border-radius:9px;color:var(--tx2);font-size:17px}
+.t.on{background:var(--accbg);color:var(--acc)}.t.sep{height:1px;width:22px;margin:5px auto;background:var(--bd)}
+.map{flex:1;position:relative;overflow:hidden;background:radial-gradient(900px 600px at 55% 42%,#0e1524,#080a0f 72%)}
+.stars{position:absolute;inset:0;background-image:
+  radial-gradient(1.4px 1.4px at 20% 30%,#cdd6e6 40%,transparent),radial-gradient(1.1px 1.1px at 70% 60%,#aeb8cc 40%,transparent),
+  radial-gradient(1.6px 1.6px at 45% 75%,#fff 40%,transparent),radial-gradient(1px 1px at 85% 20%,#9aa3b2 40%,transparent),
+  radial-gradient(2px 2px at 55% 45%,#fff 40%,transparent),radial-gradient(1.2px 1.2px at 62% 22%,#ccd 40%,transparent);opacity:.8}
+.footprint{position:absolute;left:26%;top:12%;width:48%;height:70%;transform:rotate(-11deg);
+  border:1px dashed rgba(160,180,220,.18);background:radial-gradient(60% 60% at 50% 45%,rgba(120,140,180,.10),transparent 70%)}
+.inspector{width:288px;background:var(--glass);border-left:1px solid var(--bd);padding:14px;overflow:auto}
+.sect{border-bottom:1px solid var(--bd);padding:12px 0}
+.sect:first-child{padding-top:0}
+.sect h4{font-size:11.5px;text-transform:uppercase;letter-spacing:.6px;color:var(--tx3);margin-bottom:10px;display:flex;justify-content:space-between}
+.chips{display:flex;gap:5px;flex-wrap:wrap;margin-bottom:10px}
+.chip{padding:5px 8px;border-radius:7px;font-size:11px;background:rgba(255,255,255,.05);color:var(--tx2)}.chip.on{background:var(--accbg);color:var(--acc)}
+.row{display:flex;align-items:center;justify-content:space-between;font-size:12.5px;color:var(--tx2);padding:6px 0}
+.slider{height:4px;border-radius:2px;background:linear-gradient(90deg,var(--acc),rgba(245,165,36,.15));margin:9px 0;position:relative}
+.knob{position:absolute;top:50%;width:12px;height:12px;border-radius:50%;background:#fff;transform:translate(-50%,-50%)}
+.cmap{display:flex;gap:5px;margin-top:6px}.cm{flex:1;height:15px;border-radius:4px}
+.tog{width:34px;height:19px;border-radius:10px;background:rgba(255,255,255,.12);position:relative}
+.tog.on{background:var(--acc)}.tog i{position:absolute;top:2px;left:2px;width:15px;height:15px;border-radius:50%;background:#fff}.tog.on i{left:17px}
+.legend{display:flex;gap:8px;font-size:10px;color:var(--tx3);flex-wrap:wrap;margin-top:2px}
+.dot{width:8px;height:8px;border-radius:50%;display:inline-block;margin-right:3px}
+.status{position:absolute;bottom:0;left:0;right:0;height:34px;display:flex;align-items:center;gap:16px;padding:0 16px;
+  background:var(--glass);border-top:1px solid var(--bd);font-size:12px}
+.status .k{color:var(--tx3)}.status b{color:var(--tx);font-weight:500}
+.cap{position:absolute;bottom:44px;left:64px;font-size:11px;color:var(--tx3);z-index:6}
+.note{position:absolute;font-size:10px;color:#ef6a6a;opacity:.9;z-index:6;font-style:italic}
+</style></head><body>
+<div class="hdr"><div class="logo">🔥 CAMPFIRE</div>
+  <div class="nav"><a>Home</a><a>NIRCam</a><a>NIRSpec</a><a class="on">Map</a><a>Docs</a></div>
+  <div class="spacer"></div><div class="who"><span>🛡 Admin</span><span>Admin User</span></div></div>
+<div class="wrap">
+  <div class="bandrail"><span class="b">F090W</span><span class="b">F115W</span><span class="b">F150W</span>
+    <span class="b">F200W</span><span class="b">F277W</span><span class="b">F356W</span><span class="b on">F444W</span>
+    <span class="b rgb">RGB</span><span style="flex:1"></span><span class="mono" style="color:var(--tx3);font-size:12px">rj0911 ▾</span></div>
+  <div class="mid">
+    <div class="toolrail"><div class="t on">✥</div><div class="t">📏</div><div class="t">⤢</div><div class="t">🧭</div>
+      <div class="t sep"></div><div class="t">⌖</div><div class="t">▣</div></div>
+    <div class="map"><div class="stars"></div><div class="footprint"></div>
+      <div class="note" style="left:50%;top:6px;transform:translateX(-50%)">↑ band rail (fixed)  ·  ← tools (fixed)  ·  inspector (fixed) →  ·  status (fixed) ↓</div>
+      <div class="note" style="left:50%;top:48%;transform:translate(-50%,-50%);font-size:12px;color:#ef6a6a">map is boxed into the center well —<br>shrinks as controls grow</div>
+    </div>
+    <div class="inspector">
+      <div class="sect"><h4>Display</h4>
+        <div class="chips"><span class="chip on">asinh</span><span class="chip">log</span><span class="chip">sqrt</span><span class="chip">linear</span><span class="chip">zscale</span></div>
+        <div class="row"><span>Black / White</span></div>
+        <div class="slider"><span class="knob" style="left:18%"></span><span class="knob" style="left:82%"></span></div>
+        <div class="row"><span>Colormap</span></div>
+        <div class="cmap"><span class="cm" style="background:linear-gradient(90deg,#000,#fff)"></span>
+          <span class="cm" style="background:linear-gradient(90deg,#440154,#21918c,#fde725)"></span>
+          <span class="cm" style="background:linear-gradient(90deg,#000004,#b73779,#fcfdbf)"></span>
+          <span class="cm" style="background:linear-gradient(90deg,#000,#f57d15,#fff)"></span></div>
+        <div class="row" style="margin-top:6px"><span>North up</span><span class="tog"><i></i></span></div></div>
+      <div class="sect"><h4>Layers</h4>
+        <div class="row"><span>NIRSpec objects</span><span class="tog on"><i></i></span></div>
+        <div class="legend"><span><span class="dot" style="background:#22c55e"></span>secure</span><span><span class="dot" style="background:#f59e0b"></span>probable</span><span><span class="dot" style="background:#ef4444"></span>impossible</span></div>
+        <div class="row"><span>MSA shutters</span><span class="tog on"><i></i></span></div>
+        <div class="row"><span>Graticule</span><span class="tog"><i></i></span></div></div>
+      <div class="sect"><h4>NIRSpec Filters</h4>
+        <div class="row"><span>Program</span><span class="k">all ▾</span></div>
+        <div class="row"><span>Redshift q ≥</span><span class="k">2 ▾</span></div>
+        <div class="row"><span>Grating</span><span class="k">any ▾</span></div></div>
+    </div>
+  </div>
+  <div class="status mono"><span><span class="k">RA</span> <b>09:11:13.2</b></span><span><span class="k">Dec</span> <b>+17:47:59</b></span>
+    <span><span class="k">z</span> <b>0.045</b></span><span><span class="k">px</span> <b>1.24e3</b></span><span class="k">F444W · asinh</span></div>
+  <div class="cap">Variant A — “Docked” (FitsExplorer-faithful): fixed band rail / tool rail / inspector / status — with the CAMPFIRE header + filters added</div>
+</div>
+</body></html>

--- a/docs/wireframes/map-ux-floating-pole.html
+++ b/docs/wireframes/map-ux-floating-pole.html
@@ -1,0 +1,138 @@
+<!doctype html><html><head><meta charset="utf-8"><style>
+:root{
+  --bg:#080a0f; --glass:rgba(22,27,36,.55); --glass2:rgba(28,34,45,.62);
+  --bd:rgba(255,255,255,.09); --tx:#e7eaf0; --tx2:#9aa3b2; --tx3:#69707e;
+  --acc:#f5a524; --accbg:rgba(245,165,36,.16); --blue:#3b82f6;
+}
+*{box-sizing:border-box;margin:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Inter,sans-serif}
+body{background:var(--bg);color:var(--tx);overflow:hidden}
+.mono{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.glass{background:var(--glass);backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px);
+  border:1px solid var(--bd);border-radius:14px;box-shadow:0 8px 32px rgba(0,0,0,.45)}
+/* header */
+.hdr{height:52px;display:flex;align-items:center;gap:26px;padding:0 22px;
+  background:rgba(8,10,15,.92);border-bottom:1px solid var(--bd);position:relative;z-index:5}
+.logo{font-weight:800;letter-spacing:.3px;display:flex;align-items:center;gap:9px;font-size:15px}
+.nav{display:flex;gap:20px;color:var(--tx2);font-size:13.5px}
+.nav a{color:var(--tx2);text-decoration:none}.nav .on{color:var(--tx);border-bottom:2px solid var(--acc);padding-bottom:15px}
+.spacer{flex:1}
+.hdr .who{color:var(--tx2);font-size:13px;display:flex;gap:16px;align-items:center}
+/* map */
+.stage{position:absolute;inset:52px 0 0 0;overflow:hidden;
+  background:radial-gradient(1200px 700px at 60% 40%,#0e1524 0%,#080a0f 70%)}
+.stars{position:absolute;inset:0;background-image:
+  radial-gradient(1.4px 1.4px at 20% 30%,#cdd6e6 40%,transparent),
+  radial-gradient(1.1px 1.1px at 70% 60%,#aeb8cc 40%,transparent),
+  radial-gradient(1.6px 1.6px at 45% 75%,#fff 40%,transparent),
+  radial-gradient(1px 1px at 85% 20%,#9aa3b2 40%,transparent),
+  radial-gradient(1.2px 1.2px at 30% 85%,#dde 40%,transparent),
+  radial-gradient(2px 2px at 55% 45%,#fff 40%,transparent),
+  radial-gradient(1px 1px at 12% 60%,#889 40%,transparent),
+  radial-gradient(1.3px 1.3px at 62% 22%,#ccd 40%,transparent);
+  opacity:.8}
+.footprint{position:absolute;left:34%;top:14%;width:44%;height:66%;transform:rotate(-11deg);
+  background:radial-gradient(60% 60% at 50% 45%,rgba(120,140,180,.10),transparent 70%);
+  border:1px dashed rgba(160,180,220,.18)}
+.marker{position:absolute;width:12px;height:12px;border-radius:50%;border:2px solid;transform:translate(-50%,-50%)}
+/* floating pieces */
+.field{position:absolute;left:16px;top:68px;display:flex;align-items:center;gap:8px;padding:7px 9px;z-index:4}
+.field select{background:transparent;border:1px solid var(--bd);color:var(--tx);border-radius:7px;padding:4px 8px;font-size:12.5px}
+.badge{font-size:10px;padding:2px 6px;border-radius:5px;background:rgba(255,255,255,.08);color:var(--tx2)}
+.bandrail{position:absolute;top:68px;left:50%;transform:translateX(-50%);display:flex;gap:4px;padding:6px;z-index:4}
+.b{padding:6px 10px;border-radius:8px;font-size:12px;color:var(--tx2);cursor:default}
+.b.on{background:var(--accbg);color:var(--acc);box-shadow:inset 0 0 0 1px rgba(245,165,36,.4)}
+.b.rgb{color:var(--tx);margin-left:6px;border-left:1px solid var(--bd);padding-left:14px}
+.tools{position:absolute;left:16px;top:50%;transform:translateY(-50%);display:flex;flex-direction:column;
+  gap:3px;padding:7px;z-index:4}
+.t{width:38px;height:38px;display:flex;align-items:center;justify-content:center;border-radius:9px;
+  color:var(--tx2);font-size:17px;cursor:default}
+.t.on{background:var(--accbg);color:var(--acc)}
+.t.sep{height:1px;width:22px;margin:5px auto;background:var(--bd)}
+.status{position:absolute;bottom:16px;left:50%;transform:translateX(-50%);display:flex;align-items:center;
+  gap:14px;padding:8px 16px;font-size:12.5px;z-index:4}
+.status .k{color:var(--tx3)}.status b{color:var(--tx);font-weight:500}
+/* panels */
+.panel{position:absolute;width:246px;padding:13px 14px;z-index:4}
+.panel h4{font-size:12px;text-transform:uppercase;letter-spacing:.6px;color:var(--tx3);margin-bottom:10px;
+  display:flex;justify-content:space-between;align-items:center}
+.panel .x{color:var(--tx3);cursor:default;font-size:15px}
+.chips{display:flex;gap:5px;flex-wrap:wrap;margin-bottom:12px}
+.chip{padding:5px 9px;border-radius:7px;font-size:11.5px;background:rgba(255,255,255,.05);color:var(--tx2)}
+.chip.on{background:var(--accbg);color:var(--acc)}
+.row{display:flex;align-items:center;justify-content:space-between;font-size:12.5px;color:var(--tx2);padding:6px 0}
+.slider{height:4px;border-radius:2px;background:linear-gradient(90deg,var(--acc),rgba(245,165,36,.15));margin:9px 0 4px;position:relative}
+.knob{position:absolute;top:50%;width:12px;height:12px;border-radius:50%;background:#fff;transform:translate(-50%,-50%);box-shadow:0 1px 4px rgba(0,0,0,.5)}
+.cmap{display:flex;gap:5px;margin-top:6px}
+.cm{flex:1;height:16px;border-radius:4px}
+.tog{width:34px;height:19px;border-radius:10px;background:rgba(255,255,255,.12);position:relative}
+.tog.on{background:var(--acc)}.tog i{position:absolute;top:2px;width:15px;height:15px;border-radius:50%;background:#fff;transition:.2s}
+.tog i{left:2px}.tog.on i{left:17px}
+.legend{display:flex;gap:9px;font-size:10.5px;color:var(--tx3);margin-top:2px;flex-wrap:wrap}
+.dot{width:8px;height:8px;border-radius:50%;display:inline-block;margin-right:3px;vertical-align:middle}
+.cap{position:absolute;bottom:14px;left:16px;font-size:11px;color:var(--tx3);z-index:6}
+.note{position:absolute;font-size:10px;color:var(--acc);opacity:.85;z-index:6;font-style:italic}
+</style></head><body>
+<div class="hdr"><div class="logo">🔥 CAMPFIRE</div>
+  <div class="nav"><a>Home</a><a>NIRCam</a><a>NIRSpec</a><a class="on">Map</a><a>Docs</a></div>
+  <div class="spacer"></div><div class="who"><span>🛡 Admin</span><span>Admin User</span></div></div>
+
+<div class="stage">
+  <div class="stars"></div><div class="footprint"></div>
+  <!-- sample markers -->
+  <div class="marker" style="left:47%;top:38%;border-color:#22c55e;background:rgba(34,197,94,.15)"></div>
+  <div class="marker" style="left:55%;top:52%;border-color:#f59e0b;background:rgba(245,158,11,.15)"></div>
+  <div class="marker" style="left:41%;top:60%;border-color:#ef4444;background:rgba(239,68,68,.15)"></div>
+
+  <!-- field switcher (top-left) -->
+  <div class="field glass"><select><option>rj0911</option></select><span class="badge">FitsGL</span></div>
+
+  <!-- band rail (top-center) -->
+  <div class="bandrail glass"><span class="b">F090W</span><span class="b">F115W</span><span class="b">F150W</span>
+    <span class="b">F200W</span><span class="b">F277W</span><span class="b">F356W</span><span class="b on">F444W</span>
+    <span class="b rgb">RGB</span></div>
+
+  <!-- tool rail (left-center) -->
+  <div class="tools glass">
+    <div class="t on" title="Pan">✥</div><div class="t" title="Ruler">📏</div><div class="t" title="Fit">⤢</div>
+    <div class="t" title="North up">🧭</div><div class="t sep"></div>
+    <div class="t on" title="Display">◐</div><div class="t on" title="Layers">▦</div>
+    <div class="t" title="Filters">⛃</div><div class="t" title="Search coord">⌖</div><div class="t" title="Export PNG">▣</div>
+  </div>
+
+  <!-- status pill (bottom-center) -->
+  <div class="status glass mono"><span><span class="k">RA</span> <b>09:11:13.2</b></span>
+    <span><span class="k">Dec</span> <b>+17:47:59</b></span><span><span class="k">z</span> <b>0.045</b></span>
+    <span><span class="k">px</span> <b>1.24e3</b></span><span class="k">F444W · asinh</span></div>
+
+  <!-- Display panel (right) -->
+  <div class="panel glass" style="right:16px;top:120px">
+    <h4>Display <span class="x">×</span></h4>
+    <div class="chips"><span class="chip on">asinh</span><span class="chip">log</span><span class="chip">sqrt</span><span class="chip">linear</span><span class="chip">zscale</span></div>
+    <div class="row"><span>Black / White</span></div>
+    <div class="slider"><span class="knob" style="left:18%"></span><span class="knob" style="left:82%"></span></div>
+    <div class="row"><span>Colormap</span><span class="k mono" style="color:var(--tx3);font-size:11px">gray</span></div>
+    <div class="cmap"><span class="cm" style="background:linear-gradient(90deg,#000,#fff)"></span>
+      <span class="cm" style="background:linear-gradient(90deg,#440154,#21918c,#fde725)"></span>
+      <span class="cm" style="background:linear-gradient(90deg,#000004,#b73779,#fcfdbf)"></span>
+      <span class="cm" style="background:linear-gradient(90deg,#000,#f57d15,#fff)"></span></div>
+    <div class="row" style="margin-top:8px"><span>North up</span><span class="tog"><i></i></span></div>
+  </div>
+
+  <!-- Layers panel (right lower) -->
+  <div class="panel glass" style="right:16px;top:360px">
+    <h4>Layers &amp; Overlays <span class="x">×</span></h4>
+    <div class="row"><span>NIRSpec objects</span><span class="tog on"><i></i></span></div>
+    <div class="legend"><span><span class="dot" style="background:#22c55e"></span>secure</span>
+      <span><span class="dot" style="background:#f59e0b"></span>probable</span>
+      <span><span class="dot" style="background:#f97316"></span>tentative</span>
+      <span><span class="dot" style="background:#ef4444"></span>impossible</span></div>
+    <div class="row"><span>MSA shutters</span><span class="tog on"><i></i></span></div>
+    <div class="row"><span>Graticule (RA/Dec)</span><span class="tog"><i></i></span></div>
+    <div class="row" style="border-top:1px solid var(--bd);margin-top:6px;padding-top:10px"><span>Advanced filters…</span><span class="k">3 active</span></div>
+  </div>
+
+  <div class="note" style="left:62px;top:52%">left: tool rail —<br>tools + panel launchers</div>
+  <div class="note" style="right:270px;top:150px;text-align:right">summonable glass panels →<br>(closeable, only what you need)</div>
+  <div class="cap">Variant B — “Floating glass”: full-bleed map · slim floating spine · everything heavy is a summonable panel</div>
+</div>
+</body></html>

--- a/docs/wireframes/map-ux-refined.html
+++ b/docs/wireframes/map-ux-refined.html
@@ -1,0 +1,90 @@
+<!doctype html><html><head><meta charset="utf-8"><style>
+:root{--bg:#080a0f;--glass:rgba(22,27,36,.62);--bd:rgba(255,255,255,.09);--tx:#e7eaf0;--tx2:#9aa3b2;--tx3:#69707e;
+  --acc:#f5a524;--accbg:rgba(245,165,36,.16)}
+*{box-sizing:border-box;margin:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Inter,sans-serif}
+body{background:var(--bg);color:var(--tx);overflow:hidden}
+.mono{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.glass{background:var(--glass);backdrop-filter:blur(14px);border:1px solid var(--bd);box-shadow:0 8px 32px rgba(0,0,0,.45)}
+.hdr{height:52px;display:flex;align-items:center;gap:26px;padding:0 22px;background:rgba(8,10,15,.95);border-bottom:1px solid var(--bd);position:relative;z-index:5}
+.logo{font-weight:800;letter-spacing:.3px;display:flex;align-items:center;gap:9px;font-size:15px}
+.nav{display:flex;gap:20px;color:var(--tx2);font-size:13.5px}.nav .on{color:var(--tx);border-bottom:2px solid var(--acc);padding-bottom:15px}
+.spacer{flex:1}.who{color:var(--tx2);font-size:13px;display:flex;gap:16px}
+.stage{position:absolute;inset:52px 0 0 0;overflow:hidden;background:radial-gradient(1200px 700px at 55% 42%,#0e1524,#080a0f 72%)}
+.stars{position:absolute;inset:0;background-image:radial-gradient(1.4px 1.4px at 20% 30%,#cdd6e6 40%,transparent),radial-gradient(1.1px 1.1px at 70% 60%,#aeb8cc 40%,transparent),radial-gradient(1.6px 1.6px at 45% 75%,#fff 40%,transparent),radial-gradient(1px 1px at 85% 20%,#9aa3b2 40%,transparent),radial-gradient(2px 2px at 55% 45%,#fff 40%,transparent),radial-gradient(1.2px 1.2px at 62% 22%,#ccd 40%,transparent);opacity:.8}
+.footprint{position:absolute;left:30%;top:12%;width:46%;height:70%;transform:rotate(-11deg);border:1px dashed rgba(160,180,220,.18);background:radial-gradient(60% 60% at 50% 45%,rgba(120,140,180,.10),transparent 70%)}
+.marker{position:absolute;width:12px;height:12px;border-radius:50%;border:2px solid;transform:translate(-50%,-50%)}
+/* field pill */
+.field{position:absolute;left:16px;top:66px;display:flex;align-items:center;gap:8px;padding:7px 9px;border-radius:12px;z-index:4}
+.field select{background:transparent;border:1px solid var(--bd);color:var(--tx);border-radius:7px;padding:4px 8px;font-size:12.5px}
+.badge{font-size:10px;padding:2px 6px;border-radius:5px;background:rgba(255,255,255,.08);color:var(--tx2)}
+/* band rail */
+.bandrail{position:absolute;top:66px;left:50%;transform:translateX(-50%);display:flex;gap:4px;padding:6px;border-radius:12px;z-index:4}
+.b{padding:6px 10px;border-radius:8px;font-size:12px;color:var(--tx2)}
+.b.on{background:var(--accbg);color:var(--acc);box-shadow:inset 0 0 0 1px rgba(245,165,36,.4)}
+.b.rgb{color:var(--tx);margin-left:6px;border-left:1px solid var(--bd);padding-left:14px}
+/* LEFT tool rail — docked flush, rounded right, collapse chevron */
+.tools{position:absolute;left:0;top:50%;transform:translateY(-50%);display:flex;flex-direction:column;gap:3px;padding:8px 7px;
+  border-radius:0 14px 14px 0;border-left:0;z-index:4}
+.t{width:38px;height:38px;display:flex;align-items:center;justify-content:center;border-radius:9px;color:var(--tx2);font-size:17px}
+.t.on{background:var(--accbg);color:var(--acc)}.t.sep{height:1px;width:22px;margin:5px auto;background:var(--bd)}
+.chev{position:absolute;width:16px;height:44px;display:flex;align-items:center;justify-content:center;color:var(--tx3);font-size:12px;
+  background:var(--glass);border:1px solid var(--bd);z-index:4}
+.chevL{left:53px;top:50%;transform:translateY(-50%);border-radius:0 8px 8px 0;border-left:0}
+/* RIGHT dock — docked flush, rounded left, collapse chevron */
+.dock{position:absolute;right:0;top:110px;bottom:64px;width:250px;padding:14px;border-radius:14px 0 0 14px;border-right:0;overflow:auto;z-index:4}
+.chevR{right:251px;top:130px;border-radius:8px 0 0 8px;border-right:0}
+.sect{border-bottom:1px solid var(--bd);padding:13px 0}.sect:first-child{padding-top:0}
+.sect h4{font-size:11.5px;text-transform:uppercase;letter-spacing:.6px;color:var(--tx3);margin-bottom:10px;display:flex;justify-content:space-between;align-items:center}
+.seg{display:flex;background:rgba(255,255,255,.05);border-radius:8px;padding:2px;font-size:11px}
+.seg span{padding:3px 10px;border-radius:6px;color:var(--tx2)}.seg .on{background:var(--acc);color:#111;font-weight:600}
+.chips{display:flex;gap:5px;flex-wrap:wrap;margin:10px 0}
+.chip{padding:5px 8px;border-radius:7px;font-size:11px;background:rgba(255,255,255,.05);color:var(--tx2)}.chip.on{background:var(--accbg);color:var(--acc)}
+.row{display:flex;align-items:center;justify-content:space-between;font-size:12.5px;color:var(--tx2);padding:6px 0}
+.slider{height:4px;border-radius:2px;background:linear-gradient(90deg,var(--acc),rgba(245,165,36,.15));margin:9px 0;position:relative}
+.knob{position:absolute;top:50%;width:12px;height:12px;border-radius:50%;background:#fff;transform:translate(-50%,-50%)}
+.cmap{display:flex;gap:5px;margin-top:6px}.cm{flex:1;height:15px;border-radius:4px}
+.tog{width:34px;height:19px;border-radius:10px;background:rgba(255,255,255,.12);position:relative}.tog.on{background:var(--acc)}
+.tog i{position:absolute;top:2px;left:2px;width:15px;height:15px;border-radius:50%;background:#fff}.tog.on i{left:17px}
+.legend{display:flex;gap:8px;font-size:10px;color:var(--tx3);flex-wrap:wrap;margin-top:2px}
+.dot{width:8px;height:8px;border-radius:50%;display:inline-block;margin-right:3px}
+.status{position:absolute;bottom:16px;left:50%;transform:translateX(-50%);display:flex;align-items:center;gap:14px;padding:8px 16px;border-radius:12px;font-size:12.5px;z-index:4}
+.status .k{color:var(--tx3)}.status b{color:var(--tx);font-weight:500}
+.cap{position:absolute;bottom:14px;left:16px;font-size:11px;color:var(--tx3);z-index:6}
+.note{position:absolute;font-size:10px;color:var(--acc);opacity:.85;font-style:italic;z-index:6}
+</style></head><body>
+<div class="hdr"><div class="logo">🔥 CAMPFIRE</div><div class="nav"><a>Home</a><a>NIRCam</a><a>NIRSpec</a><a class="on">Map</a><a>Docs</a></div><div class="spacer"></div><div class="who"><span>🛡 Admin</span><span>Admin User</span></div></div>
+<div class="stage"><div class="stars"></div><div class="footprint"></div>
+  <div class="marker" style="left:45%;top:38%;border-color:#22c55e;background:rgba(34,197,94,.15)"></div>
+  <div class="marker" style="left:52%;top:52%;border-color:#f59e0b;background:rgba(245,158,11,.15)"></div>
+  <div class="marker" style="left:39%;top:60%;border-color:#ef4444;background:rgba(239,68,68,.15)"></div>
+
+  <div class="field glass"><select><option>rj0911</option></select><span class="badge">FitsGL</span></div>
+  <div class="bandrail glass"><span class="b">F090W</span><span class="b">F115W</span><span class="b">F150W</span><span class="b">F200W</span><span class="b">F277W</span><span class="b">F356W</span><span class="b on">F444W</span><span class="b rgb">RGB</span></div>
+
+  <div class="tools glass"><div class="t on" title="Pan">✥</div><div class="t" title="Ruler">📏</div><div class="t" title="Fit">⤢</div><div class="t" title="North up">🧭</div>
+    <div class="t sep"></div><div class="t on" title="Display">◐</div><div class="t on" title="Layers">▦</div><div class="t" title="Filters">⛃</div><div class="t" title="Coord search">⌖</div><div class="t" title="Export">▣</div></div>
+  <div class="chev chevL glass">‹</div>
+
+  <div class="dock glass">
+    <div class="sect"><h4>Display <span class="mono" style="color:var(--tx3);font-size:10px">F444W</span></h4>
+      <div class="seg"><span class="on">Single</span><span>RGB</span></div>
+      <div class="chips"><span class="chip on">asinh</span><span class="chip">log</span><span class="chip">sqrt</span><span class="chip">linear</span><span class="chip">zscale</span></div>
+      <div class="row"><span>Black / White</span></div>
+      <div class="slider"><span class="knob" style="left:18%"></span><span class="knob" style="left:82%"></span></div>
+      <div class="row"><span>Colormap</span><span class="mono" style="color:var(--tx3);font-size:11px">gray</span></div>
+      <div class="cmap"><span class="cm" style="background:linear-gradient(90deg,#000,#fff)"></span><span class="cm" style="background:linear-gradient(90deg,#440154,#21918c,#fde725)"></span><span class="cm" style="background:linear-gradient(90deg,#000004,#b73779,#fcfdbf)"></span><span class="cm" style="background:linear-gradient(90deg,#000,#f57d15,#fff)"></span></div></div>
+    <div class="sect"><h4>Layers</h4>
+      <div class="row"><span>NIRSpec objects</span><span class="tog on"><i></i></span></div>
+      <div class="legend"><span><span class="dot" style="background:#22c55e"></span>secure</span><span><span class="dot" style="background:#f59e0b"></span>probable</span><span><span class="dot" style="background:#ef4444"></span>impossible</span></div>
+      <div class="row"><span>MSA shutters</span><span class="tog on"><i></i></span></div>
+      <div class="row"><span>Graticule</span><span class="tog"><i></i></span></div>
+      <div class="row"><span>North up</span><span class="tog"><i></i></span></div></div>
+  </div>
+  <div class="chev chevR glass">›</div>
+
+  <div class="status glass mono"><span><span class="k">RA</span> <b>09:11:13.2</b></span><span><span class="k">Dec</span> <b>+17:47:59</b></span><span><span class="k">z</span> <b>0.045</b></span><span><span class="k">px</span> <b>1.24e3</b></span><span class="k">F444W · asinh</span></div>
+
+  <div class="note" style="left:78px;top:40%">‹ collapse rail</div>
+  <div class="note" style="right:270px;top:96px;text-align:right">collapse dock ›</div>
+  <div class="cap">Variant B — refined · docked glass panels (collapsible via edge arrows) · full-height Filters slide-over is separate · Display holds Single↔RGB</div>
+</div></body></html>

--- a/docs/wireframes/map-ux-rgb-and-filters.html
+++ b/docs/wireframes/map-ux-rgb-and-filters.html
@@ -1,0 +1,67 @@
+<!doctype html><html><head><meta charset="utf-8"><style>
+:root{--bg:#080a0f;--glass:rgba(22,27,36,.72);--bd:rgba(255,255,255,.09);--tx:#e7eaf0;--tx2:#9aa3b2;--tx3:#69707e;--acc:#f5a524;--accbg:rgba(245,165,36,.16)}
+*{box-sizing:border-box;margin:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Inter,sans-serif}
+body{background:radial-gradient(900px 600px at 40% 30%,#0e1524,#080a0f 72%);color:var(--tx);padding:34px;display:flex;gap:40px;align-items:flex-start}
+.mono{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.glass{background:var(--glass);backdrop-filter:blur(14px);border:1px solid var(--bd);box-shadow:0 8px 32px rgba(0,0,0,.5)}
+.lbl{font-size:11px;color:var(--acc);font-style:italic;margin-bottom:9px}
+.panel{width:262px;padding:15px;border-radius:14px}
+h4{font-size:11.5px;text-transform:uppercase;letter-spacing:.6px;color:var(--tx3);margin-bottom:11px;display:flex;justify-content:space-between;align-items:center}
+.x{color:var(--tx3);font-size:15px}
+.seg{display:flex;background:rgba(255,255,255,.05);border-radius:8px;padding:2px;font-size:11px;margin-bottom:12px}
+.seg span{padding:4px 12px;border-radius:6px;color:var(--tx2)}.seg .on{background:var(--acc);color:#111;font-weight:600}
+.chips{display:flex;gap:5px;flex-wrap:wrap;margin:8px 0}
+.chip{padding:5px 8px;border-radius:7px;font-size:11px;background:rgba(255,255,255,.05);color:var(--tx2)}.chip.on{background:var(--accbg);color:var(--acc)}
+.ch{display:flex;align-items:center;gap:9px;margin:9px 0}
+.sw{width:12px;height:12px;border-radius:3px}
+.dd{flex:1;display:flex;justify-content:space-between;background:rgba(255,255,255,.05);border:1px solid var(--bd);border-radius:7px;padding:5px 9px;font-size:12px;color:var(--tx)}
+.dd .a{color:var(--tx3)}
+.mini{height:4px;flex:1;border-radius:2px;background:linear-gradient(90deg,var(--acc),rgba(245,165,36,.15));position:relative}
+.knob{position:absolute;top:50%;width:11px;height:11px;border-radius:50%;background:#fff;transform:translate(-50%,-50%)}
+.row{display:flex;align-items:center;justify-content:space-between;font-size:12.5px;color:var(--tx2);padding:6px 0}
+.btn{width:100%;text-align:center;padding:7px;border-radius:8px;background:var(--accbg);color:var(--acc);font-size:12px;margin-top:6px}
+.cmap{display:flex;gap:5px;margin-top:6px}.cm{flex:1;height:15px;border-radius:4px}
+.sep{border-top:1px solid var(--bd);margin:12px 0}
+/* filters slide-over is taller */
+.slide{width:300px;height:560px;padding:16px;border-radius:14px;overflow:auto}
+.field{display:flex;justify-content:space-between;background:rgba(255,255,255,.05);border:1px solid var(--bd);border-radius:8px;padding:8px 10px;font-size:12.5px;margin:6px 0;color:var(--tx)}
+.qchip{padding:4px 9px;border-radius:14px;font-size:11px;border:1px solid var(--bd);color:var(--tx2)}
+.qchip.on{border-color:transparent}
+.search{width:100%;background:rgba(255,255,255,.05);border:1px solid var(--bd);border-radius:9px;padding:9px 11px;color:var(--tx2);font-size:12.5px;margin-bottom:12px}
+.dot{width:8px;height:8px;border-radius:50%;display:inline-block;margin-right:4px}
+</style></head><body>
+<div>
+  <div class="lbl">Display panel — RGB mode (③ folds in; no new panel)</div>
+  <div class="panel glass">
+    <h4>Display <span class="mono" style="color:var(--tx3);font-size:10px">trilogy</span></h4>
+    <div class="seg"><span>Single</span><span class="on">RGB</span></div>
+    <div class="ch"><span class="sw" style="background:#ef4444"></span><span class="dd">F444W <span class="a">▾</span></span><span class="mini" style="max-width:54px"><span class="knob" style="left:70%"></span></span></div>
+    <div class="ch"><span class="sw" style="background:#22c55e"></span><span class="dd">F277W <span class="a">▾</span></span><span class="mini" style="max-width:54px"><span class="knob" style="left:55%"></span></span></div>
+    <div class="ch"><span class="sw" style="background:#3b82f6"></span><span class="dd">F150W <span class="a">▾</span></span><span class="mini" style="max-width:54px"><span class="knob" style="left:60%"></span></span></div>
+    <div class="btn">✦ Rainbow auto-assign</div>
+    <div class="sep"></div>
+    <div class="row" style="padding-top:0"><span>Stretch</span></div>
+    <div class="chips"><span class="chip on">trilogy</span><span class="chip">asinh</span><span class="chip">log</span><span class="chip">sqrt</span></div>
+  </div>
+</div>
+<div>
+  <div class="lbl">NIRSpec Filters — full-height slide-over (② kept distinct)</div>
+  <div class="slide glass">
+    <h4>NIRSpec Filters <span class="x">×</span></h4>
+    <input class="search" placeholder="🔍  Search name / RA Dec / cone…">
+    <div class="row" style="color:var(--tx3);font-size:11px;text-transform:uppercase;letter-spacing:.5px">Redshift quality</div>
+    <div class="chips"><span class="qchip on" style="background:rgba(239,68,68,.18);color:#ef4444">1</span><span class="qchip on" style="background:rgba(249,115,22,.18);color:#f97316">2</span><span class="qchip on" style="background:rgba(245,158,11,.18);color:#f59e0b">3</span><span class="qchip on" style="background:rgba(34,197,94,.18);color:#22c55e">4</span></div>
+    <div class="sep"></div>
+    <div class="row" style="color:var(--tx3);font-size:11px;text-transform:uppercase;letter-spacing:.5px">Program</div>
+    <div class="field">all programs <span style="color:var(--tx3)">▾</span></div>
+    <div class="row" style="color:var(--tx3);font-size:11px;text-transform:uppercase;letter-spacing:.5px;margin-top:6px">Redshift</div>
+    <div style="display:flex;gap:8px"><div class="field" style="flex:1">z min</div><div class="field" style="flex:1">z max</div></div>
+    <div class="row" style="color:var(--tx3);font-size:11px;text-transform:uppercase;letter-spacing:.5px;margin-top:6px">Grating</div>
+    <div class="chips"><span class="chip">PRISM</span><span class="chip">G140M</span><span class="chip">G235M</span><span class="chip">G395M</span><span class="chip">G395H</span></div>
+    <div class="sep"></div>
+    <div class="row"><span>Max SNR</span><span class="mono" style="color:var(--tx3)">any</span></div>
+    <div class="row"><span>Exposure time</span><span class="mono" style="color:var(--tx3)">any</span></div>
+    <div class="btn" style="margin-top:14px;background:var(--acc);color:#111;font-weight:600">Apply · 128 objects</div>
+  </div>
+</div>
+</body></html>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -285,3 +285,29 @@ pre code.hljs {
 .hljs-strong {
   font-weight: bold;
 }
+
+/* FitsGL map chrome (epic #337) — the glass panels float over always-dark
+   imagery, so their colours are pinned to the dusk palette regardless of the
+   app theme (redeclaring the tokens here overrides the inherited :root/.dark
+   values for all descendants). Combined with the more opaque glass surface,
+   text stays legible even over a white/grey colormap stretch. */
+.fitsgl-chrome {
+  --background: #16131c;
+  --card: #1f1b27;
+  --card-hover: #2a2435;
+  --surface-2: #241f2e;
+  --border: #332c40;
+  --border-strong: #423a52;
+  --text-primary: #f1ecf6;
+  --text-secondary: #b8aec6;
+  --text-tertiary: #8b8398;
+  --primary: #fb923c;
+  --primary-hover: #fdba74;
+  --primary-text: #fb923c;
+  --primary-soft: rgba(251, 146, 60, 0.14);
+  --on-primary: #1a1206;
+  /* Pre-composed translucent panel fill — the `/opacity` utility modifier isn't
+     supported on these var-based colour tokens, so the glass surface uses this
+     directly (opaque enough to stay legible over a white/grey stretch). */
+  --glass-bg: rgba(28, 24, 36, 0.88);
+}

--- a/web/app/map/MapPageContent.tsx
+++ b/web/app/map/MapPageContent.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { useSearchParams, usePathname } from 'next/navigation';
-import type { MapLayer, MapObjectMarker } from '@/lib/actions/map';
+import type { MapLayer, MapObjectMarker, FitsglDataset } from '@/lib/actions/map';
 import { MapViewerWrapper } from '@/components/map/MapViewerWrapper';
 import { AdvancedFiltersPanel } from '@/components/spectra/AdvancedFiltersPanel';
 import type { FilterOptions } from '@/lib/actions/filter-params';
@@ -13,6 +13,7 @@ import { useFilteredObjectIds } from '@/lib/hooks/useFilteredObjectIds';
 
 interface MapPageContentProps {
   layers: MapLayer[];
+  fitsglDatasets: FitsglDataset[];
   initialField?: string;
   initialFilter?: string;
   initialCenter?: { ra: number; dec: number };
@@ -22,6 +23,7 @@ interface MapPageContentProps {
 
 export function MapPageContent({
   layers,
+  fitsglDatasets,
   initialField,
   initialFilter,
   initialCenter,
@@ -139,6 +141,7 @@ export function MapPageContent({
     <div className="h-[calc(100vh-72px)] relative">
       <MapViewerWrapper
         layers={layers}
+        fitsglDatasets={fitsglDatasets}
         initialField={initialField}
         initialFilter={initialFilter}
         initialCenter={initialCenter}

--- a/web/app/map/page.tsx
+++ b/web/app/map/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { LogIn } from 'lucide-react';
-import { getMapLayers } from '@/lib/actions/map';
+import { getMapLayers, getFitsglDatasets } from '@/lib/actions/map';
 import { MapPageContent } from './MapPageContent';
 
 export const dynamic = 'force-dynamic';
@@ -23,8 +23,12 @@ export default async function MapPage({ searchParams }: MapPageProps) {
 
   const initialCenter = ra !== undefined && dec !== undefined ? { ra, dec } : undefined;
 
-  // Fetch available map layers
-  const { layers, isAuthenticated } = await getMapLayers();
+  // Fetch available map layers + FitsGL datasets (the map prefers FitsGL for a
+  // field that has one; RLS keeps draft-backed datasets admin-only).
+  const [{ layers, isAuthenticated }, fitsglDatasets] = await Promise.all([
+    getMapLayers(),
+    getFitsglDatasets(),
+  ]);
 
   if (!isAuthenticated) {
     return (
@@ -54,6 +58,7 @@ export default async function MapPage({ searchParams }: MapPageProps) {
   return (
     <MapPageContent
       layers={layers}
+      fitsglDatasets={fitsglDatasets}
       initialField={field}
       initialFilter={filter}
       initialCenter={initialCenter}

--- a/web/app/map/page.tsx
+++ b/web/app/map/page.tsx
@@ -18,7 +18,10 @@ export default async function MapPage({ searchParams }: MapPageProps) {
   const ra = typeof params.ra === 'string' ? parseFloat(params.ra) : undefined;
   const dec = typeof params.dec === 'string' ? parseFloat(params.dec) : undefined;
   const zoomRaw = typeof params.z === 'string' ? params.z : typeof params.zoom === 'string' ? params.zoom : undefined;
-  const zoom = zoomRaw !== undefined ? parseInt(zoomRaw, 10) : undefined;
+  // parseFloat (not parseInt): the FitsGL map writes fractional zoom (e.g. 0.43),
+  // and Leaflet's integer levels parse identically as floats.
+  const zoomParsed = zoomRaw !== undefined ? parseFloat(zoomRaw) : undefined;
+  const zoom = zoomParsed !== undefined && Number.isFinite(zoomParsed) ? zoomParsed : undefined;
   const highlight = typeof params.highlight === 'string' ? params.highlight : undefined;
 
   const initialCenter = ra !== undefined && dec !== undefined ? { ra, dec } : undefined;

--- a/web/components/map/CanvasMarkerLayer.tsx
+++ b/web/components/map/CanvasMarkerLayer.tsx
@@ -6,18 +6,7 @@ import { useMap } from 'react-leaflet';
 import type { MapObjectMarker } from '@/lib/actions/map';
 import type { WCSParams } from '@/lib/utils/wcs';
 import { skyToPixel } from '@/lib/utils/wcs';
-
-// ============================================
-// Quality color mapping (shared with MapViewer)
-// ============================================
-
-const QUALITY_COLORS: Record<number, string> = {
-  0: '#9ca3af', // Not inspected - gray
-  1: '#ef4444', // Impossible - red
-  2: '#f97316', // Tentative - orange
-  3: '#f59e0b', // Probable - amber
-  4: '#22c55e', // Secure - green
-};
+import { MARKER_QUALITY_COLORS as QUALITY_COLORS } from '@/lib/types';
 
 // Draw order: bottom → top (higher quality drawn on top)
 const QUALITY_DRAW_ORDER = [0, 1, 2, 3, 4];

--- a/web/components/map/FitsGLMapSurface.tsx
+++ b/web/components/map/FitsGLMapSurface.tsx
@@ -1,0 +1,368 @@
+'use client';
+
+/**
+ * FitsGL map surface (epic #337, Phase 4). Renders a deployed FitsGL tile-pyramid
+ * dataset in `<FitsViewer>` as the map for a field that has one, replacing the
+ * Leaflet + PNG-tile path (`MapViewer` dispatches to it per field). Self-contained:
+ * loads the dataset's `fitsgl.json`, owns band/RGB switching, pushes NIRSpec object
+ * markers through the viewer's ref handle (FitsGL owns culling/hit-test/tooltip —
+ * no `CanvasMarkerLayer` here), and feeds the shared `CoordinateOverlay` /
+ * `MapContextMenu` via callbacks. Shutters are Phase 4b (the region primitive).
+ *
+ * `onCursor`/`onFrame` are fixed at viewer construction, so everything they touch
+ * is read through refs (never stale closures).
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+import {
+  FitsViewer,
+  deriveViewerConfig,
+  explorerBandsFromConfig,
+  defaultViewFromConfig,
+  defaultExplorerState,
+  loadFitsglConfig,
+  type FitsViewerHandle,
+  type ExplorerBand,
+  type ExplorerState,
+  type FitsglConfig,
+} from '@fitsgl/core/react';
+import {
+  pixToSky,
+  skyToPix,
+  type CursorInfo,
+  type MarkerEvent,
+  type MarkerInput,
+  type ViewerConfig,
+  type ViewerFrameInfo,
+} from '@fitsgl/core';
+import type { FitsglDataset, MapObjectMarker } from '@/lib/actions/map';
+import { MARKER_QUALITY_COLORS, QUALITY_LABELS } from '@/lib/types';
+import { makeFitsglWorker } from '@/lib/fits/fitsglWorker';
+
+interface FitsGLMapSurfaceProps {
+  dataset: FitsglDataset;
+  markers: MapObjectMarker[];
+  showMarkers: boolean;
+  highlightObjectId?: string;
+  markerFilter?: (marker: MapObjectMarker) => boolean;
+  initialCenter?: { ra: number; dec: number };
+  initialZoom?: number;
+  /** Field switcher (shared across the Leaflet + FitsGL surfaces). */
+  fields: string[];
+  selectedField: string;
+  onFieldChange: (field: string) => void;
+  onToggleMarkers: (visible: boolean) => void;
+  markerCount: number;
+  /** Live RA/Dec under the cursor → shared CoordinateOverlay (null on leave). */
+  onCursorCoords: (coords: { ra: number; dec: number } | null) => void;
+  /** Right-click at a sky position → shared MapContextMenu. */
+  onContextMenu: (data: { coords: { ra: number; dec: number }; position: { x: number; y: number } }) => void;
+}
+
+function hexToRgba(hex: string, a: number): [number, number, number, number] {
+  const h = hex.replace('#', '');
+  return [
+    parseInt(h.slice(0, 2), 16) / 255,
+    parseInt(h.slice(2, 4), 16) / 255,
+    parseInt(h.slice(4, 6), 16) / 255,
+    a,
+  ];
+}
+
+function updateMapUrl(params: Record<string, string | undefined>) {
+  const url = new URL(window.location.href);
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) url.searchParams.set(key, value);
+    else url.searchParams.delete(key);
+  }
+  window.history.replaceState(null, '', url.toString());
+}
+
+export function FitsGLMapSurface({
+  dataset,
+  markers,
+  showMarkers,
+  highlightObjectId,
+  markerFilter,
+  initialCenter,
+  initialZoom,
+  fields,
+  selectedField,
+  onFieldChange,
+  onToggleMarkers,
+  markerCount,
+  onCursorCoords,
+  onContextMenu,
+}: FitsGLMapSurfaceProps) {
+  const [config, setConfig] = useState<FitsglConfig | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [bands, setBands] = useState<ExplorerBand[]>([]);
+  const [viewState, setViewState] = useState<ExplorerState | null>(null);
+
+  const handleRef = useRef<FitsViewerHandle | null>(null);
+  const lastCursorSky = useRef<{ ra: number; dec: number } | null>(null);
+  const initialApplied = useRef(false);
+  // Popup: the clicked marker + its world position (repositioned every frame).
+  const popupWorld = useRef<{ worldX: number; worldY: number } | null>(null);
+  const [popup, setPopup] = useState<{ marker: MapObjectMarker; x: number; y: number } | null>(null);
+  const urlDebounce = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  // Latest prop callbacks read through refs (onCursor/onFrame are fixed at
+  // construction, so their closures must never capture stale props).
+  const onCursorCoordsRef = useRef(onCursorCoords);
+  const onContextMenuRef = useRef(onContextMenu);
+  useEffect(() => { onCursorCoordsRef.current = onCursorCoords; }, [onCursorCoords]);
+  useEffect(() => { onContextMenuRef.current = onContextMenu; }, [onContextMenu]);
+
+  // Load fitsgl.json → inventory + default view → initial explorer state.
+  useEffect(() => {
+    let cancelled = false;
+    setConfig(null);
+    setLoadError(null);
+    loadFitsglConfig(dataset.fitsgl_json_url)
+      .then((cfg) => {
+        if (cancelled) return;
+        const b = explorerBandsFromConfig(cfg);
+        setConfig(cfg);
+        setBands(b);
+        setViewState(defaultExplorerState(b, defaultViewFromConfig(cfg)));
+      })
+      .catch((e) => { if (!cancelled) setLoadError(String(e?.message ?? e)); });
+    return () => { cancelled = true; };
+  }, [dataset.fitsgl_json_url]);
+
+  const viewerConfig: ViewerConfig | null = useMemo(
+    () => (bands.length && viewState ? deriveViewerConfig(bands, viewState) : null),
+    [bands, viewState],
+  );
+
+  // Marker inputs (sky-positioned; FitsGL projects via the manifest WCS). A filter
+  // dims non-matching objects rather than hiding them; the highlighted object gets
+  // a larger white glyph, matching the Leaflet layer's emphasis.
+  const markerInputs = useMemo<MarkerInput[]>(() => {
+    return markers.map((m) => {
+      const matches = !markerFilter || markerFilter(m);
+      const highlighted = m.object_id === highlightObjectId;
+      const base = MARKER_QUALITY_COLORS[m.redshift_quality] ?? MARKER_QUALITY_COLORS[0];
+      return {
+        id: m.object_id,
+        ra: m.ra,
+        dec: m.dec,
+        shape: 'point',
+        size: highlighted ? 16 : matches ? 10 : 6,
+        color: highlighted ? '#ffffff' : matches ? base : hexToRgba(base, 0.25),
+        data: { objectId: m.object_id },
+      };
+    });
+  }, [markers, markerFilter, highlightObjectId]);
+
+  // Push markers whenever they (or the toggle) change and the viewer is ready.
+  useEffect(() => {
+    const h = handleRef.current;
+    if (!h) return;
+    h.setMarkers(showMarkers ? markerInputs : []);
+  }, [markerInputs, showMarkers]);
+
+  const markerById = useMemo(() => {
+    const map = new Map<string, MapObjectMarker>();
+    for (const m of markers) map.set(m.object_id, m);
+    return map;
+  }, [markers]);
+
+  const onReady = useCallback((handle: FitsViewerHandle) => {
+    handleRef.current = handle;
+    handle.setMarkers(showMarkers ? markerInputs : []);
+    if (!initialApplied.current) {
+      initialApplied.current = true;
+      handle.fitToImage();
+      const wcs = handle.getViewer()?.getWcs() ?? null;
+      if (initialCenter && wcs) {
+        const p = skyToPix(wcs, initialCenter.ra, initialCenter.dec);
+        handle.setCenter(p.x, p.y);
+      }
+      if (initialZoom !== undefined) handle.setZoom(initialZoom);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const onCursor = useCallback((info: CursorInfo | null) => {
+    const sky = info && info.ra !== null && info.dec !== null ? { ra: info.ra, dec: info.dec } : null;
+    lastCursorSky.current = sky;
+    onCursorCoordsRef.current(sky);
+  }, []);
+
+  const onFrame = useCallback((info: ViewerFrameInfo) => {
+    const h = handleRef.current;
+    // Reposition the open popup to track its marker across pan/zoom.
+    if (popupWorld.current && h) {
+      const s = h.imageToScreen(popupWorld.current.worldX, popupWorld.current.worldY);
+      setPopup((prev) => (prev && s ? { ...prev, x: s.x, y: s.y } : prev));
+    }
+    // Debounced URL sync (centre → sky via the manifest WCS + FitsGL zoom).
+    const wcs = h?.getViewer()?.getWcs() ?? null;
+    if (urlDebounce.current) clearTimeout(urlDebounce.current);
+    urlDebounce.current = setTimeout(() => {
+      const params: Record<string, string> = { z: info.zoom.toFixed(3) };
+      if (wcs) {
+        const sky = pixToSky(wcs, info.centerX, info.centerY);
+        params.ra = sky.ra.toFixed(4);
+        params.dec = sky.dec.toFixed(4);
+      }
+      updateMapUrl(params);
+    }, 300);
+  }, []);
+
+  const onMarkerClick = useCallback((e: MarkerEvent) => {
+    const objectId = e.marker.data?.objectId as string | undefined;
+    const marker = objectId ? markerById.get(objectId) : undefined;
+    if (!marker) return;
+    popupWorld.current = { worldX: e.worldX, worldY: e.worldY };
+    setPopup({ marker, x: e.screenX, y: e.screenY });
+  }, [markerById]);
+
+  const closePopup = useCallback(() => {
+    popupWorld.current = null;
+    setPopup(null);
+  }, []);
+
+  // Right-click → context menu at the cursor's sky position. Passes ABSOLUTE
+  // client coords; the parent (MapViewer.handleContextMenu) subtracts the map
+  // wrapper rect itself, exactly as the Leaflet MapEvents path does.
+  const handleContextMenu = useCallback((ev: React.MouseEvent<HTMLDivElement>) => {
+    const coords = lastCursorSky.current;
+    if (!coords) return;
+    ev.preventDefault();
+    onContextMenuRef.current({
+      coords,
+      position: { x: ev.clientX, y: ev.clientY },
+    });
+  }, []);
+
+  // Band control model.
+  const single = viewState?.mode !== 'rgb';
+  const canRgb = bands.length >= 3;
+  const setSingleBand = (name: string) =>
+    setViewState((s) => (s ? { ...s, mode: 'single', band: name } : s));
+  const toggleRgb = () =>
+    setViewState((s) => (s ? { ...s, mode: s.mode === 'rgb' ? 'single' : 'rgb' } : s));
+
+  if (loadError) {
+    return (
+      <div className="flex items-center justify-center h-full bg-surface-2">
+        <div className="text-center text-text-secondary">
+          <p className="text-lg font-medium mb-2">Could not load the FitsGL map</p>
+          <p className="text-sm font-mono">{loadError}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative h-full w-full" onContextMenu={handleContextMenu}>
+      {viewerConfig && (
+        <FitsViewer
+          config={viewerConfig}
+          tileOptions={{ workerFactory: makeFitsglWorker }}
+          onReady={onReady}
+          onCursor={onCursor}
+          onFrame={onFrame}
+          onMarkerClick={onMarkerClick}
+          onError={(err) => setLoadError(String((err as Error)?.message ?? err))}
+          className="h-full w-full"
+          style={{ background: 'var(--header)' }}
+        />
+      )}
+      {!config && !loadError && (
+        <div className="absolute inset-0 flex items-center justify-center bg-surface-2 text-text-secondary">
+          Loading FitsGL map…
+        </div>
+      )}
+
+      {/* Control panel: field switcher + band/RGB switcher + marker toggle. */}
+      <div className="absolute top-3 left-3 z-[500] w-56 space-y-2 rounded-lg border border-border bg-card/90 p-2 backdrop-blur">
+        <div className="flex items-center gap-2">
+          <select
+            value={selectedField}
+            onChange={(e) => onFieldChange(e.target.value)}
+            className="min-w-0 flex-1 rounded border border-border bg-card px-2 py-1 text-xs"
+          >
+            {fields.map((f) => (
+              <option key={f} value={f}>{f}</option>
+            ))}
+          </select>
+          <span className="shrink-0 rounded bg-surface-2 px-1.5 py-0.5 text-[10px] font-medium text-text-tertiary">FitsGL</span>
+        </div>
+
+        {bands.length > 1 && viewState && (
+          <div className="flex flex-wrap items-center gap-1">
+            {canRgb && (
+              <button
+                onClick={toggleRgb}
+                className={`rounded px-2 py-1 text-xs font-medium ${!single ? 'bg-primary text-on-primary' : 'text-text-secondary hover:bg-card-hover'}`}
+              >
+                RGB
+              </button>
+            )}
+            {bands.map((b) => (
+              <button
+                key={b.name}
+                onClick={() => setSingleBand(b.name)}
+                className={`rounded px-2 py-1 font-mono text-xs ${single && viewState.band === b.name ? 'bg-primary text-on-primary' : 'text-text-secondary hover:bg-card-hover'}`}
+              >
+                {b.label ?? b.name}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <label className="flex items-center justify-between text-xs text-text-secondary">
+          <span>Objects ({markerCount})</span>
+          <input
+            type="checkbox"
+            checked={showMarkers}
+            onChange={(e) => onToggleMarkers(e.target.checked)}
+          />
+        </label>
+      </div>
+
+      {/* Clicked-marker popup (custom; FitsGL has no Leaflet Popup). */}
+      {popup && (() => {
+        const q = QUALITY_LABELS.find((l) => l.value === popup.marker.redshift_quality);
+        return (
+          <div
+            className="absolute z-[600] min-w-[200px] -translate-x-1/2 -translate-y-full rounded-lg border border-border bg-card p-3 text-sm shadow-lg"
+            style={{ left: popup.x, top: popup.y - 12 }}
+          >
+            <button
+              onClick={closePopup}
+              className="absolute right-2 top-1 text-text-tertiary hover:text-text-primary"
+              aria-label="Close"
+            >
+              ×
+            </button>
+            <div className="mb-1 font-mono font-bold">
+              <Link
+                href={`/nirspec/objects/${encodeURIComponent(popup.marker.object_id)}`}
+                className="text-primary-text underline hover:text-primary"
+                onClick={() => sessionStorage.setItem('campfire-map-return-url', window.location.href)}
+              >
+                {popup.marker.object_id}
+              </Link>
+            </div>
+            <div className="space-y-0.5 text-xs">
+              {popup.marker.redshift !== null && <div>z = {popup.marker.redshift.toFixed(4)}</div>}
+              <div>Quality: {q?.icon} {q?.label ?? 'Unknown'}</div>
+              <div className="text-text-tertiary">
+                {popup.marker.n_targets} target{popup.marker.n_targets !== 1 ? 's' : ''}, {popup.marker.n_spectra} spectr{popup.marker.n_spectra !== 1 ? 'a' : 'um'}
+              </div>
+              <div className="text-text-tertiary">
+                RA: {popup.marker.ra.toFixed(5)}, Dec: {popup.marker.dec.toFixed(5)}
+              </div>
+            </div>
+          </div>
+        );
+      })()}
+    </div>
+  );
+}

--- a/web/components/map/FitsGLMapSurface.tsx
+++ b/web/components/map/FitsGLMapSurface.tsx
@@ -1,16 +1,19 @@
 'use client';
 
 /**
- * FitsGL map surface (epic #337, Phase 4). Renders a deployed FitsGL tile-pyramid
+ * FitsGL map surface (epic #337, Phase 4.5). Renders a deployed FitsGL tile-pyramid
  * dataset in `<FitsViewer>` as the map for a field that has one, replacing the
- * Leaflet + PNG-tile path (`MapViewer` dispatches to it per field). Self-contained:
- * loads the dataset's `fitsgl.json`, owns band/RGB switching, pushes NIRSpec object
- * markers through the viewer's ref handle (FitsGL owns culling/hit-test/tooltip —
- * no `CanvasMarkerLayer` here), and feeds the shared `CoordinateOverlay` /
- * `MapContextMenu` via callbacks. Shutters are Phase 4b (the region primitive).
+ * Leaflet + PNG-tile path (`MapViewer` dispatches to it per field). The full CAMPFIRE
+ * "cloud DS9" control surface (`docs/design-fitsgl-map-ux.md`): the map is the hero,
+ * full-bleed, with glass/blur chrome floating over it — a top-center band rail
+ * (field + band/RGB) and a collapsible right dock (Display panel). Object markers go
+ * through the viewer's ref handle (FitsGL owns culling/hit-test), and the shared
+ * `CoordinateOverlay` / `MapContextMenu` are fed via callbacks. Shutters + the Layers
+ * panel + tool rail + status pill land in later chunks; the NIRSpec Filters slide-over
+ * reuses the existing `AdvancedFiltersPanel`.
  *
- * `onCursor`/`onFrame` are fixed at viewer construction, so everything they touch
- * is read through refs (never stale closures).
+ * `onCursor`/`onFrame` are fixed at viewer construction, so everything they touch is
+ * read through refs (never stale closures).
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -30,6 +33,8 @@ import {
 import {
   pixToSky,
   skyToPix,
+  type ColormapName,
+  type StretchMode,
   type CursorInfo,
   type MarkerEvent,
   type MarkerInput,
@@ -39,6 +44,21 @@ import {
 import type { FitsglDataset, MapObjectMarker } from '@/lib/actions/map';
 import { MARKER_QUALITY_COLORS, QUALITY_LABELS } from '@/lib/types';
 import { makeFitsglWorker } from '@/lib/fits/fitsglWorker';
+import { BandRail } from './fitsgl/BandRail';
+import { DisplayPanel } from './fitsgl/DisplayPanel';
+import { LayersPanel } from './fitsgl/LayersPanel';
+import { ToolRail } from './fitsgl/ToolRail';
+import { StatusPill } from './fitsgl/StatusPill';
+import { FitsglOverlays, type FitsglOverlaysHandle } from './fitsgl/FitsglOverlays';
+import { useDisplayStretch, type ChannelKey } from './fitsgl/useDisplayStretch';
+import { useColormap } from './fitsgl/useColormap';
+import type { RulerMeasurement } from './fitsgl/ruler';
+import { GLASS } from './fitsgl/glass';
+
+/** Ruler/graticule colours drawn over the always-dark map well (theme-independent). */
+const RULER_ACCENT = '#fb923c';
+const GRID_LINE = 'rgba(148,163,184,0.35)';
+const GRID_LABEL = 'rgba(203,213,225,0.8)';
 
 interface FitsGLMapSurfaceProps {
   dataset: FitsglDataset;
@@ -58,6 +78,9 @@ interface FitsGLMapSurfaceProps {
   onCursorCoords: (coords: { ra: number; dec: number } | null) => void;
   /** Right-click at a sky position → shared MapContextMenu. */
   onContextMenu: (data: { coords: { ra: number; dec: number }; position: { x: number; y: number } }) => void;
+  /** Opens the shared NIRSpec-filters slide-over (page-level AdvancedFiltersPanel). */
+  onOpenFilters?: () => void;
+  hasActiveFilters?: boolean;
 }
 
 function hexToRgba(hex: string, a: number): [number, number, number, number] {
@@ -79,6 +102,22 @@ function updateMapUrl(params: Record<string, string | undefined>) {
   window.history.replaceState(null, '', url.toString());
 }
 
+/** Strict-3 rainbow: reddest→R, bluest→B, middle→G by pivot wavelength (falls back
+ *  to declaration order when wavelengths are absent). The >3-band weighted-trilogy
+ *  rainbow is a later refinement (needs the core trilogy-weight primitives). */
+function rainbowRgb(bands: ExplorerBand[]): { r: string; g: string; b: string } | null {
+  if (bands.length < 3) return null;
+  const withWl = bands.filter((b) => b.wavelengthMicron != null);
+  const pool = withWl.length >= 3
+    ? [...withWl].sort((a, b) => a.wavelengthMicron! - b.wavelengthMicron!)
+    : bands;
+  return {
+    b: pool[0].name,
+    g: pool[Math.floor((pool.length - 1) / 2)].name,
+    r: pool[pool.length - 1].name,
+  };
+}
+
 export function FitsGLMapSurface({
   dataset,
   markers,
@@ -94,13 +133,30 @@ export function FitsGLMapSurface({
   markerCount,
   onCursorCoords,
   onContextMenu,
+  onOpenFilters,
+  hasActiveFilters,
 }: FitsGLMapSurfaceProps) {
   const [config, setConfig] = useState<FitsglConfig | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [bands, setBands] = useState<ExplorerBand[]>([]);
   const [viewState, setViewState] = useState<ExplorerState | null>(null);
+  const [dockOpen, setDockOpen] = useState(true);
+  const [readyTick, setReadyTick] = useState(0);
+  // Colormap is driven imperatively (reverse needs a LUT, which the controlled
+  // config can't carry), so it lives outside `viewState` (whose `colormap` stays
+  // pinned to 'gray' to keep deriveViewerConfig off the colormap path).
+  const [colormapName, setColormapName] = useState<ColormapName>('gray');
+  const [colormapReversed, setColormapReversed] = useState(false);
+  // Layers + cursor tools + live readouts (status pill).
+  const [graticule, setGraticule] = useState(false);
+  const [tool, setTool] = useState<'pan' | 'ruler'>('pan');
+  const [cursor, setCursor] = useState<{ ra: number | null; dec: number | null; values: ReadonlyArray<number | null> | null; native: boolean } | null>(null);
+  const [zoom, setZoom] = useState<number | null>(null);
+  const [rulerMeasure, setRulerMeasure] = useState<RulerMeasurement | null>(null);
 
   const handleRef = useRef<FitsViewerHandle | null>(null);
+  const overlaysRef = useRef<FitsglOverlaysHandle | null>(null);
+  const lastZoom = useRef(0);
   const lastCursorSky = useRef<{ ra: number; dec: number } | null>(null);
   const initialApplied = useRef(false);
   // Popup: the clicked marker + its world position (repositioned every frame).
@@ -108,25 +164,52 @@ export function FitsGLMapSurface({
   const [popup, setPopup] = useState<{ marker: MapObjectMarker; x: number; y: number } | null>(null);
   const urlDebounce = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
-  // Latest prop callbacks read through refs (onCursor/onFrame are fixed at
+  // Display (stretch / limits / trilogy) imperative bridge.
+  const display = useDisplayStretch({ handleRef, bands, state: viewState, readyTick });
+
+  // Colormap is applied imperatively (single-band only; reverse → reversed LUT).
+  const sourceKey = viewState
+    ? viewState.mode === 'rgb'
+      ? `rgb:${viewState.rgb.r}|${viewState.rgb.g}|${viewState.rgb.b}`
+      : `single:${viewState.band}`
+    : 'none';
+  useColormap({
+    handleRef,
+    name: colormapName,
+    reversed: colormapReversed,
+    single: viewState?.mode !== 'rgb',
+    sourceKey,
+    readyTick,
+  });
+
+  // Latest prop/hook callbacks read through refs (onCursor/onFrame are fixed at
   // construction, so their closures must never capture stale props).
   const onCursorCoordsRef = useRef(onCursorCoords);
   const onContextMenuRef = useRef(onContextMenu);
+  const seedFromFrameRef = useRef(display.seedFromFrame);
   useEffect(() => { onCursorCoordsRef.current = onCursorCoords; }, [onCursorCoords]);
   useEffect(() => { onContextMenuRef.current = onContextMenu; }, [onContextMenu]);
+  useEffect(() => { seedFromFrameRef.current = display.seedFromFrame; }, [display.seedFromFrame]);
 
   // Load fitsgl.json → inventory + default view → initial explorer state.
+  // North-up is forced on and not exposed (locked decision 4).
   useEffect(() => {
     let cancelled = false;
     setConfig(null);
     setLoadError(null);
+    initialApplied.current = false;
     loadFitsglConfig(dataset.fitsgl_json_url)
       .then((cfg) => {
         if (cancelled) return;
         const b = explorerBandsFromConfig(cfg);
+        const dv = defaultViewFromConfig(cfg);
         setConfig(cfg);
         setBands(b);
-        setViewState(defaultExplorerState(b, defaultViewFromConfig(cfg)));
+        // north-up forced on (decision 4); colormap pinned to 'gray' so it is driven
+        // imperatively (useColormap) rather than through the config.
+        setViewState({ ...defaultExplorerState(b, dv), northUp: true, colormap: 'gray' });
+        setColormapName(dv.colormap ?? 'gray');
+        setColormapReversed(false);
       })
       .catch((e) => { if (!cancelled) setLoadError(String(e?.message ?? e)); });
     return () => { cancelled = true; };
@@ -173,6 +256,7 @@ export function FitsGLMapSurface({
   const onReady = useCallback((handle: FitsViewerHandle) => {
     handleRef.current = handle;
     handle.setMarkers(showMarkers ? markerInputs : []);
+    setReadyTick((t) => t + 1);
     if (!initialApplied.current) {
       initialApplied.current = true;
       handle.fitToImage();
@@ -190,10 +274,21 @@ export function FitsGLMapSurface({
     const sky = info && info.ra !== null && info.dec !== null ? { ra: info.ra, dec: info.dec } : null;
     lastCursorSky.current = sky;
     onCursorCoordsRef.current(sky);
+    setCursor(info ? { ra: info.ra, dec: info.dec, values: info.values, native: info.native } : null);
   }, []);
 
   const onFrame = useCallback((info: ViewerFrameInfo) => {
     const h = handleRef.current;
+    // Seed the Display histogram handles from the viewer's auto-stretch once a
+    // freshly-switched source has drawn (no-op until a seed is pending).
+    seedFromFrameRef.current();
+    // Reproject the Canvas2D overlays (graticule / ruler) for the new view.
+    overlaysRef.current?.redraw();
+    // Track zoom for the status pill (only on meaningful change → fewer renders).
+    if (!lastZoom.current || Math.abs(info.zoom - lastZoom.current) / info.zoom > 0.01) {
+      lastZoom.current = info.zoom;
+      setZoom(info.zoom);
+    }
     // Reposition the open popup to track its marker across pan/zoom.
     if (popupWorld.current && h) {
       const s = h.imageToScreen(popupWorld.current.worldX, popupWorld.current.worldY);
@@ -239,13 +334,43 @@ export function FitsGLMapSurface({
     });
   }, []);
 
-  // Band control model.
-  const single = viewState?.mode !== 'rgb';
-  const canRgb = bands.length >= 3;
-  const setSingleBand = (name: string) =>
-    setViewState((s) => (s ? { ...s, mode: 'single', band: name } : s));
-  const toggleRgb = () =>
-    setViewState((s) => (s ? { ...s, mode: s.mode === 'rgb' ? 'single' : 'rgb' } : s));
+  // Band-rail intent handlers (all pure state updates → deriveViewerConfig).
+  // trilogy is RGB-only, so leaving RGB coerces the curve back to a single-band one.
+  const canComposite = bands.length >= 2;
+  const leaveTrilogy = (stretch: StretchMode): StretchMode => (stretch === 'trilogy' ? 'asinh' : stretch);
+  const onSelectBand = useCallback((name: string) =>
+    setViewState((s) => (s ? { ...s, mode: 'single', band: name, stretch: leaveTrilogy(s.stretch) } : s)), []);
+  const onToggleRgb = useCallback(() =>
+    setViewState((s) => {
+      if (!s) return s;
+      const mode = s.mode === 'rgb' ? 'single' : 'rgb';
+      return { ...s, mode, stretch: mode === 'single' ? leaveTrilogy(s.stretch) : s.stretch };
+    }), []);
+  const onSetRgbRole = useCallback((role: 'r' | 'g' | 'b', band: string) =>
+    setViewState((s) => (s ? { ...s, rgb: { ...s.rgb, [role]: band } } : s)), []);
+  const onRainbow = useCallback(() =>
+    setViewState((s) => {
+      if (!s) return s;
+      const rgb = rainbowRgb(bands);
+      return rgb ? { ...s, mode: 'rgb', rgb } : s;
+    }), [bands]);
+
+  // Display-panel intent handlers.
+  const onSetStretch = useCallback((mode: StretchMode) =>
+    setViewState((s) => (s ? { ...s, stretch: mode } : s)), []);
+  const onSetHandle = useCallback((key: ChannelKey, min: number, max: number) =>
+    display.setHandle(key, min, max), [display]);
+
+  // Tool-rail actions.
+  const onFit = useCallback(() => handleRef.current?.fitToImage(), []);
+  const onExport = useCallback(() => {
+    const url = handleRef.current?.exportPNG();
+    if (!url) return;
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${selectedField}-fitsgl.png`;
+    a.click();
+  }, [selectedField]);
 
   if (loadError) {
     return (
@@ -259,7 +384,7 @@ export function FitsGLMapSurface({
   }
 
   return (
-    <div className="relative h-full w-full" onContextMenu={handleContextMenu}>
+    <div className="fitsgl-chrome relative h-full w-full" onContextMenu={handleContextMenu}>
       {viewerConfig && (
         <FitsViewer
           config={viewerConfig}
@@ -273,58 +398,107 @@ export function FitsGLMapSurface({
           style={{ background: 'var(--header)' }}
         />
       )}
+      {viewerConfig && (
+        <FitsglOverlays
+          ref={overlaysRef}
+          handleRef={handleRef}
+          graticule={graticule}
+          tool={tool}
+          readyTick={readyTick}
+          accent={RULER_ACCENT}
+          gridLine={GRID_LINE}
+          gridLabel={GRID_LABEL}
+          onMeasure={setRulerMeasure}
+        />
+      )}
       {!config && !loadError && (
         <div className="absolute inset-0 flex items-center justify-center bg-surface-2 text-text-secondary">
           Loading FitsGL map…
         </div>
       )}
 
-      {/* Control panel: field switcher + band/RGB switcher + marker toggle. */}
-      <div className="absolute top-3 left-3 z-[500] w-56 space-y-2 rounded-lg border border-border bg-card/90 p-2 backdrop-blur">
-        <div className="flex items-center gap-2">
-          <select
-            value={selectedField}
-            onChange={(e) => onFieldChange(e.target.value)}
-            className="min-w-0 flex-1 rounded border border-border bg-card px-2 py-1 text-xs"
-          >
-            {fields.map((f) => (
-              <option key={f} value={f}>{f}</option>
-            ))}
-          </select>
-          <span className="shrink-0 rounded bg-surface-2 px-1.5 py-0.5 text-[10px] font-medium text-text-tertiary">FitsGL</span>
-        </div>
+      {/* Left tool rail — modal tools + actions + filters launcher. */}
+      {viewState && (
+        <ToolRail
+          tool={tool}
+          onSetTool={setTool}
+          onFit={onFit}
+          onExport={onExport}
+          onOpenFilters={onOpenFilters}
+          hasActiveFilters={hasActiveFilters}
+        />
+      )}
 
-        {bands.length > 1 && viewState && (
-          <div className="flex flex-wrap items-center gap-1">
-            {canRgb && (
-              <button
-                onClick={toggleRgb}
-                className={`rounded px-2 py-1 text-xs font-medium ${!single ? 'bg-primary text-on-primary' : 'text-text-secondary hover:bg-card-hover'}`}
-              >
-                RGB
-              </button>
-            )}
-            {bands.map((b) => (
-              <button
-                key={b.name}
-                onClick={() => setSingleBand(b.name)}
-                className={`rounded px-2 py-1 font-mono text-xs ${single && viewState.band === b.name ? 'bg-primary text-on-primary' : 'text-text-secondary hover:bg-card-hover'}`}
-              >
-                {b.label ?? b.name}
-              </button>
-            ))}
-          </div>
-        )}
+      {/* Band rail — merged field select + band/RGB (top-center). */}
+      {viewState && (fields.length > 1 || bands.length > 1) && (
+        <BandRail
+          fields={fields}
+          selectedField={selectedField}
+          onFieldChange={onFieldChange}
+          bands={bands}
+          state={viewState}
+          canComposite={canComposite}
+          onSelectBand={onSelectBand}
+          onToggleRgb={onToggleRgb}
+          onSetRgbRole={onSetRgbRole}
+          onRainbow={onRainbow}
+        />
+      )}
 
-        <label className="flex items-center justify-between text-xs text-text-secondary">
-          <span>Objects ({markerCount})</span>
-          <input
-            type="checkbox"
-            checked={showMarkers}
-            onChange={(e) => onToggleMarkers(e.target.checked)}
+      {/* Right control dock — Display panel (+ objects toggle placeholder until the
+          Layers panel lands in chunk 3). Collapsible via the edge chevron. */}
+      {viewState && dockOpen && (
+        <div className={`absolute right-0 top-16 bottom-16 z-[500] w-72 overflow-y-auto rounded-l-xl ${GLASS} p-3`}>
+          <DisplayPanel
+            state={viewState}
+            channels={display.channels}
+            hasZscale={display.hasZscale}
+            hasTrilogy={display.hasTrilogy}
+            colormap={colormapName}
+            colormapReversed={colormapReversed}
+            onSetStretch={onSetStretch}
+            onSetColormap={setColormapName}
+            onToggleReverseColormap={setColormapReversed}
+            onSetHandle={onSetHandle}
+            onApplyPreset={display.applyPreset}
           />
-        </label>
-      </div>
+          <div className="mt-3 border-t border-border pt-3">
+            <LayersPanel
+              showMarkers={showMarkers}
+              onToggleMarkers={onToggleMarkers}
+              markerCount={markerCount}
+              graticule={graticule}
+              onToggleGraticule={setGraticule}
+            />
+          </div>
+        </div>
+      )}
+      {viewState && (
+        <button
+          type="button"
+          onClick={() => setDockOpen((o) => !o)}
+          className={`absolute top-20 z-[501] flex h-11 w-4 items-center justify-center rounded-l-lg ${GLASS} text-text-tertiary hover:text-text-primary`}
+          style={{ right: dockOpen ? '18rem' : 0 }}
+          aria-label={dockOpen ? 'Collapse controls' : 'Expand controls'}
+          title={dockOpen ? 'Collapse controls' : 'Expand controls'}
+        >
+          {dockOpen ? '›' : '‹'}
+        </button>
+      )}
+
+      {/* Status pill — dual RA/Dec + value + zoom + band·stretch (+ ruler). */}
+      {viewState && (
+        <StatusPill
+          ra={cursor?.ra ?? null}
+          dec={cursor?.dec ?? null}
+          values={cursor?.values ?? null}
+          native={cursor?.native ?? false}
+          zoom={zoom}
+          bandLabel={viewState.mode === 'rgb' ? 'RGB' : viewState.band}
+          stretch={viewState.stretch}
+          ruler={tool === 'ruler' ? rulerMeasure : null}
+        />
+      )}
 
       {/* Clicked-marker popup (custom; FitsGL has no Leaflet Popup). */}
       {popup && (() => {

--- a/web/components/map/FitsGLMapSurface.tsx
+++ b/web/components/map/FitsGLMapSurface.tsx
@@ -156,7 +156,14 @@ export function FitsGLMapSurface({
 
   const handleRef = useRef<FitsViewerHandle | null>(null);
   const overlaysRef = useRef<FitsglOverlaysHandle | null>(null);
+  const rootRef = useRef<HTMLDivElement | null>(null);
   const lastZoom = useRef(0);
+  // Initial view read through refs: onReady is fixed at construction but re-fires
+  // on a dataset reload (field switch), so it must see the CURRENT initial props.
+  const initialCenterRef = useRef(initialCenter);
+  const initialZoomRef = useRef(initialZoom);
+  useEffect(() => { initialCenterRef.current = initialCenter; }, [initialCenter]);
+  useEffect(() => { initialZoomRef.current = initialZoom; }, [initialZoom]);
   const lastCursorSky = useRef<{ ra: number; dec: number } | null>(null);
   const initialApplied = useRef(false);
   // Popup: the clicked marker + its world position (repositioned every frame).
@@ -260,12 +267,14 @@ export function FitsGLMapSurface({
     if (!initialApplied.current) {
       initialApplied.current = true;
       handle.fitToImage();
+      const center = initialCenterRef.current;
+      const zoom = initialZoomRef.current;
       const wcs = handle.getViewer()?.getWcs() ?? null;
-      if (initialCenter && wcs) {
-        const p = skyToPix(wcs, initialCenter.ra, initialCenter.dec);
+      if (center && wcs) {
+        const p = skyToPix(wcs, center.ra, center.dec);
         handle.setCenter(p.x, p.y);
       }
-      if (initialZoom !== undefined) handle.setZoom(initialZoom);
+      if (zoom !== undefined) handle.setZoom(zoom);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -289,10 +298,13 @@ export function FitsGLMapSurface({
       lastZoom.current = info.zoom;
       setZoom(info.zoom);
     }
-    // Reposition the open popup to track its marker across pan/zoom.
+    // Reposition the open popup to track its marker across pan/zoom. imageToScreen
+    // returns viewport-client coords; the popup is absolute inside the map root, so
+    // localise to the root (matching the canvas-relative click position).
     if (popupWorld.current && h) {
       const s = h.imageToScreen(popupWorld.current.worldX, popupWorld.current.worldY);
-      setPopup((prev) => (prev && s ? { ...prev, x: s.x, y: s.y } : prev));
+      const rect = rootRef.current?.getBoundingClientRect();
+      setPopup((prev) => (prev && s && rect ? { ...prev, x: s.x - rect.left, y: s.y - rect.top } : prev));
     }
     // Debounced URL sync (centre → sky via the manifest WCS + FitsGL zoom).
     const wcs = h?.getViewer()?.getWcs() ?? null;
@@ -384,7 +396,7 @@ export function FitsGLMapSurface({
   }
 
   return (
-    <div className="fitsgl-chrome relative h-full w-full" onContextMenu={handleContextMenu}>
+    <div ref={rootRef} className="fitsgl-chrome relative h-full w-full" onContextMenu={handleContextMenu}>
       {viewerConfig && (
         <FitsViewer
           config={viewerConfig}

--- a/web/components/map/MapViewer.tsx
+++ b/web/components/map/MapViewer.tsx
@@ -407,7 +407,11 @@ export function MapViewer({
               ? initialCenter
               : undefined
           }
-          initialZoom={initialZoom}
+          initialZoom={
+            initialCenter && (!initialField || initialField === selectedField)
+              ? initialZoom
+              : undefined
+          }
           fields={fields}
           selectedField={selectedField}
           onFieldChange={handleFieldChange}

--- a/web/components/map/MapViewer.tsx
+++ b/web/components/map/MapViewer.tsx
@@ -415,8 +415,10 @@ export function MapViewer({
           markerCount={markers.length}
           onCursorCoords={setCursorCoords}
           onContextMenu={handleContextMenu}
+          onOpenFilters={onOpenFilters}
+          hasActiveFilters={hasActiveFilters}
         />
-        <CoordinateOverlay coords={cursorCoords} />
+        {/* Cursor readout is the FitsGL StatusPill (bottom-center); no separate overlay. */}
         {contextMenu && (
           <MapContextMenu
             coords={contextMenu.coords}

--- a/web/components/map/MapViewer.tsx
+++ b/web/components/map/MapViewer.tsx
@@ -10,7 +10,8 @@ import {
   useMapEvents,
 } from 'react-leaflet';
 import Link from 'next/link';
-import type { MapLayer, MapObjectMarker } from '@/lib/actions/map';
+import type { MapLayer, MapObjectMarker, FitsglDataset } from '@/lib/actions/map';
+import { FitsGLMapSurface } from './FitsGLMapSurface';
 import { useFieldObjectMarkers } from '@/lib/hooks/useFieldObjectMarkers';
 import { useFieldSlits } from '@/lib/hooks/useFieldSlits';
 import type { WCSParams } from '@/lib/utils/wcs';
@@ -165,6 +166,7 @@ function MapUpdater({ activeLayer, bounds }: { activeLayer: MapLayer; bounds: L.
 
 interface MapViewerProps {
   layers: MapLayer[];
+  fitsglDatasets?: FitsglDataset[];
   initialField?: string;
   initialFilter?: string;
   initialCenter?: { ra: number; dec: number };
@@ -179,6 +181,7 @@ interface MapViewerProps {
 
 export function MapViewer({
   layers,
+  fitsglDatasets = [],
   initialField,
   initialFilter,
   initialCenter,
@@ -208,7 +211,29 @@ export function MapViewer({
     return groups;
   }, [layers]);
 
-  const fields = useMemo(() => Object.keys(fieldGroups).sort(), [fieldGroups]);
+  // The field's default FitsGL composite dataset, keyed by field.
+  const fitsglByField = useMemo(() => {
+    const map = new Map<string, FitsglDataset>();
+    for (const d of fitsglDatasets) {
+      if (d.kind === 'field') map.set(d.field, d);
+    }
+    return map;
+  }, [fitsglDatasets]);
+
+  // Fields = union of PNG-layer fields and FitsGL-dataset fields (a field may be
+  // FitsGL-only once its PNG tiles are retired — Phase 5).
+  const fields = useMemo(() => {
+    const set = new Set([...Object.keys(fieldGroups), ...fitsglByField.keys()]);
+    return [...set].sort();
+  }, [fieldGroups, fitsglByField]);
+
+  // Per-field flag: prefer FitsGL when the field has a dataset. `?engine=leaflet`
+  // forces the legacy Leaflet path (side-by-side comparison during cutover).
+  const forceLeaflet = useMemo(
+    () => typeof window !== 'undefined'
+      && new URLSearchParams(window.location.search).get('engine') === 'leaflet',
+    [],
+  );
 
   // State
   const [selectedField, setSelectedField] = useState<string>(
@@ -364,6 +389,44 @@ export function MapViewer({
   }, []);
 
   const closeContextMenu = useCallback(() => setContextMenu(null), []);
+
+  // --- FitsGL surface (per-field flag, epic #337 Phase 4) -------------------
+  // Chosen before the Leaflet null-guard: a FitsGL field may have no PNG layer.
+  const activeDataset = fitsglByField.get(selectedField);
+  if (activeDataset && !forceLeaflet) {
+    return (
+      <div ref={mapWrapperRef} className="relative h-full w-full">
+        <FitsGLMapSurface
+          dataset={activeDataset}
+          markers={markers}
+          showMarkers={showMarkers}
+          highlightObjectId={highlightObjectId}
+          markerFilter={markerFilter}
+          initialCenter={
+            initialCenter && (!initialField || initialField === selectedField)
+              ? initialCenter
+              : undefined
+          }
+          initialZoom={initialZoom}
+          fields={fields}
+          selectedField={selectedField}
+          onFieldChange={handleFieldChange}
+          onToggleMarkers={setShowMarkers}
+          markerCount={markers.length}
+          onCursorCoords={setCursorCoords}
+          onContextMenu={handleContextMenu}
+        />
+        <CoordinateOverlay coords={cursorCoords} />
+        {contextMenu && (
+          <MapContextMenu
+            coords={contextMenu.coords}
+            position={contextMenu.position}
+            onClose={closeContextMenu}
+          />
+        )}
+      </div>
+    );
+  }
 
   if (!activeLayer || !mapConfig) {
     if (layers.length === 0) {

--- a/web/components/map/MapViewerWrapper.tsx
+++ b/web/components/map/MapViewerWrapper.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import type { MapLayer, MapObjectMarker } from '@/lib/actions/map';
+import type { MapLayer, MapObjectMarker, FitsglDataset } from '@/lib/actions/map';
 
 // Dynamic import to avoid SSR issues with Leaflet (requires window/document)
 const MapViewer = dynamic(
@@ -18,6 +18,7 @@ const MapViewer = dynamic(
 
 interface MapViewerWrapperProps {
   layers: MapLayer[];
+  fitsglDatasets: FitsglDataset[];
   initialField?: string;
   initialFilter?: string;
   initialCenter?: { ra: number; dec: number };

--- a/web/components/map/fitsgl/BandRail.tsx
+++ b/web/components/map/fitsgl/BandRail.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+/**
+ * Band rail (epic #337, Phase 4.5) — the top-center glass pill that merges the
+ * field selector with band selection (`docs/design-fitsgl-map-ux.md` §4). Mode is
+ * implicit in the selection (locked decision 1): a single band chip → single mode;
+ * the `RGB` affordance → three R/G/B channel pickers + a rainbow auto-assign. There
+ * is no `Single | RGB` segmented toggle.
+ *
+ * Purely presentational — the parent owns the `ExplorerState` and derives the
+ * `ViewerConfig`; this only renders the model and calls back on intent.
+ */
+
+import type { ExplorerBand, ExplorerState } from '@fitsgl/core/react';
+import { GLASS_PILL, chipClass, INSET } from './glass';
+
+type RgbRole = 'r' | 'g' | 'b';
+const RGB_ROLES: readonly RgbRole[] = ['r', 'g', 'b'];
+const ROLE_LABEL: Record<RgbRole, string> = { r: 'R', g: 'G', b: 'B' };
+const ROLE_DOT: Record<RgbRole, string> = { r: '#ef4444', g: '#22c55e', b: '#3b82f6' };
+
+interface BandRailProps {
+  fields: string[];
+  selectedField: string;
+  onFieldChange: (field: string) => void;
+  bands: ExplorerBand[];
+  state: ExplorerState;
+  /** Whether an RGB composite is possible (≥2 co-gridded bands). */
+  canComposite: boolean;
+  onSelectBand: (name: string) => void;
+  onToggleRgb: () => void;
+  onSetRgbRole: (role: RgbRole, band: string) => void;
+  /** Auto-assign R/G/B by pivot wavelength (reddest→R, bluest→B). */
+  onRainbow: () => void;
+}
+
+export function BandRail({
+  fields,
+  selectedField,
+  onFieldChange,
+  bands,
+  state,
+  canComposite,
+  onSelectBand,
+  onToggleRgb,
+  onSetRgbRole,
+  onRainbow,
+}: BandRailProps) {
+  const rgb = state.mode === 'rgb';
+  const showBands = bands.length > 1;
+
+  return (
+    <div
+      className={`absolute left-1/2 top-3 z-[500] flex -translate-x-1/2 items-center gap-1.5 ${GLASS_PILL} px-2 py-1.5`}
+    >
+      {/* Field selector — merged in (locked decision 2). */}
+      {fields.length > 1 ? (
+        <select
+          value={selectedField}
+          onChange={(e) => onFieldChange(e.target.value)}
+          className={`${INSET} font-mono`}
+          aria-label="Field"
+        >
+          {fields.map((f) => (
+            <option key={f} value={f}>{f}</option>
+          ))}
+        </select>
+      ) : (
+        <span className="px-1.5 font-mono text-xs text-text-secondary">{selectedField}</span>
+      )}
+
+      {showBands && (
+        <>
+          <span className="mx-0.5 h-5 w-px bg-border" aria-hidden />
+
+          {rgb ? (
+            // RGB mode: three channel pickers + rainbow.
+            <div className="flex items-center gap-1">
+              {RGB_ROLES.map((role) => (
+                <label key={role} className="flex items-center gap-1" title={`${ROLE_LABEL[role]} channel`}>
+                  <span
+                    className="inline-block h-2.5 w-2.5 rounded-sm"
+                    style={{ background: ROLE_DOT[role] }}
+                    aria-hidden
+                  />
+                  <select
+                    value={state.rgb[role]}
+                    onChange={(e) => onSetRgbRole(role, e.target.value)}
+                    className={`${INSET} font-mono`}
+                    aria-label={`${ROLE_LABEL[role]} channel band`}
+                  >
+                    {bands.map((b) => (
+                      <option key={b.name} value={b.name}>{b.label ?? b.name}</option>
+                    ))}
+                  </select>
+                </label>
+              ))}
+              <button
+                type="button"
+                onClick={onRainbow}
+                className={chipClass(false)}
+                title="Auto-assign channels by wavelength (reddest→R, bluest→B)"
+              >
+                ✦ rainbow
+              </button>
+            </div>
+          ) : (
+            // Single mode: one chip per band.
+            <div className="flex flex-wrap items-center gap-1">
+              {bands.map((b) => (
+                <button
+                  key={b.name}
+                  type="button"
+                  onClick={() => onSelectBand(b.name)}
+                  className={`${chipClass(state.band === b.name)} font-mono`}
+                >
+                  {b.label ?? b.name}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {canComposite && (
+            <>
+              <span className="mx-0.5 h-5 w-px bg-border" aria-hidden />
+              <button
+                type="button"
+                onClick={onToggleRgb}
+                className={chipClass(rgb)}
+                title={rgb ? 'Back to single-band' : 'Compose an RGB image'}
+              >
+                RGB
+              </button>
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/components/map/fitsgl/ColormapControl.tsx
+++ b/web/components/map/fitsgl/ColormapControl.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+/**
+ * ColormapControl (epic #337, Phase 4.5) — a custom colormap picker for the
+ * Display panel (`docs/design-fitsgl-map-ux.md`, locked decision 3: a dropdown,
+ * not a swatch row), replacing the native `<select>`. The trigger and every option
+ * render the actual colormap as a gradient bar (sampled from the engine's
+ * `colormapRGB` LUT), and a "reverse" toggle lives inside the popover — reversing
+ * flips the applied LUT, which the parent drives imperatively (deriveViewerConfig
+ * only carries colormap *names*, so reverse can't ride the controlled path).
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { colormapRGB, type ColormapName } from '@fitsgl/core';
+import { INSET } from './glass';
+import { SwitchVisual } from './Switch';
+
+/** CSS `linear-gradient` sampled from a colormap's LUT (memoised per name+dir). */
+const gradientCache = new Map<string, string>();
+function gradientCss(name: ColormapName, reversed: boolean, stops = 12): string {
+  const key = `${name}:${reversed ? 'r' : 'f'}`;
+  const cached = gradientCache.get(key);
+  if (cached) return cached;
+  const lut = colormapRGB(name);
+  const n = lut.length / 3;
+  const parts: string[] = [];
+  for (let j = 0; j < stops; j++) {
+    const t = j / (stops - 1);
+    const idx = Math.round((reversed ? 1 - t : t) * (n - 1));
+    parts.push(`rgb(${lut[idx * 3]},${lut[idx * 3 + 1]},${lut[idx * 3 + 2]}) ${Math.round(t * 100)}%`);
+  }
+  const css = `linear-gradient(90deg, ${parts.join(',')})`;
+  gradientCache.set(key, css);
+  return css;
+}
+
+interface ColormapControlProps {
+  names: readonly ColormapName[];
+  value: ColormapName;
+  reversed: boolean;
+  onChange: (name: ColormapName) => void;
+  onToggleReverse: (reversed: boolean) => void;
+}
+
+export function ColormapControl({ names, value, reversed, onChange, onToggleReverse }: ColormapControlProps) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  // Close on outside click / Escape.
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    window.addEventListener('mousedown', onDown);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('mousedown', onDown);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className={`${INSET} flex w-full items-center gap-2`}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <span
+          className="h-3.5 flex-1 rounded-sm ring-1 ring-inset ring-border"
+          style={{ background: gradientCss(value, reversed) }}
+          aria-hidden
+        />
+        <span className="font-mono capitalize">{value}{reversed ? ' ⟲' : ''}</span>
+        <span className="text-text-tertiary">▾</span>
+      </button>
+
+      {open && (
+        <div
+          role="listbox"
+          className="absolute right-0 z-[550] mt-1 w-full min-w-44 rounded-md border border-border bg-card p-1 shadow-xl"
+        >
+          {/* Reverse toggle (applies to the selected colormap). */}
+          <button
+            type="button"
+            onClick={() => onToggleReverse(!reversed)}
+            className="mb-1 flex w-full items-center justify-between rounded px-2 py-1 text-xs text-text-secondary hover:bg-card-hover"
+          >
+            <span>Reverse</span>
+            <SwitchVisual on={reversed} />
+          </button>
+          <div className="my-1 border-t border-border" />
+          {names.map((name) => (
+            <button
+              key={name}
+              type="button"
+              role="option"
+              aria-selected={name === value}
+              onClick={() => { onChange(name); setOpen(false); }}
+              className={`flex w-full items-center gap-2 rounded px-1.5 py-1 text-xs hover:bg-card-hover ${name === value ? 'text-text-primary' : 'text-text-secondary'}`}
+            >
+              <span
+                className="h-3.5 flex-1 rounded-sm ring-1 ring-inset ring-border"
+                style={{ background: gradientCss(name, reversed) }}
+                aria-hidden
+              />
+              <span className="w-14 text-right font-mono capitalize">{name}</span>
+              <span className="w-3 text-primary-text">{name === value ? '✓' : ''}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/components/map/fitsgl/DisplayPanel.tsx
+++ b/web/components/map/fitsgl/DisplayPanel.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+/**
+ * Display panel (epic #337, Phase 4.5) — the docked-right control for how the
+ * imagery is rendered (`docs/design-fitsgl-map-ux.md` §4). Scale (transfer curve)
+ * + Limits (black/white presets) + the fine-adjust histogram + a colormap dropdown
+ * (locked decision 3: a dropdown, not a swatch row). No north-up control — it is
+ * forced on (decision 4). RGB channel *assignment* lives in the band rail, not
+ * here (decision 1); this panel only styles whatever the active view is.
+ *
+ * Controlled: stretch mode + colormap flow up to the parent's `ExplorerState`
+ * (→ `deriveViewerConfig`); the histogram/preset black-white points are pushed
+ * imperatively by `useDisplayStretch` (see that hook).
+ */
+
+import { COLORMAP_NAMES, type ColormapName, type StretchMode } from '@fitsgl/core';
+import type { ExplorerState } from '@fitsgl/core/react';
+import { StretchHistogram } from './StretchHistogram';
+import { ColormapControl } from './ColormapControl';
+import { PANEL_CAP, chipClass } from './glass';
+import type { DisplayChannel, LimitPreset, ChannelKey } from './useDisplayStretch';
+
+/** Transfer curves offered as chips (zscale is a *limit* preset, not a curve). */
+const SCALE_MODES: StretchMode[] = ['asinh', 'log', 'sqrt', 'linear'];
+const ROLE_LABEL: Record<ChannelKey, string> = { single: '', r: 'R', g: 'G', b: 'B' };
+
+interface DisplayPanelProps {
+  state: ExplorerState;
+  channels: DisplayChannel[];
+  hasZscale: boolean;
+  hasTrilogy: boolean;
+  colormap: ColormapName;
+  colormapReversed: boolean;
+  onSetStretch: (mode: StretchMode) => void;
+  onSetColormap: (name: ColormapName) => void;
+  onToggleReverseColormap: (reversed: boolean) => void;
+  onSetHandle: (key: ChannelKey, min: number, max: number) => void;
+  onApplyPreset: (preset: LimitPreset) => void;
+}
+
+export function DisplayPanel({
+  state,
+  channels,
+  hasZscale,
+  hasTrilogy,
+  colormap,
+  colormapReversed,
+  onSetStretch,
+  onSetColormap,
+  onToggleReverseColormap,
+  onSetHandle,
+  onApplyPreset,
+}: DisplayPanelProps) {
+  const trilogy = state.stretch === 'trilogy';
+  const single = state.mode === 'single';
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h4 className={PANEL_CAP}>Display</h4>
+        <span className="font-mono text-[10px] text-text-tertiary">
+          {single ? state.band : 'RGB'} · {state.stretch}
+        </span>
+      </div>
+
+      {/* Scale (transfer curve). */}
+      <div className="space-y-1.5">
+        <span className={PANEL_CAP}>Scale</span>
+        <div className="flex flex-wrap gap-1">
+          {SCALE_MODES.map((m) => (
+            <button key={m} type="button" onClick={() => onSetStretch(m)} className={chipClass(state.stretch === m)}>
+              {m}
+            </button>
+          ))}
+          {/* Trilogy is the RGB weighted composite — not offered in single-band. */}
+          {!single && hasTrilogy && (
+            <button
+              type="button"
+              onClick={() => onSetStretch('trilogy')}
+              className={chipClass(trilogy)}
+              title="Faithful colour-preserving trilogy stretch (precomputed levels)"
+            >
+              trilogy
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Limits + fine adjust. Trilogy sets its levels from precomputed stats. */}
+      {trilogy ? (
+        <p className="text-[11px] italic text-text-tertiary">
+          Levels set from precomputed trilogy stats.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className={PANEL_CAP}>Limits</span>
+            <div className="flex gap-1">
+              <button type="button" onClick={() => onApplyPreset('auto')} className={chipClass(false)} title="Auto-stretch to the data in view">auto</button>
+              {hasZscale && (
+                <button type="button" onClick={() => onApplyPreset('zscale')} className={chipClass(false)} title="Whole-image DS9/IRAF zscale cuts">zscale</button>
+              )}
+              <button type="button" onClick={() => onApplyPreset('minmax')} className={chipClass(false)} title="Full data min–max in view">minmax</button>
+              <button type="button" onClick={() => onApplyPreset('p995')} className={chipClass(false)} title="0.25–99.75% in view">99.5%</button>
+            </div>
+          </div>
+
+          {channels.map((c) =>
+            c.histogram ? (
+              <div key={c.key} className="space-y-0.5">
+                {!single && (
+                  <div className="flex items-center gap-1.5 text-[10px] font-mono text-text-tertiary">
+                    <span className="inline-block h-2 w-2 rounded-sm" style={{ background: c.color }} aria-hidden />
+                    {ROLE_LABEL[c.key]} · {c.band.label ?? c.band.name}
+                  </div>
+                )}
+                <StretchHistogram
+                  histogram={c.histogram}
+                  min={c.min}
+                  max={c.max}
+                  color={c.color}
+                  onChange={(min, max) => onSetHandle(c.key, min, max)}
+                />
+              </div>
+            ) : null,
+          )}
+        </div>
+      )}
+
+      {/* Colormap — single mode only (an RGB composite carries its own colour). */}
+      {single && !trilogy && (
+        <div className="space-y-1.5">
+          <span className={PANEL_CAP}>Colormap</span>
+          <ColormapControl
+            names={COLORMAP_NAMES}
+            value={colormap}
+            reversed={colormapReversed}
+            onChange={onSetColormap}
+            onToggleReverse={onToggleReverseColormap}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/components/map/fitsgl/FitsglOverlays.tsx
+++ b/web/components/map/fitsgl/FitsglOverlays.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+/**
+ * FitsglOverlays (epic #337, Phase 4.5) — the Canvas2D layers stacked over the GL
+ * canvas: the RA/Dec graticule and the ruler line. Both reproject every drawn frame
+ * from the viewer's public accessors, so the parent calls the imperative `redraw()`
+ * from its `onFrame` (React state per frame would thrash). The ruler also installs a
+ * `PointerTool` via the viewer handle while the ruler tool is active, feeding its
+ * live measurement back to the status pill through `onMeasure`.
+ */
+
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef } from 'react';
+import type { PointerTool } from '@fitsgl/core';
+import type { FitsViewerHandle } from '@fitsgl/core/react';
+import { drawGraticule } from './graticule';
+import { drawRuler, measureRuler, type RulerGeometry, type RulerMeasurement, type Point } from './ruler';
+
+export interface FitsglOverlaysHandle {
+  redraw(): void;
+}
+
+interface FitsglOverlaysProps {
+  handleRef: React.RefObject<FitsViewerHandle | null>;
+  graticule: boolean;
+  tool: 'pan' | 'ruler';
+  /** Bumped on viewer (re)ready — re-installs the pointer tool after a reload. */
+  readyTick: number;
+  accent: string;
+  gridLine: string;
+  gridLabel: string;
+  onMeasure: (m: RulerMeasurement | null) => void;
+}
+
+/** Size a canvas to its CSS box × DPR, clear it, and hand back a CSS-space ctx. */
+function prepare(canvas: HTMLCanvasElement | null): { ctx: CanvasRenderingContext2D; rect: DOMRect } | null {
+  if (!canvas) return null;
+  const dpr = window.devicePixelRatio || 1;
+  const w = canvas.clientWidth, h = canvas.clientHeight;
+  if (w < 2 || h < 2) return null;
+  if (canvas.width !== Math.round(w * dpr) || canvas.height !== Math.round(h * dpr)) {
+    canvas.width = Math.round(w * dpr);
+    canvas.height = Math.round(h * dpr);
+  }
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  ctx.clearRect(0, 0, w, h);
+  return { ctx, rect: canvas.getBoundingClientRect() };
+}
+
+export const FitsglOverlays = forwardRef<FitsglOverlaysHandle, FitsglOverlaysProps>(function FitsglOverlays(
+  { handleRef, graticule, tool, readyTick, accent, gridLine, gridLabel, onMeasure },
+  ref,
+) {
+  const gratRef = useRef<HTMLCanvasElement | null>(null);
+  const rulerRef = useRef<HTMLCanvasElement | null>(null);
+  const geom = useRef<RulerGeometry | null>(null);
+
+  // Latest values through refs so the fixed PointerTool never captures stale props.
+  const onMeasureRef = useRef(onMeasure);
+  const accentRef = useRef(accent);
+  useEffect(() => { onMeasureRef.current = onMeasure; }, [onMeasure]);
+  useEffect(() => { accentRef.current = accent; }, [accent]);
+
+  const redraw = useCallback(() => {
+    const viewer = handleRef.current?.getViewer() ?? null;
+    const g = prepare(gratRef.current);
+    if (g && graticule && viewer) drawGraticule(g.ctx, g.rect, viewer, { line: gridLine, label: gridLabel });
+    const r = prepare(rulerRef.current);
+    if (r && tool === 'ruler' && viewer) drawRuler(r.ctx, r.rect, viewer, geom.current, accentRef.current);
+  }, [handleRef, graticule, tool, gridLine, gridLabel]);
+
+  useImperativeHandle(ref, () => ({ redraw }), [redraw]);
+
+  // Redraw when a layer toggles (a frame may not follow a pure UI toggle).
+  useEffect(() => { redraw(); }, [redraw]);
+
+  // Install / tear down the ruler PointerTool while the ruler tool is active.
+  useEffect(() => {
+    const h = handleRef.current;
+    if (!h) return;
+    if (tool !== 'ruler') {
+      h.setTool(null);
+      geom.current = null;
+      onMeasureRef.current(null);
+      redraw();
+      return;
+    }
+    const measure = (a: Point, b: Point): RulerMeasurement =>
+      measureRuler(h.getViewer()?.getWcs() ?? null, a, b);
+    const commit = (a: Point, b: Point, dragging: boolean) => {
+      const m = measure(a, b);
+      geom.current = { a, b, dragging, ...m };
+      onMeasureRef.current(m);
+      redraw();
+    };
+    const rulerTool: PointerTool = {
+      cursor: 'crosshair',
+      onPointerDown(world) { commit({ x: world.x, y: world.y }, { x: world.x, y: world.y }, true); },
+      onPointerMove(world) { const g = geom.current; if (g) commit(g.a, { x: world.x, y: world.y }, true); },
+      onPointerUp(world) { const g = geom.current; if (g) commit(g.a, { x: world.x, y: world.y }, false); },
+    };
+    h.setTool(rulerTool);
+    return () => { h.setTool(null); };
+  }, [tool, readyTick, handleRef, redraw]);
+
+  return (
+    <>
+      <canvas ref={gratRef} className="pointer-events-none absolute inset-0 z-[400] h-full w-full" aria-hidden />
+      <canvas ref={rulerRef} className="pointer-events-none absolute inset-0 z-[400] h-full w-full" aria-hidden />
+    </>
+  );
+});

--- a/web/components/map/fitsgl/LayersPanel.tsx
+++ b/web/components/map/fitsgl/LayersPanel.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+/**
+ * Layers panel (epic #337, Phase 4.5) — docked-right toggles for what's drawn OVER
+ * the imagery (`docs/design-fitsgl-map-ux.md` §4): NIRSpec objects, MSA shutters
+ * (Phase 4b), and the RA/Dec graticule. No quality legend (locked decision 5).
+ */
+
+import { PANEL_CAP } from './glass';
+import { SwitchVisual } from './Switch';
+
+interface ToggleRowProps {
+  label: string;
+  on: boolean;
+  onToggle: (on: boolean) => void;
+  disabled?: boolean;
+  hint?: string;
+}
+
+function ToggleRow({ label, on, onToggle, disabled, hint }: ToggleRowProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={on}
+      aria-label={label}
+      disabled={disabled}
+      onClick={() => onToggle(!on)}
+      className={`flex w-full items-center justify-between py-1 text-xs ${disabled ? 'cursor-default text-text-tertiary' : 'text-text-secondary hover:text-text-primary'}`}
+    >
+      <span>{label}{hint && <span className="ml-1.5 text-[10px] text-text-tertiary">{hint}</span>}</span>
+      <SwitchVisual on={on} />
+    </button>
+  );
+}
+
+interface LayersPanelProps {
+  showMarkers: boolean;
+  onToggleMarkers: (on: boolean) => void;
+  markerCount: number;
+  graticule: boolean;
+  onToggleGraticule: (on: boolean) => void;
+  /** MSA shutters — the region overlay lands in Phase 4b; the row is inert until then. */
+  shuttersAvailable?: boolean;
+  showShutters?: boolean;
+  onToggleShutters?: (on: boolean) => void;
+}
+
+export function LayersPanel({
+  showMarkers,
+  onToggleMarkers,
+  markerCount,
+  graticule,
+  onToggleGraticule,
+  shuttersAvailable = false,
+  showShutters = false,
+  onToggleShutters,
+}: LayersPanelProps) {
+  return (
+    <div className="space-y-1">
+      <h4 className={PANEL_CAP}>Layers</h4>
+      <ToggleRow label={`NIRSpec objects (${markerCount})`} on={showMarkers} onToggle={onToggleMarkers} />
+      <ToggleRow
+        label="MSA shutters"
+        on={shuttersAvailable ? showShutters : false}
+        onToggle={onToggleShutters ?? (() => {})}
+        disabled={!shuttersAvailable}
+        hint={shuttersAvailable ? undefined : 'soon'}
+      />
+      <ToggleRow label="Graticule" on={graticule} onToggle={onToggleGraticule} />
+    </div>
+  );
+}

--- a/web/components/map/fitsgl/StatusPill.tsx
+++ b/web/components/map/fitsgl/StatusPill.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+/**
+ * Status pill (epic #337, Phase 4.5) — the bottom-center glass readout
+ * (`docs/design-fitsgl-map-ux.md` §4): dual RA/Dec (sexagesimal + decimal, keeping
+ * the existing CAMPFIRE formatters — decision 8), the cursor's pixel value per
+ * active band, zoom, and `band · stretch`. Grows to show separation + position
+ * angle while the ruler tool has a measurement.
+ */
+
+import { formatRA, formatDec } from '@/lib/utils/wcs';
+import { formatSeparation } from '@fitsgl/core';
+import { GLASS_PILL } from './glass';
+import type { RulerMeasurement } from './ruler';
+
+interface StatusPillProps {
+  ra: number | null;
+  dec: number | null;
+  values: ReadonlyArray<number | null> | null;
+  native: boolean;
+  zoom: number | null;
+  bandLabel: string;
+  stretch: string;
+  ruler: RulerMeasurement | null;
+}
+
+function fmtVal(v: number | null): string {
+  if (v === null || !Number.isFinite(v)) return '—';
+  const a = Math.abs(v);
+  if (a !== 0 && (a < 1e-3 || a >= 1e5)) return v.toExponential(2);
+  return v.toPrecision(4);
+}
+
+function Item({ k, children }: { k: string; children: React.ReactNode }) {
+  return (
+    <span className="flex items-baseline gap-1">
+      <span className="text-text-tertiary">{k}</span>
+      <b className="font-medium text-text-primary">{children}</b>
+    </span>
+  );
+}
+
+export function StatusPill({ ra, dec, values, native, zoom, bandLabel, stretch, ruler }: StatusPillProps) {
+  const hasVal = !!values && values.some((v) => v !== null && Number.isFinite(v));
+  const valStr = hasVal ? values!.map(fmtVal).join(' ') + (native ? '' : '*') : '—';
+  return (
+    <div
+      className={`absolute bottom-4 left-1/2 z-[500] flex -translate-x-1/2 items-center gap-4 whitespace-nowrap ${GLASS_PILL} px-4 py-2 font-mono text-xs`}
+    >
+      <Item k="α">{ra !== null ? formatRA(ra) : '—'}</Item>
+      <Item k="δ">{dec !== null ? formatDec(dec) : '—'}</Item>
+      <span className="text-[10px] text-text-tertiary">
+        {ra !== null && dec !== null ? `(${ra.toFixed(5)}, ${dec.toFixed(5)})` : ''}
+      </span>
+      <span className="h-3.5 w-px bg-border" aria-hidden />
+      <Item k="val">{valStr}</Item>
+      <Item k="zoom">{zoom !== null ? `${zoom.toFixed(2)}×` : '—'}</Item>
+      <span className="text-text-tertiary">{bandLabel} · {stretch}</span>
+      {ruler && (
+        <>
+          <span className="h-3.5 w-px bg-border" aria-hidden />
+          <Item k="sep">
+            {ruler.sepDeg !== null ? formatSeparation(ruler.sepDeg) : `${ruler.pixelDist.toFixed(1)} px`}
+          </Item>
+          {ruler.paDeg !== null && <Item k="PA">{ruler.paDeg.toFixed(1)}°</Item>}
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/components/map/fitsgl/StretchHistogram.tsx
+++ b/web/components/map/fitsgl/StretchHistogram.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+/**
+ * StretchHistogram (epic #337, Phase 4.5) — the FitsExplorer-style "fine adjust"
+ * (`docs/design-fitsgl-map-ux.md` §4, locked decision 6), rebuilt in CAMPFIRE
+ * chrome. Draws one band's precomputed display histogram (`ExplorerBand.histogram`,
+ * 128 bins over `[lo, hi]`) and overlays draggable black/white-point handles that
+ * live-drive the viewer's stretch (`setStretch` / `setChannelStretch`). Controlled:
+ * the parent holds the `[min, max]` and pushes each change to the GPU imperatively.
+ *
+ * The handle range is tied to the precomputed `[lo, hi]` domain (a robust wide
+ * percentile), which is where any useful black/white point sits; a value that
+ * auto-stretch placed outside the domain simply pins a handle to the edge.
+ */
+
+import { useCallback, useRef } from 'react';
+
+const W = 256;
+const H = 40;
+
+interface StretchHistogramProps {
+  histogram: { counts: number[] | Float32Array; lo: number; hi: number };
+  min: number;
+  max: number;
+  /** Bar/fill tint (e.g. an RGB channel colour); defaults to the accent. */
+  color?: string;
+  onChange: (min: number, max: number) => void;
+}
+
+/** Filled-area SVG path for the histogram outline; sqrt-scaled so faint tails show. */
+function histPath(counts: number[] | Float32Array): string {
+  const n = counts.length;
+  if (n === 0) return '';
+  let peak = 0;
+  for (let i = 0; i < n; i++) peak = Math.max(peak, counts[i]);
+  if (peak <= 0) return `M0,${H} L${W},${H} Z`;
+  const dx = W / n;
+  let d = `M0,${H}`;
+  for (let i = 0; i < n; i++) {
+    const h = Math.sqrt(counts[i] / peak) * H;
+    const x = i * dx;
+    d += ` L${x.toFixed(2)},${(H - h).toFixed(2)} L${(x + dx).toFixed(2)},${(H - h).toFixed(2)}`;
+  }
+  d += ` L${W},${H} Z`;
+  return d;
+}
+
+export function StretchHistogram({ histogram, min, max, color, onChange }: StretchHistogramProps) {
+  const { counts, lo, hi } = histogram;
+  const span = hi - lo || 1;
+  const tint = color ?? 'var(--primary)';
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  // Latest range through a ref so a drag started on one handle reads the other's
+  // current value without a stale closure.
+  const rangeRef = useRef({ min, max });
+  rangeRef.current = { min, max };
+
+  const frac = (v: number) => Math.min(1, Math.max(0, (v - lo) / span));
+  const loPct = frac(min) * 100;
+  const hiPct = frac(max) * 100;
+
+  const startDrag = useCallback(
+    (handle: 'lo' | 'hi') => (e: React.PointerEvent) => {
+      e.preventDefault();
+      const el = containerRef.current;
+      if (!el) return;
+      const move = (ev: PointerEvent) => {
+        const rect = el.getBoundingClientRect();
+        const f = Math.min(1, Math.max(0, (ev.clientX - rect.left) / rect.width));
+        const v = lo + f * span;
+        const cur = rangeRef.current;
+        const EPS = span * 1e-3;
+        if (handle === 'lo') onChange(Math.min(v, cur.max - EPS), cur.max);
+        else onChange(cur.min, Math.max(v, cur.min + EPS));
+      };
+      const up = () => {
+        window.removeEventListener('pointermove', move);
+        window.removeEventListener('pointerup', up);
+      };
+      window.addEventListener('pointermove', move);
+      window.addEventListener('pointerup', up);
+    },
+    [lo, span, onChange],
+  );
+
+  return (
+    <div ref={containerRef} className="relative select-none" style={{ touchAction: 'none' }}>
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        preserveAspectRatio="none"
+        className="block h-10 w-full"
+        aria-hidden
+      >
+        <path d={histPath(counts)} fill={tint} fillOpacity={0.35} />
+        {/* Clipped-out regions (below black / above white) dimmed. */}
+        <rect x={0} y={0} width={(loPct / 100) * W} height={H} fill="var(--background)" fillOpacity={0.55} />
+        <rect
+          x={(hiPct / 100) * W}
+          y={0}
+          width={W - (hiPct / 100) * W}
+          height={H}
+          fill="var(--background)"
+          fillOpacity={0.55}
+        />
+      </svg>
+
+      {/* Black-point handle. */}
+      <div
+        role="slider"
+        aria-label="Black point"
+        aria-valuenow={min}
+        tabIndex={0}
+        onPointerDown={startDrag('lo')}
+        className="absolute top-0 h-10 w-2 -translate-x-1/2 cursor-ew-resize"
+        style={{ left: `${loPct}%` }}
+      >
+        <div className="mx-auto h-full w-px bg-[var(--text-primary)]" />
+        <div className="absolute -bottom-0.5 left-1/2 h-2 w-2 -translate-x-1/2 rounded-full bg-white shadow" />
+      </div>
+      {/* White-point handle. */}
+      <div
+        role="slider"
+        aria-label="White point"
+        aria-valuenow={max}
+        tabIndex={0}
+        onPointerDown={startDrag('hi')}
+        className="absolute top-0 h-10 w-2 -translate-x-1/2 cursor-ew-resize"
+        style={{ left: `${hiPct}%` }}
+      >
+        <div className="mx-auto h-full w-px bg-[var(--text-primary)]" />
+        <div className="absolute -top-0.5 left-1/2 h-2 w-2 -translate-x-1/2 rounded-full bg-white shadow" />
+      </div>
+    </div>
+  );
+}

--- a/web/components/map/fitsgl/Switch.tsx
+++ b/web/components/map/fitsgl/Switch.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+/**
+ * SwitchVisual (epic #337, Phase 4.5) — the decorative on/off knob shared by the
+ * glass panels' toggle rows (Layers toggles, the colormap "reverse"). Presentational
+ * only: wrap it in a `<button>` row that owns the click + `aria`, so it never nests
+ * interactive elements.
+ */
+
+export function SwitchVisual({ on }: { on: boolean }) {
+  return (
+    <span
+      className={`relative inline-block h-4 w-7 shrink-0 rounded-full transition-colors ${on ? 'bg-primary' : 'bg-border-strong'}`}
+      aria-hidden
+    >
+      <span
+        className="absolute top-0.5 h-3 w-3 rounded-full bg-white transition-all"
+        style={{ left: on ? '0.875rem' : '0.125rem' }}
+      />
+    </span>
+  );
+}

--- a/web/components/map/fitsgl/ToolRail.tsx
+++ b/web/components/map/fitsgl/ToolRail.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+/**
+ * Left tool rail (epic #337, Phase 4.5) — a slim docked-left glass column
+ * (`docs/design-fitsgl-map-ux.md` §4): modal cursor tools (pan / ruler) above a
+ * divider, then one-shot actions (fit-to-view, export PNG) and the Filters launcher
+ * (opens the shared slide-over). The Display/Layers panels live in the right dock
+ * (its own collapse chevron), so they're not duplicated here.
+ */
+
+import { Hand, Ruler, Maximize2, Download, SlidersHorizontal } from 'lucide-react';
+import { GLASS } from './glass';
+
+type Tool = 'pan' | 'ruler';
+
+interface ToolButtonProps {
+  label: string;
+  active?: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+  /** A small accent dot (e.g. active-filters indicator). */
+  dot?: boolean;
+}
+
+function ToolButton({ label, active, onClick, children, dot }: ToolButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={label}
+      aria-label={label}
+      aria-pressed={active}
+      className={`relative flex h-9 w-9 items-center justify-center rounded-lg transition-colors ${active ? 'bg-primary-soft text-primary-text' : 'text-text-secondary hover:bg-card-hover hover:text-text-primary'}`}
+    >
+      {children}
+      {dot && <span className="absolute right-1 top-1 h-1.5 w-1.5 rounded-full bg-primary" />}
+    </button>
+  );
+}
+
+interface ToolRailProps {
+  tool: Tool;
+  onSetTool: (tool: Tool) => void;
+  onFit: () => void;
+  onExport: () => void;
+  onOpenFilters?: () => void;
+  hasActiveFilters?: boolean;
+}
+
+export function ToolRail({ tool, onSetTool, onFit, onExport, onOpenFilters, hasActiveFilters }: ToolRailProps) {
+  return (
+    <div className={`absolute left-0 top-1/2 z-[500] flex -translate-y-1/2 flex-col gap-1 rounded-r-xl ${GLASS} p-1.5`}>
+      <ToolButton label="Pan" active={tool === 'pan'} onClick={() => onSetTool('pan')}>
+        <Hand className="h-4 w-4" />
+      </ToolButton>
+      <ToolButton label="Ruler (measure)" active={tool === 'ruler'} onClick={() => onSetTool('ruler')}>
+        <Ruler className="h-4 w-4" />
+      </ToolButton>
+
+      <div className="mx-auto my-0.5 h-px w-5 bg-border" />
+
+      <ToolButton label="Fit to view" onClick={onFit}>
+        <Maximize2 className="h-4 w-4" />
+      </ToolButton>
+      <ToolButton label="Export PNG" onClick={onExport}>
+        <Download className="h-4 w-4" />
+      </ToolButton>
+      {onOpenFilters && (
+        <ToolButton label="NIRSpec filters" onClick={onOpenFilters} dot={hasActiveFilters}>
+          <SlidersHorizontal className="h-4 w-4" />
+        </ToolButton>
+      )}
+    </div>
+  );
+}

--- a/web/components/map/fitsgl/glass.ts
+++ b/web/components/map/fitsgl/glass.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared "glass" surface vocabulary for the FitsGL map chrome (epic #337,
+ * Phase 4.5). Every floating control — band rail, Display/Layers dock, status
+ * pill, tool rail — sits on the same translucent, blurred panel over the
+ * full-bleed viewer, so the map stays the hero (see `docs/design-fitsgl-map-ux.md`
+ * §2). Centralised here so the aesthetic is defined once, not copy-pasted per
+ * panel, and follows the Ember & Dusk tokens (`bg-card`, `border-border`, …) in
+ * both themes.
+ */
+
+/**
+ * Base translucent+blur panel surface. Compose with a radius/padding per panel.
+ * Kept fairly opaque + dark-tinted (the chrome sits on the always-dark map well via
+ * the `.fitsgl-chrome` token pin) so text stays legible over a white/grey stretch.
+ */
+export const GLASS = 'bg-[var(--glass-bg)] backdrop-blur-md border border-border shadow-xl';
+
+/** A free-floating pill/panel (band rail, status pill): fully rounded corners. */
+export const GLASS_PILL = `${GLASS} rounded-xl`;
+
+/** Uppercase section caption inside a panel (matches the wireframes' tiny labels). */
+export const PANEL_CAP =
+  'text-[11px] font-medium uppercase tracking-wide text-text-tertiary';
+
+/** A small toggle "chip" (stretch mode, band, preset). `active` fills with the accent. */
+export function chipClass(active: boolean): string {
+  return [
+    'rounded-md px-2 py-1 text-xs transition-colors',
+    active
+      ? 'bg-primary-soft text-primary-text ring-1 ring-inset ring-[rgba(251,146,60,0.45)]'
+      : 'text-text-secondary hover:bg-card-hover',
+  ].join(' ');
+}
+
+/** A compact inset control (dropdown, channel picker) on the glass surface. */
+export const INSET =
+  'rounded-md border border-border bg-[var(--surface-2)] px-2 py-1 text-xs text-text-primary';

--- a/web/components/map/fitsgl/graticule.ts
+++ b/web/components/map/fitsgl/graticule.ts
@@ -1,0 +1,108 @@
+/**
+ * RA/Dec coordinate-grid (graticule) drawing (epic #337, Phase 4.5). FitsGL ships
+ * `drawGraticule` but doesn't re-export it from `@fitsgl/core/react`, so we rebuild
+ * it on the public API: `getWcs` + `screenToImage` (client→world) bound the visible
+ * sky, then each iso-RA / iso-Dec line is traced by sampling `skyToPix` → world →
+ * `imageToScreen`, so the grid stays correct under the TAN projection, pan/zoom and
+ * North-up. (Swap for FitsGL's own `drawGraticule` if it's ever exported — see the
+ * epic notes.)
+ */
+
+import { pixToSky, skyToPix, type TanWcs } from '@fitsgl/core';
+import type { FitsViewerCore } from '@fitsgl/core/react';
+
+/** Candidate grid steps in degrees: 10°…1° … arcmin … arcsec. */
+const STEPS = [
+  10, 5, 2, 1, 0.5, 0.25,
+  10 / 60, 5 / 60, 2 / 60, 1 / 60,
+  30 / 3600, 15 / 3600, 10 / 3600, 5 / 3600, 2 / 3600, 1 / 3600,
+];
+
+/** Largest step giving ~4 divisions across `span` (falls back to the finest). */
+function niceStep(span: number): number {
+  const target = span / 4;
+  for (const s of STEPS) if (s <= target) return s;
+  return STEPS[STEPS.length - 1];
+}
+
+function fmtDeg(v: number, step: number): string {
+  const dp = step >= 1 ? 1 : step >= 1 / 60 ? 3 : 5;
+  return `${v.toFixed(dp)}°`;
+}
+
+export function drawGraticule(
+  ctx: CanvasRenderingContext2D,
+  rect: DOMRect,
+  viewer: FitsViewerCore | null,
+  opts: { line: string; label: string },
+): void {
+  const wcs: TanWcs | null = viewer?.getWcs() ?? null;
+  if (!viewer || !wcs) return;
+  const W = rect.width, H = rect.height;
+  if (W < 2 || H < 2) return;
+
+  // Bound the visible sky: sample a 5×5 grid of client points → world → sky.
+  const ras: number[] = [];
+  const decs: number[] = [];
+  for (let i = 0; i <= 4; i++) {
+    for (let j = 0; j <= 4; j++) {
+      const cx = rect.left + (W * i) / 4;
+      const cy = rect.top + (H * j) / 4;
+      const world = viewer.screenToImage(cx, cy);
+      const sky = pixToSky(wcs, world.x, world.y);
+      ras.push(sky.ra); decs.push(sky.dec);
+    }
+  }
+  if (ras.length < 4) return;
+
+  // Unwrap RA if the field straddles 0/360.
+  let unwrapped = ras;
+  if (Math.max(...ras) - Math.min(...ras) > 180) unwrapped = ras.map((r) => (r < 180 ? r + 360 : r));
+  const raMin = Math.min(...unwrapped), raMax = Math.max(...unwrapped);
+  const decMin = Math.min(...decs), decMax = Math.max(...decs);
+  const raStep = niceStep(raMax - raMin);
+  const decStep = niceStep(decMax - decMin);
+  const SAMPLES = 48;
+
+  ctx.save();
+  ctx.lineWidth = 0.6;
+  ctx.strokeStyle = opts.line;
+  ctx.fillStyle = opts.label;
+  ctx.font = '10px ui-monospace, monospace';
+
+  // Iso-Dec lines (constant dec, vary ra).
+  for (let dec = Math.ceil(decMin / decStep) * decStep; dec <= decMax; dec += decStep) {
+    let left: { x: number; y: number } | null = null;
+    ctx.beginPath();
+    for (let k = 0; k <= SAMPLES; k++) {
+      const ra = raMin + ((raMax - raMin) * k) / SAMPLES;
+      const p = project(viewer, wcs, ra, dec, rect);
+      if (k === 0) ctx.moveTo(p.x, p.y); else ctx.lineTo(p.x, p.y);
+      if (p.y >= 0 && p.y <= H && (!left || p.x < left.x)) left = p;
+    }
+    ctx.stroke();
+    if (left) ctx.fillText(fmtDeg(dec, decStep), Math.max(4, left.x + 4), Math.min(H - 4, left.y - 3));
+  }
+
+  // Iso-RA lines (constant ra, vary dec).
+  for (let ra = Math.ceil(raMin / raStep) * raStep; ra <= raMax; ra += raStep) {
+    let bottom: { x: number; y: number } | null = null;
+    ctx.beginPath();
+    for (let k = 0; k <= SAMPLES; k++) {
+      const dec = decMin + ((decMax - decMin) * k) / SAMPLES;
+      const p = project(viewer, wcs, ra, dec, rect);
+      if (k === 0) ctx.moveTo(p.x, p.y); else ctx.lineTo(p.x, p.y);
+      if (p.x >= 0 && p.x <= W && (!bottom || p.y > bottom.y)) bottom = p;
+    }
+    ctx.stroke();
+    if (bottom) ctx.fillText(fmtDeg(((ra % 360) + 360) % 360, raStep), Math.min(W - 40, bottom.x + 4), Math.max(12, bottom.y - 4));
+  }
+  ctx.restore();
+}
+
+/** Project a sky point to canvas-local coords via the viewer's accessors. */
+function project(viewer: FitsViewerCore, wcs: TanWcs, ra: number, dec: number, rect: DOMRect) {
+  const w = skyToPix(wcs, ((ra % 360) + 360) % 360, dec);
+  const s = viewer.imageToScreen(w.x, w.y);
+  return { x: s.x - rect.left, y: s.y - rect.top };
+}

--- a/web/components/map/fitsgl/ruler.ts
+++ b/web/components/map/fitsgl/ruler.ts
@@ -1,0 +1,84 @@
+/**
+ * Ruler / measure-tool math + Canvas2D drawing (epic #337, Phase 4.5). FitsGL ships
+ * `measureRuler`/`drawRuler` but does not re-export them from `@fitsgl/core/react`,
+ * so we rebuild them on the public API (the exported spherical helpers + the
+ * viewer's `getWcs`/`imageToScreen`). Endpoints are stored in world (native
+ * image-pixel) coords so the line stays glued to the sky under pan/zoom/North-up.
+ *
+ * (If FitsGL later exports its own `measureRuler`/`drawRuler`, swap these for the
+ * upstream versions to stay DRY — see the epic notes.)
+ */
+
+import {
+  pixToSky,
+  angularSeparationDeg,
+  positionAngleDeg,
+  type TanWcs,
+} from '@fitsgl/core';
+import type { FitsViewerCore } from '@fitsgl/core/react';
+
+export interface Point { x: number; y: number }
+
+export interface RulerMeasurement {
+  /** Straight native-pixel distance between the endpoints. */
+  pixelDist: number;
+  /** Great-circle separation in degrees, or null without a WCS. */
+  sepDeg: number | null;
+  /** Position angle (North→East) at the first endpoint, or null. */
+  paDeg: number | null;
+}
+
+export interface RulerGeometry extends RulerMeasurement {
+  a: Point;
+  b: Point;
+  dragging: boolean;
+}
+
+/** Measure a two-point ruler in world (native-pixel) coords. Pure. */
+export function measureRuler(wcs: TanWcs | null, a: Point, b: Point): RulerMeasurement {
+  const pixelDist = Math.hypot(b.x - a.x, b.y - a.y);
+  if (!wcs) return { pixelDist, sepDeg: null, paDeg: null };
+  const sa = pixToSky(wcs, a.x, a.y);
+  const sb = pixToSky(wcs, b.x, b.y);
+  return {
+    pixelDist,
+    sepDeg: angularSeparationDeg(sa, sb),
+    paDeg: positionAngleDeg(sa, sb),
+  };
+}
+
+/**
+ * Draw the ruler line + endpoint ticks into a Canvas2D overlay stacked exactly
+ * over the viewer. `ctx` is expected pre-scaled to CSS pixels; `rect` is the
+ * canvas's client rect (to localise the viewer's client-space `imageToScreen`).
+ */
+export function drawRuler(
+  ctx: CanvasRenderingContext2D,
+  rect: DOMRect,
+  viewer: FitsViewerCore | null,
+  ruler: RulerGeometry | null,
+  accent: string,
+): void {
+  if (!viewer || !ruler) return;
+  const pa = viewer.imageToScreen(ruler.a.x, ruler.a.y);
+  const pb = viewer.imageToScreen(ruler.b.x, ruler.b.y);
+  const ax = pa.x - rect.left, ay = pa.y - rect.top;
+  const bx = pb.x - rect.left, by = pb.y - rect.top;
+
+  ctx.save();
+  ctx.strokeStyle = accent;
+  ctx.fillStyle = accent;
+  ctx.lineWidth = 1.5;
+  ctx.setLineDash([5, 4]);
+  ctx.beginPath();
+  ctx.moveTo(ax, ay);
+  ctx.lineTo(bx, by);
+  ctx.stroke();
+  ctx.setLineDash([]);
+  for (const [x, y] of [[ax, ay], [bx, by]] as const) {
+    ctx.beginPath();
+    ctx.arc(x, y, 3, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.restore();
+}

--- a/web/components/map/fitsgl/useColormap.ts
+++ b/web/components/map/fitsgl/useColormap.ts
@@ -1,0 +1,55 @@
+'use client';
+
+/**
+ * useColormap (epic #337, Phase 4.5) — applies the single-band colormap
+ * imperatively. Colormap is deliberately kept OFF the controlled
+ * `deriveViewerConfig` path (which can only express a `ColormapName`, not a
+ * reversed LUT), so `viewState.colormap` stays pinned to `'gray'` and this hook is
+ * the sole driver: a forward colormap passes the bundled name (grayscale → null),
+ * and a reversed one passes a reversed `ColormapLUT`. Re-applies on band/source
+ * change (setSource keeps the viewer-level colormap, but re-applying is cheap and
+ * safe).
+ */
+
+import { useEffect } from 'react';
+import { colormapRGB, type ColormapName } from '@fitsgl/core';
+import type { FitsViewerHandle } from '@fitsgl/core/react';
+
+/** Reverse a colormap LUT by flipping the order of its RGB triplets. */
+function reverseLut(lut: Uint8Array): Uint8Array {
+  const n = lut.length / 3;
+  const out = new Uint8Array(lut.length);
+  for (let i = 0; i < n; i++) {
+    const src = (n - 1 - i) * 3;
+    const dst = i * 3;
+    out[dst] = lut[src];
+    out[dst + 1] = lut[src + 1];
+    out[dst + 2] = lut[src + 2];
+  }
+  return out;
+}
+
+interface UseColormapArgs {
+  handleRef: React.RefObject<FitsViewerHandle | null>;
+  name: ColormapName;
+  reversed: boolean;
+  /** Only single-band mode uses a colormap (an RGB composite carries its colour). */
+  single: boolean;
+  /** Identity of the active source; re-applies after a band switch. */
+  sourceKey: string;
+  /** Bumped on viewer (re)ready. */
+  readyTick: number;
+}
+
+export function useColormap({ handleRef, name, reversed, single, sourceKey, readyTick }: UseColormapArgs) {
+  useEffect(() => {
+    if (!single) return;
+    const v = handleRef.current?.getViewer();
+    if (!v) return;
+    if (!reversed) {
+      v.setColormap(name === 'gray' ? null : name);
+    } else {
+      v.setColormap(reverseLut(colormapRGB(name)));
+    }
+  }, [handleRef, name, reversed, single, sourceKey, readyTick]);
+}

--- a/web/components/map/fitsgl/useDisplayStretch.ts
+++ b/web/components/map/fitsgl/useDisplayStretch.ts
@@ -1,0 +1,196 @@
+'use client';
+
+/**
+ * useDisplayStretch (epic #337, Phase 4.5) — the imperative bridge between the
+ * Display panel and the FitsGL `CoreViewer`. The band, stretch *mode*, colormap
+ * and north-up ride the controlled `deriveViewerConfig` path; the black/white
+ * points do NOT (deriveViewerConfig deliberately omits stretch ranges — a
+ * high-frequency drag shouldn't churn React/reload), so they are driven here
+ * through the ref handle, exactly as `<FitsExplorer>` does.
+ *
+ * Responsibilities:
+ *  - expose the active channel(s) (1 single, or R/G/B) with each band's precomputed
+ *    histogram + current [min,max] for the fine-adjust control;
+ *  - apply the limit presets (auto / zscale / minmax / 99.5%);
+ *  - apply the precomputed trilogy levels when the trilogy curve is selected;
+ *  - seed the handles from the viewer's auto-stretch after a band/mode switch
+ *    (called once per pending change from the parent's `onFrame`).
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ExplorerBand, ExplorerState, FitsViewerHandle } from '@fitsgl/core/react';
+
+export type ChannelKey = 'single' | 'r' | 'g' | 'b';
+export type LimitPreset = 'auto' | 'zscale' | 'minmax' | 'p995';
+
+const RGB_TINT: Record<'r' | 'g' | 'b', string> = { r: '#ef4444', g: '#22c55e', b: '#3b82f6' };
+
+export interface DisplayChannel {
+  key: ChannelKey;
+  band: ExplorerBand;
+  histogram?: { counts: number[] | Float32Array; lo: number; hi: number };
+  min: number;
+  max: number;
+  /** Bar tint for the histogram (accent in single mode, channel colour in RGB). */
+  color?: string;
+}
+
+interface UseDisplayStretchArgs {
+  handleRef: React.RefObject<FitsViewerHandle | null>;
+  bands: ExplorerBand[];
+  /** Null until the dataset's default view has been derived. */
+  state: ExplorerState | null;
+  /** Bumped on viewer (re)ready so seeding re-arms after a band reload. */
+  readyTick: number;
+}
+
+/** Fallback range for a channel before the viewer reports a real stretch. */
+function fallbackRange(band: ExplorerBand): { min: number; max: number } {
+  if (band.zscale) return { min: band.zscale[0], max: band.zscale[1] };
+  if (band.histogram) return { min: band.histogram.lo, max: band.histogram.hi };
+  return { min: 0, max: 1 };
+}
+
+export function useDisplayStretch({ handleRef, bands, state, readyTick }: UseDisplayStretchArgs) {
+  const bandByName = useMemo(() => {
+    const m = new Map<string, ExplorerBand>();
+    for (const b of bands) m.set(b.name, b);
+    return m;
+  }, [bands]);
+
+  // Viewer-reported (or user-dragged) ranges per channel key. Absent → fallback.
+  const [ranges, setRanges] = useState<Partial<Record<ChannelKey, { min: number; max: number }>>>({});
+
+  const trilogy = state?.stretch === 'trilogy';
+
+  // The channel(s) currently driving the display.
+  const activeRoles = useMemo<Array<{ key: ChannelKey; band: ExplorerBand | undefined; color?: string }>>(() => {
+    if (!state) return [];
+    if (state.mode === 'rgb') {
+      return (['r', 'g', 'b'] as const).map((role) => ({
+        key: role,
+        band: bandByName.get(state.rgb[role]),
+        color: RGB_TINT[role],
+      }));
+    }
+    return [{ key: 'single', band: bandByName.get(state.band) }];
+  }, [state, bandByName]);
+
+  const channels = useMemo<DisplayChannel[]>(() => {
+    return activeRoles
+      .filter((r): r is { key: ChannelKey; band: ExplorerBand; color?: string } => !!r.band)
+      .map(({ key, band, color }) => {
+        const r = ranges[key] ?? fallbackRange(band);
+        return { key, band, histogram: band.histogram, min: r.min, max: r.max, color };
+      });
+  }, [activeRoles, ranges]);
+
+  const hasZscale = channels.length > 0 && channels.every((c) => !!c.band.zscale);
+  const hasTrilogy = channels.length > 0 && channels.every((c) => !!c.band.trilogy);
+
+  // Re-seed the handles whenever the active source identity changes or the viewer
+  // reloads (readyTick). The actual read happens on the next drawn frame.
+  const channelIdentity = !state
+    ? 'none'
+    : state.mode === 'rgb'
+      ? `rgb:${state.rgb.r}|${state.rgb.g}|${state.rgb.b}`
+      : `single:${state.band}`;
+  const pendingSeed = useRef(true);
+  useEffect(() => {
+    pendingSeed.current = true;
+  }, [channelIdentity, readyTick]);
+
+  /** Read the viewer's applied stretch once, after a fresh source auto-stretches. */
+  const seedFromFrame = useCallback(() => {
+    if (!pendingSeed.current || trilogy) return;
+    const v = handleRef.current?.getViewer();
+    if (!v) return;
+    const ds = v.getDisplayState();
+    pendingSeed.current = false;
+    if (ds.mode === 'rgb') {
+      setRanges({
+        r: { min: ds.channelMin[0], max: ds.channelMax[0] },
+        g: { min: ds.channelMin[1], max: ds.channelMax[1] },
+        b: { min: ds.channelMin[2], max: ds.channelMax[2] },
+      });
+    } else {
+      setRanges({ single: { min: ds.stretchMin, max: ds.stretchMax } });
+    }
+  }, [handleRef, trilogy]);
+
+  // Apply precomputed trilogy levels when the trilogy curve is active.
+  useEffect(() => {
+    if (!trilogy || !state) return;
+    const v = handleRef.current?.getViewer();
+    if (!v) return;
+    if (state.mode === 'rgb') {
+      const stats = (['r', 'g', 'b'] as const).map((role) => bandByName.get(state.rgb[role])?.trilogy);
+      if (stats.every((s): s is NonNullable<typeof s> => !!s)) v.applyTrilogy(stats);
+    } else {
+      const stat = bandByName.get(state.band)?.trilogy;
+      if (stat) v.applyTrilogy(stat);
+    }
+  }, [trilogy, state, bandByName, handleRef, readyTick]);
+
+  /** Fine-adjust: push one channel's black/white point to the GPU + store it. */
+  const setHandle = useCallback(
+    (key: ChannelKey, min: number, max: number) => {
+      const v = handleRef.current?.getViewer();
+      if (!v) return;
+      if (key === 'single') v.setStretch(min, max);
+      else v.setChannelStretch(key, min, max);
+      setRanges((prev) => ({ ...prev, [key]: { min, max } }));
+    },
+    [handleRef],
+  );
+
+  const applyPreset = useCallback(
+    async (preset: LimitPreset) => {
+      const h = handleRef.current;
+      const v = h?.getViewer();
+      if (!h || !v || !state) return;
+      if (preset === 'zscale') {
+        if (state.mode === 'rgb') {
+          const next: Partial<Record<ChannelKey, { min: number; max: number }>> = {};
+          for (const role of ['r', 'g', 'b'] as const) {
+            const z = bandByName.get(state.rgb[role])?.zscale;
+            if (z) {
+              v.setChannelStretch(role, z[0], z[1]);
+              next[role] = { min: z[0], max: z[1] };
+            }
+          }
+          setRanges((prev) => ({ ...prev, ...next }));
+        } else {
+          const z = bandByName.get(state.band)?.zscale;
+          if (z) {
+            v.setStretch(z[0], z[1]);
+            setRanges((prev) => ({ ...prev, single: { min: z[0], max: z[1] } }));
+          }
+        }
+        return;
+      }
+      // auto / minmax / 99.5% all go through the viewer's percentile autostretch.
+      const pctl: Record<Exclude<LimitPreset, 'zscale'>, [number | undefined, number | undefined]> = {
+        auto: [undefined, undefined],
+        minmax: [0, 1],
+        p995: [0.0025, 0.9975],
+      };
+      const [pLo, pHi] = pctl[preset];
+      const res = await v.autoStretch(pLo, pHi);
+      if (!res) return;
+      if (res.mode === 'rgb') {
+        const next: Partial<Record<ChannelKey, { min: number; max: number }>> = {};
+        for (const role of ['r', 'g', 'b'] as const) {
+          const r = res[role];
+          if (r) next[role] = { min: r[0], max: r[1] };
+        }
+        setRanges((prev) => ({ ...prev, ...next }));
+      } else {
+        setRanges((prev) => ({ ...prev, single: { min: res.min, max: res.max } }));
+      }
+    },
+    [handleRef, state, bandByName],
+  );
+
+  return { channels, hasZscale, hasTrilogy, setHandle, applyPreset, seedFromFrame };
+}

--- a/web/lib/actions/map.ts
+++ b/web/lib/actions/map.ts
@@ -62,6 +62,20 @@ export interface MapLayersResult {
   isAuthenticated: boolean;
 }
 
+// FitsGL tile-pyramid dataset (epic #337, Phase 4). The thin per-field/tile
+// pointer the FitsGL map surface reads; row visibility is RLS-derived from the
+// backing mosaics' deploy_status (non-admins only see published-backed rows).
+export interface FitsglDataset {
+  prefix: string;
+  field: string;
+  kind: 'field' | 'tile';
+  tile: string | null;
+  pixel_scale: string;
+  fitsgl_json_url: string;
+  bands: string[];
+  is_default: boolean;
+}
+
 export interface MapMarkersResult {
   markers: MapMarker[];
   error?: string;
@@ -143,6 +157,29 @@ export async function getMapLayers(
   }
 
   return { layers: data || [], isAuthenticated: true };
+}
+
+/**
+ * Fetch the FitsGL datasets the caller may see (epic #337, Phase 4). RLS on
+ * `fitsgl_datasets` derives visibility from the backing mosaics' deploy_status,
+ * so this returns only datasets whose mosaics are published (plus everything for
+ * admins). The map picks the FitsGL surface for a field that has a `kind='field'`
+ * dataset; otherwise it falls back to Leaflet PNG tiles.
+ */
+export async function getFitsglDatasets(field?: string): Promise<FitsglDataset[]> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return [];
+
+  let query = supabase
+    .from('fitsgl_datasets')
+    .select('prefix, field, kind, tile, pixel_scale, fitsgl_json_url, bands, is_default')
+    .order('field');
+  if (field) query = query.eq('field', field);
+
+  const { data, error } = await query;
+  if (error) return [];
+  return (data as FitsglDataset[]) || [];
 }
 
 /**

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -622,6 +622,17 @@ export const QUALITY_LABELS: FlagDefinition[] = REDSHIFT_QUALITY.map(q => ({
   description: q.description,
 }));
 
+// Map-marker fill/stroke color per redshift_quality (0–4), shared by the Leaflet
+// (CanvasMarkerLayer) and FitsGL (FitsGLMapSurface) marker renderers so both map
+// engines color objects identically.
+export const MARKER_QUALITY_COLORS: Record<number, string> = {
+  0: '#9ca3af', // Not inspected - gray
+  1: '#ef4444', // Impossible - red
+  2: '#f97316', // Tentative - orange
+  3: '#f59e0b', // Probable - amber
+  4: '#22c55e', // Secure - green
+};
+
 export const GRATINGS = ['PRISM', 'G140H', 'G140M', 'G235H', 'G235M', 'G395H', 'G395M'] as const;
 
 // D3 category10 palette for coloring member targets in object detail views

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.932.0",
         "@aws-sdk/s3-request-presigner": "^3.932.0",
-        "@fitsgl/core": "^0.1.0",
+        "@fitsgl/core": "^0.2.0",
         "@supabase/ssr": "^0.7.0",
         "@supabase/supabase-js": "^2.81.1",
         "@tanstack/react-query": "^5.90.12",
@@ -2103,9 +2103,9 @@
       }
     },
     "node_modules/@fitsgl/core": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@fitsgl/core/-/core-0.1.0.tgz",
-      "integrity": "sha512-tzHb39LIKpYvknmMZFcy6Q+tXPOOcc1O/m34E3Kn9MmdCWAWvx5lwM1aGACMFLpZAECXdHBMa+gnq2dBcbXwbw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fitsgl/core/-/core-0.2.0.tgz",
+      "integrity": "sha512-irufmLerlJ8dszFXYpWD1M2W2mFEolvCaU53sqsKumOI5NqeAKWQykVq4BOdzBesP4osx7GYvwlHKtxZqoYtwA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": ">=18.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.932.0",
     "@aws-sdk/s3-request-presigner": "^3.932.0",
-    "@fitsgl/core": "^0.1.0",
+    "@fitsgl/core": "^0.2.0",
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.81.1",
     "@tanstack/react-query": "^5.90.12",


### PR DESCRIPTION
Closes #341 (epic #337, FitsGL "cloud DS9" integration). Phases 1–3 are already on `main`; this is **Phase 4 + the 4.5 UX build**. Web-only — no pipeline / supabase / python changes.

Renders a deployed FitsGL tile-pyramid in `<FitsViewer>` as the map for any field that has a `fitsgl_datasets` row (per-field dispatch in `MapViewer`; `?engine=leaflet` forces the legacy path), then wraps it in the full CAMPFIRE control surface. All CAMPFIRE chrome over the existing `@fitsgl/core` engine — **no engine change**. Design: `docs/design-fitsgl-map-ux.md`.

## What's in it
- **Band rail** — merged field selector + band chips + RGB channel pickers + wavelength "rainbow" (hidden when a field has one band and is the only field).
- **Display panel** — stretch-mode chips, limit presets (auto / zscale / minmax / 99.5 %), a draggable black/white **histogram** over the band's precomputed stats, and a custom **colormap dropdown** with gradient swatches + a **reverse** toggle. trilogy is RGB-only. Colormap is driven imperatively (a reversed LUT can't ride the controlled config).
- **Layers panel** — NIRSpec-objects + graticule toggles (MSA-shutters row stubbed for Phase 4b).
- **Left tool rail** — pan / **ruler** modal tools, fit-to-view, export PNG, filters launcher.
- **Status pill** — dual RA/Dec + per-band pixel value + zoom + band·stretch, growing to separation + PA under the ruler.
- **Graticule + ruler** overlays as Canvas2D layers reprojected each frame.
- **Filters** — reuses the existing page-level `AdvancedFiltersPanel` slide-over via the tool-rail launcher.
- **Glass chrome** pinned to the dusk palette regardless of app theme and given an opaque background so text stays legible over a white/grey stretch.

## Notes for review
- **Graticule/ruler are reimplemented on the public API.** FitsGL ships `drawGraticule`/`drawRuler`/`measureRuler` but doesn't re-export them from `@fitsgl/core/react`, so `web/components/map/fitsgl/{graticule,ruler}.ts` rebuild them on the exported WCS helpers + viewer accessors. **DRY alternative:** add two export lines to FitsGL's react barrel + bump `@fitsgl/core` to 0.2.1, then delete those bodies — happy to follow up if preferred.
- **Tailwind gotcha fixed:** the `/opacity` modifier generates no rule on the var-based colour tokens (`bg-card/70` was silently transparent — panels only looked dark over black space). Glass now uses a pre-composed `--glass-bg` rgba.
- **Deferred:** RGB / band rail are type- and build-verified but not render-tested (the local rj0911 dataset is a single-band tile); MSA shutters land in Phase 4b (#342).

## Verification
Render-verified end-to-end on `rj0911` (real WebGL2): imagery, stretch/colormap/reverse, histogram drag, presets, ruler measurement, graticule, status pill, filters launcher, theme-independent glass. `tsc` + `eslint` + `next build` all green.

Generated with Claude Code