### PR TITLE
feat(map): MSA shutter overlay on the FitsGL surface (#342)

### DIFF
--- a/web/components/map/FitsGLMapSurface.tsx
+++ b/web/components/map/FitsGLMapSurface.tsx
@@ -38,12 +38,15 @@ import {
   type CursorInfo,
   type MarkerEvent,
   type MarkerInput,
+  type RegionInput,
+  type ResolvedRegion,
   type ViewerConfig,
   type ViewerFrameInfo,
 } from '@fitsgl/core';
-import type { FitsglDataset, MapObjectMarker } from '@/lib/actions/map';
+import type { FitsglDataset, MapObjectMarker, SlitRegion, Shutter } from '@/lib/actions/map';
 import { MARKER_QUALITY_COLORS, QUALITY_LABELS } from '@/lib/types';
 import { makeFitsglWorker } from '@/lib/fits/fitsglWorker';
+import { getObservationColor } from './observation-colors';
 import { BandRail } from './fitsgl/BandRail';
 import { DisplayPanel } from './fitsgl/DisplayPanel';
 import { LayersPanel } from './fitsgl/LayersPanel';
@@ -60,6 +63,13 @@ const RULER_ACCENT = '#fb923c';
 const GRID_LINE = 'rgba(148,163,184,0.35)';
 const GRID_LABEL = 'rgba(203,213,225,0.8)';
 
+/** Default MSA shutter extents (arcsec); fixed slits carry their own aperture dims.
+ *  Mirrors CanvasSlitLayer's constants so the two map surfaces render identically. */
+const SHUTTER_WIDTH_ARCSEC = 0.22;
+const SHUTTER_HEIGHT_ARCSEC = 0.46;
+/** Stuck-closed shutters read red-dashed on both surfaces. */
+const SHUTTER_STUCK_COLOR = '#ef4444';
+
 interface FitsGLMapSurfaceProps {
   dataset: FitsglDataset;
   markers: MapObjectMarker[];
@@ -74,6 +84,12 @@ interface FitsGLMapSurfaceProps {
   onFieldChange: (field: string) => void;
   onToggleMarkers: (visible: boolean) => void;
   markerCount: number;
+  /** NIRSpec MSA shutters for the field (rendered as FitsGL sky-polygon regions). */
+  shutters: (SlitRegion | Shutter)[];
+  showShutters: boolean;
+  onToggleShutters: (visible: boolean) => void;
+  /** Restricts the drawn shutters to those whose target belongs to a filtered object. */
+  shutterFilter?: (shutter: SlitRegion | Shutter) => boolean;
   /** Live RA/Dec under the cursor → shared CoordinateOverlay (null on leave). */
   onCursorCoords: (coords: { ra: number; dec: number } | null) => void;
   /** Right-click at a sky position → shared MapContextMenu. */
@@ -118,6 +134,87 @@ function rainbowRgb(bands: ExplorerBand[]): { r: string; g: string; b: string } 
   };
 }
 
+/**
+ * The four sky corners (ICRS deg) of a shutter, from its centre + position angle +
+ * full angular extents. Worked in a local tangent plane of (East, North) arcsec
+ * offsets: the along-slit (height) axis points `paDeg` East of North, the across-slit
+ * (width) axis is perpendicular; East offsets divide by cos(dec) to become ΔRA.
+ * Returned CCW, non-self-intersecting.
+ */
+function shutterCorners(
+  ra: number,
+  dec: number,
+  paDeg: number,
+  widthArcsec: number,
+  heightArcsec: number,
+): Array<{ ra: number; dec: number }> {
+  const pa = (paDeg * Math.PI) / 180;
+  const sinPa = Math.sin(pa);
+  const cosPa = Math.cos(pa);
+  const hw = widthArcsec / 2;
+  const hh = heightArcsec / 2;
+  const cosDec = Math.cos((dec * Math.PI) / 180) || 1e-8;
+  // width axis û_w = (cosPa, -sinPa); height axis û_h = (sinPa, cosPa) in (East, North).
+  return [
+    [-1, -1],
+    [1, -1],
+    [1, 1],
+    [-1, 1],
+  ].map(([i, j]) => {
+    const dEast = i * hw * cosPa + j * hh * sinPa;
+    const dNorth = -i * hw * sinPa + j * hh * cosPa;
+    return { ra: ra + dEast / 3600 / cosDec, dec: dec + dNorth / 3600 };
+  });
+}
+
+/**
+ * Map NIRSpec shutters to FitsGL sky-polygon regions (epic #337, Phase 4b). Each
+ * shutter is a `center_ra`/`center_dec` + `position_angle` (deg East of North) +
+ * angular extents; we project its four corners to ICRS `vertices` and let FitsGL
+ * place them through the mosaic WCS (a footprint that scales with zoom / rotates with
+ * the display). Colour matches the Leaflet `CanvasSlitLayer`: per-observation stroke
+ * with a faint fill, stuck-closed = red dashed. Non-matching shutters are dropped.
+ *
+ * Polygons (not the instanced sky-*rect* path) because `@fitsgl/core` 0.2.0's sky-rect
+ * `skyBasis` guard mis-measures the East pixel scale by a factor of cos(dec) and drops
+ * every rect on a field more than a few degrees off the equator (bug reported upstream;
+ * a sky polygon projects each vertex independently and is unaffected).
+ */
+function shuttersToRegions(
+  shutters: readonly (SlitRegion | Shutter)[],
+  filter?: (s: SlitRegion | Shutter) => boolean,
+): RegionInput[] {
+  const visible = filter ? shutters.filter(filter) : shutters;
+  // Stable per-observation colours from the FULL set (so a filter never reshuffles them).
+  const observations = [...new Set(shutters.map((s) => s.observation))].sort();
+  return visible.map((s, i): RegionInput => {
+    const isShutter = 'shutter_state' in s;
+    const stuck = isShutter && (s as Shutter).shutter_state === 'stuck_closed';
+    const color = stuck ? SHUTTER_STUCK_COLOR : getObservationColor(s.observation, observations);
+    const sh = s as Shutter;
+    return {
+      id: `shutter-${i}`,
+      shape: 'polygon',
+      vertices: shutterCorners(
+        s.center_ra,
+        s.center_dec,
+        s.position_angle,
+        sh.aperture_width_arcsec ?? SHUTTER_WIDTH_ARCSEC,
+        sh.aperture_height_arcsec ?? SHUTTER_HEIGHT_ARCSEC,
+      ),
+      stroke: color,
+      fill: `${color}22`, // ~13% — the faint footprint tint (CanvasSlitLayer uses 0.08 alpha)
+      strokeWidth: stuck ? 1.5 : 1,
+      dash: stuck ? ([3, 2] as const) : undefined,
+      data: {
+        targetId: s.object_id,
+        observation: s.observation,
+        state: isShutter ? sh.shutter_state : 'slit',
+      },
+    };
+  });
+}
+
 export function FitsGLMapSurface({
   dataset,
   markers,
@@ -131,6 +228,10 @@ export function FitsGLMapSurface({
   onFieldChange,
   onToggleMarkers,
   markerCount,
+  shutters,
+  showShutters,
+  onToggleShutters,
+  shutterFilter,
   onCursorCoords,
   onContextMenu,
   onOpenFilters,
@@ -254,6 +355,30 @@ export function FitsGLMapSurface({
     h.setMarkers(showMarkers ? markerInputs : []);
   }, [markerInputs, showMarkers]);
 
+  // Shutter region inputs (sky-polygon footprints; FitsGL projects via the manifest WCS).
+  const shutterRegions = useMemo<RegionInput[]>(
+    () => shuttersToRegions(shutters, shutterFilter),
+    [shutters, shutterFilter],
+  );
+
+  // Push shutter regions on change, mirroring the marker path.
+  useEffect(() => {
+    const h = handleRef.current;
+    if (!h) return;
+    h.setRegions(showShutters ? shutterRegions : []);
+  }, [shutterRegions, showShutters]);
+
+  // Re-apply both overlays after a (re)ready. onReady is fixed at construction and
+  // re-fires on every band reload; reading the latest marker/shutter state through a
+  // ref keeps a reload (e.g. an RGB toggle) from restoring stale overlay visibility.
+  const applyOverlaysRef = useRef<(h: FitsViewerHandle) => void>(() => {});
+  useEffect(() => {
+    applyOverlaysRef.current = (h) => {
+      h.setMarkers(showMarkers ? markerInputs : []);
+      h.setRegions(showShutters ? shutterRegions : []);
+    };
+  }, [showMarkers, markerInputs, showShutters, shutterRegions]);
+
   const markerById = useMemo(() => {
     const map = new Map<string, MapObjectMarker>();
     for (const m of markers) map.set(m.object_id, m);
@@ -262,7 +387,7 @@ export function FitsGLMapSurface({
 
   const onReady = useCallback((handle: FitsViewerHandle) => {
     handleRef.current = handle;
-    handle.setMarkers(showMarkers ? markerInputs : []);
+    applyOverlaysRef.current(handle);
     setReadyTick((t) => t + 1);
     if (!initialApplied.current) {
       initialApplied.current = true;
@@ -276,7 +401,6 @@ export function FitsGLMapSurface({
       }
       if (zoom !== undefined) handle.setZoom(zoom);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const onCursor = useCallback((info: CursorInfo | null) => {
@@ -384,6 +508,14 @@ export function FitsGLMapSurface({
     a.click();
   }, [selectedField]);
 
+  // Hover tooltip for a shutter region (FitsGL's built-in popup).
+  const regionTooltip = useCallback((r: ResolvedRegion) => {
+    const d = r.data as { targetId?: string; observation?: string; state?: string };
+    if (!d?.targetId) return null;
+    const stuck = d.state === 'stuck_closed';
+    return `${d.targetId} · ${d.observation ?? ''}${stuck ? ' · stuck' : ''}`;
+  }, []);
+
   if (loadError) {
     return (
       <div className="flex items-center justify-center h-full bg-surface-2">
@@ -405,6 +537,7 @@ export function FitsGLMapSurface({
           onCursor={onCursor}
           onFrame={onFrame}
           onMarkerClick={onMarkerClick}
+          regionTooltip={regionTooltip}
           onError={(err) => setLoadError(String((err as Error)?.message ?? err))}
           className="h-full w-full"
           style={{ background: 'var(--header)' }}
@@ -481,6 +614,10 @@ export function FitsGLMapSurface({
               markerCount={markerCount}
               graticule={graticule}
               onToggleGraticule={setGraticule}
+              shuttersAvailable={shutters.length > 0}
+              showShutters={showShutters}
+              onToggleShutters={onToggleShutters}
+              shutterCount={shutters.length}
             />
           </div>
         </div>

--- a/web/components/map/MapViewer.tsx
+++ b/web/components/map/MapViewer.tsx
@@ -417,6 +417,10 @@ export function MapViewer({
           onFieldChange={handleFieldChange}
           onToggleMarkers={setShowMarkers}
           markerCount={markers.length}
+          shutters={slits}
+          showShutters={showSlits}
+          onToggleShutters={setShowSlits}
+          shutterFilter={slitFilter}
           onCursorCoords={setCursorCoords}
           onContextMenu={handleContextMenu}
           onOpenFilters={onOpenFilters}

--- a/web/components/map/fitsgl/LayersPanel.tsx
+++ b/web/components/map/fitsgl/LayersPanel.tsx
@@ -3,7 +3,8 @@
 /**
  * Layers panel (epic #337, Phase 4.5) — docked-right toggles for what's drawn OVER
  * the imagery (`docs/design-fitsgl-map-ux.md` §4): NIRSpec objects, MSA shutters
- * (Phase 4b), and the RA/Dec graticule. No quality legend (locked decision 5).
+ * (Phase 4b, rendered as FitsGL regions), and the RA/Dec graticule. No quality
+ * legend (locked decision 5).
  */
 
 import { PANEL_CAP } from './glass';
@@ -40,10 +41,11 @@ interface LayersPanelProps {
   markerCount: number;
   graticule: boolean;
   onToggleGraticule: (on: boolean) => void;
-  /** MSA shutters — the region overlay lands in Phase 4b; the row is inert until then. */
+  /** MSA shutters (Phase 4b) — disabled when the field carries none. */
   shuttersAvailable?: boolean;
   showShutters?: boolean;
   onToggleShutters?: (on: boolean) => void;
+  shutterCount?: number;
 }
 
 export function LayersPanel({
@@ -55,17 +57,17 @@ export function LayersPanel({
   shuttersAvailable = false,
   showShutters = false,
   onToggleShutters,
+  shutterCount = 0,
 }: LayersPanelProps) {
   return (
     <div className="space-y-1">
       <h4 className={PANEL_CAP}>Layers</h4>
       <ToggleRow label={`NIRSpec objects (${markerCount})`} on={showMarkers} onToggle={onToggleMarkers} />
       <ToggleRow
-        label="MSA shutters"
+        label={`MSA shutters (${shutterCount})`}
         on={shuttersAvailable ? showShutters : false}
         onToggle={onToggleShutters ?? (() => {})}
         disabled={!shuttersAvailable}
-        hint={shuttersAvailable ? undefined : 'soon'}
       />
       <ToggleRow label="Graticule" on={graticule} onToggle={onToggleGraticule} />
     </div>


### PR DESCRIPTION
## Phase 4b — MSA shutters on the FitsGL map (epic #337)

Flips the **"MSA shutters"** Layers row from its "soon" stub to a live overlay on the FitsGL map surface. Each NIRSpec shutter (`center_ra`/`center_dec` + `position_angle` + aperture extents) is rendered as a **FitsGL sky-polygon region**, projected through the mosaic WCS so it scales with zoom and rotates with the display like a real footprint.

- **Colour** mirrors the Leaflet `CanvasSlitLayer`: per-observation stroke (`getObservationColor`) + faint fill, stuck-closed = red dashed.
- **Hover tooltip** shows `target · observation` (`· stuck` when stuck-closed) via FitsGL's built-in `regionTooltip`.
- **Toggle + count** wired through `LayersPanel` (`MSA shutters (N)`), disabled when the field has none.

### The data path already existed
The Leaflet map already fetches shutters (`useFieldSlits` → `get_field_shutters`) and builds the `member_target_ids` slit filter — and both live in `MapViewer` *above* the FitsGL early-return. So this PR just threads `slits` / `showSlits` / `slitFilter` into `FitsGLMapSurface` and drives the viewer's imperative `setRegions` handle, exactly mirroring the existing marker path. (`Shutter.object_id` is a *target* id; the filter bridges target → object via `member_target_ids`.)

A unified `applyOverlaysRef` re-applies **markers and regions** on each band reload. This also **fixes a latent marker bug**: after hiding markers, an RGB/band reload used to restore them from `onReady`'s stale mount closure.

### ⚠️ Why polygons, not the instanced sky-rect path — an upstream `@fitsgl/core` 0.2.0 bug
A shutter is a natural fit for the instanced sky-`rect` `RegionInput` (`{ra, dec, paDeg, widthArcsec, heightArcsec}`), but **0.2.0's sky-rect `skyBasis()` silently drops every rect on any field more than ~8° off the equator.** It measures the East pixel scale as `eastPerDeg = eLen / dRa` with `dRa = eps/cosDec`, but `eLen` spans an angular separation of `eps`, so `eastPerDeg = pixPerDeg·cos(dec)` → `scaleSkew = |1 − cos(dec)|`, which exceeds the 1e-2 tolerance for |dec| ≳ 8°. Verified live on rj0911 (dec +17.8°, skew 4.78%): a rect **at CRVAL** on a perfectly diagonal square CD is dropped (count 0), while a sky **polygon** places fine (count 1).

**Workaround shipped here:** emit sky polygons (`vertices: {ra,dec}[]`) — they project each vertex independently, no `skyBasis`, correct at any dec. `shutterCorners()` computes the four corners in a local tangent plane (East offsets ÷ cos dec). Non-instanced, but still 2 draw calls for the whole set — fine for thousands of shutters.

**Suggested upstream fix (@hollisakins):** in `overlay/regions.ts` `skyBasis`, divide the East offset by the true angular separation (multiply `dRa` by `cosDec`) so `eastPerDeg` matches `pixPerDeg`. Then sky rects become usable and the shutter overlay could switch to the instanced path.

## Testing
- **Render-verified** against a synthetic slitlet inserted into the local rj0911 dataset (2 MSA slitlets in different observations/colours + 1 stuck-closed + 1 fixed-slit `S200A2` 0.2″×3.2″), exercising the real DB → `get_field_shutters` → `useFieldSlits` → `setRegions` path. Confirmed: geometry, PA orientation (0/45/90°), aperture sizing, per-observation colour, stuck red-dashed, hover tooltip, toggle on/off (`clearRegions`).
- `tsc --noEmit`, `eslint`, and `npm run build` all green.
- Web-only (no `pipeline/**` change) → no changelog entry needed.

> Note: the local rj0911 mosaic is only ~44% covered (two pointings straddle a gap), so its geometric centre pixel is NaN and zooming there shows black — the deep-zoom imagery renders in full detail on an actual source. The `per-tile GZIP fallback not supported` warnings are only for the all-NaN centre supertiles and don't affect real data. Shutters verified over real F444W imagery on-source, not just over the empty centre.

Generated with Claude Code
