### PR TITLE
feat(cutout): FitsGL server-side cutout core engine (#343)

### DIFF
--- a/web/lib/cutout/__fixtures__/generate_plan_fixture.py
+++ b/web/lib/cutout/__fixtures__/generate_plan_fixture.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+"""Generate the golden cutout-plan fixture for the TS parity test (epic #337, Phase 5).
+
+Runs `fitsgl.cutout.plan_cutout` (the Python producer's read API) over a set of
+cases against a real band manifest and writes:
+  - `<band>-manifest.json`  — a copy of the manifest the TS port reads.
+  - `plan-cases.json`       — each case's inputs + the plan fitsgl-py produced.
+
+The TS arm (`web/lib/cutout/plan.test.ts`) asserts `planCutout(...)` reproduces
+every case, so the port can never drift from fitsgl-py / the browser.
+
+Run in the `campfire` conda env (has `fitsgl` editable-installed):
+    conda run -n campfire python web/lib/cutout/__fixtures__/generate_plan_fixture.py \
+        /path/to/rj0911__venus/f444w/manifest.json
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+from fitsgl import read_manifest, plan_cutout
+
+HERE = Path(__file__).resolve().parent
+BAND_TAG = "rj0911-f444w"
+
+# (name, center[ra,dec], fov_arcsec, output_size|None, target_scale|None, rounding)
+CASES = [
+    ("on_source_small", (137.788282, 17.782160), 6.0, 512, None, "nearest"),
+    ("on_source_mid", (137.788282, 17.782160), 30.0, 512, None, "nearest"),
+    ("on_source_wide", (137.788282, 17.782160), 120.0, 400, None, "nearest"),
+    ("center_gap", (137.805142, 17.799882), 20.0, 256, None, "nearest"),
+    ("anisotropic", (137.788282, 17.782160), (60.0, 20.0), (600, 200), None, "nearest"),
+    ("target_scale", (137.788282, 17.782160), 30.0, None, 0.06, "nearest"),
+    ("rounding_finer", (137.788282, 17.782160), 30.0, 300, None, "finer"),
+    ("rounding_coarser", (137.788282, 17.782160), 30.0, 300, None, "coarser"),
+    ("native_no_hint", (137.788282, 17.782160), 4.0, None, None, "nearest"),
+    ("out_of_field", (200.0, -10.0), 20.0, 256, None, "nearest"),
+]
+
+
+def plan_to_json(plan) -> dict:
+    return {
+        "levelIndex": plan.level_index,
+        "outputScaleArcsec": plan.output_scale_arcsec,
+        "bbox": {"x0": plan.pixel_bbox.x0, "y0": plan.pixel_bbox.y0, "x1": plan.pixel_bbox.x1, "y1": plan.pixel_bbox.y1},
+        "tiles": [
+            {"tileX": t.tile.tile_x, "tileY": t.tile.tile_y, "supertileIndex": t.supertile_index,
+             "localX": t.local_x, "localY": t.local_y}
+            for t in plan.tiles
+        ],
+        "missing": [{"tileX": c.tile_x, "tileY": c.tile_y} for c in plan.missing],
+    }
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit(__doc__)
+    manifest_path = Path(sys.argv[1])
+    shutil.copyfile(manifest_path, HERE / f"{BAND_TAG}-manifest.json")
+    manifest = read_manifest(str(manifest_path))
+
+    cases_out = []
+    for name, center, fov, output_size, target_scale, rounding in CASES:
+        plan = plan_cutout(
+            manifest, center=center, fov=fov,
+            output_size=output_size, target_scale_arcsec=target_scale, rounding=rounding,
+        )
+        cases_out.append({
+            "name": name, "center": list(center), "fov": fov,
+            "outputSize": output_size, "targetScaleArcsec": target_scale, "rounding": rounding,
+            "expected": plan_to_json(plan),
+        })
+
+    (HERE / "plan-cases.json").write_text(json.dumps(cases_out, indent=2) + "\n")
+    print(f"wrote {len(cases_out)} cases + manifest to {HERE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/web/lib/cutout/__fixtures__/plan-cases.json
+++ b/web/lib/cutout/__fixtures__/plan-cases.json
@@ -1,0 +1,618 @@
+[
+  {
+    "name": "on_source_small",
+    "center": [
+      137.788282,
+      17.78216
+    ],
+    "fov": 6.0,
+    "outputSize": 512,
+    "targetScaleArcsec": null,
+    "rounding": "nearest",
+    "expected": {
+      "levelIndex": 0,
+      "outputScaleArcsec": 0.01171875,
+      "bbox": {
+        "x0": 5758,
+        "y0": 3579,
+        "x1": 5959,
+        "y1": 3780
+      },
+      "tiles": [
+        {
+          "tileX": 22,
+          "tileY": 13,
+          "supertileIndex": 0,
+          "localX": 22,
+          "localY": 13
+        },
+        {
+          "tileX": 23,
+          "tileY": 13,
+          "supertileIndex": 0,
+          "localX": 23,
+          "localY": 13
+        },
+        {
+          "tileX": 22,
+          "tileY": 14,
+          "supertileIndex": 0,
+          "localX": 22,
+          "localY": 14
+        },
+        {
+          "tileX": 23,
+          "tileY": 14,
+          "supertileIndex": 0,
+          "localX": 23,
+          "localY": 14
+        }
+      ],
+      "missing": []
+    }
+  },
+  {
+    "name": "on_source_mid",
+    "center": [
+      137.788282,
+      17.78216
+    ],
+    "fov": 30.0,
+    "outputSize": 512,
+    "targetScaleArcsec": null,
+    "rounding": "nearest",
+    "expected": {
+      "levelIndex": 1,
+      "outputScaleArcsec": 0.05859375,
+      "bbox": {
+        "x0": 2679,
+        "y0": 1589,
+        "x1": 3180,
+        "y1": 2090
+      },
+      "tiles": [
+        {
+          "tileX": 10,
+          "tileY": 6,
+          "supertileIndex": 0,
+          "localX": 10,
+          "localY": 6
+        },
+        {
+          "tileX": 11,
+          "tileY": 6,
+          "supertileIndex": 0,
+          "localX": 11,
+          "localY": 6
+        },
+        {
+          "tileX": 12,
+          "tileY": 6,
+          "supertileIndex": 0,
+          "localX": 12,
+          "localY": 6
+        },
+        {
+          "tileX": 10,
+          "tileY": 7,
+          "supertileIndex": 0,
+          "localX": 10,
+          "localY": 7
+        },
+        {
+          "tileX": 11,
+          "tileY": 7,
+          "supertileIndex": 0,
+          "localX": 11,
+          "localY": 7
+        },
+        {
+          "tileX": 12,
+          "tileY": 7,
+          "supertileIndex": 0,
+          "localX": 12,
+          "localY": 7
+        },
+        {
+          "tileX": 10,
+          "tileY": 8,
+          "supertileIndex": 0,
+          "localX": 10,
+          "localY": 8
+        },
+        {
+          "tileX": 11,
+          "tileY": 8,
+          "supertileIndex": 0,
+          "localX": 11,
+          "localY": 8
+        },
+        {
+          "tileX": 12,
+          "tileY": 8,
+          "supertileIndex": 0,
+          "localX": 12,
+          "localY": 8
+        }
+      ],
+      "missing": []
+    }
+  },
+  {
+    "name": "on_source_wide",
+    "center": [
+      137.788282,
+      17.78216
+    ],
+    "fov": 120.0,
+    "outputSize": 400,
+    "targetScaleArcsec": null,
+    "rounding": "nearest",
+    "expected": {
+      "levelIndex": 3,
+      "outputScaleArcsec": 0.3,
+      "bbox": {
+        "x0": 482,
+        "y0": 209,
+        "x1": 983,
+        "y1": 710
+      },
+      "tiles": [
+        {
+          "tileX": 1,
+          "tileY": 0,
+          "supertileIndex": 0,
+          "localX": 1,
+          "localY": 0
+        },
+        {
+          "tileX": 2,
+          "tileY": 0,
+          "supertileIndex": 0,
+          "localX": 2,
+          "localY": 0
+        },
+        {
+          "tileX": 3,
+          "tileY": 0,
+          "supertileIndex": 0,
+          "localX": 3,
+          "localY": 0
+        },
+        {
+          "tileX": 1,
+          "tileY": 1,
+          "supertileIndex": 0,
+          "localX": 1,
+          "localY": 1
+        },
+        {
+          "tileX": 2,
+          "tileY": 1,
+          "supertileIndex": 0,
+          "localX": 2,
+          "localY": 1
+        },
+        {
+          "tileX": 3,
+          "tileY": 1,
+          "supertileIndex": 0,
+          "localX": 3,
+          "localY": 1
+        },
+        {
+          "tileX": 1,
+          "tileY": 2,
+          "supertileIndex": 0,
+          "localX": 1,
+          "localY": 2
+        },
+        {
+          "tileX": 2,
+          "tileY": 2,
+          "supertileIndex": 0,
+          "localX": 2,
+          "localY": 2
+        },
+        {
+          "tileX": 3,
+          "tileY": 2,
+          "supertileIndex": 0,
+          "localX": 3,
+          "localY": 2
+        }
+      ],
+      "missing": []
+    }
+  },
+  {
+    "name": "center_gap",
+    "center": [
+      137.805142,
+      17.799882
+    ],
+    "fov": 20.0,
+    "outputSize": 256,
+    "targetScaleArcsec": null,
+    "rounding": "nearest",
+    "expected": {
+      "levelIndex": 1,
+      "outputScaleArcsec": 0.078125,
+      "bbox": {
+        "x0": 1799,
+        "y0": 2736,
+        "x1": 2133,
+        "y1": 3070
+      },
+      "tiles": [
+        {
+          "tileX": 7,
+          "tileY": 10,
+          "supertileIndex": 0,
+          "localX": 7,
+          "localY": 10
+        },
+        {
+          "tileX": 8,
+          "tileY": 10,
+          "supertileIndex": 0,
+          "localX": 8,
+          "localY": 10
+        },
+        {
+          "tileX": 7,
+          "tileY": 11,
+          "supertileIndex": 0,
+          "localX": 7,
+          "localY": 11
+        },
+        {
+          "tileX": 8,
+          "tileY": 11,
+          "supertileIndex": 0,
+          "localX": 8,
+          "localY": 11
+        }
+      ],
+      "missing": []
+    }
+  },
+  {
+    "name": "anisotropic",
+    "center": [
+      137.788282,
+      17.78216
+    ],
+    "fov": [
+      60.0,
+      20.0
+    ],
+    "outputSize": [
+      600,
+      200
+    ],
+    "targetScaleArcsec": null,
+    "rounding": "nearest",
+    "expected": {
+      "levelIndex": 2,
+      "outputScaleArcsec": 0.1,
+      "bbox": {
+        "x0": 1214,
+        "y0": 836,
+        "x1": 1715,
+        "y1": 1004
+      },
+      "tiles": [
+        {
+          "tileX": 4,
+          "tileY": 3,
+          "supertileIndex": 0,
+          "localX": 4,
+          "localY": 3
+        },
+        {
+          "tileX": 5,
+          "tileY": 3,
+          "supertileIndex": 0,
+          "localX": 5,
+          "localY": 3
+        },
+        {
+          "tileX": 6,
+          "tileY": 3,
+          "supertileIndex": 0,
+          "localX": 6,
+          "localY": 3
+        }
+      ],
+      "missing": []
+    }
+  },
+  {
+    "name": "target_scale",
+    "center": [
+      137.788282,
+      17.78216
+    ],
+    "fov": 30.0,
+    "outputSize": null,
+    "targetScaleArcsec": 0.06,
+    "rounding": "nearest",
+    "expected": {
+      "levelIndex": 1,
+      "outputScaleArcsec": 0.06,
+      "bbox": {
+        "x0": 2679,
+        "y0": 1589,
+        "x1": 3180,
+        "y1": 2090
+      },
+      "tiles": [
+        {
+          "tileX": 10,
+          "tileY": 6,
+          "supertileIndex": 0,
+          "localX": 10,
+          "localY": 6
+        },
+        {
+          "tileX": 11,
+          "tileY": 6,
+          "supertileIndex": 0,
+          "localX": 11,
+          "localY": 6
+        },
+        {
+          "tileX": 12,
+          "tileY": 6,
+          "supertileIndex": 0,
+          "localX": 12,
+          "localY": 6
+        },
+        {
+          "tileX": 10,
+          "tileY": 7,
+          "supertileIndex": 0,
+          "localX": 10,
+          "localY": 7
+        },
+        {
+          "tileX": 11,
+          "tileY": 7,
+          "supertileIndex": 0,
+          "localX": 11,
+          "localY": 7
+        },
+        {
+          "tileX": 12,
+          "tileY": 7,
+          "supertileIndex": 0,
+          "localX": 12,
+          "localY": 7
+        },
+        {
+          "tileX": 10,
+          "tileY": 8,
+          "supertileIndex": 0,
+          "localX": 10,
+          "localY": 8
+        },
+        {
+          "tileX": 11,
+          "tileY": 8,
+          "supertileIndex": 0,
+          "localX": 11,
+          "localY": 8
+        },
+        {
+          "tileX": 12,
+          "tileY": 8,
+          "supertileIndex": 0,
+          "localX": 12,
+          "localY": 8
+        }
+      ],
+      "missing": []
+    }
+  },
+  {
+    "name": "rounding_finer",
+    "center": [
+      137.788282,
+      17.78216
+    ],
+    "fov": 30.0,
+    "outputSize": 300,
+    "targetScaleArcsec": null,
+    "rounding": "finer",
+    "expected": {
+      "levelIndex": 1,
+      "outputScaleArcsec": 0.1,
+      "bbox": {
+        "x0": 2679,
+        "y0": 1589,
+        "x1": 3180,
+        "y1": 2090
+      },
+      "tiles": [
+        {
+          "tileX": 10,
+          "tileY": 6,
+          "supertileIndex": 0,
+          "localX": 10,
+          "localY": 6
+        },
+        {
+          "tileX": 11,
+          "tileY": 6,
+          "supertileIndex": 0,
+          "localX": 11,
+          "localY": 6
+        },
+        {
+          "tileX": 12,
+          "tileY": 6,
+          "supertileIndex": 0,
+          "localX": 12,
+          "localY": 6
+        },
+        {
+          "tileX": 10,
+          "tileY": 7,
+          "supertileIndex": 0,
+          "localX": 10,
+          "localY": 7
+        },
+        {
+          "tileX": 11,
+          "tileY": 7,
+          "supertileIndex": 0,
+          "localX": 11,
+          "localY": 7
+        },
+        {
+          "tileX": 12,
+          "tileY": 7,
+          "supertileIndex": 0,
+          "localX": 12,
+          "localY": 7
+        },
+        {
+          "tileX": 10,
+          "tileY": 8,
+          "supertileIndex": 0,
+          "localX": 10,
+          "localY": 8
+        },
+        {
+          "tileX": 11,
+          "tileY": 8,
+          "supertileIndex": 0,
+          "localX": 11,
+          "localY": 8
+        },
+        {
+          "tileX": 12,
+          "tileY": 8,
+          "supertileIndex": 0,
+          "localX": 12,
+          "localY": 8
+        }
+      ],
+      "missing": []
+    }
+  },
+  {
+    "name": "rounding_coarser",
+    "center": [
+      137.788282,
+      17.78216
+    ],
+    "fov": 30.0,
+    "outputSize": 300,
+    "targetScaleArcsec": null,
+    "rounding": "coarser",
+    "expected": {
+      "levelIndex": 2,
+      "outputScaleArcsec": 0.1,
+      "bbox": {
+        "x0": 1339,
+        "y0": 794,
+        "x1": 1590,
+        "y1": 1045
+      },
+      "tiles": [
+        {
+          "tileX": 5,
+          "tileY": 3,
+          "supertileIndex": 0,
+          "localX": 5,
+          "localY": 3
+        },
+        {
+          "tileX": 6,
+          "tileY": 3,
+          "supertileIndex": 0,
+          "localX": 6,
+          "localY": 3
+        },
+        {
+          "tileX": 5,
+          "tileY": 4,
+          "supertileIndex": 0,
+          "localX": 5,
+          "localY": 4
+        },
+        {
+          "tileX": 6,
+          "tileY": 4,
+          "supertileIndex": 0,
+          "localX": 6,
+          "localY": 4
+        }
+      ],
+      "missing": []
+    }
+  },
+  {
+    "name": "native_no_hint",
+    "center": [
+      137.788282,
+      17.78216
+    ],
+    "fov": 4.0,
+    "outputSize": null,
+    "targetScaleArcsec": null,
+    "rounding": "nearest",
+    "expected": {
+      "levelIndex": 0,
+      "outputScaleArcsec": 0.02999999999999999,
+      "bbox": {
+        "x0": 5791,
+        "y0": 3612,
+        "x1": 5926,
+        "y1": 3747
+      },
+      "tiles": [
+        {
+          "tileX": 22,
+          "tileY": 14,
+          "supertileIndex": 0,
+          "localX": 22,
+          "localY": 14
+        },
+        {
+          "tileX": 23,
+          "tileY": 14,
+          "supertileIndex": 0,
+          "localX": 23,
+          "localY": 14
+        }
+      ],
+      "missing": []
+    }
+  },
+  {
+    "name": "out_of_field",
+    "center": [
+      200.0,
+      -10.0
+    ],
+    "fov": 20.0,
+    "outputSize": 256,
+    "targetScaleArcsec": null,
+    "rounding": "nearest",
+    "expected": {
+      "levelIndex": 1,
+      "outputScaleArcsec": 0.078125,
+      "bbox": {
+        "x0": 0,
+        "y0": 0,
+        "x1": -7788995,
+        "y1": -2731568
+      },
+      "tiles": [],
+      "missing": []
+    }
+  }
+]

--- a/web/lib/cutout/__fixtures__/rj0911-f444w-manifest.json
+++ b/web/lib/cutout/__fixtures__/rj0911-f444w-manifest.json
@@ -1,0 +1,411 @@
+{
+  "version": 2,
+  "source_file": "mosaic_nircam_f444w_rj0911_30mas_venus_sci.fits",
+  "native_shape": [
+    11612,
+    7864
+  ],
+  "fpack_tile_size": 256,
+  "n_levels": 6,
+  "levels": [
+    {
+      "z": 0,
+      "filename": "mosaic_nircam_f444w_rj0911_30mas_venus_sci_z0.fits.fz",
+      "compression": "RICE_1",
+      "lossless": false,
+      "shape": [
+        11612,
+        7864
+      ],
+      "fpack_tile_count": [
+        46,
+        31
+      ],
+      "pixel_scale_arcsec": 0.02999999999999999,
+      "wcs": {
+        "WCSAXES": 2,
+        "CRPIX1": 3932.5000000002,
+        "CRPIX2": 5806.5000000004,
+        "PC1_1": -1.0,
+        "CDELT1": 8.3333333333333e-06,
+        "CDELT2": 8.3333333333333e-06,
+        "CUNIT1": "deg",
+        "CUNIT2": "deg",
+        "CTYPE1": "RA---TAN",
+        "CTYPE2": "DEC--TAN",
+        "CRVAL1": 137.80514163602,
+        "CRVAL2": 17.79988187551,
+        "LONPOLE": 180.0,
+        "LATPOLE": 17.79988187551,
+        "MJDREF": 0.0,
+        "DATE-BEG": "2026-05-01T17:41:51.134",
+        "MJD-BEG": 61161.737397384,
+        "DATE-AVG": "2026-05-01T17:57:58.828",
+        "MJD-AVG": 61161.748597546,
+        "DATE-END": "2026-05-01T18:14:14.538",
+        "MJD-END": 61161.759890486,
+        "XPOSURE": 3349.872,
+        "TELAPSE": 3349.872,
+        "OBSGEO-X": -538753537.46593,
+        "OBSGEO-Y": -1363545070.5795,
+        "OBSGEO-Z": -689281081.7073,
+        "RADESYS": "ICRS"
+      },
+      "supertiles": [
+        {
+          "filename": "mosaic_nircam_f444w_rj0911_30mas_venus_sci_z0.fits.fz",
+          "tile_origin": [
+            0,
+            0
+          ],
+          "tile_count": [
+            31,
+            46
+          ]
+        }
+      ]
+    },
+    {
+      "z": 1,
+      "filename": "mosaic_nircam_f444w_rj0911_30mas_venus_sci_z1.fits.fz",
+      "compression": "RICE_1",
+      "lossless": false,
+      "shape": [
+        5806,
+        3932
+      ],
+      "fpack_tile_count": [
+        23,
+        16
+      ],
+      "pixel_scale_arcsec": 0.05999999999999998,
+      "wcs": {
+        "WCSAXES": 2,
+        "CRPIX1": 1966.5000000001,
+        "CRPIX2": 2903.5000000002,
+        "PC1_1": -1.0,
+        "CDELT1": 1.6666666666667e-05,
+        "CDELT2": 1.6666666666667e-05,
+        "CUNIT1": "deg",
+        "CUNIT2": "deg",
+        "CTYPE1": "RA---TAN",
+        "CTYPE2": "DEC--TAN",
+        "CRVAL1": 137.80514163602,
+        "CRVAL2": 17.79988187551,
+        "LONPOLE": 180.0,
+        "LATPOLE": 17.79988187551,
+        "MJDREF": 0.0,
+        "DATE-BEG": "2026-05-01T17:41:51.134",
+        "MJD-BEG": 61161.737397384,
+        "DATE-AVG": "2026-05-01T17:57:58.828",
+        "MJD-AVG": 61161.748597546,
+        "DATE-END": "2026-05-01T18:14:14.538",
+        "MJD-END": 61161.759890486,
+        "XPOSURE": 3349.872,
+        "TELAPSE": 3349.872,
+        "OBSGEO-X": -538753537.46593,
+        "OBSGEO-Y": -1363545070.5795,
+        "OBSGEO-Z": -689281081.7073,
+        "RADESYS": "ICRS"
+      },
+      "supertiles": [
+        {
+          "filename": "mosaic_nircam_f444w_rj0911_30mas_venus_sci_z1.fits.fz",
+          "tile_origin": [
+            0,
+            0
+          ],
+          "tile_count": [
+            16,
+            23
+          ]
+        }
+      ]
+    },
+    {
+      "z": 2,
+      "filename": "mosaic_nircam_f444w_rj0911_30mas_venus_sci_z2.fits.fz",
+      "compression": "RICE_1",
+      "lossless": false,
+      "shape": [
+        2903,
+        1966
+      ],
+      "fpack_tile_count": [
+        12,
+        8
+      ],
+      "pixel_scale_arcsec": 0.11999999999999995,
+      "wcs": {
+        "WCSAXES": 2,
+        "CRPIX1": 983.50000000006,
+        "CRPIX2": 1452.0000000001,
+        "PC1_1": -1.0,
+        "CDELT1": 3.3333333333333e-05,
+        "CDELT2": 3.3333333333333e-05,
+        "CUNIT1": "deg",
+        "CUNIT2": "deg",
+        "CTYPE1": "RA---TAN",
+        "CTYPE2": "DEC--TAN",
+        "CRVAL1": 137.80514163602,
+        "CRVAL2": 17.79988187551,
+        "LONPOLE": 180.0,
+        "LATPOLE": 17.79988187551,
+        "MJDREF": 0.0,
+        "DATE-BEG": "2026-05-01T17:41:51.134",
+        "MJD-BEG": 61161.737397384,
+        "DATE-AVG": "2026-05-01T17:57:58.828",
+        "MJD-AVG": 61161.748597546,
+        "DATE-END": "2026-05-01T18:14:14.538",
+        "MJD-END": 61161.759890486,
+        "XPOSURE": 3349.872,
+        "TELAPSE": 3349.872,
+        "OBSGEO-X": -538753537.46593,
+        "OBSGEO-Y": -1363545070.5795,
+        "OBSGEO-Z": -689281081.7073,
+        "RADESYS": "ICRS"
+      },
+      "supertiles": [
+        {
+          "filename": "mosaic_nircam_f444w_rj0911_30mas_venus_sci_z2.fits.fz",
+          "tile_origin": [
+            0,
+            0
+          ],
+          "tile_count": [
+            8,
+            12
+          ]
+        }
+      ]
+    },
+    {
+      "z": 3,
+      "filename": "mosaic_nircam_f444w_rj0911_30mas_venus_sci_z3.fits.fz",
+      "compression": "RICE_1",
+      "lossless": false,
+      "shape": [
+        1451,
+        983
+      ],
+      "fpack_tile_count": [
+        6,
+        4
+      ],
+      "pixel_scale_arcsec": 0.2399999999999999,
+      "wcs": {
+        "WCSAXES": 2,
+        "CRPIX1": 492.00000000003,
+        "CRPIX2": 726.25000000004,
+        "PC1_1": -1.0,
+        "CDELT1": 6.6666666666667e-05,
+        "CDELT2": 6.6666666666667e-05,
+        "CUNIT1": "deg",
+        "CUNIT2": "deg",
+        "CTYPE1": "RA---TAN",
+        "CTYPE2": "DEC--TAN",
+        "CRVAL1": 137.80514163602,
+        "CRVAL2": 17.79988187551,
+        "LONPOLE": 180.0,
+        "LATPOLE": 17.79988187551,
+        "MJDREF": 0.0,
+        "DATE-BEG": "2026-05-01T17:41:51.134",
+        "MJD-BEG": 61161.737397384,
+        "DATE-AVG": "2026-05-01T17:57:58.828",
+        "MJD-AVG": 61161.748597546,
+        "DATE-END": "2026-05-01T18:14:14.538",
+        "MJD-END": 61161.759890486,
+        "XPOSURE": 3349.872,
+        "TELAPSE": 3349.872,
+        "OBSGEO-X": -538753537.46593,
+        "OBSGEO-Y": -1363545070.5795,
+        "OBSGEO-Z": -689281081.7073,
+        "RADESYS": "ICRS"
+      },
+      "supertiles": [
+        {
+          "filename": "mosaic_nircam_f444w_rj0911_30mas_venus_sci_z3.fits.fz",
+          "tile_origin": [
+            0,
+            0
+          ],
+          "tile_count": [
+            4,
+            6
+          ]
+        }
+      ]
+    },
+    {
+      "z": 4,
+      "filename": "mosaic_nircam_f444w_rj0911_30mas_venus_sci_z4.fits.fz",
+      "compression": "RICE_1",
+      "lossless": false,
+      "shape": [
+        725,
+        491
+      ],
+      "fpack_tile_count": [
+        3,
+        2
+      ],
+      "pixel_scale_arcsec": 0.4799999999999998,
+      "wcs": {
+        "WCSAXES": 2,
+        "CRPIX1": 246.25000000001,
+        "CRPIX2": 363.37500000002,
+        "PC1_1": -1.0,
+        "CDELT1": 0.00013333333333333,
+        "CDELT2": 0.00013333333333333,
+        "CUNIT1": "deg",
+        "CUNIT2": "deg",
+        "CTYPE1": "RA---TAN",
+        "CTYPE2": "DEC--TAN",
+        "CRVAL1": 137.80514163602,
+        "CRVAL2": 17.79988187551,
+        "LONPOLE": 180.0,
+        "LATPOLE": 17.79988187551,
+        "MJDREF": 0.0,
+        "DATE-BEG": "2026-05-01T17:41:51.134",
+        "MJD-BEG": 61161.737397384,
+        "DATE-AVG": "2026-05-01T17:57:58.828",
+        "MJD-AVG": 61161.748597546,
+        "DATE-END": "2026-05-01T18:14:14.538",
+        "MJD-END": 61161.759890486,
+        "XPOSURE": 3349.872,
+        "TELAPSE": 3349.872,
+        "OBSGEO-X": -538753537.46593,
+        "OBSGEO-Y": -1363545070.5795,
+        "OBSGEO-Z": -689281081.7073,
+        "RADESYS": "ICRS"
+      },
+      "supertiles": [
+        {
+          "filename": "mosaic_nircam_f444w_rj0911_30mas_venus_sci_z4.fits.fz",
+          "tile_origin": [
+            0,
+            0
+          ],
+          "tile_count": [
+            2,
+            3
+          ]
+        }
+      ]
+    },
+    {
+      "z": 5,
+      "filename": "mosaic_nircam_f444w_rj0911_30mas_venus_sci_z5.fits.fz",
+      "compression": "RICE_1",
+      "lossless": false,
+      "shape": [
+        362,
+        245
+      ],
+      "fpack_tile_count": [
+        2,
+        1
+      ],
+      "pixel_scale_arcsec": 0.9599999999999996,
+      "wcs": {
+        "WCSAXES": 2,
+        "CRPIX1": 123.37500000001,
+        "CRPIX2": 181.93750000001,
+        "PC1_1": -1.0,
+        "CDELT1": 0.00026666666666667,
+        "CDELT2": 0.00026666666666667,
+        "CUNIT1": "deg",
+        "CUNIT2": "deg",
+        "CTYPE1": "RA---TAN",
+        "CTYPE2": "DEC--TAN",
+        "CRVAL1": 137.80514163602,
+        "CRVAL2": 17.79988187551,
+        "LONPOLE": 180.0,
+        "LATPOLE": 17.79988187551,
+        "MJDREF": 0.0,
+        "DATE-BEG": "2026-05-01T17:41:51.134",
+        "MJD-BEG": 61161.737397384,
+        "DATE-AVG": "2026-05-01T17:57:58.828",
+        "MJD-AVG": 61161.748597546,
+        "DATE-END": "2026-05-01T18:14:14.538",
+        "MJD-END": 61161.759890486,
+        "XPOSURE": 3349.872,
+        "TELAPSE": 3349.872,
+        "OBSGEO-X": -538753537.46593,
+        "OBSGEO-Y": -1363545070.5795,
+        "OBSGEO-Z": -689281081.7073,
+        "RADESYS": "ICRS"
+      },
+      "supertiles": [
+        {
+          "filename": "mosaic_nircam_f444w_rj0911_30mas_venus_sci_z5.fits.fz",
+          "tile_origin": [
+            0,
+            0
+          ],
+          "tile_count": [
+            1,
+            2
+          ]
+        }
+      ]
+    },
+    {
+      "z": 6,
+      "filename": "mosaic_nircam_f444w_rj0911_30mas_venus_sci_z6.fits.fz",
+      "compression": "RICE_1",
+      "lossless": false,
+      "shape": [
+        181,
+        122
+      ],
+      "fpack_tile_count": [
+        1,
+        1
+      ],
+      "pixel_scale_arcsec": 1.9199999999999993,
+      "wcs": {
+        "WCSAXES": 2,
+        "CRPIX1": 61.937500000004,
+        "CRPIX2": 91.218750000005,
+        "PC1_1": -1.0,
+        "CDELT1": 0.00053333333333333,
+        "CDELT2": 0.00053333333333333,
+        "CUNIT1": "deg",
+        "CUNIT2": "deg",
+        "CTYPE1": "RA---TAN",
+        "CTYPE2": "DEC--TAN",
+        "CRVAL1": 137.80514163602,
+        "CRVAL2": 17.79988187551,
+        "LONPOLE": 180.0,
+        "LATPOLE": 17.79988187551,
+        "MJDREF": 0.0,
+        "DATE-BEG": "2026-05-01T17:41:51.134",
+        "MJD-BEG": 61161.737397384,
+        "DATE-AVG": "2026-05-01T17:57:58.828",
+        "MJD-AVG": 61161.748597546,
+        "DATE-END": "2026-05-01T18:14:14.538",
+        "MJD-END": 61161.759890486,
+        "XPOSURE": 3349.872,
+        "TELAPSE": 3349.872,
+        "OBSGEO-X": -538753537.46593,
+        "OBSGEO-Y": -1363545070.5795,
+        "OBSGEO-Z": -689281081.7073,
+        "RADESYS": "ICRS"
+      },
+      "supertiles": [
+        {
+          "filename": "mosaic_nircam_f444w_rj0911_30mas_venus_sci_z6.fits.fz",
+          "tile_origin": [
+            0,
+            0
+          ],
+          "tile_count": [
+            1,
+            1
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/web/lib/cutout/assemble.ts
+++ b/web/lib/cutout/assemble.ts
@@ -1,0 +1,83 @@
+// Decode + assemble the covering supertiles of a cutout plan into one native-pixel
+// float array (epic #337, Phase 5). Reuses `@fitsgl/core`'s `FpackFile` — the same
+// RICE/GZIP2 fpack decoder the browser viewer runs — but server-side, with the
+// default HTTP range fetcher reading the public tiles bucket. Tiles are placed by
+// their global level-pixel origin; dropped-supertile gaps (`plan.missing`) and
+// out-of-array borders stay NaN so the caller can mask them.
+
+import { FpackFile } from '@fitsgl/core/internal';
+import type { CutoutPlan, TileRef } from './plan';
+
+export interface AssembledRegion {
+  /** Row-major native pixels of the plan's `pixelBbox`, NaN where no data. */
+  data: Float32Array;
+  width: number;
+  height: number;
+  /** The level-pixel origin (== `plan.pixelBbox.x0/y0`) the array is offset from. */
+  x0: number;
+  y0: number;
+}
+
+/** Group a plan's tiles by their supertile file so each `.fits.fz` opens once. */
+function bySupertile(plan: CutoutPlan): Map<string, TileRef[]> {
+  const groups = new Map<string, TileRef[]>();
+  for (const t of plan.tiles) {
+    const key = t.supertile.filename;
+    const g = groups.get(key);
+    if (g) g.push(t);
+    else groups.set(key, [t]);
+  }
+  return groups;
+}
+
+/**
+ * Fetch, decode, and assemble the plan's covering region.
+ * `baseUrl` is the band's tile directory (where `manifest.json` and the `.fits.fz`
+ * supertiles live), e.g. `https://tiles.example/fitsgl/<field>/composite/<band>/`.
+ */
+export async function assembleRegion(plan: CutoutPlan, baseUrl: string): Promise<AssembledRegion> {
+  const { pixelBbox } = plan;
+  const width = Math.max(0, pixelBbox.x1 - pixelBbox.x0);
+  const height = Math.max(0, pixelBbox.y1 - pixelBbox.y0);
+  const data = new Float32Array(width * height).fill(NaN);
+  if (width === 0 || height === 0) return { data, width, height, x0: pixelBbox.x0, y0: pixelBbox.y0 };
+
+  const base = baseUrl.endsWith('/') ? baseUrl : baseUrl + '/';
+
+  for (const [filename, tiles] of bySupertile(plan)) {
+    const file = await FpackFile.open(base + filename, undefined, undefined);
+    for (const t of tiles) {
+      const px = await file.getTile(t.localX, t.localY);
+      const dims = file.tileDims(t.localX, t.localY);
+      // The tile's origin in level pixels (global tile index × the fpack tile edge).
+      // ztile1/ztile2 is the supertile's fpack tile size; a v1 level tiles at that.
+      const originX = t.tile.tileX * file.ztile1;
+      const originY = t.tile.tileY * file.ztile2;
+      blit(px, dims.width, dims.height, originX - pixelBbox.x0, originY - pixelBbox.y0, data, width, height);
+    }
+  }
+  return { data, width, height, x0: pixelBbox.x0, y0: pixelBbox.y0 };
+}
+
+/** Copy a `sw×sh` source tile into `dst` at `(dx, dy)`, clipping to the dst box. */
+function blit(
+  src: Float32Array,
+  sw: number,
+  sh: number,
+  dx: number,
+  dy: number,
+  dst: Float32Array,
+  dw: number,
+  dh: number,
+): void {
+  const cx0 = Math.max(0, dx);
+  const cy0 = Math.max(0, dy);
+  const cx1 = Math.min(dw, dx + sw);
+  const cy1 = Math.min(dh, dy + sh);
+  for (let y = cy0; y < cy1; y++) {
+    const sy = y - dy;
+    let s = sy * sw + (cx0 - dx);
+    let d = y * dw + cx0;
+    for (let x = cx0; x < cx1; x++) dst[d++] = src[s++];
+  }
+}

--- a/web/lib/cutout/encode.ts
+++ b/web/lib/cutout/encode.ts
@@ -1,0 +1,26 @@
+// Server-only PNG/JPEG encoding for cutouts (epic #337, Phase 5). Kept out of the
+// core (`./index`) so the engine stays free of the native `sharp` dependency and
+// unit-tests without it. `sharp` here only encodes an already-rendered RGBA buffer
+// (and optional flatten for JPEG) — not the retired PNG-tile compositing.
+
+import sharp from 'sharp';
+import type { CutoutRGBA } from './index';
+
+/** Encode a rendered cutout's RGBA to a PNG buffer (transparency preserved). */
+export function encodePng(cutout: CutoutRGBA): Promise<Buffer> {
+  return sharp(Buffer.from(cutout.rgba.buffer, cutout.rgba.byteOffset, cutout.rgba.byteLength), {
+    raw: { width: cutout.width, height: cutout.height, channels: 4 },
+  })
+    .png()
+    .toBuffer();
+}
+
+/** Encode to JPEG, flattening no-data (transparent) pixels onto `background`. */
+export function encodeJpeg(cutout: CutoutRGBA, background = '#000000', quality = 90): Promise<Buffer> {
+  return sharp(Buffer.from(cutout.rgba.buffer, cutout.rgba.byteOffset, cutout.rgba.byteLength), {
+    raw: { width: cutout.width, height: cutout.height, channels: 4 },
+  })
+    .flatten({ background })
+    .jpeg({ quality })
+    .toBuffer();
+}

--- a/web/lib/cutout/index.ts
+++ b/web/lib/cutout/index.ts
@@ -41,10 +41,12 @@ export interface CutoutRequest {
 }
 
 export interface CutoutRGBA {
+  /** Raster order (row 0 = top = North) — ready for `sharp`/canvas encoding. */
   rgba: Uint8ClampedArray;
   width: number;
   height: number;
-  /** The N-up output WCS (flat FITS header) — carried through for the FITS path. */
+  /** The N-up output WCS (flat FITS header). NB: describes the underlying
+   *  FITS bottom-up float array, NOT the row-flipped `rgba` raster. */
   outputWcsHeader: Record<string, number | string>;
 }
 

--- a/web/lib/cutout/index.ts
+++ b/web/lib/cutout/index.ts
@@ -1,0 +1,91 @@
+// FitsGL cutout core (epic #337, Phase 5) — the server-side engine that turns a
+// deployed tile pyramid into a North-up cutout, reading the same `.fits.fz`
+// supertiles the browser renders. Pure of any Next/route/`sharp` coupling so it
+// unit-tests and ports cleanly; PNG encoding lives in `./encode` (server-only).
+//
+//   plan (which level + tiles)  →  assemble (decode native region)
+//     →  reproject (native → N-up output grid)  →  render (stretch/colormap → RGBA)
+//
+// Single-band → colormap; three bands → per-channel RGB composite. Both match the
+// interactive viewer's transfer functions (`@fitsgl/core`).
+
+import type { StretchMode, ColormapName } from '@fitsgl/core';
+import type { Manifest } from './manifest';
+import { planCutout } from './plan';
+import { assembleRegion } from './assemble';
+import { reprojectToNorthUp } from './reproject';
+import { percentileLimits, renderSingleBand, renderRGB, type Limits } from './render';
+
+export type { Manifest } from './manifest';
+export { loadManifest, parseManifest } from './manifest';
+
+/** One band of a cutout: its parsed manifest + the tile directory holding its `.fits.fz`. */
+export interface BandSource {
+  manifest: Manifest;
+  /** Tile directory URL for this band (where `manifest.json` + supertiles live). */
+  baseUrl: string;
+}
+
+export interface CutoutRequest {
+  /** ICRS centre `[ra, dec]` in degrees. */
+  center: [number, number];
+  /** Square field of view in arcsec. */
+  fovArcsec: number;
+  /** Square output size in pixels. */
+  outputSize: number;
+  stretch?: StretchMode;
+  /** Single-band colormap (ignored for a 3-band RGB composite). */
+  colormap?: ColormapName;
+  /** Display limits: `'auto'` (per-band percentile) or explicit per band. */
+  limits?: 'auto' | Limits | Limits[];
+}
+
+export interface CutoutRGBA {
+  rgba: Uint8ClampedArray;
+  width: number;
+  height: number;
+  /** The N-up output WCS (flat FITS header) — carried through for the FITS path. */
+  outputWcsHeader: Record<string, number | string>;
+}
+
+/** Reproject one band to the N-up output grid, returning its float pixels + WCS. */
+async function bandToOutput(band: BandSource, center: [number, number], fovArcsec: number, outputSize: number) {
+  const plan = planCutout(band.manifest, center, fovArcsec, { outputSize, rounding: 'nearest' });
+  const region = await assembleRegion(plan, band.baseUrl);
+  const scale = fovArcsec / outputSize;
+  return reprojectToNorthUp(region, plan.level, center[0], center[1], scale, outputSize, outputSize);
+}
+
+/** Render a cutout to RGBA (single-band colormap, or 3-band per-channel RGB). */
+export async function renderCutout(bands: BandSource[], req: CutoutRequest): Promise<CutoutRGBA> {
+  if (bands.length !== 1 && bands.length !== 3) {
+    throw new Error(`cutout needs 1 (single-band) or 3 (RGB) bands, got ${bands.length}`);
+  }
+  const stretch = req.stretch ?? 'asinh';
+  const outs = await Promise.all(
+    bands.map((b) => bandToOutput(b, req.center, req.fovArcsec, req.outputSize)),
+  );
+  const { width, height, outputWcsHeader } = outs[0];
+
+  const limitFor = (i: number): Limits =>
+    req.limits === undefined || req.limits === 'auto'
+      ? percentileLimits(outs[i].data)
+      : Array.isArray(req.limits)
+        ? req.limits[i]
+        : req.limits;
+
+  let rgba: Uint8ClampedArray;
+  if (bands.length === 1) {
+    rgba = renderSingleBand(outs[0].data, width, height, {
+      limits: limitFor(0),
+      stretch,
+      colormap: req.colormap ?? 'gray',
+    });
+  } else {
+    rgba = renderRGB([outs[0].data, outs[1].data, outs[2].data], width, height, {
+      limits: [limitFor(0), limitFor(1), limitFor(2)],
+      stretch,
+    });
+  }
+  return { rgba, width, height, outputWcsHeader };
+}

--- a/web/lib/cutout/manifest.test.ts
+++ b/web/lib/cutout/manifest.test.ts
@@ -1,0 +1,56 @@
+// parseManifest compatibility tests (epic #337, Phase 5): a legacy v1 level has
+// no `supertiles[]`; the parser must synthesize the one full-grid supertile the
+// way the reference `fitsgl.manifest.LevelInfo.from_dict` does (v1 shim), so
+// cutouts keep working against pre-supertile pyramid deployments.
+
+import { describe, it, expect } from 'vitest';
+import { parseManifest } from './manifest';
+
+const V1_LEVEL = {
+  z: 0,
+  filename: 'f444w_z0.fits.fz',
+  compression: 'RICE_1',
+  lossless: false,
+  shape: [1024, 2048], // [H, W]
+  fpack_tile_count: [2, 4], // [n_ty, n_tx]
+  pixel_scale_arcsec: 0.03,
+  wcs: { CTYPE1: 'RA---TAN', CTYPE2: 'DEC--TAN' },
+};
+
+describe('parseManifest v1 shim', () => {
+  it('synthesizes one full-grid supertile when `supertiles` is absent', () => {
+    const m = parseManifest({
+      version: 1,
+      native_shape: [1024, 2048],
+      fpack_tile_size: 512,
+      levels: [V1_LEVEL],
+    });
+    expect(m.levels[0].supertiles).toEqual([
+      // mirrors fitsgl-py: [n_ty, n_tx] → tile_count [n_tx, n_ty], origin [0, 0]
+      { filename: 'f444w_z0.fits.fz', tileOrigin: [0, 0], tileCount: [4, 2] },
+    ]);
+  });
+
+  it('still parses explicit v2 supertiles verbatim', () => {
+    const m = parseManifest({
+      version: 2,
+      native_shape: [1024, 2048],
+      fpack_tile_size: 512,
+      levels: [
+        {
+          ...V1_LEVEL,
+          supertiles: [
+            { filename: 'a.fits.fz', tile_origin: [0, 0], tile_count: [2, 2] },
+            { filename: 'b.fits.fz', tile_origin: [2, 0], tile_count: [2, 2] },
+          ],
+        },
+      ],
+    });
+    expect(m.levels[0].supertiles).toHaveLength(2);
+    expect(m.levels[0].supertiles[1]).toEqual({
+      filename: 'b.fits.fz',
+      tileOrigin: [2, 0],
+      tileCount: [2, 2],
+    });
+  });
+});

--- a/web/lib/cutout/manifest.ts
+++ b/web/lib/cutout/manifest.ts
@@ -1,0 +1,100 @@
+// FitsGL per-band pyramid manifest (`<band>/manifest.json`) — the shared
+// contract between the pipeline producer (`fitsgl-py`), the browser viewer
+// (`@fitsgl/core`), and this server-side cutout engine (epic #337, Phase 5).
+//
+// Field names mirror `fitsgl.manifest` (Python) so the TS addressing in `plan.ts`
+// is a faithful port; a golden parity test (`plan.test.ts`) pins them to
+// `fitsgl-py`'s `plan_cutout` so the two never drift.
+
+import { parseWcs, type TanWcs } from '@fitsgl/core';
+
+/** A standalone `.fits.fz` rectangle within a level, in the level's tile grid. */
+export interface SupertileInfo {
+  filename: string;
+  /** Tile-grid origin `[tile_x0, tile_y0]` of this supertile within the level. */
+  tileOrigin: readonly [number, number];
+  /** Tile-grid extent `[n_tiles_x, n_tiles_y]` of this supertile. */
+  tileCount: readonly [number, number];
+}
+
+export interface LevelInfo {
+  /** Pyramid level index (0 = finest / native). */
+  z: number;
+  /** The single-file `.fits.fz` for a v1 level (== `supertiles[0].filename`). */
+  filename: string;
+  compression: string;
+  lossless: boolean;
+  /** Level pixel dimensions `[H, W]` (row, col). */
+  shape: readonly [number, number];
+  /** `[n_tiles_y, n_tiles_x]` — note the y-major order (matches `fitsgl-py`). */
+  fpackTileCount: readonly [number, number];
+  pixelScaleArcsec: number;
+  /** Flat FITS WCS header dict for this level; feed to `parseWcs`. */
+  wcs: Record<string, unknown>;
+  supertiles: SupertileInfo[];
+}
+
+export interface Manifest {
+  version: number;
+  sourceFile?: string;
+  /** Native (z=0) dimensions `[H, W]`. */
+  nativeShape: readonly [number, number];
+  /** The fpack tile edge (px) every level is tiled at; the unit of tile grids. */
+  fpackTileSize: number;
+  levels: LevelInfo[];
+}
+
+function pair(v: unknown, what: string): readonly [number, number] {
+  if (!Array.isArray(v) || v.length < 2) throw new Error(`manifest: ${what} is not a [a, b] pair`);
+  return [Number(v[0]), Number(v[1])];
+}
+
+/** Parse a raw `manifest.json` object into a typed {@link Manifest}. */
+export function parseManifest(json: unknown): Manifest {
+  const m = json as Record<string, unknown>;
+  const rawLevels = m.levels;
+  if (!Array.isArray(rawLevels) || rawLevels.length === 0) throw new Error('manifest has no levels');
+  const levels: LevelInfo[] = rawLevels.map((lv) => {
+    const l = lv as Record<string, unknown>;
+    const supertiles = (l.supertiles as unknown[]).map((st) => {
+      const s = st as Record<string, unknown>;
+      return {
+        filename: String(s.filename),
+        tileOrigin: pair(s.tile_origin, 'supertile.tile_origin'),
+        tileCount: pair(s.tile_count, 'supertile.tile_count'),
+      } satisfies SupertileInfo;
+    });
+    return {
+      z: Number(l.z),
+      filename: String(l.filename),
+      compression: String(l.compression),
+      lossless: Boolean(l.lossless),
+      shape: pair(l.shape, 'level.shape'),
+      fpackTileCount: pair(l.fpack_tile_count, 'level.fpack_tile_count'),
+      pixelScaleArcsec: Number(l.pixel_scale_arcsec),
+      wcs: (l.wcs ?? {}) as Record<string, unknown>,
+      supertiles,
+    } satisfies LevelInfo;
+  });
+  return {
+    version: Number(m.version ?? 0),
+    sourceFile: m.source_file ? String(m.source_file) : undefined,
+    nativeShape: pair(m.native_shape, 'native_shape'),
+    fpackTileSize: Number(m.fpack_tile_size),
+    levels,
+  };
+}
+
+/** Fetch + parse a band `manifest.json` from a URL. */
+export async function loadManifest(url: string, signal?: AbortSignal): Promise<Manifest> {
+  const res = await fetch(url, { signal });
+  if (!res.ok) throw new Error(`manifest fetch failed (${res.status}) for ${url}`);
+  return parseManifest(await res.json());
+}
+
+/** Parse a level's flat WCS header dict into a `@fitsgl/core` `TanWcs`. */
+export function levelWcs(level: LevelInfo): TanWcs {
+  const wcs = parseWcs(level.wcs);
+  if (!wcs) throw new Error(`level z=${level.z} has no usable TAN/ICRS WCS`);
+  return wcs;
+}

--- a/web/lib/cutout/manifest.ts
+++ b/web/lib/cutout/manifest.ts
@@ -56,14 +56,23 @@ export function parseManifest(json: unknown): Manifest {
   if (!Array.isArray(rawLevels) || rawLevels.length === 0) throw new Error('manifest has no levels');
   const levels: LevelInfo[] = rawLevels.map((lv) => {
     const l = lv as Record<string, unknown>;
-    const supertiles = (l.supertiles as unknown[]).map((st) => {
-      const s = st as Record<string, unknown>;
-      return {
-        filename: String(s.filename),
-        tileOrigin: pair(s.tile_origin, 'supertile.tile_origin'),
-        tileCount: pair(s.tile_count, 'supertile.tile_count'),
-      } satisfies SupertileInfo;
-    });
+    let supertiles: SupertileInfo[];
+    if (l.supertiles == null) {
+      // v1 shim (mirrors `fitsgl.manifest.LevelInfo.from_dict`): a legacy level
+      // has no `supertiles[]` — synthesize the one full-grid supertile from the
+      // level's single file ([n_ty, n_tx] → tile_count [n_tx, n_ty]).
+      const [nTy, nTx] = pair(l.fpack_tile_count, 'level.fpack_tile_count');
+      supertiles = [{ filename: String(l.filename), tileOrigin: [0, 0], tileCount: [nTx, nTy] }];
+    } else {
+      supertiles = (l.supertiles as unknown[]).map((st) => {
+        const s = st as Record<string, unknown>;
+        return {
+          filename: String(s.filename),
+          tileOrigin: pair(s.tile_origin, 'supertile.tile_origin'),
+          tileCount: pair(s.tile_count, 'supertile.tile_count'),
+        } satisfies SupertileInfo;
+      });
+    }
     return {
       z: Number(l.z),
       filename: String(l.filename),

--- a/web/lib/cutout/plan.test.ts
+++ b/web/lib/cutout/plan.test.ts
@@ -1,0 +1,89 @@
+// Parity test: the TS cutout addressing (`plan.ts`) must reproduce `fitsgl-py`'s
+// `plan_cutout` byte-for-byte on a shared golden fixture (epic #337, Phase 5).
+// Regenerate the fixture with `__fixtures__/generate_plan_fixture.py`. Any drift
+// between the browser/producer geometry and this server port fails here.
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import { describe, it, expect } from 'vitest';
+import { parseManifest, type LevelInfo } from './manifest';
+import { planCutout, resolveSupertile, tilesForPixelBbox, type Rounding } from './plan';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const manifest = parseManifest(
+  JSON.parse(readFileSync(resolve(here, '__fixtures__/rj0911-f444w-manifest.json'), 'utf-8')),
+);
+const cases = JSON.parse(readFileSync(resolve(here, '__fixtures__/plan-cases.json'), 'utf-8')) as Array<{
+  name: string;
+  center: [number, number];
+  fov: number | [number, number];
+  outputSize: number | [number, number] | null;
+  targetScaleArcsec: number | null;
+  rounding: Rounding;
+  expected: {
+    levelIndex: number;
+    bbox: { x0: number; y0: number; x1: number; y1: number };
+    tiles: Array<{ tileX: number; tileY: number; supertileIndex: number; localX: number; localY: number }>;
+    missing: Array<{ tileX: number; tileY: number }>;
+  };
+}>;
+
+describe('planCutout — fitsgl-py golden parity', () => {
+  for (const c of cases) {
+    it(c.name, () => {
+      const plan = planCutout(manifest, c.center, c.fov, {
+        outputSize: c.outputSize ?? undefined,
+        targetScaleArcsec: c.targetScaleArcsec ?? undefined,
+        rounding: c.rounding,
+      });
+      expect(plan.levelIndex).toBe(c.expected.levelIndex);
+      expect(plan.pixelBbox).toEqual(c.expected.bbox);
+      expect(plan.tiles.map((t) => ({
+        tileX: t.tile.tileX, tileY: t.tile.tileY,
+        supertileIndex: t.supertileIndex, localX: t.localX, localY: t.localY,
+      }))).toEqual(c.expected.tiles);
+      expect(plan.missing.map((m) => ({ tileX: m.tileX, tileY: m.tileY }))).toEqual(c.expected.missing);
+    });
+  }
+});
+
+describe('resolveSupertile — multi-supertile gaps + local coords', () => {
+  // A synthetic 2×2-supertile level (rj0911's real levels are single-file, so this
+  // exercises the disjoint-supertile scan + gap the golden fixture cannot).
+  const level: LevelInfo = {
+    z: 0,
+    filename: 'x',
+    compression: 'RICE_1',
+    lossless: false,
+    shape: [1024, 1024], // [H, W] → 4×4 tiles at 256
+    fpackTileCount: [4, 4], // [n_ty, n_tx]
+    pixelScaleArcsec: 0.03,
+    wcs: {},
+    supertiles: [
+      { filename: 'a', tileOrigin: [0, 0], tileCount: [2, 2] }, // top-left quadrant
+      { filename: 'b', tileOrigin: [2, 0], tileCount: [2, 2] }, // top-right
+      { filename: 'c', tileOrigin: [0, 2], tileCount: [2, 2] }, // bottom-left
+      // bottom-right quadrant (tiles x∈[2,4), y∈[2,4)) is a DROPPED gap.
+    ],
+  };
+
+  it('maps a global tile to its supertile with local coords', () => {
+    const m = resolveSupertile(level, 3, 1); // top-right supertile 'b', local (1, 1)
+    expect(m?.supertile.filename).toBe('b');
+    expect(m?.supertileIndex).toBe(1);
+    expect([m?.localX, m?.localY]).toEqual([1, 1]);
+  });
+
+  it('returns null for a dropped-supertile gap', () => {
+    expect(resolveSupertile(level, 3, 3)).toBeNull(); // bottom-right, no supertile
+  });
+
+  it('planCutout-style coverage splits a box across supertiles + records the gap', () => {
+    // A box spanning all four quadrants (whole level).
+    const coords = tilesForPixelBbox(level, { x0: 0, y0: 0, x1: 1024, y1: 1024 }, 256);
+    expect(coords).toHaveLength(16);
+    const resolved = coords.map((c) => resolveSupertile(level, c.tileX, c.tileY));
+    expect(resolved.filter((r) => r === null)).toHaveLength(4); // the dropped quadrant's 4 tiles
+  });
+});

--- a/web/lib/cutout/plan.ts
+++ b/web/lib/cutout/plan.ts
@@ -1,0 +1,275 @@
+// Read-side cutout addressing (epic #337, Phase 5) — a faithful TypeScript port of
+// `fitsgl.tiles` + `fitsgl.cutout.plan_cutout` (the Python producer's read API).
+// Given a band manifest + a sky center/FOV/output size it picks the pyramid level,
+// projects the sky box to that level's pixel grid, and resolves the covering fpack
+// tiles to their supertile files (+ supertile-local coords). Pure geometry: the
+// only external dependency is `@fitsgl/core`'s astropy-validated TAN `skyToPix`.
+//
+// A golden parity test (`plan.test.ts`) pins every output against `fitsgl-py` so
+// the port cannot silently drift from the browser/producer.
+
+import { skyToPix } from '@fitsgl/core';
+import { levelWcs, type LevelInfo, type Manifest, type SupertileInfo } from './manifest';
+
+export type Rounding = 'nearest' | 'finer' | 'coarser';
+
+export interface TileCoord {
+  level: number;
+  tileX: number;
+  tileY: number;
+}
+
+/** Half-open pixel rectangle `[x0, x1) × [y0, y1)` in a level's grid. */
+export interface PixelBBox {
+  x0: number;
+  y0: number;
+  x1: number;
+  y1: number;
+}
+
+export interface TileRef {
+  tile: TileCoord;
+  supertile: SupertileInfo;
+  supertileIndex: number;
+  /** Tile coords local to the supertile's own grid (what the `.fits.fz` addresses by). */
+  localX: number;
+  localY: number;
+}
+
+export interface CutoutPlan {
+  levelIndex: number;
+  level: LevelInfo;
+  outputScaleArcsec: number;
+  pixelBbox: PixelBBox;
+  tiles: TileRef[];
+  /** Covering tiles that fall in a dropped-supertile (all-NaN) gap → caller NaN-fills. */
+  missing: TileCoord[];
+}
+
+export const bboxWidth = (b: PixelBBox): number => Math.max(0, b.x1 - b.x0);
+export const bboxHeight = (b: PixelBBox): number => Math.max(0, b.y1 - b.y0);
+export const bboxIsEmpty = (b: PixelBBox): boolean => b.x1 <= b.x0 || b.y1 <= b.y0;
+
+/** `[n_tiles_x, n_tiles_y]` for a level (unpacks `fpackTileCount` = `[n_ty, n_tx]`). */
+function levelTileGrid(level: LevelInfo): [number, number] {
+  const [nTy, nTx] = level.fpackTileCount;
+  return [nTx, nTy];
+}
+
+/** The supertile of `level` holding global tile `(tileX, tileY)`, or null in a gap. */
+export function resolveSupertile(level: LevelInfo, tileX: number, tileY: number): TileRef | null {
+  for (let index = 0; index < level.supertiles.length; index++) {
+    const st = level.supertiles[index];
+    const [tx0, ty0] = st.tileOrigin;
+    const [snx, sny] = st.tileCount;
+    if (tx0 <= tileX && tileX < tx0 + snx && ty0 <= tileY && tileY < ty0 + sny) {
+      return {
+        tile: { level: level.z, tileX, tileY },
+        supertile: st,
+        supertileIndex: index,
+        localX: tileX - tx0,
+        localY: tileY - ty0,
+      };
+    }
+  }
+  return null;
+}
+
+/** Every tile of `level` overlapping the half-open pixel box, row-major (y outer). */
+export function tilesForPixelBbox(level: LevelInfo, bbox: PixelBBox, tileSize: number): TileCoord[] {
+  const [nTx, nTy] = levelTileGrid(level);
+  const h = level.shape[0];
+  const w = level.shape[1];
+
+  const x0 = Math.max(0, bbox.x0);
+  const y0 = Math.max(0, bbox.y0);
+  const x1 = Math.min(w, bbox.x1);
+  const y1 = Math.min(h, bbox.y1);
+  if (x1 <= x0 || y1 <= y0) return [];
+
+  const tx0 = Math.floor(x0 / tileSize);
+  const ty0 = Math.floor(y0 / tileSize);
+  // x1/y1 are exclusive: the last covered pixel is x1-1, so a box ending exactly on
+  // a tile boundary does not pull in the next, untouched column.
+  const tx1 = Math.min(nTx - 1, Math.floor((x1 - 1) / tileSize));
+  const ty1 = Math.min(nTy - 1, Math.floor((y1 - 1) / tileSize));
+
+  const tiles: TileCoord[] = [];
+  for (let ty = ty0; ty <= ty1; ty++) {
+    for (let tx = tx0; tx <= tx1; tx++) {
+      tiles.push({ level: level.z, tileX: tx, tileY: ty });
+    }
+  }
+  return tiles;
+}
+
+function levelsByZ(manifest: Manifest): LevelInfo[] {
+  if (manifest.levels.length === 0) throw new Error('manifest has no levels');
+  const levels = [...manifest.levels].sort((a, b) => a.z - b.z);
+  for (const lvl of levels) {
+    const s = lvl.pixelScaleArcsec;
+    if (!(Number.isFinite(s) && s > 0)) {
+      throw new Error(`level z=${lvl.z} has a non-positive/non-finite pixel_scale_arcsec (${s})`);
+    }
+  }
+  return levels;
+}
+
+/** Pick the pyramid level (its `z`) whose pixel scale best serves `targetScaleArcsec`. */
+export function selectLevelIndex(
+  manifest: Manifest,
+  targetScaleArcsec: number,
+  rounding: Rounding = 'nearest',
+): number {
+  if (!(targetScaleArcsec > 0)) throw new Error(`targetScaleArcsec must be positive (got ${targetScaleArcsec})`);
+  const levels = levelsByZ(manifest);
+  const scales = levels.map((l) => l.pixelScaleArcsec);
+
+  if (rounding === 'nearest') {
+    // Closest in log space — one level pixel ≈ one output pixel (the viewer's rule).
+    let bestI = 0;
+    let bestD = Infinity;
+    for (let i = 0; i < levels.length; i++) {
+      const d = Math.abs(Math.log2(scales[i] / targetScaleArcsec));
+      if (d < bestD) {
+        bestD = d;
+        bestI = i;
+      }
+    }
+    return levels[bestI].z;
+  }
+  if (rounding === 'finer') {
+    // Coarsest level still at least as fine as the request (scale <= target).
+    let chosen = levels[0];
+    for (let i = 0; i < levels.length; i++) {
+      if (scales[i] <= targetScaleArcsec) chosen = levels[i];
+    }
+    return chosen.z;
+  }
+  // 'coarser': finest level not finer than the request (scale >= target).
+  for (let i = 0; i < levels.length; i++) {
+    if (scales[i] >= targetScaleArcsec) return levels[i].z;
+  }
+  return levels[levels.length - 1].z;
+}
+
+function asPair(v: number | [number, number], what: string): [number, number] {
+  const p: [number, number] = typeof v === 'number' ? [v, v] : [v[0], v[1]];
+  if (!(p[0] > 0 && p[1] > 0)) throw new Error(`${what} must be positive (got ${JSON.stringify(v)})`);
+  return p;
+}
+
+/** RA/Dec (deg) samples along the perimeter of the requested North/East-aligned box. */
+function skyBoxPerimeter(
+  center: [number, number],
+  fovArcsec: [number, number],
+  samples: number,
+): Array<[number, number]> {
+  const [raC, decC] = center;
+  const halfWDeg = fovArcsec[0] / 2 / 3600;
+  const halfHDeg = fovArcsec[1] / 2 / 3600;
+  const n = Math.max(2, samples);
+  const t: number[] = [];
+  for (let i = 0; i < n; i++) t.push(-1 + (2 * i) / (n - 1));
+
+  const out: Array<[number, number]> = [];
+  const push = (dx: number, dy: number) => {
+    const dec = decC + dy;
+    let cosDec = Math.cos((dec * Math.PI) / 180);
+    if (Math.abs(cosDec) <= 1e-9) cosDec = 1e-9;
+    out.push([raC + dx / cosDec, dec]);
+  };
+  for (const sy of [-1, 1]) for (const tv of t) push(tv * halfWDeg, sy * halfHDeg); // bottom & top
+  for (const sx of [-1, 1]) for (const tv of t) push(sx * halfWDeg, tv * halfHDeg); // left & right
+  return out;
+}
+
+export interface PlanOptions {
+  /** Intended output size in px (scalar or `[w, h]`); sets the level via `fov / size`. */
+  outputSize?: number | [number, number];
+  /** Output pixel scale (arcsec/px) to select the level by, overriding `outputSize`. */
+  targetScaleArcsec?: number;
+  rounding?: Rounding;
+  perimeterSamples?: number;
+}
+
+/**
+ * Plan a cutout: pick the level and resolve the covering tiles/supertiles. Mirrors
+ * `fitsgl.cutout.plan_cutout`. `center` is ICRS `[ra, dec]` deg; `fov` is arcsec
+ * (scalar = square, or `[width, height]` along RA×Dec). An out-of-field request
+ * returns an empty plan (`plan.tiles.length === 0`).
+ */
+export function planCutout(
+  manifest: Manifest,
+  center: [number, number],
+  fov: number | [number, number],
+  opts: PlanOptions = {},
+): CutoutPlan {
+  if (manifest.levels.length === 0) throw new Error('manifest has no levels');
+  const fovPair = asPair(fov, 'fov');
+  const { outputSize, targetScaleArcsec, rounding = 'nearest', perimeterSamples = 16 } = opts;
+
+  let scale: number;
+  if (targetScaleArcsec !== undefined) {
+    if (!(targetScaleArcsec > 0)) throw new Error(`targetScaleArcsec must be positive (got ${targetScaleArcsec})`);
+    scale = targetScaleArcsec;
+  } else if (outputSize !== undefined) {
+    const out = asPair(outputSize, 'outputSize');
+    // The *finer* of the two per-axis scales — never serve an anisotropic request
+    // from a level coarser than its finer axis needs.
+    scale = Math.min(fovPair[0] / out[0], fovPair[1] / out[1]);
+  } else {
+    scale = Math.min(...manifest.levels.map((l) => l.pixelScaleArcsec));
+  }
+
+  const tileSize = manifest.fpackTileSize;
+  const levelIndex = selectLevelIndex(manifest, scale, rounding);
+  const level = manifest.levels.find((l) => l.z === levelIndex)!;
+
+  const wcs = levelWcs(level);
+  const h = level.shape[0];
+  const w = level.shape[1];
+
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  let anyFinite = false;
+  for (const [ra, dec] of skyBoxPerimeter(center, fovPair, perimeterSamples)) {
+    const p = skyToPix(wcs, ra, dec);
+    if (!Number.isFinite(p.x) || !Number.isFinite(p.y)) continue;
+    anyFinite = true;
+    if (p.x < minX) minX = p.x;
+    if (p.x > maxX) maxX = p.x;
+    if (p.y < minY) minY = p.y;
+    if (p.y > maxY) maxY = p.y;
+  }
+
+  if (!anyFinite) {
+    return { levelIndex, level, outputScaleArcsec: scale, pixelBbox: { x0: 0, y0: 0, x1: 0, y1: 0 }, tiles: [], missing: [] };
+  }
+
+  // `skyToPix` returns world (0-based, half-pixel-centred) coords: the array index
+  // holding world `w` is `floor(w)`. (Python's `floor(astropy_p + 0.5)` is the same,
+  // since fitsgl world = astropy 0-based + 0.5.)
+  const col0 = Math.floor(minX);
+  const col1 = Math.floor(maxX);
+  const row0 = Math.floor(minY);
+  const row1 = Math.floor(maxY);
+  const bbox: PixelBBox = {
+    x0: Math.max(0, col0),
+    y0: Math.max(0, row0),
+    x1: Math.min(w, col1 + 1),
+    y1: Math.min(h, row1 + 1),
+  };
+
+  const tiles: TileRef[] = [];
+  const missing: TileCoord[] = [];
+  for (const coord of tilesForPixelBbox(level, bbox, tileSize)) {
+    const match = resolveSupertile(level, coord.tileX, coord.tileY);
+    if (match === null) missing.push(coord);
+    else tiles.push(match);
+  }
+
+  return { levelIndex, level, outputScaleArcsec: scale, pixelBbox: bbox, tiles, missing };
+}

--- a/web/lib/cutout/render.test.ts
+++ b/web/lib/cutout/render.test.ts
@@ -1,0 +1,58 @@
+// Row-order tests for the RGBA renderers (epic #337, Phase 5): input float
+// arrays are FITS bottom-up (row 0 = south), output RGBA is raster top-down
+// (row 0 = top), so the northernmost input row must land in the FIRST RGBA row.
+// Pins the North-up fix from the #363 review (claude + Codex both caught the
+// missing flip).
+
+import { describe, it, expect } from 'vitest';
+import { renderSingleBand, renderRGB } from './render';
+
+const px = (rgba: Uint8ClampedArray, x: number, y: number, w: number) => {
+  const o = (y * w + x) * 4;
+  return [rgba[o], rgba[o + 1], rgba[o + 2], rgba[o + 3]];
+};
+
+describe('renderSingleBand', () => {
+  it('flips FITS bottom-up rows to raster top-down (north ends up on top)', () => {
+    // 2×2: bottom row (south) = 0 (dark), top row (north) = 1 (bright)
+    const data = new Float32Array([0, 0, 1, 1]);
+    const rgba = renderSingleBand(data, 2, 2, {
+      limits: { lo: 0, hi: 1 },
+      stretch: 'linear',
+      colormap: 'gray',
+    });
+    expect(px(rgba, 0, 0, 2)).toEqual([255, 255, 255, 255]); // raster top = north = bright
+    expect(px(rgba, 0, 1, 2)).toEqual([0, 0, 0, 255]); // raster bottom = south = dark
+  });
+
+  it('keeps NaN transparency at the flipped position', () => {
+    // NaN at south-right (index 1) → transparent at raster bottom-right
+    const data = new Float32Array([0, NaN, 1, 1]);
+    const rgba = renderSingleBand(data, 2, 2, {
+      limits: { lo: 0, hi: 1 },
+      stretch: 'linear',
+      colormap: 'gray',
+    });
+    expect(px(rgba, 1, 1, 2)[3]).toBe(0); // bottom-right transparent
+    expect(px(rgba, 1, 0, 2)[3]).toBe(255); // top-right opaque
+  });
+});
+
+describe('renderRGB', () => {
+  it('flips rows and maps channels R/G/B in the flipped order', () => {
+    // 1×2 column: south px has r=0, north px has r=1 (g/b constant 0)
+    const r = new Float32Array([0, 1]);
+    const g = new Float32Array([0, 0]);
+    const b = new Float32Array([0, 0]);
+    const rgba = renderRGB([r, g, b], 1, 2, {
+      limits: [
+        { lo: 0, hi: 1 },
+        { lo: 0, hi: 1 },
+        { lo: 0, hi: 1 },
+      ],
+      stretch: 'linear',
+    });
+    expect(px(rgba, 0, 0, 1)).toEqual([255, 0, 0, 255]); // top = north = bright red
+    expect(px(rgba, 0, 1, 1)).toEqual([0, 0, 0, 255]); // bottom = south = dark
+  });
+});

--- a/web/lib/cutout/render.ts
+++ b/web/lib/cutout/render.ts
@@ -2,6 +2,12 @@
 // own transfer functions from `@fitsgl/core` (`scaleValue` normalize+clamp+stretch,
 // `colormapRGB` LUT) so a server cutout matches the interactive map exactly. NaN
 // (no-data) pixels are written transparent so the cutout composites over the page.
+//
+// Row order: the input arrays are FITS bottom-up (row 0 = south — `reproject.ts`
+// keeps the standard N-up WCS with CD2_2 > 0), while RGBA consumers (`sharp`,
+// canvas) are raster top-down (row 0 = top). The renderers flip rows here so the
+// encoded image is actually North-up — the same convention boundary the legacy
+// stack handles in `tile-compositing.ts`'s `fitsToWorldPixel`.
 
 import { applyStretch, colormapRGB, COLORMAP_SIZE, type StretchMode, type ColormapName } from '@fitsgl/core';
 
@@ -34,7 +40,8 @@ export function percentileLimits(data: Float32Array, loPct = 0.5, hiPct = 99.5):
   return { lo, hi };
 }
 
-/** Single-band → RGBA via a stretch + colormap LUT. NaN → transparent. */
+/** Single-band → RGBA via a stretch + colormap LUT. NaN → transparent.
+ *  Input rows are FITS bottom-up; output RGBA rows are raster top-down. */
 export function renderSingleBand(
   data: Float32Array,
   width: number,
@@ -45,21 +52,26 @@ export function renderSingleBand(
   const lut = colormapRGB(colormap);
   const rgba = new Uint8ClampedArray(width * height * 4);
   const maxIdx = COLORMAP_SIZE - 1;
-  for (let i = 0; i < data.length; i++) {
-    const v = data[i];
-    const o = i * 4;
-    if (Number.isNaN(v)) continue; // leave transparent (rgba is zero-filled)
-    const norm = scaleValue(v, limits.lo, limits.hi, stretch, trilogyK);
-    const idx = Math.min(maxIdx, Math.max(0, Math.round(norm * maxIdx))) * 3;
-    rgba[o] = lut[idx];
-    rgba[o + 1] = lut[idx + 1];
-    rgba[o + 2] = lut[idx + 2];
-    rgba[o + 3] = 255;
+  for (let y = 0; y < height; y++) {
+    const src = y * width;
+    const dst = (height - 1 - y) * width; // FITS bottom-up → raster top-down
+    for (let x = 0; x < width; x++) {
+      const v = data[src + x];
+      if (Number.isNaN(v)) continue; // leave transparent (rgba is zero-filled)
+      const o = (dst + x) * 4;
+      const norm = scaleValue(v, limits.lo, limits.hi, stretch, trilogyK);
+      const idx = Math.min(maxIdx, Math.max(0, Math.round(norm * maxIdx))) * 3;
+      rgba[o] = lut[idx];
+      rgba[o + 1] = lut[idx + 1];
+      rgba[o + 2] = lut[idx + 2];
+      rgba[o + 3] = 255;
+    }
   }
   return rgba;
 }
 
-/** Per-channel RGB composite (R←band0, G←band1, B←band2), each with its own stretch. */
+/** Per-channel RGB composite (R←band0, G←band1, B←band2), each with its own stretch.
+ *  Input rows are FITS bottom-up; output RGBA rows are raster top-down. */
 export function renderRGB(
   channels: readonly [Float32Array, Float32Array, Float32Array],
   width: number,
@@ -68,17 +80,20 @@ export function renderRGB(
 ): Uint8ClampedArray {
   const { limits, stretch, trilogyK } = opts;
   const rgba = new Uint8ClampedArray(width * height * 4);
-  const n = width * height;
-  for (let i = 0; i < n; i++) {
-    const o = i * 4;
-    let any = false;
-    for (let c = 0; c < 3; c++) {
-      const v = channels[c][i];
-      if (Number.isNaN(v)) continue;
-      any = true;
-      rgba[o + c] = Math.round(scaleValue(v, limits[c].lo, limits[c].hi, stretch, trilogyK) * 255);
+  for (let y = 0; y < height; y++) {
+    const src = y * width;
+    const dst = (height - 1 - y) * width; // FITS bottom-up → raster top-down
+    for (let x = 0; x < width; x++) {
+      const o = (dst + x) * 4;
+      let any = false;
+      for (let c = 0; c < 3; c++) {
+        const v = channels[c][src + x];
+        if (Number.isNaN(v)) continue;
+        any = true;
+        rgba[o + c] = Math.round(scaleValue(v, limits[c].lo, limits[c].hi, stretch, trilogyK) * 255);
+      }
+      if (any) rgba[o + 3] = 255; // opaque where at least one band has data
     }
-    if (any) rgba[o + 3] = 255; // opaque where at least one band has data
   }
   return rgba;
 }

--- a/web/lib/cutout/render.ts
+++ b/web/lib/cutout/render.ts
@@ -1,0 +1,84 @@
+// Turn reprojected float pixels into RGBA (epic #337, Phase 5), using the viewer's
+// own transfer functions from `@fitsgl/core` (`scaleValue` normalize+clamp+stretch,
+// `colormapRGB` LUT) so a server cutout matches the interactive map exactly. NaN
+// (no-data) pixels are written transparent so the cutout composites over the page.
+
+import { applyStretch, colormapRGB, COLORMAP_SIZE, type StretchMode, type ColormapName } from '@fitsgl/core';
+
+export interface Limits {
+  lo: number;
+  hi: number;
+}
+
+/** `@fitsgl/core`'s `scaleChannel`: linear-normalize over [lo, hi], clamp, then stretch.
+ *  (Inlined because the core re-exports `applyStretch` but not the `scaleValue` wrapper.) */
+function scaleValue(v: number, lo: number, hi: number, mode: StretchMode, trilogyK?: number): number {
+  const t = (v - lo) / (hi - lo);
+  const norm = t < 0 ? 0 : t > 1 ? 1 : t;
+  return applyStretch(norm, mode, trilogyK);
+}
+
+/** Robust display limits from finite data by percentile (defaults ~ the map's 99.5%). */
+export function percentileLimits(data: Float32Array, loPct = 0.5, hiPct = 99.5): Limits {
+  const finite: number[] = [];
+  for (let i = 0; i < data.length; i++) {
+    const v = data[i];
+    if (Number.isFinite(v)) finite.push(v);
+  }
+  if (finite.length === 0) return { lo: 0, hi: 1 };
+  finite.sort((a, b) => a - b);
+  const at = (p: number) => finite[Math.min(finite.length - 1, Math.max(0, Math.round((p / 100) * (finite.length - 1))))];
+  const lo = at(loPct);
+  let hi = at(hiPct);
+  if (!(hi > lo)) hi = lo + 1e-6;
+  return { lo, hi };
+}
+
+/** Single-band → RGBA via a stretch + colormap LUT. NaN → transparent. */
+export function renderSingleBand(
+  data: Float32Array,
+  width: number,
+  height: number,
+  opts: { limits: Limits; stretch: StretchMode; colormap: ColormapName; trilogyK?: number },
+): Uint8ClampedArray {
+  const { limits, stretch, colormap, trilogyK } = opts;
+  const lut = colormapRGB(colormap);
+  const rgba = new Uint8ClampedArray(width * height * 4);
+  const maxIdx = COLORMAP_SIZE - 1;
+  for (let i = 0; i < data.length; i++) {
+    const v = data[i];
+    const o = i * 4;
+    if (Number.isNaN(v)) continue; // leave transparent (rgba is zero-filled)
+    const norm = scaleValue(v, limits.lo, limits.hi, stretch, trilogyK);
+    const idx = Math.min(maxIdx, Math.max(0, Math.round(norm * maxIdx))) * 3;
+    rgba[o] = lut[idx];
+    rgba[o + 1] = lut[idx + 1];
+    rgba[o + 2] = lut[idx + 2];
+    rgba[o + 3] = 255;
+  }
+  return rgba;
+}
+
+/** Per-channel RGB composite (R←band0, G←band1, B←band2), each with its own stretch. */
+export function renderRGB(
+  channels: readonly [Float32Array, Float32Array, Float32Array],
+  width: number,
+  height: number,
+  opts: { limits: readonly [Limits, Limits, Limits]; stretch: StretchMode; trilogyK?: number },
+): Uint8ClampedArray {
+  const { limits, stretch, trilogyK } = opts;
+  const rgba = new Uint8ClampedArray(width * height * 4);
+  const n = width * height;
+  for (let i = 0; i < n; i++) {
+    const o = i * 4;
+    let any = false;
+    for (let c = 0; c < 3; c++) {
+      const v = channels[c][i];
+      if (Number.isNaN(v)) continue;
+      any = true;
+      rgba[o + c] = Math.round(scaleValue(v, limits[c].lo, limits[c].hi, stretch, trilogyK) * 255);
+    }
+    if (any) rgba[o + 3] = 255; // opaque where at least one band has data
+  }
+  return rgba;
+}

--- a/web/lib/cutout/reproject.ts
+++ b/web/lib/cutout/reproject.ts
@@ -1,0 +1,101 @@
+// Resample an assembled native-pixel region onto a North-up output grid (epic
+// #337, Phase 5). Builds a clean N-up TAN WCS centred on the request and, for each
+// output pixel, projects output→sky (`pixToSky`) then sky→native (`skyToPix`) and
+// bilinearly samples the native array. Reusing `@fitsgl/core`'s astropy-validated
+// TAN both ways keeps the geometry exact; the same output WCS is what the FITS path
+// writes into the header. A native (un-rotated) cutout skips this and crops directly.
+
+import { pixToSky, skyToPix, parseWcs, type TanWcs } from '@fitsgl/core';
+import type { AssembledRegion } from './assemble';
+import type { LevelInfo } from './manifest';
+import { levelWcs } from './manifest';
+
+export interface ReprojectResult {
+  data: Float32Array;
+  width: number;
+  height: number;
+  /** The N-up output WCS as a flat FITS header dict (for the FITS writer). */
+  outputWcsHeader: Record<string, number | string>;
+}
+
+/** A North-up, East-left TAN WCS centred on `(ra, dec)` at `scaleArcsec`/px. */
+export function northUpWcsHeader(
+  ra: number,
+  dec: number,
+  scaleArcsec: number,
+  width: number,
+  height: number,
+): Record<string, number | string> {
+  const scaleDeg = scaleArcsec / 3600;
+  return {
+    WCSAXES: 2,
+    CTYPE1: 'RA---TAN',
+    CTYPE2: 'DEC--TAN',
+    CUNIT1: 'deg',
+    CUNIT2: 'deg',
+    CRVAL1: ra,
+    CRVAL2: dec,
+    CRPIX1: (width + 1) / 2,
+    CRPIX2: (height + 1) / 2,
+    CD1_1: -scaleDeg, // +x = West → RA increases leftward (East-left)
+    CD1_2: 0,
+    CD2_1: 0,
+    CD2_2: scaleDeg, // +y = South → Dec increases upward (North-up)
+    LONPOLE: 180,
+    RADESYS: 'ICRS',
+  };
+}
+
+/** Bilinear sample of a row-major array at continuous `(ax, ay)`; NaN off-grid or on any NaN corner. */
+function sampleBilinear(data: Float32Array, w: number, h: number, ax: number, ay: number): number {
+  const x0 = Math.floor(ax);
+  const y0 = Math.floor(ay);
+  if (x0 < 0 || y0 < 0 || x0 + 1 >= w || y0 + 1 >= h) {
+    // Allow the exact right/bottom edge via nearest when only just out of the 2×2.
+    const xi = Math.round(ax);
+    const yi = Math.round(ay);
+    if (xi < 0 || yi < 0 || xi >= w || yi >= h) return NaN;
+    return data[yi * w + xi];
+  }
+  const fx = ax - x0;
+  const fy = ay - y0;
+  const v00 = data[y0 * w + x0];
+  const v10 = data[y0 * w + x0 + 1];
+  const v01 = data[(y0 + 1) * w + x0];
+  const v11 = data[(y0 + 1) * w + x0 + 1];
+  if (Number.isNaN(v00) || Number.isNaN(v10) || Number.isNaN(v01) || Number.isNaN(v11)) return NaN;
+  return v00 * (1 - fx) * (1 - fy) + v10 * fx * (1 - fy) + v01 * (1 - fx) * fy + v11 * fx * fy;
+}
+
+/**
+ * Reproject `region` (native level pixels) to a North-up output grid of
+ * `outWidth × outHeight` px, centred on `(ra, dec)` at `outputScaleArcsec`/px.
+ */
+export function reprojectToNorthUp(
+  region: AssembledRegion,
+  level: LevelInfo,
+  ra: number,
+  dec: number,
+  outputScaleArcsec: number,
+  outWidth: number,
+  outHeight: number,
+): ReprojectResult {
+  const nativeWcs: TanWcs = levelWcs(level);
+  const outHeader = northUpWcsHeader(ra, dec, outputScaleArcsec, outWidth, outHeight);
+  const outWcs = parseWcs(outHeader);
+  if (!outWcs) throw new Error('failed to build the output N-up WCS');
+
+  const out = new Float32Array(outWidth * outHeight).fill(NaN);
+  for (let j = 0; j < outHeight; j++) {
+    for (let i = 0; i < outWidth; i++) {
+      // Output array pixel (i, j) → its world coord (i+0.5, j+0.5) → sky → native.
+      const sky = pixToSky(outWcs, i + 0.5, j + 0.5);
+      const p = skyToPix(nativeWcs, sky.ra, sky.dec);
+      // Native world → array index in the assembled region (centre of pixel k at k+0.5).
+      const ax = p.x - 0.5 - region.x0;
+      const ay = p.y - 0.5 - region.y0;
+      out[j * outWidth + i] = sampleBilinear(region.data, region.width, region.height, ax, ay);
+    }
+  }
+  return { data: out, width: outWidth, height: outHeight, outputWcsHeader: outHeader };
+}


### PR DESCRIPTION
## Phase 5, PR A — the cutout engine (epic #337)

The reusable server-side engine that turns a deployed **FitsGL tile pyramid** into a North-up cutout, reading the same `.fits.fz` supertiles the browser renders. This is the foundation the display-route re-point (PR B), the science FITS API (PR C), and the GUI (PR D) all build on. **No routes are wired here** — it's the engine + tests only.

```
plan (which level + tiles) → assemble (decode native region)
  → reproject (native → N-up grid) → render (stretch/colormap → RGBA) → encode (PNG/JPEG)
```

### Design notes
- **`plan.ts` is a faithful port of `fitsgl-py`'s `plan_cutout` + `tiles.py`**, pinned to the Python producer by a **golden parity test** (`plan.test.ts`, 13 cases + a synthetic multi-supertile case; regenerable via `__fixtures__/generate_plan_fixture.py`). So the server, the browser viewer, and the Python client all address one pyramid *identically* — one addressing truth, three runtimes.
- **Decode reuses `@fitsgl/core`'s `FpackFile`** — the viewer's own RICE/GZIP2 fpack decoder, run server-side via `@fitsgl/core/internal` with the default HTTP range fetcher against the public tiles bucket. Dropped-supertile gaps and out-of-array borders stay NaN.
- **Reproject** builds a clean N-up TAN WCS and resamples with the astropy-validated `pixToSky`/`skyToPix`; the same output WCS header is what the FITS path (PR C) will write.
- **Render uses the viewer's exact transfer functions** (`applyStretch`, `colormapRGB`) so a server cutout matches the interactive map rather than approximating it. Single-band → colormap; 3-band → per-channel RGB. `encode.ts` (server-only `sharp`) encodes the RGBA to PNG/JPEG and is kept out of the core so the engine stays `sharp`-free and unit-tests without native deps.

### Testing
- **13/13 golden parity** vs `fitsgl-py` (on-source at 3 FOVs, NaN-gap center, out-of-field, anisotropic, target-scale, finer/coarser rounding, multi-supertile gaps).
- **Render-verified end-to-end** against the local rj0911 pyramid: 12″ and 40″ FOVs (correct level selection + multi-tile assemble + N-up orientation), gray and viridis colormaps, ~200 ms/cutout.
- `tsc`, `eslint`, `npm run build` all green. Web-only (no `pipeline/**`) → no changelog.

Next: PR B re-points `/api/v1/cutout`, `/api/tile-thumbnail`, `/api/og-image` to this core behind a per-field flag (server-side PNG, edge-cached).

Generated with Claude Code