### PR TITLE
Storage unification: one sync engine for deploy and download, push/pull CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,7 +204,6 @@ lifecycle. Part of the unified `campfire` CLI (install from `python/`):
 cd python && pip install -e .
 campfire deploy --obs <obs_name>                         # full deploy
 campfire deploy --obs <obs_name> --dry-run               # validate only
-campfire deploy rgb --obs <obs_name>                     # RGB cutouts only
 campfire deploy pointings --obs <obs_name>               # pointings JSONB backfill
 campfire deploy tiles --field cosmos --filter f444w      # map tiles
 campfire deploy sync-programs                            # upsert from programs.toml
@@ -216,7 +215,10 @@ A1/A2 storage migrations complete. `deploy registry budget` is gone — the
 number shows in `campfire status` (admins). Registry↔bucket verification is
 `campfire verify --cloud`. The `deploy nircam pull*` / `deploy nirspec pull-*`
 annotation round-trips are folded into `campfire pull` (hidden but working
-individually).
+individually). RGB/SED static cutouts are fully deprecated (superseded by the
+on-the-fly `/api/v1/cutout` API): deploy neither generates nor uploads them,
+and the `deploy rgb`/`deploy sed` subcommands are removed — their legacy R2
+remnants retire with A2.
 
 **Deploy auth (issue #250).** Two decisions, kept independent:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,9 +170,35 @@ cd web && npm run build && cd ..
 - **Auth**: Supabase Auth with email/password
 - **CI/CD**: Supabase GitHub integration (branching + migration checks) + Vercel (preview deploys)
 
-### Deploy CLI
+### Storage plane (push / pull / verify)
 
-Deploy commands are part of the unified `campfire` CLI (install from `python/`):
+The local products tree and cloud storage are two ends of one sync relationship,
+mediated by the `storage_objects` registry (server) and its local mirror
+(`$CAMPFIRE_ROOT/meta/campfire.db`). One engine (`python/campfire/storage/` +
+`campfire/deploy/push.py`) serves both directions with content-identity dedup
+(sci_dq for NIRCam exposures, whole-file otherwise), a stat fast-path (unchanged
+files are never re-read), and per-batch registration (interrupted transfers
+resume at file granularity). **All data products live on OSN; map tiles are the
+sole R2 exception.**
+
+```bash
+campfire sync                          # refresh the local index (never touches the tree)
+campfire status [--obs X | --field Y]  # bidirectional diff; scoped = push-side dry run
+campfire pull --obs X [--intermediate] # cloud→local products (+ review annotations, admins)
+campfire push --obs X | --field Y      # local→cloud bytes ONLY — no catalog, no publication
+campfire verify [--cloud] [--json]     # tree↔index; --cloud adds registry↔bucket (CI-able)
+campfire drop-local --obs X --yes      # delete local files verified in cloud
+```
+
+Slow-link workflow (CANDIDE→OSN): `campfire push` for the heavy bytes
+(re-runnable until clean), then `campfire deploy` — it dedup-skips everything
+already landed and attaches it to the new deployment. `download` remains an
+alias of `pull`.
+
+### Deploy CLI (publication)
+
+`campfire deploy` = push (via the shared engine) + catalog upserts + deployment
+lifecycle. Part of the unified `campfire` CLI (install from `python/`):
 
 ```bash
 cd python && pip install -e .
@@ -183,6 +209,14 @@ campfire deploy pointings --obs <obs_name>               # pointings JSONB backf
 campfire deploy tiles --field cosmos --filter f444w      # map tiles
 campfire deploy sync-programs                            # upsert from programs.toml
 ```
+
+Migration-era one-time tools (`deploy registry backfill/copy/prune`, `deploy
+nircam import-*`) are hidden from `--help` but still work; they retire once the
+A1/A2 storage migrations complete. `deploy registry budget` is gone — the
+number shows in `campfire status` (admins). Registry↔bucket verification is
+`campfire verify --cloud`. The `deploy nircam pull*` / `deploy nirspec pull-*`
+annotation round-trips are folded into `campfire pull` (hidden but working
+individually).
 
 **Deploy auth (issue #250).** Two decisions, kept independent:
 

--- a/python/campfire/api/session.py
+++ b/python/campfire/api/session.py
@@ -9,8 +9,6 @@ import threading
 from typing import Optional
 
 import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 
 from ..auth.tokens import TokenManager
 from ..exceptions import AuthenticationError
@@ -156,22 +154,9 @@ class APISession:
 def create_download_session(max_workers: int = 4) -> requests.Session:
     """Create a requests.Session with connection pooling and retry for downloads.
 
-    Presigned R2 URLs are self-authenticating, so no auth headers are needed.
-    The pool is sized to match the number of workers so each thread gets a
-    persistent connection without contention.
+    Presigned URLs are self-authenticating, so no auth headers are needed.
+    Thin wrapper over the shared transfer-session factory (GET-only retry);
+    kept under this name for the established import path.
     """
-    session = requests.Session()
-    retry = Retry(
-        total=4,
-        backoff_factor=2,
-        status_forcelist=[429, 500, 502, 503, 504],
-        allowed_methods=["GET"],
-        raise_on_status=False,
-    )
-    adapter = HTTPAdapter(
-        max_retries=retry,
-        pool_connections=max_workers,
-        pool_maxsize=max_workers,
-    )
-    session.mount("https://", adapter)
-    return session
+    from ..storage.session import create_transfer_session
+    return create_transfer_session(max_workers, methods=("GET",))

--- a/python/campfire/cli.py
+++ b/python/campfire/cli.py
@@ -945,7 +945,9 @@ def download(obs_filter, program_filter, field_filter, grating_filter, filter_fi
         store.close()
         # Annotations are not hash-tracked — regenerate them even when the
         # products are current (an inspector may have edited masks since).
-        _maybe_pull_annotations(obs_filter, target_fields, no_annotations)
+        # target_obs is the RESOLVED observation set (--obs, --program, a
+        # NIRSpec --field, --stale all land here), not just the literal --obs.
+        _maybe_pull_annotations(target_obs, target_fields, no_annotations)
         return
 
     if dry_run:
@@ -989,7 +991,9 @@ def download(obs_filter, program_filter, field_filter, grating_filter, filter_fi
 
     store.close()
 
-    _maybe_pull_annotations(obs_filter, target_fields, no_annotations)
+    # Resolved observations (not just literal --obs): --program, NIRSpec
+    # --field, and --stale selections regenerate their annotations too.
+    _maybe_pull_annotations(target_obs, target_fields, no_annotations)
 
 
 # Back-compat alias: `campfire download` ≡ `campfire pull`.

--- a/python/campfire/cli.py
+++ b/python/campfire/cli.py
@@ -573,11 +573,11 @@ def status(obs_scope, field_scope, base_url: Optional[str]):
         except Exception as e:
             click.echo(f"\n✗ Push-side status unavailable: {e}")
             return
-        click.echo("\nPush-side diff (dry run):")
+        click.echo("\nPush-side diff (what `campfire push` would transfer):")
         for name in obs_scope:
-            push_observation(name, config, dry_run=True)
+            push_observation(name, config, dry_run=True, dry_run_note=False)
         for name in field_scope:
-            push_field(name, config, dry_run=True)
+            push_field(name, config, dry_run=True, dry_run_note=False)
 
 
 # ---------------------------------------------------------------------------

--- a/python/campfire/cli.py
+++ b/python/campfire/cli.py
@@ -27,6 +27,29 @@ from .auth.tokens import TokenManager
 from .exceptions import AuthenticationError
 
 
+class _VariadicOption(click.Option):
+    """Click option that consumes multiple space-separated values after a single flag.
+
+    Allows e.g. ``--obs obs1 obs2 obs3`` in addition to the standard
+    ``--obs obs1 --obs obs2 --obs obs3`` syntax.
+    """
+
+    def add_to_parser(self, parser, ctx):
+        super().add_to_parser(parser, ctx)
+        name = self.opts[-1]
+        opt = parser._long_opt.get(name)
+        if opt is None:
+            return
+        original_process = opt.process
+
+        def _eat_remaining(value, state):
+            original_process(value, state)
+            while state.rargs and not state.rargs[0].startswith('-'):
+                original_process(state.rargs.pop(0), state)
+
+        opt.process = _eat_remaining
+
+
 def _require_auth(base_url: str) -> APISession:
     """Verify credentials and return an APISession. Exits on failure."""
     try:
@@ -153,14 +176,29 @@ def cli():
 
 
 def _register_deploy_group():
-    """Register deploy subgroup. Imported lazily to avoid loading deploy deps for non-deploy commands."""
+    """Register the operator-side commands lazily (deploy deps stay optional).
+
+    ``deploy`` (publication), ``push`` (bytes-only local→cloud transfer), and
+    ``drop-local`` (delete local files verified in cloud) all live in the deploy
+    package; consumers without the extra get an install-hint stub instead.
+    """
     try:
-        from campfire.deploy.cli import deploy_group
+        from campfire.deploy.cli import delete_local, deploy_group, push_cmd
         cli.add_command(deploy_group, name='deploy')
+        cli.add_command(push_cmd, name='push')
+        # Same command as `campfire deploy delete-local`, surfaced top-level as
+        # the storage-plane verb paired with pull/push.
+        cli.add_command(delete_local, name='drop-local')
     except ImportError:
         @cli.command('deploy', hidden=False)
         def deploy_stub():
-            """Deploy CAMPFIRE pipeline products to Supabase + R2. (Requires: pip install campfire[deploy])"""
+            """Deploy CAMPFIRE pipeline products to Supabase + OSN. (Requires: pip install campfire[deploy])"""
+            click.echo("Deploy dependencies not installed. Run: pip install campfire[deploy]")
+            sys.exit(1)
+
+        @cli.command('push', hidden=False)
+        def push_stub():
+            """Push local products to cloud storage. (Requires: pip install campfire[deploy])"""
             click.echo("Deploy dependencies not installed. Run: pip install campfire[deploy]")
             sys.exit(1)
 
@@ -392,9 +430,23 @@ def whoami(base_url: Optional[str]):
 
 
 @cli.command()
+@click.option("--obs", "obs_scope", multiple=True, cls=_VariadicOption,
+              help="Also show the push-side diff for these observation(s) "
+                   "(admin, deploy extra)")
+@click.option("--field", "field_scope", multiple=True, cls=_VariadicOption,
+              help="Also show the push-side diff for these NIRCam field(s)")
 @click.option("--base-url", default=None, help="API base URL")
-def status(base_url: Optional[str]):
-    """Check credentials, catalog, and download status."""
+def status(obs_scope, field_scope, base_url: Optional[str]):
+    """Check credentials, catalog, and the local↔cloud storage state.
+
+    Unscoped: consumer view — what the cloud has vs what is materialized
+    locally, plus staleness and (for admins) the storage budget.
+
+    Scoped with --obs/--field (operators): additionally runs the push planner
+    in dry mode and reports the other direction — how many local tree products
+    are new / changed / unchanged relative to the cloud registry (what
+    `campfire push` would transfer).
+    """
     base_url = base_url or resolve_base_url()
 
     try:
@@ -496,7 +548,7 @@ def status(base_url: Optional[str]):
     # Stale files (server hash != local hash, via the mirror)
     stale = store.get_stale_objects()
     if stale:
-        click.echo(f"\n⚠ {len(stale)} local file(s) updated on server. Run: campfire download --stale")
+        click.echo(f"\n⚠ {len(stale)} local file(s) updated on server. Run: campfire pull --stale")
 
     # Disk usage
     if data_dir.exists():
@@ -504,6 +556,28 @@ def status(base_url: Optional[str]):
         click.echo(f"\nDisk usage: {format_size(total)}")
 
     store.close()
+
+    # Push-side diff (operators): what `campfire push` would transfer for the
+    # requested scope — new / changed / unchanged local tree products vs the
+    # cloud registry (live key-scoped fetch + the mirror's stat fast path).
+    if obs_scope or field_scope:
+        try:
+            from campfire.deploy.config import load_config
+            from campfire.deploy.push import push_field, push_observation
+        except ImportError:
+            click.echo("\n✗ --obs/--field status needs the deploy extra: "
+                       "pip install campfire[deploy]")
+            return
+        try:
+            config = load_config(None)
+        except Exception as e:
+            click.echo(f"\n✗ Push-side status unavailable: {e}")
+            return
+        click.echo("\nPush-side diff (dry run):")
+        for name in obs_scope:
+            push_observation(name, config, dry_run=True)
+        for name in field_scope:
+            push_field(name, config, dry_run=True)
 
 
 # ---------------------------------------------------------------------------
@@ -601,37 +675,14 @@ def sync_cmd(full: bool, base_url: Optional[str], migrate_layout: Optional[bool]
 
 
 # ---------------------------------------------------------------------------
-# Download command (FITS files)
+# Pull command (cloud→local data products; alias: download)
 # ---------------------------------------------------------------------------
 
 
-class _VariadicOption(click.Option):
-    """Click option that consumes multiple space-separated values after a single flag.
-
-    Allows e.g. ``--obs obs1 obs2 obs3`` in addition to the standard
-    ``--obs obs1 --obs obs2 --obs obs3`` syntax.
-    """
-
-    def add_to_parser(self, parser, ctx):
-        super().add_to_parser(parser, ctx)
-        name = self.opts[-1]
-        opt = parser._long_opt.get(name)
-        if opt is None:
-            return
-        original_process = opt.process
-
-        def _eat_remaining(value, state):
-            original_process(value, state)
-            while state.rargs and not state.rargs[0].startswith('-'):
-                original_process(state.rargs.pop(0), state)
-
-        opt.process = _eat_remaining
-
-
-@cli.command()
-@click.option("--obs", "obs_filter", multiple=True, cls=_VariadicOption, help="Download by observation name")
-@click.option("--program", "program_filter", multiple=True, cls=_VariadicOption, help="Download by program slug")
-@click.option("--field", "field_filter", multiple=True, cls=_VariadicOption, help="Download by field name")
+@cli.command(name="pull")
+@click.option("--obs", "obs_filter", multiple=True, cls=_VariadicOption, help="Pull by observation name")
+@click.option("--program", "program_filter", multiple=True, cls=_VariadicOption, help="Pull by program slug")
+@click.option("--field", "field_filter", multiple=True, cls=_VariadicOption, help="Pull by field name")
 @click.option("--grating", "grating_filter", multiple=True, cls=_VariadicOption,
               help="NIRSpec: narrow finals to these gratings (e.g. PRISM G395M)")
 @click.option("--filters", "filter_filter", multiple=True, cls=_VariadicOption,
@@ -643,15 +694,19 @@ class _VariadicOption(click.Option):
 @click.option("--workers", default=4, help="Parallel download workers")
 @click.option("--yes", is_flag=True, help="Skip confirmation")
 @click.option("--dry-run", is_flag=True, help="Show plan without downloading")
+@click.option("--no-annotations", "no_annotations", is_flag=True,
+              help="Skip regenerating review annotations (masks, stuck shutters, "
+                   "exclusions) for admins with the deploy extra installed")
 @click.option("--base-url", default=None, help="API base URL")
 def download(obs_filter, program_filter, field_filter, grating_filter, filter_filter,
-             stale, include_intermediate, download_all, workers, yes, dry_run, base_url):
-    """Download data products (NIRSpec spectra + NIRCam field products).
+             stale, include_intermediate, download_all, workers, yes, dry_run,
+             no_annotations, base_url):
+    """Pull cloud data products into the local tree (alias: download).
 
-    Requires a prior 'campfire sync' to populate the local catalog. Select what
-    to download with --obs / --program (NIRSpec) or --field (NIRSpec observations
-    in a field, or NIRCam field products), then optionally scope within a
-    selection:
+    The cloud→local half of the storage plane. Requires a prior 'campfire sync'
+    to populate the local catalog (run automatically here). Select what to pull
+    with --obs / --program (NIRSpec) or --field (NIRSpec observations in a
+    field, or NIRCam field products), then optionally scope within a selection:
 
     \b
       --grating   NIRSpec: narrow finals to these gratings (e.g. PRISM G395M)
@@ -662,16 +717,21 @@ def download(obs_filter, program_filter, field_filter, grating_filter, filter_fi
     exposures, NIRCam exposures + expmaps) so you can restore a deleted-local
     observation or inspect a stage-1/2 draft.
 
+    For admins with the deploy extra installed, a scoped pull also regenerates
+    the web-authored review annotations (NIRSpec rate masks / stuck shutters /
+    bkg overrides; NIRCam masks + exclusions) into reference/ — the pipeline
+    inputs for the next reduction. --no-annotations skips that step.
+
     \b
     Examples:
-      campfire download --obs ember_uds_p4
-      campfire download --obs ember_uds_p4 ember_uds_p5
-      campfire download --program EMBER-UDS --grating PRISM
-      campfire download --obs ember_egs_p1 --intermediate
-      campfire download --field egs --filters f277w f356w f444w --intermediate
-      campfire download --field cosmos
-      campfire download --stale
-      campfire download --all
+      campfire pull --obs ember_uds_p4
+      campfire pull --obs ember_uds_p4 ember_uds_p5
+      campfire pull --program EMBER-UDS --grating PRISM
+      campfire pull --obs ember_egs_p1 --intermediate
+      campfire pull --field egs --filters f277w f356w f444w --intermediate
+      campfire pull --field cosmos
+      campfire pull --stale
+      campfire pull --all
     """
     from .config import products_dir as _products_dir, meta_dir as _meta_dir
     from .sync import (
@@ -883,6 +943,9 @@ def download(obs_filter, program_filter, field_filter, grating_filter, filter_fi
     if total_files == 0:
         click.echo("\nAll files up to date.")
         store.close()
+        # Annotations are not hash-tracked — regenerate them even when the
+        # products are current (an inspector may have edited masks since).
+        _maybe_pull_annotations(obs_filter, target_fields, no_annotations)
         return
 
     if dry_run:
@@ -925,6 +988,136 @@ def download(obs_filter, program_filter, field_filter, grating_filter, filter_fi
     click.echo(f"  Total size: {format_size(total_download)}")
 
     store.close()
+
+    _maybe_pull_annotations(obs_filter, target_fields, no_annotations)
+
+
+# Back-compat alias: `campfire download` ≡ `campfire pull`.
+cli.add_command(cli.commands["pull"], name="download")
+
+
+def _maybe_pull_annotations(obs_names, nircam_fields, disabled: bool) -> None:
+    """Regenerate review annotations for a scoped pull (admins, deploy extra).
+
+    The annotation half of `campfire pull`: web-authored review state (masks,
+    stuck shutters, bkg overrides, exclusions) regenerated into reference/ for
+    the pipeline. Best-effort and quiet by design — consumers without the
+    deploy extra (or without admin) skip silently; a real failure prints a
+    note but never fails the pull.
+    """
+    if disabled or (not obs_names and not nircam_fields):
+        return
+    try:
+        from campfire.deploy.annotations import (
+            pull_field_annotations,
+            pull_observation_annotations,
+        )
+        from campfire.deploy.config import load_config
+        from campfire.deploy.supabase import get_supabase_client
+    except ImportError:
+        return  # consumer install — annotations are an operator concern
+
+    try:
+        config = load_config(None)
+        sb = get_supabase_client(config)
+        try:
+            if not sb.rpc("is_admin").execute().data:
+                return
+        except Exception:
+            return
+        for obs in obs_names:
+            pull_observation_annotations(obs, config)
+        for field in nircam_fields:
+            pull_field_annotations(field, config)
+    except Exception as e:
+        click.echo(f"  (annotations skipped: {e})")
+
+
+@cli.command()
+@click.option("--obs", "obs_filter", multiple=True, cls=_VariadicOption,
+              help="Limit to observation(s)")
+@click.option("--cloud", "cloud", is_flag=True,
+              help="Also verify the cloud registry against the actual buckets "
+                   "(admin; needs S3 LIST credentials — OSN primary, legacy R2)")
+@click.option("--json", "as_json", is_flag=True,
+              help="Machine-readable report (for CI); exit 1 on drift")
+@click.option("--local", is_flag=True,
+              help="--cloud against local Supabase (127.0.0.1:54321)")
+def verify(obs_filter, cloud, as_json, local):
+    """Verify local tree ↔ index, and optionally index ↔ cloud buckets.
+
+    Without --cloud: reconciles the local products tree against the storage
+    index (stat fast-path; re-hashes only files whose size/mtime changed;
+    clears vanished files; adopts files that appeared).
+
+    With --cloud (admin): additionally compares live DB pointers vs the
+    registry vs actual bucket LISTs — OSN first (the data home), then the
+    legacy R2 data bucket. Exits non-zero when live pointers lack registry
+    rows (missing) or registry rows lack bucket objects (dangling), so a
+    scheduled CI run can alarm on drift.
+    """
+    import json as _json
+
+    from .config import products_dir as _products_dir
+
+    payload = {}
+    if not as_json:
+        click.echo("Verifying local tree against the index...")
+    store = _open_store()
+    local_totals = {"cleared": 0, "rehashed": 0, "discovered": 0}
+    scopes = list(obs_filter) or [None]
+    for scope in scopes:
+        res = store.verify_local_objects(
+            _products_dir(), observation=scope, show_progress=not as_json)
+        for k in local_totals:
+            local_totals[k] += res.get(k, 0)
+    store.close()
+    payload["local"] = local_totals
+    if not as_json:
+        click.echo(f"  cleared (file vanished): {local_totals['cleared']}")
+        click.echo(f"  re-hashed (file changed): {local_totals['rehashed']}")
+        click.echo(f"  discovered (already present): {local_totals['discovered']}")
+
+    drift = False
+    if cloud:
+        try:
+            from campfire.deploy.config import load_config
+            from campfire.deploy.registry import cloud_reconcile_report
+            from campfire.deploy.supabase import get_supabase_client
+        except ImportError:
+            click.echo("✗ --cloud requires the deploy extra: pip install campfire[deploy]")
+            sys.exit(2)
+        config = load_config(None, local=local)
+        sb = get_supabase_client(config)
+        report = cloud_reconcile_report(config, sb)
+        payload["cloud"] = report
+        drift = not report.get("ok", False)
+        if not as_json:
+            click.echo(f"\nCloud registry: {report['registry_rows']} rows, "
+                       f"{report['live_pointers']} live DB pointers")
+            if report["missing"]:
+                click.echo(f"  ✗ {len(report['missing'])} live pointer(s) with NO registry row:")
+                for k in report["missing"][:10]:
+                    click.echo(f"      missing: {k}")
+            for label, b in report["backends"].items():
+                click.echo(f"  [{label}] bucket objects: {b['bucket_objects']}, "
+                           f"registry rows homed here: {b['registry_rows']}")
+                if b["dangling"]:
+                    click.echo(f"    ✗ {len(b['dangling'])} registry row(s) with no bucket object:")
+                    for k in b["dangling"][:10]:
+                        click.echo(f"        dangling: {k}")
+                if b["orphans"]:
+                    click.echo(f"    {len(b['orphans'])} orphan bucket object(s) "
+                               f"({len(b['adoptable'])} adoptable)")
+            for label, err in report.get("errors", {}).items():
+                click.echo(f"  [{label}] bucket LIST unavailable: {err}")
+            click.echo("\n  Cloud verification: "
+                       + ("PASS" if report.get("ok") else "DRIFT DETECTED"))
+
+    if as_json:
+        click.echo(_json.dumps(payload, indent=2))
+    if drift:
+        sys.exit(1)
 
 
 def main():

--- a/python/campfire/db/store.py
+++ b/python/campfire/db/store.py
@@ -20,7 +20,11 @@ from typing import Dict, List, Optional, Tuple
 #   local-download bookkeeping moved to the storage_objects mirror.
 #   v7: storage_objects.filter — per-filter NIRCam scope column (mirrors the
 #   server registry), so `campfire download --filters` scopes without key parsing.
-SCHEMA_VERSION = 7
+#   v8 (storage unification): storage_objects.sci_dq_hash mirrors the server's
+#   science-only NIRCam identity, and the pushed_* columns carry the PUSH-side
+#   bookkeeping (`campfire push` / deploy dedup) — the mirror now serves both
+#   transfer directions.
+SCHEMA_VERSION = 8
 
 
 # Product-type classes the client download engine understands. Finals are the
@@ -178,16 +182,22 @@ CREATE INDEX IF NOT EXISTS idx_spectra_crds_context ON spectra(crds_context);
 CREATE INDEX IF NOT EXISTS idx_spectra_cfpipe_version ON spectra(cfpipe_version);
 
 -- storage_objects: local mirror of the server registry (epic #210). The single
--- download/availability layer for every product type — finals, intermediates,
--- and future NIRCam share one engine. Server columns mirror /api/v1/sync/storage
--- (content_hash is the server's authoritative hash); the local_* columns track
--- what's materialized on disk and are preserved across metadata refreshes.
+-- local↔cloud availability layer for every product type and BOTH transfer
+-- directions. Server columns mirror /api/v1/sync/storage (content_hash is the
+-- server's authoritative whole-file hash; sci_dq_hash the science-only NIRCam
+-- identity). The local_* columns track what's materialized on disk (pull side);
+-- the pushed_* columns track what this machine last confirmed in the cloud
+-- (push side: pushed_identity is the content identity — sci_dq for NIRCam
+-- exposures, whole-file otherwise — at last successful push, pushed_mtime/size
+-- the file stat at that moment, giving the rsync-style skip-without-rehashing
+-- fast path). Both families are preserved across metadata refreshes.
 CREATE TABLE IF NOT EXISTS storage_objects (
     storage_key TEXT PRIMARY KEY,
     id INTEGER,
     backend TEXT,
     bucket TEXT,
     content_hash TEXT,
+    sci_dq_hash TEXT,
     size_bytes INTEGER,
     content_type TEXT,
     product_type TEXT,
@@ -207,6 +217,10 @@ CREATE TABLE IF NOT EXISTS storage_objects (
     local_file_mtime REAL,
     local_file_size INTEGER,
     synced_at TEXT,
+    pushed_identity TEXT,
+    pushed_mtime REAL,
+    pushed_size INTEGER,
+    pushed_at TEXT,
     _synced_at TEXT
 );
 
@@ -1088,9 +1102,11 @@ class LocalStore:
     def upsert_storage_objects(self, rows: List[dict]) -> int:
         """Insert/update the local storage_objects mirror from /sync/storage.
 
-        Preserves the local_* download bookkeeping on conflict — those track
-        on-disk state and must survive a metadata refresh. ``content_hash`` is
-        the server's authoritative hash (the staleness reference).
+        Preserves the local_* (pull) and pushed_* (push) bookkeeping on
+        conflict — those track this machine's state and must survive a metadata
+        refresh. ``content_hash`` is the server's authoritative whole-file hash
+        (the staleness reference); ``sci_dq_hash`` the server's science-only
+        NIRCam identity (the push-dedup reference).
         """
         now = datetime.now(timezone.utc).isoformat()
         count = 0
@@ -1098,16 +1114,17 @@ class LocalStore:
             self._conn.execute(
                 """
                 INSERT INTO storage_objects
-                    (storage_key, id, backend, bucket, content_hash, size_bytes,
-                     content_type, product_type, instrument, status, observation,
-                     field, filter, spectrum_id, exposure_ref, deployment_id, cfpipe_version,
-                     created_at, updated_at, _synced_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    (storage_key, id, backend, bucket, content_hash, sci_dq_hash,
+                     size_bytes, content_type, product_type, instrument, status,
+                     observation, field, filter, spectrum_id, exposure_ref,
+                     deployment_id, cfpipe_version, created_at, updated_at, _synced_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(storage_key) DO UPDATE SET
                     id=excluded.id,
                     backend=excluded.backend,
                     bucket=excluded.bucket,
                     content_hash=excluded.content_hash,
+                    sci_dq_hash=excluded.sci_dq_hash,
                     size_bytes=excluded.size_bytes,
                     content_type=excluded.content_type,
                     product_type=excluded.product_type,
@@ -1130,6 +1147,7 @@ class LocalStore:
                     r.get("backend"),
                     r.get("bucket"),
                     r.get("content_hash"),
+                    r.get("sci_dq_hash"),
                     r.get("size_bytes"),
                     r.get("content_type"),
                     r.get("product_type"),
@@ -1150,6 +1168,62 @@ class LocalStore:
             count += 1
         self._conn.commit()
         return count
+
+    # ------------------------------------------------------------------
+    # Push-side bookkeeping (`campfire push` / deploy dedup)
+    # ------------------------------------------------------------------
+
+    def get_storage_rows_by_keys(self, keys: List[str]) -> Dict[str, dict]:
+        """Fetch mirror rows for specific storage keys → ``{storage_key: row}``.
+
+        The push planner's read: candidate keys come from local discovery, and
+        the returned rows carry both the server identities (content_hash /
+        sci_dq_hash) and this machine's pushed_* fast-path state.
+        """
+        out: Dict[str, dict] = {}
+        CHUNK = 500
+        for i in range(0, len(keys), CHUNK):
+            chunk = keys[i:i + CHUNK]
+            ph = ",".join("?" * len(chunk))
+            rows = self._conn.execute(
+                f"SELECT * FROM storage_objects WHERE storage_key IN ({ph})",
+                chunk,
+            ).fetchall()
+            for row in rows:
+                d = dict(row)
+                out[d["storage_key"]] = d
+        return out
+
+    def mark_object_pushed(
+        self,
+        storage_key: str,
+        identity: Optional[str],
+        mtime: Optional[float],
+        size: Optional[int],
+        *,
+        commit: bool = True,
+    ) -> None:
+        """Record that the local file for ``storage_key`` is confirmed in-cloud.
+
+        ``identity`` is the content identity that was pushed (sci_dq hash for
+        NIRCam exposures, whole-file sha256 otherwise); ``mtime``/``size`` are
+        the file's stat at that moment — together they are the next run's
+        skip-without-rehashing fast path. Also called for dedup-skipped files
+        whose identity matched the cloud (refreshing the stat), so a
+        science-identical re-save takes the fast path from then on.
+        """
+        now = datetime.now(timezone.utc).isoformat()
+        self._conn.execute(
+            """UPDATE storage_objects SET pushed_identity = ?, pushed_mtime = ?,
+               pushed_size = ?, pushed_at = ? WHERE storage_key = ?""",
+            (identity, mtime, size, now, storage_key),
+        )
+        if commit:
+            self._conn.commit()
+
+    def commit(self) -> None:
+        """Flush pending writes (for callers batching mark_object_* calls)."""
+        self._conn.commit()
 
     def get_max_storage_updated_at(self) -> Optional[str]:
         row = self._conn.execute(

--- a/python/campfire/deploy/annotations.py
+++ b/python/campfire/deploy/annotations.py
@@ -1,0 +1,47 @@
+"""Annotation materialization — the cloud→local half of the review loop.
+
+Web-authored review state (masks, stuck shutters, background overrides,
+exposure exclusions) lives in the database; the pipeline consumes it as files
+under ``$CAMPFIRE_ROOT/reference/``. These helpers regenerate those files for
+a scope — they are the annotation half of ``campfire pull`` (admin-only; the
+storage engine handles the products half).
+
+Unlike products, annotations are KB-scale DB rows with no content-hash
+tracking: regeneration is unconditional and cheap. Overwrite safety lives in
+the materializers themselves (e.g. stuck-shutters merges hand > web > auto),
+not in a diff layer.
+"""
+
+from __future__ import annotations
+
+
+def pull_observation_annotations(obs_name: str, config: dict, *, dry_run: bool = False) -> None:
+    """Materialize a NIRSpec observation's review annotations to reference/.
+
+    Rate masks (``masks/*.reg``), stuck shutters
+    (``stuck_closed_shutters.toml``, hand > web > auto merge), and nodded
+    background overrides (``nodded_background_overrides.toml``).
+    """
+    from campfire.deploy.nirspec_masks import pull_rate_masks
+    from campfire.deploy.nirspec_flags import pull_bkg_overrides, pull_stuck_shutters
+
+    print(f"\nAnnotations for {obs_name}:")
+    pull_rate_masks(obs_name, config, dry_run=dry_run)
+    pull_stuck_shutters(obs_name, config, dry_run=dry_run)
+    pull_bkg_overrides(obs_name, config, dry_run=dry_run)
+
+
+def pull_field_annotations(field: str, config: dict, *, dry_run: bool = False) -> None:
+    """Materialize a NIRCam field's review annotations to reference/.
+
+    Masks (``masks/*.reg``), excluded exposures (``exposures.json``, honored by
+    ``cfpipe nircam combine``), plus a drift report of local .reg vs DB masks.
+    """
+    from campfire.deploy.nircam_exclusions import pull_exclusions
+    from campfire.deploy.nircam_masks import mask_drift_report, pull_masks
+
+    print(f"\nAnnotations for field {field}:")
+    pull_masks(field, config, dry_run=dry_run)
+    pull_exclusions(field, config, dry_run=dry_run)
+    if not dry_run:
+        mask_drift_report(field, config)

--- a/python/campfire/deploy/cli.py
+++ b/python/campfire/deploy/cli.py
@@ -352,6 +352,75 @@ def deploy_group(ctx, config_path, obs, field, filter_names, dry_run, source_ids
 
 
 # ---------------------------------------------------------------------------
+# push — bytes-only transfer (registered TOP-LEVEL as `campfire push`)
+# ---------------------------------------------------------------------------
+
+@click.command('push')
+@click.option('--config', 'config_path', default=None,
+              help='Path to deploy config TOML.')
+@click.option('--obs', multiple=True, type=str, cls=_VariadicOption,
+              help='NIRSpec observation name(s) to push.')
+@click.option('--field', 'fields', multiple=True, type=str, cls=_VariadicOption,
+              help='NIRCam field(s) to push.')
+@click.option('--filter', 'filter_names', multiple=True, type=str, cls=_VariadicOption,
+              help='NIRCam: limit a field push to these filters.')
+@click.option('--source-ids', multiple=True, type=str, default=None,
+              cls=_VariadicOption, callback=_parse_source_ids,
+              help='NIRSpec: push only specific source IDs.')
+@click.option('--dry-run', is_flag=True,
+              help='Plan only: show new/changed/unchanged counts.')
+@click.option('--workers', type=int, default=None,
+              help='Parallel upload streams (default 16; '
+                   'env CAMPFIRE_DEPLOY_UPLOAD_WORKERS).')
+@click.option('--local', is_flag=True,
+              help='Use local Supabase (127.0.0.1:54321).')
+@click.option('--service-role', 'service_role', is_flag=True,
+              help='Explicit service-role mode for unattended pushes.')
+@click.pass_context
+def push_cmd(ctx, config_path, obs, fields, filter_names, source_ids, dry_run,
+             workers, local, service_role):
+    """Push local tree products to cloud storage (bytes only — no publication).
+
+    The local→cloud half of the storage plane (mirror image of `campfire
+    pull`): discovers the scope's pipeline-written products, diffs them against
+    the cloud registry (content-identity dedup + a stat fast path via the
+    local mirror), uploads only new/changed files, and registers each landed
+    object durably per batch — so an interrupted push resumes at file
+    granularity instead of restarting.
+
+    Nothing is published: no catalog rows are written and no deployment is
+    recorded. The intended slow-link workflow is `campfire push` for the heavy
+    bytes (re-runnable until clean), then `campfire deploy`, which dedup-skips
+    everything already landed and completes in minutes.
+
+    \b
+    Examples:
+      campfire push --obs ember_uds_p4 --dry-run
+      campfire push --obs ember_uds_p4 ember_uds_p5
+      campfire push --field cosmos --filter f444w
+    """
+    if not obs and not fields:
+        raise click.UsageError('Provide --obs and/or --field to scope the push.')
+    config = load_config(
+        config_path, local=_resolve_local(ctx, local),
+        service_role=bool(service_role) or _resolve_service_role(ctx))
+    _gate_admin(config)
+    _announce_auth_mode(config)
+
+    from campfire.deploy.push import push_field, push_observation
+    for obs_name in obs:
+        push_observation(
+            obs_name, config,
+            source_ids=list(source_ids) if source_ids else None,
+            dry_run=dry_run, workers=workers)
+    for field in fields:
+        push_field(
+            field, config,
+            filters=list(filter_names) if filter_names else None,
+            dry_run=dry_run, workers=workers)
+
+
+# ---------------------------------------------------------------------------
 # Subcommands
 # ---------------------------------------------------------------------------
 
@@ -872,9 +941,13 @@ def objects_rebuild(ctx, config_path, field, all_fields, dry_run, radius, force,
 @deploy_group.group(invoke_without_command=True)
 @click.pass_context
 def registry(ctx):
-    """Manage the storage_objects registry (backfill / reconcile / budget).
+    """storage_objects registry maintenance (migration-era tools, hidden).
 
-    Bare `campfire deploy registry` defaults to `reconcile`.
+    Day-to-day verification moved to `campfire verify --cloud`; the storage
+    budget shows in `campfire status` (admins). The hidden subcommands
+    (backfill / reconcile / copy / prune) are one-time migration tools kept
+    until their migrations (A1/A2) complete. Bare invocation runs the legacy
+    reconcile report.
     """
     if ctx.invoked_subcommand is None:
         ctx.invoke(registry_reconcile)
@@ -890,7 +963,7 @@ def _fmt_bytes(n: int | float) -> str:
     return f"{n:.2f} PB"
 
 
-@registry.command('backfill')
+@registry.command('backfill', hidden=True)
 @click.option('--config', 'config_path', default=None,
               help='Path to deploy config TOML.')
 @click.option('--dry-run', is_flag=True,
@@ -981,7 +1054,7 @@ def registry_backfill(ctx, config_path, dry_run, orphans, local):
     print("Backfill complete.")
 
 
-@registry.command('reconcile')
+@registry.command('reconcile', hidden=True)
 @click.option('--config', 'config_path', default=None,
               help='Path to deploy config TOML.')
 @click.option('--no-bucket', is_flag=True,
@@ -1038,34 +1111,7 @@ def registry_reconcile(ctx, config_path, no_bucket, local):
         print("\n  Coverage gate: PASS (registry covers all live pointers).")
 
 
-@registry.command('budget')
-@click.option('--config', 'config_path', default=None,
-              help='Path to deploy config TOML.')
-@click.option('--local', is_flag=True,
-              help='Use local Supabase (127.0.0.1:54321).')
-@click.pass_context
-def registry_budget(ctx, config_path, local):
-    """Show bytes-at-rest against the 20 TB cap (via get_storage_budget RPC)."""
-    config = load_config(config_path, local=_resolve_local(ctx, local))
-    _gate_admin(config)
-    sb = get_supabase_client(config)
-
-    resp = sb.rpc('get_storage_budget').execute()
-    b = resp.data or {}
-    total = b.get('total_bytes', 0)
-    cap = b.get('cap_bytes', 0)
-    print(f"Storage budget: {_fmt_bytes(total)} / {_fmt_bytes(cap)} "
-          f"({b.get('pct_used', 0)}%)")
-    print(f"  registry (data): {_fmt_bytes(b.get('registry_bytes', 0))}")
-    print(f"  tiles (map_layers): {_fmt_bytes(b.get('tile_bytes', 0))}")
-    by_pt = b.get('by_product_type') or {}
-    if by_pt:
-        print("  by product_type:")
-        for pt, n in sorted(by_pt.items(), key=lambda kv: -kv[1]):
-            print(f"    {pt:28} {_fmt_bytes(n)}")
-
-
-@registry.command('copy')
+@registry.command('copy', hidden=True)
 @click.option('--config', 'config_path', default=None,
               help='Path to deploy config TOML.')
 @click.option('--obs', 'observations', default=None, multiple=True, type=str,
@@ -1179,7 +1225,7 @@ def registry_copy(ctx, config_path, observations, fields, product_types, limit,
     print("Copy complete.")
 
 
-@registry.command('prune')
+@registry.command('prune', hidden=True)
 @click.option('--config', 'config_path', default=None,
               help='Path to deploy config TOML.')
 @click.option('--duplicates/--no-duplicates', default=True,
@@ -1378,7 +1424,7 @@ def nircam():
     pass
 
 
-@nircam.command('import-masks')
+@nircam.command('import-masks', hidden=True)
 @click.option('--config', 'config_path', default=None,
               help='Path to deploy config TOML.')
 @click.option('--field', required=True, help='Field name (e.g. cosmos).')
@@ -1399,7 +1445,7 @@ def nircam_import_masks(ctx, config_path, field, dry_run, local):
     import_masks(field, config, dry_run=dry_run)
 
 
-@nircam.command('pull-masks')
+@nircam.command('pull-masks', hidden=True)
 @click.option('--config', 'config_path', default=None,
               help='Path to deploy config TOML.')
 @click.option('--field', required=True, help='Field name (e.g. cosmos).')
@@ -1434,7 +1480,7 @@ def nirspec():
     pass
 
 
-@nirspec.command('pull-rate-masks')
+@nirspec.command('pull-rate-masks', hidden=True)
 @click.option('--config', 'config_path', default=None,
               help='Path to deploy config TOML.')
 @click.option('--obs', required=True, help='Observation name (e.g. ember_uds_p4).')
@@ -1455,7 +1501,7 @@ def nirspec_pull_rate_masks(ctx, config_path, obs, dry_run, local):
     pull_rate_masks(obs, config, dry_run=dry_run)
 
 
-@nirspec.command('pull-stuck-shutters')
+@nirspec.command('pull-stuck-shutters', hidden=True)
 @click.option('--config', 'config_path', default=None,
               help='Path to deploy config TOML.')
 @click.option('--obs', required=True, help='Observation name (e.g. ember_uds_p4).')
@@ -1476,7 +1522,7 @@ def nirspec_pull_stuck_shutters(ctx, config_path, obs, dry_run, local):
     pull_stuck_shutters(obs, config, dry_run=dry_run)
 
 
-@nirspec.command('pull-bkg-overrides')
+@nirspec.command('pull-bkg-overrides', hidden=True)
 @click.option('--config', 'config_path', default=None,
               help='Path to deploy config TOML.')
 @click.option('--obs', required=True, help='Observation name (e.g. ember_uds_p4).')
@@ -1496,7 +1542,7 @@ def nirspec_pull_bkg_overrides(ctx, config_path, obs, dry_run, local):
     pull_bkg_overrides(obs, config, dry_run=dry_run)
 
 
-@nircam.command('pull')
+@nircam.command('pull', hidden=True)
 @click.option('--config', 'config_path', default=None,
               help='Path to deploy config TOML.')
 @click.option('--field', required=True, help='Field name (e.g. cosmos).')
@@ -1521,7 +1567,7 @@ def nircam_pull(ctx, config_path, field, dry_run, local):
         mask_drift_report(field, config)
 
 
-@nircam.command('import-skip')
+@nircam.command('import-skip', hidden=True)
 @click.option('--config', 'config_path', default=None,
               help='Path to deploy config TOML.')
 @click.option('--field', required=True, help='Field name (e.g. cosmos).')

--- a/python/campfire/deploy/cli.py
+++ b/python/campfire/deploy/cli.py
@@ -75,8 +75,6 @@ from campfire.deploy.deploy import (
     deploy_json,
     deploy_observation,
     deploy_pointings,
-    deploy_rgb,
-    deploy_sed,
     deploy_shutters,
     deploy_slits,
     deploy_thumbnails,
@@ -222,8 +220,6 @@ def source_ids_option(f):
 @click.option('--supabase-only', is_flag=True, help='Skip R2 uploads, only update Supabase.')
 @click.option('--force-overwrite', is_flag=True, help='Reset inspection data for existing objects.')
 @click.option('--auto-approve', is_flag=True, help='Skip confirmation prompts.')
-@click.option('--rgb', is_flag=True, help='Include RGB image deployment (skipped by default).')
-@click.option('--no-sed', is_flag=True, help='Skip SED plot deployment.')
 @click.option('--no-shutters', is_flag=True, help='Skip shutter deployment.')
 @click.option('--no-photometry', is_flag=True,
               help='Skip photometry upsert after objects reconcile.')
@@ -242,7 +238,7 @@ def source_ids_option(f):
                    'Equivalent to CAMPFIRE_DEPLOY_MODE=service-role.')
 @click.pass_context
 def deploy_group(ctx, config_path, obs, field, filter_names, dry_run, source_ids,
-                 supabase_only, force_overwrite, auto_approve, rgb, no_sed,
+                 supabase_only, force_overwrite, auto_approve,
                  no_shutters, no_photometry, skip_astrometry, draft, local,
                  service_role):
     """Deploy CAMPFIRE pipeline products to Supabase + object storage.
@@ -304,8 +300,6 @@ def deploy_group(ctx, config_path, obs, field, filter_names, dry_run, source_ids
                 dry_run=dry_run,
                 supabase_only=supabase_only,
                 force_overwrite=force_overwrite,
-                include_rgb=rgb,
-                include_sed=not no_sed,
                 include_shutters=not no_shutters,
                 include_photometry=not no_photometry,
                 skip_astrometry=skip_astrometry,
@@ -423,40 +417,6 @@ def push_cmd(ctx, config_path, obs, fields, filter_names, source_ids, dry_run,
 # ---------------------------------------------------------------------------
 # Subcommands
 # ---------------------------------------------------------------------------
-
-@deploy_group.command()
-@shared_options
-@source_ids_option
-@click.option('--overwrite', is_flag=True, help='Regenerate files even if they exist.')
-@click.pass_context
-def rgb(ctx, config_path, obs, dry_run, local, source_ids, overwrite):
-    """Generate and deploy RGB images to R2."""
-    config = load_config(config_path, local=_resolve_local(ctx, local))
-    for obs_name in obs:
-        deploy_rgb(
-            obs_name, config,
-            dry_run=dry_run,
-            source_ids=list(source_ids) if source_ids else None,
-            overwrite=overwrite,
-        )
-
-
-@deploy_group.command()
-@shared_options
-@source_ids_option
-@click.option('--overwrite', is_flag=True, help='Regenerate files even if they exist.')
-@click.pass_context
-def sed(ctx, config_path, obs, dry_run, local, source_ids, overwrite):
-    """Generate and deploy SED plots to R2 and update has_sed_plot."""
-    config = load_config(config_path, local=_resolve_local(ctx, local))
-    for obs_name in obs:
-        deploy_sed(
-            obs_name, config,
-            dry_run=dry_run,
-            source_ids=list(source_ids) if source_ids else None,
-            overwrite=overwrite,
-        )
-
 
 @deploy_group.command('json')
 @shared_options

--- a/python/campfire/deploy/deploy.py
+++ b/python/campfire/deploy/deploy.py
@@ -314,20 +314,39 @@ def _deploy_intermediates_only(
                                   scheme=KeyScheme.CANONICAL), 'application/fits')
         for p in rate_files
     ]
-    uploaded_keys: set[str] = set()
-    print(f"Uploading {len(upload_tasks)} intermediates "
-          f"({len(exposure_files)} spectrum-exposures + {len(rate_files)} rate files) to OSN...")
-    success, failed, failed_msgs = upload_files_parallel(
-        config, upload_tasks, desc="OSN uploads", succeeded_out=uploaded_keys,
-        backend='osn')
-    print(f"Uploaded {success}/{len(upload_tasks)} files")
-
     # Best-effort provenance from the first exposure header (Phase 3): the
     # intermediates carry whatever cards the reduction stamped. Absent → NULL.
     # For a rate-only deploy (stage 1 done, stage 2 not yet) there are no
     # spectrum-exposures, so fall back to a rate header for provenance.
     cfpipe_version, jwst_version, crds_context = _read_exposure_provenance(
         exposure_files or rate_files)
+
+    # Push plan: dedup against the server registry (with the local mirror's
+    # stat fast path), then upload only new/changed bytes, registering per
+    # batch so an interrupted run resumes at file granularity.
+    from campfire.deploy.push import (
+        open_reducer_store, plan_remote_push, registration_flusher,
+    )
+    store = open_reducer_store()
+    plan, _server_rows = plan_remote_push(sb, store, upload_tasks, backend='osn')
+    print(f"Plan: {plan.summary()}")
+
+    uploaded_keys: set[str] = set()
+    success, failed, failed_msgs = 0, 0, []
+    flusher = registration_flusher(
+        sb, store, plan, backend='osn', deployment_id=None,
+        uploaded_by=user_id, cfpipe_version=cfpipe_version)
+    if plan.to_upload:
+        print(f"Uploading {len(plan.to_upload)} of {len(upload_tasks)} intermediates "
+              f"({len(exposure_files)} spectrum-exposures + {len(rate_files)} rate files) to OSN...")
+        success, failed, failed_msgs = upload_files_parallel(
+            config, plan.to_upload, desc="OSN uploads", succeeded_out=uploaded_keys,
+            backend='osn', on_success=flusher.add)
+        flusher.flush()
+        print(f"Uploaded {success}/{len(plan.to_upload)} files "
+              f"({len(plan.unchanged)} unchanged skipped)")
+    else:
+        print("Cloud already matches local intermediates — nothing to upload.")
 
     deployment_id = insert_deployment(
         sb, observation=obs_name, deployed_by=user_id, status='draft',
@@ -342,20 +361,15 @@ def _deploy_intermediates_only(
             observation=obs_name, affected_count=success,
             metadata=deploy_event_metadata(
                 'nirspec', observation=obs_name, planned=len(upload_tasks),
-                succeeded=success, failed=failed, items=len(upload_tasks),
-                draft=True, intermediates_only=True))
-
-    if uploaded_keys:
-        from campfire.deploy.registry import (
-            build_registry_rows, upsert_storage_objects,
-        )
-        # NIRSpec products are homed on OSN under canonical keys (epic #210 / #216).
-        reg_rows = build_registry_rows(
-            upload_tasks, backend='osn',
-            deployment_id=deployment_id, uploaded_by=user_id,
-            cfpipe_version=cfpipe_version, succeeded_keys=uploaded_keys)
-        n_reg = upsert_storage_objects(sb, reg_rows)
-        print(f"Registered {n_reg} storage objects")
+                succeeded=success, failed=failed, skipped=len(plan.unchanged),
+                items=len(upload_tasks), draft=True, intermediates_only=True))
+        # Attach this deploy's landed objects to the deployment (rows were
+        # registered durably per batch, before the deployment row existed).
+        # Draft semantics: only the uploaded objects stage as draft; unchanged
+        # objects stay on their prior (possibly published) deployment.
+        if uploaded_keys:
+            from campfire.deploy.registry import set_active_deployment
+            set_active_deployment(sb, sorted(uploaded_keys), deployment_id)
 
     # Rate-mask triage rows (P2, design §3.2): one per (obs, exposure, detector),
     # split-ownership upsert so re-deploy never clobbers web review state.
@@ -663,7 +677,13 @@ def deploy_observation(
         uploaded_keys: set[str] = set()  # r2_keys that actually landed (for the registry)
         rate_files: list = []  # populated in the not-supabase_only block; drives P2 triage upsert
         exposure_files: list = []  # canonical spectrum-exposures; drives the P4 nods grid
+        push_plan = None  # set in the not-supabase_only block; drives deployment attach
+        # Initialized here so a --supabase-only deploy (which skips the upload
+        # block entirely) can still evaluate the audit-event metadata below —
+        # previously a latent NameError on that path.
+        total_tasks, success, failed = 0, 0, 0
         scope = Scope(obs=obs_name)
+        user_id = get_user_id_from_token(config)
 
         # NIRSpec science products are homed on OSN under CANONICAL keys (epic #210 /
         # #216 — deploy → OSN); rgb/sed are dead products that stay on R2 under legacy
@@ -718,12 +738,33 @@ def deploy_observation(
             if rate_files:
                 print(f"  + {len(rate_files)} detector rate files")
 
-            total_tasks = len(upload_tasks) + len(legacy_tasks)
-            print(f"Uploading {total_tasks} files ({len(upload_tasks)} NIRSpec → OSN)...")
-            success, failed, failed_msgs = upload_files_parallel(
-                config, upload_tasks, desc="OSN uploads", succeeded_out=uploaded_keys,
-                backend='osn',
+            # Push plan (storage unification): dedup the OSN-bound products
+            # against the server registry — pipeline-written FITS that a prior
+            # `campfire push` (or deploy) already landed skip entirely, and the
+            # local mirror's stat fast path means unchanged files are skipped
+            # without re-reading them. Registration is durable per batch, so an
+            # interrupted deploy resumes at file granularity.
+            from campfire.deploy.push import (
+                open_reducer_store, plan_remote_push, registration_flusher,
             )
+            store = open_reducer_store()
+            push_plan, _server_rows = plan_remote_push(
+                sb, store, upload_tasks, backend='osn')
+            print(f"Plan: {push_plan.summary()}")
+            flusher = registration_flusher(
+                sb, store, push_plan, backend='osn', deployment_id=None,
+                uploaded_by=user_id,
+                cfpipe_version=summary.meta.get('cfpipe_version'))
+
+            total_tasks = len(upload_tasks) + len(legacy_tasks)
+            print(f"Uploading {len(push_plan.to_upload)} of {len(upload_tasks)} "
+                  f"NIRSpec file(s) → OSN "
+                  f"({len(push_plan.unchanged)} unchanged skipped)...")
+            success, failed, failed_msgs = upload_files_parallel(
+                config, push_plan.to_upload, desc="OSN uploads",
+                succeeded_out=uploaded_keys, backend='osn', on_success=flusher.add,
+            )
+            flusher.flush()
             if legacy_tasks:
                 s2, f2, m2 = upload_files_parallel(
                     config, legacy_tasks, desc="R2 uploads (rgb/sed)",
@@ -876,7 +917,6 @@ def deploy_observation(
         # Record deployment provenance
         config_snapshot = _load_config_snapshot(obs_dir, obs_name)
         stuck_shutters = _load_stuck_shutters(resolve_reference_obs_dir(obs_name))
-        user_id = get_user_id_from_token(config)
 
         deployment_id = insert_deployment(
             sb,
@@ -933,24 +973,25 @@ def deploy_observation(
             print("   Both deploys' writes are present; re-check the result and "
                   "re-deploy if a re-reduction was clobbered.")
 
-        # Storage registry (#214): index the objects that actually landed in this
-        # deploy. Shadow index — additive, nothing reads it as authoritative yet.
-        if uploaded_keys:
-            from campfire.deploy.registry import (
-                build_registry_rows, upsert_storage_objects,
-            )
-            # upload_tasks are the NIRSpec products, homed on OSN under canonical
-            # keys (rgb/sed are in legacy_tasks and never register). backend='osn'.
-            reg_rows = build_registry_rows(
-                upload_tasks,
-                backend='osn',
-                deployment_id=deployment_id,
-                uploaded_by=user_id,
-                cfpipe_version=summary.meta.get('cfpipe_version'),
-                succeeded_keys=uploaded_keys,
-            )
-            n_reg = upsert_storage_objects(sb, reg_rows)
-            print(f"Registered {n_reg} storage objects")
+        # Storage registry (#214): rows were registered durably PER BATCH during
+        # the upload (registration_flusher), before this deployment row existed.
+        # Attach them now: everything uploaded this run, plus — on a published
+        # deploy — the unchanged dedup-skipped objects, so deployment-gated
+        # intermediates ride the current deployment's visibility. On --draft,
+        # unchanged objects stay on their prior (possibly published) deployment
+        # (staging must not take live data dark). rgb/sed legacy keys have no
+        # registry rows, so their presence in uploaded_keys is a no-op here.
+        if deployment_id and push_plan is not None:
+            from campfire.deploy.registry import set_active_deployment
+            osn_keys = {t.r2_key for t in upload_tasks}
+            attach = set(uploaded_keys) & osn_keys
+            if not draft:
+                attach |= {t.r2_key for t in push_plan.unchanged}
+            if attach:
+                n_att = set_active_deployment(sb, sorted(attach), deployment_id)
+                if n_att:
+                    print(f"Attached {n_att} storage object(s) to deployment "
+                          f"#{deployment_id}")
 
         # Rate-mask triage rows (P2, design §3.2): split-ownership upsert so a
         # re-deploy refreshes render columns without clobbering web review state.
@@ -1039,7 +1080,8 @@ def deploy_rgb(
         return
 
     tasks = [UploadTask(p, storage_key('rgb', Scope(obs=obs_name), p.name), 'image/png') for p in rgb_files]
-    success, failed, failed_msgs = upload_files_parallel(config, tasks, desc="RGB images")
+    # rgb is a dead legacy product: R2 is correct here (data products live on OSN).
+    success, failed, failed_msgs = upload_files_parallel(config, tasks, desc="RGB images", backend='r2')
 
     if failed_msgs:
         print(f"\n  {failed} failed:")
@@ -1092,7 +1134,8 @@ def deploy_sed(
         return
 
     tasks = [UploadTask(p, storage_key('sed', Scope(obs=obs_name), p.name), 'application/pdf') for p in sed_files]
-    success, failed, failed_msgs = upload_files_parallel(config, tasks, desc="SED plots")
+    # sed is a dead legacy product: R2 is correct here (data products live on OSN).
+    success, failed, failed_msgs = upload_files_parallel(config, tasks, desc="SED plots", backend='r2')
 
     if failed_msgs:
         print(f"\n  {failed} failed:")

--- a/python/campfire/deploy/deploy.py
+++ b/python/campfire/deploy/deploy.py
@@ -780,7 +780,12 @@ def deploy_observation(
                     print(f"    - {msg}")
                 if len(failed_msgs) > 10:
                     print(f"    ... and {len(failed_msgs) - 10} more")
-            print(f"Uploaded {success}/{total_tasks} files")
+            # `success` counts only the files that were actually transferred
+            # (planned uploads + rgb/sed legacy); unchanged files were never
+            # candidates, so they are reported as skipped — not as failures.
+            print(f"Uploaded {success}"
+                  + (f", failed {failed}" if failed else "")
+                  + f" ({len(push_plan.unchanged)} unchanged skipped)")
             print()
 
         # Generate thumbnails and enrich spectra records
@@ -1014,17 +1019,29 @@ def deploy_observation(
                 sb, build_spectrum_exposure_records(exposure_files, observation=obs_name, scope=scope))
             print(f"Upserted {n_grid} spectrum-exposure grid rows")
 
-        print()
-        msg = f"Deployed {len(spectra)} spectra from {len(objects)} objects"
+        # Closing summary — the wall of stage output above scrolls away; the
+        # last block states what actually happened, in one place.
+        extras = []
         if zfit_paths:
-            msg += f" + {len(zfit_paths)} zfit files"
+            extras.append(f"{len(zfit_paths)} zfit")
         if rgb_files:
-            msg += f" + {len(rgb_files)} RGB images"
+            extras.append(f"{len(rgb_files)} RGB")
         if sed_files:
-            msg += f" + {len(sed_files)} SED plots"
+            extras.append(f"{len(sed_files)} SED")
         if n_shutters:
-            msg += f" + {n_shutters} shutters"
-        print(msg)
+            extras.append(f"{n_shutters} shutters")
+        print()
+        print(f"Deploy complete: {obs_name}")
+        if deployment_id:
+            print(f"  deployment:  #{deployment_id} ({'draft — admin-only' if draft else 'published'})")
+        print(f"  catalog:     {len(spectra)} spectra, {len(objects)} objects"
+              + (f"  (+ {', '.join(extras)})" if extras else ""))
+        if supabase_only:
+            print("  files:       none (--supabase-only)")
+        elif push_plan is not None:
+            print(f"  files:       {success} uploaded, "
+                  f"{len(push_plan.unchanged)} unchanged skipped"
+                  + (f", {failed} FAILED — re-run to retry" if failed else ""))
 
         # Phase C: any successful deploy potentially affected member spectra
         # or membership; the deferred multi-obs path always wants to reconcile.

--- a/python/campfire/deploy/deploy.py
+++ b/python/campfire/deploy/deploy.py
@@ -19,14 +19,10 @@ from tqdm import tqdm
 from campfire.deploy.config import load_observations, load_programs, resolve_field, resolve_imaging_config, resolve_obs_dir, resolve_reference_obs_dir, validate_program_slug
 from campfire.deploy.discover import (
     discover_pointings_ecsv,
-    discover_rgb_images,
-    discover_sed_plots,
     discover_rate_files,
     discover_shutters_ecsv,
     discover_spectrum_exposures,
     discover_slits_json,
-    extract_object_ids_from_files,
-    filter_files_by_source_ids,
     load_pointings_ecsv,
     load_shutters_ecsv,
     load_slits_json,
@@ -57,7 +53,6 @@ from campfire.deploy.supabase import (
     recompute_target_aggregates,
     refresh_filter_options,
     refresh_programs_overview,
-    update_has_sed_plot,
     update_latest_deployment,
     update_observation_pointings,
     upsert_observation,
@@ -412,8 +407,6 @@ def deploy_observation(
     dry_run: bool = False,
     supabase_only: bool = False,
     force_overwrite: bool = False,
-    include_rgb: bool = False,
-    include_sed: bool = True,
     include_shutters: bool = True,
     include_photometry: bool = True,
     skip_astrometry: bool = False,
@@ -518,37 +511,10 @@ def deploy_observation(
                 print("Aborted.")
                 return {'field': field, 'needs_reconcile': False}
 
-    # Generate RGB/SED if requested (skips existing files)
-    if not dry_run:
-        if include_rgb:
-            from campfire.deploy.generate_rgb import generate_rgb_images
-            n = generate_rgb_images(obs_name, obs_dir, field,
-                                    source_ids=source_ids)
-            if n:
-                print(f"  Generated {n} RGB images")
-        if include_sed:
-            from campfire.deploy.generate_sed import generate_sed_plots
-            n = generate_sed_plots(obs_name, obs_dir, field,
-                                   source_ids=source_ids)
-            if n:
-                print(f"  Generated {n} SED plots")
-
-    # Discover optional file types
-    rgb_files = discover_rgb_images(obs_dir) if include_rgb else []
-    sed_files = discover_sed_plots(obs_dir) if include_sed else []
-
-    if source_ids:
-        rgb_files = filter_files_by_source_ids(rgb_files, source_ids, obs_name)
-        sed_files = filter_files_by_source_ids(sed_files, source_ids, obs_name)
-
-    if rgb_files:
-        print(f"  RGB images: {len(rgb_files)}")
-    if sed_files:
-        print(f"  SED plots: {len(sed_files)}")
+    # RGB/SED static cutouts are fully deprecated: superseded by the on-the-fly
+    # /api/v1/cutout API, never registered, not served anywhere. Deploy no
+    # longer generates or uploads them (legacy R2 remnants retire with A2).
     print()
-
-    # Build set of object_ids with SED plots
-    objects_with_sed = extract_object_ids_from_files(sed_files, '_sed.pdf') if sed_files else set()
 
     # --- Dry run ---
     if dry_run:
@@ -561,12 +527,6 @@ def deploy_observation(
             print(f"  {len(spec_paths)} spectrum JSON files")
             if zfit_paths:
                 print(f"  {len(zfit_paths)} zfit JSON files")
-            if rgb_files or sed_files:
-                print(f"Would upload to R2 (dead rgb/sed, legacy keys):")
-                if rgb_files:
-                    print(f"  {len(rgb_files)} RGB images")
-                if sed_files:
-                    print(f"  {len(sed_files)} SED plots")
         print(f"Would upsert to Supabase:")
         print(f"  Program: {program_slug}")
         print(f"  {len(objects)} object(s)")
@@ -759,21 +719,13 @@ def deploy_observation(
             if fits_name in thumb_map:
                 rec.update(thumb_map[fits_name])
 
-        # NIRSpec science products are homed on OSN under CANONICAL keys (epic #210 /
-        # #216 — deploy → OSN); rgb/sed are dead products that stay on R2 under legacy
-        # keys (unregistered, 404, not migrated). They upload in separate batches.
-        legacy_tasks: list[UploadTask] = []
+        # NIRSpec science products are homed on OSN under CANONICAL keys
+        # (epic #210 / #216 — deploy → OSN).
         if not supabase_only:
             # Zfit JSONs
             for zfit_path in zfit_paths:
                 zfit_json = generate_zfit_json(zfit_path, temp_dir)
                 upload_tasks.append(UploadTask(zfit_json, storage_key('zfit', scope, zfit_json.name, scheme=KeyScheme.CANONICAL), 'application/json'))
-
-            # RGB images / SED plots — dead products (kept on R2/legacy, unchanged).
-            for rgb_path in rgb_files:
-                legacy_tasks.append(UploadTask(rgb_path, storage_key('rgb', scope, rgb_path.name), 'image/png'))
-            for sed_path in sed_files:
-                legacy_tasks.append(UploadTask(sed_path, storage_key('sed', scope, sed_path.name), 'application/pdf'))
 
             # Canonical spectrum-exposure intermediates (epic #210, B5): uploaded on
             # EVERY deploy (cloud-as-source-of-truth + delete-local→restore), filtered
@@ -824,7 +776,7 @@ def deploy_observation(
                 uploaded_by=user_id,
                 cfpipe_version=summary.meta.get('cfpipe_version'))
 
-            total_tasks = len(upload_tasks) + len(legacy_tasks)
+            total_tasks = len(upload_tasks)
             print(f"Uploading {len(push_plan.to_upload)} of {len(upload_tasks)} "
                   f"NIRSpec file(s) → OSN "
                   f"({len(push_plan.unchanged)} unchanged skipped)...")
@@ -833,24 +785,15 @@ def deploy_observation(
                 succeeded_out=uploaded_keys, backend='osn', on_success=flusher.add,
             )
             flusher.flush()
-            if legacy_tasks:
-                s2, f2, m2 = upload_files_parallel(
-                    config, legacy_tasks, desc="R2 uploads (rgb/sed)",
-                    succeeded_out=uploaded_keys, backend='r2',
-                )
-                success += s2
-                failed += f2
-                failed_msgs = failed_msgs + m2
-
             if failed_msgs:
                 print(f"\n  {failed} uploads failed:")
                 for msg in failed_msgs[:10]:
                     print(f"    - {msg}")
                 if len(failed_msgs) > 10:
                     print(f"    ... and {len(failed_msgs) - 10} more")
-            # `success` counts only the files that were actually transferred
-            # (planned uploads + rgb/sed legacy); unchanged files were never
-            # candidates, so they are reported as skipped — not as failures.
+            # `success` counts only the files that were actually transferred;
+            # unchanged files were never candidates, so they are reported as
+            # skipped — not as failures.
             print(f"Uploaded {success}"
                   + (f", failed {failed}" if failed else "")
                   + f" ({len(push_plan.unchanged)} unchanged skipped)")
@@ -858,7 +801,7 @@ def deploy_observation(
 
         # Supabase upserts
         print("Upserting objects...")
-        n_obj, new_object_ids, _n_quality_reset = batch_upsert_objects(sb, objects, field, force_overwrite, objects_with_sed)
+        n_obj, new_object_ids, _n_quality_reset = batch_upsert_objects(sb, objects, field, force_overwrite)
         print(f"  {n_obj} objects")
         # Backfill the deployment row's new-target count — the row is recorded
         # up front (parity with deploy_nircam), before this number exists.
@@ -1032,10 +975,6 @@ def deploy_observation(
         extras = []
         if zfit_paths:
             extras.append(f"{len(zfit_paths)} zfit")
-        if rgb_files:
-            extras.append(f"{len(rgb_files)} RGB")
-        if sed_files:
-            extras.append(f"{len(sed_files)} SED")
         if n_shutters:
             extras.append(f"{n_shutters} shutters")
         print()
@@ -1063,117 +1002,6 @@ def deploy_observation(
 # ---------------------------------------------------------------------------
 # Standalone subcommand handlers
 # ---------------------------------------------------------------------------
-
-def deploy_rgb(
-    obs_name: str,
-    config: dict,
-    *,
-    dry_run: bool = False,
-    source_ids: list[int] | None = None,
-    overwrite: bool = False,
-) -> None:
-    """Generate and deploy RGB images to R2."""
-    obs_dir = resolve_obs_dir(obs_name)
-
-    # Generate RGB images (skips existing unless overwrite=True)
-    if not dry_run:
-        field = resolve_field(obs_name)
-        if field:
-            from campfire.deploy.generate_rgb import generate_rgb_images
-            n = generate_rgb_images(obs_name, obs_dir, field,
-                                    overwrite=overwrite, source_ids=source_ids)
-            if n:
-                print(f"Generated {n} RGB images")
-
-    rgb_files = discover_rgb_images(obs_dir)
-
-    if source_ids:
-        rgb_files = filter_files_by_source_ids(rgb_files, source_ids, obs_name)
-
-    if not rgb_files:
-        print("No RGB images found.")
-        return
-
-    print(f"Found {len(rgb_files)} RGB images")
-
-    if dry_run:
-        print("=== DRY RUN ===")
-        for path in rgb_files[:5]:
-            print(f"  {path.name} -> {storage_key('rgb', Scope(obs=obs_name), path.name)}")
-        if len(rgb_files) > 5:
-            print(f"  ... and {len(rgb_files) - 5} more")
-        return
-
-    tasks = [UploadTask(p, storage_key('rgb', Scope(obs=obs_name), p.name), 'image/png') for p in rgb_files]
-    # rgb is a dead legacy product: R2 is correct here (data products live on OSN).
-    success, failed, failed_msgs = upload_files_parallel(config, tasks, desc="RGB images", backend='r2')
-
-    if failed_msgs:
-        print(f"\n  {failed} failed:")
-        for msg in failed_msgs[:5]:
-            print(f"    - {msg}")
-
-    print(f"Uploaded {success}/{len(rgb_files)} RGB images")
-
-
-def deploy_sed(
-    obs_name: str,
-    config: dict,
-    *,
-    dry_run: bool = False,
-    source_ids: list[int] | None = None,
-    overwrite: bool = False,
-) -> None:
-    """Generate and deploy SED plots to R2 and update has_sed_plot in Supabase."""
-    obs_dir = resolve_obs_dir(obs_name)
-
-    # Generate SED plots (skips existing unless overwrite=True)
-    if not dry_run:
-        field = resolve_field(obs_name)
-        if field:
-            from campfire.deploy.generate_sed import generate_sed_plots
-            n = generate_sed_plots(obs_name, obs_dir, field,
-                                   overwrite=overwrite, source_ids=source_ids)
-            if n:
-                print(f"Generated {n} SED plots")
-
-    sed_files = discover_sed_plots(obs_dir)
-
-    if source_ids:
-        sed_files = filter_files_by_source_ids(sed_files, source_ids, obs_name)
-
-    if not sed_files:
-        print("No SED plots found.")
-        return
-
-    objects_with_sed = extract_object_ids_from_files(sed_files, '_sed.pdf')
-    print(f"Found {len(sed_files)} SED plots ({len(objects_with_sed)} objects)")
-
-    if dry_run:
-        print("=== DRY RUN ===")
-        for path in sed_files[:5]:
-            print(f"  {path.name} -> {storage_key('sed', Scope(obs=obs_name), path.name)}")
-        if len(sed_files) > 5:
-            print(f"  ... and {len(sed_files) - 5} more")
-        print(f"Would set has_sed_plot=true for {len(objects_with_sed)} objects")
-        return
-
-    tasks = [UploadTask(p, storage_key('sed', Scope(obs=obs_name), p.name), 'application/pdf') for p in sed_files]
-    # sed is a dead legacy product: R2 is correct here (data products live on OSN).
-    success, failed, failed_msgs = upload_files_parallel(config, tasks, desc="SED plots", backend='r2')
-
-    if failed_msgs:
-        print(f"\n  {failed} failed:")
-        for msg in failed_msgs[:5]:
-            print(f"    - {msg}")
-
-    print(f"Uploaded {success}/{len(sed_files)} SED plots")
-
-    # Update database
-    sb = get_supabase_client(config)
-    n = update_has_sed_plot(sb, objects_with_sed)
-    print(f"Updated has_sed_plot for {n} objects")
-
 
 def deploy_json(
     obs_name: str,

--- a/python/campfire/deploy/deploy.py
+++ b/python/campfire/deploy/deploy.py
@@ -33,6 +33,7 @@ from campfire.deploy.discover import (
 )
 from campfire.deploy.generate import (
     generate_spectrum_json,
+    generate_spectrum_products,
     generate_thumbnails_from_fits,
     generate_zfit_json,
 )
@@ -321,6 +322,18 @@ def _deploy_intermediates_only(
     cfpipe_version, jwst_version, crds_context = _read_exposure_provenance(
         exposure_files or rate_files)
 
+    # Record the deployment UP FRONT (parity with the main deploy paths): the
+    # flusher registers landed objects directly against it as batches complete.
+    # Draft semantics: only uploaded objects stage as draft; unchanged objects
+    # stay on their prior (possibly published) deployment.
+    deployment_id = insert_deployment(
+        sb, observation=obs_name, deployed_by=user_id, status='draft',
+        cfpipe_version=cfpipe_version, jwst_version=jwst_version,
+        crds_context=crds_context, n_targets=0, n_spectra=0,
+    )
+    if deployment_id:
+        print(f"Deployment #{deployment_id} recorded (draft — intermediates only)")
+
     # Push plan: dedup against the server registry (with the local mirror's
     # stat fast path), then upload only new/changed bytes, registering per
     # batch so an interrupted run resumes at file granularity.
@@ -334,7 +347,7 @@ def _deploy_intermediates_only(
     uploaded_keys: set[str] = set()
     success, failed, failed_msgs = 0, 0, []
     flusher = registration_flusher(
-        sb, store, plan, backend='osn', deployment_id=None,
+        sb, store, plan, backend='osn', deployment_id=deployment_id,
         uploaded_by=user_id, cfpipe_version=cfpipe_version)
     if plan.to_upload:
         print(f"Uploading {len(plan.to_upload)} of {len(upload_tasks)} intermediates "
@@ -343,19 +356,14 @@ def _deploy_intermediates_only(
             config, plan.to_upload, desc="OSN uploads", succeeded_out=uploaded_keys,
             backend='osn', on_success=flusher.add)
         flusher.flush()
-        print(f"Uploaded {success}/{len(plan.to_upload)} files "
-              f"({len(plan.unchanged)} unchanged skipped)")
+        print(f"Uploaded {success}"
+              + (f", failed {failed}" if failed else "")
+              + f" ({len(plan.unchanged)} unchanged skipped)")
     else:
         print("Cloud already matches local intermediates — nothing to upload.")
 
-    deployment_id = insert_deployment(
-        sb, observation=obs_name, deployed_by=user_id, status='draft',
-        cfpipe_version=cfpipe_version, jwst_version=jwst_version,
-        crds_context=crds_context, n_targets=0, n_spectra=0,
-    )
     if deployment_id:
         update_latest_deployment(sb, obs_name, deployment_id)
-        print(f"\nDeployment #{deployment_id} recorded (draft — intermediates only)")
         log_deploy_event(
             sb, action='upload', actor=user_id, deployment_id=deployment_id,
             observation=obs_name, affected_count=success,
@@ -363,13 +371,6 @@ def _deploy_intermediates_only(
                 'nirspec', observation=obs_name, planned=len(upload_tasks),
                 succeeded=success, failed=failed, skipped=len(plan.unchanged),
                 items=len(upload_tasks), draft=True, intermediates_only=True))
-        # Attach this deploy's landed objects to the deployment (rows were
-        # registered durably per batch, before the deployment row existed).
-        # Draft semantics: only the uploaded objects stage as draft; unchanged
-        # objects stay on their prior (possibly published) deployment.
-        if uploaded_keys:
-            from campfire.deploy.registry import set_active_deployment
-            set_active_deployment(sb, sorted(uploaded_keys), deployment_id)
 
     # Rate-mask triage rows (P2, design §3.2): one per (obs, exposure, detector),
     # split-ownership upsert so re-deploy never clobbers web review state.
@@ -648,6 +649,24 @@ def deploy_observation(
                 if resp.lower() != 'y':
                     print("Aborted.")
                     return
+
+    # B2: a draft deploy forces deploy_status='draft' on every spectrum it
+    # writes — the whole observation lands as an admin-only draft. Confirm the
+    # re-drafting of currently-PUBLISHED rows HERE, with the other interactive
+    # gates, so every prompt happens before the deployment row exists and any
+    # bytes move. A single spectra row per (target,grating) can't hold a live +
+    # draft version at once, so this is "take the observation back to draft".
+    if draft:
+        already_published = _count_published_spectra(sb, spectra)
+        if already_published and not auto_approve:
+            print(f"WARNING: --draft will hide {already_published} currently-PUBLISHED "
+                  f"spectrum row(s) until you re-publish them.")
+            resp = input("  Take these back to draft? [y/N]: ")
+            if resp.lower() != 'y':
+                print("Aborted.")
+                return {'field': field, 'needs_reconcile': False}
+        for rec in spectra:
+            rec['deploy_status'] = 'draft'
     print()
 
     # Upsert program
@@ -668,6 +687,37 @@ def deploy_observation(
     )
     print()
 
+    # Record the deployment UP FRONT (parity with deploy_nircam): it is the
+    # provenance anchor and the visibility gate this deploy's registered
+    # objects hang off — the flusher tags rows with it as uploads land, instead
+    # of a post-hoc re-point. n_new_targets isn't known yet (it comes from the
+    # objects upsert), so it's backfilled onto this row in the catalog phase.
+    user_id = get_user_id_from_token(config)
+    deployment_id = insert_deployment(
+        sb,
+        observation=obs_name,
+        deployed_by=user_id,
+        cfpipe_version=summary.meta.get('cfpipe_version'),
+        jwst_version=summary.meta.get('jwst_version'),
+        crds_context=summary.meta.get('crds_context'),
+        config_snapshot=_load_config_snapshot(obs_dir, obs_name),
+        stuck_shutters=_load_stuck_shutters(resolve_reference_obs_dir(obs_name)),
+        # Real reduction time (earliest CMPFRTIM across products), not the
+        # summary-build wall-clock — so re-running `summary` on unchanged
+        # pixels no longer advances reduced_at.
+        reduced_at=summary.meta.get('reduced_at'),
+        n_targets=len(objects),
+        n_spectra=len(spectra),
+        n_new_targets=0,
+        force_overwrite=force_overwrite,
+        source_ids_filter=source_ids,
+        supabase_only=supabase_only,
+        status='draft' if draft else 'published',
+    )
+    if deployment_id:
+        print(f"Deployment #{deployment_id} recorded "
+              f"({'draft — admin-only' if draft else 'published'})")
+
     # Generate content and upload
     temp_dir = obs_dir / '.deploy_temp'
     temp_dir.mkdir(exist_ok=True)
@@ -677,28 +727,43 @@ def deploy_observation(
         uploaded_keys: set[str] = set()  # r2_keys that actually landed (for the registry)
         rate_files: list = []  # populated in the not-supabase_only block; drives P2 triage upsert
         exposure_files: list = []  # canonical spectrum-exposures; drives the P4 nods grid
-        push_plan = None  # set in the not-supabase_only block; drives deployment attach
+        push_plan = None  # set in the not-supabase_only block; drives the unchanged re-point
         # Initialized here so a --supabase-only deploy (which skips the upload
         # block entirely) can still evaluate the audit-event metadata below —
         # previously a latent NameError on that path.
         total_tasks, success, failed = 0, 0, 0
         scope = Scope(obs=obs_name)
-        user_id = get_user_id_from_token(config)
+
+        # One pass per final generates BOTH derivatives from a single FITS read:
+        # the spectrum JSON (uploaded) and the SVG thumbnails (embedded in the
+        # spectra rows) — previously two stages, each re-opening every final.
+        # Thumbnails are needed even on --supabase-only (the rows still update).
+        print("Generating content...")
+        thumb_map: dict[str, dict] = {}
+        for spec_path in tqdm(spec_paths, desc="Processing", unit="file"):
+            if supabase_only:
+                try:
+                    thumb_map[spec_path.name] = generate_thumbnails_from_fits(spec_path)
+                except Exception as e:
+                    print(f"  Warning: {spec_path.name}: {e}")
+                continue
+            # FITS file + JSON derivative + thumbnails (single read)
+            upload_tasks.append(UploadTask(spec_path, storage_key('nirspec_spec', scope, spec_path.name, scheme=KeyScheme.CANONICAL), 'application/fits'))
+            json_path, thumbs = generate_spectrum_products(spec_path, temp_dir)
+            thumb_map[spec_path.name] = thumbs
+            upload_tasks.append(UploadTask(json_path, storage_key('spectrum_json', scope, json_path.name, scheme=KeyScheme.CANONICAL), 'application/json'))
+
+        # Enrich spectra records with thumbnails before the catalog upsert.
+        for rec in spectra:
+            fits_name = rec['fits_path'].split('/')[-1]
+            if fits_name in thumb_map:
+                rec.update(thumb_map[fits_name])
 
         # NIRSpec science products are homed on OSN under CANONICAL keys (epic #210 /
         # #216 — deploy → OSN); rgb/sed are dead products that stay on R2 under legacy
         # keys (unregistered, 404, not migrated). They upload in separate batches.
         legacy_tasks: list[UploadTask] = []
         if not supabase_only:
-            print("Generating content...")
-            for spec_path in tqdm(spec_paths, desc="Processing", unit="file"):
-                # FITS file
-                upload_tasks.append(UploadTask(spec_path, storage_key('nirspec_spec', scope, spec_path.name, scheme=KeyScheme.CANONICAL), 'application/fits'))
-
-                # Spectrum JSON
-                json_path = generate_spectrum_json(spec_path, temp_dir)
-                upload_tasks.append(UploadTask(json_path, storage_key('spectrum_json', scope, json_path.name, scheme=KeyScheme.CANONICAL), 'application/json'))
-
             # Zfit JSONs
             for zfit_path in zfit_paths:
                 zfit_json = generate_zfit_json(zfit_path, temp_dir)
@@ -751,8 +816,11 @@ def deploy_observation(
             push_plan, _server_rows = plan_remote_push(
                 sb, store, upload_tasks, backend='osn')
             print(f"Plan: {push_plan.summary()}")
+            # Uploaded objects register directly against this deploy's
+            # deployment row (recorded up front); only the unchanged
+            # dedup-skipped ones need the post-hoc re-point below.
             flusher = registration_flusher(
-                sb, store, push_plan, backend='osn', deployment_id=None,
+                sb, store, push_plan, backend='osn', deployment_id=deployment_id,
                 uploaded_by=user_id,
                 cfpipe_version=summary.meta.get('cfpipe_version'))
 
@@ -788,47 +856,16 @@ def deploy_observation(
                   + f" ({len(push_plan.unchanged)} unchanged skipped)")
             print()
 
-        # Generate thumbnails and enrich spectra records
-        print("Generating thumbnails...")
-        thumb_map = {}
-        for spec_path in tqdm(spec_paths, desc="Thumbnails", unit="file"):
-            try:
-                thumbs = generate_thumbnails_from_fits(spec_path)
-                thumb_map[spec_path.name] = thumbs
-            except Exception as e:
-                print(f"  Warning: {spec_path.name}: {e}")
-
-        # Enrich spectra records with thumbnails
-        for rec in spectra:
-            fits_name = rec['fits_path'].split('/')[-1]
-            if fits_name in thumb_map:
-                rec.update(thumb_map[fits_name])
-
         # Supabase upserts
         print("Upserting objects...")
         n_obj, new_object_ids, _n_quality_reset = batch_upsert_objects(sb, objects, field, force_overwrite, objects_with_sed)
         print(f"  {n_obj} objects")
-
-        # B2: an draft deploy forces deploy_status='draft' on every spectrum it
-        # writes — the whole observation lands as an admin-only draft. Guard first
-        # against silently hiding data that is already live: warn (and require
-        # confirmation) if any of these (target_id, grating) rows are currently
-        # 'published', since re-drafting them would pull them from users until an
-        # explicit publish. A single spectra row per (target,grating) can't hold a
-        # live + draft version at once, so this is "take the observation back to
-        # draft", not zero-downtime staging of a re-reduction.
-        if draft:
-            already_published = _count_published_spectra(sb, spectra)
-            if already_published and not auto_approve:
-                print()
-                print(f"WARNING: --in-prep will hide {already_published} currently-PUBLISHED "
-                      f"spectrum row(s) until you re-publish them.")
-                resp = input("  Take these back to draft (draft)? [y/N]: ")
-                if resp.lower() != 'y':
-                    print("Aborted.")
-                    return {'field': field, 'needs_reconcile': False}
-            for rec in spectra:
-                rec['deploy_status'] = 'draft'
+        # Backfill the deployment row's new-target count — the row is recorded
+        # up front (parity with deploy_nircam), before this number exists.
+        if deployment_id and new_object_ids:
+            sb.table('deployments').update(
+                {'n_new_targets': len(new_object_ids)}
+            ).eq('id', deployment_id).execute()
 
         print("Upserting spectra...")
         n_spec, changed_hashes = batch_upsert_spectra(sb, spectra)
@@ -838,6 +875,28 @@ def deploy_observation(
         target_ids = [o['object_id'] for o in objects]
         n_agg = recompute_target_aggregates(sb, target_ids)
         print(f"  Recomputed aggregates for {n_agg} targets")
+
+        # Review-surface rows — catalog upserts like the ones above (they feed
+        # the admin review views), published here in the catalog phase rather
+        # than trailing the deployment record (historical P2/P4 placement).
+        # Rate-mask triage rows: split-ownership upsert so a re-deploy
+        # refreshes render columns without clobbering web review state.
+        if rate_files:
+            from campfire.deploy.rate_exposures import (
+                build_rate_exposure_records, upsert_rate_exposures,
+            )
+            n_rate = upsert_rate_exposures(
+                sb, build_rate_exposure_records(rate_files, observation=obs_name, scope=scope))
+            print(f"  Upserted {n_rate} rate-exposure triage rows")
+        # Nods-renderer grid rows: one per (obs, exposure_root, nod, detector,
+        # source); exposure_files is already source-filtered (grid is per-source).
+        if exposure_files:
+            from campfire.deploy.spectrum_grid import (
+                build_spectrum_exposure_records, upsert_spectrum_exposures,
+            )
+            n_grid = upsert_spectrum_exposures(
+                sb, build_spectrum_exposure_records(exposure_files, observation=obs_name, scope=scope))
+            print(f"  Upserted {n_grid} spectrum-exposure grid rows")
 
         # Phase C: incremental object reconciliation. Preserves inspection
         # state on existing objects, inserts only when new clusters appear,
@@ -919,35 +978,10 @@ def deploy_observation(
             else:
                 print(f"\nNo shutters ECSV found for {obs_name}, skipping shutter deployment")
 
-        # Record deployment provenance
-        config_snapshot = _load_config_snapshot(obs_dir, obs_name)
-        stuck_shutters = _load_stuck_shutters(resolve_reference_obs_dir(obs_name))
-
-        deployment_id = insert_deployment(
-            sb,
-            observation=obs_name,
-            deployed_by=user_id,
-            cfpipe_version=summary.meta.get('cfpipe_version'),
-            jwst_version=summary.meta.get('jwst_version'),
-            crds_context=summary.meta.get('crds_context'),
-            config_snapshot=config_snapshot,
-            stuck_shutters=stuck_shutters,
-            # Real reduction time (earliest CMPFRTIM across products), not the
-            # summary-build wall-clock — so re-running `summary` on unchanged
-            # pixels no longer advances reduced_at.
-            reduced_at=summary.meta.get('reduced_at'),
-            n_targets=len(objects),
-            n_spectra=len(spectra),
-            n_new_targets=len(new_object_ids),
-            force_overwrite=force_overwrite,
-            source_ids_filter=source_ids,
-            supabase_only=supabase_only,
-            status='draft' if draft else 'published',
-        )
+        # --- Record phase: the deployment row was inserted up front (parity
+        # with deploy_nircam); finalize it now that outcomes are known.
         if deployment_id:
             update_latest_deployment(sb, obs_name, deployment_id)
-            print(f"\nDeployment #{deployment_id} recorded"
-                  f"{' (draft)' if draft else ''}")
             # B2: record the deploy in the lifecycle audit log (normalized
             # envelope, Phase 3). `success`/`failed` are the actual OSN+R2 upload
             # tallies; `affected_count` stays the spectra count for continuity.
@@ -964,6 +998,21 @@ def deploy_observation(
                     draft=draft, n_objects=len(objects)),
             )
 
+        # Re-point unchanged dedup-skipped objects at this deployment — only on
+        # a PUBLISHED deploy, so deployment-gated intermediates ride the current
+        # deployment's visibility. Uploaded objects were already registered with
+        # this deployment_id as batches landed (registration_flusher). On
+        # --draft, unchanged objects stay on their prior (possibly published)
+        # deployment — staging must not take live data dark.
+        if deployment_id and push_plan is not None and not draft:
+            skipped = {t.r2_key for t in push_plan.unchanged}
+            if skipped:
+                from campfire.deploy.registry import set_active_deployment
+                n_att = set_active_deployment(sb, sorted(skipped), deployment_id)
+                if n_att:
+                    print(f"Re-pointed {n_att} unchanged storage object(s) to "
+                          f"deployment #{deployment_id}")
+
         # B4 multi-reducer safety: compare-and-set the scope version. A conflict
         # means another reducer deployed this same observation while we were
         # running — surface it so the operator can re-check (the writes are
@@ -977,47 +1026,6 @@ def deploy_observation(
                   f"{claim.get('current')}) while this one was running.")
             print("   Both deploys' writes are present; re-check the result and "
                   "re-deploy if a re-reduction was clobbered.")
-
-        # Storage registry (#214): rows were registered durably PER BATCH during
-        # the upload (registration_flusher), before this deployment row existed.
-        # Attach them now: everything uploaded this run, plus — on a published
-        # deploy — the unchanged dedup-skipped objects, so deployment-gated
-        # intermediates ride the current deployment's visibility. On --draft,
-        # unchanged objects stay on their prior (possibly published) deployment
-        # (staging must not take live data dark). rgb/sed legacy keys have no
-        # registry rows, so their presence in uploaded_keys is a no-op here.
-        if deployment_id and push_plan is not None:
-            from campfire.deploy.registry import set_active_deployment
-            osn_keys = {t.r2_key for t in upload_tasks}
-            attach = set(uploaded_keys) & osn_keys
-            if not draft:
-                attach |= {t.r2_key for t in push_plan.unchanged}
-            if attach:
-                n_att = set_active_deployment(sb, sorted(attach), deployment_id)
-                if n_att:
-                    print(f"Attached {n_att} storage object(s) to deployment "
-                          f"#{deployment_id}")
-
-        # Rate-mask triage rows (P2, design §3.2): split-ownership upsert so a
-        # re-deploy refreshes render columns without clobbering web review state.
-        if rate_files:
-            from campfire.deploy.rate_exposures import (
-                build_rate_exposure_records, upsert_rate_exposures,
-            )
-            n_rate = upsert_rate_exposures(
-                sb, build_rate_exposure_records(rate_files, observation=obs_name, scope=scope))
-            print(f"Upserted {n_rate} rate-exposure triage rows")
-
-        # Nods-renderer grid rows (P4, design §4.2): one per (obs, exposure_root,
-        # nod, detector, source), exp_group from the CFEXPGRP header stamp.
-        # Split-ownership upsert; exposure_files is already source-filtered.
-        if exposure_files:
-            from campfire.deploy.spectrum_grid import (
-                build_spectrum_exposure_records, upsert_spectrum_exposures,
-            )
-            n_grid = upsert_spectrum_exposures(
-                sb, build_spectrum_exposure_records(exposure_files, observation=obs_name, scope=scope))
-            print(f"Upserted {n_grid} spectrum-exposure grid rows")
 
         # Closing summary — the wall of stage output above scrolls away; the
         # last block states what actually happened, in one place.

--- a/python/campfire/deploy/generate.py
+++ b/python/campfire/deploy/generate.py
@@ -142,58 +142,63 @@ def read_spectrum_data(fits_path: Path) -> dict:
     and cross-dispersion profile data.
     """
     with fits.open(fits_path) as hdul:
-        spec1d = hdul['SPEC1D'].data
-        sci = hdul['SCI'].data
-        err = hdul['ERR'].data
-        prof1d = hdul['PROF1D'].data
+        return _spectrum_data_from_hdul(hdul)
 
-        # 1D spectrum
-        wave = [round(x, 6) for x in spec1d['wave'].tolist()]
-        fnu = [None if np.isnan(x) else round(float(x), 6) for x in spec1d['fnu']]
-        fnu_err = [None if np.isnan(x) or np.isinf(x) else round(float(x), 6) for x in spec1d['fnu_err']]
 
-        # 2D S/N
-        with np.errstate(divide='ignore', invalid='ignore'):
-            snr_2d = sci / err
-            snr_2d = np.where(np.isfinite(snr_2d), snr_2d, 0)
-        snr_2d_list = [[round(x, 2) for x in row] for row in snr_2d.tolist()]
+def _spectrum_data_from_hdul(hdul) -> dict:
+    """JSON-export payload from an already-open HDUList (single-read path)."""
+    spec1d = hdul['SPEC1D'].data
+    sci = hdul['SCI'].data
+    err = hdul['ERR'].data
+    prof1d = hdul['PROF1D'].data
 
-        # Cross-dispersion profile
-        with np.errstate(divide='ignore', invalid='ignore'):
-            collapsed = np.nanmedian(sci, axis=1)
+    # 1D spectrum
+    wave = [round(x, 6) for x in spec1d['wave'].tolist()]
+    fnu = [None if np.isnan(x) else round(float(x), 6) for x in spec1d['fnu']]
+    fnu_err = [None if np.isnan(x) or np.isinf(x) else round(float(x), 6) for x in spec1d['fnu_err']]
 
-        ypos = prof1d['ypos']
-        opt_weight = prof1d['opt']
+    # 2D S/N
+    with np.errstate(divide='ignore', invalid='ignore'):
+        snr_2d = sci / err
+        snr_2d = np.where(np.isfinite(snr_2d), snr_2d, 0)
+    snr_2d_list = [[round(x, 2) for x in row] for row in snr_2d.tolist()]
 
-        valid_opt = opt_weight > 0
-        if np.any(valid_opt):
-            cen = np.average(ypos[valid_opt], weights=opt_weight[valid_opt])
-        else:
-            cen = np.median(ypos)
+    # Cross-dispersion profile
+    with np.errstate(divide='ignore', invalid='ignore'):
+        collapsed = np.nanmedian(sci, axis=1)
 
-        pix_centered = ypos - cen
+    ypos = prof1d['ypos']
+    opt_weight = prof1d['opt']
 
-        with np.errstate(divide='ignore', invalid='ignore'):
-            collapsed_norm = collapsed / np.nanmax(np.abs(collapsed[valid_opt])) if np.any(valid_opt) else collapsed
-            collapsed_norm = np.where(np.isfinite(collapsed_norm), collapsed_norm, 0)
-            opt_norm = opt_weight / np.nanmax(opt_weight) if np.nanmax(opt_weight) > 0 else opt_weight
-            # opt weights can be non-finite at masked/edge pixels; a NaN here would
-            # be serialized as the bare token `NaN` (invalid JSON) and make the
-            # browser's JSON.parse reject the whole spectrum payload. Guard it the
-            # same way as snr_2d / collapsed_norm above.
-            opt_norm = np.where(np.isfinite(opt_norm), opt_norm, 0)
+    valid_opt = opt_weight > 0
+    if np.any(valid_opt):
+        cen = np.average(ypos[valid_opt], weights=opt_weight[valid_opt])
+    else:
+        cen = np.median(ypos)
 
-        return {
-            'wave': wave,
-            'fnu': fnu,
-            'fnu_err': fnu_err,
-            'snr_2d': snr_2d_list,
-            'n_spatial': sci.shape[0],
-            'n_wave': sci.shape[1],
-            'profile': [round(float(x), 3) for x in collapsed_norm.tolist()],
-            'profile_fit': [round(float(x), 3) for x in opt_norm.tolist()],
-            'profile_pix': [round(float(x), 2) for x in pix_centered.tolist()],
-        }
+    pix_centered = ypos - cen
+
+    with np.errstate(divide='ignore', invalid='ignore'):
+        collapsed_norm = collapsed / np.nanmax(np.abs(collapsed[valid_opt])) if np.any(valid_opt) else collapsed
+        collapsed_norm = np.where(np.isfinite(collapsed_norm), collapsed_norm, 0)
+        opt_norm = opt_weight / np.nanmax(opt_weight) if np.nanmax(opt_weight) > 0 else opt_weight
+        # opt weights can be non-finite at masked/edge pixels; a NaN here would
+        # be serialized as the bare token `NaN` (invalid JSON) and make the
+        # browser's JSON.parse reject the whole spectrum payload. Guard it the
+        # same way as snr_2d / collapsed_norm above.
+        opt_norm = np.where(np.isfinite(opt_norm), opt_norm, 0)
+
+    return {
+        'wave': wave,
+        'fnu': fnu,
+        'fnu_err': fnu_err,
+        'snr_2d': snr_2d_list,
+        'n_spatial': sci.shape[0],
+        'n_wave': sci.shape[1],
+        'profile': [round(float(x), 3) for x in collapsed_norm.tolist()],
+        'profile_fit': [round(float(x), 3) for x in opt_norm.tolist()],
+        'profile_pix': [round(float(x), 2) for x in pix_centered.tolist()],
+    }
 
 
 def generate_spectrum_json(fits_path: Path, output_dir: Path) -> Path:
@@ -209,6 +214,38 @@ def generate_spectrum_json(fits_path: Path, output_dir: Path) -> Path:
         # sanitized in read_spectrum_data().
         json.dump(data, f, allow_nan=False)
     return json_path
+
+
+def generate_spectrum_products(
+    fits_path: Path, output_dir: Path,
+) -> tuple[Path, dict[str, str]]:
+    """Generate BOTH per-final derivatives in a single FITS read.
+
+    One open yields the spectrum JSON (uploaded to storage) and the
+    fnu/flambda SVG thumbnails (embedded in the spectra rows). Deploy
+    previously ran two separate passes — 'Generating content' then
+    'Generating thumbnails' — each re-opening every final off NFS.
+
+    Returns ``(json_path, thumbnails_dict)``.
+    """
+    with fits.open(fits_path) as hdul:
+        spec1d = hdul['SPEC1D'].data
+        wave_raw = spec1d['wave'].tolist()
+        fnu_raw = spec1d['fnu'].tolist()
+        data = _spectrum_data_from_hdul(hdul)
+
+    json_path = output_dir / (fits_path.stem + '.json')
+    with open(json_path, 'w') as f:
+        # allow_nan=False — see generate_spectrum_json.
+        json.dump(data, f, allow_nan=False)
+
+    thumbs = {
+        'thumbnail_svg_fnu': generate_spectrum_thumbnail_svg(
+            wave_raw, fnu_raw, flux_unit='fnu'),
+        'thumbnail_svg_flambda': generate_spectrum_thumbnail_svg(
+            wave_raw, fnu_raw, flux_unit='flambda'),
+    }
+    return json_path, thumbs
 
 
 # ---------------------------------------------------------------------------

--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -33,20 +33,16 @@ rootnames. The DB is the source of truth; the JSON file is a generated,
 fully-overwritten artifact — don't hand-edit it.
 """
 
-import hashlib
 import os
 import sys
 from collections import Counter
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
 
 from astropy.io import fits
-from tqdm import tqdm
 
 from campfire_layout import KeyScheme, Scope, storage_key
 from campfire.deploy.r2 import UploadTask, upload_files_parallel
-from campfire.deploy.registry import default_hash_workers
 from campfire.deploy.supabase import (
     claim_deploy_scope, deploy_event_metadata, get_deploy_scope_version,
     get_supabase_client, get_user_id_from_token, insert_deployment, log_deploy_event,
@@ -95,84 +91,34 @@ def _stage_from_header(header):
     return stage
 
 
-def _sci_dq_hash(path):
-    """Return ``'sha256:<hex>'`` over the SCI+DQ+CFMASK arrays, or None.
-
-    The science-only change-detection digest for the deploy dedup (epic #261, D1).
-    Reproduces ``campfire_pipeline.nircam.manifest.compute_file_hash`` deploy-side
-    (deploy must not import the pipeline): ``do_not_scale_image_data=True`` hashes
-    the raw stored bytes regardless of BZERO/BSCALE, ``memmap=False`` forces a real
-    read. Whole-file hashes churn on every pipeline re-save (header timestamps), so
-    they can't drive dedup; the SCI+DQ+CFMASK digest is stable across a
-    science-identical re-save.
-
-    CFMASK (the user manual-mask extension) is included so a mask edit — which the
-    N7 freeze records as CFMASK on the canonical without touching SCI/DQ — still
-    re-uploads the exposure. It is hashed *last*, and the ``not in hdul`` guard
-    skips it when absent, so an un-masked exposure hashes byte-identically to the
-    old SCI+DQ-only digest (no spurious re-upload on the first post-N7 deploy).
-
-    Returns None if none of the arrays are present (never dedup on an empty hash).
-    """
-    h = hashlib.sha256()
-    hashed_any = False
-    try:
-        with fits.open(path, memmap=False, do_not_scale_image_data=True) as hdul:
-            for extname in ('SCI', 'DQ', 'CFMASK'):
-                if extname not in hdul:
-                    continue
-                data = hdul[extname].data
-                if data is not None:
-                    h.update(data.tobytes())
-                    hashed_any = True
-    except Exception:
-        return None
-    return f'sha256:{h.hexdigest()}' if hashed_any else None
+# The science-only change-detection digest (SCI+DQ+CFMASK; epic #261, D1) lives
+# in the shared storage core — it is the push-dedup identity for NIRCam
+# exposures on every access point. Re-exported under the established name.
+from campfire.storage.hashing import sci_dq_hash as _sci_dq_hash  # noqa: E402
 
 
 def _compute_sci_dq_hashes(fits_tasks, *, max_workers=None):
     """Return ``{r2_key: sci_dq_hash}`` for *fits_tasks*, hashed in parallel.
 
-    Computing the SCI+DQ+CFMASK digest for every candidate exposure is the
-    dominant cost *before* any upload starts — each :func:`_sci_dq_hash` reads
-    tens of MB off disk, and a field carries hundreds of exposures. Serially
-    this is the long pause before the first byte uploads. The reads are
-    I/O-bound and overlap across threads, so a pool cuts it to a fraction of the
-    serial time. A per-file read failure records ``None`` (never dedup on it),
-    matching the serial behaviour.
+    Computing the SCI+DQ+CFMASK digest for candidate exposures is the dominant
+    local cost before any upload starts; the shared parallel hasher overlaps
+    the I/O-bound reads. A per-file read failure records ``None`` (never dedup
+    on it).
     """
+    from campfire.storage.hashing import sci_dq_hashes_parallel
+
     if not fits_tasks:
         return {}
-    workers = max(1, min(max_workers or default_hash_workers(), len(fits_tasks)))
-    out: dict[str, str | None] = {}
-    with ThreadPoolExecutor(max_workers=workers) as ex:
-        futures = {ex.submit(_sci_dq_hash, t.local_path): t.r2_key for t in fits_tasks}
-        with tqdm(total=len(futures), desc='Hashing exposures', unit='file') as pbar:
-            for fut in as_completed(futures):
-                key = futures[fut]
-                try:
-                    out[key] = fut.result()
-                except Exception:
-                    out[key] = None
-                pbar.update(1)
-    return out
+    by_path = sci_dq_hashes_parallel(
+        [t.local_path for t in fits_tasks], max_workers=max_workers,
+        progress_desc='Hashing exposures',
+    )
+    return {t.r2_key: by_path.get(Path(t.local_path)) for t in fits_tasks}
 
 
-def _upload_workers():
-    """Parallel upload streams for NIRCam OSN uploads.
-
-    Overridable via ``CAMPFIRE_DEPLOY_UPLOAD_WORKERS``. Defaults to 16 (up from
-    the shared upload helper's 12): NIRCam ships many ~20-40 MB exposure/PNG
-    files whose upload is network-bound, so extra concurrent streams help fill
-    the uplink. Clamped to a sane range.
-    """
-    raw = os.environ.get('CAMPFIRE_DEPLOY_UPLOAD_WORKERS')
-    if raw:
-        try:
-            return max(1, min(64, int(raw)))
-        except ValueError:
-            pass
-    return 16
+# Parallel upload streams (CAMPFIRE_DEPLOY_UPLOAD_WORKERS-tunable) — the shared
+# push-side default; kept under the established local name.
+from campfire.deploy.push import default_upload_workers as _upload_workers  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -615,10 +561,10 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
         print("Dry run — no changes made.")
         return
 
-    from campfire.deploy.registry import (
-        build_registry_rows, fetch_active_content_hashes, fetch_active_sci_dq_hashes,
-        hash_files_parallel, set_active_deployment, upsert_storage_objects,
+    from campfire.deploy.push import (
+        open_reducer_store, plan_remote_push, registration_flusher,
     )
+    from campfire.deploy.registry import set_active_deployment
 
     client = get_supabase_client(config)
     user_id = get_user_id_from_token(config)
@@ -642,103 +588,61 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
     print(f"Deployment #{deployment_id} recorded "
           f"({'draft — admin-only' if draft else 'published — public'})")
 
-    # --- Content-hash dedup for the canonical FITS (D1) ---------------------
-    # Compare each exposure's local sha256(SCI+DQ) to the digest already stored in
-    # the registry; skip the upload when the science is unchanged (a pipeline
-    # re-save with fresh header timestamps shifts the whole-file hash but not this).
-    # Hashed in parallel — this is the dominant "pause before uploading" cost.
-    local_sci_dq = _compute_sci_dq_hashes(fits_tasks)
-    existing_sci_dq = fetch_active_sci_dq_hashes(client, [t.r2_key for t in fits_tasks])
-    fits_to_upload = [
-        t for t in fits_tasks
-        if not (local_sci_dq.get(t.r2_key)
-                and existing_sci_dq.get(t.r2_key) == local_sci_dq[t.r2_key])
-    ]
-    n_skipped = len(fits_tasks) - len(fits_to_upload)
-    if n_skipped:
-        print(f"\nSkipping {n_skipped} unchanged exposure(s) (SCI+DQ hash match)")
+    # --- Plan the exposure/expmap/PNG push (D1 dedup, unified) ---------------
+    # One plan over every OSN-bound tree product: the differ compares NIRCam
+    # exposures on the science-only sci_dq identity (a pipeline re-save with
+    # fresh header timestamps shifts the whole-file hash but not this) and
+    # expmaps/PNGs on the whole-file hash. Files this machine already confirmed
+    # against the same cloud identity skip via the pushed_* stat fast path —
+    # without reading a byte — so an unchanged re-deploy no longer pays the
+    # "hash every exposure" pause before uploading.
+    png_upload_list = [t[0] for t in png_tasks]
+    osn_tasks = fits_tasks + expmap_tasks + png_upload_list
+    store = open_reducer_store()
+    plan, _server_rows = plan_remote_push(
+        client, store, osn_tasks, backend=_CANONICAL_BACKEND)
+    print(f"\nPlan: {plan.summary()}")
 
-    # --- Upload canonical FITS + expmaps to OSN ----------------------------
+    # --- Upload new/changed products to OSN, registering per batch -----------
+    # Visibility rides deployment.status via the storage_objects gate: published
+    # -> public to everyone, draft -> admin-only. The FITS carry a science-only
+    # sci_dq_hash for change detection; content_hash stays the authoritative
+    # whole-file digest for download/copy verification. Registration is durable
+    # per batch (registration_flusher), so an interrupted deploy resumes at file
+    # granularity instead of re-uploading everything already landed.
     upload_workers = _upload_workers()
     n_failed = 0
-    osn_tasks = fits_to_upload + expmap_tasks
     osn_uploaded: set[str] = set()
-    if osn_tasks:
-        print(f"\nUploading {len(osn_tasks)} canonical FITS/expmap(s) to OSN...")
+    flusher = registration_flusher(
+        client, store, plan, backend=_CANONICAL_BACKEND,
+        deployment_id=deployment_id, uploaded_by=user_id,
+        cfpipe_version=cfpipe_version, max_workers=upload_workers)
+    if plan.to_upload:
+        print(f"Uploading {len(plan.to_upload)} canonical FITS/expmap/PNG(s) to OSN...")
         success, failed, failures = upload_files_parallel(
-            config, osn_tasks, desc='OSN uploads', max_workers=upload_workers,
-            succeeded_out=osn_uploaded, backend=_CANONICAL_BACKEND)
+            config, plan.to_upload, desc='OSN uploads', max_workers=upload_workers,
+            succeeded_out=osn_uploaded, backend=_CANONICAL_BACKEND,
+            on_success=flusher.add)
+        flusher.flush()
         n_failed += failed
         print(f"  Uploaded: {success}, Failed: {failed}")
         for msg in failures:
             print(f"  Error: {msg}")
-
-    # --- Upload preview PNGs to OSN (canonical keys, epic #261 N5) ----------
-    # Content-hash dedup (mirrors the FITS/mosaic paths): every deploy previously
-    # re-uploaded *all* preview + native-res PNGs, which dominates a re-deploy's
-    # upload time. Skip the ones whose bytes are unchanged; the nircam_exposures
-    # png_path columns are set from the task keys regardless of upload, so a
-    # skipped PNG stays correctly referenced.
-    png_upload_list = [t[0] for t in png_tasks]
-    existing_png = fetch_active_content_hashes(client, [t.r2_key for t in png_upload_list])
-    png_hashes = hash_files_parallel([t.local_path for t in png_upload_list])
-    local_png = {t.r2_key: png_hashes.get(t.local_path, (None, 0))[0] for t in png_upload_list}
-    png_to_upload = [
-        t for t in png_upload_list
-        if not (local_png.get(t.r2_key)
-                and existing_png.get(t.r2_key) == local_png[t.r2_key])
-    ]
-    n_png_skipped = len(png_upload_list) - len(png_to_upload)
-    png_uploaded: set[str] = set()
-    if png_to_upload:
-        if n_png_skipped:
-            print(f"\nSkipping {n_png_skipped} unchanged preview PNG(s) (content-hash match)")
-        print("Uploading preview PNGs to OSN...")
-        success, failed, failures = upload_files_parallel(
-            config, png_to_upload, desc='Uploading PNGs', max_workers=upload_workers,
-            succeeded_out=png_uploaded, backend=_CANONICAL_BACKEND)
-        n_failed += failed
-        print(f"  Uploaded: {success}, Failed: {failed}")
-        for msg in failures:
-            print(f"  Error: {msg}")
-    elif n_png_skipped:
-        print(f"\nSkipping {n_png_skipped} unchanged preview PNG(s) (content-hash match)")
+    if flusher.flushed:
+        print(f"  Registered {flusher.flushed} storage object(s)")
 
     print("\nUpserting exposures to Supabase...")
     _upsert_exposures(client, records)
     print(f"  Upserted {len(records)} exposures")
 
-    # --- Register storage objects, tagged with the field deployment ---------
-    # Visibility rides deployment.status via the storage_objects gate: published ->
-    # public to everyone, draft -> admin-only. The FITS carry a science-only
-    # sci_dq_hash for change detection; content_hash stays the authoritative
-    # whole-file digest for download/copy verification.
-    n_reg = 0
-    if osn_uploaded:
-        reg_rows = build_registry_rows(
-            osn_tasks, backend=_CANONICAL_BACKEND, deployment_id=deployment_id,
-            uploaded_by=user_id, cfpipe_version=cfpipe_version,
-            succeeded_keys=osn_uploaded, sci_dq_hashes=local_sci_dq,
-            max_workers=upload_workers)
-        n_reg += upsert_storage_objects(client, reg_rows)
-    if png_uploaded:
-        reg_rows = build_registry_rows(
-            png_to_upload, backend=_CANONICAL_BACKEND, cfpipe_version=cfpipe_version,
-            deployment_id=deployment_id, uploaded_by=user_id, succeeded_keys=png_uploaded,
-            max_workers=upload_workers)
-        n_reg += upsert_storage_objects(client, reg_rows)
-    if n_reg:
-        print(f"  Registered {n_reg} storage object(s)")
-
     # Re-point dedup-skipped objects (unchanged bytes, not re-registered) to this
     # deployment so a PUBLISHED re-deploy flips the whole field consistently. NOT on
     # a --draft re-deploy: draft is staging — leave already-published unchanged
     # objects on their published deployment (only the new/changed ones stage as
-    # draft), else the whole live field goes dark. Covers both the canonical FITS
-    # and the now-deduped preview PNGs.
+    # draft), else the whole live field goes dark. Covers the canonical FITS,
+    # expmaps, and preview PNGs alike.
     if deployment_id and not draft:
-        skipped_keys = [t.r2_key for t in fits_tasks if t.r2_key not in osn_uploaded]
-        skipped_keys += [t.r2_key for t in png_upload_list if t.r2_key not in png_uploaded]
+        skipped_keys = [t.r2_key for t in plan.unchanged]
     else:
         skipped_keys = []
     if skipped_keys:
@@ -746,9 +650,13 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
         if n_moved:
             print(f"  Re-pointed {n_moved} unchanged object(s) to deployment #{deployment_id}")
 
+    # Exposure-only skip count for the audit-event metadata (fits_skipped).
+    _fits_keys = {t.r2_key for t in fits_tasks}
+    n_skipped = sum(1 for t in plan.unchanged if t.r2_key in _fits_keys)
+
     # --- Mosaics: deploy under the same field deployment (epic #261, N2) ----
     _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
-                          draft, user_id)
+                          draft, user_id, store=store)
 
     # --- Multi-reducer scope claim + audit (epic #210, B4 / D12) -----------
     claim = claim_deploy_scope(client, 'field', field, scope_version, actor=user_id)
@@ -935,61 +843,67 @@ def discover_mosaics(dirs, field, filters):
 
 
 def _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
-                          draft, user_id):
+                          draft, user_id, store=None):
     """Deploy this field's mosaics under the field deployment (epic #261, N2).
 
     Called from :func:`deploy_nircam` so ``campfire deploy --field`` ships exposures
     and mosaics as one field deployment. Uploads each mosaic product (the ``_i2d``
     cube + any split ``_sci/_err/_wht/_srcmask`` extensions) to OSN under canonical
-    keys — whole-file content-hash deduped — upserts one ``nircam_images`` row per
+    keys — whole-file content-hash deduped via the push planner (with the pushed_*
+    stat fast path, so an unchanged multi-GB mosaic is skipped without re-hashing)
+    — upserts one ``nircam_images`` row per
     ``(field, tile, filter, pixel_scale, extension)`` carrying ``deploy_status``
     (draft/published to match the deployment) + ``deployment_id``, and registers
     ``nircam_mosaic`` storage objects tagged with the deployment. Re-combine
     overwrites the same key in place (stable, version-free — D3/D4); visibility
     rides the deployment (published => public to everyone).
     """
-    from campfire.deploy.registry import (
-        fetch_active_content_hashes, hash_files_parallel, row_for_key,
-        set_active_deployment, upsert_storage_objects,
+    from campfire.deploy.push import (
+        open_reducer_store, plan_remote_push, registration_flusher,
     )
+    from campfire.deploy.registry import set_active_deployment
+
     mosaics = discover_mosaics(dirs, field, filters)
     if not mosaics:
         return
     print(f"\nMosaics: {len(mosaics)} product(s)")
 
-    # Whole-file content-hash dedup: skip re-uploading a byte-identical mosaic.
-    # Mosaics are multi-GB, so hash them in parallel rather than one at a time.
-    existing = fetch_active_content_hashes(client, [m['storage_key'] for m in mosaics])
-    mosaic_hashes = hash_files_parallel([m['path'] for m in mosaics])
-    upload_tasks = []
+    if store is None:
+        store = open_reducer_store()
+
+    mosaic_tasks = [UploadTask(local_path=m['path'], r2_key=m['storage_key'],
+                               content_type=_FITS_CONTENT_TYPE) for m in mosaics]
+    plan, server_rows = plan_remote_push(
+        client, store, mosaic_tasks, backend=_CANONICAL_BACKEND)
+    unchanged_keys = {t.r2_key for t in plan.unchanged}
+    if plan.unchanged:
+        print(f"  Skipping {len(plan.unchanged)} unchanged mosaic file(s)")
+
+    # Local file size for nircam_images.file_size: the plan stat()s every file.
     for m in mosaics:
-        local_hash, local_size = mosaic_hashes[m['path']]
-        m['content_hash'] = local_hash
-        m['size'] = local_size
-        if existing.get(m['storage_key']) != local_hash:
-            upload_tasks.append(UploadTask(local_path=m['path'],
-                                           r2_key=m['storage_key'],
-                                           content_type=_FITS_CONTENT_TYPE))
-    n_skipped = len(mosaics) - len(upload_tasks)
-    if n_skipped:
-        print(f"  Skipping {n_skipped} unchanged mosaic file(s)")
+        m['size'] = plan.stats.get(m['storage_key'], (None, None))[1]
 
     uploaded: set[str] = set()
-    if upload_tasks:
-        print(f"  Uploading {len(upload_tasks)} mosaic file(s) to OSN...")
+    flusher = registration_flusher(
+        client, store, plan, backend=_CANONICAL_BACKEND,
+        deployment_id=deployment_id, uploaded_by=user_id,
+        max_workers=_upload_workers())
+    if plan.to_upload:
+        print(f"  Uploading {len(plan.to_upload)} mosaic file(s) to OSN...")
         success, failed, failures = upload_files_parallel(
-            config, upload_tasks, desc='OSN mosaic uploads', max_workers=_upload_workers(),
-            succeeded_out=uploaded, backend=_CANONICAL_BACKEND)
+            config, plan.to_upload, desc='OSN mosaic uploads', max_workers=_upload_workers(),
+            succeeded_out=uploaded, backend=_CANONICAL_BACKEND,
+            on_success=flusher.add)
+        flusher.flush()
         print(f"    Uploaded: {success}, Failed: {failed}")
         for msg in failures:
             print(f"    Error: {msg}")
+        if flusher.flushed:
+            print(f"  Registered {flusher.flushed} mosaic storage object(s)")
 
     # A failed upload must NOT get a nircam_images row (it would advertise a
     # file_path with no object + no registry row; the slot 404s). A re-run heals.
-    present = set(uploaded) | {
-        m['storage_key'] for m in mosaics
-        if existing.get(m['storage_key']) == m['content_hash']
-    }
+    present = set(uploaded) | unchanged_keys
     # PUBLISHED: (re-)index every present mosaic under this deployment. DRAFT is
     # staging — only index the NEW/CHANGED (uploaded) mosaics as draft; leave
     # unchanged, already-published mosaics on their live deployment so the field
@@ -1009,27 +923,11 @@ def _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
     if n_failed:
         print(f"  ({n_failed} mosaic(s) not indexed — upload failed; re-run to retry)")
 
-    # Register landed objects, reusing the dedup hash (no re-hash of multi-GB files).
-    reg_rows = []
-    for m in mosaics:
-        if m['storage_key'] not in uploaded:
-            continue
-        row = row_for_key(
-            m['storage_key'], backend=_CANONICAL_BACKEND,
-            content_hash=m['content_hash'], size_bytes=m['size'],
-            content_type=_FITS_CONTENT_TYPE, deployment_id=deployment_id,
-            uploaded_by=user_id)
-        if row is not None:
-            reg_rows.append(row)
-    if reg_rows:
-        print(f"  Registered {upsert_storage_objects(client, reg_rows)} mosaic storage object(s)")
-
     # Re-point unchanged (skipped) mosaics to the current deployment — only on a
     # PUBLISHED deploy. On --draft, leave unchanged mosaics on their live deployment
     # (staging: don't take the published field dark).
     if not draft:
-        skipped_keys = [m['storage_key'] for m in mosaics
-                        if m['storage_key'] in present and m['storage_key'] not in uploaded]
+        skipped_keys = sorted(unchanged_keys - uploaded)
         if skipped_keys:
             set_active_deployment(client, skipped_keys, deployment_id)
 

--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -515,12 +515,10 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
         (filtname, basename): _read_full_png_dimensions(task.local_path)
         for task, basename, filtname, kind in png_tasks if kind == 'full'
     }
-    print(f"Preview PNGs to upload: {len(png_tasks)} "
+    print(f"Preview PNGs: {len(png_tasks)} "
           f"({len(thumb_r2_keys)} thumb, {len(full_r2_keys)} full)")
 
     fits_tasks = build_fits_upload_tasks(field, exposures)
-    print(f"→ OSN: {len(fits_tasks)} exposure(s), {len(expmap_tasks)} expmap(s), "
-          f"{n_mosaics} mosaic(s)")
 
     records = []
     for (filtname, basename), info in sorted(exposures.items()):
@@ -655,8 +653,8 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
     n_skipped = sum(1 for t in plan.unchanged if t.r2_key in _fits_keys)
 
     # --- Mosaics: deploy under the same field deployment (epic #261, N2) ----
-    _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
-                          draft, user_id, store=store)
+    mosaic_stats = _deploy_field_mosaics(dirs, field, config, client, filters,
+                                         deployment_id, draft, user_id, store=store)
 
     # --- Multi-reducer scope claim + audit (epic #210, B4 / D12) -----------
     claim = claim_deploy_scope(client, 'field', field, scope_version, actor=user_id)
@@ -681,6 +679,22 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
         suggest_fitsgl_rebuild(client, field)
     except Exception:
         pass
+
+    # Closing summary — one block stating what happened, after the stage output.
+    print()
+    print(f"Deploy complete: {field}")
+    print(f"  deployment:  #{deployment_id} "
+          f"({'draft — admin-only' if draft else 'published'})")
+    print(f"  catalog:     {len(records)} exposures"
+          + (f", {mosaic_stats['indexed']} mosaic rows" if mosaic_stats else ""))
+    files_line = (f"  files:       {len(osn_uploaded)} uploaded, "
+                  f"{len(plan.unchanged)} unchanged skipped")
+    if mosaic_stats:
+        files_line += (f"; mosaics: {mosaic_stats['uploaded']} uploaded, "
+                       f"{mosaic_stats['unchanged']} unchanged")
+    if n_failed:
+        files_line += f", {n_failed} FAILED — re-run to retry"
+    print(files_line)
 
 
 def _upsert_exposures(client, records, batch_size=500):
@@ -865,7 +879,7 @@ def _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
 
     mosaics = discover_mosaics(dirs, field, filters)
     if not mosaics:
-        return
+        return None
     print(f"\nMosaics: {len(mosaics)} product(s)")
 
     if store is None:
@@ -876,8 +890,7 @@ def _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
     plan, server_rows = plan_remote_push(
         client, store, mosaic_tasks, backend=_CANONICAL_BACKEND)
     unchanged_keys = {t.r2_key for t in plan.unchanged}
-    if plan.unchanged:
-        print(f"  Skipping {len(plan.unchanged)} unchanged mosaic file(s)")
+    print(f"  Plan: {plan.summary()}")
 
     # Local file size for nircam_images.file_size: the plan stat()s every file.
     for m in mosaics:
@@ -895,9 +908,9 @@ def _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
             succeeded_out=uploaded, backend=_CANONICAL_BACKEND,
             on_success=flusher.add)
         flusher.flush()
-        print(f"    Uploaded: {success}, Failed: {failed}")
+        print(f"  Uploaded: {success}, Failed: {failed}")
         for msg in failures:
-            print(f"    Error: {msg}")
+            print(f"  Error: {msg}")
         if flusher.flushed:
             print(f"  Registered {flusher.flushed} mosaic storage object(s)")
 
@@ -930,6 +943,9 @@ def _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
         skipped_keys = sorted(unchanged_keys - uploaded)
         if skipped_keys:
             set_active_deployment(client, skipped_keys, deployment_id)
+
+    return {'uploaded': len(uploaded), 'unchanged': len(unchanged_keys),
+            'indexed': n_img}
 
 
 def _upsert_nircam_images(client, rows, batch_size=500):

--- a/python/campfire/deploy/push.py
+++ b/python/campfire/deploy/push.py
@@ -1,0 +1,440 @@
+"""Bytes-only push: make the cloud match local products (no catalog writes).
+
+``campfire push`` is the local→cloud half of the storage plane — the mirror
+image of ``campfire pull``. It discovers tree products for a scope, diffs them
+against the **server** registry (``campfire.storage.plan``), uploads only
+new/changed content, and registers each landed object durably *per batch*
+while the transfer runs. It never touches the science catalog (targets/spectra/
+exposure upserts), never records a deployment, and never flips visibility —
+that is ``campfire deploy``'s job, which now rides this same machinery and
+dedup-skips everything a prior push already landed.
+
+The intended slow-link workflow (CANDIDE → OSN): run ``campfire push`` for the
+heavy bytes (resumable at file granularity — per-batch registration means an
+interruption costs at most one batch), then ``campfire deploy`` afterwards,
+which completes in minutes because every unchanged byte dedups.
+
+Two things to know about push semantics:
+
+* **Registry rows land with ``deployment_id=None``** (there is no deployment
+  yet). Deployment-gated objects therefore stay admin-only until a real deploy
+  attaches them (``set_active_deployment`` re-points unchanged objects at the
+  new deployment). Spectrum-family objects follow their spectrum's
+  ``deploy_status`` as always.
+* **Pushing to the key of an already-published product replaces the served
+  bytes immediately** (cloud-as-source-of-truth; same behavior as a re-deploy,
+  just decoupled from the catalog update).
+
+The local mirror ($CAMPFIRE_ROOT/meta/campfire.db — the same store ``campfire
+pull``/``status`` use) caches the server rows and records the pushed_* stat
+fast-path, so an unchanged re-push never re-reads file contents. The mirror is
+a cache, not an authority: planning always re-fetches the candidate keys from
+the server registry, so a stale mirror can never mis-skip.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+from campfire_layout import KeyScheme, Scope, storage_key
+
+from campfire.config import ensure_data_dir, meta_dir, products_dir
+from campfire.storage.hashing import sci_dq_hashes_parallel
+from campfire.storage.plan import PushPlan, identity_kind_for_key, plan_push
+from campfire.storage.transfer import BatchFlusher
+from campfire.deploy.r2 import UploadTask, upload_files_parallel
+
+# Registry columns fetched for push planning — the mirror-row shape (everything
+# the local storage_objects cache carries), so fetched rows double as a cache
+# refresh for the keys being pushed.
+_PLAN_COLUMNS = (
+    'id, backend, bucket, storage_key, content_hash, sci_dq_hash, size_bytes, '
+    'content_type, product_type, instrument, status, observation, field, '
+    'filter, spectrum_id, exposure_ref, deployment_id, cfpipe_version, '
+    'created_at, updated_at'
+)
+
+# Registration batch: server registry rows + local mirror bookkeeping are
+# flushed every N landed files, so an interrupted push loses at most one batch
+# of bookkeeping (the bytes themselves are already in the store; the next run
+# re-plans those keys as changed and re-lands them idempotently).
+REGISTRATION_BATCH = 200
+
+
+def default_upload_workers() -> int:
+    """Parallel upload streams for data pushes.
+
+    Overridable via ``CAMPFIRE_DEPLOY_UPLOAD_WORKERS``. Defaults to 16: data
+    products are many ~20-40 MB files whose upload is network-bound over a
+    high-latency link, so extra concurrent streams help fill the uplink.
+    Clamped to a sane range.
+    """
+    raw = os.environ.get('CAMPFIRE_DEPLOY_UPLOAD_WORKERS')
+    if raw:
+        try:
+            return max(1, min(64, int(raw)))
+        except ValueError:
+            pass
+    return 16
+
+
+def open_reducer_store():
+    """Open the local storage mirror for push bookkeeping, or None.
+
+    Best-effort by design: the mirror only supplies the stat fast-path and the
+    write-through cache — planning is correct without it (every candidate with
+    a comparable server identity is hashed instead of stat-skipped). A schema
+    mismatch (older client db) degrades gracefully rather than blocking a
+    deploy.
+    """
+    try:
+        from campfire.db.store import LocalStore
+        ensure_data_dir()
+        return LocalStore(meta_dir() / 'campfire.db')
+    except Exception as e:
+        print(f"  Note: local storage mirror unavailable ({e}); "
+              f"pushing without the stat fast-path.")
+        return None
+
+
+def fetch_registry_rows(client, keys: list[str], *, backend: str) -> dict[str, dict]:
+    """Fetch server registry rows for candidate keys → ``{storage_key: row}``.
+
+    Always a live, key-scoped read (chunked ``IN`` filters) — never the full
+    mirror — so push planning cannot act on stale state regardless of when
+    ``campfire sync`` last ran. ``backend`` scopes to the destination store
+    (a legacy R2 twin row must not satisfy an OSN push).
+    """
+    out: dict[str, dict] = {}
+    CHUNK = 200
+    for i in range(0, len(keys), CHUNK):
+        chunk = keys[i:i + CHUNK]
+        resp = (
+            client.table('storage_objects')
+            .select(_PLAN_COLUMNS)
+            .eq('backend', backend)
+            .in_('storage_key', chunk)
+            .execute()
+        )
+        for r in (resp.data or []):
+            out[r['storage_key']] = r
+    return out
+
+
+def plan_remote_push(
+    client,
+    store,
+    tasks: list[UploadTask],
+    *,
+    backend: str,
+    max_workers: Optional[int] = None,
+    progress: bool = True,
+) -> tuple[PushPlan, dict[str, dict]]:
+    """Plan a push: live server-row fetch + local fast-path + classification.
+
+    Returns ``(plan, server_rows)`` — callers that index derived tables (the
+    NIRCam mosaic path) need the server rows for the sizes/hashes of
+    dedup-skipped objects.
+    """
+    keys = [t.r2_key for t in tasks]
+    server_rows = fetch_registry_rows(client, keys, backend=backend)
+    local_rows = store.get_storage_rows_by_keys(keys) if store else {}
+
+    plan = plan_push(tasks, server_rows, local_rows=local_rows,
+                     max_workers=max_workers, progress=progress)
+
+    if store:
+        # Cache the fresh server rows (preserves local_*/pushed_* on conflict)
+        # and record identity-confirmed unchanged files so the next run takes
+        # the stat fast path.
+        if server_rows:
+            store.upsert_storage_objects(list(server_rows.values()))
+        for key, identity, mtime, size in plan.confirmed:
+            store.mark_object_pushed(key, identity, mtime, size, commit=False)
+        store.commit()
+
+    return plan, server_rows
+
+
+def registration_flusher(
+    client,
+    store,
+    plan: PushPlan,
+    *,
+    backend: str,
+    deployment_id: Optional[int] = None,
+    uploaded_by: Optional[str] = None,
+    cfpipe_version: Optional[str] = None,
+    max_workers: Optional[int] = None,
+    batch_size: int = REGISTRATION_BATCH,
+) -> BatchFlusher:
+    """Build the per-batch registration hook for an upload pass.
+
+    Feed the returned flusher as ``on_success=flusher.add`` to
+    ``upload_files_parallel`` and call ``flusher.flush()`` after. Every
+    ``batch_size`` landed files it: builds registry rows (reusing the plan's
+    hashes — no second read for plan-hashed files), upserts them to the server
+    registry, mirrors them locally, and records the pushed_* fast-path state.
+    Durable-progress is the point: bytes already in the store stay skippable
+    even if the process dies mid-run.
+    """
+    from campfire.deploy.registry import build_registry_rows, upsert_storage_objects
+
+    prod_dir = products_dir().resolve()
+
+    def _flush(batch: list[UploadTask]) -> None:
+        # Science-only digests for exposure-identity products: reuse the plan's
+        # value when it hashed the file, compute for plan-unhashed (new) files.
+        sci_dq: dict[str, str] = {}
+        need = []
+        for t in batch:
+            if identity_kind_for_key(t.r2_key) != 'sci_dq':
+                continue
+            h = plan.identities.get(t.r2_key)
+            if h:
+                sci_dq[t.r2_key] = h
+            else:
+                need.append(t)
+        if need:
+            by_path = sci_dq_hashes_parallel(
+                [t.local_path for t in need], max_workers=max_workers)
+            for t in need:
+                h = by_path.get(Path(t.local_path))
+                if h:
+                    sci_dq[t.r2_key] = h
+
+        rows = build_registry_rows(
+            batch, backend=backend, deployment_id=deployment_id,
+            uploaded_by=uploaded_by, cfpipe_version=cfpipe_version,
+            sci_dq_hashes=sci_dq, precomputed=plan.whole_file,
+            max_workers=max_workers,
+        )
+        upsert_storage_objects(client, rows)
+
+        if store:
+            store.upsert_storage_objects(rows)
+            by_key = {r['storage_key']: r for r in rows}
+            for t in batch:
+                row = by_key.get(t.r2_key)
+                if row is None:
+                    continue  # unregistered product type
+                try:
+                    st = os.stat(t.local_path)
+                except OSError:
+                    continue
+                kind = identity_kind_for_key(t.r2_key)
+                identity = row.get('sci_dq_hash') if kind == 'sci_dq' else row.get('content_hash')
+                store.mark_object_pushed(
+                    t.r2_key, identity, st.st_mtime, st.st_size, commit=False)
+                # Pull-side write-through: a pushed tree file IS materialized
+                # locally and byte-identical to the cloud copy — record it so
+                # `status`/`pull` see it without a verify pass. Generated
+                # (temp-dir) products fall outside the products tree and skip.
+                try:
+                    rel = Path(t.local_path).resolve().relative_to(prod_dir)
+                except ValueError:
+                    continue
+                store.mark_object_synced(
+                    storage_key=t.r2_key,
+                    local_path=str(rel),
+                    local_file_hash=row.get('content_hash'),
+                    local_file_size=st.st_size,
+                    local_file_mtime=st.st_mtime,
+                )
+            store.commit()
+
+    return BatchFlusher(_flush, batch_size=batch_size)
+
+
+# ---------------------------------------------------------------------------
+# Scope-level pushes (the `campfire push` entry points)
+# ---------------------------------------------------------------------------
+
+def push_observation(
+    obs_name: str,
+    config: dict,
+    *,
+    source_ids: Optional[list[int]] = None,
+    dry_run: bool = False,
+    workers: Optional[int] = None,
+) -> dict:
+    """Push a NIRSpec observation's tree products to OSN (bytes only).
+
+    Covers the pipeline-written products: stage-3 finals, canonical
+    spectrum-exposure intermediates, and detector rate files. Deploy-generated
+    derivatives (spectrum JSON, zfit JSON, thumbnails) are NOT pushed — they
+    are cheap, regenerated at deploy time, and belong to the publication step.
+    """
+    from campfire.deploy.deploy import resolve_obs_dir, _filter_exposures_by_source_ids
+    from campfire.deploy.discover import discover_rate_files, discover_spectrum_exposures
+    from campfire.deploy.summary import filter_by_source_ids, get_spec_paths, load_summary
+    from campfire.deploy.supabase import get_supabase_client, get_user_id_from_token
+
+    obs_dir = resolve_obs_dir(obs_name)
+    scope = Scope(obs=obs_name)
+    tasks: list[UploadTask] = []
+    cfpipe_version = None
+
+    summary = load_summary(obs_dir, obs_name, required=False)
+    if summary is not None and len(summary) > 0:
+        cfpipe_version = summary.meta.get('cfpipe_version')
+        if source_ids:
+            summary = filter_by_source_ids(summary, source_ids)
+        for p in get_spec_paths(summary, obs_dir):
+            tasks.append(UploadTask(
+                p, storage_key('nirspec_spec', scope, p.name,
+                               scheme=KeyScheme.CANONICAL),
+                'application/fits'))
+
+    exposure_files = discover_spectrum_exposures(obs_dir)
+    if source_ids:
+        exposure_files = _filter_exposures_by_source_ids(exposure_files, source_ids)
+    for p in exposure_files:
+        tasks.append(UploadTask(
+            p, storage_key('nirspec_spectrum_exposure', scope, p.name,
+                           scheme=KeyScheme.CANONICAL),
+            'application/fits'))
+
+    # Rate files are source-independent (per-detector) — never filtered.
+    for p in discover_rate_files(obs_dir):
+        tasks.append(UploadTask(
+            p, storage_key('nirspec_rate', scope, p.name,
+                           scheme=KeyScheme.CANONICAL),
+            'application/fits'))
+
+    print(f"Observation: {obs_name}")
+    print(f"  Tree products discovered: {len(tasks)}")
+    if not tasks:
+        print("  Nothing to push.")
+        return {'planned': 0, 'pushed': 0, 'failed': 0, 'skipped': 0}
+
+    client = get_supabase_client(config)
+    store = open_reducer_store()
+    plan, _server_rows = plan_remote_push(client, store, tasks, backend='osn')
+    print(f"  Plan: {plan.summary()}")
+    for t in plan.missing:
+        print(f"    missing locally: {t.local_path}")
+
+    if dry_run or not plan.to_upload:
+        if dry_run:
+            print("Dry run — no changes made.")
+        else:
+            print("  Cloud already matches local products.")
+        return {'planned': len(tasks), 'pushed': 0, 'failed': 0,
+                'skipped': len(plan.unchanged)}
+
+    user_id = get_user_id_from_token(config)
+    flusher = registration_flusher(
+        client, store, plan, backend='osn', deployment_id=None,
+        uploaded_by=user_id, cfpipe_version=cfpipe_version)
+
+    upload_workers = workers or default_upload_workers()
+    total_bytes = sum(plan.stats[t.r2_key][1] for t in plan.to_upload
+                      if t.r2_key in plan.stats)
+    print(f"  Pushing {len(plan.to_upload)} file(s) "
+          f"({total_bytes / 1e9:.2f} GB) to OSN...")
+    success, failed, failures = upload_files_parallel(
+        config, plan.to_upload, desc='Pushing to OSN',
+        max_workers=upload_workers, backend='osn', on_success=flusher.add)
+    flusher.flush()
+
+    print(f"  Pushed: {success}, Failed: {failed}, "
+          f"Skipped (unchanged): {len(plan.unchanged)}")
+    for msg in failures[:10]:
+        print(f"    Error: {msg}")
+    if len(failures) > 10:
+        print(f"    ... and {len(failures) - 10} more")
+    if failed:
+        print("  Re-run `campfire push` to retry the failed files "
+              "(landed files will dedup-skip).")
+
+    return {'planned': len(tasks), 'pushed': success, 'failed': failed,
+            'skipped': len(plan.unchanged)}
+
+
+def push_field(
+    field: str,
+    config: dict,
+    *,
+    filters: Optional[list[str]] = None,
+    dry_run: bool = False,
+    workers: Optional[int] = None,
+) -> dict:
+    """Push a NIRCam field's tree products to OSN (bytes only).
+
+    Covers canonical exposures (sci_dq identity), expmaps, preview/full PNGs,
+    and mosaics (whole-file identity). No deployment is recorded and no
+    ``nircam_exposures``/``nircam_images`` rows are touched — a later
+    ``campfire deploy --field`` attaches everything to a deployment and
+    dedup-skips the bytes this push landed.
+    """
+    from campfire.deploy.nircam import (
+        _discover_filters, _resolve_nircam_dirs, build_fits_upload_tasks,
+        build_upload_tasks, discover_expmap_tasks, discover_exposures,
+        discover_mosaics, _read_field_provenance,
+    )
+    from campfire.deploy.supabase import get_supabase_client, get_user_id_from_token
+
+    dirs = _resolve_nircam_dirs(field)
+    if not dirs['products'].exists():
+        print(f"Error: Products directory not found: {dirs['products']}")
+        return {'planned': 0, 'pushed': 0, 'failed': 0, 'skipped': 0}
+
+    available = _discover_filters(dirs)
+    filters = [f for f in (filters or available) if f in available] or available
+
+    exposures = discover_exposures(dirs, filters)
+    tasks: list[UploadTask] = list(build_fits_upload_tasks(field, exposures))
+    tasks += list(discover_expmap_tasks(dirs, field, filters))
+    tasks += [t[0] for t in build_upload_tasks(dirs, field, filters)]
+    tasks += [UploadTask(m['path'], m['storage_key'], 'application/fits')
+              for m in discover_mosaics(dirs, field, filters)]
+
+    print(f"Field: {field}")
+    print(f"  Filters: {', '.join(filters)}")
+    print(f"  Tree products discovered: {len(tasks)}")
+    if not tasks:
+        print("  Nothing to push.")
+        return {'planned': 0, 'pushed': 0, 'failed': 0, 'skipped': 0}
+
+    client = get_supabase_client(config)
+    store = open_reducer_store()
+    plan, _server_rows = plan_remote_push(client, store, tasks, backend='osn')
+    print(f"  Plan: {plan.summary()}")
+
+    if dry_run or not plan.to_upload:
+        if dry_run:
+            print("Dry run — no changes made.")
+        else:
+            print("  Cloud already matches local products.")
+        return {'planned': len(tasks), 'pushed': 0, 'failed': 0,
+                'skipped': len(plan.unchanged)}
+
+    cfpipe_version, _jwst, _crds = _read_field_provenance(dirs, field, filters)
+    user_id = get_user_id_from_token(config)
+    flusher = registration_flusher(
+        client, store, plan, backend='osn', deployment_id=None,
+        uploaded_by=user_id, cfpipe_version=cfpipe_version)
+
+    upload_workers = workers or default_upload_workers()
+    total_bytes = sum(plan.stats[t.r2_key][1] for t in plan.to_upload
+                      if t.r2_key in plan.stats)
+    print(f"  Pushing {len(plan.to_upload)} file(s) "
+          f"({total_bytes / 1e9:.2f} GB) to OSN...")
+    success, failed, failures = upload_files_parallel(
+        config, plan.to_upload, desc='Pushing to OSN',
+        max_workers=upload_workers, backend='osn', on_success=flusher.add)
+    flusher.flush()
+
+    print(f"  Pushed: {success}, Failed: {failed}, "
+          f"Skipped (unchanged): {len(plan.unchanged)}")
+    for msg in failures[:10]:
+        print(f"    Error: {msg}")
+    if failed:
+        print("  Re-run `campfire push` to retry the failed files "
+              "(landed files will dedup-skip).")
+
+    return {'planned': len(tasks), 'pushed': success, 'failed': failed,
+            'skipped': len(plan.unchanged)}

--- a/python/campfire/deploy/push.py
+++ b/python/campfire/deploy/push.py
@@ -259,6 +259,7 @@ def push_observation(
     source_ids: Optional[list[int]] = None,
     dry_run: bool = False,
     workers: Optional[int] = None,
+    dry_run_note: bool = True,
 ) -> dict:
     """Push a NIRSpec observation's tree products to OSN (bytes only).
 
@@ -318,9 +319,9 @@ def push_observation(
         print(f"    missing locally: {t.local_path}")
 
     if dry_run or not plan.to_upload:
-        if dry_run:
+        if dry_run and dry_run_note:
             print("Dry run — no changes made.")
-        else:
+        elif not dry_run:
             print("  Cloud already matches local products.")
         return {'planned': len(tasks), 'pushed': 0, 'failed': 0,
                 'skipped': len(plan.unchanged)}
@@ -361,6 +362,7 @@ def push_field(
     filters: Optional[list[str]] = None,
     dry_run: bool = False,
     workers: Optional[int] = None,
+    dry_run_note: bool = True,
 ) -> dict:
     """Push a NIRCam field's tree products to OSN (bytes only).
 
@@ -405,9 +407,9 @@ def push_field(
     print(f"  Plan: {plan.summary()}")
 
     if dry_run or not plan.to_upload:
-        if dry_run:
+        if dry_run and dry_run_note:
             print("Dry run — no changes made.")
-        else:
+        elif not dry_run:
             print("  Cloud already matches local products.")
         return {'planned': len(tasks), 'pushed': 0, 'failed': 0,
                 'skipped': len(plan.unchanged)}

--- a/python/campfire/deploy/push.py
+++ b/python/campfire/deploy/push.py
@@ -385,7 +385,20 @@ def push_field(
         return {'planned': 0, 'pushed': 0, 'failed': 0, 'skipped': 0}
 
     available = _discover_filters(dirs)
-    filters = [f for f in (filters or available) if f in available] or available
+    if filters:
+        # An explicit selection stays a selection: unknown filters are dropped
+        # with a warning, and an all-unknown selection pushes NOTHING — falling
+        # back to every filter here would turn a typo (--filter f999w) into an
+        # unintended full-field transfer.
+        missing = [f for f in filters if f not in available]
+        if missing:
+            print(f"Warning: no products for filter(s): {', '.join(missing)}")
+        filters = [f for f in filters if f in available]
+        if not filters:
+            print("No matching filters — nothing to push.")
+            return {'planned': 0, 'pushed': 0, 'failed': 0, 'skipped': 0}
+    else:
+        filters = available
 
     exposures = discover_exposures(dirs, filters)
     tasks: list[UploadTask] = list(build_fits_upload_tasks(field, exposures))

--- a/python/campfire/deploy/r2.py
+++ b/python/campfire/deploy/r2.py
@@ -16,10 +16,9 @@ fallback (issue #250):
    URLs structurally cannot express.
 
 Destinations are explicit: **data products live on OSN** under canonical keys;
-map tiles are the sole R2 exception (CDN edge); rgb/sed are dead legacy R2
-products awaiting retirement. ``backend`` is therefore a REQUIRED argument on
-the upload entry points — encoding an ``'r2'`` default was the "surely this
-deploys to R2" trap.
+map tiles are the sole R2 exception (CDN edge). ``backend`` is therefore a
+REQUIRED argument on the upload entry points — encoding an ``'r2'`` default
+was the "surely this deploys to R2" trap.
 
 Transport details shared with the download side via ``campfire.storage``:
 pooled sessions with retry (PUT is idempotent, so it retries safely),
@@ -109,8 +108,7 @@ def request_presigned_urls(
         Cache-Control header to set on uploaded objects.
     backend : str
         Storage backend to sign against — REQUIRED. 'osn' for data products
-        (canonical keys, epic #210 / #216); 'r2' only for tiles and the dead
-        legacy rgb/sed products.
+        (canonical keys, epic #210 / #216); 'r2' only for map tiles.
 
     Returns
     -------
@@ -399,8 +397,7 @@ def upload_files_parallel(
         the caller can register exactly what landed (used for storage_objects).
     backend : str
         Destination backend — REQUIRED, no default. 'osn' for all data products
-        (canonical keys; epic #210 / #216). 'r2' is correct ONLY for map tiles
-        and the dead legacy rgb/sed products.
+        (canonical keys; epic #210 / #216). 'r2' is correct ONLY for map tiles.
     on_success : callable, optional
         ``on_success(task)`` runs on the calling thread as each upload lands —
         the hook for durable mid-transfer bookkeeping (per-batch registry

--- a/python/campfire/deploy/r2.py
+++ b/python/campfire/deploy/r2.py
@@ -1,5 +1,4 @@
-"""
-Object-store upload helpers.
+"""Object-store upload transport, built on the shared ``campfire.storage`` core.
 
 Two upload modes, selected by the resolved deploy auth mode — NOT by a silent
 fallback (issue #250):
@@ -15,22 +14,36 @@ fallback (issue #250):
    maintenance paths (``remove`` / ``reconcile`` / ``registry copy``) use for the
    LIST / HEAD / DELETE / cross-bucket-COPY operations that presigned PutObject
    URLs structurally cannot express.
+
+Destinations are explicit: **data products live on OSN** under canonical keys;
+map tiles are the sole R2 exception (CDN edge); rgb/sed are dead legacy R2
+products awaiting retirement. ``backend`` is therefore a REQUIRED argument on
+the upload entry points — encoding an ``'r2'`` default was the "surely this
+deploys to R2" trap.
+
+Transport details shared with the download side via ``campfire.storage``:
+pooled sessions with retry (PUT is idempotent, so it retries safely),
+just-in-time presign batches (URLs are minted per 500-task batch immediately
+before that batch transfers, so a multi-hour push never races the 1-hour
+presign TTL), and per-item success callbacks that run on the calling thread
+(safe for registry/mirror bookkeeping mid-transfer).
 """
 
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from typing import NamedTuple, Optional
+from typing import Callable, NamedTuple, Optional
+
+import requests as http_requests  # module-global: patchable seam for tests
 from urllib.parse import urlparse
 
-import requests as http_requests
-from tqdm import tqdm
+from campfire.storage.session import create_transfer_session
+from campfire.storage.transfer import run_transfers
 
 # A returned presigned URL on this host means the web route signed R2, not OSN.
 _R2_PRESIGN_HOST_FRAGMENT = 'r2.cloudflarestorage.com'
 
 
 class UploadTask(NamedTuple):
-    """Represents a file to be uploaded to R2."""
+    """Represents a file to be uploaded to the object store."""
     local_path: Path
     r2_key: str
     content_type: str
@@ -40,7 +53,7 @@ class UploadTask(NamedTuple):
 # Presigned URL mode
 # ---------------------------------------------------------------------------
 
-PRESIGN_BATCH_SIZE = 500  # Max URLs per presign request
+PRESIGN_BATCH_SIZE = 500  # Max URLs per presign request (matches the web route)
 
 
 def _get_presign_headers(config: dict) -> Optional[dict]:
@@ -78,7 +91,8 @@ def request_presigned_urls(
     tasks: list[UploadTask],
     bucket: str = 'data',
     cache_control: Optional[str] = None,
-    backend: str = 'r2',
+    *,
+    backend: str,
 ) -> Optional[dict[str, str]]:
     """
     Request presigned PutObject URLs from the web API in batches.
@@ -94,16 +108,15 @@ def request_presigned_urls(
     cache_control : str, optional
         Cache-Control header to set on uploaded objects.
     backend : str
-        Storage backend to sign against: 'r2' (default) or 'osn'. 'osn' signs
-        canonical data keys against the OSN bucket (epic #210 / #216 — deploy →
-        OSN); the web route requires ``backend='osn'`` to be implemented for this
-        to land in OSN rather than R2 (see the host guard in upload_files_parallel).
+        Storage backend to sign against — REQUIRED. 'osn' for data products
+        (canonical keys, epic #210 / #216); 'r2' only for tiles and the dead
+        legacy rgb/sed products.
 
     Returns
     -------
     dict or None
         Mapping of r2_key → presigned URL, or None if presigning
-        is not available (falls back to direct upload).
+        is not available (the caller decides how loudly to fail).
     """
     headers = _get_presign_headers(config)
     if not headers:
@@ -162,10 +175,17 @@ def _assert_presigned_backend_osn(urls: dict[str, str]) -> None:
         )
 
 
-def _upload_to_presigned_url(url: str, local_path: Path, content_type: str) -> None:
-    """Upload a single file to a presigned PutObject URL."""
+def _upload_to_presigned_url(
+    session, url: str, local_path: Path, content_type: str,
+) -> None:
+    """Upload a single file to a presigned PutObject URL via a pooled session.
+
+    The shared session gives each worker a persistent connection (one TCP+TLS
+    handshake per thread, not per file) and retries transient failures —
+    presigned PutObject is idempotent, so a retried PUT can only converge.
+    """
     with open(local_path, 'rb') as f:
-        resp = http_requests.put(
+        resp = session.put(
             url,
             data=f,
             headers={'Content-Type': content_type},
@@ -180,6 +200,9 @@ def upload_files_presigned(
     max_workers: int = 12,
     desc: str = 'Uploading',
     succeeded_out: Optional[set[str]] = None,
+    *,
+    session=None,
+    on_success: Optional[Callable[[UploadTask], None]] = None,
 ) -> tuple[int, int, list[str]]:
     """
     Upload files using presigned URLs.
@@ -198,46 +221,46 @@ def upload_files_presigned(
         If given, the ``r2_key`` of each successfully-uploaded object is added to
         this set. Lets the caller register only objects that actually landed
         (write-after-success) without changing the return arity.
+    session : requests.Session, optional
+        Pooled transfer session to reuse across batches. Created per-call when
+        omitted.
+    on_success : callable, optional
+        ``on_success(task)`` runs on the calling thread as each upload lands —
+        safe for single-threaded bookkeeping (registry batches, the local
+        mirror) *during* the transfer, which is what makes an interrupted push
+        resumable at file granularity.
 
     Returns
     -------
     tuple
         (success_count, failure_count, list_of_failure_messages)
     """
-    if not tasks:
+    runnable = [t for t in tasks if t.r2_key in urls]
+    if not runnable:
         return 0, 0, []
 
-    success, failed = 0, 0
-    failed_files: list[str] = []
+    if session is None:
+        session = create_transfer_session(max_workers, methods=("GET", "PUT"))
 
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        future_to_task = {
-            executor.submit(
-                _upload_to_presigned_url,
-                urls[task.r2_key], task.local_path, task.content_type,
-            ): task
-            for task in tasks
-            if task.r2_key in urls
-        }
+    def _success(task: UploadTask, _result) -> None:
+        if succeeded_out is not None:
+            succeeded_out.add(task.r2_key)
+        if on_success is not None:
+            on_success(task)
 
-        with tqdm(total=len(future_to_task), desc=desc, unit='file') as pbar:
-            for future in as_completed(future_to_task):
-                task = future_to_task[future]
-                try:
-                    future.result()
-                    success += 1
-                    if succeeded_out is not None:
-                        succeeded_out.add(task.r2_key)
-                except Exception as e:
-                    failed += 1
-                    failed_files.append(f"{task.local_path.name}: {e}")
-                pbar.update(1)
-
-    return success, failed, failed_files
+    result = run_transfers(
+        runnable,
+        lambda t: _upload_to_presigned_url(session, urls[t.r2_key], t.local_path, t.content_type),
+        max_workers=max_workers,
+        desc=desc,
+        label=lambda t: t.local_path.name,
+        on_success=_success,
+    )
+    return result.succeeded, result.failed, result.failures
 
 
 # ---------------------------------------------------------------------------
-# Direct boto3 mode (legacy fallback)
+# Direct boto3 mode (explicit service-role / local opt-in)
 # ---------------------------------------------------------------------------
 
 def get_r2_client(config: dict):
@@ -270,7 +293,7 @@ def upload_to_r2(
     content_type: str | None = None,
     cache_control: str | None = None,
 ) -> None:
-    """Upload a single file to R2 via boto3."""
+    """Upload a single file via boto3 (any S3-compatible backend)."""
     extra_args = {}
     if content_type:
         extra_args['ContentType'] = content_type
@@ -292,11 +315,15 @@ def upload_files_direct(
     max_workers: int = 12,
     desc: str = 'Uploading',
     succeeded_out: Optional[set[str]] = None,
+    *,
+    cache_control: Optional[str] = None,
+    on_success: Optional[Callable[[UploadTask], None]] = None,
 ) -> tuple[int, int, list[str]]:
     """
-    Upload multiple files to R2 via boto3 in parallel with progress bar.
+    Upload multiple files via boto3 in parallel with progress bar.
 
-    ``succeeded_out``, if given, collects the ``r2_key`` of each landed object.
+    ``succeeded_out``, if given, collects the ``r2_key`` of each landed object;
+    ``on_success(task)`` runs on the calling thread per landed object.
 
     Returns
     -------
@@ -306,32 +333,22 @@ def upload_files_direct(
     if not tasks:
         return 0, 0, []
 
-    success, failed = 0, 0
-    failed_files: list[str] = []
+    def _success(task: UploadTask, _result) -> None:
+        if succeeded_out is not None:
+            succeeded_out.add(task.r2_key)
+        if on_success is not None:
+            on_success(task)
 
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        future_to_task = {
-            executor.submit(
-                upload_to_r2, client, bucket,
-                task.local_path, task.r2_key, task.content_type,
-            ): task
-            for task in tasks
-        }
-
-        with tqdm(total=len(tasks), desc=desc, unit='file') as pbar:
-            for future in as_completed(future_to_task):
-                task = future_to_task[future]
-                try:
-                    future.result()
-                    success += 1
-                    if succeeded_out is not None:
-                        succeeded_out.add(task.r2_key)
-                except Exception as e:
-                    failed += 1
-                    failed_files.append(f"{task.local_path.name}: {e}")
-                pbar.update(1)
-
-    return success, failed, failed_files
+    result = run_transfers(
+        tasks,
+        lambda t: upload_to_r2(client, bucket, t.local_path, t.r2_key,
+                               t.content_type, cache_control),
+        max_workers=max_workers,
+        desc=desc,
+        label=lambda t: t.local_path.name,
+        on_success=_success,
+    )
+    return result.succeeded, result.failed, result.failures
 
 
 # ---------------------------------------------------------------------------
@@ -346,16 +363,22 @@ def upload_files_parallel(
     desc: str = 'Uploading',
     cache_control: Optional[str] = None,
     succeeded_out: Optional[set[str]] = None,
-    backend: str = 'r2',
+    *,
+    backend: str,
+    on_success: Optional[Callable[[UploadTask], None]] = None,
 ) -> tuple[int, int, list[str]]:
     """
-    Upload files to the data store, dispatching on the resolved deploy auth mode.
+    Upload files to the object store, dispatching on the resolved deploy auth mode.
 
     This is the main entry point for all uploads. In ``login`` mode (the default)
     it uploads via presigned URLs ONLY — if presigning is unavailable it raises,
     rather than silently falling back to direct boto3 (the footgun #250 removed).
     In the explicit ``service_role`` / ``local`` modes it uploads directly with
     boto3 using local object-store credentials.
+
+    Presigned URLs are minted **just-in-time per batch** (500 tasks), so a push
+    that runs longer than the 1-hour presign TTL never fails late files on
+    signature expiry.
 
     Parameters
     ----------
@@ -364,7 +387,7 @@ def upload_files_parallel(
     tasks : list[UploadTask]
         Files to upload.
     bucket_id : str
-        'data' for spectra/rgb/sed, 'tiles' for map tiles.
+        'data' for data products, 'tiles' for map tiles.
     max_workers : int
         Parallel upload threads.
     desc : str
@@ -375,10 +398,13 @@ def upload_files_parallel(
         If given, collects the ``r2_key`` of each successfully-uploaded object so
         the caller can register exactly what landed (used for storage_objects).
     backend : str
-        Destination backend: 'r2' (default) or 'osn'. 'osn' routes NIRSpec
-        canonical products to OSN (epic #210 / #216). The presigned path signs
-        against OSN via the web route; the direct-boto3 fallback resolves the
-        'osn' purpose (CAMPFIRE_S3_OSN_*).
+        Destination backend — REQUIRED, no default. 'osn' for all data products
+        (canonical keys; epic #210 / #216). 'r2' is correct ONLY for map tiles
+        and the dead legacy rgb/sed products.
+    on_success : callable, optional
+        ``on_success(task)`` runs on the calling thread as each upload lands —
+        the hook for durable mid-transfer bookkeeping (per-batch registry
+        writes, local-mirror updates).
 
     Returns
     -------
@@ -392,27 +418,40 @@ def upload_files_parallel(
     # fallback. In login mode (default) uploads go only via presigned URLs.
     mode = config.get('supabase', {}).get('_auth_mode')
     if mode not in ('service_role', 'local'):
-        urls = request_presigned_urls(
-            config, tasks, bucket=bucket_id, cache_control=cache_control, backend=backend,
-        )
-        if not urls:
-            raise RuntimeError(
-                "Presigned upload URLs are unavailable, and login-mode deploys "
-                "upload only via presigned URLs (no direct-S3 fallback — issue #250). "
-                "This usually means the login session expired or the deploy API is "
-                "unreachable. Re-run `campfire login`; or, for an unattended run, set "
-                "CAMPFIRE_DEPLOY_MODE=service-role with CAMPFIRE_S3_* credentials to "
-                "upload directly."
+        session = create_transfer_session(max_workers, methods=("GET", "PUT"))
+        total_success, total_failed = 0, 0
+        all_failures: list[str] = []
+        # Just-in-time presigning: mint each batch's URLs immediately before
+        # that batch uploads so none can expire mid-run.
+        for i in range(0, len(tasks), PRESIGN_BATCH_SIZE):
+            batch = tasks[i:i + PRESIGN_BATCH_SIZE]
+            urls = request_presigned_urls(
+                config, batch, bucket=bucket_id, cache_control=cache_control,
+                backend=backend,
             )
-        # Guard against a web deployment that predates OSN upload support: an old
-        # /deploy/presign ignores `backend` and signs R2, which would land bytes in
-        # R2 under canonical keys while the registry records backend='osn' — silent
-        # divergence. Refuse if we asked for OSN but got R2-host URLs.
-        if backend == 'osn':
-            _assert_presigned_backend_osn(urls)
-        return upload_files_presigned(
-            urls, tasks, max_workers=max_workers, desc=desc, succeeded_out=succeeded_out,
-        )
+            if not urls:
+                raise RuntimeError(
+                    "Presigned upload URLs are unavailable, and login-mode deploys "
+                    "upload only via presigned URLs (no direct-S3 fallback — issue #250). "
+                    "This usually means the login session expired or the deploy API is "
+                    "unreachable. Re-run `campfire login`; or, for an unattended run, set "
+                    "CAMPFIRE_DEPLOY_MODE=service-role with CAMPFIRE_S3_* credentials to "
+                    "upload directly."
+                )
+            # Guard against a web deployment that predates OSN upload support: an old
+            # /deploy/presign ignores `backend` and signs R2, which would land bytes in
+            # R2 under canonical keys while the registry records backend='osn' — silent
+            # divergence. Refuse if we asked for OSN but got R2-host URLs.
+            if backend == 'osn':
+                _assert_presigned_backend_osn(urls)
+            s, f, msgs = upload_files_presigned(
+                urls, batch, max_workers=max_workers, desc=desc,
+                succeeded_out=succeeded_out, session=session, on_success=on_success,
+            )
+            total_success += s
+            total_failed += f
+            all_failures.extend(msgs)
+        return total_success, total_failed, all_failures
 
     # Explicit direct-boto3 upload via the per-purpose backend factory.
     from campfire.deploy.backend import (
@@ -433,44 +472,12 @@ def upload_files_parallel(
     # A present-but-incomplete section surfaces resolve_backend's specific
     # diagnostic (which key/endpoint is missing), not the generic message above.
     backend_cfg = resolve_backend(config, purpose)
-    client = make_s3_client(backend_cfg)
-    bucket_name = backend_cfg.bucket
-
-    # For direct mode, apply cache_control per-file
-    if cache_control:
-        original_tasks = tasks
-        tasks_with_cache = []
-        for task in original_tasks:
-            tasks_with_cache.append(task)
-
-        success, failed = 0, 0
-        failed_files: list[str] = []
-
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            future_to_task = {
-                executor.submit(
-                    upload_to_r2, client, bucket_name,
-                    task.local_path, task.r2_key, task.content_type, cache_control,
-                ): task
-                for task in tasks
-            }
-
-            with tqdm(total=len(tasks), desc=desc, unit='file') as pbar:
-                for future in as_completed(future_to_task):
-                    task = future_to_task[future]
-                    try:
-                        future.result()
-                        success += 1
-                        if succeeded_out is not None:
-                            succeeded_out.add(task.r2_key)
-                    except Exception as e:
-                        failed += 1
-                        failed_files.append(f"{task.local_path.name}: {e}")
-                    pbar.update(1)
-
-        return success, failed, failed_files
+    # Pool sized to the worker count: botocore's default pool (10) is smaller
+    # than the thread pools used here, which silently serializes the excess.
+    client = make_s3_client(backend_cfg, max_pool_connections=max(max_workers, 10))
 
     return upload_files_direct(
-        client, bucket_name, tasks, max_workers=max_workers, desc=desc,
-        succeeded_out=succeeded_out,
+        client, backend_cfg.bucket, tasks, max_workers=max_workers, desc=desc,
+        succeeded_out=succeeded_out, cache_control=cache_control,
+        on_success=on_success,
     )

--- a/python/campfire/deploy/registry.py
+++ b/python/campfire/deploy/registry.py
@@ -28,7 +28,6 @@ byte-aggregated in ``map_layers.total_size_bytes`` (the budget RPC unions both).
 
 from __future__ import annotations
 
-import hashlib
 import os
 import tempfile
 from dataclasses import dataclass, field
@@ -48,9 +47,6 @@ from campfire_layout.products import get as get_product
 
 from campfire.deploy.r2 import UploadTask, download_to_path, upload_to_r2
 
-# Streamed-hash chunk size (1 MiB).
-_HASH_CHUNK = 1 << 20
-
 # Supabase upsert batch size — matches batch_upsert_spectra.
 UPSERT_BATCH = 500
 
@@ -61,56 +57,16 @@ UNREGISTERED_PRODUCT_TYPES = frozenset({'rgb', 'sed'})
 
 
 # ---------------------------------------------------------------------------
-# Hashing
+# Hashing — single implementation lives in campfire.storage.hashing; these
+# names are re-exported here for the deploy-side callers (and tests) that
+# import them from the registry module.
 # ---------------------------------------------------------------------------
 
-def hash_file(path: Path) -> tuple[str, int]:
-    """Return ``('sha256:<hex>', size_bytes)`` for a local file, streamed."""
-    h = hashlib.sha256()
-    size = 0
-    with open(path, 'rb') as f:
-        while True:
-            chunk = f.read(_HASH_CHUNK)
-            if not chunk:
-                break
-            h.update(chunk)
-            size += len(chunk)
-    return f"sha256:{h.hexdigest()}", size
-
-
-def default_hash_workers() -> int:
-    """Thread count for parallel local-file hashing.
-
-    Whole-file (and NIRCam SCI+DQ) hashing of a field's worth of exposures is
-    I/O-bound — the reads overlap well across threads, so a small pool cuts the
-    serial hash time to a fraction. Sized off the CPU count and capped so we
-    don't thrash a spinning disk with too many concurrent large reads.
-    """
-    return min(16, (os.cpu_count() or 4) * 2)
-
-
-def hash_files_parallel(
-    paths: Iterable[Path], *, max_workers: Optional[int] = None,
-) -> dict[Path, tuple[str, int]]:
-    """Hash many local files concurrently → ``{path: ('sha256:<hex>', size)}``.
-
-    Order-independent (callers key by path). De-duplicates repeated paths so a
-    file is hashed once. Falls back to a serial loop for a single file.
-    """
-    from concurrent.futures import ThreadPoolExecutor, as_completed
-
-    unique = list({Path(p) for p in paths})
-    if not unique:
-        return {}
-    workers = max(1, min(max_workers or default_hash_workers(), len(unique)))
-    if workers == 1:
-        return {p: hash_file(p) for p in unique}
-    out: dict[Path, tuple[str, int]] = {}
-    with ThreadPoolExecutor(max_workers=workers) as ex:
-        futures = {ex.submit(hash_file, p): p for p in unique}
-        for fut in as_completed(futures):
-            out[futures[fut]] = fut.result()
-    return out
+from campfire.storage.hashing import (  # noqa: E402  (re-export)
+    default_hash_workers,
+    hash_file,
+    hash_files_parallel,
+)
 
 
 def normalize_sha256(file_hash: str | None) -> str | None:
@@ -267,6 +223,7 @@ def build_registry_rows(
     succeeded_keys: Optional[set[str]] = None,
     sci_dq_hashes: Optional[dict[str, str]] = None,
     max_workers: Optional[int] = None,
+    precomputed: Optional[dict[str, tuple[str, int]]] = None,
 ) -> list[dict]:
     """Build ``storage_objects`` rows for the objects an upload actually landed.
 
@@ -282,8 +239,13 @@ def build_registry_rows(
     digest per storage key (NIRCam exposures, epic #261) — the ``content_hash`` is
     still the whole-file sha256, but ``sci_dq_hash`` carries the science-only digest
     that change-detection compares against.
+
+    ``precomputed`` optionally supplies ``{r2_key: ('sha256:<hex>', size)}``
+    whole-file digests already computed upstream (the push planner hashes
+    changed files to decide the upload) — those files are not re-read here.
     """
     sci_dq_hashes = sci_dq_hashes or {}
+    precomputed = precomputed or {}
     selected: list[tuple[UploadTask, Path]] = []
     for task in tasks:
         if succeeded_keys is not None and task.r2_key not in succeeded_keys:
@@ -293,11 +255,14 @@ def build_registry_rows(
             continue
         selected.append((task, local))
 
-    hashed = hash_files_parallel((local for _, local in selected), max_workers=max_workers)
+    hashed = hash_files_parallel(
+        (local for task, local in selected if task.r2_key not in precomputed),
+        max_workers=max_workers,
+    )
 
     rows: list[dict] = []
     for task, local in selected:
-        content_hash, size_bytes = hashed[local]
+        content_hash, size_bytes = precomputed.get(task.r2_key) or hashed[local]
         row = row_for_key(
             task.r2_key,
             backend=backend,
@@ -709,9 +674,16 @@ def _osn_client_and_bucket(config: dict, *, max_pool_connections: Optional[int] 
             bcfg.bucket, bcfg.backend)
 
 
-def list_bucket_keys(config: dict, prefix: str = '') -> Iterator[str]:
-    """Yield every object key under ``prefix`` in the data bucket (paginated)."""
-    client, bucket, _ = _data_client_and_bucket(config)
+def list_bucket_keys(config: dict, prefix: str = '', *, purpose: str = 'data') -> Iterator[str]:
+    """Yield every object key under ``prefix`` in a data bucket (paginated).
+
+    ``purpose`` selects the backend block: ``'data'`` (the legacy R2 data
+    bucket) or ``'osn'`` (the OSN home of all current data products).
+    """
+    if purpose == 'osn':
+        client, bucket, _ = _osn_client_and_bucket(config)
+    else:
+        client, bucket, _ = _data_client_and_bucket(config)
     token = None
     while True:
         kwargs = {'Bucket': bucket, 'Prefix': prefix}
@@ -723,6 +695,61 @@ def list_bucket_keys(config: dict, prefix: str = '') -> Iterator[str]:
         if not resp.get('IsTruncated'):
             break
         token = resp.get('NextContinuationToken')
+
+
+def cloud_reconcile_report(config: dict, client, *, include_buckets: bool = True) -> dict:
+    """Multi-backend registry↔bucket↔DB verification (``campfire verify --cloud``).
+
+    Three vocabularies are compared: the live denormalized DB pointers, the
+    registry rows, and — per storage backend — the actual bucket contents.
+    **OSN is the primary data bucket** (all current data products live there;
+    map tiles are the sole R2 exception), so the OSN LIST is the one that
+    verifies current products; the legacy R2 data-bucket LIST covers pre-#216
+    remnants until A2 retires them. Each backend's ``dangling`` is computed
+    only over registry rows homed on that backend.
+
+    Returns a JSON-able dict; ``ok`` is False when live pointers lack registry
+    rows (``missing``) or registry rows lack bucket objects (``dangling``) —
+    the drift conditions a scheduled CI run should alarm on. A bucket whose
+    credentials are unavailable is reported under ``errors`` and does NOT fail
+    the report (coverage is still checked).
+    """
+    pointers = live_pointers(client)
+    live = pointers['spectra'] + pointers['nircam_images'] + pointers['nircam_exposures']
+    reg_keys = registry_keys(client)
+
+    base = compute_reconcile(live, reg_keys, None)
+    report: dict = {
+        'live_pointers': len({k for k in live if k}),
+        'registry_rows': len(set(reg_keys)),
+        'missing': sorted(base.missing),
+        'backends': {},
+        'errors': {},
+    }
+
+    if include_buckets:
+        # (purpose, registry backend label) — OSN first: it is the data home.
+        targets = [('osn', 'osn'), ('data', resolve_backend_label(config))]
+        for purpose, label in targets:
+            try:
+                bucket_keys = list(list_bucket_keys(config, purpose=purpose))
+            except Exception as e:
+                report['errors'][label] = str(e)
+                continue
+            danglable = registry_keys(client, backend=label)
+            rep = compute_reconcile(live, reg_keys, bucket_keys,
+                                    danglable_keys=danglable)
+            report['backends'][label] = {
+                'bucket_objects': len(bucket_keys),
+                'registry_rows': len(set(danglable)),
+                'dangling': sorted(rep.dangling),
+                'orphans': sorted(rep.orphans),
+                'adoptable': sorted(rep.adoptable),
+            }
+
+    any_dangling = any(b['dangling'] for b in report['backends'].values())
+    report['ok'] = not report['missing'] and not any_dangling
+    return report
 
 
 def head_object(config: dict, key: str) -> tuple[str | None, int | None]:

--- a/python/campfire/deploy/tiles.py
+++ b/python/campfire/deploy/tiles.py
@@ -128,6 +128,9 @@ def upload_tiles(
             config, tasks, bucket_id='tiles', max_workers=max_workers,
             desc=f"{field}/{fname}",
             cache_control='public, max-age=31536000, immutable',
+            # Map tiles are the SOLE product that lives on R2 (CDN edge);
+            # everything else deploys to OSN.
+            backend='r2',
         )
 
         if failed:

--- a/python/campfire/storage/__init__.py
+++ b/python/campfire/storage/__init__.py
@@ -1,0 +1,40 @@
+"""Shared local↔cloud storage engine.
+
+One transfer core for both directions of the storage plane:
+
+* ``campfire pull`` / ``campfire download`` — cloud→local (presigned GET)
+* ``campfire push`` / ``campfire deploy``   — local→cloud (presigned PUT)
+
+The pieces here were previously duplicated between the consumer sync engine
+(``campfire/sync.py``) and the deploy transport (``campfire/deploy/r2.py``):
+two SHA-256 streamers with different chunk sizes, two thread-pool transfer
+loops, two presign clients, and sessions with retry on one side only. This
+package is the single implementation; both sides delegate to it.
+
+Backend vocabulary is purpose-based, never provider-based: ``data`` products
+live on **OSN** under canonical keys; map ``tiles`` are the sole R2 exception
+(CDN edge). Nothing in this package defaults to a backend — call sites say it
+out loud (see ``presign.request_put_urls``).
+"""
+
+from .hashing import (
+    compute_file_hash,
+    default_hash_workers,
+    hash_file,
+    hash_files_parallel,
+    sci_dq_hash,
+)
+from .session import create_transfer_session
+from .transfer import BatchFlusher, TransferResult, run_transfers
+
+__all__ = [
+    "BatchFlusher",
+    "TransferResult",
+    "compute_file_hash",
+    "create_transfer_session",
+    "default_hash_workers",
+    "hash_file",
+    "hash_files_parallel",
+    "run_transfers",
+    "sci_dq_hash",
+]

--- a/python/campfire/storage/hashing.py
+++ b/python/campfire/storage/hashing.py
@@ -59,23 +59,36 @@ def default_hash_workers() -> int:
 
 def hash_files_parallel(
     paths: Iterable[Path], *, max_workers: Optional[int] = None,
+    progress_desc: Optional[str] = None,
 ) -> dict[Path, tuple[str, int]]:
     """Hash many local files concurrently → ``{path: ('sha256:<hex>', size)}``.
 
     Order-independent (callers key by path). De-duplicates repeated paths so a
     file is hashed once. Falls back to a serial loop for a single file.
+    ``progress_desc`` shows a tqdm bar — hashing hundreds of GB off NFS takes
+    minutes, and silence there is indistinguishable from a hang.
     """
     unique = list({Path(p) for p in paths})
     if not unique:
         return {}
     workers = max(1, min(max_workers or default_hash_workers(), len(unique)))
-    if workers == 1:
+    if workers == 1 and not progress_desc:
         return {p: hash_file(p) for p in unique}
+    pbar = None
+    if progress_desc:
+        from tqdm import tqdm
+        pbar = tqdm(total=len(unique), desc=progress_desc, unit='file')
     out: dict[Path, tuple[str, int]] = {}
-    with ThreadPoolExecutor(max_workers=workers) as ex:
-        futures = {ex.submit(hash_file, p): p for p in unique}
-        for fut in as_completed(futures):
-            out[futures[fut]] = fut.result()
+    try:
+        with ThreadPoolExecutor(max_workers=workers) as ex:
+            futures = {ex.submit(hash_file, p): p for p in unique}
+            for fut in as_completed(futures):
+                out[futures[fut]] = fut.result()
+                if pbar:
+                    pbar.update(1)
+    finally:
+        if pbar:
+            pbar.close()
     return out
 
 

--- a/python/campfire/storage/hashing.py
+++ b/python/campfire/storage/hashing.py
@@ -1,0 +1,153 @@
+"""Content hashing — the single implementation for both transfer directions.
+
+Two kinds of content identity live here:
+
+* **Whole-file** (``hash_file`` / ``compute_file_hash``): the authoritative
+  ``content_hash`` stored in the ``storage_objects`` registry and verified on
+  download. Byte-exact, so it churns whenever a FITS is re-saved with fresh
+  header timestamps.
+* **Science-only** (``sci_dq_hash``): SHA-256 over the SCI+DQ+CFMASK arrays of
+  a FITS file — the *change-detection* identity for push dedup (epic #261, D1).
+  Stable across a science-identical re-save, which is exactly why whole-file
+  hashes can't drive "should I re-upload this exposure".
+
+Historically ``campfire/sync.py`` and ``campfire/deploy/registry.py`` each had
+their own streamer (64 KB vs 1 MB chunks, hash-only vs hash+size); both now
+delegate here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Iterable, Optional
+
+_HASH_CHUNK = 1 << 20  # 1 MB: one sequential read beats many small reads on NFS
+
+
+def hash_file(path: Path) -> tuple[str, int]:
+    """Return ``('sha256:<hex>', size_bytes)`` for a local file, streamed."""
+    h = hashlib.sha256()
+    size = 0
+    with open(path, 'rb') as f:
+        while True:
+            chunk = f.read(_HASH_CHUNK)
+            if not chunk:
+                break
+            h.update(chunk)
+            size += len(chunk)
+    return f"sha256:{h.hexdigest()}", size
+
+
+def compute_file_hash(path: Path) -> str:
+    """SHA-256 of a file as ``'sha256:<hex>'`` (hash only, no size)."""
+    return hash_file(Path(path))[0]
+
+
+def default_hash_workers() -> int:
+    """Thread count for parallel local-file hashing.
+
+    Whole-file (and NIRCam SCI+DQ) hashing of a field's worth of exposures is
+    I/O-bound — the reads overlap well across threads, so a small pool cuts the
+    serial hash time to a fraction. Sized off the CPU count and capped so we
+    don't thrash a spinning disk with too many concurrent large reads.
+    """
+    return min(16, (os.cpu_count() or 4) * 2)
+
+
+def hash_files_parallel(
+    paths: Iterable[Path], *, max_workers: Optional[int] = None,
+) -> dict[Path, tuple[str, int]]:
+    """Hash many local files concurrently → ``{path: ('sha256:<hex>', size)}``.
+
+    Order-independent (callers key by path). De-duplicates repeated paths so a
+    file is hashed once. Falls back to a serial loop for a single file.
+    """
+    unique = list({Path(p) for p in paths})
+    if not unique:
+        return {}
+    workers = max(1, min(max_workers or default_hash_workers(), len(unique)))
+    if workers == 1:
+        return {p: hash_file(p) for p in unique}
+    out: dict[Path, tuple[str, int]] = {}
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        futures = {ex.submit(hash_file, p): p for p in unique}
+        for fut in as_completed(futures):
+            out[futures[fut]] = fut.result()
+    return out
+
+
+def sci_dq_hash(path) -> Optional[str]:
+    """Return ``'sha256:<hex>'`` over the SCI+DQ+CFMASK arrays, or None.
+
+    The science-only change-detection digest for the push dedup (epic #261,
+    D1). Reproduces ``campfire_pipeline.nircam.manifest.compute_file_hash``
+    client-side (the client must not import the pipeline):
+    ``do_not_scale_image_data=True`` hashes the raw stored bytes regardless of
+    BZERO/BSCALE, ``memmap=False`` forces a real sequential read.
+
+    CFMASK (the user manual-mask extension) is included so a mask edit — which
+    the N7 freeze records as CFMASK on the canonical without touching SCI/DQ —
+    still re-uploads the exposure. It is hashed *last*, and the ``not in hdul``
+    guard skips it when absent, so an un-masked exposure hashes byte-identically
+    to the old SCI+DQ-only digest (no spurious re-upload on the first
+    post-N7 deploy).
+
+    Returns None if none of the arrays are present or the file is unreadable
+    (never dedup on an empty hash).
+    """
+    from astropy.io import fits
+
+    h = hashlib.sha256()
+    hashed_any = False
+    try:
+        with fits.open(path, memmap=False, do_not_scale_image_data=True) as hdul:
+            for extname in ('SCI', 'DQ', 'CFMASK'):
+                if extname not in hdul:
+                    continue
+                data = hdul[extname].data
+                if data is not None:
+                    h.update(data.tobytes())
+                    hashed_any = True
+    except Exception:
+        return None
+    return f'sha256:{h.hexdigest()}' if hashed_any else None
+
+
+def sci_dq_hashes_parallel(
+    paths: Iterable[Path], *, max_workers: Optional[int] = None,
+    progress_desc: Optional[str] = None,
+) -> dict[Path, Optional[str]]:
+    """Compute :func:`sci_dq_hash` for many files concurrently → ``{path: hash}``.
+
+    The reads are I/O-bound and overlap across threads. A per-file failure
+    records ``None`` (never dedup on it). When ``progress_desc`` is given, a
+    tqdm bar tracks the pass — computing these digests is the dominant local
+    cost before a NIRCam upload starts.
+    """
+    unique = list({Path(p) for p in paths})
+    if not unique:
+        return {}
+    workers = max(1, min(max_workers or default_hash_workers(), len(unique)))
+    out: dict[Path, Optional[str]] = {}
+    pbar = None
+    if progress_desc:
+        from tqdm import tqdm
+        pbar = tqdm(total=len(unique), desc=progress_desc, unit='file')
+    try:
+        with ThreadPoolExecutor(max_workers=workers) as ex:
+            futures = {ex.submit(sci_dq_hash, p): p for p in unique}
+            for fut in as_completed(futures):
+                path = futures[fut]
+                try:
+                    out[path] = fut.result()
+                except Exception:
+                    out[path] = None
+                if pbar:
+                    pbar.update(1)
+    finally:
+        if pbar:
+            pbar.close()
+    return out

--- a/python/campfire/storage/plan.py
+++ b/python/campfire/storage/plan.py
@@ -196,10 +196,12 @@ def plan_push(
 
     sci_dq_local = sci_dq_hashes_parallel(
         sci_dq_paths, max_workers=max_workers,
-        progress_desc='Hashing exposures' if progress else None,
+        progress_desc='Hashing exposures (SCI+DQ)' if progress else None,
     ) if sci_dq_paths else {}
     whole_local = hash_files_parallel(
-        whole_paths, max_workers=max_workers) if whole_paths else {}
+        whole_paths, max_workers=max_workers,
+        progress_desc='Hashing changed candidates' if progress else None,
+    ) if whole_paths else {}
 
     for task, kind, identity, st in undecided:
         key = task.r2_key

--- a/python/campfire/storage/plan.py
+++ b/python/campfire/storage/plan.py
@@ -1,0 +1,223 @@
+"""Push planning — the local→cloud differ.
+
+The pull direction has always had a differ (``LocalStore.get_pending_objects``:
+a cloud row is pending when no local hash matches it). This module is its
+mirror image: given locally-discovered upload tasks and the server registry's
+rows for those keys, classify each file as **new** (no active cloud object),
+**changed** (content identity differs), or **unchanged** (skip the upload).
+
+Content identity is per-product-type, not per-direction:
+
+* NIRCam canonical exposures compare on the science-only ``sci_dq_hash`` —
+  whole-file hashes churn on every pipeline re-save (header timestamps), so
+  they cannot drive dedup (epic #261, D1).
+* Everything else compares on the whole-file ``content_hash``. Only an
+  authoritative ``sha256:`` value is comparable; a provisional ``etag:`` row
+  (bucket-metadata backfill) always re-uploads.
+
+The stat fast path: when the local mirror's ``pushed_*`` bookkeeping records
+that this same file (mtime+size unchanged) was already confirmed against the
+same server identity, the file is skipped **without reading it** — the
+rsync-style short-circuit that keeps a no-op re-push at directory-walk cost
+instead of a full re-hash of hundreds of GB. Files are only hashed when their
+stat changed, and then only to answer "did the science change or was this a
+re-save". The pipeline's own manifest logic (``file_unchanged``) uses the same
+idiom at reduction time.
+
+This module is pure bookkeeping — no Supabase, no network. The deploy-side
+wrapper (``campfire.deploy.push``) fetches the server rows for the candidate
+keys and applies the plan's bookkeeping to the local mirror.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from .hashing import hash_files_parallel, sci_dq_hashes_parallel
+
+# Product types whose push identity is the science-only SCI+DQ+CFMASK digest.
+IDENTITY_SCI_DQ_TYPES = frozenset({'nircam_exposure'})
+
+# mtime comparison tolerance (matches verify_local_objects).
+_MTIME_TOL = 1e-3
+
+
+def identity_kind_for_key(storage_key: str) -> str:
+    """Return ``'sci_dq'`` or ``'whole_file'`` for a storage key.
+
+    Unknown/unparseable keys fall back to whole-file identity (the
+    conservative choice: whole-file mismatches always re-upload).
+    """
+    try:
+        from campfire_layout import parse_key
+        parsed = parse_key(storage_key)
+        product_type = parsed.product_type
+    except Exception:
+        return 'whole_file'
+    return 'sci_dq' if product_type in IDENTITY_SCI_DQ_TYPES else 'whole_file'
+
+
+def server_identity_for(row: Optional[dict], kind: str) -> Optional[str]:
+    """The comparable cloud-side identity for a registry row, or None.
+
+    None means "no comparable identity" — the caller must treat the file as
+    changed (always upload): a missing/inactive row, a provisional ``etag:``
+    whole-file hash, or a legacy exposure row without a science digest.
+    """
+    if not row or row.get('status') != 'active':
+        return None
+    if kind == 'sci_dq':
+        h = row.get('sci_dq_hash')
+    else:
+        h = row.get('content_hash')
+    if h and h.startswith('sha256:'):
+        return h
+    return None
+
+
+@dataclass
+class PushPlan:
+    """Classification of upload tasks against the cloud registry.
+
+    ``to_upload`` preserves the input task order (new + changed interleaved).
+    ``identities`` maps ``r2_key`` → the local content identity for every task
+    that was hashed at plan time (uploads whose identity was needed for the
+    decision); ``whole_file`` carries ``(sha256, size)`` for plan-hashed
+    whole-file tasks so registration never re-reads them. ``confirmed``
+    lists ``(r2_key, identity, mtime, size)`` for identity-verified unchanged
+    files — the caller records these in the mirror so the next run takes the
+    stat fast path.
+    """
+
+    to_upload: List = field(default_factory=list)
+    new: List = field(default_factory=list)
+    changed: List = field(default_factory=list)
+    unchanged: List = field(default_factory=list)
+    missing: List = field(default_factory=list)
+    fast_skipped: int = 0
+    identities: Dict[str, Optional[str]] = field(default_factory=dict)
+    whole_file: Dict[str, Tuple[str, int]] = field(default_factory=dict)
+    stats: Dict[str, Tuple[float, int]] = field(default_factory=dict)
+    confirmed: List[Tuple[str, str, float, int]] = field(default_factory=list)
+
+    def summary(self) -> str:
+        parts = [
+            f"{len(self.new)} new",
+            f"{len(self.changed)} changed",
+            f"{len(self.unchanged)} unchanged",
+        ]
+        if self.fast_skipped:
+            parts.append(f"{self.fast_skipped} via stat fast-path")
+        if self.missing:
+            parts.append(f"{len(self.missing)} missing locally")
+        return ", ".join(parts)
+
+
+def plan_push(
+    tasks,
+    server_rows: Dict[str, dict],
+    *,
+    local_rows: Optional[Dict[str, dict]] = None,
+    max_workers: Optional[int] = None,
+    progress: bool = True,
+) -> PushPlan:
+    """Classify ``tasks`` (UploadTask-shaped) against the server registry.
+
+    Parameters
+    ----------
+    tasks
+        Locally-discovered candidates (``.local_path`` / ``.r2_key`` /
+        ``.content_type``).
+    server_rows
+        ``{storage_key: row}`` fetched from the **server** registry for these
+        keys (authoritative — never a possibly-stale full mirror). Rows carry
+        ``status`` / ``content_hash`` / ``sci_dq_hash``.
+    local_rows
+        ``{storage_key: row}`` from the local mirror, supplying the
+        ``pushed_*`` stat fast-path bookkeeping. Optional: without it every
+        candidate with a comparable server identity is hashed (still correct,
+        just slower).
+    """
+    plan = PushPlan()
+    local_rows = local_rows or {}
+
+    # (task, kind, server_identity, stat) needing a local hash to decide.
+    undecided: List[Tuple] = []
+
+    for task in tasks:
+        key = task.r2_key
+        path = Path(task.local_path)
+        try:
+            st = os.stat(path)
+        except OSError:
+            plan.missing.append(task)
+            continue
+        plan.stats[key] = (st.st_mtime, st.st_size)
+
+        kind = identity_kind_for_key(key)
+        row = server_rows.get(key)
+        identity = server_identity_for(row, kind)
+
+        if identity is None:
+            # No comparable cloud identity: brand-new object, inactive row, or
+            # provisional/absent digest → always upload.
+            if row and row.get('status') == 'active':
+                plan.changed.append(task)
+            else:
+                plan.new.append(task)
+            plan.to_upload.append(task)
+            continue
+
+        # Stat fast path: this machine already confirmed this exact file
+        # (mtime+size) against this exact server identity — skip without
+        # reading a byte.
+        lrow = local_rows.get(key)
+        if (
+            lrow
+            and lrow.get('pushed_identity') == identity
+            and lrow.get('pushed_mtime') is not None
+            and lrow.get('pushed_size') is not None
+            and abs(st.st_mtime - lrow['pushed_mtime']) < _MTIME_TOL
+            and st.st_size == lrow['pushed_size']
+        ):
+            plan.unchanged.append(task)
+            plan.fast_skipped += 1
+            continue
+
+        undecided.append((task, kind, identity, st))
+
+    # Hash the undecided files (stat changed, or no fast-path record), grouped
+    # by identity kind so each file is read once with the right reader.
+    sci_dq_paths = [Path(t.local_path) for t, k, _i, _s in undecided if k == 'sci_dq']
+    whole_paths = [Path(t.local_path) for t, k, _i, _s in undecided if k == 'whole_file']
+
+    sci_dq_local = sci_dq_hashes_parallel(
+        sci_dq_paths, max_workers=max_workers,
+        progress_desc='Hashing exposures' if progress else None,
+    ) if sci_dq_paths else {}
+    whole_local = hash_files_parallel(
+        whole_paths, max_workers=max_workers) if whole_paths else {}
+
+    for task, kind, identity, st in undecided:
+        key = task.r2_key
+        path = Path(task.local_path)
+        if kind == 'sci_dq':
+            local_identity = sci_dq_local.get(path)
+        else:
+            local_identity, size = whole_local[path]
+            plan.whole_file[key] = (local_identity, size)
+        plan.identities[key] = local_identity
+
+        if local_identity is not None and local_identity == identity:
+            # Science-identical (or byte-identical) — skip the upload and
+            # record the fresh stat so the next run takes the fast path.
+            plan.unchanged.append(task)
+            plan.confirmed.append((key, local_identity, st.st_mtime, st.st_size))
+        else:
+            plan.changed.append(task)
+            plan.to_upload.append(task)
+
+    return plan

--- a/python/campfire/storage/session.py
+++ b/python/campfire/storage/session.py
@@ -1,0 +1,55 @@
+"""Pooled, retrying HTTP sessions for presigned-URL transfers.
+
+Presigned URLs are self-authenticating, so these sessions carry no auth
+headers — what they carry is the transport tuning both directions need on a
+high-latency link:
+
+* **Connection reuse.** One persistent connection per worker thread. The old
+  upload path called module-level ``requests.put`` per file, paying a full
+  TCP+TLS handshake for every object — a large hidden tax at thousands of
+  files over a ~150 ms RTT path.
+* **Retry with backoff.** Transient 5xx/429 and connection errors retry
+  automatically. PUT is safe to include: presigned PutObject is idempotent
+  (same bytes, same key), so a retried upload can only converge.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+def create_transfer_session(
+    max_workers: int = 4,
+    methods: Iterable[str] = ("GET",),
+) -> requests.Session:
+    """Create a ``requests.Session`` pooled and retrying for parallel transfers.
+
+    Parameters
+    ----------
+    max_workers : int
+        Size of the connection pool — match the transfer thread count so each
+        worker gets a persistent connection without contention.
+    methods : iterable of str
+        HTTP methods eligible for automatic retry. ``("GET",)`` for downloads,
+        ``("GET", "PUT")`` for uploads (presigned PutObject is idempotent).
+    """
+    session = requests.Session()
+    retry = Retry(
+        total=4,
+        backoff_factor=2,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=list(methods),
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(
+        max_retries=retry,
+        pool_connections=max_workers,
+        pool_maxsize=max_workers,
+    )
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session

--- a/python/campfire/storage/transfer.py
+++ b/python/campfire/storage/transfer.py
@@ -1,0 +1,132 @@
+"""The parallel transfer harness — one loop for both directions.
+
+``run_transfers`` is the ThreadPoolExecutor + ``as_completed`` + tqdm +
+failure-collection pattern that ``sync.download_objects`` and the two upload
+loops in ``deploy/r2.py`` each reimplemented. The one behavioral guarantee
+that matters architecturally: **callbacks run on the calling thread**, inside
+the ``as_completed`` drain loop. That makes per-item bookkeeping safe against
+single-threaded stores (the SQLite mirror, the Supabase client's HTTP/2
+connection) without any locking — workers only touch the network/disk.
+
+``BatchFlusher`` builds on that guarantee to turn per-item success callbacks
+into chunked writes (e.g. registry upserts every N objects), so progress is
+durable *during* a long transfer instead of only at the end — the difference
+between resuming at file 301/500 and restarting at file 1 after an
+interruption.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Callable, Generic, Iterable, List, NamedTuple, Optional, TypeVar
+
+from tqdm import tqdm
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+
+class TransferResult(NamedTuple):
+    """Outcome of a :func:`run_transfers` pass."""
+
+    succeeded: int
+    failed: int
+    failures: List[str]  # human-readable "item: error" lines
+
+
+def run_transfers(
+    items: Iterable[T],
+    worker: Callable[[T], R],
+    *,
+    max_workers: int,
+    desc: str = "Transferring",
+    unit: str = "file",
+    label: Callable[[T], str] = str,
+    on_success: Optional[Callable[[T, R], None]] = None,
+    on_failure: Optional[Callable[[T, Exception], None]] = None,
+    show_progress: bool = True,
+) -> TransferResult:
+    """Run ``worker(item)`` for every item in a thread pool, with progress.
+
+    ``worker`` does the I/O (upload one file, download one object) and runs on
+    pool threads. ``on_success(item, result)`` / ``on_failure(item, exc)`` run
+    on the **calling thread** as completions drain, so they may safely touch
+    single-threaded state (SQLite, the Supabase client). A callback exception
+    is not swallowed — it aborts the drain loop, because losing bookkeeping
+    silently is worse than stopping.
+
+    Returns a :class:`TransferResult`; failures never raise out of the pool.
+    """
+    items = list(items)
+    if not items:
+        return TransferResult(0, 0, [])
+
+    succeeded, failed = 0, 0
+    failures: List[str] = []
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_to_item = {executor.submit(worker, item): item for item in items}
+        pbar = tqdm(total=len(items), desc=desc, unit=unit, disable=not show_progress)
+        try:
+            for future in as_completed(future_to_item):
+                item = future_to_item[future]
+                try:
+                    result = future.result()
+                except Exception as e:
+                    failed += 1
+                    failures.append(f"{label(item)}: {e}")
+                    if on_failure is not None:
+                        on_failure(item, e)
+                else:
+                    succeeded += 1
+                    if on_success is not None:
+                        on_success(item, result)
+                pbar.update(1)
+        finally:
+            pbar.close()
+
+    return TransferResult(succeeded, failed, failures)
+
+
+class BatchFlusher(Generic[T]):
+    """Collect items and flush them through a callback every ``batch_size``.
+
+    Single-threaded by design — feed it only from :func:`run_transfers`
+    callbacks (which run on the calling thread). Typical use is durable
+    mid-transfer bookkeeping::
+
+        flusher = BatchFlusher(lambda rows: upsert_storage_objects(sb, rows),
+                               batch_size=200)
+        run_transfers(tasks, upload_one,
+                      on_success=lambda t, _: flusher.add(registry_row(t)), ...)
+        flusher.flush()   # the remainder
+
+    A flush failure propagates (and aborts the transfer drain) — registry
+    durability is the point, so it must not fail silently. Items from a failed
+    flush are retained and retried on the next flush.
+    """
+
+    def __init__(self, flush_fn: Callable[[List[T]], None], *, batch_size: int = 200):
+        if batch_size < 1:
+            raise ValueError("batch_size must be >= 1")
+        self._flush_fn = flush_fn
+        self._batch_size = batch_size
+        self._pending: List[T] = []
+        self.flushed = 0
+
+    def add(self, item: T) -> None:
+        self._pending.append(item)
+        if len(self._pending) >= self._batch_size:
+            self.flush()
+
+    def flush(self) -> None:
+        if not self._pending:
+            return
+        batch, self._pending = self._pending, []
+        try:
+            self._flush_fn(batch)
+        except Exception:
+            # Retain for a later retry (e.g. the caller's final flush()).
+            self._pending = batch + self._pending
+            raise
+        self.flushed += len(batch)

--- a/python/campfire/sync.py
+++ b/python/campfire/sync.py
@@ -18,13 +18,9 @@ from .api.session import create_download_session
 from .exceptions import DownloadError
 
 
-def compute_file_hash(path: Path) -> str:
-    """Compute SHA-256 hash of a file, returning ``sha256:<hex>`` format."""
-    hasher = hashlib.sha256()
-    with open(path, "rb") as f:
-        while chunk := f.read(65536):
-            hasher.update(chunk)
-    return f"sha256:{hasher.hexdigest()}"
+# Single hashing implementation lives in the shared storage core; re-exported
+# here for the established import path (store.verify_local_objects, tests).
+from .storage.hashing import compute_file_hash  # noqa: E402  (re-export)
 
 
 def _make_progress(show, unit, desc, position=None):
@@ -386,30 +382,36 @@ def download_objects(
 
     dl_session = download_session or create_download_session(max_workers)
 
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        future_to_obj = {
-            executor.submit(
-                _download_and_verify_key, r, urls[r["storage_key"]], products_dir, dl_session
-            ): r
-            for r in fetchable
-        }
-        with tqdm(total=len(fetchable), desc="Downloading", unit="file") as pbar:
-            for future in as_completed(future_to_obj):
-                obj = future_to_obj[future]
-                try:
-                    result = future.result()
-                    store.mark_object_synced(
-                        storage_key=result["storage_key"],
-                        local_path=result["local_path"],
-                        local_file_hash=result["local_file_hash"],
-                        local_file_size=result["local_file_size"],
-                        local_file_mtime=result["local_file_mtime"],
-                    )
-                    stats["downloaded"] += 1
-                except Exception as e:
-                    stats["failed"] += 1
-                    tqdm.write(f"  Failed: {obj['storage_key']}: {e}")
-                pbar.update(1)
+    # Shared transfer harness: workers only touch the network/disk; the
+    # mark_object_synced bookkeeping runs on this thread per completed file
+    # (the SQLite store is single-threaded), so an interrupted run resumes at
+    # file granularity on the next invocation.
+    from .storage.transfer import run_transfers
+
+    def _record(obj: dict, result: dict) -> None:
+        store.mark_object_synced(
+            storage_key=result["storage_key"],
+            local_path=result["local_path"],
+            local_file_hash=result["local_file_hash"],
+            local_file_size=result["local_file_size"],
+            local_file_mtime=result["local_file_mtime"],
+        )
+
+    def _report(obj: dict, e: Exception) -> None:
+        tqdm.write(f"  Failed: {obj['storage_key']}: {e}")
+
+    result = run_transfers(
+        fetchable,
+        lambda r: _download_and_verify_key(
+            r, urls[r["storage_key"]], products_dir, dl_session),
+        max_workers=max_workers,
+        desc="Downloading",
+        label=lambda r: r["storage_key"],
+        on_success=_record,
+        on_failure=_report,
+    )
+    stats["downloaded"] = result.succeeded
+    stats["failed"] = result.failed
 
     return stats
 

--- a/python/tests/test_cli_storage_plane.py
+++ b/python/tests/test_cli_storage_plane.py
@@ -1,0 +1,85 @@
+"""CLI wiring tests for the storage-plane restructure.
+
+The seven-verb surface: pull (alias download) / push / verify / drop-local /
+status / sync, with the deploy group's migration-era commands hidden. These
+tests exercise registration and help rendering — the engine itself is covered
+by test_storage_plan / test_registry / test_download_objects.
+"""
+
+from click.testing import CliRunner
+
+import campfire.cli as main_cli
+
+
+def _cli():
+    main_cli._register_deploy_group()
+    main_cli._register_fitsgl_group()
+    return main_cli.cli
+
+
+def test_top_level_commands_registered():
+    cli = _cli()
+    for name in ('pull', 'download', 'push', 'verify', 'drop-local',
+                 'status', 'sync', 'deploy'):
+        assert name in cli.commands, name
+
+
+def test_download_is_alias_of_pull():
+    cli = _cli()
+    assert cli.commands['download'] is cli.commands['pull']
+
+
+def test_help_screens_render():
+    cli = _cli()
+    runner = CliRunner()
+    for args in (['--help'], ['pull', '--help'], ['push', '--help'],
+                 ['verify', '--help'], ['drop-local', '--help'],
+                 ['status', '--help']):
+        res = runner.invoke(cli, args)
+        assert res.exit_code == 0, (args, res.output)
+
+
+def test_push_requires_scope():
+    cli = _cli()
+    res = CliRunner().invoke(cli, ['push'])
+    assert res.exit_code != 0
+    assert '--obs' in res.output and '--field' in res.output
+
+
+def test_migration_era_commands_hidden_but_working():
+    from campfire.deploy.cli import deploy_group
+
+    registry = deploy_group.commands['registry']
+    for name in ('backfill', 'copy', 'prune', 'reconcile'):
+        assert registry.commands[name].hidden, name
+    # budget is retired outright (campfire status carries the number).
+    assert 'budget' not in registry.commands
+
+    nircam = deploy_group.commands['nircam']
+    for name in ('import-masks', 'import-skip', 'pull', 'pull-masks'):
+        assert nircam.commands[name].hidden, name
+    nirspec = deploy_group.commands['nirspec']
+    for name in ('pull-rate-masks', 'pull-stuck-shutters', 'pull-bkg-overrides'):
+        assert nirspec.commands[name].hidden, name
+
+
+def test_hidden_commands_absent_from_help():
+    cli = _cli()
+    runner = CliRunner()
+    res = runner.invoke(cli, ['deploy', 'registry', '--help'])
+    assert res.exit_code == 0
+    # Every registry subcommand is hidden, so click renders no Commands section
+    # (the docstring may mention their names; the listing must not).
+    assert 'Commands:' not in res.output
+
+
+def test_status_accepts_scope_flags():
+    cli = _cli()
+    params = {p.name for p in cli.commands['status'].params}
+    assert {'obs_scope', 'field_scope'} <= params
+
+
+def test_verify_has_cloud_and_json_flags():
+    cli = _cli()
+    params = {p.name for p in cli.commands['verify'].params}
+    assert {'cloud', 'as_json', 'obs_filter'} <= params

--- a/python/tests/test_deploy_upload_mode.py
+++ b/python/tests/test_deploy_upload_mode.py
@@ -28,14 +28,14 @@ def test_login_mode_no_presign_raises_not_fallback(monkeypatch):
 
     config = {"supabase": {"_auth_mode": "login"}}
     with pytest.raises(RuntimeError, match="presigned"):
-        upload_files_parallel(config, [_task()])
+        upload_files_parallel(config, [_task()], backend="osn")
 
 
 def test_untagged_mode_treated_as_presigned_only(monkeypatch):
     # A config with no explicit direct mode is treated like login: presigned only.
     monkeypatch.setattr(r2, "request_presigned_urls", lambda *a, **k: None)
     with pytest.raises(RuntimeError, match="presigned"):
-        upload_files_parallel({"supabase": {}}, [_task()])
+        upload_files_parallel({"supabase": {}}, [_task()], backend="osn")
 
 
 def test_service_role_mode_skips_presign_goes_direct(monkeypatch):
@@ -50,10 +50,18 @@ def test_service_role_mode_skips_presign_goes_direct(monkeypatch):
 
     config = {"supabase": {"_auth_mode": "service_role"}}  # no 'r2' section
     with pytest.raises(ValueError, match="No storage credentials"):
-        upload_files_parallel(config, [_task()])
+        upload_files_parallel(config, [_task()], backend="osn")
     assert called["presign"] is False
 
 
 def test_no_tasks_short_circuits():
     # Empty task list returns cleanly regardless of mode (no presign, no boto3).
-    assert upload_files_parallel({"supabase": {"_auth_mode": "login"}}, []) == (0, 0, [])
+    assert upload_files_parallel(
+        {"supabase": {"_auth_mode": "login"}}, [], backend="osn") == (0, 0, [])
+
+
+def test_backend_is_required():
+    # Data lives on OSN; tiles are the sole R2 exception. There is deliberately
+    # no default backend — every call site must say where bytes land.
+    with pytest.raises(TypeError):
+        upload_files_parallel({"supabase": {"_auth_mode": "login"}}, [_task()])

--- a/python/tests/test_push_field_filters.py
+++ b/python/tests/test_push_field_filters.py
@@ -1,0 +1,44 @@
+"""Regression: an explicit --filter selection must stay a selection.
+
+A typo'd filter (`campfire push --field X --filter f999w`) previously fell
+back to `available` — planning/uploading the ENTIRE field instead of nothing
+(Codex review, PR #364). The guard drops unknown filters with a warning and
+returns before any Supabase/network work when none remain.
+"""
+
+import pytest
+
+from campfire.deploy.push import push_field
+
+
+@pytest.fixture()
+def nircam_root(tmp_path, monkeypatch):
+    (tmp_path / 'products' / 'nircam' / 'cosmos' / 'f444w').mkdir(parents=True)
+    monkeypatch.setenv('CAMPFIRE_ROOT', str(tmp_path))
+    return tmp_path
+
+
+def test_unknown_filter_pushes_nothing(nircam_root, monkeypatch, capsys):
+    import campfire.deploy.supabase as sup
+
+    def _boom(cfg):
+        raise AssertionError("a typo'd --filter must return before touching Supabase")
+    monkeypatch.setattr(sup, 'get_supabase_client', _boom)
+
+    stats = push_field('cosmos', {}, filters=['f999w'])
+    assert stats == {'planned': 0, 'pushed': 0, 'failed': 0, 'skipped': 0}
+    out = capsys.readouterr().out
+    assert 'f999w' in out and 'nothing to push' in out.lower()
+
+
+def test_known_plus_unknown_filter_keeps_only_known(nircam_root, monkeypatch, capsys):
+    # One valid + one typo'd filter: warn about the typo, proceed with the
+    # valid one only. The empty valid filter dir has no products, so push
+    # stops at "Nothing to push" — before any Supabase call.
+    import campfire.deploy.supabase as sup
+    monkeypatch.setattr(sup, 'get_supabase_client',
+                        lambda cfg: (_ for _ in ()).throw(AssertionError('no supabase')))
+    stats = push_field('cosmos', {}, filters=['f444w', 'f999w'])
+    assert stats['planned'] == 0
+    out = capsys.readouterr().out
+    assert 'f999w' in out  # warned

--- a/python/tests/test_storage_plan.py
+++ b/python/tests/test_storage_plan.py
@@ -1,0 +1,230 @@
+"""Unit tests for the push planner (campfire.storage.plan).
+
+Pure classification: no Supabase, no network. Covers the new/changed/unchanged
+split, the pushed_* stat fast path (skip without reading), identity-kind
+selection (sci_dq for NIRCam exposures vs whole-file), provisional-etag
+handling, and the confirmed-unchanged bookkeeping that arms the fast path.
+"""
+
+import os
+from pathlib import Path
+
+from campfire_layout import KeyScheme, Scope, storage_key
+
+from campfire.deploy.r2 import UploadTask
+from campfire.storage.hashing import compute_file_hash, sci_dq_hash
+from campfire.storage.plan import (
+    identity_kind_for_key,
+    plan_push,
+    server_identity_for,
+)
+
+
+def _spec_task(tmp_path, name="a_spec.fits", content=b"spec-bytes"):
+    p = tmp_path / name
+    p.write_bytes(content)
+    key = storage_key('nirspec_spec', Scope(obs='obs1'), name,
+                      scheme=KeyScheme.CANONICAL)
+    return UploadTask(p, key, 'application/fits')
+
+
+def _row(key, content_hash=None, sci_dq=None, status='active', **extra):
+    row = {'storage_key': key, 'status': status,
+           'content_hash': content_hash, 'sci_dq_hash': sci_dq}
+    row.update(extra)
+    return row
+
+
+# --- identity selection -------------------------------------------------------
+
+def test_identity_kind_selection():
+    k_exp = storage_key('nircam_exposure', Scope(field='cosmos', filt='f444w'),
+                        'jw1_nrca1.fits', scheme=KeyScheme.CANONICAL)
+    k_spec = storage_key('nirspec_spec', Scope(obs='o'), 'x_spec.fits',
+                         scheme=KeyScheme.CANONICAL)
+    assert identity_kind_for_key(k_exp) == 'sci_dq'
+    assert identity_kind_for_key(k_spec) == 'whole_file'
+    assert identity_kind_for_key('garbage/not/a/key.bin') == 'whole_file'
+
+
+def test_server_identity_requires_active_and_sha256():
+    key = 'data/products/nirspec/o/x_spec.fits'
+    assert server_identity_for(None, 'whole_file') is None
+    assert server_identity_for(_row(key, 'sha256:' + 'a' * 64, status='superseded'),
+                               'whole_file') is None
+    # Provisional etag hashes are not comparable → always re-upload.
+    assert server_identity_for(_row(key, 'etag:abc'), 'whole_file') is None
+    assert server_identity_for(_row(key, 'sha256:' + 'a' * 64),
+                               'whole_file') == 'sha256:' + 'a' * 64
+    # sci_dq kind reads the science digest, not the whole-file hash.
+    assert server_identity_for(
+        _row(key, 'sha256:' + 'a' * 64, sci_dq='sha256:' + 'b' * 64),
+        'sci_dq') == 'sha256:' + 'b' * 64
+    assert server_identity_for(_row(key, 'sha256:' + 'a' * 64), 'sci_dq') is None
+
+
+# --- classification -----------------------------------------------------------
+
+def test_new_file_uploads_without_plan_time_hash(tmp_path):
+    task = _spec_task(tmp_path)
+    plan = plan_push([task], server_rows={}, progress=False)
+    assert plan.new == [task]
+    assert plan.to_upload == [task]
+    # New files are not hashed at plan time (registration hashes per batch).
+    assert task.r2_key not in plan.identities
+
+
+def test_unchanged_file_skips_and_confirms(tmp_path):
+    task = _spec_task(tmp_path)
+    h = compute_file_hash(task.local_path)
+    rows = {task.r2_key: _row(task.r2_key, h)}
+    plan = plan_push([task], rows, progress=False)
+    assert plan.unchanged == [task]
+    assert plan.to_upload == []
+    # Identity-confirmed → bookkeeping entry arms the stat fast path.
+    (key, identity, mtime, size) = plan.confirmed[0]
+    assert key == task.r2_key and identity == h
+    st = os.stat(task.local_path)
+    assert size == st.st_size
+
+
+def test_changed_file_uploads_and_reuses_hash(tmp_path):
+    task = _spec_task(tmp_path, content=b"new-bytes")
+    rows = {task.r2_key: _row(task.r2_key, 'sha256:' + '0' * 64)}
+    plan = plan_push([task], rows, progress=False)
+    assert plan.changed == [task]
+    assert plan.to_upload == [task]
+    # Whole-file hash computed for the decision is exposed for registration.
+    h, size = plan.whole_file[task.r2_key]
+    assert h == compute_file_hash(task.local_path)
+    assert size == len(b"new-bytes")
+
+
+def test_active_row_with_etag_hash_always_uploads(tmp_path):
+    task = _spec_task(tmp_path)
+    rows = {task.r2_key: _row(task.r2_key, 'etag:abc123')}
+    plan = plan_push([task], rows, progress=False)
+    assert plan.changed == [task]
+    # No comparable identity → not hashed at plan time either.
+    assert task.r2_key not in plan.identities
+
+
+def test_inactive_row_treated_as_new(tmp_path):
+    task = _spec_task(tmp_path)
+    rows = {task.r2_key: _row(task.r2_key, 'sha256:' + 'a' * 64,
+                              status='superseded')}
+    plan = plan_push([task], rows, progress=False)
+    assert plan.new == [task]
+
+
+def test_missing_local_file_reported(tmp_path):
+    key = storage_key('nirspec_spec', Scope(obs='obs1'), 'gone_spec.fits',
+                      scheme=KeyScheme.CANONICAL)
+    task = UploadTask(tmp_path / 'gone_spec.fits', key, 'application/fits')
+    plan = plan_push([task], server_rows={}, progress=False)
+    assert plan.missing == [task]
+    assert plan.to_upload == []
+
+
+# --- stat fast path -----------------------------------------------------------
+
+def test_stat_fast_path_skips_without_reading(tmp_path, monkeypatch):
+    task = _spec_task(tmp_path)
+    h = compute_file_hash(task.local_path)
+    st = os.stat(task.local_path)
+    rows = {task.r2_key: _row(task.r2_key, h)}
+    local = {task.r2_key: {'pushed_identity': h,
+                           'pushed_mtime': st.st_mtime,
+                           'pushed_size': st.st_size}}
+
+    # Any attempt to hash would blow up — the fast path must not read files.
+    import campfire.storage.plan as plan_mod
+
+    def _boom(*a, **k):
+        raise AssertionError("fast path must not hash")
+    monkeypatch.setattr(plan_mod, 'hash_files_parallel', _boom)
+    monkeypatch.setattr(plan_mod, 'sci_dq_hashes_parallel', _boom)
+
+    plan = plan_push([task], rows, local_rows=local, progress=False)
+    assert plan.unchanged == [task]
+    assert plan.fast_skipped == 1
+    assert plan.confirmed == []  # already armed; nothing to record
+
+
+def test_stat_mismatch_falls_back_to_hash(tmp_path):
+    task = _spec_task(tmp_path)
+    h = compute_file_hash(task.local_path)
+    rows = {task.r2_key: _row(task.r2_key, h)}
+    # Recorded stat is stale (different size) → must re-hash; identity still
+    # matches → unchanged, and confirmed refreshes the stat for next time.
+    local = {task.r2_key: {'pushed_identity': h,
+                           'pushed_mtime': 1.0, 'pushed_size': 1}}
+    plan = plan_push([task], rows, local_rows=local, progress=False)
+    assert plan.unchanged == [task]
+    assert plan.fast_skipped == 0
+    assert len(plan.confirmed) == 1
+
+
+def test_fast_path_ignored_when_server_identity_moved(tmp_path):
+    # Another machine re-uploaded different bytes: server identity no longer
+    # matches our pushed_identity → the stale stat record must NOT skip.
+    task = _spec_task(tmp_path)
+    st = os.stat(task.local_path)
+    local_h = compute_file_hash(task.local_path)
+    rows = {task.r2_key: _row(task.r2_key, 'sha256:' + 'f' * 64)}
+    local = {task.r2_key: {'pushed_identity': local_h,
+                           'pushed_mtime': st.st_mtime,
+                           'pushed_size': st.st_size}}
+    plan = plan_push([task], rows, local_rows=local, progress=False)
+    assert plan.changed == [task]
+
+
+# --- sci_dq identity end-to-end ------------------------------------------------
+
+def _exposure_task(tmp_path, name='jw001_nrca1.fits', seed=1.0):
+    import numpy as np
+    from astropy.io import fits as afits
+    sci = afits.ImageHDU(np.full((4, 4), seed, dtype='f4'), name='SCI')
+    dq = afits.ImageHDU(np.zeros((4, 4), dtype='i4'), name='DQ')
+    hdul = afits.HDUList([afits.PrimaryHDU(), sci, dq])
+    p = tmp_path / name
+    hdul.writeto(p)
+    key = storage_key('nircam_exposure', Scope(field='cosmos', filt='f444w'),
+                      name, scheme=KeyScheme.CANONICAL)
+    return UploadTask(p, key, 'application/fits')
+
+
+def test_sci_dq_resave_with_header_change_skips(tmp_path):
+    from astropy.io import fits as afits
+    task = _exposure_task(tmp_path)
+    digest = sci_dq_hash(task.local_path)
+    # Server row: matching science digest, but a DIFFERENT whole-file hash
+    # (as after a pipeline re-save).
+    rows = {task.r2_key: _row(task.r2_key, 'sha256:' + '9' * 64, sci_dq=digest)}
+    # Touch a header keyword → whole file changes, science unchanged.
+    with afits.open(task.local_path, mode='update') as hdul:
+        hdul[0].header['HISTORY'] = 'resaved'
+    plan = plan_push([task], rows, progress=False)
+    assert plan.unchanged == [task]
+    assert plan.to_upload == []
+
+
+def test_sci_dq_science_change_uploads(tmp_path):
+    task = _exposure_task(tmp_path, seed=1.0)
+    other = _exposure_task(tmp_path, name='jw002_nrca1.fits', seed=2.0)
+    digest_other = sci_dq_hash(other.local_path)
+    rows = {task.r2_key: _row(task.r2_key, 'sha256:' + '9' * 64,
+                              sci_dq=digest_other)}
+    plan = plan_push([task], rows, progress=False)
+    assert plan.changed == [task]
+    # sci_dq identity exposed for registration reuse; whole-file NOT computed
+    # at plan time for sci_dq products.
+    assert plan.identities[task.r2_key] == sci_dq_hash(task.local_path)
+    assert task.r2_key not in plan.whole_file
+
+
+def test_legacy_exposure_row_without_sci_dq_uploads(tmp_path):
+    task = _exposure_task(tmp_path)
+    rows = {task.r2_key: _row(task.r2_key, 'sha256:' + '9' * 64, sci_dq=None)}
+    plan = plan_push([task], rows, progress=False)
+    assert plan.changed == [task]

--- a/supabase/migrations/20260711181915_sync_storage_sci_dq_hash.sql
+++ b/supabase/migrations/20260711181915_sync_storage_sci_dq_hash.sql
@@ -1,0 +1,90 @@
+-- Add sci_dq_hash to the get_storage_objects_for_sync payload (storage
+-- unification): the client mirror needs the science-only NIRCam identity to
+-- plan pushes (dedup) without a live registry query. Column already exists on
+-- storage_objects (epic #261, N1); this only extends the sync JSONB.
+--
+-- NOTE: hand-trimmed after `supabase db diff` — the diff engine's untracked-MV
+-- limitation (AGENTS.md) emitted spurious drop/recreate statements for
+-- mv_filter_options / mv_programs_overview / two views; those are unchanged in
+-- the schema files and are omitted here (recreating the MVs would drop their
+-- indexes and data).
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_storage_objects_for_sync(p_program_slugs text[], p_updated_since timestamp with time zone DEFAULT NULL::timestamp with time zone, p_limit integer DEFAULT 1000, p_offset integer DEFAULT 0, p_include_counts boolean DEFAULT true, p_include_unpublished boolean DEFAULT false)
+ RETURNS TABLE(objects jsonb, total_count bigint, total_accessible_count bigint)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+ SET statement_timeout TO '120s'
+AS $function$
+BEGIN
+  RETURN QUERY
+  WITH scoped AS (
+    SELECT so.*
+    FROM storage_objects so
+    WHERE so.status = 'active'
+      AND (
+        p_include_unpublished
+        OR (so.spectrum_id IS NOT NULL AND EXISTS (
+              SELECT 1 FROM spectra s
+              JOIN targets t ON t.target_id = s.target_id
+              WHERE s.spectrum_id = so.spectrum_id
+                AND s.deploy_status = 'published'
+                AND t.program_slug = ANY(p_program_slugs)))
+        OR (so.spectrum_id IS NULL AND so.deployment_id IS NOT NULL AND EXISTS (
+              SELECT 1 FROM deployments d
+              LEFT JOIN observations o ON o.name = d.observation
+              WHERE d.id = so.deployment_id
+                AND d.status = 'published'
+                -- NIRCam field deploy (epic #261, N1): multi-program, public to all
+                -- when published. NIRSpec obs deploy stays program-scoped.
+                AND (d.field IS NOT NULL OR o.program_slug = ANY(p_program_slugs))))
+      )
+  ),
+  matched AS MATERIALIZED (
+    SELECT * FROM scoped
+    WHERE (p_updated_since IS NULL OR scoped.updated_at > p_updated_since)
+    ORDER BY scoped.storage_key
+    LIMIT p_limit OFFSET p_offset
+  ),
+  total AS (
+    SELECT COUNT(*) AS cnt FROM scoped
+    WHERE p_include_counts
+      AND (p_updated_since IS NULL OR scoped.updated_at > p_updated_since)
+  ),
+  accessible AS (
+    SELECT COUNT(*) AS cnt FROM scoped
+    WHERE p_include_counts
+  )
+  SELECT
+    COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'id', m.id,
+        'backend', m.backend,
+        'bucket', m.bucket,
+        'storage_key', m.storage_key,
+        'content_hash', m.content_hash,
+        'sci_dq_hash', m.sci_dq_hash,
+        'size_bytes', m.size_bytes,
+        'content_type', m.content_type,
+        'product_type', m.product_type,
+        'instrument', m.instrument,
+        'status', m.status,
+        'observation', m.observation,
+        'field', m.field,
+        'filter', m.filter,
+        'spectrum_id', m.spectrum_id,
+        'exposure_ref', m.exposure_ref,
+        'deployment_id', m.deployment_id,
+        'cfpipe_version', m.cfpipe_version,
+        'created_at', m.created_at,
+        'updated_at', m.updated_at
+      )
+    ), '[]'::jsonb),
+    COALESCE((SELECT cnt FROM total), 0)::BIGINT,
+    COALESCE((SELECT cnt FROM accessible), 0)::BIGINT
+  FROM matched m;
+END;
+$function$
+;

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -2615,6 +2615,7 @@ BEGIN
         'bucket', m.bucket,
         'storage_key', m.storage_key,
         'content_hash', m.content_hash,
+        'sci_dq_hash', m.sci_dq_hash,
         'size_bytes', m.size_bytes,
         'content_type', m.content_type,
         'product_type', m.product_type,


### PR DESCRIPTION
## Why

Deploying large NIRCam volumes from CANDIDE was slow and untrackable: the deploy path was a **stateless batch push** (re-hash everything every run, re-upload everything on interruption, registry written only at end-of-phase), while \"cloud as source of truth\" needs an **incremental sync**. Meanwhile the download side already had the full sync architecture (local `storage_objects` mirror, hash differ, stat fast-path, per-file checkpointing) — built in #239 and never shared. This PR unifies the two onto one engine and restructures the CLI around the resulting mental model.

## What

### Shared transfer core (`python/campfire/storage/`)
- One SHA-256 streamer (was two, different chunk sizes), parallel pools, and the `sci_dq` science identity shared by every access point
- Pooled retrying sessions for uploads (was: fresh TCP+TLS handshake **per file**, no retry)
- One transfer harness with calling-thread callbacks + `BatchFlusher` for durable per-batch bookkeeping
- Presigned PUT URLs minted **just-in-time per 500-task batch** — multi-hour pushes can no longer race the 1-hour presign TTL
- `backend` is now a **required** argument on the upload API: data lives on OSN; map tiles are the sole R2 exception. No more `'r2'` defaults to trip over.

### Deploy becomes an incremental sync
- **Push planner** (`storage/plan.py` + `deploy/push.py`): diffs discovered local products against the *server* registry (live key-scoped fetch — never a stale mirror), with per-product identity (sci_dq for NIRCam exposures, whole-file otherwise) and a **stat fast-path** via the local mirror — unchanged files are skipped *without reading a byte*. The every-run \"hash all exposures\" pause (and the every-run multi-GB mosaic re-hash) only happens for stat-changed files now.
- **NIRSpec gains dedup for the first time** — previously every deploy re-uploaded every FITS/exposure/rate file unconditionally.
- **Per-batch registration**: registry rows + mirror bookkeeping flush every 200 landed files. An interrupted 500-file deploy resumes at file 301, not file 1.
- Local mirror (schema v8) gains `sci_dq_hash` (+ sync RPC change, migration included) and `pushed_*` fast-path columns.

### CLI: the storage plane
```
campfire sync                          # refresh the index (never touches the tree)
campfire status [--obs X | --field Y]  # bidirectional diff (scoped = push-side dry run)
campfire pull                          # cloud→local (alias: download) + annotations for admins
campfire push --obs X | --field Y      # local→cloud bytes only — no catalog, no publication
campfire verify [--cloud] [--json]     # tree↔index; --cloud = registry↔bucket (OSN primary)
campfire drop-local                    # delete local files verified in cloud
campfire deploy ...                    # publication: push (same engine) + catalog + lifecycle
```
- **The slow-link workflow this enables:** `campfire push` overnight on CANDIDE (re-runnable until clean), then `campfire deploy` — it dedup-skips every byte already landed and completes in minutes.
- `deploy nircam pull*` / `nirspec pull-*` annotation round-trips folded into `campfire pull` (hidden but working individually)
- Migration-era tools (`registry backfill/copy/prune`, `nircam import-*`) hidden, kept functional until A1/A2 complete; `registry budget` removed (`campfire status` carries it); `registry reconcile` superseded by `campfire verify --cloud` (which finally LISTs **OSN**, closing the verification blind spot on the actual data home)

### Drive-by fix
- Latent `NameError` on `--supabase-only` deploys (audit-event metadata referenced upload-block locals that path never defined)

## Migration
One migration: `CREATE OR REPLACE FUNCTION get_storage_objects_for_sync` (adds `sci_dq_hash` to the payload). Hand-trimmed of the diff engine's spurious untracked-MV drop/recreates (per AGENTS.md caveat). Verified via `supabase db reset` + live RPC call against local. Client DBs at v7 rebuild on next sync (established path).

## Verification
- `pytest`: **447 passed, 1 skipped** (14 new planner tests, 8 new CLI tests)
- `supabase db reset` green (migration + seed), RPC returns `sci_dq_hash`
- `cd web && npm run build` green (no web source changes; sync route passes JSONB through)

## Deferred follow-ups (deliberately out of scope)
- Scheduled CI workflow for `campfire verify --cloud --json` (needs repo secrets: service-role + read-only S3 LIST creds; the command is CI-ready)
- Multipart upload / mid-file resume on the presigned path (needs `/deploy/presign` route to sign `UploadPart`)
- `remove.py` OSN-orphan bug (deletes DB rows but strands OSN bytes + active registry rows — pre-existing, separate fix)
- Deleting the hidden migration-era commands once A1/A2 complete

Note: `storage/plan.py` landed in the first commit (whole-directory add) though it's described in the third — history cosmetics only.

Generated with Claude Code