### PR TITLE
feat(cutout): re-point the 3 display PNG routes to the FitsGL engine (PR B of #343)

### DIFF
--- a/web/app/api/og-image/[id]/route.ts
+++ b/web/app/api/og-image/[id]/route.ts
@@ -4,6 +4,8 @@ import {
   compositeTileThumbnail,
   type MapLayerInfo,
 } from '@/lib/utils/tile-compositing';
+import { resolveFieldCutoutSource } from '@/lib/cutout/source';
+import { renderDisplayCutoutPng } from '@/lib/cutout/display';
 
 /**
  * GET /api/og-image/[id]
@@ -51,6 +53,30 @@ export async function GET(
 
     if (!obj) {
       return new Response('Image not found', { status: 404 });
+    }
+
+    // FitsGL path (epic #337, Phase 5). Service-role client bypasses RLS, so
+    // requirePublic mirrors the fitsgl_datasets policy — an unpublished-backed
+    // pyramid never serves this public route.
+    const fitsglSrc = await resolveFieldCutoutSource(supabase, obj.field, { requirePublic: true });
+    if (fitsglSrc) {
+      try {
+        const png = await renderDisplayCutoutPng(fitsglSrc, {
+          ra: obj.ra,
+          dec: obj.dec,
+          fovArcsec: 5,
+          outputSize: 300,
+        });
+        return new Response(new Uint8Array(png), {
+          status: 200,
+          headers: {
+            'Content-Type': 'image/png',
+            'Cache-Control': 'public, max-age=604800', // 1 week
+          },
+        });
+      } catch (err) {
+        console.error('FitsGL OG-image render failed; falling back to PNG tiles:', err);
+      }
     }
 
     // Get RGB map layer for this field

--- a/web/app/api/tile-thumbnail/route.ts
+++ b/web/app/api/tile-thumbnail/route.ts
@@ -5,12 +5,16 @@ import {
   TRANSPARENT_GIF,
   type MapLayerInfo,
 } from '@/lib/utils/tile-compositing';
+import { resolveFieldCutoutSource } from '@/lib/cutout/source';
+import { renderDisplayCutoutPng } from '@/lib/cutout/display';
 
 /**
  * GET /api/tile-thumbnail?target_id=<id>&size=<px>&fov=<arcsec>
  *
- * Composites map tiles into a thumbnail PNG centered on the object.
- * Returns a clean RGB cutout without shutter overlays.
+ * Thumbnail PNG centered on the object — a clean RGB (or single-band) cutout
+ * without shutter overlays. Fields with a deployed FitsGL pyramid render
+ * North-up from the FITS tiles (epic #337, Phase 5); others keep the legacy
+ * PNG-tile compositing until it is retired per-field.
  */
 export async function GET(request: NextRequest) {
   const supabase = await createClient();
@@ -63,6 +67,30 @@ export async function GET(request: NextRequest) {
         status: 404,
         headers: { 'Content-Type': 'image/gif' },
       });
+    }
+
+    // FitsGL path: render from the field's FITS pyramid when one is deployed
+    // (RLS scopes draft-backed datasets to admins). Falls through to the
+    // legacy PNG tiles on any render failure while both stacks coexist.
+    const fitsglSrc = await resolveFieldCutoutSource(supabase, obj.field);
+    if (fitsglSrc) {
+      try {
+        const png = await renderDisplayCutoutPng(fitsglSrc, {
+          ra: obj.ra,
+          dec: obj.dec,
+          fovArcsec: fov,
+          outputSize: size,
+        });
+        return new Response(new Uint8Array(png), {
+          status: 200,
+          headers: {
+            'Content-Type': 'image/png',
+            'Cache-Control': 'public, max-age=604800, stale-while-revalidate=86400',
+          },
+        });
+      } catch (err) {
+        console.error('FitsGL thumbnail render failed; falling back to PNG tiles:', err);
+      }
     }
 
     // Get RGB map layer for this field

--- a/web/app/api/tile-thumbnail/route.ts
+++ b/web/app/api/tile-thumbnail/route.ts
@@ -85,7 +85,11 @@ export async function GET(request: NextRequest) {
           status: 200,
           headers: {
             'Content-Type': 'image/png',
-            'Cache-Control': 'public, max-age=604800, stale-while-revalidate=86400',
+            // A draft-backed render only an admin's RLS could see must never
+            // enter a shared cache keyed on the URL alone.
+            'Cache-Control': fitsglSrc.isPublic
+              ? 'public, max-age=604800, stale-while-revalidate=86400'
+              : 'private, no-store',
           },
         });
       } catch (err) {

--- a/web/app/api/v1/cutout/route.ts
+++ b/web/app/api/v1/cutout/route.ts
@@ -131,7 +131,11 @@ export async function GET(request: NextRequest) {
           status: 200,
           headers: {
             'Content-Type': 'image/png',
-            'Cache-Control': 'public, max-age=604800, stale-while-revalidate=86400',
+            // A draft-backed render (admin API key) must never enter a shared
+            // cache keyed on the URL alone.
+            'Cache-Control': fitsglSrc.isPublic
+              ? 'public, max-age=604800, stale-while-revalidate=86400'
+              : 'private, no-store',
           },
         });
       } catch (err) {

--- a/web/app/api/v1/cutout/route.ts
+++ b/web/app/api/v1/cutout/route.ts
@@ -7,13 +7,17 @@ import {
   type MapLayerInfo,
 } from '@/lib/utils/tile-compositing';
 import type { WCSParams } from '@/lib/utils/wcs';
+import { resolveFieldCutoutSource } from '@/lib/cutout/source';
+import { renderDisplayCutoutPng } from '@/lib/cutout/display';
 
 /**
  * GET /api/v1/cutout?object_id=<id>&size=<px>&fov=<arcsec>
  *
- * Returns a PNG cutout image centered on the object, composited from
- * pre-generated RGB map tiles. No shutter overlays — clients render
- * those as vectors (SVG in browser, matplotlib patches in Python).
+ * Returns a PNG cutout image centered on the object. Fields with a deployed
+ * FitsGL pyramid render North-up from the FITS tiles (epic #337, Phase 5);
+ * others composite from the legacy pre-generated RGB map tiles. No shutter
+ * overlays — clients render those as vectors (SVG in browser, matplotlib
+ * patches in Python).
  *
  * Query parameters:
  * - object_id (required): Object identifier (IAU name from objects.object_id)
@@ -91,7 +95,51 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Get RGB map layer for this field
+    // Requested size, validated once; the default (native resolution for the
+    // FOV) depends on which tile stack serves the field, so it's applied below.
+    const sizeParam = params.get('size');
+    let requestedSize: number | null = null;
+    if (sizeParam !== null) {
+      requestedSize = parseInt(sizeParam, 10);
+      if (!Number.isFinite(requestedSize)) {
+        return NextResponse.json(
+          { error: 'Invalid parameter: size must be a number' },
+          { status: 400 }
+        );
+      }
+    }
+    const clampSize = (px: number) => Math.min(2048, Math.max(16, px));
+
+    // FitsGL path (epic #337, Phase 5). Service-role client bypasses RLS, so
+    // non-admins mirror the fitsgl_datasets policy via requirePublic; admins
+    // may render from draft-backed pyramids (matching the map).
+    const fitsglSrc = await resolveFieldCutoutSource(supabase, obj.field, {
+      requirePublic: !isAdmin,
+    });
+    if (fitsglSrc) {
+      try {
+        const outputSize = clampSize(
+          requestedSize ?? Math.round(fov / fitsglSrc.nativeScaleArcsec),
+        );
+        const png = await renderDisplayCutoutPng(fitsglSrc, {
+          ra: obj.ra,
+          dec: obj.dec,
+          fovArcsec: fov,
+          outputSize,
+        });
+        return new Response(new Uint8Array(png), {
+          status: 200,
+          headers: {
+            'Content-Type': 'image/png',
+            'Cache-Control': 'public, max-age=604800, stale-while-revalidate=86400',
+          },
+        });
+      } catch (err) {
+        console.error('FitsGL cutout render failed; falling back to PNG tiles:', err);
+      }
+    }
+
+    // Legacy path: composite from pre-generated RGB map tiles.
     const { data: layers, error: layerErr } = await supabase
       .from('map_layers')
       .select('tile_base_url, min_zoom, max_zoom, tile_size, wcs_params, tile_version, is_default, filter')
@@ -111,26 +159,10 @@ export async function GET(request: NextRequest) {
       || layers[0]
     ) as MapLayerInfo;
 
-    // Compute native resolution (pixels in FOV at the tile's pixel scale)
+    // Native resolution (pixels in FOV at the tile's pixel scale)
     const wcs = layer.wcs_params as WCSParams;
     const pixPerArcsec = 1 / (Math.abs(wcs.cd2_2) * 3600);
-    const nativeSize = Math.round(fov * pixPerArcsec);
-
-    // Use requested size or native resolution, clamped to 16–2048
-    const sizeParam = params.get('size');
-    let outputSize: number;
-    if (sizeParam !== null) {
-      const parsedSize = parseInt(sizeParam, 10);
-      if (!Number.isFinite(parsedSize)) {
-        return NextResponse.json(
-          { error: 'Invalid parameter: size must be a number' },
-          { status: 400 }
-        );
-      }
-      outputSize = Math.min(2048, Math.max(16, parsedSize));
-    } else {
-      outputSize = Math.min(2048, Math.max(16, nativeSize));
-    }
+    const outputSize = clampSize(requestedSize ?? Math.round(fov * pixPerArcsec));
 
     // Composite the thumbnail
     const png = await compositeTileThumbnail({

--- a/web/lib/cutout/display.ts
+++ b/web/lib/cutout/display.ts
@@ -1,0 +1,35 @@
+// Display-cutout helper for the three PNG routes (`/api/tile-thumbnail`,
+// `/api/og-image`, `/api/v1/cutout`) — epic #337, Phase 5. Renders a field's
+// FitsGL pyramid to an opaque black-backed PNG, matching the legacy PNG-tile
+// compositor's canvas so consumers see no visual regime change. Server-only
+// (pulls in `sharp` via `./encode`).
+
+import { renderCutout } from './index';
+import { encodePng } from './encode';
+import type { FieldCutoutSource } from './source';
+
+export interface DisplayCutoutArgs {
+  ra: number;
+  dec: number;
+  fovArcsec: number;
+  outputSize: number;
+}
+
+/**
+ * Render a North-up display cutout PNG from a resolved field source.
+ * Throws on fetch/decode failure — callers catch and fall back to the legacy
+ * PNG-tile path while both stacks coexist.
+ */
+export async function renderDisplayCutoutPng(
+  src: FieldCutoutSource,
+  args: DisplayCutoutArgs,
+): Promise<Buffer> {
+  const cutout = await renderCutout(src.bands, {
+    center: [args.ra, args.dec],
+    fovArcsec: args.fovArcsec,
+    outputSize: args.outputSize,
+  });
+  // No-coverage (NaN) pixels render transparent; flatten onto black like the
+  // legacy compositor's opaque canvas.
+  return encodePng(cutout, { background: '#000000' });
+}

--- a/web/lib/cutout/encode.ts
+++ b/web/lib/cutout/encode.ts
@@ -6,13 +6,14 @@
 import sharp from 'sharp';
 import type { CutoutRGBA } from './index';
 
-/** Encode a rendered cutout's RGBA to a PNG buffer (transparency preserved). */
-export function encodePng(cutout: CutoutRGBA): Promise<Buffer> {
-  return sharp(Buffer.from(cutout.rgba.buffer, cutout.rgba.byteOffset, cutout.rgba.byteLength), {
+/** Encode a rendered cutout's RGBA to a PNG buffer. Transparency is preserved
+ *  unless a `background` is given, which flattens no-data pixels onto it. */
+export function encodePng(cutout: CutoutRGBA, opts: { background?: string } = {}): Promise<Buffer> {
+  let img = sharp(Buffer.from(cutout.rgba.buffer, cutout.rgba.byteOffset, cutout.rgba.byteLength), {
     raw: { width: cutout.width, height: cutout.height, channels: 4 },
-  })
-    .png()
-    .toBuffer();
+  });
+  if (opts.background) img = img.flatten({ background: opts.background });
+  return img.png().toBuffer();
 }
 
 /** Encode to JPEG, flattening no-data (transparent) pixels onto `background`. */

--- a/web/lib/cutout/manifest.ts
+++ b/web/lib/cutout/manifest.ts
@@ -86,8 +86,12 @@ export function parseManifest(json: unknown): Manifest {
 }
 
 /** Fetch + parse a band `manifest.json` from a URL. */
-export async function loadManifest(url: string, signal?: AbortSignal): Promise<Manifest> {
-  const res = await fetch(url, { signal });
+export async function loadManifest(
+  url: string,
+  signal?: AbortSignal,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Manifest> {
+  const res = await fetchImpl(url, { signal });
   if (!res.ok) throw new Error(`manifest fetch failed (${res.status}) for ${url}`);
   return parseManifest(await res.json());
 }

--- a/web/lib/cutout/source.ts
+++ b/web/lib/cutout/source.ts
@@ -21,6 +21,11 @@ export interface FieldCutoutSource {
   bandNames: string[];
   /** Native (finest-level) pixel scale in arcsec/px, for native-size defaults. */
   nativeScaleArcsec: number;
+  /** Whether every backing mosaic is published (`fitsgl_dataset_is_public`).
+   *  `false` ⇒ this render is admin-only: the response must NOT be
+   *  shared-cacheable (`private, no-store`), or a CDN keyed only on the URL
+   *  would replay draft imagery to non-admins. */
+  isPublic: boolean;
 }
 
 /** `fetch` with Next data-cache revalidation, so a re-deployed dataset's
@@ -85,15 +90,20 @@ export async function resolveFieldCutoutSource(
   if (error || !rows || rows.length === 0) return null;
   const ds = rows.find((r) => r.is_default) ?? rows[0];
 
-  if (opts.requirePublic) {
-    const { data: isPublic, error: pubErr } = await supabase.rpc('fitsgl_dataset_is_public', {
-      p_field: ds.field,
-      p_tiles: ds.tiles,
-      p_bands: ds.bands,
-      p_pixel_scale: ds.pixel_scale,
-    });
-    if (pubErr || !isPublic) return null;
+  // Publicity is always evaluated (not only under requirePublic): callers that
+  // may render draft-backed pyramids (admin RLS / admin API) need it to pick a
+  // non-shared cache policy for the response.
+  const { data: isPublic, error: pubErr } = await supabase.rpc('fitsgl_dataset_is_public', {
+    p_field: ds.field,
+    p_tiles: ds.tiles,
+    p_bands: ds.bands,
+    p_pixel_scale: ds.pixel_scale,
+  });
+  if (pubErr) {
+    console.error(`fitsgl_dataset_is_public failed for field ${field}:`, pubErr);
+    return null;
   }
+  if (opts.requirePublic && !isPublic) return null;
 
   try {
     const config = await loadFitsglConfig(ds.fitsgl_json_url, cachingFetch);
@@ -111,6 +121,7 @@ export async function resolveFieldCutoutSource(
       bands,
       bandNames: chosen.map((b) => b.name),
       nativeScaleArcsec: bands[0].manifest.levels[0].pixelScaleArcsec,
+      isPublic: Boolean(isPublic),
     };
   } catch (err) {
     console.error(`FitsGL cutout source unavailable for field ${field}:`, err);

--- a/web/lib/cutout/source.ts
+++ b/web/lib/cutout/source.ts
@@ -1,0 +1,119 @@
+// Per-field cutout dispatch (epic #337, Phase 5): resolve a field's deployed
+// FitsGL tile pyramid into the `BandSource[]` the cutout engine consumes. A field
+// with a `kind='field'` row in `fitsgl_datasets` renders display cutouts from the
+// FITS pyramid; a `null` return means "no (visible) pyramid" and the caller falls
+// back to the legacy PNG-tile compositing (retired per-field in the follow-up PR).
+//
+// Kept free of `sharp`/route coupling so the science-FITS route can share it;
+// PNG-flattening display helpers live in `./display`.
+
+import { loadFitsglConfig, type FitsglConfig } from '@fitsgl/core';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { loadManifest } from './manifest';
+import type { BandSource } from './index';
+
+type FitsglBand = FitsglConfig['dataset']['bands'][number];
+
+export interface FieldCutoutSource {
+  /** 1 band (single-band colormap) or 3 ordered `[R, G, B]` (composite). */
+  bands: BandSource[];
+  /** Band names matching `bands`, for labeling/provenance. */
+  bandNames: string[];
+  /** Native (finest-level) pixel scale in arcsec/px, for native-size defaults. */
+  nativeScaleArcsec: number;
+}
+
+/** `fetch` with Next data-cache revalidation, so a re-deployed dataset's
+ *  `fitsgl.json`/`manifest.json` refresh within an hour (mirrors the legacy
+ *  PNG tile fetcher's `revalidate: 3600`). */
+const cachingFetch: typeof fetch = (input, init) =>
+  fetch(input, { ...init, next: { revalidate: 3600 } });
+
+/**
+ * Pick the display bands from a dataset inventory.
+ *
+ * Producer default view first (`mode:'rgb'` with named channels); otherwise a
+ * wavelength-ordered composite — reddest→R, middle→G, bluest→B — when the field
+ * has ≥3 bands, else the default single band. Grid-group compatibility is NOT
+ * required here (unlike the live viewer's composite): every band reprojects
+ * independently onto the same North-up output grid.
+ */
+function chooseBands(config: FitsglConfig): FitsglBand[] {
+  const { bands } = config.dataset;
+  const dv = config.defaultView;
+
+  if (dv.mode === 'rgb' && dv.r && dv.g && dv.b) {
+    const byName = new Map(bands.map((b) => [b.name, b]));
+    const rgb = [dv.r, dv.g, dv.b].map((n) => byName.get(n));
+    if (rgb.every(Boolean)) return rgb as FitsglBand[];
+  }
+
+  if (bands.length >= 3) {
+    // Blue→red by pivot wavelength; producers omit pivotUm ⇒ declaration order.
+    const ordered = bands.every((b) => b.pivotUm != null)
+      ? [...bands].sort((a, b) => a.pivotUm! - b.pivotUm!)
+      : bands;
+    const mid = Math.floor((ordered.length - 1) / 2);
+    return [ordered[ordered.length - 1], ordered[mid], ordered[0]];
+  }
+
+  const single = (dv.band && bands.find((b) => b.name === dv.band)) || bands[0];
+  return [single];
+}
+
+/**
+ * Resolve a field's FitsGL cutout source, or `null` when the field has no
+ * (visible) pyramid — including on any fetch/parse failure, so callers can fall
+ * back to the legacy path during the transition.
+ *
+ * `requirePublic` is for service-role callers, which bypass RLS: it mirrors the
+ * `authenticated_select_fitsgl_datasets` policy via the same SECURITY DEFINER
+ * `fitsgl_dataset_is_public()` check, so an unpublished-backed dataset never
+ * serves public/API cutouts. User-scoped clients rely on RLS instead (admins
+ * intentionally see draft-backed datasets, matching the map).
+ */
+export async function resolveFieldCutoutSource(
+  supabase: SupabaseClient,
+  field: string,
+  opts: { requirePublic?: boolean } = {},
+): Promise<FieldCutoutSource | null> {
+  const { data: rows, error } = await supabase
+    .from('fitsgl_datasets')
+    .select('field, kind, tiles, bands, pixel_scale, fitsgl_json_url, is_default')
+    .eq('field', field)
+    .eq('kind', 'field');
+  if (error || !rows || rows.length === 0) return null;
+  const ds = rows.find((r) => r.is_default) ?? rows[0];
+
+  if (opts.requirePublic) {
+    const { data: isPublic, error: pubErr } = await supabase.rpc('fitsgl_dataset_is_public', {
+      p_field: ds.field,
+      p_tiles: ds.tiles,
+      p_bands: ds.bands,
+      p_pixel_scale: ds.pixel_scale,
+    });
+    if (pubErr || !isPublic) return null;
+  }
+
+  try {
+    const config = await loadFitsglConfig(ds.fitsgl_json_url, cachingFetch);
+    const chosen = chooseBands(config);
+    const bands: BandSource[] = await Promise.all(
+      chosen.map(async (b) => {
+        const manifestUrl = b.tiles[0]; // absolute after loadFitsglConfig
+        return {
+          manifest: await loadManifest(manifestUrl, undefined, cachingFetch),
+          baseUrl: new URL('.', manifestUrl).toString(),
+        };
+      }),
+    );
+    return {
+      bands,
+      bandNames: chosen.map((b) => b.name),
+      nativeScaleArcsec: bands[0].manifest.levels[0].pixelScaleArcsec,
+    };
+  } catch (err) {
+    console.error(`FitsGL cutout source unavailable for field ${field}:`, err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

**PR B of the Phase 5 sub-PR sequence** (epic #337, issue #343) — **stacked on #363 (PR A)**; only the last 1 commit is new here.

Fields with a deployed FitsGL pyramid now serve the three display routes — `/api/tile-thumbnail`, `/api/og-image/[id]`, `/api/v1/cutout` — as **North-up PNGs rendered server-side from the FITS tiles** by the PR A engine. Fields without a pyramid keep the legacy PNG-tile compositing, byte-for-byte untouched (that stack is retired per-field in PR E). **Route params and all consumers are unchanged** — `TileThumbnail.tsx`, the og-image meta tags, and the Python client's `plot_cutout()` need no edits.

## How it works

- **`lib/cutout/source.ts`** — the per-field dispatch: `fitsgl_datasets` lookup (default `kind='field'` row) → `loadFitsglConfig` (Node-safe, Next data-cache `revalidate: 3600`, mirroring the legacy tile fetcher) → band pick → band manifests → `BandSource[]` for the engine. `null` ⇒ caller falls back to legacy.
- **Band pick**: producer `defaultView` RGB when it names channels; else, with ≥3 bands, a wavelength-ordered composite (reddest→R, middle→G, bluest→B); else the default single band (colormapped gray). Note grid-group compatibility is *not* required here, unlike the live viewer's composite — every band reprojects independently onto the same N-up output grid.
- **`lib/cutout/display.ts`** — `renderCutout` + PNG flattened onto black, matching the legacy compositor's opaque canvas (no visual regime change for consumers; NaN/no-coverage renders black as before).
- **`/api/v1/cutout`** native-size default now derives from the pyramid's finest `pixelScaleArcsec` instead of `map_layers.wcs_params`; `map_layers` is only consulted on the legacy path. Size-param validation is unchanged (one edge: `?size=abc` on a field with no layers now 400s before the 404 — arguably more correct).
- **Fallback**: any FitsGL fetch/render failure logs and falls through to the legacy path while both stacks coexist.

## Visibility (service-role routes)

`/api/og-image` and `/api/v1/cutout` use service-role clients, which bypass RLS on `fitsgl_datasets`. `resolveFieldCutoutSource(..., { requirePublic })` mirrors the `authenticated_select_fitsgl_datasets` policy via the same SECURITY DEFINER `fitsgl_dataset_is_public()` RPC, so an unpublished-backed pyramid never serves the public og-image route or a non-admin API cutout. `/api/tile-thumbnail` uses the user-scoped client and relies on RLS (admins intentionally see draft-backed pyramids, matching the map). No schema change.

## Verification (local: rj0911 pyramid on `fitsgl serve`, seeded local Supabase)

All three routes render-verified end-to-end against the live dev server — the on-source galaxy renders N-up at correct FOV/scale on each:
- `og-image` (public, curl): 200 PNG, 5″/300px
- `v1/cutout` (API key): 200 PNG, 12″/400px, native-size default exercised
- `tile-thumbnail` (cookie auth via puppeteer): 200 PNG, 8″/300px

**Draft-state security matrix** (backing mosaic flipped to `draft`):
| route | result |
|---|---|
| og-image (public) | 404 — no leak |
| v1/cutout, admin key | 200 PNG — admins see drafts (matches map) |
| v1/cutout, non-admin key | 404 — blocked from FitsGL, no imagery leak |

Plus: `tsc` clean, `eslint` clean, 13/13 plan-parity tests, `npm run build` compiled successfully.

Web-only — no pipeline changelog entry needed.

**Next:** PR C adds the science cutout API (FITS + multi-band figure) + Python client `get_cutout()`; PR D the GUI; PR E retires the PNG stack per-field.

Generated with Claude Code