### PR TITLE
feat(cutout): science FITS + figure API + Python client (PR C of #343)

### DIFF
--- a/python/campfire/api/client.py
+++ b/python/campfire/api/client.py
@@ -431,6 +431,93 @@ class APIClient:
         _handle_response_error(response, f"Cutout for {object_id}")
         return response.content
 
+    def get_fits_cutout(
+        self,
+        field: str,
+        ra: float,
+        dec: float,
+        fov: float = 10.0,
+        bands: Optional[List[str]] = None,
+        scale: Optional[float] = None,
+    ) -> bytes:
+        """Fetch a science FITS cutout from a field's FitsGL tile pyramid.
+
+        A direct crop of the tiles at the requested (default native) pyramid
+        level — no resampling, no stretch. Multi-extension FITS: one float32
+        IMAGE extension per band (EXTNAME = band), each carrying the level's
+        WCS. Pixels are the display pyramid's RICE-quantized values
+        (~0.03% photometry-faithful; flagged in the FITS headers).
+
+        Parameters
+        ----------
+        field : str
+            Field name (must have a deployed FitsGL dataset).
+        ra, dec : float
+            ICRS centre in degrees.
+        fov : float, optional
+            Square field of view in arcseconds (default 10, max 600).
+        bands : list of str, optional
+            Band subset (e.g. ``["f277w", "f444w"]``). Default: every band.
+        scale : float, optional
+            Output pixel scale in arcsec/px — selects a coarser pyramid level
+            for wide fields. Default: native.
+        """
+        params: Dict[str, Union[str, int, float]] = {
+            "field": field, "ra": ra, "dec": dec, "fov": fov,
+        }
+        if bands:
+            params["bands"] = ",".join(bands)
+        if scale is not None:
+            params["scale"] = scale
+        response = self._session.get("/cutout/fits", params=params, timeout=120)
+        _handle_response_error(response, f"FITS cutout at ({ra}, {dec}) in {field}")
+        return response.content
+
+    def get_cutout_figure(
+        self,
+        field: str,
+        ra: float,
+        dec: float,
+        fov: float = 10.0,
+        bands: Optional[List[str]] = None,
+        size: int = 300,
+        cols: Optional[int] = None,
+        stretch: str = "asinh",
+        colormap: str = "gray",
+    ) -> bytes:
+        """Fetch a multi-band cutout figure PNG (one labeled panel per band).
+
+        Parameters
+        ----------
+        field : str
+            Field name (must have a deployed FitsGL dataset).
+        ra, dec : float
+            ICRS centre in degrees.
+        fov : float, optional
+            Square field of view in arcseconds (default 10, max 600).
+        bands : list of str, optional
+            Band subset; default every band, in deployed inventory order.
+        size : int, optional
+            Panel edge in pixels (default 300, max 1024).
+        cols : int, optional
+            Panels per row (default: all in one row).
+        stretch : str, optional
+            One of ``linear``, ``log``, ``sqrt``, ``asinh`` (default).
+        colormap : str, optional
+            e.g. ``gray`` (default), ``viridis``, ``magma``, ``inferno``.
+        """
+        params: Dict[str, Union[str, int, float]] = {
+            "field": field, "ra": ra, "dec": dec, "fov": fov,
+            "size": size, "stretch": stretch, "colormap": colormap,
+        }
+        if bands:
+            params["bands"] = ",".join(bands)
+        if cols is not None:
+            params["cols"] = cols
+        response = self._session.get("/cutout/figure", params=params, timeout=120)
+        _handle_response_error(response, f"Cutout figure at ({ra}, {dec}) in {field}")
+        return response.content
+
     def fetch_all_photometry(
         self,
         updated_since: Optional[str] = None,

--- a/python/campfire/client.py
+++ b/python/campfire/client.py
@@ -823,8 +823,11 @@ class Campfire:
 
         band_tag = f"_{'-'.join(bands)}" if bands else ""
         scale_tag = f"_s{format(scale, 'g')}" if scale is not None else ""
+        # repr() is the shortest lossless float text — rounded keys (e.g. .5f)
+        # would silently alias nearby centres (~a native pixel at 1e-5 deg)
+        # to the same cached cutout.
         filename = (
-            f"{field}_{ra:.5f}{dec:+.5f}_fov{format(fov, 'g')}{band_tag}{scale_tag}.fits"
+            f"{field}_{ra!r}_{dec!r}_fov{format(fov, 'g')}{band_tag}{scale_tag}.fits"
         )
 
         from .config import resolve_data_dir
@@ -891,8 +894,9 @@ class Campfire:
         """
         band_tag = f"_{'-'.join(bands)}" if bands else ""
         cols_tag = f"_c{cols}" if cols is not None else ""
+        # repr() keys: lossless coordinates, no near-centre cache aliasing.
         filename = (
-            f"{field}_{ra:.5f}{dec:+.5f}_fov{format(fov, 'g')}{band_tag}"
+            f"{field}_{ra!r}_{dec!r}_fov{format(fov, 'g')}{band_tag}"
             f"_p{size}{cols_tag}_{stretch}_{colormap}.png"
         )
 

--- a/python/campfire/client.py
+++ b/python/campfire/client.py
@@ -773,6 +773,152 @@ class Campfire:
 
         return dest
 
+    def get_fits_cutout(
+        self,
+        field: str,
+        ra: float,
+        dec: float,
+        fov: float = 10.0,
+        bands: Optional[List[str]] = None,
+        scale: Optional[float] = None,
+        cache: bool = True,
+    ):
+        """Download a science FITS cutout from a field's FitsGL tile pyramid.
+
+        A direct crop of the tiles at the requested (default native) pyramid
+        level — no resampling, no stretch. The returned ``HDUList`` has one
+        float32 IMAGE extension per band (``EXTNAME`` = band, e.g.
+        ``hdul['F444W']``), each carrying the pyramid level's WCS. Pixels are
+        the display pyramid's RICE-quantized values (~0.03%
+        photometry-faithful; flagged in the FITS headers).
+
+        Parameters
+        ----------
+        field : str
+            Field name (must have a deployed FitsGL dataset).
+        ra, dec : float
+            ICRS centre in degrees.
+        fov : float, optional
+            Square field of view in arcseconds (default 10, max 600).
+        bands : list of str, optional
+            Band subset (e.g. ``["f277w", "f444w"]``). Default: every band.
+        scale : float, optional
+            Output pixel scale in arcsec/px — selects a coarser pyramid level
+            for wide fields. Default: native.
+        cache : bool, optional
+            Reuse a previously downloaded file when present (default True).
+
+        Returns
+        -------
+        astropy.io.fits.HDUList
+            Opened from the cached file (memory-mapped).
+
+        Examples
+        --------
+        >>> cf = Campfire()
+        >>> hdul = cf.get_fits_cutout('cosmos', ra=150.1, dec=2.2, fov=6)
+        >>> data, header = hdul['F444W'].data, hdul['F444W'].header
+        """
+        from astropy.io import fits
+
+        band_tag = f"_{'-'.join(bands)}" if bands else ""
+        scale_tag = f"_s{format(scale, 'g')}" if scale is not None else ""
+        filename = (
+            f"{field}_{ra:.5f}{dec:+.5f}_fov{format(fov, 'g')}{band_tag}{scale_tag}.fits"
+        )
+
+        from .config import resolve_data_dir
+        cutouts = resolve_data_dir() / "cutouts"
+
+        dest = _safe_cache_path(cutouts, filename, field)
+        if cache and dest.exists():
+            return fits.open(dest)
+
+        fits_data = self._api.get_fits_cutout(
+            field, ra, dec, fov=fov, bands=bands, scale=scale,
+        )
+
+        cutouts.mkdir(parents=True, exist_ok=True)
+        tmp = dest.with_suffix(".tmp")
+        try:
+            tmp.write_bytes(fits_data)
+            tmp.rename(dest)
+        except Exception:
+            tmp.unlink(missing_ok=True)
+            raise
+
+        return fits.open(dest)
+
+    def get_cutout_figure(
+        self,
+        field: str,
+        ra: float,
+        dec: float,
+        fov: float = 10.0,
+        bands: Optional[List[str]] = None,
+        size: int = 300,
+        cols: Optional[int] = None,
+        stretch: str = "asinh",
+        colormap: str = "gray",
+        cache: bool = True,
+    ) -> Path:
+        """Download a multi-band cutout figure PNG (one labeled panel per band).
+
+        Rendered server-side from the field's FitsGL pyramid with the same
+        transfer functions as the web map; per-panel percentile stretch.
+        Returns the path to the cached PNG.
+
+        Parameters
+        ----------
+        field : str
+            Field name (must have a deployed FitsGL dataset).
+        ra, dec : float
+            ICRS centre in degrees.
+        fov : float, optional
+            Square field of view in arcseconds (default 10, max 600).
+        bands : list of str, optional
+            Band subset; default every band, in deployed inventory order.
+        size : int, optional
+            Panel edge in pixels (default 300, max 1024).
+        cols : int, optional
+            Panels per row (default: all in one row).
+        stretch : str, optional
+            One of ``linear``, ``log``, ``sqrt``, ``asinh`` (default).
+        colormap : str, optional
+            e.g. ``gray`` (default), ``viridis``, ``magma``, ``inferno``.
+        cache : bool, optional
+            Reuse a previously downloaded file when present (default True).
+        """
+        band_tag = f"_{'-'.join(bands)}" if bands else ""
+        cols_tag = f"_c{cols}" if cols is not None else ""
+        filename = (
+            f"{field}_{ra:.5f}{dec:+.5f}_fov{format(fov, 'g')}{band_tag}"
+            f"_p{size}{cols_tag}_{stretch}_{colormap}.png"
+        )
+
+        from .config import resolve_data_dir
+        cutouts = resolve_data_dir() / "cutouts"
+
+        dest = _safe_cache_path(cutouts, filename, field)
+        if cache and dest.exists():
+            return dest
+
+        png_data = self._api.get_cutout_figure(
+            field, ra, dec, fov=fov, bands=bands, size=size, cols=cols,
+            stretch=stretch, colormap=colormap,
+        )
+
+        cutouts.mkdir(parents=True, exist_ok=True)
+        tmp = dest.with_suffix(".tmp")
+        try:
+            tmp.write_bytes(png_data)
+            tmp.rename(dest)
+        except Exception:
+            tmp.unlink(missing_ok=True)
+            raise
+
+        return dest
+
     def get_shutters(
         self,
         object_id: str,

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -217,3 +217,55 @@ class TestImagingMethods:
             client.get_shutters("CAMPFIRE-J0001+0001", fov=3.0, cache=False)
         params = mock_api_session.get.call_args.kwargs.get("params", {})
         assert params["object_id"] == "CAMPFIRE-J0001+0001"
+
+    def test_get_fits_cutout_params_and_open(self, mock_api_session, tmp_path):
+        # The response must be real FITS bytes: the client caches then opens it.
+        import io
+        import numpy as np
+        from astropy.io import fits as afits
+
+        hdul = afits.HDUList([
+            afits.PrimaryHDU(),
+            afits.ImageHDU(data=np.zeros((2, 2), dtype=np.float32), name="F444W"),
+        ])
+        buf = io.BytesIO()
+        hdul.writeto(buf)
+
+        mock_api_session.get.return_value = _make_mock_response()
+        mock_api_session.get.return_value.content = buf.getvalue()
+        with patch("campfire.config.resolve_data_dir", return_value=tmp_path), \
+                warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            client = Campfire()
+            result = client.get_fits_cutout(
+                "cosmos", ra=150.1, dec=2.2, fov=6.0,
+                bands=["f277w", "f444w"], scale=0.06, cache=False,
+            )
+        path, = mock_api_session.get.call_args.args
+        assert path == "/cutout/fits"
+        params = mock_api_session.get.call_args.kwargs.get("params", {})
+        assert params["field"] == "cosmos"
+        assert params["ra"] == 150.1 and params["dec"] == 2.2
+        assert params["fov"] == 6.0
+        assert params["bands"] == "f277w,f444w"
+        assert params["scale"] == 0.06
+        assert result["F444W"].data.shape == (2, 2)
+        result.close()
+
+    def test_get_cutout_figure_params(self, mock_api_session, tmp_path):
+        mock_api_session.get.return_value = _make_mock_response()
+        mock_api_session.get.return_value.content = b"PNGDATA"
+        with patch("campfire.config.resolve_data_dir", return_value=tmp_path), \
+                warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            client = Campfire()
+            dest = client.get_cutout_figure(
+                "cosmos", ra=150.1, dec=2.2, fov=6.0,
+                size=200, cols=3, stretch="log", colormap="viridis", cache=False,
+            )
+        path, = mock_api_session.get.call_args.args
+        assert path == "/cutout/figure"
+        params = mock_api_session.get.call_args.kwargs.get("params", {})
+        assert params["size"] == 200 and params["cols"] == 3
+        assert params["stretch"] == "log" and params["colormap"] == "viridis"
+        assert dest.read_bytes() == b"PNGDATA"

--- a/web/app/api/v1/cutout/figure/route.ts
+++ b/web/app/api/v1/cutout/figure/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { isColormapName, type StretchMode, type ColormapName } from '@fitsgl/core';
+import { createServiceClient } from '@/lib/supabase/server';
+import { isAdminUser } from '@/lib/api-helpers';
+import { resolveFieldScienceSource, UnknownBandError } from '@/lib/cutout/source';
+import { renderFigurePng } from '@/lib/cutout/figure';
+import { resolveRequestUser, parseScienceParams } from '../science-params';
+
+/** Single-band panel stretches (trilogy is an RGB-composite mode, not offered here). */
+const FIGURE_STRETCHES: StretchMode[] = ['linear', 'log', 'sqrt', 'asinh'];
+
+/**
+ * GET /api/v1/cutout/figure?field=<f>&ra=<deg>&dec=<deg>&fov=<arcsec>
+ *        [&bands=...][&size=<px>][&cols=<n>][&stretch=asinh][&colormap=gray]
+ *
+ * Multi-band cutout figure (epic #337, Phase 5): one labeled North-up panel
+ * per band — the classic postage-stamp strip — rendered from the field's
+ * FitsGL pyramid and returned as a single PNG. Same engine and transfer
+ * functions as the interactive map; per-panel percentile stretch.
+ *
+ * - `size` panel edge in px, clamped 64–1024 (default 300)
+ * - `cols` panels per row (default: all in one row)
+ *
+ * Auth: Bearer API key / JWT, or the browser cookie session (used by the
+ * cutout GUI). Non-admins only reach published-backed pyramids.
+ */
+export async function GET(request: NextRequest) {
+  const userId = await resolveRequestUser(request);
+  if (!userId) {
+    return NextResponse.json({ error: 'Invalid or missing credentials' }, { status: 401 });
+  }
+
+  const parsed = parseScienceParams(request);
+  if (parsed instanceof NextResponse) return parsed;
+  // (no `scale` here: figure level selection follows the panel size)
+  const { field, ra, dec, fovArcsec, bands } = parsed;
+
+  const params = request.nextUrl.searchParams;
+  const parsedSize = parseInt(params.get('size') || '300', 10);
+  if (!Number.isFinite(parsedSize)) {
+    return NextResponse.json({ error: 'Invalid parameter: size must be a number' }, { status: 400 });
+  }
+  const panelSize = Math.min(1024, Math.max(64, parsedSize));
+
+  let cols: number | undefined;
+  const colsParam = params.get('cols');
+  if (colsParam !== null) {
+    cols = parseInt(colsParam, 10);
+    if (!Number.isFinite(cols) || cols < 1) {
+      return NextResponse.json({ error: 'Invalid parameter: cols must be a positive integer' }, { status: 400 });
+    }
+  }
+
+  const stretch = (params.get('stretch') ?? 'asinh') as StretchMode;
+  if (!FIGURE_STRETCHES.includes(stretch)) {
+    return NextResponse.json(
+      { error: `Invalid stretch; one of: ${FIGURE_STRETCHES.join(', ')}` },
+      { status: 400 }
+    );
+  }
+  const colormap = params.get('colormap') ?? 'gray';
+  if (!isColormapName(colormap)) {
+    return NextResponse.json({ error: 'Invalid colormap' }, { status: 400 });
+  }
+
+  try {
+    const isAdmin = await isAdminUser(userId);
+    const supabase = createServiceClient();
+
+    let src;
+    try {
+      src = await resolveFieldScienceSource(supabase, field, {
+        requirePublic: !isAdmin,
+        bands,
+      });
+    } catch (err) {
+      if (err instanceof UnknownBandError) {
+        return NextResponse.json(
+          { error: err.message, available_bands: err.available },
+          { status: 400 }
+        );
+      }
+      throw err;
+    }
+    if (!src) {
+      return NextResponse.json(
+        { error: 'No FitsGL dataset for this field' },
+        { status: 404 }
+      );
+    }
+
+    const png = await renderFigurePng(src, {
+      center: [ra, dec],
+      fovArcsec,
+      panelSize,
+      cols,
+      stretch,
+      colormap: colormap as ColormapName,
+    });
+
+    return new Response(new Uint8Array(png), {
+      status: 200,
+      headers: {
+        'Content-Type': 'image/png',
+        'Cache-Control': 'private, max-age=3600',
+      },
+    });
+  } catch (error) {
+    console.error('Error in API /v1/cutout/figure:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/web/app/api/v1/cutout/fits/route.ts
+++ b/web/app/api/v1/cutout/fits/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createServiceClient } from '@/lib/supabase/server';
+import { isAdminUser } from '@/lib/api-helpers';
+import { resolveFieldScienceSource, UnknownBandError } from '@/lib/cutout/source';
+import { buildFitsCutout, CutoutTooLargeError } from '@/lib/cutout/science';
+import { resolveRequestUser, parseScienceParams, safeToken } from '../science-params';
+
+/**
+ * GET /api/v1/cutout/fits?field=<f>&ra=<deg>&dec=<deg>&fov=<arcsec>
+ *                        [&bands=f115w,f277w,f444w][&scale=<arcsec/px>]
+ *
+ * Science FITS cutout from a field's FitsGL tile pyramid (epic #337, Phase 5):
+ * a direct crop of the tiles at the requested (default native) pyramid level —
+ * no resampling, no stretch. Multi-extension FITS: empty primary + one float32
+ * IMAGE extension per band, each carrying the level's WCS with CRPIX shifted
+ * to the crop. Pixels are the display pyramid's RICE-quantized values
+ * (~0.03% photometry-faithful; flagged in the headers).
+ *
+ * - `fov` arcsec, clamped 0.5–600 (default 10)
+ * - `bands` comma-separated subset (default: every band in the dataset)
+ * - `scale` selects a coarser pyramid level for wide fields (default native)
+ *
+ * Auth: Bearer API key / JWT, or the browser cookie session (used by the
+ * cutout GUI). Non-admins only reach published-backed pyramids.
+ */
+export async function GET(request: NextRequest) {
+  const userId = await resolveRequestUser(request);
+  if (!userId) {
+    return NextResponse.json({ error: 'Invalid or missing credentials' }, { status: 401 });
+  }
+
+  const parsed = parseScienceParams(request);
+  if (parsed instanceof NextResponse) return parsed;
+  const { field, ra, dec, fovArcsec, bands, targetScaleArcsec } = parsed;
+
+  try {
+    const isAdmin = await isAdminUser(userId);
+    const supabase = createServiceClient();
+
+    let src;
+    try {
+      src = await resolveFieldScienceSource(supabase, field, {
+        requirePublic: !isAdmin,
+        bands,
+      });
+    } catch (err) {
+      if (err instanceof UnknownBandError) {
+        return NextResponse.json(
+          { error: err.message, available_bands: err.available },
+          { status: 400 }
+        );
+      }
+      throw err;
+    }
+    if (!src) {
+      return NextResponse.json(
+        { error: 'No FitsGL dataset for this field' },
+        { status: 404 }
+      );
+    }
+
+    let fits: Buffer;
+    try {
+      fits = await buildFitsCutout(src, { center: [ra, dec], fovArcsec, targetScaleArcsec, field });
+    } catch (err) {
+      if (err instanceof CutoutTooLargeError) {
+        return NextResponse.json({ error: err.message }, { status: 400 });
+      }
+      throw err;
+    }
+
+    const filename = `campfire_${safeToken(field)}_${ra.toFixed(5)}_${dec.toFixed(5)}_${fovArcsec}as.fits`;
+    return new Response(new Uint8Array(fits), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/fits',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+        'Cache-Control': 'private, max-age=3600',
+      },
+    });
+  } catch (error) {
+    console.error('Error in API /v1/cutout/fits:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/web/app/api/v1/cutout/science-params.ts
+++ b/web/app/api/v1/cutout/science-params.ts
@@ -1,0 +1,75 @@
+// Shared request handling for the science cutout routes (epic #337, Phase 5):
+// `/api/v1/cutout/fits` and `/api/v1/cutout/figure`. Both are coordinate+field
+// addressed (unlike the object_id display route), accept EITHER a Bearer
+// API-key/JWT or the browser's cookie session (so the cutout GUI hits the same
+// canonical endpoints), and resolve bands through `resolveFieldScienceSource`.
+
+import { NextRequest, NextResponse } from 'next/server';
+import { validateAuth } from '@/lib/api-auth';
+import { createClient } from '@/lib/supabase/server';
+
+/** Authenticated user id via Bearer token (API key / JWT) or cookie session. */
+export async function resolveRequestUser(request: NextRequest): Promise<string | null> {
+  if (request.headers.get('authorization')) {
+    return validateAuth(request);
+  }
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  return user?.id ?? null;
+}
+
+export interface ScienceParams {
+  field: string;
+  ra: number;
+  dec: number;
+  fovArcsec: number;
+  /** Requested band subset (lower-cased), or undefined for all. */
+  bands?: string[];
+  /** Output pixel scale (arcsec/px) → level selection; undefined for native. */
+  targetScaleArcsec?: number;
+}
+
+/** Parse + validate the shared params; returns a 400 response on failure. */
+export function parseScienceParams(request: NextRequest): ScienceParams | NextResponse {
+  const params = request.nextUrl.searchParams;
+  const bad = (error: string) => NextResponse.json({ error }, { status: 400 });
+
+  const field = params.get('field');
+  if (!field) return bad('Missing required parameter: field');
+
+  const ra = parseFloat(params.get('ra') ?? '');
+  const dec = parseFloat(params.get('dec') ?? '');
+  if (!Number.isFinite(ra) || !Number.isFinite(dec)) {
+    return bad('Missing/invalid parameters: ra and dec must be finite degrees');
+  }
+  if (ra < 0 || ra >= 360 || dec < -90 || dec > 90) {
+    return bad('Invalid coordinates: ra in [0, 360), dec in [-90, 90]');
+  }
+
+  const parsedFov = parseFloat(params.get('fov') || '10');
+  if (!Number.isFinite(parsedFov)) return bad('Invalid parameter: fov must be a finite number');
+  const fovArcsec = Math.min(600, Math.max(0.5, parsedFov));
+
+  let bands: string[] | undefined;
+  const bandsParam = params.get('bands');
+  if (bandsParam !== null) {
+    bands = bandsParam.split(',').map((b) => b.trim().toLowerCase()).filter(Boolean);
+    if (bands.length === 0) return bad('Invalid parameter: bands must be a comma-separated list');
+  }
+
+  let targetScaleArcsec: number | undefined;
+  const scaleParam = params.get('scale');
+  if (scaleParam !== null) {
+    targetScaleArcsec = parseFloat(scaleParam);
+    if (!Number.isFinite(targetScaleArcsec) || targetScaleArcsec <= 0) {
+      return bad('Invalid parameter: scale must be a positive number (arcsec/px)');
+    }
+  }
+
+  return { field, ra, dec, fovArcsec, bands, targetScaleArcsec };
+}
+
+/** Filesystem/header-safe token for Content-Disposition filenames. */
+export function safeToken(s: string): string {
+  return s.replace(/[^a-zA-Z0-9_.-]+/g, '-');
+}

--- a/web/lib/cutout/figure.ts
+++ b/web/lib/cutout/figure.ts
@@ -1,0 +1,96 @@
+// Multi-band cutout figure (epic #337, Phase 5): one labeled North-up panel per
+// band, composed into a single PNG — the classic postage-stamp strip for a
+// quick look across an object's bands. Server-only (`sharp` composition);
+// panel pixels come from the same engine path as the display routes
+// (`bandToOutput` → per-band percentile stretch → colormap).
+
+import sharp from 'sharp';
+import type { StretchMode, ColormapName } from '@fitsgl/core';
+import { bandToOutput } from './index';
+import { percentileLimits, renderSingleBand } from './render';
+import type { FieldScienceSource } from './source';
+
+/** Gap between panels, px. */
+const GAP = 4;
+/** Label inset from the panel's top-left corner, px. */
+const LABEL_PAD = 8;
+
+export interface FigureRequest {
+  /** ICRS centre `[ra, dec]` in degrees. */
+  center: [number, number];
+  /** Square field of view in arcsec (every panel shows the same box). */
+  fovArcsec: number;
+  /** Panel edge in px. */
+  panelSize: number;
+  /** Panels per row; defaults to all bands in one row. */
+  cols?: number;
+  stretch?: StretchMode;
+  colormap?: ColormapName;
+  /** Draw the band label on each panel (default true). */
+  labels?: boolean;
+}
+
+/** Escape a band label for the SVG text overlay. */
+function esc(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/** Render the per-band panels and compose them into one PNG. */
+export async function renderFigurePng(src: FieldScienceSource, req: FigureRequest): Promise<Buffer> {
+  const n = src.bands.length;
+  if (n === 0) throw new Error('figure: no bands');
+  const size = req.panelSize;
+  const cols = Math.max(1, Math.min(req.cols ?? n, n));
+  const rows = Math.ceil(n / cols);
+  const stretch = req.stretch ?? 'asinh';
+  const colormap = req.colormap ?? 'gray';
+
+  // Reproject + stretch every band on the same N-up output grid.
+  const panels = await Promise.all(
+    src.bands.map(async (band) => {
+      const out = await bandToOutput(band, req.center, req.fovArcsec, size);
+      const rgba = renderSingleBand(out.data, out.width, out.height, {
+        limits: percentileLimits(out.data),
+        stretch,
+        colormap,
+      });
+      return { rgba, label: band.label ?? band.name.toUpperCase() };
+    }),
+  );
+
+  const width = cols * size + (cols - 1) * GAP;
+  const height = rows * size + (rows - 1) * GAP;
+  const composites: sharp.OverlayOptions[] = [];
+  const labelSpans: string[] = [];
+  const fontSize = Math.max(11, Math.round(size / 14));
+
+  panels.forEach((panel, i) => {
+    const left = (i % cols) * (size + GAP);
+    const top = Math.floor(i / cols) * (size + GAP);
+    composites.push({
+      input: Buffer.from(panel.rgba.buffer, panel.rgba.byteOffset, panel.rgba.byteLength),
+      raw: { width: size, height: size, channels: 4 },
+      left,
+      top,
+    });
+    if (req.labels !== false) {
+      labelSpans.push(
+        `<text x="${left + LABEL_PAD}" y="${top + LABEL_PAD + fontSize}" ` +
+          `font-family="Helvetica, Arial, sans-serif" font-size="${fontSize}" font-weight="600" ` +
+          `fill="#ffffff" stroke="#000000" stroke-width="${fontSize / 8}" paint-order="stroke">` +
+          `${esc(panel.label)}</text>`,
+      );
+    }
+  });
+  if (labelSpans.length > 0) {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">${labelSpans.join('')}</svg>`;
+    composites.push({ input: Buffer.from(svg), left: 0, top: 0 });
+  }
+
+  return sharp({
+    create: { width, height, channels: 4, background: { r: 0, g: 0, b: 0, alpha: 255 } },
+  })
+    .composite(composites)
+    .png()
+    .toBuffer();
+}

--- a/web/lib/cutout/fits.test.ts
+++ b/web/lib/cutout/fits.test.ts
@@ -1,0 +1,123 @@
+// Structural tests for the minimal FITS writer (epic #337, Phase 5): parse the
+// emitted bytes back with a tiny card reader and check HDU structure, card
+// formatting, the CRPIX crop shift, and big-endian float32 round-tripping.
+// (End-to-end astropy verification of route output happens in the live check.)
+
+import { describe, it, expect } from 'vitest';
+import { encodeFitsCutout, type FitsBandCutout } from './fits';
+
+const CARD = 80;
+const BLOCK = 2880;
+
+/** Read the header cards of the HDU starting at `offset`; returns [cards, dataStart]. */
+function readHeader(buf: Buffer, offset: number): [Map<string, string>, number] {
+  const cards = new Map<string, string>();
+  for (let pos = offset; ; pos += CARD) {
+    const text = buf.subarray(pos, pos + CARD).toString('ascii');
+    const key = text.slice(0, 8).trim();
+    if (key === 'END') {
+      return [cards, offset + Math.ceil((pos + CARD - offset) / BLOCK) * BLOCK];
+    }
+    if (text.slice(8, 10) === '= ') {
+      cards.set(key, text.slice(10).split(' / ')[0].trim());
+    }
+  }
+}
+
+function num(cards: Map<string, string>, key: string): number {
+  const raw = cards.get(key);
+  expect(raw, `missing card ${key}`).toBeDefined();
+  return parseFloat(raw!.replace('E', 'e'));
+}
+
+function makeBand(name: string, w: number, h: number, fill: (i: number) => number): FitsBandCutout {
+  const data = new Float32Array(w * h);
+  for (let i = 0; i < data.length; i++) data[i] = fill(i);
+  return {
+    name,
+    data,
+    width: w,
+    height: h,
+    wcs: {
+      CRPIX1: 3932.5,
+      CRPIX2: 5806.5,
+      CDELT1: 8.3333333333333e-6,
+      CDELT2: 8.3333333333333e-6,
+      PC1_1: -1.0,
+      CTYPE1: 'RA---TAN',
+      CTYPE2: 'DEC--TAN',
+      CRVAL1: 137.805,
+      CRVAL2: 17.7999,
+      RADESYS: 'ICRS',
+    },
+    origin: [100, 250],
+    pixelScaleArcsec: 0.03,
+    levelZ: 0,
+  };
+}
+
+describe('encodeFitsCutout', () => {
+  it('emits a block-aligned primary + one IMAGE extension per band', () => {
+    const fits = encodeFitsCutout(
+      [makeBand('f277w', 7, 5, (i) => i), makeBand('f444w', 7, 5, (i) => -i)],
+      { primary: { FIELD: 'rj0911', RA_CEN: 137.788282 }, comments: ['test'] },
+    );
+    expect(fits.length % BLOCK).toBe(0);
+
+    const [primary, ext1Start] = readHeader(fits, 0);
+    expect(primary.get('SIMPLE')).toBe('T');
+    expect(num(primary, 'BITPIX')).toBe(8);
+    expect(num(primary, 'NAXIS')).toBe(0);
+    expect(num(primary, 'NEXTEND')).toBe(2);
+    expect(primary.get('FIELD')).toBe("'rj0911  '");
+    expect(num(primary, 'RA_CEN')).toBeCloseTo(137.788282, 6);
+
+    const [ext1, data1Start] = readHeader(fits, ext1Start);
+    expect(ext1.get('XTENSION')).toBe("'IMAGE   '");
+    expect(num(ext1, 'BITPIX')).toBe(-32);
+    expect(num(ext1, 'NAXIS1')).toBe(7);
+    expect(num(ext1, 'NAXIS2')).toBe(5);
+    expect(ext1.get('EXTNAME')).toBe("'F277W   '");
+
+    // Second extension follows the first's padded data unit.
+    const ext2Start = data1Start + Math.ceil((7 * 5 * 4) / BLOCK) * BLOCK;
+    const [ext2] = readHeader(fits, ext2Start);
+    expect(ext2.get('EXTNAME')).toBe("'F444W   '");
+  });
+
+  it('shifts CRPIX by the crop origin and keeps the rest of the WCS verbatim', () => {
+    const fits = encodeFitsCutout([makeBand('f444w', 4, 3, () => 1)]);
+    const [, extStart] = readHeader(fits, 0);
+    const [ext] = readHeader(fits, extStart);
+    expect(num(ext, 'CRPIX1')).toBeCloseTo(3932.5 - 100, 9);
+    expect(num(ext, 'CRPIX2')).toBeCloseTo(5806.5 - 250, 9);
+    expect(num(ext, 'CRVAL1')).toBeCloseTo(137.805, 9);
+    expect(num(ext, 'CDELT1')).toBeCloseTo(8.3333333333333e-6, 18);
+    expect(num(ext, 'PC1_1')).toBe(-1);
+    expect(ext.get('CTYPE1')).toBe("'RA---TAN'");
+    expect(num(ext, 'LEVEL')).toBe(0);
+    expect(num(ext, 'PIXSCALE')).toBeCloseTo(0.03, 9);
+  });
+
+  it('round-trips big-endian float32 data including NaN', () => {
+    const band = makeBand('f150w', 3, 2, (i) => (i === 4 ? NaN : i * 1.5 - 2));
+    const fits = encodeFitsCutout([band]);
+    const [, extStart] = readHeader(fits, 0);
+    const [, dataStart] = readHeader(fits, extStart);
+    const view = new DataView(fits.buffer, fits.byteOffset + dataStart);
+    for (let i = 0; i < band.data.length; i++) {
+      const v = view.getFloat32(i * 4, false);
+      if (Number.isNaN(band.data[i])) expect(Number.isNaN(v)).toBe(true);
+      else expect(v).toBeCloseTo(band.data[i], 6);
+    }
+    // Data unit zero-padded to a full block.
+    expect((fits.length - dataStart) % BLOCK).toBe(0);
+  });
+
+  it('rejects mismatched dims and empty band lists', () => {
+    const band = makeBand('f444w', 4, 3, () => 0);
+    band.width = 5;
+    expect(() => encodeFitsCutout([band])).toThrow(/data length/);
+    expect(() => encodeFitsCutout([])).toThrow(/no bands/);
+  });
+});

--- a/web/lib/cutout/fits.ts
+++ b/web/lib/cutout/fits.ts
@@ -1,0 +1,149 @@
+// Minimal FITS writer for science cutouts (epic #337, Phase 5) — enough of the
+// standard to emit an empty primary HDU + one float32 IMAGE extension per band,
+// each carrying the pyramid level's own WCS with CRPIX shifted to the crop
+// origin. No resampling ever happens on this path (pixels are the fpack tiles'
+// values verbatim), so no WCS engine is needed server-side — astropy reads the
+// shifted header exactly as it reads a fitsgl supertile's.
+//
+// Pure (no sharp/Next coupling); unit-tested by parsing the emitted bytes.
+
+const CARD = 80;
+const BLOCK = 2880;
+
+/** Format one 80-char header card. Numbers are right-justified in the fixed
+ *  20-char value field; strings are quoted (FITS 8-char minimum, '' escaping). */
+function card(key: string, value: number | string | boolean | null, comment?: string): string {
+  if (key === 'COMMENT' || key === 'HISTORY') {
+    return `${key} ${String(value ?? '')}`.padEnd(CARD).slice(0, CARD);
+  }
+  let val: string;
+  if (value === null) {
+    val = ''.padStart(20);
+  } else if (typeof value === 'boolean') {
+    val = (value ? 'T' : 'F').padStart(20);
+  } else if (typeof value === 'number') {
+    val = formatNumber(value).padStart(20);
+  } else {
+    // Quoted string, min 8 chars inside the quotes, single-quotes doubled.
+    const inner = value.replace(/'/g, "''").padEnd(8);
+    val = `'${inner}'`;
+  }
+  let text = `${key.padEnd(8).slice(0, 8)}= ${val}`;
+  if (comment) text += ` / ${comment}`;
+  return text.padEnd(CARD).slice(0, CARD);
+}
+
+/** FITS-legal number text: integers verbatim; floats via repr with `E` exponent. */
+function formatNumber(v: number): string {
+  if (!Number.isFinite(v)) throw new Error(`non-finite FITS header value: ${v}`);
+  if (Number.isInteger(v) && Math.abs(v) < 1e15) return String(v);
+  let s = String(v);
+  if (s.includes('e')) s = s.replace('e', 'E');
+  else if (!s.includes('.')) s += '.0';
+  return s;
+}
+
+/** Pad a header (array of cards) with END + blanks to a 2880-byte block. */
+function headerBlock(cards: string[]): Buffer {
+  const all = [...cards, 'END'.padEnd(CARD)];
+  const n = Math.ceil((all.length * CARD) / BLOCK) * BLOCK;
+  const buf = Buffer.alloc(n, 0x20); // space-filled
+  all.forEach((c, i) => buf.write(c, i * CARD, 'ascii'));
+  return buf;
+}
+
+/** Big-endian float32 data unit, zero-padded to a 2880-byte block. */
+function dataBlock(data: Float32Array): Buffer {
+  const nBytes = Math.ceil((data.length * 4) / BLOCK) * BLOCK;
+  const buf = Buffer.alloc(nBytes, 0);
+  const view = new DataView(buf.buffer, buf.byteOffset);
+  for (let i = 0; i < data.length; i++) view.setFloat32(i * 4, data[i], false);
+  return buf;
+}
+
+/** Structural keys the writer owns — never copied from a source WCS dict. */
+const RESERVED = new Set([
+  'SIMPLE', 'BITPIX', 'NAXIS', 'NAXIS1', 'NAXIS2', 'NAXIS3',
+  'XTENSION', 'PCOUNT', 'GCOUNT', 'EXTEND', 'EXTNAME', 'END',
+]);
+
+export interface FitsBandCutout {
+  /** Extension name (band, upper-cased on write). */
+  name: string;
+  /** Row-major pixels; row 0 is FITS row 1 (same axis order as the level). */
+  data: Float32Array;
+  width: number;
+  height: number;
+  /** The pyramid level's flat FITS WCS header dict (from the band manifest). */
+  wcs: Record<string, unknown>;
+  /** Level-pixel origin `(x0, y0)` of the crop — subtracted from CRPIX1/2. */
+  origin: readonly [number, number];
+  pixelScaleArcsec: number;
+  /** Pyramid level index the pixels came from (0 = native). */
+  levelZ: number;
+}
+
+export interface FitsCutoutMeta {
+  /** Extra primary-header keys, written in order (e.g. FIELD, RA_CEN...). */
+  primary?: Record<string, number | string | boolean>;
+  /** COMMENT lines for the primary header (provenance notes). */
+  comments?: string[];
+}
+
+/**
+ * Encode band cutouts as a multi-extension FITS: empty primary HDU + one
+ * float32 IMAGE extension per band (EXTNAME = band). Each extension carries
+ * its level's WCS with CRPIX shifted by the crop origin.
+ */
+export function encodeFitsCutout(bands: FitsBandCutout[], meta: FitsCutoutMeta = {}): Buffer {
+  if (bands.length === 0) throw new Error('encodeFitsCutout: no bands');
+
+  const primaryCards = [
+    card('SIMPLE', true, 'conforms to FITS standard'),
+    card('BITPIX', 8),
+    card('NAXIS', 0),
+    card('EXTEND', true),
+    card('ORIGIN', 'CAMPFIRE', 'FitsGL cutout service'),
+    card('NEXTEND', bands.length, 'one IMAGE extension per band'),
+  ];
+  for (const [k, v] of Object.entries(meta.primary ?? {})) {
+    if (!RESERVED.has(k.toUpperCase())) primaryCards.push(card(k.toUpperCase(), v));
+  }
+  for (const c of meta.comments ?? []) primaryCards.push(card('COMMENT', c));
+
+  const parts: Buffer[] = [headerBlock(primaryCards)];
+
+  for (const band of bands) {
+    if (band.data.length !== band.width * band.height) {
+      throw new Error(`band ${band.name}: data length != width*height`);
+    }
+    const cards = [
+      card('XTENSION', 'IMAGE', 'IMAGE extension'),
+      card('BITPIX', -32, 'IEEE single-precision float'),
+      card('NAXIS', 2),
+      card('NAXIS1', band.width),
+      card('NAXIS2', band.height),
+      card('PCOUNT', 0),
+      card('GCOUNT', 1),
+      card('EXTNAME', band.name.toUpperCase(), 'band'),
+    ];
+    for (const [k, v] of Object.entries(band.wcs)) {
+      const key = k.toUpperCase();
+      if (RESERVED.has(key)) continue;
+      let value = v as number | string | boolean;
+      if (key === 'CRPIX1') value = (v as number) - band.origin[0];
+      if (key === 'CRPIX2') value = (v as number) - band.origin[1];
+      if (typeof value !== 'number' && typeof value !== 'string' && typeof value !== 'boolean') continue;
+      cards.push(card(key, value));
+    }
+    cards.push(card('LEVEL', band.levelZ, 'fitsgl pyramid level (0 = native)'));
+    cards.push(card('PIXSCALE', band.pixelScaleArcsec, '[arcsec/px] level pixel scale'));
+    cards.push(card('COMMENT',
+      'Direct cutout from the FitsGL display pyramid (RICE_1, q=8, dither):'));
+    cards.push(card('COMMENT',
+      'lossy-quantized, ~0.03% photometry-faithful. Not the archival mosaic.'));
+    parts.push(headerBlock(cards), dataBlock(band.data));
+  }
+
+  return Buffer.concat(parts);
+}

--- a/web/lib/cutout/index.ts
+++ b/web/lib/cutout/index.ts
@@ -48,8 +48,9 @@ export interface CutoutRGBA {
   outputWcsHeader: Record<string, number | string>;
 }
 
-/** Reproject one band to the N-up output grid, returning its float pixels + WCS. */
-async function bandToOutput(band: BandSource, center: [number, number], fovArcsec: number, outputSize: number) {
+/** Reproject one band to the N-up output grid, returning its float pixels + WCS.
+ *  Exported for the multi-panel figure renderer (`./figure`). */
+export async function bandToOutput(band: BandSource, center: [number, number], fovArcsec: number, outputSize: number) {
   const plan = planCutout(band.manifest, center, fovArcsec, { outputSize, rounding: 'nearest' });
   const region = await assembleRegion(plan, band.baseUrl);
   const scale = fovArcsec / outputSize;

--- a/web/lib/cutout/science.ts
+++ b/web/lib/cutout/science.ts
@@ -1,0 +1,96 @@
+// Science FITS cutouts (epic #337, Phase 5): direct native-pixel crops from the
+// FitsGL tile pyramid — plan at the requested (default native) level, decode the
+// covering tiles, and emit one float32 IMAGE extension per band carrying the
+// level's own WCS with CRPIX shifted to the crop. NO resampling, NO stretch:
+// the pixels are the fpack tiles' values verbatim, which is exactly what
+// "direct cutouts from the tiles" means. Pure of sharp/Next (unit-testable);
+// the figure (PNG) sibling lives in `./figure`.
+
+import { planCutout } from './plan';
+import { assembleRegion } from './assemble';
+import { encodeFitsCutout, type FitsBandCutout } from './fits';
+import type { FieldScienceSource } from './source';
+
+/** Per-band pixel budget (4096² ≈ 64 MB of float32). */
+export const MAX_PIXELS_PER_BAND = 4096 * 4096;
+/** Whole-request budget across bands (≈ 256 MB of float32). */
+export const MAX_PIXELS_TOTAL = 4 * MAX_PIXELS_PER_BAND;
+
+/** Request exceeds the pixel budget — the route turns this into a 400 with advice. */
+export class CutoutTooLargeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CutoutTooLargeError';
+  }
+}
+
+export interface ScienceCutoutRequest {
+  /** ICRS centre `[ra, dec]` in degrees. */
+  center: [number, number];
+  /** Square field of view in arcsec. */
+  fovArcsec: number;
+  /** Output pixel scale (arcsec/px) → pyramid level selection; omit for native. */
+  targetScaleArcsec?: number;
+  /** Extra primary-header context (field name, request provenance). */
+  field: string;
+}
+
+/**
+ * Build a multi-extension FITS cutout from a resolved science source.
+ * Bands are assembled sequentially to bound peak memory.
+ */
+export async function buildFitsCutout(
+  src: FieldScienceSource,
+  req: ScienceCutoutRequest,
+): Promise<Buffer> {
+  const cutouts: FitsBandCutout[] = [];
+  let totalPixels = 0;
+
+  for (const band of src.bands) {
+    const plan = planCutout(band.manifest, req.center, req.fovArcsec, {
+      targetScaleArcsec: req.targetScaleArcsec,
+      rounding: 'nearest',
+    });
+    const w = Math.max(0, plan.pixelBbox.x1 - plan.pixelBbox.x0);
+    const h = Math.max(0, plan.pixelBbox.y1 - plan.pixelBbox.y0);
+    if (w * h > MAX_PIXELS_PER_BAND) {
+      throw new CutoutTooLargeError(
+        `${band.name}: ${w}x${h} px exceeds the ${Math.sqrt(MAX_PIXELS_PER_BAND)}^2 per-band budget; ` +
+          'reduce fov or pass a coarser scale',
+      );
+    }
+    totalPixels += w * h;
+    if (totalPixels > MAX_PIXELS_TOTAL) {
+      throw new CutoutTooLargeError(
+        `request totals ${totalPixels} px across bands (budget ${MAX_PIXELS_TOTAL}); ` +
+          'reduce fov, bands, or pass a coarser scale',
+      );
+    }
+
+    const region = await assembleRegion(plan, band.baseUrl);
+    cutouts.push({
+      name: band.name,
+      data: region.data,
+      width: region.width,
+      height: region.height,
+      wcs: plan.level.wcs,
+      origin: [region.x0, region.y0],
+      pixelScaleArcsec: plan.level.pixelScaleArcsec,
+      levelZ: plan.level.z,
+    });
+  }
+
+  return encodeFitsCutout(cutouts, {
+    primary: {
+      FIELD: req.field,
+      DATASET: src.datasetPrefix,
+      RA_CEN: req.center[0],
+      DEC_CEN: req.center[1],
+      FOV_AS: req.fovArcsec,
+    },
+    comments: [
+      'CAMPFIRE FitsGL science cutout: direct crop of the tile pyramid.',
+      'Each extension carries its pyramid level WCS (CRPIX shifted).',
+    ],
+  });
+}

--- a/web/lib/cutout/source.ts
+++ b/web/lib/cutout/source.ts
@@ -62,9 +62,8 @@ function chooseBands(config: FitsglConfig): FitsglBand[] {
 }
 
 /**
- * Resolve a field's FitsGL cutout source, or `null` when the field has no
- * (visible) pyramid — including on any fetch/parse failure, so callers can fall
- * back to the legacy path during the transition.
+ * Fetch the field's default `kind='field'` dataset row + its resolved
+ * `fitsgl.json`, or `null` when the field has no (visible) pyramid.
  *
  * `requirePublic` is for service-role callers, which bypass RLS: it mirrors the
  * `authenticated_select_fitsgl_datasets` policy via the same SECURITY DEFINER
@@ -72,14 +71,14 @@ function chooseBands(config: FitsglConfig): FitsglBand[] {
  * serves public/API cutouts. User-scoped clients rely on RLS instead (admins
  * intentionally see draft-backed datasets, matching the map).
  */
-export async function resolveFieldCutoutSource(
+async function fetchFieldDataset(
   supabase: SupabaseClient,
   field: string,
-  opts: { requirePublic?: boolean } = {},
-): Promise<FieldCutoutSource | null> {
+  opts: { requirePublic?: boolean },
+): Promise<{ prefix: string; config: FitsglConfig } | null> {
   const { data: rows, error } = await supabase
     .from('fitsgl_datasets')
-    .select('field, kind, tiles, bands, pixel_scale, fitsgl_json_url, is_default')
+    .select('prefix, field, kind, tiles, bands, pixel_scale, fitsgl_json_url, is_default')
     .eq('field', field)
     .eq('kind', 'field');
   if (error || !rows || rows.length === 0) return null;
@@ -95,18 +94,34 @@ export async function resolveFieldCutoutSource(
     if (pubErr || !isPublic) return null;
   }
 
+  const config = await loadFitsglConfig(ds.fitsgl_json_url, cachingFetch);
+  return { prefix: ds.prefix, config };
+}
+
+/** Load a chosen band's manifest into an engine `BandSource`. */
+async function toBandSource(band: FitsglBand): Promise<BandSource> {
+  const manifestUrl = band.tiles[0]; // absolute after loadFitsglConfig
+  return {
+    manifest: await loadManifest(manifestUrl, undefined, cachingFetch),
+    baseUrl: new URL('.', manifestUrl).toString(),
+  };
+}
+
+/**
+ * Resolve a field's *display* cutout source (the PR-B PNG routes), or `null`
+ * when the field has no (visible) pyramid — including on any fetch/parse
+ * failure, so callers can fall back to the legacy path during the transition.
+ */
+export async function resolveFieldCutoutSource(
+  supabase: SupabaseClient,
+  field: string,
+  opts: { requirePublic?: boolean } = {},
+): Promise<FieldCutoutSource | null> {
   try {
-    const config = await loadFitsglConfig(ds.fitsgl_json_url, cachingFetch);
-    const chosen = chooseBands(config);
-    const bands: BandSource[] = await Promise.all(
-      chosen.map(async (b) => {
-        const manifestUrl = b.tiles[0]; // absolute after loadFitsglConfig
-        return {
-          manifest: await loadManifest(manifestUrl, undefined, cachingFetch),
-          baseUrl: new URL('.', manifestUrl).toString(),
-        };
-      }),
-    );
+    const ds = await fetchFieldDataset(supabase, field, opts);
+    if (!ds) return null;
+    const chosen = chooseBands(ds.config);
+    const bands = await Promise.all(chosen.map(toBandSource));
     return {
       bands,
       bandNames: chosen.map((b) => b.name),
@@ -116,4 +131,59 @@ export async function resolveFieldCutoutSource(
     console.error(`FitsGL cutout source unavailable for field ${field}:`, err);
     return null;
   }
+}
+
+/** Requested band(s) not in the dataset — the science routes turn this into a 400. */
+export class UnknownBandError extends Error {
+  constructor(
+    public readonly unknown: string[],
+    public readonly available: string[],
+  ) {
+    super(`unknown band(s) ${unknown.join(', ')}; available: ${available.join(', ')}`);
+    this.name = 'UnknownBandError';
+  }
+}
+
+export interface FieldScienceSource {
+  /** One entry per requested band, in request (or inventory) order. */
+  bands: Array<BandSource & { name: string; label?: string; pivotUm?: number }>;
+  /** Dataset prefix, for provenance headers. */
+  datasetPrefix: string;
+}
+
+/**
+ * Resolve a field's *science* cutout source: every dataset band, or the
+ * requested subset (case-insensitive names), each with its manifest loaded.
+ * `null` ⇒ no (visible) pyramid for the field; throws {@link UnknownBandError}
+ * for names not in the inventory (a client error, not a fallback case).
+ */
+export async function resolveFieldScienceSource(
+  supabase: SupabaseClient,
+  field: string,
+  opts: { requirePublic?: boolean; bands?: string[] } = {},
+): Promise<FieldScienceSource | null> {
+  const ds = await fetchFieldDataset(supabase, field, opts).catch((err) => {
+    console.error(`FitsGL science source unavailable for field ${field}:`, err);
+    return null;
+  });
+  if (!ds) return null;
+
+  const inventory = ds.config.dataset.bands;
+  let chosen = inventory;
+  if (opts.bands && opts.bands.length > 0) {
+    const byName = new Map(inventory.map((b) => [b.name.toLowerCase(), b]));
+    const unknown = opts.bands.filter((n) => !byName.has(n.toLowerCase()));
+    if (unknown.length > 0) throw new UnknownBandError(unknown, inventory.map((b) => b.name));
+    chosen = opts.bands.map((n) => byName.get(n.toLowerCase())!);
+  }
+
+  const bands = await Promise.all(
+    chosen.map(async (b) => ({
+      ...(await toBandSource(b)),
+      name: b.name,
+      label: b.label,
+      pivotUm: b.pivotUm,
+    })),
+  );
+  return { bands, datasetPrefix: ds.prefix };
 }

--- a/web/lib/cutout/source.ts
+++ b/web/lib/cutout/source.ts
@@ -80,7 +80,7 @@ async function fetchFieldDataset(
   supabase: SupabaseClient,
   field: string,
   opts: { requirePublic?: boolean },
-): Promise<{ prefix: string; config: FitsglConfig } | null> {
+): Promise<{ prefix: string; config: FitsglConfig; isPublic: boolean } | null> {
   const { data: rows, error } = await supabase
     .from('fitsgl_datasets')
     .select('prefix, field, kind, tiles, bands, pixel_scale, fitsgl_json_url, is_default')
@@ -105,7 +105,7 @@ async function fetchFieldDataset(
   if (opts.requirePublic && !isPublic) return null;
 
   const config = await loadFitsglConfig(ds.fitsgl_json_url, cachingFetch);
-  return { prefix: ds.prefix, config };
+  return { prefix: ds.prefix, config, isPublic: Boolean(isPublic) };
 }
 
 /** Load a chosen band's manifest into an engine `BandSource`. */
@@ -136,7 +136,7 @@ export async function resolveFieldCutoutSource(
       bands,
       bandNames: chosen.map((b) => b.name),
       nativeScaleArcsec: bands[0].manifest.levels[0].pixelScaleArcsec,
-      isPublic: Boolean(isPublic),
+      isPublic: ds.isPublic,
     };
   } catch (err) {
     console.error(`FitsGL cutout source unavailable for field ${field}:`, err);


### PR DESCRIPTION
## Summary

**PR C of the Phase 5 sub-PR sequence** (epic #337, issue #343) — **stacked on #365 (PR B)**; only the last 1 commit is new here.

The scientifically-useful cutout API: coordinate-addressed endpoints that serve **direct FITS crops of the tile pyramid** and **multi-band postage-stamp figures**, plus the matching `Campfire` Python client methods. This is the backend the cutout GUI (PR D) will drive.

## Endpoints

### `GET /api/v1/cutout/fits?field=&ra=&dec=&fov=[&bands=][&scale=]`
Direct crop of the tiles at the requested (default **native**) pyramid level — **no resampling, no stretch**; the pixels are the fpack tiles' values verbatim. Multi-extension FITS: empty primary + one float32 IMAGE extension per band (`EXTNAME` = band), each carrying the pyramid level's full WCS (PC/CDELT, timing, OBSGEO, RADESYS) with only CRPIX shifted to the crop — astropy reads it exactly as it reads a fitsgl supertile. `scale` selects a coarser level for wide fields; pixel budgets (4096²/band, 4× total) turn oversized requests into a 400 with advice.

**Lossiness, stated plainly:** the pyramid is the display product (RICE_1, q=8, subtractive dither — ~0.03% photometry-faithful). Every extension carries COMMENT cards saying so. That is the agreed "direct cutouts from the tiles" semantics; archival-mosaic reads are out of scope.

### `GET /api/v1/cutout/figure?field=&ra=&dec=&fov=[&bands=&size=&cols=&stretch=&colormap=]`
One labeled North-up panel per band composed into a single PNG — the classic band-strip figure — using the same engine + transfer functions as the interactive map, per-panel percentile stretch.

Both accept **Bearer API key/JWT or the browser cookie session** (one canonical service for Python, curl, and the PR D GUI); non-admins mirror `fitsgl_datasets` RLS via `fitsgl_dataset_is_public()`.

## Python client

```python
cf = Campfire()
hdul = cf.get_fits_cutout('cosmos', ra=150.1, dec=2.2, fov=6, bands=['f277w', 'f444w'])
data, wcs = hdul['F444W'].data, WCS(hdul['F444W'].header)
fig = cf.get_cutout_figure('cosmos', ra=150.1, dec=2.2, fov=6, colormap='magma')  # PNG path
```

Cached downloads (same pattern as `get_cutout`); mocked unit tests added (20/20 in `test_client.py`).

**Design note (divergence from the earlier epic sketch):** the Python client goes **through the server endpoint** rather than reading tiles directly via fitsgl-py. fitsgl-py deliberately ships no RICE decoder (addressing only), so direct reads would mean whole-supertile downloads (~100 MB for a 30″ cutout) or a third decoder implementation. One server-side engine keeps web + Python byte-identical; direct byte-range reads can upgrade `get_fits_cutout()` later behind the same signature if egress ever matters.

## Verification (live, rj0911 pyramid)

- **astropy** opens the route's FITS cleanly (PrimaryHDU + F444W 401×401 float32).
- **WCS round-trip**: requested center → pixel (200.00, 199.96) of a 401² array — < 0.05 px.
- **Pixel ground truth**: vs astropy-decoding the same supertiles per the fitsgl-py plan — identical NaN masks, max |diff| = 4.8e-07 over all 160,801 px (float32 ULP; ~1e-6 relative, far below the pyramid's 0.03% quantization floor).
- Figure: single panel + 3-panel `cols=2` grid render with labels (log + viridis/magma exercised).
- Error paths: unknown band → 400 with `available_bands`; no dataset → 404; draft-backed + non-admin → 404.
- `tsc` clean, eslint clean (new files), 17/17 vitest (13 parity + 4 FITS writer), `npm run build` compiled, 20/20 Python client tests.

Web + `python/` only — no pipeline changelog entry needed.

**Found in passing** (pre-existing, not addressed here): `CAMPFIRE_API_KEY` is referenced in the client's auth error message but no code path actually reads it — credentials only come from `~/.campfire/credentials`. Worth a small follow-up issue.

**Next:** PR D — the COSMOS-style cutout GUI on these endpoints.

Generated with Claude Code