### PR TITLE
feat(cutout): cutout service GUI at /cutouts (PR D of #343)

### DIFF
--- a/web/app/cutouts/CutoutsPageContent.tsx
+++ b/web/app/cutouts/CutoutsPageContent.tsx
@@ -1,0 +1,399 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { Download, ImageIcon, Loader2, Map as MapIcon, Scissors } from 'lucide-react';
+import type { FitsglDataset } from '@/lib/actions/map';
+import { parseCoordinates } from '@/lib/utils/coordinate-parser';
+
+const STRETCHES = ['linear', 'log', 'sqrt', 'asinh'] as const;
+const COLORMAPS = ['gray', 'viridis', 'magma', 'inferno', 'plasma', 'cividis'] as const;
+
+/** Parse a dataset `pixel_scale` tag ('30mas', '0.03as') to arcsec/px, or null. */
+function pixelScaleArcsec(tag: string): number | null {
+  const mas = tag.match(/^([\d.]+)\s*mas$/i);
+  if (mas) return parseFloat(mas[1]) / 1000;
+  const as = tag.match(/^([\d.]+)\s*(as|arcsec)$/i);
+  if (as) return parseFloat(as[1]);
+  return null;
+}
+
+interface CutoutsPageContentProps {
+  datasets: FitsglDataset[];
+  initial: {
+    field?: string;
+    ra?: string;
+    dec?: string;
+    fov?: string;
+    bands?: string;
+  };
+}
+
+export const CutoutsPageContent: React.FC<CutoutsPageContentProps> = ({ datasets, initial }) => {
+  const router = useRouter();
+
+  const initialField =
+    (initial.field && datasets.find((d) => d.field === initial.field)?.field) ||
+    datasets[0].field;
+  const [field, setField] = useState(initialField);
+  const dataset = useMemo(
+    () => datasets.find((d) => d.field === field) ?? datasets[0],
+    [datasets, field],
+  );
+
+  const [coordText, setCoordText] = useState(
+    initial.ra && initial.dec ? `${initial.ra} ${initial.dec}` : '',
+  );
+  const [fov, setFov] = useState(initial.fov ?? '10');
+  const [selectedBands, setSelectedBands] = useState<string[]>(
+    initial.bands ? initial.bands.split(',').filter((b) => dataset.bands.includes(b)) : dataset.bands,
+  );
+  const [stretch, setStretch] = useState<(typeof STRETCHES)[number]>('asinh');
+  const [colormap, setColormap] = useState<(typeof COLORMAPS)[number]>('gray');
+  const [panelSize, setPanelSize] = useState('300');
+  const [cols, setCols] = useState('');
+
+  // Preview state: fetched as a blob so API error JSON can be surfaced.
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const previewUrlRef = useRef<string | null>(null);
+
+  // Reset the band selection when the field changes.
+  const onFieldChange = (f: string) => {
+    setField(f);
+    const ds = datasets.find((d) => d.field === f);
+    if (ds) setSelectedBands(ds.bands);
+  };
+
+  const toggleBand = (b: string) => {
+    setSelectedBands((prev) => {
+      const next = prev.includes(b) ? prev.filter((x) => x !== b) : [...prev, b];
+      // Keep inventory order and never allow an empty selection.
+      const ordered = dataset.bands.filter((x) => next.includes(x));
+      return ordered.length > 0 ? ordered : prev;
+    });
+  };
+
+  const parsed = useMemo(() => parseCoordinates(coordText.trim()), [coordText]);
+  const fovNum = parseFloat(fov);
+  const fovValid = Number.isFinite(fovNum) && fovNum >= 0.5 && fovNum <= 600;
+  const allBands = selectedBands.length === dataset.bands.length;
+  const ready = parsed !== null && fovValid && selectedBands.length > 0;
+
+  /** Query string shared by the figure/FITS endpoints for the current form. */
+  const buildParams = useCallback(
+    (extra: Record<string, string> = {}) => {
+      if (!parsed) return null;
+      const p = new URLSearchParams({
+        field,
+        ra: parsed.ra.toFixed(6),
+        dec: parsed.dec.toFixed(6),
+        fov: String(fovNum),
+        ...extra,
+      });
+      if (!allBands) p.set('bands', selectedBands.join(','));
+      return p;
+    },
+    [parsed, field, fovNum, allBands, selectedBands],
+  );
+
+  const figureParams = ready
+    ? buildParams({ size: panelSize || '300', stretch, colormap, ...(cols ? { cols } : {}) })
+    : null;
+  const fitsParams = ready ? buildParams() : null;
+
+  const generatePreview = useCallback(async () => {
+    if (!figureParams) return;
+    setPreviewLoading(true);
+    setPreviewError(null);
+    // Make the request shareable: mirror it into the page URL.
+    const pageParams = fitsParams!.toString();
+    router.replace(`/cutouts?${pageParams}`, { scroll: false });
+    try {
+      const res = await fetch(`/api/v1/cutout/figure?${figureParams.toString()}`);
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.error ?? `Request failed (${res.status})`);
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current);
+      previewUrlRef.current = url;
+      setPreviewUrl(url);
+    } catch (err) {
+      setPreviewError(err instanceof Error ? err.message : 'Preview failed');
+    } finally {
+      setPreviewLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [figureParams?.toString()]);
+
+  // Auto-generate when the page arrives with a shareable request in the URL.
+  const autoRan = useRef(false);
+  useEffect(() => {
+    if (!autoRan.current && initial.ra && initial.dec && ready) {
+      autoRan.current = true;
+      generatePreview();
+    }
+  }, [initial.ra, initial.dec, ready, generatePreview]);
+
+  // Estimated native FITS extent for the current request.
+  const scaleAs = pixelScaleArcsec(dataset.pixel_scale);
+  const nativePx = scaleAs && fovValid ? Math.round(fovNum / scaleAs) : null;
+  const estMb =
+    nativePx !== null ? (nativePx * nativePx * 4 * selectedBands.length) / 1024 ** 2 : null;
+  const overBudget = nativePx !== null && nativePx > 4096;
+
+  const inputCls =
+    'w-full px-3 py-2 bg-surface-2 border border-border rounded-lg text-sm text-text-primary ' +
+    'placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-primary/50';
+  const labelCls = 'block text-xs font-medium uppercase tracking-wide text-text-tertiary mb-1.5';
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="flex items-center gap-3 mb-6">
+        <Scissors className="w-6 h-6 text-primary" />
+        <div>
+          <h1 className="text-2xl font-semibold text-text-primary">Cutout Service</h1>
+          <p className="text-sm text-text-secondary">
+            Generate multi-band cutouts from the NIRCam imaging — preview a figure or download
+            science-ready FITS, cropped directly from the tiles.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-[380px_1fr] gap-6 items-start">
+        {/* ---- Controls ---- */}
+        <div className="bg-card border border-border rounded-xl p-5 space-y-4">
+          <div>
+            <label className={labelCls} htmlFor="cutout-field">Field</label>
+            <select
+              id="cutout-field"
+              value={field}
+              onChange={(e) => onFieldChange(e.target.value)}
+              className={inputCls}
+            >
+              {datasets.map((d) => (
+                <option key={d.field} value={d.field}>{d.field}</option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className={labelCls} htmlFor="cutout-coords">Coordinates (ICRS)</label>
+            <input
+              id="cutout-coords"
+              type="text"
+              value={coordText}
+              onChange={(e) => setCoordText(e.target.value)}
+              placeholder='150.11916 2.20583  or  10h00m28.6s +02d12m21.0s'
+              className={inputCls}
+            />
+            {coordText.trim() !== '' && parsed === null && (
+              <p className="mt-1 text-xs text-red-500">
+                Could not parse — use decimal degrees or sexagesimal.
+              </p>
+            )}
+            {parsed && (
+              <p className="mt-1 text-xs text-text-tertiary">
+                α = {parsed.ra.toFixed(6)}°, δ = {parsed.dec.toFixed(6)}°
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label className={labelCls} htmlFor="cutout-fov">Field of view (arcsec)</label>
+            <input
+              id="cutout-fov"
+              type="number"
+              min={0.5}
+              max={600}
+              step="any"
+              value={fov}
+              onChange={(e) => setFov(e.target.value)}
+              className={inputCls}
+            />
+            {!fovValid && fov.trim() !== '' && (
+              <p className="mt-1 text-xs text-red-500">FOV must be 0.5–600 arcsec.</p>
+            )}
+          </div>
+
+          <div>
+            <span className={labelCls}>Bands</span>
+            <div className="flex flex-wrap gap-1.5">
+              {dataset.bands.map((b) => {
+                const on = selectedBands.includes(b);
+                return (
+                  <button
+                    key={b}
+                    type="button"
+                    onClick={() => toggleBand(b)}
+                    aria-pressed={on}
+                    className={`px-2.5 py-1 rounded-md text-xs font-medium border transition-colors ${
+                      on
+                        ? 'bg-primary text-on-primary border-primary'
+                        : 'bg-surface-2 text-text-secondary border-border hover:border-primary'
+                    }`}
+                  >
+                    {b.toUpperCase()}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className={labelCls} htmlFor="cutout-stretch">Stretch</label>
+              <select
+                id="cutout-stretch"
+                value={stretch}
+                onChange={(e) => setStretch(e.target.value as (typeof STRETCHES)[number])}
+                className={inputCls}
+              >
+                {STRETCHES.map((s) => <option key={s} value={s}>{s}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className={labelCls} htmlFor="cutout-colormap">Colormap</label>
+              <select
+                id="cutout-colormap"
+                value={colormap}
+                onChange={(e) => setColormap(e.target.value as (typeof COLORMAPS)[number])}
+                className={inputCls}
+              >
+                {COLORMAPS.map((c) => <option key={c} value={c}>{c}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className={labelCls} htmlFor="cutout-size">Panel size (px)</label>
+              <input
+                id="cutout-size"
+                type="number"
+                min={64}
+                max={1024}
+                value={panelSize}
+                onChange={(e) => setPanelSize(e.target.value)}
+                className={inputCls}
+              />
+            </div>
+            <div>
+              <label className={labelCls} htmlFor="cutout-cols">Columns</label>
+              <input
+                id="cutout-cols"
+                type="number"
+                min={1}
+                placeholder="one row"
+                value={cols}
+                onChange={(e) => setCols(e.target.value)}
+                className={inputCls}
+              />
+            </div>
+          </div>
+
+          <div className="pt-1 space-y-2">
+            <button
+              type="button"
+              onClick={generatePreview}
+              disabled={!ready || previewLoading}
+              className="w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 bg-primary
+                         text-on-primary rounded-lg text-sm font-medium hover:bg-primary-hover
+                         disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {previewLoading
+                ? <Loader2 className="w-4 h-4 animate-spin" />
+                : <ImageIcon className="w-4 h-4" />}
+              Generate figure
+            </button>
+
+            <div className="grid grid-cols-2 gap-2">
+              <a
+                href={fitsParams ? `/api/v1/cutout/fits?${fitsParams.toString()}` : undefined}
+                aria-disabled={!fitsParams || overBudget}
+                className={`inline-flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm
+                            font-medium border transition-colors ${
+                              fitsParams && !overBudget
+                                ? 'bg-surface-2 text-text-primary border-border hover:border-primary'
+                                : 'bg-surface-2 text-text-tertiary border-border pointer-events-none opacity-50'
+                            }`}
+              >
+                <Download className="w-4 h-4" />
+                FITS
+              </a>
+              <a
+                href={figureParams && previewUrl ? previewUrl : undefined}
+                download={figureParams ? `campfire_${field}_cutout.png` : undefined}
+                aria-disabled={!previewUrl}
+                className={`inline-flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-sm
+                            font-medium border transition-colors ${
+                              previewUrl
+                                ? 'bg-surface-2 text-text-primary border-border hover:border-primary'
+                                : 'bg-surface-2 text-text-tertiary border-border pointer-events-none opacity-50'
+                            }`}
+              >
+                <Download className="w-4 h-4" />
+                PNG
+              </a>
+            </div>
+
+            {nativePx !== null && (
+              <p className={`text-xs ${overBudget ? 'text-red-500' : 'text-text-tertiary'}`}>
+                FITS at native scale: ~{nativePx}×{nativePx} px × {selectedBands.length} band
+                {selectedBands.length > 1 ? 's' : ''}
+                {estMb !== null && ` ≈ ${estMb < 1 ? estMb.toFixed(2) : estMb.toFixed(1)} MB`}
+                {overBudget && ' — over the 4096² budget; reduce the FOV'}
+              </p>
+            )}
+            <p className="text-xs text-text-tertiary">
+              FITS cutouts crop the display pyramid directly (RICE-quantized, ~0.03%
+              photometry-faithful) and carry the native WCS per band.
+            </p>
+          </div>
+        </div>
+
+        {/* ---- Preview ---- */}
+        <div className="bg-card border border-border rounded-xl p-5 min-h-[420px] flex flex-col">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-sm font-medium text-text-primary">Preview</h2>
+            {parsed && (
+              <Link
+                href={`/map?field=${encodeURIComponent(field)}&ra=${parsed.ra}&dec=${parsed.dec}`}
+                className="inline-flex items-center gap-1.5 text-xs text-primary hover:underline"
+              >
+                <MapIcon className="w-3.5 h-3.5" />
+                View on map
+              </Link>
+            )}
+          </div>
+          <div className="flex-1 flex items-center justify-center">
+            {previewError ? (
+              <p className="text-sm text-red-500 max-w-md text-center">{previewError}</p>
+            ) : previewUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={previewUrl}
+                alt="Cutout figure preview"
+                className={`max-w-full h-auto rounded ${previewLoading ? 'opacity-50' : ''}`}
+              />
+            ) : (
+              <div className="text-center text-text-tertiary">
+                {previewLoading ? (
+                  <Loader2 className="w-8 h-8 animate-spin mx-auto" />
+                ) : (
+                  <>
+                    <ImageIcon className="w-10 h-10 mx-auto mb-3 opacity-50" />
+                    <p className="text-sm">
+                      Enter coordinates and generate a figure to preview the cutout.
+                    </p>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/web/app/cutouts/CutoutsPageContent.tsx
+++ b/web/app/cutouts/CutoutsPageContent.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Download, ImageIcon, Loader2, Map as MapIcon, Scissors } from 'lucide-react';
 import type { FitsglDataset } from '@/lib/actions/map';
+import { MAX_PIXELS_PER_BAND, MAX_PIXELS_TOTAL } from '@/lib/cutout/science';
 import { parseCoordinates } from '@/lib/utils/coordinate-parser';
 
 const STRETCHES = ['linear', 'log', 'sqrt', 'asinh'] as const;
@@ -139,12 +140,17 @@ export const CutoutsPageContent: React.FC<CutoutsPageContentProps> = ({ datasets
     }
   }, [initial.ra, initial.dec, ready, generatePreview]);
 
-  // Estimated native FITS extent for the current request.
+  // Estimated native FITS extent for the current request, mirroring BOTH server
+  // budgets (per-band and total across bands) so the FITS button never links to
+  // a request the API would 400.
   const scaleAs = pixelScaleArcsec(dataset.pixel_scale);
   const nativePx = scaleAs && fovValid ? Math.round(fovNum / scaleAs) : null;
   const estMb =
     nativePx !== null ? (nativePx * nativePx * 4 * selectedBands.length) / 1024 ** 2 : null;
-  const overBudget = nativePx !== null && nativePx > 4096;
+  const overBandBudget = nativePx !== null && nativePx * nativePx > MAX_PIXELS_PER_BAND;
+  const overTotalBudget =
+    nativePx !== null && nativePx * nativePx * selectedBands.length > MAX_PIXELS_TOTAL;
+  const overBudget = overBandBudget || overTotalBudget;
 
   const inputCls =
     'w-full px-3 py-2 bg-surface-2 border border-border rounded-lg text-sm text-text-primary ' +
@@ -343,7 +349,9 @@ export const CutoutsPageContent: React.FC<CutoutsPageContentProps> = ({ datasets
                 FITS at native scale: ~{nativePx}×{nativePx} px × {selectedBands.length} band
                 {selectedBands.length > 1 ? 's' : ''}
                 {estMb !== null && ` ≈ ${estMb < 1 ? estMb.toFixed(2) : estMb.toFixed(1)} MB`}
-                {overBudget && ' — over the 4096² budget; reduce the FOV'}
+                {overBandBudget && ' — over the 4096² per-band budget; reduce the FOV'}
+                {!overBandBudget && overTotalBudget &&
+                  ' — over the total pixel budget; reduce the FOV or deselect bands'}
               </p>
             )}
             <p className="text-xs text-text-tertiary">

--- a/web/app/cutouts/page.tsx
+++ b/web/app/cutouts/page.tsx
@@ -1,0 +1,84 @@
+import Link from 'next/link';
+import { LogIn, Scissors } from 'lucide-react';
+import { getFitsglDatasets } from '@/lib/actions/map';
+import { createClient } from '@/lib/supabase/server';
+import { CutoutsPageContent } from './CutoutsPageContent';
+
+export const dynamic = 'force-dynamic';
+
+interface CutoutsPageProps {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}
+
+/**
+ * Cutout service (epic #337, Phase 5): a COSMOS-cutouts-style GUI over the
+ * science cutout API — pick a field + coordinates, preview a multi-band
+ * figure, download the FITS. Fields come from the deployed FitsGL datasets
+ * (RLS keeps draft-backed ones admin-only).
+ */
+export default async function CutoutsPage({ searchParams }: CutoutsPageProps) {
+  const params = await searchParams;
+  const str = (v: string | string[] | undefined) => (typeof v === 'string' ? v : undefined);
+
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <div className="w-16 h-16 bg-card rounded-full flex items-center justify-center mb-6">
+            <LogIn className="w-8 h-8 text-text-secondary" />
+          </div>
+          <h2 className="text-2xl font-semibold text-text-primary mb-2">
+            Sign in to use the cutout service
+          </h2>
+          <p className="text-text-secondary mb-6 max-w-md">
+            Generating cutouts from the imaging requires authentication.
+          </p>
+          <Link
+            href="/login"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary rounded-lg hover:bg-primary-hover transition-colors"
+          >
+            <LogIn className="w-5 h-5" />
+            Sign In
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const datasets = (await getFitsglDatasets()).filter((d) => d.kind === 'field');
+
+  if (datasets.length === 0) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <div className="w-16 h-16 bg-card rounded-full flex items-center justify-center mb-6">
+            <Scissors className="w-8 h-8 text-text-secondary" />
+          </div>
+          <h2 className="text-2xl font-semibold text-text-primary mb-2">
+            No imaging available yet
+          </h2>
+          <p className="text-text-secondary max-w-md">
+            The cutout service works on fields with a deployed FitsGL tile
+            pyramid; none are published yet.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <CutoutsPageContent
+      datasets={datasets}
+      initial={{
+        field: str(params.field),
+        ra: str(params.ra),
+        dec: str(params.dec),
+        fov: str(params.fov),
+        bands: str(params.bands),
+      }}
+    />
+  );
+}

--- a/web/components/layout/Navigation.tsx
+++ b/web/components/layout/Navigation.tsx
@@ -86,6 +86,7 @@ export const Navigation: React.FC = () => {
       ],
     },
     { href: '/map', label: 'Map' },
+    { href: '/cutouts', label: 'Cutouts' },
     { href: '/updates', label: 'Updates' },
     { href: '/docs', label: 'Docs' },
   ];


### PR DESCRIPTION
## Summary

**PR D of the Phase 5 sub-PR sequence** (epic #337, issue #343) — **stacked on #366 (PR C)**; only the last 1 commit is new here.

The COSMOS-cutout-service-style GUI: an authenticated **`/cutouts`** page (new nav entry after Map) over the PR C science endpoints. Same canonical API as the Python client and curl — the browser's cookie session authenticates directly, no separate backend.

## What it does

- **Field** select from the deployed FitsGL datasets (`getFitsglDatasets()` — RLS keeps draft-backed fields admin-only, matching the map).
- **Coordinates** via the shared `parseCoordinates` (decimal degrees or sexagesimal), with a live parsed α/δ hint; **FOV**, **band chips** (inventory-ordered, never empty), **stretch / colormap / panel size / columns**.
- **Generate figure** → the multi-band postage-stamp preview, fetched as a blob so API error JSON (unknown band, over budget…) surfaces inline instead of a broken image.
- **FITS / PNG downloads**; a native-scale size estimate (`pixel_scale` parsed from the dataset row) with an over-4096² warning that disables the FITS button before the server would 400.
- **Shareable URLs**: generating mirrors the request into `?field=&ra=&dec=&fov=`, and arriving on such a URL auto-generates the preview.
- **View on map** link at the entered coordinates.

## Verification

Render-verified end-to-end via puppeteer on the local rj0911 stack: form → labeled F444W preview (asinh/gray), FITS download from the cookie session (200, `attachment`, `application/fits`), shared-URL auto-generate, size estimate updates. `tsc` + eslint clean; `npm run build` green (`/cutouts` 5.1 kB route).

One local-env note: mid-testing the long-running dev server's `.next` chunk cache went stale after several branch switches (three core chunks 404 → page served but never hydrated). A dev-server restart fixed it — no code issue.

Web-only — no pipeline changelog entry needed.

**Next:** PR E retires the legacy PNG stack per-field (destructive, last).

Generated with Claude Code