### PR TITLE
perf(sync): keyset pagination for /sync/* catalog RPCs (#103)

### DIFF
--- a/python/campfire/api/client.py
+++ b/python/campfire/api/client.py
@@ -205,7 +205,7 @@ class APIClient:
     ) -> Tuple[List[dict], int]:
         """Fetch all objects via the lightweight /sync/objects endpoint."""
         return self._paginate_sync_endpoint(
-            "/sync/objects", updated_since, on_page_complete,
+            "/sync/objects", "object_id", updated_since, on_page_complete,
         )
 
     # ------------------------------------------------------------------
@@ -248,7 +248,7 @@ class APIClient:
     ) -> Tuple[List[dict], int]:
         """Fetch all spectra via the /sync/spectra endpoint."""
         return self._paginate_sync_endpoint(
-            "/sync/spectra", updated_since, on_page_complete,
+            "/sync/spectra", "spectrum_id", updated_since, on_page_complete,
         )
 
     # ------------------------------------------------------------------
@@ -289,10 +289,11 @@ class APIClient:
         """Fetch the storage_objects mirror via /sync/storage (program-scoped).
 
         Paginates with the larger storage page size (``_storage_page_size``) since
-        storage_objects is the biggest sync catalog.
+        storage_objects is the biggest sync catalog. Cursor is the integer ``id``
+        (storage_key is not uniquely constrained alone; see the RPC).
         """
         return self._paginate_sync_endpoint(
-            "/sync/storage", updated_since, on_page_complete,
+            "/sync/storage", "id", updated_since, on_page_complete,
             page_size=self._storage_page_size,
         )
 
@@ -323,11 +324,19 @@ class APIClient:
     def _paginate_sync_endpoint(
         self,
         path: str,
+        cursor_key: str,
         updated_since: Optional[str] = None,
         on_page_complete: Optional[Callable[[int, int], None]] = None,
         page_size: Optional[int] = None,
     ) -> Tuple[List[dict], int]:
-        """Paginate through a /sync/* endpoint.
+        """Keyset-paginate through a /sync/* endpoint.
+
+        Walks forward with a cursor on ``cursor_key`` — the endpoint's unique,
+        btree-indexed ordering column (e.g. ``"object_id"``, ``"spectrum_id"``,
+        or ``"id"``). Each page sends the previous page's last value as
+        ``after``, so the server seeks the index instead of scanning ``offset``
+        rows first: O(log N + limit) per page instead of O(offset + limit). This
+        keeps deep ``--full`` sync pages flat as the catalog grows (issue #103).
 
         ``page_size`` overrides the shared per-client page size for endpoints that
         want a different one (e.g. the larger storage page); defaults to
@@ -339,7 +348,8 @@ class APIClient:
         all_items: List[dict] = []
         total_accessible_count = 0
         total = 0
-        offset = 0
+        fetched = 0
+        cursor = None
         first_page = True
         while True:
             self._session._ensure_valid_token()
@@ -348,24 +358,32 @@ class APIClient:
             # subsequent page.
             params: dict = {
                 "limit": page_size,
-                "offset": offset,
                 "include_counts": "true" if first_page else "false",
             }
+            if cursor is not None:
+                params["after"] = cursor
             if updated_since:
                 params["updated_since"] = updated_since
             response = self._session.get(path, params=params, timeout=60)
             _handle_response_error(response, f"fetching {path}")
             data = response.json()
             items = data.get("data", [])
-            all_items.extend(items)
             if first_page:
                 total = data.get("pagination", {}).get("total", 0)
                 total_accessible_count = data.get("total_accessible_count", 0)
                 first_page = False
-            offset += len(items)
+            if not items:
+                break
+            all_items.extend(items)
+            fetched += len(items)
+            cursor = items[-1][cursor_key]
             if on_page_complete:
-                on_page_complete(offset, total)
-            if offset >= total or not items:
+                on_page_complete(fetched, total)
+            # A short page means the server has no more matching rows: stop
+            # without an extra empty round-trip. An exactly-full final page
+            # falls through and the next request returns an empty page (handled
+            # by the `not items` break above).
+            if len(items) < page_size:
                 break
         return all_items, total_accessible_count
 
@@ -436,28 +454,16 @@ class APIClient:
         updated_since: Optional[str] = None,
         on_page_complete: Optional[Callable[[int, int], None]] = None,
     ) -> Tuple[List[dict], int]:
-        """Fetch all photometry records via the /sync/photometry endpoint."""
-        all_items: List[dict] = []
-        offset = 0
-        total_count = 0
-        while True:
-            self._session._ensure_valid_token()
-            params: dict = {"limit": self._page_size, "offset": offset}
-            if updated_since:
-                params["updated_since"] = updated_since
-            response = self._session.get("/sync/photometry", params=params, timeout=60)
-            _handle_response_error(response, "fetching photometry")
-            data = response.json()
-            items = data.get("data", [])
-            all_items.extend(items)
-            total = data.get("pagination", {}).get("total", 0)
-            total_count = total
-            offset += len(items)
-            if on_page_complete:
-                on_page_complete(offset, total)
-            if offset >= total or not items:
-                break
-        return all_items, total_count
+        """Fetch all photometry records via the /sync/photometry endpoint.
+
+        Keyset cursor is the integer ``id`` (object_photometry PK). The second
+        return element is 0 here (the endpoint carries no accessible count) and
+        is ignored by the caller; kept for signature parity with the other
+        ``fetch_all_*`` streams.
+        """
+        return self._paginate_sync_endpoint(
+            "/sync/photometry", "id", updated_since, on_page_complete,
+        )
 
     def fetch_tags(self) -> List[dict]:
         """Fetch all tag metadata via the /sync/lists endpoint."""

--- a/python/campfire/api/client.py
+++ b/python/campfire/api/client.py
@@ -342,7 +342,10 @@ class APIClient:
         want a different one (e.g. the larger storage page); defaults to
         ``self._page_size``.
 
-        Returns (items, total_accessible_count).
+        Returns (items, total_accessible_count). Endpoints that carry no
+        ``total_accessible_count`` field (photometry) fall back to
+        ``pagination.total`` so callers still see a real count instead of a
+        false 0.
         """
         page_size = page_size or self._page_size
         all_items: List[dict] = []
@@ -370,7 +373,11 @@ class APIClient:
             items = data.get("data", [])
             if first_page:
                 total = data.get("pagination", {}).get("total", 0)
-                total_accessible_count = data.get("total_accessible_count", 0)
+                total_accessible_count = (
+                    data["total_accessible_count"]
+                    if "total_accessible_count" in data
+                    else total
+                )
                 first_page = False
             if not items:
                 break
@@ -456,10 +463,10 @@ class APIClient:
     ) -> Tuple[List[dict], int]:
         """Fetch all photometry records via the /sync/photometry endpoint.
 
-        Keyset cursor is the integer ``id`` (object_photometry PK). The second
-        return element is 0 here (the endpoint carries no accessible count) and
-        is ignored by the caller; kept for signature parity with the other
-        ``fetch_all_*`` streams.
+        Keyset cursor is the integer ``id`` (object_photometry PK). The
+        endpoint carries no accessible count, so the second return element is
+        ``pagination.total`` (the shared paginator's fallback); the internal
+        caller ignores it, but it's kept accurate for direct callers.
         """
         return self._paginate_sync_endpoint(
             "/sync/photometry", "id", updated_since, on_page_complete,

--- a/python/tests/test_sync_concurrent.py
+++ b/python/tests/test_sync_concurrent.py
@@ -257,3 +257,105 @@ def test_fetch_all_storage_requests_storage_page_size(monkeypatch):
     # The first (and only) page is requested with the storage limit.
     _path, kwargs = session.get.call_args
     assert kwargs["params"]["limit"] == 6000
+
+
+# ---------------------------------------------------------------------------
+# Keyset pagination (#103)
+# ---------------------------------------------------------------------------
+def _canned_session(pages):
+    """A MagicMock session whose .get() returns ``pages`` in order and records
+    the params of each request in the returned ``calls`` list."""
+    calls = []
+
+    def fake_get(path, params=None, timeout=None):
+        calls.append(params)
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = pages[len(calls) - 1]
+        return resp
+
+    session = MagicMock()
+    session.get.side_effect = fake_get
+    return session, calls
+
+
+def test_paginate_sync_endpoint_keyset_cursor_propagation(monkeypatch):
+    """The paginator seeks with ?after=<previous page's last cursor>, never
+    offset, and stops on a short page without an extra round-trip (#103)."""
+    monkeypatch.setenv("CAMPFIRE_SYNC_PAGE_SIZE", "3")
+    pages = [
+        {  # page 1: full — carries the counts
+            "data": [{"object_id": "A"}, {"object_id": "B"}, {"object_id": "C"}],
+            "pagination": {"total": 7},
+            "total_accessible_count": 42,
+        },
+        {  # page 2: full
+            "data": [{"object_id": "D"}, {"object_id": "E"}, {"object_id": "F"}],
+            "pagination": {"total": 0},
+            "total_accessible_count": 0,
+        },
+        {  # page 3: short → stop
+            "data": [{"object_id": "G"}],
+            "pagination": {"total": 0},
+            "total_accessible_count": 0,
+        },
+    ]
+    session, calls = _canned_session(pages)
+    client = APIClient(session=session)
+
+    items, accessible = client.fetch_all_objects()
+
+    # Every row, in page order; accessible count taken from the first page only.
+    assert [i["object_id"] for i in items] == ["A", "B", "C", "D", "E", "F", "G"]
+    assert accessible == 42
+    # Short final page stops the walk — three requests, no trailing empty fetch.
+    assert len(calls) == 3
+    # Keyset, not offset: no offset param anywhere.
+    assert all("offset" not in p for p in calls)
+    # First page: no cursor, counts requested at the honored page size.
+    assert "after" not in calls[0]
+    assert calls[0]["include_counts"] == "true"
+    assert calls[0]["limit"] == 3
+    # Later pages: cursor = previous page's last object_id; counts gated off.
+    assert calls[1]["after"] == "C" and calls[1]["include_counts"] == "false"
+    assert calls[2]["after"] == "F" and calls[2]["include_counts"] == "false"
+
+
+def test_paginate_sync_endpoint_stops_on_empty_after_exact_multiple(monkeypatch):
+    """An exactly-full final page falls through to one empty page, which stops
+    the walk (no infinite loop, no missed rows)."""
+    monkeypatch.setenv("CAMPFIRE_SYNC_PAGE_SIZE", "2")
+    pages = [
+        {
+            "data": [{"object_id": "A"}, {"object_id": "B"}],
+            "pagination": {"total": 2},
+            "total_accessible_count": 2,
+        },
+        {"data": [], "pagination": {"total": 0}, "total_accessible_count": 0},
+    ]
+    session, calls = _canned_session(pages)
+    client = APIClient(session=session)
+
+    items, _ = client.fetch_all_objects()
+
+    assert [i["object_id"] for i in items] == ["A", "B"]
+    assert len(calls) == 2            # exact-full page, then the empty terminator
+    assert calls[1]["after"] == "B"   # cursor advanced past the last row
+
+
+def test_fetch_all_photometry_uses_integer_id_cursor(monkeypatch):
+    """Photometry now folds into the shared keyset paginator, cursoring on the
+    integer ``id`` field (#103)."""
+    monkeypatch.setenv("CAMPFIRE_SYNC_PAGE_SIZE", "2")
+    pages = [
+        {"data": [{"id": 10}, {"id": 20}], "pagination": {"total": 3}},
+        {"data": [{"id": 30}], "pagination": {"total": 0}},
+    ]
+    session, calls = _canned_session(pages)
+    client = APIClient(session=session)
+
+    items, _ = client.fetch_all_photometry()
+
+    assert [i["id"] for i in items] == [10, 20, 30]
+    assert calls[0].get("after") is None
+    assert calls[1]["after"] == 20    # last id of the previous page

--- a/python/tests/test_sync_concurrent.py
+++ b/python/tests/test_sync_concurrent.py
@@ -354,8 +354,12 @@ def test_fetch_all_photometry_uses_integer_id_cursor(monkeypatch):
     session, calls = _canned_session(pages)
     client = APIClient(session=session)
 
-    items, _ = client.fetch_all_photometry()
+    items, total = client.fetch_all_photometry()
 
     assert [i["id"] for i in items] == [10, 20, 30]
+    # Photometry carries no total_accessible_count field; the paginator falls
+    # back to pagination.total instead of reporting a false 0 (Codex review,
+    # PR #372).
+    assert total == 3
     assert calls[0].get("after") is None
     assert calls[1]["after"] == 20    # last id of the previous page

--- a/supabase/migrations/20260711202253_keyset_sync_pagination.sql
+++ b/supabase/migrations/20260711202253_keyset_sync_pagination.sql
@@ -1,0 +1,453 @@
+-- Keyset pagination for the /sync/* catalog RPCs (issue #103).
+--
+-- OFFSET pagination is linear in offset: each page scans+orders offset+limit
+-- rows, so deep --full-sync pages grew until they tipped past the service_role
+-- statement timeout (~page 29 of a 30k-object catalog). These four RPCs scan
+-- forward only, so each gains a keyset cursor (p_after_*) on its unique,
+-- btree-indexed ordering column, making each page O(log N + limit):
+--   get_objects_for_sync         -> objects.object_id      (objects_object_id_key)
+--   get_spectra_for_sync         -> spectra.spectrum_id    (idx_spectra_spectrum_id)
+--   get_photometry_for_sync      -> object_photometry.id   (pkey)  [+ p_include_counts gating]
+--   get_storage_objects_for_sync -> storage_objects.id     (pkey; storage_key is not
+--                                   uniquely constrained alone, and its scope is
+--                                   restated inline so the page seeks the index)
+--
+-- Each final jsonb_agg is ORDER BY'd on the cursor column so the returned page
+-- is cursor-ordered (the client cursors on the last element).
+--
+-- p_offset and the 120s statement_timeout are retained so old offset-based
+-- clients keep working; both can be dropped in a follow-up once keyset clients
+-- are the norm. Old function signatures are dropped so no stale overload lingers.
+
+drop function if exists "public"."get_objects_for_sync"(p_program_slugs text[], p_user_id uuid, p_updated_since timestamp with time zone, p_limit integer, p_offset integer, p_include_counts boolean, p_include_unpublished boolean);
+
+drop function if exists "public"."get_photometry_for_sync"(p_program_slugs text[], p_updated_since timestamp with time zone, p_limit integer, p_offset integer, p_include_unpublished boolean);
+
+drop function if exists "public"."get_spectra_for_sync"(p_program_slugs text[], p_user_id uuid, p_updated_since timestamp with time zone, p_limit integer, p_offset integer, p_include_counts boolean, p_include_unpublished boolean);
+
+drop function if exists "public"."get_storage_objects_for_sync"(p_program_slugs text[], p_updated_since timestamp with time zone, p_limit integer, p_offset integer, p_include_counts boolean, p_include_unpublished boolean);
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_objects_for_sync(p_program_slugs text[], p_user_id uuid DEFAULT NULL::uuid, p_updated_since timestamp with time zone DEFAULT NULL::timestamp with time zone, p_limit integer DEFAULT 1000, p_offset integer DEFAULT 0, p_include_counts boolean DEFAULT true, p_include_unpublished boolean DEFAULT false, p_after_object_id text DEFAULT NULL::text)
+ RETURNS TABLE(objects jsonb, total_count bigint, total_accessible_count bigint)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+ SET statement_timeout TO '120s'
+AS $function$
+BEGIN
+  RETURN QUERY
+  -- matched is MATERIALIZED so the three aggregate CTEs below each see the
+  -- same ~p_limit-row set without re-evaluating the WHERE/ORDER/LIMIT.
+  WITH matched AS MATERIALIZED (
+    SELECT o.id, o.object_id, o.field, o.ra, o.dec,
+           o.n_targets, o.n_spectra, o.programs, o.gratings,
+           o.max_snr, o.max_exposure_time,
+           o.redshift, o.redshift_quality,
+           o.redshift_inspected, o.redshift_auto,
+           o.inspected_used_auto,
+           o.last_inspected_at, o.last_inspected_by,
+           o.last_data_change_at, o.staleness_reason,
+           o.version, o.is_active,
+           o.has_photometry, o.photo_z, o.photo_z_err_lo, o.photo_z_err_hi,
+           o.created_at, o.updated_at
+    FROM objects o
+    WHERE o.programs && p_program_slugs
+      -- Phase D: hide soft-deleted objects from sync. Reactivation rewrites
+      -- updated_at, so re-activated rows get re-synced naturally on next pull.
+      AND o.is_active = true
+      -- B1: drop objects with no published spectrum (fail-closed).
+      AND (p_include_unpublished OR o.has_published_spectrum)
+      AND (p_updated_since IS NULL OR o.updated_at > p_updated_since)
+      -- Keyset (#103): seek past the previous page's last object_id. object_id
+      -- is UNIQUE, so a strict > needs no (sort_col, id) tiebreaker. Any future
+      -- change to this ORDER BY must keep the ordering column UNIQUE (or switch
+      -- to a row-value cursor) or keyset will skip/duplicate rows.
+      AND (p_after_object_id IS NULL OR o.object_id > p_after_object_id)
+    ORDER BY o.object_id
+    LIMIT p_limit OFFSET p_offset
+  ),
+  member_targets_agg AS (
+    SELECT t.object_id,
+           jsonb_agg(t.target_id ORDER BY t.target_id) AS target_ids
+    FROM targets t
+    WHERE t.object_id IN (SELECT id FROM matched)
+      AND t.program_slug = ANY(p_program_slugs)
+    GROUP BY t.object_id
+  ),
+  -- Phase D: per-spectrum payload (per design doc) so the Python client
+  -- can render redshift_auto and dq_flags per grating without a second
+  -- round-trip.
+  spectra_agg AS (
+    SELECT t.object_id,
+           jsonb_agg(jsonb_build_object(
+             'id', s.id,
+             'target_id', s.target_id,
+             'grating', s.grating,
+             'signal_to_noise', s.signal_to_noise,
+             'exposure_time', s.exposure_time,
+             'redshift_auto', s.redshift_auto,
+             'dq_flags', s.dq_flags
+           ) ORDER BY s.target_id, s.grating) AS spectra
+    FROM spectra s
+    JOIN targets t ON t.target_id = s.target_id
+    WHERE t.object_id IN (SELECT id FROM matched)
+      AND t.program_slug = ANY(p_program_slugs)
+      AND (p_include_unpublished OR s.deploy_status = 'published')
+    GROUP BY t.object_id
+  ),
+  lists_agg AS (
+    SELECT olm.object_id,
+           jsonb_agg(ol.slug ORDER BY ol.slug) AS list_slugs
+    FROM object_list_members olm
+    JOIN object_lists ol ON ol.id = olm.list_id
+    WHERE olm.object_id IN (SELECT id FROM matched)
+      AND (ol.created_by = p_user_id
+           OR ol.visibility IN ('public_read', 'public_edit'))
+    GROUP BY olm.object_id
+  ),
+  -- Count CTEs are gated on p_include_counts; when FALSE the planner
+  -- collapses them to One-Time Filter: false and skips the scan.
+  total AS (
+    SELECT COUNT(*) AS cnt
+    FROM objects o
+    WHERE p_include_counts
+      AND o.programs && p_program_slugs
+      AND o.is_active = true
+      AND (p_include_unpublished OR o.has_published_spectrum)
+      AND (p_updated_since IS NULL OR o.updated_at > p_updated_since)
+  ),
+  accessible AS (
+    SELECT COUNT(*) AS cnt
+    FROM objects o
+    WHERE p_include_counts
+      AND o.programs && p_program_slugs
+      AND o.is_active = true
+      AND (p_include_unpublished OR o.has_published_spectrum)
+  )
+  SELECT
+    COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'id', m.id,
+        'object_id', m.object_id,
+        'field', m.field,
+        'ra', m.ra,
+        'dec', m.dec,
+        -- Aggregates scoped to the caller's accessible programs so a sync that
+        -- pulls a mixed-program object doesn't leak proprietary member metadata
+        -- into the Python catalog. See object_scoped_aggregates().
+        'n_targets', sa.n_targets,
+        'n_spectra', sa.n_spectra,
+        'programs', sa.programs,
+        'gratings', sa.gratings,
+        'max_snr', sa.max_snr,
+        'max_exposure_time', sa.max_exposure_time,
+        'redshift', m.redshift,
+        'redshift_quality', m.redshift_quality,
+        'redshift_inspected', m.redshift_inspected,
+        'redshift_auto', m.redshift_auto,
+        'inspected_used_auto', m.inspected_used_auto,
+        'last_inspected_at', m.last_inspected_at,
+        'last_inspected_by', m.last_inspected_by,
+        'last_data_change_at', m.last_data_change_at,
+        'staleness_reason', m.staleness_reason,
+        'version', m.version,
+        'is_active', m.is_active,
+        'has_photometry', m.has_photometry,
+        'photo_z', m.photo_z,
+        'photo_z_err_lo', m.photo_z_err_lo,
+        'photo_z_err_hi', m.photo_z_err_hi,
+        'created_at', m.created_at,
+        'updated_at', m.updated_at,
+        'member_target_ids', COALESCE(mt.target_ids, '[]'::jsonb),
+        'spectra',           COALESCE(sp.spectra,    '[]'::jsonb),
+        'lists',             COALESCE(la.list_slugs, '[]'::jsonb)
+      )
+      -- Keyset (#103): the client uses the LAST element's object_id as the next
+      -- page's cursor, so the page array MUST be in object_id order. matched is
+      -- ORDER BY object_id, but the LEFT JOINs below can reorder it, so pin the
+      -- aggregate order explicitly.
+      ORDER BY m.object_id
+    ), '[]'::jsonb),
+    COALESCE((SELECT cnt FROM total), 0)::BIGINT,
+    COALESCE((SELECT cnt FROM accessible), 0)::BIGINT
+  FROM matched m
+  LEFT JOIN member_targets_agg mt ON mt.object_id = m.id
+  LEFT JOIN spectra_agg         sp ON sp.object_id = m.id
+  LEFT JOIN lists_agg           la ON la.object_id = m.id
+  LEFT JOIN LATERAL public.object_scoped_aggregates(m.id, p_program_slugs, p_include_unpublished) sa ON true;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_photometry_for_sync(p_program_slugs text[], p_updated_since timestamp with time zone DEFAULT NULL::timestamp with time zone, p_limit integer DEFAULT 1000, p_offset integer DEFAULT 0, p_include_unpublished boolean DEFAULT false, p_include_counts boolean DEFAULT true, p_after_id integer DEFAULT NULL::integer)
+ RETURNS TABLE(photometry_records jsonb, total_count bigint)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+ SET statement_timeout TO '120s'
+AS $function$
+BEGIN
+  RETURN QUERY
+  WITH matched AS (
+    SELECT op.id, o.object_id, op.field, op.catalog_name, op.catalog_id,
+           op.match_distance_arcsec, op.photometry, op.photo_z,
+           op.photo_z_err_lo, op.photo_z_err_hi, op.has_pz,
+           op.created_at, op.updated_at
+    FROM object_photometry op
+    JOIN objects o ON o.id = op.object_id
+    WHERE o.programs && p_program_slugs
+      -- B1: fail-closed publish gate (this RPC always bypasses RLS).
+      AND (p_include_unpublished OR o.has_published_spectrum)
+      AND (p_updated_since IS NULL OR op.updated_at > p_updated_since)
+      -- Keyset (#103): op.id is the PK, so a strict > needs no tiebreaker.
+      AND (p_after_id IS NULL OR op.id > p_after_id)
+    ORDER BY op.id
+    LIMIT p_limit OFFSET p_offset
+  ),
+  -- Count CTE gated on p_include_counts; when FALSE the planner collapses it to
+  -- One-Time Filter: false and skips the scan/join.
+  total AS (
+    SELECT COUNT(*) AS cnt
+    FROM object_photometry op
+    JOIN objects o ON o.id = op.object_id
+    WHERE p_include_counts
+      AND o.programs && p_program_slugs
+      AND (p_include_unpublished OR o.has_published_spectrum)
+      AND (p_updated_since IS NULL OR op.updated_at > p_updated_since)
+  )
+  SELECT
+    COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'id', m.id,
+        'object_id', m.object_id,
+        'field', m.field,
+        'catalog_name', m.catalog_name,
+        'catalog_id', m.catalog_id,
+        'match_distance_arcsec', m.match_distance_arcsec,
+        'photometry', m.photometry,
+        'photo_z', m.photo_z,
+        'photo_z_err_lo', m.photo_z_err_lo,
+        'photo_z_err_hi', m.photo_z_err_hi,
+        'has_pz', m.has_pz,
+        'created_at', m.created_at,
+        'updated_at', m.updated_at
+      )
+      -- Keyset (#103): page array must be id-ordered (client cursors on the
+      -- last element).
+      ORDER BY m.id
+    ), '[]'::jsonb),
+    COALESCE((SELECT cnt FROM total), 0)::BIGINT
+  FROM matched m;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_spectra_for_sync(p_program_slugs text[], p_user_id uuid DEFAULT NULL::uuid, p_updated_since timestamp with time zone DEFAULT NULL::timestamp with time zone, p_limit integer DEFAULT 1000, p_offset integer DEFAULT 0, p_include_counts boolean DEFAULT true, p_include_unpublished boolean DEFAULT false, p_after_spectrum_id text DEFAULT NULL::text)
+ RETURNS TABLE(spectra jsonb, total_count bigint, total_accessible_count bigint)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+ SET statement_timeout TO '120s'
+AS $function$
+BEGIN
+  RETURN QUERY
+  WITH matched AS MATERIALIZED (
+    SELECT s.id, s.spectrum_id, s.target_id, o.object_id AS object_id,
+           s.grating, s.fits_path, s.file_hash, s.file_size,
+           s.signal_to_noise, s.exposure_time,
+           s.cfpipe_version, s.crds_context, s.jwst_version, s.date_obs, s.reduced_at,
+           s.redshift_auto, s.dq_flags,
+           t.program_slug, t.observation, t.field,
+           s.created_at, s.updated_at
+    FROM spectra s
+    JOIN targets t ON t.target_id = s.target_id
+    LEFT JOIN objects o ON o.id = t.object_id
+    WHERE t.program_slug = ANY(p_program_slugs)
+      AND (o.id IS NULL OR o.is_active = true)
+      -- B1: fail-closed publish gate (this RPC always bypasses RLS).
+      AND (p_include_unpublished OR s.deploy_status = 'published')
+      AND (p_updated_since IS NULL OR s.updated_at > p_updated_since)
+      -- Keyset (#103): spectrum_id is UNIQUE (idx_spectra_spectrum_id), so a
+      -- strict > needs no tiebreaker; keep the ordering column UNIQUE.
+      AND (p_after_spectrum_id IS NULL OR s.spectrum_id > p_after_spectrum_id)
+    ORDER BY s.spectrum_id
+    LIMIT p_limit OFFSET p_offset
+  ),
+  -- Count CTEs are gated on p_include_counts; when FALSE the planner
+  -- collapses them to One-Time Filter: false and skips the scan/join.
+  total AS (
+    SELECT COUNT(*) AS cnt
+    FROM spectra s
+    JOIN targets t ON t.target_id = s.target_id
+    LEFT JOIN objects o ON o.id = t.object_id
+    WHERE p_include_counts
+      AND t.program_slug = ANY(p_program_slugs)
+      AND (o.id IS NULL OR o.is_active = true)
+      AND (p_include_unpublished OR s.deploy_status = 'published')
+      AND (p_updated_since IS NULL OR s.updated_at > p_updated_since)
+  ),
+  accessible AS (
+    SELECT COUNT(*) AS cnt
+    FROM spectra s
+    JOIN targets t ON t.target_id = s.target_id
+    LEFT JOIN objects o ON o.id = t.object_id
+    WHERE p_include_counts
+      AND t.program_slug = ANY(p_program_slugs)
+      AND (o.id IS NULL OR o.is_active = true)
+      AND (p_include_unpublished OR s.deploy_status = 'published')
+  )
+  SELECT
+    COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'id', m.id,
+        'spectrum_id', m.spectrum_id,
+        'target_id', m.target_id,
+        'object_id', m.object_id,
+        'grating', m.grating,
+        'fits_path', m.fits_path,
+        'file_hash', m.file_hash,
+        'file_size', m.file_size,
+        'signal_to_noise', m.signal_to_noise,
+        'exposure_time', m.exposure_time,
+        'cfpipe_version', m.cfpipe_version,
+        'crds_context', m.crds_context,
+        'jwst_version', m.jwst_version,
+        'date_obs', m.date_obs,
+        'reduced_at', m.reduced_at,
+        'redshift_auto', m.redshift_auto,
+        'dq_flags', m.dq_flags,
+        'program_slug', m.program_slug,
+        'observation', m.observation,
+        'field', m.field,
+        'created_at', m.created_at,
+        'updated_at', m.updated_at
+      )
+      -- Keyset (#103): page array must be spectrum_id-ordered (client cursors on
+      -- the last element). matched has no post-ORDER joins, but pin it anyway.
+      ORDER BY m.spectrum_id
+    ), '[]'::jsonb),
+    COALESCE((SELECT cnt FROM total), 0)::BIGINT,
+    COALESCE((SELECT cnt FROM accessible), 0)::BIGINT
+  FROM matched m;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_storage_objects_for_sync(p_program_slugs text[], p_updated_since timestamp with time zone DEFAULT NULL::timestamp with time zone, p_limit integer DEFAULT 1000, p_offset integer DEFAULT 0, p_include_counts boolean DEFAULT true, p_include_unpublished boolean DEFAULT false, p_after_id bigint DEFAULT NULL::bigint)
+ RETURNS TABLE(objects jsonb, total_count bigint, total_accessible_count bigint)
+ LANGUAGE plpgsql
+ STABLE
+ SET plan_cache_mode TO 'force_custom_plan'
+ SET statement_timeout TO '120s'
+AS $function$
+BEGIN
+  RETURN QUERY
+  -- `scoped` carries the full published-scope filter and feeds the count CTEs
+  -- only (gated on p_include_counts, so it is skipped entirely on keyset pages
+  -- 2+). `matched` re-states the SAME scope inline against the base table so its
+  -- keyset seek uses the PK index instead of reading a materialized full scan.
+  -- The two copies must stay in sync (same house pattern as get_objects_for_sync's
+  -- matched vs. total/accessible).
+  WITH scoped AS (
+    SELECT so.updated_at
+    FROM storage_objects so
+    WHERE so.status = 'active'
+      AND (
+        p_include_unpublished
+        OR (so.spectrum_id IS NOT NULL AND EXISTS (
+              SELECT 1 FROM spectra s
+              JOIN targets t ON t.target_id = s.target_id
+              WHERE s.spectrum_id = so.spectrum_id
+                AND s.deploy_status = 'published'
+                AND t.program_slug = ANY(p_program_slugs)))
+        OR (so.spectrum_id IS NULL AND so.deployment_id IS NOT NULL AND EXISTS (
+              SELECT 1 FROM deployments d
+              LEFT JOIN observations o ON o.name = d.observation
+              WHERE d.id = so.deployment_id
+                AND d.status = 'published'
+                -- NIRCam field deploy (epic #261, N1): multi-program, public to all
+                -- when published. NIRSpec obs deploy stays program-scoped.
+                AND (d.field IS NOT NULL OR o.program_slug = ANY(p_program_slugs))))
+      )
+  ),
+  matched AS MATERIALIZED (
+    SELECT so.*
+    FROM storage_objects so
+    WHERE so.status = 'active'
+      AND (
+        p_include_unpublished
+        OR (so.spectrum_id IS NOT NULL AND EXISTS (
+              SELECT 1 FROM spectra s
+              JOIN targets t ON t.target_id = s.target_id
+              WHERE s.spectrum_id = so.spectrum_id
+                AND s.deploy_status = 'published'
+                AND t.program_slug = ANY(p_program_slugs)))
+        OR (so.spectrum_id IS NULL AND so.deployment_id IS NOT NULL AND EXISTS (
+              SELECT 1 FROM deployments d
+              LEFT JOIN observations o ON o.name = d.observation
+              WHERE d.id = so.deployment_id
+                AND d.status = 'published'
+                AND (d.field IS NOT NULL OR o.program_slug = ANY(p_program_slugs))))
+      )
+      AND (p_updated_since IS NULL OR so.updated_at > p_updated_since)
+      -- Keyset (#103): id is the PK, so a strict > needs no tiebreaker.
+      AND (p_after_id IS NULL OR so.id > p_after_id)
+    ORDER BY so.id
+    LIMIT p_limit OFFSET p_offset
+  ),
+  total AS (
+    SELECT COUNT(*) AS cnt FROM scoped
+    WHERE p_include_counts
+      AND (p_updated_since IS NULL OR scoped.updated_at > p_updated_since)
+  ),
+  accessible AS (
+    SELECT COUNT(*) AS cnt FROM scoped
+    WHERE p_include_counts
+  )
+  SELECT
+    COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'id', m.id,
+        'backend', m.backend,
+        'bucket', m.bucket,
+        'storage_key', m.storage_key,
+        'content_hash', m.content_hash,
+        'sci_dq_hash', m.sci_dq_hash,
+        'size_bytes', m.size_bytes,
+        'content_type', m.content_type,
+        'product_type', m.product_type,
+        'instrument', m.instrument,
+        'status', m.status,
+        'observation', m.observation,
+        'field', m.field,
+        'filter', m.filter,
+        'spectrum_id', m.spectrum_id,
+        'exposure_ref', m.exposure_ref,
+        'deployment_id', m.deployment_id,
+        'cfpipe_version', m.cfpipe_version,
+        'created_at', m.created_at,
+        'updated_at', m.updated_at
+      )
+      -- Keyset (#103): page array must be id-ordered (client cursors on the
+      -- last element).
+      ORDER BY m.id
+    ), '[]'::jsonb),
+    COALESCE((SELECT cnt FROM total), 0)::BIGINT,
+    COALESCE((SELECT cnt FROM accessible), 0)::BIGINT
+  FROM matched m;
+END;
+$function$
+;
+
+-- Grants for the new signatures (the dropped overloads did not carry them
+-- forward). Redundant with public default privileges but stated explicitly to
+-- mirror supabase/schemas/functions.sql.
+GRANT EXECUTE ON FUNCTION public.get_objects_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN, TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_objects_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN, TEXT) TO service_role;
+GRANT EXECUTE ON FUNCTION public.get_spectra_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN, TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_spectra_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN, TEXT) TO service_role;
+GRANT EXECUTE ON FUNCTION public.get_photometry_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN, INTEGER) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_photometry_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN, INTEGER) TO service_role;
+GRANT EXECUTE ON FUNCTION public.get_storage_objects_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN, BIGINT) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_storage_objects_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN, BIGINT) TO service_role;

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -283,6 +283,7 @@ GRANT ALL ON FUNCTION public.check_device_code_status(text) TO service_role;
 -- =============================================================================
 
 DROP FUNCTION IF EXISTS public.get_objects_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN);
+DROP FUNCTION IF EXISTS public.get_objects_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN);
 
 CREATE OR REPLACE FUNCTION public.get_objects_for_sync(
   p_program_slugs TEXT[],
@@ -291,18 +292,22 @@ CREATE OR REPLACE FUNCTION public.get_objects_for_sync(
   p_limit INTEGER DEFAULT 1000,
   p_offset INTEGER DEFAULT 0,
   p_include_counts BOOLEAN DEFAULT TRUE,
-  p_include_unpublished BOOLEAN DEFAULT false
+  p_include_unpublished BOOLEAN DEFAULT false,
+  -- Keyset cursor (#103): the object_id of the last row of the previous page.
+  -- When non-NULL the scan seeks straight to the next id via the
+  -- objects_object_id_key UNIQUE btree, so each page costs O(log N + limit)
+  -- instead of OFFSET's O(offset + limit). p_offset is kept for old clients.
+  p_after_object_id TEXT DEFAULT NULL
 )
 RETURNS TABLE(objects JSONB, total_count BIGINT, total_accessible_count BIGINT)
 LANGUAGE plpgsql STABLE
 SET plan_cache_mode = 'force_custom_plan'
--- OFFSET-based pagination is linear in offset: a deep-page request
--- (e.g. OFFSET 29000 on a 30k-row catalog) must materialize the ordered
--- scan up to that point plus run three aggregate CTEs, and started
--- tipping past the default service_role timeout around page ~29 of a
--- --full sync. Bumped to 120s so deep pages finish while the paginator
--- is still offset-based; a future change should switch this RPC to
--- keyset pagination (WHERE object_id > cursor) and then drop this SET.
+-- Keyset clients (p_after_object_id) never touch this timeout: each page is a
+-- shallow index range scan. It is retained only for legacy OFFSET clients,
+-- whose deep pages must materialize the ordered scan up to `offset` plus run
+-- three aggregate CTEs and were tipping past the default service_role timeout
+-- around page ~29 of a 30k-object --full sync. Drop this SET once offset
+-- clients are gone (see #103 follow-up).
 SET statement_timeout = '120s'
 AS $$
 BEGIN
@@ -329,6 +334,11 @@ BEGIN
       -- B1: drop objects with no published spectrum (fail-closed).
       AND (p_include_unpublished OR o.has_published_spectrum)
       AND (p_updated_since IS NULL OR o.updated_at > p_updated_since)
+      -- Keyset (#103): seek past the previous page's last object_id. object_id
+      -- is UNIQUE, so a strict > needs no (sort_col, id) tiebreaker. Any future
+      -- change to this ORDER BY must keep the ordering column UNIQUE (or switch
+      -- to a row-value cursor) or keyset will skip/duplicate rows.
+      AND (p_after_object_id IS NULL OR o.object_id > p_after_object_id)
     ORDER BY o.object_id
     LIMIT p_limit OFFSET p_offset
   ),
@@ -428,6 +438,11 @@ BEGIN
         'spectra',           COALESCE(sp.spectra,    '[]'::jsonb),
         'lists',             COALESCE(la.list_slugs, '[]'::jsonb)
       )
+      -- Keyset (#103): the client uses the LAST element's object_id as the next
+      -- page's cursor, so the page array MUST be in object_id order. matched is
+      -- ORDER BY object_id, but the LEFT JOINs below can reorder it, so pin the
+      -- aggregate order explicitly.
+      ORDER BY m.object_id
     ), '[]'::jsonb),
     COALESCE((SELECT cnt FROM total), 0)::BIGINT,
     COALESCE((SELECT cnt FROM accessible), 0)::BIGINT
@@ -439,8 +454,8 @@ BEGIN
 END;
 $$;
 
-GRANT EXECUTE ON FUNCTION public.get_objects_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN) TO authenticated;
-GRANT EXECUTE ON FUNCTION public.get_objects_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN) TO service_role;
+GRANT EXECUTE ON FUNCTION public.get_objects_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN, TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_objects_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN, TEXT) TO service_role;
 
 
 -- =============================================================================
@@ -451,6 +466,7 @@ GRANT EXECUTE ON FUNCTION public.get_objects_for_sync(TEXT[], UUID, TIMESTAMPTZ,
 -- =============================================================================
 
 DROP FUNCTION IF EXISTS public.get_spectra_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN);
+DROP FUNCTION IF EXISTS public.get_spectra_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN);
 
 CREATE OR REPLACE FUNCTION public.get_spectra_for_sync(
   p_program_slugs TEXT[],
@@ -459,13 +475,18 @@ CREATE OR REPLACE FUNCTION public.get_spectra_for_sync(
   p_limit INTEGER DEFAULT 1000,
   p_offset INTEGER DEFAULT 0,
   p_include_counts BOOLEAN DEFAULT TRUE,
-  p_include_unpublished BOOLEAN DEFAULT false
+  p_include_unpublished BOOLEAN DEFAULT false,
+  -- Keyset cursor (#103): the spectrum_id of the last row of the previous page,
+  -- seeked via the idx_spectra_spectrum_id UNIQUE btree. See
+  -- get_objects_for_sync for the design. p_offset is kept for old clients.
+  p_after_spectrum_id TEXT DEFAULT NULL
 )
 RETURNS TABLE(spectra JSONB, total_count BIGINT, total_accessible_count BIGINT)
 LANGUAGE plpgsql STABLE
 SET plan_cache_mode = 'force_custom_plan'
--- Mirrors get_objects_for_sync: offset-based pagination is linear in
--- offset, so deep --full-sync pages can tip past the default timeout.
+-- Mirrors get_objects_for_sync: retained only for legacy OFFSET clients, whose
+-- deep --full-sync pages can tip past the default timeout. Keyset clients
+-- (p_after_spectrum_id) never reach it. Drop once offset clients are gone (#103).
 SET statement_timeout = '120s'
 AS $$
 BEGIN
@@ -486,6 +507,9 @@ BEGIN
       -- B1: fail-closed publish gate (this RPC always bypasses RLS).
       AND (p_include_unpublished OR s.deploy_status = 'published')
       AND (p_updated_since IS NULL OR s.updated_at > p_updated_since)
+      -- Keyset (#103): spectrum_id is UNIQUE (idx_spectra_spectrum_id), so a
+      -- strict > needs no tiebreaker; keep the ordering column UNIQUE.
+      AND (p_after_spectrum_id IS NULL OR s.spectrum_id > p_after_spectrum_id)
     ORDER BY s.spectrum_id
     LIMIT p_limit OFFSET p_offset
   ),
@@ -538,6 +562,9 @@ BEGIN
         'created_at', m.created_at,
         'updated_at', m.updated_at
       )
+      -- Keyset (#103): page array must be spectrum_id-ordered (client cursors on
+      -- the last element). matched has no post-ORDER joins, but pin it anyway.
+      ORDER BY m.spectrum_id
     ), '[]'::jsonb),
     COALESCE((SELECT cnt FROM total), 0)::BIGINT,
     COALESCE((SELECT cnt FROM accessible), 0)::BIGINT
@@ -545,8 +572,8 @@ BEGIN
 END;
 $$;
 
-GRANT EXECUTE ON FUNCTION public.get_spectra_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN) TO authenticated;
-GRANT EXECUTE ON FUNCTION public.get_spectra_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN) TO service_role;
+GRANT EXECUTE ON FUNCTION public.get_spectra_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN, TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_spectra_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN, TEXT) TO service_role;
 
 
 -- =============================================================================
@@ -555,19 +582,27 @@ GRANT EXECUTE ON FUNCTION public.get_spectra_for_sync(TEXT[], UUID, TIMESTAMPTZ,
 -- =============================================================================
 
 DROP FUNCTION IF EXISTS public.get_photometry_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER);
+DROP FUNCTION IF EXISTS public.get_photometry_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN);
 
 CREATE OR REPLACE FUNCTION public.get_photometry_for_sync(
   p_program_slugs TEXT[],
   p_updated_since TIMESTAMPTZ DEFAULT NULL,
   p_limit INTEGER DEFAULT 1000,
   p_offset INTEGER DEFAULT 0,
-  p_include_unpublished BOOLEAN DEFAULT false
+  p_include_unpublished BOOLEAN DEFAULT false,
+  -- Count gating (#103): only the keyset first page needs the count; skip the
+  -- COUNT(*) scan on every subsequent page, matching the other /sync/* RPCs.
+  p_include_counts BOOLEAN DEFAULT TRUE,
+  -- Keyset cursor (#103): the id of the last row of the previous page, seeked
+  -- via the object_photometry PK btree. p_offset is kept for old clients.
+  p_after_id INTEGER DEFAULT NULL
 )
 RETURNS TABLE(photometry_records JSONB, total_count BIGINT)
 LANGUAGE plpgsql STABLE
 SET plan_cache_mode = 'force_custom_plan'
--- Mirrors get_objects_for_sync: offset-based pagination is linear in
--- offset, so deep --full-sync pages can tip past the default timeout.
+-- Mirrors get_objects_for_sync: retained only for legacy OFFSET clients whose
+-- deep --full-sync pages can tip past the default timeout. Keyset clients
+-- (p_after_id) never reach it. Drop once offset clients are gone (#103).
 SET statement_timeout = '120s'
 AS $$
 BEGIN
@@ -583,14 +618,19 @@ BEGIN
       -- B1: fail-closed publish gate (this RPC always bypasses RLS).
       AND (p_include_unpublished OR o.has_published_spectrum)
       AND (p_updated_since IS NULL OR op.updated_at > p_updated_since)
+      -- Keyset (#103): op.id is the PK, so a strict > needs no tiebreaker.
+      AND (p_after_id IS NULL OR op.id > p_after_id)
     ORDER BY op.id
     LIMIT p_limit OFFSET p_offset
   ),
+  -- Count CTE gated on p_include_counts; when FALSE the planner collapses it to
+  -- One-Time Filter: false and skips the scan/join.
   total AS (
     SELECT COUNT(*) AS cnt
     FROM object_photometry op
     JOIN objects o ON o.id = op.object_id
-    WHERE o.programs && p_program_slugs
+    WHERE p_include_counts
+      AND o.programs && p_program_slugs
       AND (p_include_unpublished OR o.has_published_spectrum)
       AND (p_updated_since IS NULL OR op.updated_at > p_updated_since)
   )
@@ -611,14 +651,17 @@ BEGIN
         'created_at', m.created_at,
         'updated_at', m.updated_at
       )
+      -- Keyset (#103): page array must be id-ordered (client cursors on the
+      -- last element).
+      ORDER BY m.id
     ), '[]'::jsonb),
     COALESCE((SELECT cnt FROM total), 0)::BIGINT
   FROM matched m;
 END;
 $$;
 
-GRANT EXECUTE ON FUNCTION public.get_photometry_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN) TO authenticated;
-GRANT EXECUTE ON FUNCTION public.get_photometry_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN) TO service_role;
+GRANT EXECUTE ON FUNCTION public.get_photometry_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN, INTEGER) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_photometry_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN, INTEGER) TO service_role;
 
 
 -- =============================================================================
@@ -2555,23 +2598,42 @@ GRANT EXECUTE ON FUNCTION public.get_observation_manifest TO authenticated;
 --     exposure/object-level rows follow their deployment's status. Drafts/revoked
 --     and out-of-program rows are excluded. Field-only products (NULL observation,
 --     e.g. NIRCam) are admin-only here until NIRCam client download lands.
+DROP FUNCTION IF EXISTS public.get_storage_objects_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN);
+
 CREATE OR REPLACE FUNCTION public.get_storage_objects_for_sync(
   p_program_slugs TEXT[],
   p_updated_since TIMESTAMPTZ DEFAULT NULL,
   p_limit INTEGER DEFAULT 1000,
   p_offset INTEGER DEFAULT 0,
   p_include_counts BOOLEAN DEFAULT TRUE,
-  p_include_unpublished BOOLEAN DEFAULT FALSE
+  p_include_unpublished BOOLEAN DEFAULT FALSE,
+  -- Keyset cursor (#103): the id of the last row of the previous page, seeked
+  -- via the storage_objects_pkey btree. storage_key is NOT usable as a cursor
+  -- (only UNIQUE as (backend, bucket, storage_key)), and sync order is
+  -- irrelevant to the client (it upserts by key), so this orders by the PK.
+  -- p_offset is kept for old clients.
+  p_after_id BIGINT DEFAULT NULL
 )
 RETURNS TABLE(objects JSONB, total_count BIGINT, total_accessible_count BIGINT)
 LANGUAGE plpgsql STABLE
 SET plan_cache_mode = 'force_custom_plan'
+-- Retained only for legacy OFFSET clients; keyset clients (p_after_id) seek the
+-- PK index and never reach it. Unlike the other /sync RPCs, the scope predicate
+-- (published EXISTS checks) is itself an O(N) floor for OFFSET clients — keyset
+-- lets a page seek straight to id > cursor and evaluate scope on only ~p_limit
+-- rows. Drop this SET once offset clients are gone (#103).
 SET statement_timeout = '120s'
 AS $$
 BEGIN
   RETURN QUERY
+  -- `scoped` carries the full published-scope filter and feeds the count CTEs
+  -- only (gated on p_include_counts, so it is skipped entirely on keyset pages
+  -- 2+). `matched` re-states the SAME scope inline against the base table so its
+  -- keyset seek uses the PK index instead of reading a materialized full scan.
+  -- The two copies must stay in sync (same house pattern as get_objects_for_sync's
+  -- matched vs. total/accessible).
   WITH scoped AS (
-    SELECT so.*
+    SELECT so.updated_at
     FROM storage_objects so
     WHERE so.status = 'active'
       AND (
@@ -2593,9 +2655,28 @@ BEGIN
       )
   ),
   matched AS MATERIALIZED (
-    SELECT * FROM scoped
-    WHERE (p_updated_since IS NULL OR scoped.updated_at > p_updated_since)
-    ORDER BY scoped.storage_key
+    SELECT so.*
+    FROM storage_objects so
+    WHERE so.status = 'active'
+      AND (
+        p_include_unpublished
+        OR (so.spectrum_id IS NOT NULL AND EXISTS (
+              SELECT 1 FROM spectra s
+              JOIN targets t ON t.target_id = s.target_id
+              WHERE s.spectrum_id = so.spectrum_id
+                AND s.deploy_status = 'published'
+                AND t.program_slug = ANY(p_program_slugs)))
+        OR (so.spectrum_id IS NULL AND so.deployment_id IS NOT NULL AND EXISTS (
+              SELECT 1 FROM deployments d
+              LEFT JOIN observations o ON o.name = d.observation
+              WHERE d.id = so.deployment_id
+                AND d.status = 'published'
+                AND (d.field IS NOT NULL OR o.program_slug = ANY(p_program_slugs))))
+      )
+      AND (p_updated_since IS NULL OR so.updated_at > p_updated_since)
+      -- Keyset (#103): id is the PK, so a strict > needs no tiebreaker.
+      AND (p_after_id IS NULL OR so.id > p_after_id)
+    ORDER BY so.id
     LIMIT p_limit OFFSET p_offset
   ),
   total AS (
@@ -2631,6 +2712,9 @@ BEGIN
         'created_at', m.created_at,
         'updated_at', m.updated_at
       )
+      -- Keyset (#103): page array must be id-ordered (client cursors on the
+      -- last element).
+      ORDER BY m.id
     ), '[]'::jsonb),
     COALESCE((SELECT cnt FROM total), 0)::BIGINT,
     COALESCE((SELECT cnt FROM accessible), 0)::BIGINT
@@ -2638,8 +2722,8 @@ BEGIN
 END;
 $$;
 
-GRANT EXECUTE ON FUNCTION public.get_storage_objects_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN) TO authenticated;
-GRANT EXECUTE ON FUNCTION public.get_storage_objects_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN) TO service_role;
+GRANT EXECUTE ON FUNCTION public.get_storage_objects_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN, BIGINT) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_storage_objects_for_sync(TEXT[], TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN, BIGINT) TO service_role;
 
 
 -- =============================================================================

--- a/web/app/api/v1/sync/objects/route.ts
+++ b/web/app/api/v1/sync/objects/route.ts
@@ -14,7 +14,10 @@ import { getAccessibleProgramsCached, isAdminUserCached } from '@/lib/api-helper
  * Query parameters:
  * - updated_since: ISO 8601 timestamp (only return objects updated after this)
  * - limit: page size (default 1000)
- * - offset: pagination offset (default 0)
+ * - after: keyset cursor — object_id of the previous page's last row (#103).
+ *          Preferred over offset; O(log N + limit) per page. When set, offset
+ *          is ignored by the RPC's cursor predicate.
+ * - offset: legacy pagination offset (default 0); kept for old clients.
  * - include_counts: 'false' to skip total_count / total_accessible_count (default true)
  */
 export async function GET(request: NextRequest) {
@@ -40,6 +43,7 @@ export async function GET(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams;
     const limit = parseInt(searchParams.get('limit') || '1000', 10);
     const offset = parseInt(searchParams.get('offset') || '0', 10);
+    const afterObjectId = searchParams.get('after') || null;
     const updatedSince = searchParams.get('updated_since') || null;
     const includeCounts = searchParams.get('include_counts') !== 'false';
 
@@ -60,6 +64,7 @@ export async function GET(request: NextRequest) {
       p_offset: offset,
       p_include_counts: includeCounts,
       p_include_unpublished: includeUnpublished,
+      p_after_object_id: afterObjectId,
     });
 
     if (error) {

--- a/web/app/api/v1/sync/photometry/route.ts
+++ b/web/app/api/v1/sync/photometry/route.ts
@@ -14,7 +14,10 @@ import { getAccessibleProgramsCached, isAdminUserCached } from '@/lib/api-helper
  * Query parameters:
  * - updated_since: ISO 8601 timestamp (only return records updated after this)
  * - limit: page size (default 1000)
- * - offset: pagination offset (default 0)
+ * - after: keyset cursor — integer id of the previous page's last row (#103).
+ *          Preferred over offset; O(log N + limit) per page.
+ * - offset: legacy pagination offset (default 0); kept for old clients.
+ * - include_counts: 'false' to skip total_count (default true)
  */
 export async function GET(request: NextRequest) {
   const userId = await validateAuth(request);
@@ -39,7 +42,10 @@ export async function GET(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams;
     const limit = parseInt(searchParams.get('limit') || '1000', 10);
     const offset = parseInt(searchParams.get('offset') || '0', 10);
+    const afterRaw = searchParams.get('after');
+    const afterId = afterRaw ? parseInt(afterRaw, 10) : null;
     const updatedSince = searchParams.get('updated_since') || null;
+    const includeCounts = searchParams.get('include_counts') !== 'false';
 
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
     const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
@@ -56,6 +62,8 @@ export async function GET(request: NextRequest) {
       p_limit: limit,
       p_offset: offset,
       p_include_unpublished: includeUnpublished,
+      p_include_counts: includeCounts,
+      p_after_id: afterId,
     });
 
     if (error) {

--- a/web/app/api/v1/sync/spectra/route.ts
+++ b/web/app/api/v1/sync/spectra/route.ts
@@ -13,7 +13,9 @@ import { getAccessibleProgramsCached, isAdminUserCached } from '@/lib/api-helper
  * Query parameters:
  * - updated_since: ISO 8601 timestamp (only return spectra updated after this)
  * - limit: page size (default 1000)
- * - offset: pagination offset (default 0)
+ * - after: keyset cursor — spectrum_id of the previous page's last row (#103).
+ *          Preferred over offset; O(log N + limit) per page.
+ * - offset: legacy pagination offset (default 0); kept for old clients.
  * - include_counts: 'false' to skip total_count / total_accessible_count (default true)
  */
 export async function GET(request: NextRequest) {
@@ -39,6 +41,7 @@ export async function GET(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams;
     const limit = parseInt(searchParams.get('limit') || '1000', 10);
     const offset = parseInt(searchParams.get('offset') || '0', 10);
+    const afterSpectrumId = searchParams.get('after') || null;
     const updatedSince = searchParams.get('updated_since') || null;
     const includeCounts = searchParams.get('include_counts') !== 'false';
 
@@ -59,6 +62,7 @@ export async function GET(request: NextRequest) {
       p_offset: offset,
       p_include_counts: includeCounts,
       p_include_unpublished: includeUnpublished,
+      p_after_spectrum_id: afterSpectrumId,
     });
 
     if (error) {

--- a/web/app/api/v1/sync/storage/route.ts
+++ b/web/app/api/v1/sync/storage/route.ts
@@ -18,7 +18,9 @@ import { getAccessibleProgramsCached, isAdminUserCached } from '@/lib/api-helper
  * Query parameters:
  * - updated_since: ISO 8601 timestamp (only rows updated after this)
  * - limit: page size (default 1000)
- * - offset: pagination offset (default 0)
+ * - after: keyset cursor — integer id of the previous page's last row (#103).
+ *          Preferred over offset; O(log N + limit) per page.
+ * - offset: legacy pagination offset (default 0); kept for old clients.
  * - include_counts: 'false' to skip total/accessible counts (default true)
  */
 export async function GET(request: NextRequest) {
@@ -48,6 +50,8 @@ export async function GET(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams;
     const limit = parseInt(searchParams.get('limit') || '1000', 10);
     const offset = parseInt(searchParams.get('offset') || '0', 10);
+    const afterRaw = searchParams.get('after');
+    const afterId = afterRaw ? parseInt(afterRaw, 10) : null;
     const updatedSince = searchParams.get('updated_since') || null;
     const includeCounts = searchParams.get('include_counts') !== 'false';
 
@@ -65,6 +69,7 @@ export async function GET(request: NextRequest) {
       // Admins mirror everything (drafts + field-only products); everyone else
       // is fail-closed to published, in-program rows.
       p_include_unpublished: admin,
+      p_after_id: afterId,
     });
 
     if (error) {


### PR DESCRIPTION
Closes #103.

## Problem
OFFSET pagination is linear in offset: each `/sync/*` page scans+orders `offset + limit` rows, so deep `campfire sync --full` pages grow in cost until they tip past the 120s service_role statement timeout (the hotfix in `20260423160000_bump_sync_rpc_timeout.sql` just pushed the cliff out). This reappears as the catalog grows.

## Fix
All four `/sync/*` RPCs scan forward only — a perfect fit for keyset. Each gains a `p_after_*` cursor on its unique, btree-indexed ordering column, making each page `O(log N + limit)`:

| RPC | Cursor | Index |
|---|---|---|
| `get_objects_for_sync` | `objects.object_id` | `objects_object_id_key` |
| `get_spectra_for_sync` | `spectra.spectrum_id` | `idx_spectra_spectrum_id` |
| `get_photometry_for_sync` | `object_photometry.id` | pkey |
| `get_storage_objects_for_sync` | `storage_objects.id` | pkey |

## Deviations from the (April-2026) issue text
1. **Four RPCs, not three** — the issue predates `get_storage_objects_for_sync` (epic #210 storage unification), which is the *largest* sync catalog and also OFFSET-based.
2. **Storage cursors on `id`, not `storage_key`** — `storage_key` is only UNIQUE as `(backend,bucket,storage_key)`, so keyset on it could skip/dup rows. Sync order is irrelevant (the client upserts by key). Its RPC is also **restructured**: the old shared `scoped` CTE was referenced 3× (materialized → full scan every page, defeating keyset), so `matched` now restates the scope inline against the base table and seeks the PK index; `scoped` (trimmed to `updated_at`) feeds only the gated count CTEs.
3. **Photometry got `p_include_counts` gating** — it was the only sync RPC counting on every page — and folds into the shared paginator.

## Subtle correctness fix
The client cursors on the **last** returned element (`items[-1][cursor_key]`), so each final `jsonb_agg(...)` now has an explicit `ORDER BY <cursor_col>`. The `matched` CTE's ordering does **not** survive into the aggregate (objects has LEFT JOINs after `matched`, and PG doesn't guarantee aggregate input order). Without this, keyset would silently skip/dup rows.

## Backward compatibility
`p_offset` and `SET statement_timeout = '120s'` are **retained** on all four RPCs so old offset-based clients keep working. Both can be dropped in a follow-up migration once keyset clients are the norm.

## Changes
- **SQL**: `supabase/schemas/functions.sql` + migration `20260711202253_keyset_sync_pagination.sql`. (The migration was hand-trimmed of a spurious matview drop+recreate that `supabase db diff` emits for pre-existing, unrelated matview drift — see #228.)
- **Web**: the four `web/app/api/v1/sync/*/route.ts` accept `?after=<cursor>`.
- **Python**: `_paginate_sync_endpoint(path, cursor_key, ...)` is keyset-based; `fetch_all_photometry` folds into it (duplicate offset loop removed). +3 tests.

## Validation (local Supabase, 89 obj / 138 spec / 138 storage seed)
- Keyset walk == offset walk == full-scan enumeration for objects/spectra/storage, verified with the last-element cursor exactly as the client does.
- Confirmed `Index Scan using objects_object_id_key` with `object_id > cursor` + early `LIMIT` stop.
- Count-gating, empty-photometry, past-end-cursor edge cases pass; storage scope-leak SQL tests still green.
- 452 pytest pass, 1 skipped; `npm run build` green.

No pipeline changelog entry (touches `web/`, `python/`, `supabase/` only).

Generated with Claude Code