### PR TITLE
feat(nircam): dark expmap PNGs, field layout plot, exact survey area (redesign PR 1/5)

### DIFF
--- a/docs/design-nircam-page-redesign.md
+++ b/docs/design-nircam-page-redesign.md
@@ -1,0 +1,161 @@
+# NIRCam Page Redesign — Implementation Plan
+
+Status: Draft · Design reference: [`docs/wireframes/nircam-page-redesign.html`](wireframes/nircam-page-redesign.html)
+
+## Goal
+
+The map view (FitsGL, epic #337) becomes the definitive *visual* view of a field. `/nircam`
+becomes the *detailed data access* surface and cleanly links into the map. Two routes:
+
+- **`/nircam`** — landing: a grid of fields, each with a `_layout.png` coverage preview + key stats.
+- **`/nircam/[field]`** — field detail: searchable field selector, overview (metadata + exposure-map
+  browser), and the full data-products table (mosaics + exposure maps + thumbnails), with a
+  per-mosaic "View in map" bridge.
+
+No program metadata for now. Copy stays minimal (data access, not marketing).
+
+## New/changed data products
+
+| Product | Naming | Scope | Status today | Action |
+|---|---|---|---|---|
+| Exposure-map plot | `expmap_<field>_<filter>.png` | field·filter | pipeline emits **light** PDF, local-only | re-theme **dark**, emit PNG, deploy+register |
+| Field layout plot | `<field>_layout.png` | field | does not exist | **new** pipeline plot, deploy+register |
+| Mosaic thumbnail | `<mosaic>_thumb.png` | field·filter·tile (sci) | produced, local-only | deploy+register (sci only) |
+| Exposure-map FITS | `expmap_<field>_<filter>.fits` | field·filter | deployed | none (already `nircam_expmap`) |
+| Science mosaic | `mosaic_..._<ext>.fits` | field·filter·tile | deployed | none |
+
+---
+
+## Layer 1 — Pipeline (`pipeline/campfire_pipeline/nircam/`)
+
+**1a. Dark exposure-map PNG.** `expmap.py` currently renders a **light-mode** PDF in `_render_pdf`
+(~L469) with a shared vmin/vmax across filters (~L576). Add a dark PNG output:
+- Bake on a dark well (`#0d0b12`-ish), light-gray axes/ticks/labels, keep viridis and the shared
+  vmin/vmax (so filters stay comparable). One artifact, theme-agnostic — matches the CAMPFIRE house
+  rule that data wells stay dark in both themes.
+- Emit `expmap_<field>_<filter>.png` beside the `.fits` (naming via `_expmap_stem`, ~L396). Keep the
+  PDF for local inspection (optionally re-theme it dark too, low priority).
+
+**1b. Field layout plot (new).** New `<field>_layout.png` at the field root
+(`field.products_dir`, `field.py:533`): the stack of all per-filter expmaps (union coverage, viridis)
+with **tile outlines** drawn on top.
+- Reuse the expmap auto-WCS (union footprint, 0.5″/pix) as the canvas; project each fiducial tile's
+  sky corners into it via `field.get_tile_wcs()` (`field.py:926`) / `fiducial_tile_set()` (~L1002)
+  and stroke the polygons. Dark theme, minimal chrome.
+- New helper (e.g. `run_layout_plot(field)` in `expmap.py` or a small `layout_plot.py`), invoked after
+  `run_expmap`.
+
+**1c. Mosaic thumbnails.** Already produced by `resample.py:434` (`plot_mosaic_thumbnail`,
+`steps/_plots.py:194`). No pipeline change — only deploy coverage (Layer 3).
+
+**1d. Changelog.** These are plots — no change to pixel/flux science output → **PATCH /
+Infrastructure** entry in `pipeline/CHANGELOG.md` `## Unreleased` (per AGENTS.md, required before the
+pipeline PR opens).
+
+---
+
+## Layer 2 — Layout contract (`layout/campfire_layout/` + `web/lib/layout.ts`)
+
+Register the three new keys in the declarative registry `products.py` (~L169–188) and mirror in
+`web/lib/layout.ts` (~L228–239); update the golden fixture (pytest + vitest):
+
+- `nircam_expmap_plot` — `data/products/nircam/<field>/<filter>/expmap_<field>_<filter>.png`
+- `nircam_layout` — `data/products/nircam/<field>/<field>_layout.png`
+- `nircam_mosaic_thumbnail` — `data/products/nircam/<field>/<filter>/<mosaic>_thumb.png`
+
+**Bijection caveat.** Reverse dispatch (`bijection.py:98`) currently keys `nircam_mosaic`/`nircam_expmap`
+by filename **prefix** (`mosaic`/`expmap`) — but `expmap_*.png` and `expmap_*.fits` share the `expmap`
+prefix. Update dispatch to branch on **extension** (`.png` → plot; `.fits` → FITS) before the prefix
+check. `_thumb.png`/`_layout.png` dispatch cleanly by suffix.
+
+---
+
+## Layer 3 — Deploy / registry (`python/campfire/deploy/nircam.py`)
+
+`deploy_nircam()` (~L492) already records a field `deployments` row, uploads to **OSN**, and registers
+`storage_objects` tagged with `deployment_id` (visibility rides `deployment.status`). Add:
+
+- **Expmap PNGs** — extend `discover_expmap_tasks` (~L416) to also glob `expmap_*.png`; register
+  `product_type='nircam_expmap_plot'`, scope field·filter, `content_type=image/png`.
+- **Layout PNG** — new discover for `<field>_layout.png`; register `nircam_layout`, scope field.
+- **Mosaic thumbnails** — in `discover_mosaics`/`_deploy_field_mosaics` (~L874/937), upload the
+  `_thumb.png` for **sci** mosaics only; register `nircam_mosaic_thumbnail`, scope field·filter·tile.
+
+`storage_objects.product_type` is free-form text (no enum/CHECK) — **no migration** for the new types;
+they ride the existing `select_storage_objects_by_access` RLS via `deployment_id`. Verify the leak-test
+gate still passes with the new types.
+
+---
+
+## Layer 4 — DB / RPC (`supabase/schemas/`)
+
+No table changes. Two read RPCs in `functions.sql` (RLS-safe: respect `deploy_status`), plus indexes
+if needed:
+
+- **`get_nircam_fields()`** — landing grid. One row per field with ≥1 published mosaic:
+  `field`, filter count, tile count, mosaic-file count, `sum(file_size)` volume, `max(created_at)`
+  (last reduced), and the `nircam_layout` storage_key for the preview.
+- **`get_nircam_field_summary(p_field)`** — field-page overview: filters[], tiles, pixel_scales[],
+  extensions[], epochs[], file count, volume, sky coverage.
+
+**Sky coverage / area — decision needed.** Options: (a) approximate from `map_layers` ra/dec bounds
+(cheap, bbox-inflated); (b) compute the *exact* covered area in the pipeline from the expmap
+(non-zero pixels × pixel area) and surface it — more accurate, which matters for survey-area use, but
+needs somewhere to store a per-field scalar (there's no `fields` table). Recommend (b) with the value
+written at deploy time onto the `nircam_layout`/expmap `storage_objects` row (or a lightweight
+`nircam_field_summary` view/table); fall back to (a) if we want to ship the web first.
+
+---
+
+## Layer 5 — Web (`web/`)
+
+**Routes**
+- `web/app/nircam/page.tsx` → **landing** (field grid). Move today's flat table into the field route.
+- `web/app/nircam/[field]/page.tsx` → **field detail**.
+- Nav "NIRCam" → `/nircam`; field card / breadcrumb link into `/nircam/[field]`.
+
+**Server actions (`web/lib/actions/nircam.ts`)**
+- `getNircamFields()` → landing cards (`get_nircam_fields` RPC) + presigned `_layout.png` URLs.
+- `getNircamFieldSummary(field)` → overview metadata.
+- Scope `getNircamImages(field)` / `getNircamExpmaps(field)` / `getNircamFilterOptions(field)` by field.
+  Merge expmaps into the products list as synthetic `extension='exp'` rows with `tile=null`.
+- Image presign: extend the `download.ts` presign pattern (`generateNircamExpmapDownloadUrls`, etc.)
+  to return **GET** URLs for the expmap-plot / thumbnail `<img>` sources.
+- `getFitsglDatasets()` (from `map.ts`) → to enable per-row "View in map".
+
+**Components (`web/components/nircam/`)**
+- Landing: `NircamFieldGrid` / `NircamFieldCard` (layout preview `<img>` + stats + last-reduced).
+- Field: reuse `NircamTable` (add Preview col + Actions col, `exp` rows), `NircamFilterBar` (drop the
+  Field facet — page is scoped), `CurlScriptGenerator` (unchanged). New: `NircamFieldOverview`
+  (metadata + `ExpmapBrowser`), `ExpmapBrowser` (left vertical filter tabs, ↑/↓ keyboard nav, dark
+  expmap-PNG `<img>` + all-filter-overlay = the `_layout.png`), `FieldSelectorDropdown` (searchable
+  single-select), `ThumbnailPopup`.
+- **Actions**: `↓ FITS` (download) on every row; `↗ View` + inline thumbnail on **sci** rows only.
+  "View" links to `/map?field=<field>&filter=<filter>` (reuse `ShowOnMapLink`), enabled when
+  `getFitsglDatasets()` shows the field's dataset covers that filter.
+
+**Types (`web/lib/types.ts`)** — `NircamFieldCard`, `NircamFieldSummary`; extend `NircamImage` for
+`extension:'exp'` + optional `thumbnail_key`.
+
+**Seed** — regenerate `supabase/seed.sql` to include the new `storage_objects` product_types so
+preview branches render previews/thumbnails.
+
+---
+
+## Sequencing (stackable PRs)
+
+1. **Pipeline** — dark expmap PNG + `<field>_layout.png` (+ CHANGELOG PATCH/Infrastructure).
+2. **Layout contract** — 3 product specs + extension-aware bijection + golden fixtures (py + ts).
+3. **Deploy** — register the 3 new product types.
+4. **DB** — `get_nircam_fields` + `get_nircam_field_summary` RPCs (+ area decision).
+5. **Web** — landing route + field route + components + View-in-map wiring; regenerate seed.
+
+Web (5) can start against a hand-seeded row before the pipeline products exist; it only hard-depends
+on the RPCs (4) and the registered keys (2–3) for live data.
+
+## Decisions needed
+
+1. **Expmap PDF** — keep the local PDF alongside the new dark PNG, or drop it? (recommend keep)
+2. **Sky area** — exact (pipeline-computed, stored) vs. approximate (`map_layers` bbox)? (recommend exact)
+3. **Layout plot styling** — colorbar/labels on `<field>_layout.png`, or bare coverage + tile
+   outlines? (wireframe assumes bare + outlines)

--- a/docs/wireframes/nircam-page-redesign.html
+++ b/docs/wireframes/nircam-page-redesign.html
@@ -1,0 +1,417 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>NIRCam Redesign — Landing + Field</title>
+<style>
+/* ===== CAMPFIRE tokens (from web/app/globals.css) ===== */
+:root{
+  --primary:#fb923c;--primary-hover:#fdba74;--primary-text:#fb923c;--on-primary:#1a1206;--primary-soft:rgba(251,146,60,.14);
+  --background:#16131c;--card:#1f1b27;--card-hover:#2a2435;--border:#332c40;--border-strong:#423a52;
+  --text-primary:#f1ecf6;--text-secondary:#b8aec6;--text-tertiary:#8b8398;--surface-2:#241f2e;--table-header:#221d2a;
+}
+body.light{
+  --primary:#c63f0c;--primary-hover:#ad3408;--primary-text:#b8390a;--on-primary:#fff;--primary-soft:rgba(198,63,12,.10);
+  --background:#fffefb;--card:#fefcfa;--card-hover:#f6f0ea;--border:#e6ddce;--border-strong:#d7cbb9;
+  --text-primary:#211c17;--text-secondary:#5c5346;--text-tertiary:#6c6150;--surface-2:#f3ede5;--table-header:#f6f0ea;
+}
+*{box-sizing:border-box;margin:0;padding:0}
+body{background:var(--background);color:var(--text-primary);font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Inter,system-ui,sans-serif;font-size:14px;line-height:1.5}
+.mono{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+a{color:var(--primary-text);text-decoration:none;cursor:pointer}
+h1{font-size:26px;font-weight:700;letter-spacing:-.02em}
+h2{font-size:16px;font-weight:650}
+h3{font-size:12px;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--text-tertiary)}
+.container{max-width:1160px;margin:0 auto;padding:0 24px}
+.card{background:var(--card);border:1px solid var(--border);border-radius:14px}
+.muted{color:var(--text-secondary)}.dim{color:var(--text-tertiary)}
+.spacer{flex:1}
+.btn{display:inline-flex;align-items:center;gap:7px;padding:8px 14px;border-radius:9px;font-size:13px;font-weight:550;border:1px solid var(--border-strong);background:var(--surface-2);color:var(--text-primary);cursor:pointer;white-space:nowrap}
+.btn:hover{background:var(--card-hover)}
+.btn.pri{background:var(--primary);color:var(--on-primary);border-color:transparent}
+.btn.pri:hover{background:var(--primary-hover)}
+.btn.sm{padding:5px 10px;font-size:12px;border-radius:7px}
+.btn.ghost{background:transparent;border-color:var(--border)}
+.pchip{display:inline-block;font-size:11px;padding:2px 8px;border-radius:6px;background:var(--surface-2);border:1px solid var(--border);color:var(--text-secondary);margin:2px 3px 0 0}
+/* app nav */
+.appnav{border-bottom:1px solid var(--border);background:var(--card);position:sticky;top:0;z-index:30}
+.appnav .in{max-width:1160px;margin:0 auto;padding:12px 24px;display:flex;align-items:center;gap:26px}
+.appnav .logo{font-weight:800;display:flex;gap:8px;align-items:center}
+.appnav nav{display:flex;gap:20px;color:var(--text-secondary);font-size:13.5px}
+.appnav nav a.on{color:var(--text-primary);position:relative}
+.appnav nav a.on::after{content:"";position:absolute;left:0;right:0;bottom:-13px;height:2px;background:var(--primary)}
+.appnav .who{margin-left:auto;color:var(--text-tertiary);font-size:12.5px;display:flex;gap:14px;align-items:center}
+.tglbtn{border:1px solid var(--border);background:var(--surface-2);color:var(--text-secondary);border-radius:7px;width:28px;height:26px;cursor:pointer;font-size:13px}
+.crumb{font-size:12.5px;color:var(--text-tertiary);padding:18px 0 0;display:flex;gap:7px;align-items:center}
+/* dropdown (searchable single-select) */
+.dd{position:relative;display:inline-block}
+.dd-btn{display:inline-flex;align-items:center;gap:9px;padding:7px 12px;border-radius:9px;background:var(--surface-2);border:1px solid var(--border-strong);color:var(--text-primary);font-size:13px;font-weight:600;cursor:pointer}
+.dd-btn .lbl{color:var(--text-tertiary);font-weight:500;font-size:11.5px;text-transform:uppercase;letter-spacing:.05em}
+.dd-btn .car{color:var(--text-tertiary);font-size:11px}
+.dd-menu{display:none;position:absolute;top:calc(100% + 6px);left:0;width:280px;background:var(--card);border:1px solid var(--border-strong);border-radius:11px;box-shadow:0 12px 34px rgba(0,0,0,.35);z-index:20;overflow:hidden}
+.dd.open .dd-menu{display:block}
+.dd-search{width:100%;border:0;border-bottom:1px solid var(--border);background:transparent;color:var(--text-primary);padding:11px 13px;font-size:13px;outline:none}
+.dd-list{max-height:280px;overflow:auto;padding:5px}
+.dd-item{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:8px 10px;border-radius:7px;cursor:pointer;font-size:13px}
+.dd-item:hover{background:var(--card-hover)}
+.dd-item.on{background:var(--primary-soft);color:var(--primary-text)}
+.dd-item .sub{font-size:11px;color:var(--text-tertiary)}
+.dd-item.on .sub{color:var(--primary-text);opacity:.75}
+/* meta grid */
+.metagrid{display:grid;grid-template-columns:1fr}
+.metagrid .m{display:flex;justify-content:space-between;gap:12px;padding:7px 0;border-bottom:1px solid var(--border);font-size:13px}
+.metagrid .m:last-child{border-bottom:0}
+.metagrid .m .k{color:var(--text-tertiary)}.metagrid .m .v{font-weight:550;text-align:right}
+/* exposure-map panel */
+.ov{display:grid;grid-template-columns:300px 1fr;gap:26px}
+.exp-body{display:flex;gap:0;background:var(--background);border:1px solid var(--border);border-radius:11px;overflow:hidden}
+.vtabs{width:86px;border-right:1px solid var(--border);padding:5px;overflow:auto;max-height:308px;outline:none;flex:none}
+.vtabs:focus{box-shadow:inset 0 0 0 2px var(--primary-soft)}
+.vtab{font-family:ui-monospace,Menlo,monospace;font-size:11px;padding:5px 8px;border-radius:6px;color:var(--text-secondary);cursor:pointer;white-space:nowrap}
+.vtab:hover{background:var(--card-hover)}
+.vtab.on{background:var(--primary-soft);color:var(--primary-text);font-weight:600}
+.exp-plot-wrap{flex:1;padding:12px}
+.kbd{font-family:ui-monospace,Menlo,monospace;font-size:10px;color:var(--text-tertiary);border:1px solid var(--border);border-radius:4px;padding:1px 5px}
+/* facets */
+.facets{display:flex;gap:8px;flex-wrap:wrap;align-items:center}
+.facet{display:inline-flex;align-items:center;gap:6px;font-size:12.5px;padding:6px 11px;border-radius:8px;background:var(--surface-2);border:1px solid var(--border);color:var(--text-secondary);cursor:pointer}
+.facet .cnt{font-size:10px;background:var(--primary-soft);color:var(--primary-text);border-radius:10px;padding:0 6px;font-weight:700}
+/* table */
+table{width:100%;border-collapse:collapse}
+thead th{text-align:left;font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--text-tertiary);padding:10px 12px;background:var(--table-header);border-bottom:1px solid var(--border)}
+tbody td{padding:8px 12px;border-bottom:1px solid var(--border);font-size:13px;white-space:nowrap;vertical-align:middle}
+tbody tr:hover{background:var(--card-hover)}
+.thumb{width:32px;height:32px;border-radius:6px;border:1px solid var(--border-strong);cursor:zoom-in;display:block;background:var(--background)}
+.tag{font-family:ui-monospace,Menlo,monospace;font-size:11px;padding:2px 7px;border-radius:5px;background:var(--surface-2);border:1px solid var(--border);color:var(--text-secondary)}
+.tag.ext{text-transform:uppercase}
+.act{display:inline-flex;align-items:center;gap:4px;font-size:12px;font-weight:550;color:var(--text-secondary);background:transparent;border:0;padding:4px 7px;border-radius:6px;cursor:pointer;font-family:inherit}
+.act:hover{background:var(--surface-2);color:var(--text-primary)}
+.act .g{font-family:ui-monospace,Menlo,monospace;color:var(--text-tertiary)}
+.act:hover .g{color:var(--primary-text)}
+.act[disabled]{opacity:.32;cursor:not-allowed}
+/* landing */
+.stat-strip{display:flex;gap:0;border:1px solid var(--border);border-radius:12px;overflow:hidden;background:var(--card);margin:20px 0 30px}
+.stat{flex:1;padding:16px 20px;border-right:1px solid var(--border)}
+.stat:last-child{border-right:0}
+.stat .n{font-size:22px;font-weight:700}
+.stat .l{font-size:11.5px;color:var(--text-tertiary);text-transform:uppercase;letter-spacing:.05em;margin-top:2px}
+.field-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(340px,1fr));gap:18px}
+.field-card{background:var(--card);border:1px solid var(--border);border-radius:14px;overflow:hidden;cursor:pointer;transition:border-color .12s,transform .12s}
+.field-card:hover{border-color:var(--border-strong);transform:translateY(-2px)}
+.field-card .prev{height:150px;position:relative;border-bottom:1px solid var(--border)}
+.field-card .prev .fname{position:absolute;left:14px;bottom:10px;font-size:20px;font-weight:750;letter-spacing:-.01em;color:#fff;text-shadow:0 2px 10px rgba(0,0,0,.7)}
+.field-card .prev .coord{position:absolute;right:12px;top:10px;font-family:ui-monospace,Menlo,monospace;font-size:10.5px;color:rgba(255,255,255,.82);background:rgba(0,0,0,.42);padding:2px 7px;border-radius:5px}
+.field-card .body{padding:13px 15px}
+.fstats{display:flex;gap:16px;flex-wrap:wrap;margin-bottom:10px}
+.fstats .s .n{font-weight:650;font-size:14px}.fstats .s .k{font-size:10.5px;color:var(--text-tertiary);text-transform:uppercase;letter-spacing:.04em}
+.field-card .foot{display:flex;align-items:center;justify-content:space-between;border-top:1px solid var(--border);padding-top:9px;margin-top:2px;font-size:11.5px;color:var(--text-tertiary)}
+/* popup */
+.pop-bg{position:fixed;inset:0;background:rgba(0,0,0,.62);display:none;align-items:center;justify-content:center;z-index:60}
+.pop-bg.open{display:flex}
+.pop{background:var(--card);border:1px solid var(--border-strong);border-radius:14px;padding:14px;max-width:560px}
+.pop .cap{display:flex;justify-content:space-between;align-items:center;margin-bottom:10px}
+.iconbtn{cursor:pointer;color:var(--text-tertiary);padding:4px 8px;border-radius:6px}.iconbtn:hover{background:var(--surface-2);color:var(--text-primary)}
+.hr{height:1px;background:var(--border);margin:34px 0}
+[hidden]{display:none!important}
+@media(max-width:860px){.metagrid,.ov{grid-template-columns:1fr}.stat-strip{flex-wrap:wrap}}
+</style></head>
+<body>
+
+<!-- ================= APP NAV ================= -->
+<div class="appnav"><div class="in">
+  <span class="logo">🔥 CAMPFIRE</span>
+  <nav><a>Home</a><a class="on" onclick="show('landing')">NIRCam</a><a>NIRSpec</a><a>Map</a><a>Docs</a></nav>
+  <span class="who">Hollis Akins <button class="tglbtn" title="Toggle theme" onclick="document.body.classList.toggle('light')">◐</button></span>
+</div></div>
+
+
+<!-- ==================================================================
+     SCREEN 1 — NIRCam LANDING (list of fields)
+     ================================================================== -->
+<div id="screen-landing" class="container">
+  <div class="crumb">CAMPFIRE <span>›</span> NIRCam</div>
+  <div style="margin:8px 0 6px"><h1>NIRCam Imaging</h1></div>
+
+  <div class="stat-strip">
+    <div class="stat"><div class="n">6</div><div class="l">Fields</div></div>
+    <div class="stat"><div class="n">21</div><div class="l">Filters</div></div>
+    <div class="stat"><div class="n">62</div><div class="l">Tiles</div></div>
+    <div class="stat"><div class="n">2,341</div><div class="l">Mosaic files</div></div>
+    <div class="stat"><div class="n">1.78 TB</div><div class="l">Total volume</div></div>
+  </div>
+
+  <div class="field-grid" id="fieldGrid"></div>
+</div>
+
+
+<!-- ==================================================================
+     SCREEN 2 — FIELD PAGE (COSMOS)
+     ================================================================== -->
+<div id="screen-field" class="container" hidden>
+  <div class="crumb">CAMPFIRE <span>›</span> <a onclick="show('landing')">NIRCam</a> <span>›</span> <span id="crumbField">COSMOS</span></div>
+
+  <!-- field selector — top-left, above the field header -->
+  <div style="margin:14px 0 12px">
+    <div class="dd" id="fieldDD">
+      <button class="dd-btn" onclick="toggleDD(event)"><span class="lbl">Field</span> <span id="ddCur">COSMOS</span> <span class="car">▾</span></button>
+      <div class="dd-menu">
+        <input class="dd-search" id="ddSearch" placeholder="Search fields…" oninput="filterDD()" autocomplete="off">
+        <div class="dd-list" id="ddList"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- field-specific header + map bridge -->
+  <div style="display:flex;align-items:flex-start;gap:18px;flex-wrap:wrap;margin-bottom:22px">
+    <div>
+      <h1><span id="titleField">COSMOS</span> NIRCam Imaging</h1>
+      <div class="dim" style="font-size:12.5px;margin-top:4px">Last reduced 2025-07-30 · pipeline <span class="mono">v0.7</span> · CRDS <span class="mono">jwst_1322.pmap</span></div>
+    </div>
+    <div class="spacer"></div>
+    <button class="btn pri">Open field in Map <span class="mono">↗</span></button>
+  </div>
+
+  <!-- FIELD OVERVIEW -->
+  <div class="card" style="padding:20px;margin-bottom:26px">
+    <div class="ov">
+      <!-- metadata -->
+      <div>
+        <h3 style="margin-bottom:12px">Field overview</h3>
+        <div class="metagrid">
+          <div class="m"><span class="k">Filters</span><span class="v">17 <span class="dim">(7 SW · 10 LW)</span></span></div>
+          <div class="m"><span class="k">Tiles</span><span class="v">21</span></div>
+          <div class="m"><span class="k">Pixel scale</span><span class="v mono">30 mas</span></div>
+          <div class="m"><span class="k">Extensions</span><span class="v mono" style="font-size:12px">sci · err · wht · srcmask</span></div>
+          <div class="m"><span class="k">Epochs</span><span class="v">full field + 1</span></div>
+          <div class="m"><span class="k">Mosaic files</span><span class="v">986</span></div>
+          <div class="m"><span class="k">Sky coverage</span><span class="v">~0.54 deg²</span></div>
+          <div class="m"><span class="k">Data volume</span><span class="v">743.6 GB</span></div>
+        </div>
+      </div>
+
+      <!-- exposure map: left filter tabs + plot -->
+      <div>
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px;gap:10px">
+          <h3 style="margin:0">Exposure map · filter coverage</h3>
+          <div style="display:flex;align-items:center;gap:14px">
+            <span class="dim" style="font-size:11px"><span class="kbd">↑</span> <span class="kbd">↓</span> to browse</span>
+            <label class="dim" style="font-size:11.5px;display:flex;gap:6px;align-items:center;cursor:pointer;user-select:none">
+              <input type="checkbox" id="covToggle" onchange="renderExp()"> all-filter overlay
+            </label>
+          </div>
+        </div>
+        <div class="exp-body">
+          <div class="vtabs" id="vtabs" tabindex="0"></div>
+          <div class="exp-plot-wrap" id="expPlot"></div>
+        </div>
+        <div class="dim" style="font-size:11.5px;margin-top:8px" id="expCaption"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- DATA PRODUCTS -->
+  <div style="display:flex;align-items:center;gap:12px;margin-bottom:12px">
+    <h2>Data products</h2>
+    <span class="dim" style="font-size:12.5px">990 files · 743.6 GB</span>
+    <div class="spacer"></div>
+    <button class="btn sm ghost">Bulk download script</button>
+  </div>
+  <div class="facets" style="margin-bottom:12px">
+    <span class="facet">Filter <span class="cnt">3</span></span>
+    <span class="facet">Tile <span class="cnt">2</span></span>
+    <span class="facet">Pixel scale</span>
+    <span class="facet">Extension <span class="cnt">1</span></span>
+    <span class="facet">Epoch</span>
+    <a style="font-size:12px;margin-left:4px">Clear all</a>
+    <div class="spacer"></div>
+    <span class="dim mono" style="font-size:12px">Selected 132 of 990 · 92.7 GB</span>
+  </div>
+  <div class="card" style="overflow:hidden">
+    <table>
+      <thead><tr>
+        <th style="width:44px"></th><th>Filter</th><th>Tile</th><th>Scale</th><th>Ext</th><th>Epoch</th><th>Size</th>
+        <th style="text-align:right;width:160px">Actions</th>
+      </tr></thead>
+      <tbody id="tbody"></tbody>
+    </table>
+  </div>
+
+  <!-- reduction notes (minimal, factual) -->
+  <div class="hr"></div>
+  <div style="padding-bottom:60px">
+    <h2 style="margin-bottom:8px">Reduction notes</h2>
+    <p class="muted" style="font-size:13px;max-width:760px">Drizzled to 30 mas per fiducial tile set with cfpipe <span class="mono">v0.7</span> (CRDS <span class="mono">jwst_1322.pmap</span>). <a>Full methodology →</a></p>
+  </div>
+</div>
+
+<!-- thumbnail popup -->
+<div class="pop-bg" id="popBg" onclick="if(event.target.id==='popBg')closePop()">
+  <div class="pop">
+    <div class="cap"><span class="mono" id="popTitle" style="font-size:13px"></span><span class="iconbtn" onclick="closePop()">✕</span></div>
+    <div id="popImg"></div>
+  </div>
+</div>
+
+<script>
+/* ---------- filters + coverage model ---------- */
+const SW=['F090W','F115W','F140M','F150W','F182M','F200W','F210M'];
+const LW=['F250M','F277W','F335M','F356W','F360M','F410M','F430M','F444W','F460M','F480M'];
+const FILTERS=[...SW,...LW];
+const REGIONS={WEB:[1,10,1,6],PRIMER:[4,7,3,5],C3D:[2,9,3,4]};
+const COV={F090W:['PRIMER'],F115W:['WEB','PRIMER','C3D'],F140M:['PRIMER'],F150W:['WEB','PRIMER','C3D'],
+  F182M:['PRIMER'],F200W:['PRIMER','C3D'],F210M:['PRIMER'],F250M:['PRIMER'],F277W:['WEB','PRIMER','C3D'],
+  F335M:['PRIMER'],F356W:['PRIMER','C3D'],F360M:['PRIMER'],F410M:['PRIMER'],F430M:['PRIMER'],
+  F444W:['WEB','PRIMER','C3D'],F460M:['PRIMER'],F480M:['PRIMER']};
+const NEXP={WEB:6,PRIMER:9,C3D:4};const GW=12,GH=8;
+function viridis(t){const s=[[68,1,84],[59,82,139],[33,145,140],[94,201,98],[253,231,37]];t=Math.max(0,Math.min(1,t));
+  const x=t*(s.length-1),i=Math.floor(x),f=x-i,a=s[i],b=s[Math.min(i+1,s.length-1)];
+  return`rgb(${a.map((v,k)=>Math.round(v+(b[k]-v)*f)).join(',')})`;}
+function depthGrid(filter){const g=Array.from({length:GH},()=>Array(GW).fill(0));
+  for(const r of COV[filter]){const[x0,x1,y0,y1]=REGIONS[r];for(let y=y0;y<=y1;y++)for(let x=x0;x<=x1;x++)g[y][x]+=NEXP[r];}return g;}
+function expSVG(filter,W,H,overlay,bare){
+  const pad=(overlay||bare)?4:26,cw=(W-2*pad)/GW,ch=(H-2*pad)/GH,cx=W/2,cy=H/2;let cells='';
+  if(overlay){const g=Array.from({length:GH},()=>Array(GW).fill(0));
+    for(const f of FILTERS){const d=depthGrid(f);for(let y=0;y<GH;y++)for(let x=0;x<GW;x++)if(d[y][x]>0)g[y][x]++;}
+    const mx=Math.max(...g.flat(),1);
+    for(let y=0;y<GH;y++)for(let x=0;x<GW;x++)if(g[y][x]>0)
+      cells+=`<rect x="${pad+x*cw}" y="${pad+y*ch}" width="${cw+.6}" height="${ch+.6}" fill="${viridis(g[y][x]/mx)}" opacity="${.35+.6*g[y][x]/mx}"/>`;
+  }else{const d=depthGrid(filter),mx=Math.max(...depthGrid(filter).flat(),1);
+    for(let y=0;y<GH;y++)for(let x=0;x<GW;x++)if(d[y][x]>0)
+      cells+=`<rect x="${pad+x*cw}" y="${pad+y*ch}" width="${cw+.6}" height="${ch+.6}" fill="${viridis(d[y][x]/mx)}"/>`;}
+  const axis=(overlay||bare)?'':`
+    <rect x="${pad}" y="${pad}" width="${W-2*pad}" height="${H-2*pad}" fill="none" stroke="#5c5c6e" stroke-width="1"/>
+    ${[0,1,2,3].map(i=>`<line x1="${pad+i*(W-2*pad)/3}" y1="${H-pad}" x2="${pad+i*(W-2*pad)/3}" y2="${H-pad+4}" stroke="#8b8398"/>
+      <text x="${pad+i*(W-2*pad)/3}" y="${H-pad+15}" fill="#8b8398" font-size="8" text-anchor="middle" font-family="monospace">${(150.30-i*0.14).toFixed(2)}</text>`).join('')}
+    ${[0,1,2].map(i=>`<text x="${pad-6}" y="${pad+6+i*(H-2*pad)/2}" fill="#8b8398" font-size="8" text-anchor="end" font-family="monospace">${(2.55-i*0.18).toFixed(2)}</text>`).join('')}
+    <text x="${W/2}" y="${H-2}" fill="#8b8398" font-size="8" text-anchor="middle">RA [deg]</text>`;
+  const cb=(overlay||bare)?'':(()=>{const bx=W-pad+7,bw=6,bh=H-2*pad;let g='';for(let i=0;i<20;i++)g+=`<rect x="${bx}" y="${pad+i*bh/20}" width="${bw}" height="${bh/20+.5}" fill="${viridis(1-i/20)}"/>`;
+    return g+`<text x="${bx+bw+3}" y="${pad+7}" fill="#8b8398" font-size="7" font-family="monospace">hi</text><text x="${bx+bw+3}" y="${H-pad}" fill="#8b8398" font-size="7" font-family="monospace">lo</text>`;})();
+  return`<svg viewBox="0 0 ${W} ${H}" width="100%" style="display:block;border-radius:6px;background:#0d0b12">
+    <g transform="rotate(-9 ${cx} ${cy})">${cells}</g>${axis}${cb}
+    ${overlay?`<text x="7" y="14" fill="#f1ecf6" font-size="9" font-family="monospace">all filters · union coverage</text>`:''}</svg>`;
+}
+
+/* ---------- exposure-map panel (left tabs + keyboard) ---------- */
+let curFilter='F444W';
+function renderExp(){
+  const overlay=document.getElementById('covToggle').checked;
+  document.getElementById('expPlot').innerHTML=expSVG(curFilter,300,220,overlay);
+  document.getElementById('vtabs').innerHTML=FILTERS.map(f=>
+    `<div class="vtab ${f===curFilter&&!overlay?'on':''}" onclick="pickFilter('${f}')">${f}</div>`).join('');
+  const d=depthGrid(curFilter),frac=Math.round(100*d.flat().filter(v=>v>0).length/(GW*GH));
+  document.getElementById('expCaption').innerHTML=overlay
+    ?'Union of all 17 filters — brighter where more filters overlap. Toggle off to inspect one filter.'
+    :`<b class="mono" style="color:var(--text-secondary)">${curFilter}</b> · ${frac}% field coverage · ${Math.max(...d.flat())} max exposures · colour = exposure time (s)`;
+}
+function pickFilter(f){curFilter=f;document.getElementById('covToggle').checked=false;renderExp();}
+document.getElementById('vtabs').addEventListener('keydown',e=>{
+  if(e.key!=='ArrowDown'&&e.key!=='ArrowUp')return;e.preventDefault();
+  let i=FILTERS.indexOf(curFilter);i=(i+(e.key==='ArrowDown'?1:-1)+FILTERS.length)%FILTERS.length;
+  pickFilter(FILTERS[i]);document.querySelector('.vtab.on')?.scrollIntoView({block:'nearest'});
+});
+
+/* ---------- data products table ---------- */
+// [filter, tile, scale, ext, epoch, size]  — thumb+View only on ext==='sci'
+const ROWS=[
+  ['F090W','A3','30 mas','sci','','621.4 MB'],
+  ['F090W','A3','30 mas','err','','598.1 MB'],
+  ['F115W','A3','30 mas','sci','','654.1 MB'],
+  ['F150W','A3','30 mas','sci','','651.8 MB'],
+  ['F277W','A3','30 mas','sci','','712.0 MB'],
+  ['F444W','A3','30 mas','sci','','743.6 MB'],
+  ['F444W','A3','30 mas','err','','698.2 MB'],
+  ['F444W','A3','30 mas','wht','','690.0 MB'],
+  ['F444W','A3','30 mas','srcmask','','4.1 MB'],
+  ['F356W','A5','30 mas','sci','ep1','89.4 MB'],
+  ['F115W','—','—','exp','','12.4 MB'],
+  ['F150W','—','—','exp','','12.4 MB'],
+  ['F277W','—','—','exp','','12.4 MB'],
+  ['F444W','—','—','exp','','12.4 MB'],
+];
+function sciThumb(flt){const c=viridis(FILTERS.indexOf(flt)/FILTERS.length);
+  return`<svg width="32" height="32"><rect width="32" height="32" fill="#0d0b12"/><circle cx="16" cy="16" r="8.5" fill="${c}" opacity="0.85"/><circle cx="11" cy="12" r="2.4" fill="#fff" opacity="0.7"/><circle cx="21" cy="20" r="1.6" fill="#fff" opacity="0.55"/></svg>`;}
+function renderTable(){
+  document.getElementById('tbody').innerHTML=ROWS.map(r=>{
+    const[flt,tile,scale,ext,ep,size]=r,isSci=ext==='sci';
+    const thumb=isSci?`<span class="thumb" onclick="openPop('${flt} · ${tile} · sci',' ${flt}')">${sciThumb(flt)}</span>`:'';
+    const view=isSci?`<button class="act" title="Open ${flt} tile ${tile} in the FitsGL map"><span class="g">↗</span> View</button>`:'';
+    return`<tr>
+      <td>${thumb}</td>
+      <td class="mono">${flt}</td>
+      <td class="mono ${tile==='—'?'dim':''}">${tile}</td>
+      <td class="mono dim">${scale}</td>
+      <td><span class="tag ext">${ext}</span></td>
+      <td>${ep?`<span class="tag">${ep}</span>`:'<span class="dim">full field</span>'}</td>
+      <td class="mono">${size}</td>
+      <td style="text-align:right">${view}<button class="act" title="Download FITS"><span class="g">↓</span> FITS</button></td>
+    </tr>`;}).join('');
+}
+function openPop(title,flt){document.getElementById('popTitle').textContent=title;
+  const stars=Array.from({length:70},()=>`<circle cx="${Math.random()*520}" cy="${Math.random()*320}" r="${Math.random()*1.8}" fill="#fff" opacity="${Math.random()*.7}"/>`).join('');
+  document.getElementById('popImg').innerHTML=`<svg width="100%" viewBox="0 0 520 320" style="border-radius:8px"><rect width="520" height="320" fill="#0d0b12"/>${stars}<circle cx="260" cy="160" r="52" fill="${viridis(FILTERS.indexOf(flt.trim())/FILTERS.length)}" opacity="0.5"/><circle cx="260" cy="160" r="19" fill="#fff" opacity="0.9"/></svg>`;
+  document.getElementById('popBg').classList.add('open');}
+function closePop(){document.getElementById('popBg').classList.remove('open');}
+
+/* ---------- field selector dropdown ---------- */
+const FIELDS=[
+  {name:'COSMOS',ra:'150.12',dec:'+2.21',filters:17,tiles:21,area:'0.54 deg²',vol:'743.6 GB',progs:['COSMOS-Web','PRIMER','COSMOS-3D','+3'],updated:'2025-07-30'},
+  {name:'UDS',ra:'34.41',dec:'−5.20',filters:9,tiles:12,area:'0.09 deg²',vol:'248 GB',progs:['PRIMER','MegaScience'],updated:'2025-06-10'},
+  {name:'EGS',ra:'214.83',dec:'+52.83',filters:10,tiles:10,area:'0.07 deg²',vol:'196 GB',progs:['CEERS','EMBER'],updated:'2025-05-22'},
+  {name:'GOODS-S',ra:'53.12',dec:'−27.80',filters:14,tiles:9,area:'0.06 deg²',vol:'312 GB',progs:['JADES','FRESCO','JEMS'],updated:'2025-04-18'},
+  {name:'GOODS-N',ra:'189.23',dec:'+62.24',filters:11,tiles:8,area:'0.05 deg²',vol:'254 GB',progs:['JADES','FRESCO'],updated:'2025-04-02'},
+  {name:'Abell 2744',ra:'3.58',dec:'−30.39',filters:7,tiles:6,area:'0.04 deg²',vol:'118 GB',progs:['UNCOVER','MegaScience'],updated:'2025-03-11'},
+];
+function toggleDD(e){e.stopPropagation();const dd=document.getElementById('fieldDD');dd.classList.toggle('open');
+  if(dd.classList.contains('open')){document.getElementById('ddSearch').value='';filterDD();document.getElementById('ddSearch').focus();}}
+function filterDD(){const q=document.getElementById('ddSearch').value.toLowerCase();
+  document.getElementById('ddList').innerHTML=FIELDS.filter(f=>f.name.toLowerCase().includes(q)).map(f=>
+    `<div class="dd-item ${f.name===curField?'on':''}" onclick="chooseField('${f.name}')">
+      <span>${f.name}</span><span class="sub mono">${f.filters} filt · ${f.vol}</span></div>`).join('')
+    ||`<div class="dd-item dim" style="cursor:default">No match</div>`;}
+let curField='COSMOS';
+function chooseField(n){curField=n;document.getElementById('ddCur').textContent=n;
+  document.getElementById('titleField').textContent=n;document.getElementById('crumbField').textContent=n;
+  document.getElementById('fieldDD').classList.remove('open');}
+document.addEventListener('click',e=>{const dd=document.getElementById('fieldDD');if(dd&&!dd.contains(e.target))dd.classList.remove('open');});
+
+/* ---------- landing field cards ---------- */
+function rng(seed){let s=seed>>>0;return()=>{s=(s*1664525+1013904223)>>>0;return s/4294967296;};}
+function hash(str){let h=2166136261;for(let i=0;i<str.length;i++){h^=str.charCodeAt(i);h=Math.imul(h,16777619);}return h>>>0;}
+// field "layout" preview = stack of all expmaps (union coverage) + tile outlines — mirrors the pipeline's <field>_layout.png
+function layoutPreview(name){const r=rng(hash(name)),rot=(-15+r()*22).toFixed(1),W=340,H=150,pad=14;
+  const g=Array.from({length:GH},()=>Array(GW).fill(0));
+  for(const f of FILTERS){const d=depthGrid(f);for(let y=0;y<GH;y++)for(let x=0;x<GW;x++)if(d[y][x]>0)g[y][x]++;}
+  const mx=Math.max(...g.flat(),1),cw=(W-2*pad)/GW,ch=(H-2*pad)/GH;
+  let cells='';for(let y=0;y<GH;y++)for(let x=0;x<GW;x++)if(g[y][x]>0)
+    cells+=`<rect x="${pad+x*cw}" y="${pad+y*ch}" width="${cw+.5}" height="${ch+.5}" fill="${viridis(g[y][x]/mx)}" opacity="${(.4+.55*g[y][x]/mx).toFixed(2)}"/>`;
+  const ntx=3+Math.floor(r()*3),nty=2+Math.floor(r()*2),tw=(W-2*pad)/ntx,thh=(H-2*pad)/nty;let tiles='';
+  for(let i=0;i<ntx;i++)for(let j=0;j<nty;j++)
+    tiles+=`<rect x="${pad+i*tw}" y="${pad+j*thh}" width="${tw}" height="${thh}" fill="none" stroke="rgba(255,255,255,.26)" stroke-width="0.7"/>`;
+  return`<svg width="100%" height="100%" viewBox="0 0 340 150" preserveAspectRatio="xMidYMid slice" style="display:block">
+    <defs><linearGradient id="sc${hash(name)}" x1="0" y1="0" x2="0" y2="1"><stop offset="0.5" stop-color="#000" stop-opacity="0"/><stop offset="1" stop-color="#000" stop-opacity="0.72"/></linearGradient></defs>
+    <rect width="340" height="150" fill="#0b0a10"/>
+    <g transform="rotate(${rot} 170 75)">${cells}${tiles}</g>
+    <rect width="340" height="150" fill="url(#sc${hash(name)})"/></svg>`;}
+function renderLanding(){
+  document.getElementById('fieldGrid').innerHTML=FIELDS.map(f=>`
+    <div class="field-card" onclick="chooseField('${f.name}');show('field')">
+      <div class="prev">${layoutPreview(f.name)}<span class="coord mono">α ${f.ra} · δ ${f.dec}</span><span class="fname">${f.name}</span></div>
+      <div class="body">
+        <div class="fstats">
+          <div class="s"><div class="n">${f.filters}</div><div class="k">Filters</div></div>
+          <div class="s"><div class="n">${f.tiles}</div><div class="k">Tiles</div></div>
+          <div class="s"><div class="n">${f.area}</div><div class="k">Coverage</div></div>
+          <div class="s"><div class="n">${f.vol}</div><div class="k">Volume</div></div>
+        </div>
+        <div class="foot"><span>Last reduced ${f.updated}</span><span class="mono" style="color:var(--primary-text)">Open →</span></div>
+      </div>
+    </div>`).join('');
+}
+
+/* ---------- screen switching ---------- */
+function show(which){
+  document.getElementById('screen-landing').hidden=which!=='landing';
+  document.getElementById('screen-field').hidden=which!=='field';
+  window.scrollTo(0,0);
+}
+renderLanding();renderExp();renderTable();
+show('landing');
+</script>
+</body></html>

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -81,8 +81,12 @@ Release procedure: edit the `## Unreleased` section below, then run
   and a companion `<field>_layout.json` records the **exact survey area**
   (non-zero pixels of the stack × pixel area) + per-filter areas for the
   deploy/DB layer. Each per-filter expmap FITS also gains an `AREA` header
-  (covered arcmin²). Plots + metadata only — no change to expmap pixel values
-  (`nircam/expmap.py`, `nircam/cli.py`).
+  (covered arcmin²). The layout + coverage summary is written only on full-field
+  runs: a `cfpipe nircam expmap --filters <subset>` rerun skips it so a partial
+  stack never overwrites the complete survey area, and a cached expmap FITS
+  predating the `AREA` header has its per-filter area recomputed from the array
+  rather than reported as zero. Plots + metadata only — no change to expmap pixel
+  values (`nircam/expmap.py`, `nircam/cli.py`).
 - NIRCam wisp templates are now fetched from a public HTTPS host into
   `$CAMPFIRE_ROOT/cache/wisps/` against a checksummed manifest shipped with the
   package (`data/wisp_manifest.toml`), instead of being manually copied into the

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -70,6 +70,19 @@ Release procedure: edit the `## Unreleased` section below, then run
   fiducial map (the `_uncal`/legacy `_canonical` variants are skipped) and it is now
   surfaced for download on the web NIRCam page. Pure output-file naming change with
   no effect on pixel values (`nircam/expmap.py`).
+- NIRCam exposure maps now emit web-ready plots + a coverage summary (for the
+  NIRCam page redesign). Each per-filter map gains a **dark PNG**
+  (`expmap_<field>_<filter>[_uncal].png`) beside the existing light PDF —
+  rendered on a dark plot well to match CAMPFIRE's data surfaces (map/spectrum
+  wells stay dark in both app themes); the PDF is kept as the local diagnostic.
+  A new **field layout** plot (`<field>_layout[_uncal].png`) stacks every
+  per-filter expmap (total exposure across filters) with tile-footprint
+  outlines + axes + colorbar so it stands alone as a coverage/tiling product,
+  and a companion `<field>_layout.json` records the **exact survey area**
+  (non-zero pixels of the stack × pixel area) + per-filter areas for the
+  deploy/DB layer. Each per-filter expmap FITS also gains an `AREA` header
+  (covered arcmin²). Plots + metadata only — no change to expmap pixel values
+  (`nircam/expmap.py`, `nircam/cli.py`).
 - NIRCam wisp templates are now fetched from a public HTTPS host into
   `$CAMPFIRE_ROOT/cache/wisps/` against a checksummed manifest shipped with the
   package (`data/wisp_manifest.toml`), instead of being manually copied into the

--- a/pipeline/campfire_pipeline/nircam/cli.py
+++ b/pipeline/campfire_pipeline/nircam/cli.py
@@ -372,15 +372,18 @@ def rgb(config, field, tiles, pixel_scale, preview_max_dim, processes, overwrite
 @click.option('--padding', type=float, default=30.0, show_default=True,
               help='Sky padding around the union footprint, arcsec.')
 @click.option('--out-dir', default=None,
-              help='Base products dir; per-filter FITS/PDFs land in '
-                   '<out-dir>/<filter>/ (default: {products}/nircam/<field>/).')
+              help='Base products dir; per-filter FITS/PDF/PNG land in '
+                   '<out-dir>/<filter>/, the field layout + footprints at its '
+                   'root (default: {products}/nircam/<field>/).')
 @click.option('--processes', '-p', default=1, type=int, show_default=True,
               help='Per-filter parallelism (one filter per worker).')
 @click.option('--overwrite', is_flag=True,
-              help='Rebuild even if FITS + PDF already exist.')
+              help='Rebuild even if the expmap FITS already exists '
+                   '(plots + layout are always re-rendered).')
 def expmap(config, field, filters, stage, pixel_scale, padding,
            out_dir, processes, overwrite):
-    """Build per-filter exposure maps, footprint regions, and diagnostic plots."""
+    """Build per-filter exposure maps (FITS + light PDF + dark PNG), the field
+    layout plot + coverage JSON, and footprint regions."""
     _, field_obj = _setup(config, field)
     from campfire_pipeline.nircam.expmap import run_expmap
     run_expmap(

--- a/pipeline/campfire_pipeline/nircam/expmap.py
+++ b/pipeline/campfire_pipeline/nircam/expmap.py
@@ -19,17 +19,25 @@ The fiducial ``canonical`` map is undecorated — to a user it is simply *the*
 exposure map — while the reducer-only ``uncal`` quick-look keeps an explicit
 ``_uncal`` suffix (shown below as ``[_uncal]``):
 
-    <filter>/expmap_{field}_{filter}[_uncal].fits   float32, ``BUNIT='s'``, WCS in header
-    <filter>/expmap_{field}_{filter}[_uncal].pdf    diagnostic with RA/Dec gridlines + colorbar
+    <filter>/expmap_{field}_{filter}[_uncal].fits   float32, ``BUNIT='s'``, ``AREA`` header, WCS
+    <filter>/expmap_{field}_{filter}[_uncal].pdf    light diagnostic (RA/Dec grid + colorbar)
+    <filter>/expmap_{field}_{filter}[_uncal].png    dark web plot (same view, deployable)
+    {field}_layout[_uncal].png                      stacked-filter coverage + tile outlines (dark)
+    {field}_layout[_uncal].json                     coverage summary: exact area, per-filter areas
     footprints[_uncal].reg                          ds9 fk5 polygons across all filters
 
 The per-filter FITS sits in the canonical filter directory alongside the
 mosaics/exposures so the deployed coverage map carries a real filter in the
 registry (same key shape as every other per-filter NIRCam product).
 
-All per-filter PDFs in one invocation share the same colorbar
-``vmin``/``vmax`` (log-norm across the union of nonzero pixels) so the
-plots are identical apart from the data — easy to tab through.
+Both the per-filter ``.pdf`` (light, local diagnostic) and ``.png`` (dark,
+deployable) share the same colorbar ``vmin``/``vmax`` (log-norm across the
+union of nonzero pixels) so the plots are identical apart from the data —
+easy to tab through. The dark PNG matches CAMPFIRE's data wells, which stay
+dark in both app themes. The ``{field}_layout`` plot stacks every per-filter
+expmap (total exposure across filters) and overlays the tile footprints; the
+companion ``.json`` records the exact survey area (non-zero pixels of the
+stack × pixel area) for the deploy/DB layer.
 
 The .reg file only contains polygons for filters that were (re)built in this
 invocation. To regenerate a combined .reg after up-to-date FITS already exist,
@@ -54,6 +62,7 @@ import tqdm
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.wcs import WCS
+from astropy.wcs.utils import proj_plane_pixel_area
 from regions import PolygonSkyRegion
 
 from campfire_pipeline.common.io import log
@@ -179,25 +188,37 @@ def _write_fits(path, expmap, wcs, *, field_name, filter_name, stage, metas):
     hdr['NEXP'] = (len(metas), 'Number of contributing exposures')
     hdr['TEXPTOT'] = (float(sum(m.xposure for m in metas)),
                       'Sum of XPOSURE across all exposures [s]')
+    n_cov = int(np.count_nonzero(expmap > 0))
+    hdr['AREA'] = (round(n_cov * proj_plane_pixel_area(wcs) * 3600.0, 6),
+                   'Covered area [arcmin2] (nonzero pixels)')
     fits.writeto(path, expmap, header=hdr, overwrite=True)
 
 
-def _write_pdf(path, expmap, wcs, *, field_name, filter_name, stage, metas,
-               vmin=None, vmax=None):
-    """Render one filter's expmap as a log-norm PDF.
+def _render_expmap_figure(path, data, wcs, *, title, cbar_label,
+                          vmin=None, vmax=None, dark=False,
+                          tile_outlines=None):
+    """Render one exposure map (per-filter or stacked layout) to ``path``.
 
-    ``vmin``/``vmax`` default to the filter's own nonzero min/max. The
-    caller in ``run_expmap`` overrides both with values shared across
-    all filters in the invocation so the diagnostic PDFs are visually
-    identical except for the data itself.
+    ``vmin``/``vmax`` default to the map's own nonzero min/max; the per-filter
+    caller overrides both with values shared across all filters so the plots
+    are identical apart from the data.
+
+    ``dark=True`` produces the deployable web plot on a dark plot well
+    (matching CAMPFIRE's map + spectrum wells, which stay dark in both app
+    themes); ``dark=False`` keeps the light local-diagnostic look. Zeros are
+    masked so the off-footprint background renders via ``set_bad`` and stays
+    distinct from the lowest exposure values. ``tile_outlines`` is an optional
+    list of ``(name, [[ra, dec], ...])`` footprints drawn as thin polygons —
+    used by the field layout plot. Returns ``False`` (writing nothing) when the
+    map is all zero.
     """
     import matplotlib.pyplot as plt
     import matplotlib as mpl
 
-    nonzero = expmap[expmap > 0]
+    nonzero = data[data > 0]
     if nonzero.size == 0:
-        log('  expmap is all zero; skipping PDF')
-        return
+        log('  expmap is all zero; skipping plot')
+        return False
 
     if vmin is None:
         vmin = max(float(nonzero.min()), 1.0)
@@ -206,36 +227,57 @@ def _write_pdf(path, expmap, wcs, *, field_name, filter_name, stage, metas,
     if vmax <= vmin:
         vmax = vmin * 10
     norm = mpl.colors.LogNorm(vmin=vmin, vmax=vmax)
+    masked = np.ma.masked_where(data <= 0, data)
 
-    # Mask zeros so the off-footprint background renders via ``set_bad``
-    # (white) and remains visually distinct from the lowest exposure
-    # values, which sit at the bottom of the colormap.
-    masked = np.ma.masked_where(expmap <= 0, expmap)
+    bg = '#0d0b12' if dark else 'white'
+    fg = '#c9c4d6' if dark else 'black'
+    grid_c = '#4a4a5a' if dark else 'lightgray'
+    tile_c = '#e6e1f0' if dark else '#333333'
 
     fig = plt.figure(figsize=(7.5, 6.5), dpi=200, constrained_layout=True)
+    fig.patch.set_facecolor(bg)
     ax = fig.add_subplot(111, projection=wcs)
+    ax.set_facecolor(bg)
     cmap = mpl.colormaps['magma'].copy()
-    cmap.set_bad('w')
+    cmap.set_bad(bg if dark else 'w')
     im = ax.imshow(masked, origin='lower', cmap=cmap, norm=norm,
                    interpolation='nearest')
 
-    ax.set_xlabel('RA')
-    ax.set_ylabel('Dec')
     ax.coords[0].set_major_formatter('hh:mm:ss')
     ax.coords[1].set_major_formatter('dd:mm:ss')
-    ax.grid(color='lightgray', lw=0.4, alpha=0.6)
+    ax.coords[0].set_axislabel('RA', color=fg)
+    ax.coords[1].set_axislabel('Dec', color=fg)
+    ax.grid(color=grid_c, lw=0.4, alpha=0.6)
+    if dark:
+        for coord in ax.coords:
+            coord.set_ticklabel(color=fg)
+            coord.set_ticks(color=fg)
+        ax.coords.frame.set_color(fg)
 
-    ax.set_title(
-        f'{field_name} · {filter_name.upper()} · {stage} · N={len(metas)}',
-        fontsize=10,
-    )
+    if tile_outlines:
+        world = ax.get_transform('world')
+        for name, corners in tile_outlines:
+            ras = [c[0] for c in corners] + [corners[0][0]]
+            decs = [c[1] for c in corners] + [corners[0][1]]
+            ax.plot(ras, decs, transform=world, color=tile_c,
+                    lw=0.7, alpha=0.55)
+            ax.text(float(np.mean([c[0] for c in corners])),
+                    float(np.mean([c[1] for c in corners])),
+                    name, transform=world, color=tile_c, fontsize=6,
+                    ha='center', va='center', alpha=0.75)
 
+    ax.set_title(title, fontsize=10, color=fg)
     cbar = fig.colorbar(im, ax=ax, orientation='vertical',
                         shrink=0.85, pad=0.02)
-    cbar.set_label('Exposure time [s]')
+    cbar.set_label(cbar_label, color=fg)
+    if dark:
+        cbar.ax.yaxis.set_tick_params(color=fg)
+        cbar.outline.set_edgecolor(fg)
+        plt.setp(plt.getp(cbar.ax, 'yticklabels'), color=fg)
 
-    fig.savefig(path)
+    fig.savefig(path, facecolor=bg)
     plt.close(fig)
+    return True
 
 
 def _write_region_file(path, per_filter_metas):
@@ -410,16 +452,16 @@ def _expmap_stem(field_name, filter_name, stage):
 
 
 def _expmap_paths(base_dir, field_name, filter_name, stage):
-    """Per-filter FITS + PDF paths.
+    """Per-filter FITS + PDF + PNG paths.
 
     Expmaps live in the filter directory alongside the mosaics/exposures
-    (``<base_dir>/<filter>/``) so the deployed FITS carries a real filter in the
-    registry — same key shape as every other per-filter NIRCam product.
+    (``<base_dir>/<filter>/``) so the deployed FITS/PNG carry a real filter in
+    the registry — same key shape as every other per-filter NIRCam product.
     ``base_dir`` is the per-field products dir.
     """
     base = os.path.join(base_dir, filter_name,
                         _expmap_stem(field_name, filter_name, stage))
-    return base + '.fits', base + '.pdf'
+    return base + '.fits', base + '.pdf', base + '.png'
 
 
 def _nz_range(expmap):
@@ -441,7 +483,7 @@ def _accumulate_filter(args):
     (field, filter_name, stage, wcs, shape, metas,
      out_dir, overwrite) = args
 
-    fits_path, _ = _expmap_paths(out_dir, field.name, filter_name, stage)
+    fits_path, _, _ = _expmap_paths(out_dir, field.name, filter_name, stage)
 
     if not metas:
         log(f'[{filter_name}] no {stage} files found; skipping')
@@ -466,17 +508,101 @@ def _accumulate_filter(args):
     return filter_name, metas, fits_path, nz_min, nz_max
 
 
-def _render_pdf(field_name, filter_name, stage, metas, fits_path,
-                out_dir, wcs, vmin, vmax):
-    """Re-read FITS from disk and render PDF with the shared colorbar."""
-    _, pdf_path = _expmap_paths(out_dir, field_name, filter_name, stage)
+def _render_filter_plots(field_name, filter_name, stage, metas, fits_path,
+                         out_dir, wcs, vmin, vmax):
+    """Re-read the filter FITS and render the light PDF + dark PNG.
+
+    Both share the invocation-wide ``vmin``/``vmax`` so tabbing through
+    filters shows the same colour scale. The PDF is the local diagnostic
+    (kept), the PNG the deployable web plot.
+    """
+    _, pdf_path, png_path = _expmap_paths(out_dir, field_name, filter_name,
+                                          stage)
     with fits.open(fits_path, memmap=False) as hdul:
         expmap = np.asarray(hdul['EXPMAP'].data, dtype=np.float32)
-    _write_pdf(pdf_path, expmap, wcs,
-               field_name=field_name, filter_name=filter_name,
-               stage=stage, metas=metas, vmin=vmin, vmax=vmax)
-    log(f'[{filter_name}] wrote {os.path.basename(pdf_path)}')
+    title = f'{field_name} · {filter_name.upper()} · {stage} · N={len(metas)}'
+    _render_expmap_figure(pdf_path, expmap, wcs, title=title,
+                          cbar_label='Exposure time [s]',
+                          vmin=vmin, vmax=vmax, dark=False)
+    _render_expmap_figure(png_path, expmap, wcs, title=title,
+                          cbar_label='Exposure time [s]',
+                          vmin=vmin, vmax=vmax, dark=True)
+    log(f'[{filter_name}] wrote {os.path.basename(pdf_path)} + '
+        f'{os.path.basename(png_path)}')
     return pdf_path
+
+
+def _layout_paths(base_dir, field_name, stage):
+    """Field layout plot (PNG) + coverage summary (JSON) at the products root.
+
+    The fiducial ``canonical`` layout is undecorated (``<field>_layout.png``);
+    the reducer-only ``uncal`` quick-look keeps a ``_uncal`` suffix so the two
+    never collide and the deploy step picks up only the canonical one.
+    """
+    stem = f'{field_name}_layout'
+    if stage != 'canonical':
+        stem += f'_{stage}'
+    base = os.path.join(base_dir, stem)
+    return base + '.png', base + '.json'
+
+
+def _render_layout(out_dir, field, stage, results, wcs, pixel_scale,
+                   tile_outlines, texp_total):
+    """Stack every per-filter expmap into the field layout plot + JSON summary.
+
+    The stack is the per-pixel sum of exposure across all filters (the
+    "stacked exposure map"); the exact survey area is the area of its non-zero
+    pixels. Writes ``<field>_layout.png`` (dark, with tile outlines + axes +
+    colorbar so it stands alone as a cfpipe product) and ``<field>_layout.json``
+    (coverage area, per-filter areas, filters, total exposure) for the
+    deploy/DB layer to surface on the web.
+    """
+    built = [(name, metas, fp)
+             for name, metas, fp, *_ in results if fp and metas]
+    if not built:
+        return
+
+    stack = None
+    per_filter_area = {}
+    for name, _metas, fp in built:
+        with fits.open(fp, memmap=False) as hdul:
+            arr = np.asarray(hdul['EXPMAP'].data, dtype=np.float64)
+            per_filter_area[name] = float(hdul['EXPMAP'].header.get('AREA',
+                                                                    0.0))
+        stack = arr if stack is None else stack + arr
+
+    pix_area_deg2 = proj_plane_pixel_area(wcs)
+    n_cov = int(np.count_nonzero(stack > 0))
+    area_deg2 = n_cov * pix_area_deg2
+    area_arcmin2 = area_deg2 * 3600.0
+
+    png_path, json_path = _layout_paths(out_dir, field.name, stage)
+    filters = [name for name, _, _ in built]
+    ok = _render_expmap_figure(
+        png_path, stack, wcs,
+        title=f'{field.name} · layout · {len(filters)} filters',
+        cbar_label='Total exposure [s]',
+        dark=True, tile_outlines=tile_outlines,
+    )
+
+    summary = {
+        'field': field.name,
+        'stage': stage,
+        'pixel_scale_arcsec': float(pixel_scale),
+        'n_filters': len(filters),
+        'filters': filters,
+        'n_tiles': len(tile_outlines),
+        'coverage_area_arcmin2': round(area_arcmin2, 6),
+        'coverage_area_deg2': round(area_deg2, 8),
+        'per_filter_area_arcmin2': {k: round(v, 6)
+                                    for k, v in per_filter_area.items()},
+        'texp_total_s': float(texp_total),
+    }
+    with open(json_path, 'w') as fh:
+        json.dump(summary, fh, indent=2)
+    log(f'wrote {os.path.basename(json_path)}'
+        + (f' + {os.path.basename(png_path)}' if ok else '')
+        + f' (area {area_arcmin2:.1f} arcmin², {len(filters)} filters)')
 
 
 def run_expmap(
@@ -589,14 +715,27 @@ def run_expmap(
     else:
         global_vmin = global_vmax = None
 
-    # Phase 3c: PDFs. Always regenerated (cheap; the shared norm is
-    # invocation-dependent so a cached PDF from a prior run with a
-    # different filter set would not match the current colorbar).
+    # Phase 3c: per-filter plots (light PDF + dark PNG). Always regenerated
+    # (cheap; the shared norm is invocation-dependent so a cached plot from a
+    # prior run with a different filter set would not match the colorbar).
     for filter_name, metas, fits_path, _, _ in results:
         if fits_path is None or not metas:
             continue
-        _render_pdf(field.name, filter_name, stage, metas, fits_path,
-                    out_dir, wcs, global_vmin, global_vmax)
+        _render_filter_plots(field.name, filter_name, stage, metas, fits_path,
+                             out_dir, wcs, global_vmin, global_vmax)
+
+    # Phase 3d: field layout — stack of every per-filter expmap with tile
+    # outlines + the exact survey area (non-zero pixels of the stack). Tile
+    # outlines are decorative and a bad/missing tile config never blocks the
+    # plot; fields without a [tiles] block simply get coverage, no outlines.
+    tile_outlines = []
+    for tname in (getattr(field, 'tiles', None) or {}):
+        try:
+            tile_outlines.append((tname, field.get_tile_corners(tname)))
+        except Exception as e:  # noqa: BLE001 - decorative overlay, never fatal
+            log(f'  layout: skipping tile {tname} outline ({e})')
+    _render_layout(out_dir, field, stage, results, wcs, pixel_scale,
+                   tile_outlines, float(sum(m.xposure for m in all_metas)))
 
     reg_metas = [(name, metas)
                  for name, metas, *_ in results if metas]

--- a/pipeline/campfire_pipeline/nircam/expmap.py
+++ b/pipeline/campfire_pipeline/nircam/expmap.py
@@ -562,16 +562,21 @@ def _render_layout(out_dir, field, stage, results, wcs, pixel_scale,
     if not built:
         return
 
+    pix_area_deg2 = proj_plane_pixel_area(wcs)
     stack = None
     per_filter_area = {}
     for name, _metas, fp in built:
         with fits.open(fp, memmap=False) as hdul:
             arr = np.asarray(hdul['EXPMAP'].data, dtype=np.float64)
-            per_filter_area[name] = float(hdul['EXPMAP'].header.get('AREA',
-                                                                    0.0))
+            area = hdul['EXPMAP'].header.get('AREA')
+        if area is None:
+            # Cached FITS written before the AREA card existed: recompute the
+            # per-filter area from the array on the shared WCS rather than
+            # reporting a spurious zero.
+            area = int(np.count_nonzero(arr > 0)) * pix_area_deg2 * 3600.0
+        per_filter_area[name] = float(area)
         stack = arr if stack is None else stack + arr
 
-    pix_area_deg2 = proj_plane_pixel_area(wcs)
     n_cov = int(np.count_nonzero(stack > 0))
     area_deg2 = n_cov * pix_area_deg2
     area_arcmin2 = area_deg2 * 3600.0
@@ -725,17 +730,25 @@ def run_expmap(
                              out_dir, wcs, global_vmin, global_vmax)
 
     # Phase 3d: field layout — stack of every per-filter expmap with tile
-    # outlines + the exact survey area (non-zero pixels of the stack). Tile
-    # outlines are decorative and a bad/missing tile config never blocks the
-    # plot; fields without a [tiles] block simply get coverage, no outlines.
-    tile_outlines = []
-    for tname in (getattr(field, 'tiles', None) or {}):
-        try:
-            tile_outlines.append((tname, field.get_tile_corners(tname)))
-        except Exception as e:  # noqa: BLE001 - decorative overlay, never fatal
-            log(f'  layout: skipping tile {tname} outline ({e})')
-    _render_layout(out_dir, field, stage, results, wcs, pixel_scale,
-                   tile_outlines, float(sum(m.xposure for m in all_metas)))
+    # outlines + the exact survey area (non-zero pixels of the stack). Only a
+    # full-field run may (over)write the canonical layout + coverage area: a
+    # filtered rerun stacks a subset and would publish an under-reported survey
+    # area over the complete one, so partial runs skip the layout entirely.
+    if set(filter_list) >= set(field.filters):
+        # Tile outlines are decorative and a bad/missing tile config never
+        # blocks the plot; fields without a [tiles] block get coverage only.
+        tile_outlines = []
+        for tname in (getattr(field, 'tiles', None) or {}):
+            try:
+                tile_outlines.append((tname, field.get_tile_corners(tname)))
+            except Exception as e:  # noqa: BLE001 - decorative overlay, never fatal
+                log(f'  layout: skipping tile {tname} outline ({e})')
+        _render_layout(out_dir, field, stage, results, wcs, pixel_scale,
+                       tile_outlines, float(sum(m.xposure for m in all_metas)))
+    else:
+        missing = sorted(set(field.filters) - set(filter_list))
+        log(f'Partial filter run (field filters missing: {missing}); '
+            f'skipping {field.name}_layout to preserve the full-field coverage.')
 
     reg_metas = [(name, metas)
                  for name, metas, *_ in results if metas]

--- a/pipeline/tests/test_expmap_plots.py
+++ b/pipeline/tests/test_expmap_plots.py
@@ -1,0 +1,153 @@
+"""Tests for expmap plot outputs: the dark web PNG, the field layout plot,
+per-filter ``AREA`` header, and the coverage/area JSON summary.
+
+Pure numpy / matplotlib / astropy — no CRDS/jwst. Exercises the new plot and
+survey-area code paths on synthetic exposure maps built from a couple of
+overlapping S_REGION polygons, plus a ``Field`` loaded from an in-memory
+``fields.toml`` for the tile-outline geometry.
+"""
+
+import json
+import textwrap
+
+import matplotlib
+
+matplotlib.use('Agg')
+
+import numpy as np
+import pytest
+from astropy.io import fits
+from astropy.wcs.utils import proj_plane_pixel_area
+
+from campfire_pipeline.nircam import expmap as em
+from campfire_pipeline.nircam.field import Field
+
+
+def _synthetic_expmap(pixel_scale=0.5, padding=15.0):
+    """Real TAN WCS + expmap array from two overlapping polygons."""
+    metas = [
+        em._ExposureMeta(path='a.fits', rootname='a', xposure=1000.0,
+                         ra=[150.00, 150.02, 150.02, 150.00],
+                         dec=[2.00, 2.00, 2.02, 2.02]),
+        em._ExposureMeta(path='b.fits', rootname='b', xposure=500.0,
+                         ra=[150.01, 150.03, 150.03, 150.01],
+                         dec=[2.005, 2.005, 2.025, 2.025]),
+    ]
+    wcs, shape = em._auto_wcs(metas, pixel_scale, padding)
+    arr = em._accumulate_expmap(metas, wcs, shape)
+    return metas, wcs, shape, arr
+
+
+def test_expmap_paths_canonical_and_uncal():
+    fits_p, pdf_p, png_p = em._expmap_paths('/base', 'cosmos', 'f444w',
+                                            'canonical')
+    # per-filter products live in the filter subdir <base>/<filter>/
+    assert fits_p.endswith('/f444w/expmap_cosmos_f444w.fits')
+    assert pdf_p.endswith('/f444w/expmap_cosmos_f444w.pdf')
+    assert png_p.endswith('/f444w/expmap_cosmos_f444w.png')
+    # uncal quick-look keeps the stage suffix so it never collides
+    f2, _p2, png2 = em._expmap_paths('/base', 'cosmos', 'f444w', 'uncal')
+    assert f2.endswith('expmap_cosmos_f444w_uncal.fits')
+    assert png2.endswith('expmap_cosmos_f444w_uncal.png')
+
+
+def test_layout_paths_canonical_and_uncal():
+    png, js = em._layout_paths('/base', 'cosmos', 'canonical')
+    assert png.endswith('/cosmos_layout.png')
+    assert js.endswith('/cosmos_layout.json')
+    png_u, _js_u = em._layout_paths('/base', 'cosmos', 'uncal')
+    assert png_u.endswith('/cosmos_layout_uncal.png')
+
+
+def test_write_fits_area_header(tmp_path):
+    metas, wcs, _shape, arr = _synthetic_expmap()
+    out = tmp_path / 'expmap.fits'
+    em._write_fits(str(out), arr, wcs, field_name='cosmos',
+                   filter_name='f444w', stage='canonical', metas=metas)
+    with fits.open(out) as hdul:
+        hdr = hdul['EXPMAP'].header
+    assert hdr['BUNIT'] == 's'
+    expect = int(np.count_nonzero(arr > 0)) * proj_plane_pixel_area(wcs) * 3600
+    assert hdr['AREA'] == pytest.approx(expect, rel=1e-6)
+    assert hdr['AREA'] > 0
+
+
+@pytest.mark.parametrize('dark', [False, True])
+def test_render_figure(tmp_path, dark):
+    _metas, wcs, _shape, arr = _synthetic_expmap()
+    out = tmp_path / ('dark.png' if dark else 'light.pdf')
+    ok = em._render_expmap_figure(str(out), arr, wcs, title='t',
+                                  cbar_label='Exposure time [s]', dark=dark)
+    assert ok is True
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_render_figure_all_zero_writes_nothing(tmp_path):
+    _metas, wcs, shape, _arr = _synthetic_expmap()
+    out = tmp_path / 'zero.png'
+    ok = em._render_expmap_figure(str(out), np.zeros(shape, np.float32), wcs,
+                                  title='t', cbar_label='c', dark=True)
+    assert ok is False
+    assert not out.exists()
+
+
+_FIELDS_TOML = """
+    [cosmos]
+    filters = ["f200w", "f444w"]
+    files = ["jw01727*"]
+    tangent_point = [150.02, 2.01]
+
+    [cosmos.A1]
+    "30mas" = { crpix = [500, 500], naxis = [1000, 1000] }
+"""
+
+
+def test_render_layout_stack_and_area(tmp_path):
+    metas, wcs, _shape, arr = _synthetic_expmap()
+    # two per-filter FITS on the shared WCS (as run_expmap writes them)
+    results = []
+    for filt in ('f200w', 'f444w'):
+        fdir = tmp_path / filt
+        fdir.mkdir()
+        fp = fdir / f'expmap_cosmos_{filt}.fits'
+        em._write_fits(str(fp), arr, wcs, field_name='cosmos',
+                       filter_name=filt, stage='canonical', metas=metas)
+        results.append((filt, metas, str(fp), None, None))
+
+    ff = tmp_path / 'fields.toml'
+    ff.write_text(textwrap.dedent(_FIELDS_TOML))
+    field = Field.load('cosmos', fields_file=str(ff))
+    tile_outlines = [(t, field.get_tile_corners(t)) for t in field.tiles]
+    assert len(tile_outlines) == 1  # A1
+
+    em._render_layout(str(tmp_path), field, 'canonical', results, wcs,
+                      0.5, tile_outlines, texp_total=3000.0)
+
+    png = tmp_path / 'cosmos_layout.png'
+    js = tmp_path / 'cosmos_layout.json'
+    assert png.exists() and png.stat().st_size > 0
+
+    summary = json.loads(js.read_text())
+    assert summary['field'] == 'cosmos'
+    assert summary['stage'] == 'canonical'
+    assert summary['n_filters'] == 2
+    assert sorted(summary['filters']) == ['f200w', 'f444w']
+    assert summary['n_tiles'] == 1
+    assert summary['texp_total_s'] == 3000.0
+    # Footprint (non-zero area) of the summed stack == one filter's footprint,
+    # since both filters share the same polygons.
+    single = int(np.count_nonzero(arr > 0))
+    expect = single * proj_plane_pixel_area(wcs) * 3600
+    assert summary['coverage_area_arcmin2'] == pytest.approx(expect, rel=1e-6)
+
+
+def test_render_layout_no_built_results_noop(tmp_path):
+    _metas, wcs, _shape, _arr = _synthetic_expmap()
+    # results with empty metas / no FITS path → nothing written
+    em._render_layout(str(tmp_path), _DummyField(), 'canonical',
+                      [('f444w', [], None, None, None)], wcs, 0.5, [], 0.0)
+    assert not list(tmp_path.glob('*_layout.*'))
+
+
+class _DummyField:
+    name = 'cosmos'

--- a/pipeline/tests/test_expmap_plots.py
+++ b/pipeline/tests/test_expmap_plots.py
@@ -141,6 +141,68 @@ def test_render_layout_stack_and_area(tmp_path):
     assert summary['coverage_area_arcmin2'] == pytest.approx(expect, rel=1e-6)
 
 
+def test_render_layout_backfills_area_when_header_missing(tmp_path):
+    # A cached FITS from before the AREA card existed must not report a
+    # spurious zero per-filter area — it's recomputed from the array.
+    metas, wcs, _shape, arr = _synthetic_expmap()
+    results = []
+    for filt in ('f200w', 'f444w'):
+        fdir = tmp_path / filt
+        fdir.mkdir()
+        fp = fdir / f'expmap_cosmos_{filt}.fits'
+        em._write_fits(str(fp), arr, wcs, field_name='cosmos',
+                       filter_name=filt, stage='canonical', metas=metas)
+        with fits.open(fp, mode='update') as hdul:
+            del hdul['EXPMAP'].header['AREA']       # simulate a pre-AREA FITS
+        results.append((filt, metas, str(fp), None, None))
+
+    ff = tmp_path / 'fields.toml'
+    ff.write_text(textwrap.dedent(_FIELDS_TOML))
+    field = Field.load('cosmos', fields_file=str(ff))
+    tile_outlines = [(t, field.get_tile_corners(t)) for t in field.tiles]
+
+    em._render_layout(str(tmp_path), field, 'canonical', results, wcs,
+                      0.5, tile_outlines, texp_total=3000.0)
+
+    summary = json.loads((tmp_path / 'cosmos_layout.json').read_text())
+    single = int(np.count_nonzero(arr > 0))
+    expect = single * proj_plane_pixel_area(wcs) * 3600
+    for filt in ('f200w', 'f444w'):
+        area = summary['per_filter_area_arcmin2'][filt]
+        assert area > 0
+        assert area == pytest.approx(expect, rel=1e-6)
+
+
+def test_run_expmap_skips_layout_on_partial_filter_run(tmp_path, monkeypatch):
+    # A filtered rerun must not overwrite the full-field layout/coverage; a
+    # full run (covering every field filter) still writes it.
+    metas, wcs, shape, _arr = _synthetic_expmap()
+
+    ff = tmp_path / 'fields.toml'
+    ff.write_text(textwrap.dedent(_FIELDS_TOML))    # cosmos: [f200w, f444w]
+    field = Field.load('cosmos', fields_file=str(ff))
+
+    monkeypatch.setattr(em, '_load_metadata_cache', lambda *a, **k: {})
+    monkeypatch.setattr(em, '_save_metadata_cache', lambda *a, **k: None)
+    monkeypatch.setattr(em, '_collect_metas',
+                        lambda field, filt, stage, cache=None: [metas[0]])
+    monkeypatch.setattr(em, '_auto_wcs', lambda ms, ps, pad: (wcs, shape))
+    monkeypatch.setattr(em, '_accumulate_filter',
+                        lambda w: (w[1], w[5], f'/fake/{w[1]}.fits', 1.0, 10.0))
+    monkeypatch.setattr(em, '_render_filter_plots', lambda *a, **k: None)
+    monkeypatch.setattr(em, '_write_region_file', lambda *a, **k: None)
+
+    calls = []
+    monkeypatch.setattr(em, '_render_layout',
+                        lambda *a, **k: calls.append(a))
+
+    em.run_expmap(field, filters=['f444w'], out_dir=str(tmp_path))
+    assert calls == []                              # partial → skipped
+
+    em.run_expmap(field, filters=['f200w', 'f444w'], out_dir=str(tmp_path))
+    assert len(calls) == 1                          # full → rendered
+
+
 def test_render_layout_no_built_results_noop(tmp_path):
     _metas, wcs, _shape, _arr = _synthetic_expmap()
     # results with empty metas / no FITS path → nothing written


### PR DESCRIPTION
**PR 1 of 5** in the NIRCam page redesign stack. Design reference: `docs/design-nircam-page-redesign.md` + interactive wireframe `docs/wireframes/nircam-page-redesign.html` (both included here as the base of the stack).

This PR is the **pipeline layer** — the web page needs web-ready coverage plots and a real survey-area number, but `cfpipe nircam expmap` only produced a light-mode PDF.

## Changes (`nircam/expmap.py`, `nircam/cli.py`)
- **Dark per-filter expmap PNG** — `expmap_<field>_<filter>[_uncal].png` beside the kept light PDF, rendered on a dark plot well so it matches CAMPFIRE's data surfaces (map/spectrum wells stay dark in both app themes). Both share one invocation-wide colorbar. The single PDF renderer is refactored into `_render_expmap_figure(dark=…)`, reused by the per-filter plots and the layout.
- **Field layout plot** — `<field>_layout[_uncal].png` stacks every per-filter expmap (total exposure across filters) and overlays the tile footprints with axes + colorbar, so it stands alone as a coverage/tiling product (also the landing-page card preview in later PRs).
- **Exact survey area** — `<field>_layout.json` records the area (non-zero pixels of the stack × pixel area), per-filter areas, filters, and total exposure for the deploy/DB layer. Each per-filter expmap FITS also gains an `AREA` header (covered arcmin²).

Fiducial (`canonical`) outputs are undecorated; the `uncal` quick-look keeps its `_uncal` suffix (matching the existing expmap/`footprints.reg` convention). Plots + metadata only — **no change to expmap pixel values**.

## Testing
- New `pipeline/tests/test_expmap_plots.py` — 8 tests (paths, `AREA` header, light+dark render, all-zero no-op, layout stack + area from a synthetic `Field` with tiles). All pass.
- Rendered the dark expmap PNG and the layout PNG on synthetic data and confirmed the dark theme + tile outlines visually.

## Changelog
Infrastructure (**PATCH**) — plots + metadata, no scientific-output change.

## Stack
1. **This PR** — pipeline plots + area
2. Layout contract (`campfire-layout` product specs + TS mirror + bijection extension fix)
3. Deploy (register the 3 new product types; read layout area)
4. DB (`get_nircam_fields` + `get_nircam_field_summary` RPCs)
5. Web (`/nircam` landing + `/nircam/[field]` routes)

Generated with Claude Code