### PR TITLE
feat(layout): register nircam expmap-plot / mosaic-thumbnail / layout products (redesign PR 2/5)

### DIFF
--- a/layout/campfire_layout/bijection.py
+++ b/layout/campfire_layout/bijection.py
@@ -44,6 +44,7 @@ _NIRSPEC_OBS_SUFFIXES = (
 _NIRCAM_FILTER_SUFFIXES = (
     ("_preview.png", "nircam_exposure_preview"),
     ("_full.png", "nircam_exposure_full"),
+    ("_thumb.png", "nircam_mosaic_thumbnail"),  # before the 'mosaic' prefix check
 )
 _EXPOSURE_RE = re.compile(r"_nrs[12]_\d+\.fits$")
 _TILE_RE = re.compile(r"^(?P<field>[^/]+)/(?P<filt>[^/]+)/(?P<z>\d+)/(?P<x>\d+)/(?P<y>\d+)\.png$")
@@ -99,6 +100,8 @@ def parse_relpath(relpath: str) -> ParsedKey:
         field = seg[2]
         if len(seg) == 4 and seg[3].endswith("_rgb.png"):
             return ParsedKey("nircam_rgb", Scope(field=field), seg[3])
+        if len(seg) == 4 and seg[3].endswith("_layout.png"):
+            return ParsedKey("nircam_layout", Scope(field=field), seg[3])
         if len(seg) == 5:
             filt, fname = seg[3], seg[4]
             scope = Scope(field=field, filt=filt)
@@ -108,7 +111,10 @@ def parse_relpath(relpath: str) -> ParsedKey:
             if fname.startswith("mosaic"):
                 return ParsedKey("nircam_mosaic", scope, fname)
             if fname.startswith("expmap"):
-                return ParsedKey("nircam_expmap", scope, fname)
+                # '.png' is the dark web plot; '.fits' is the coverage map.
+                return ParsedKey(
+                    "nircam_expmap_plot" if fname.endswith(".png")
+                    else "nircam_expmap", scope, fname)
             if fname.endswith(".fits"):
                 return ParsedKey("nircam_exposure", scope, fname)
 

--- a/layout/campfire_layout/products.py
+++ b/layout/campfire_layout/products.py
@@ -186,6 +186,30 @@ _register(ProductSpec(
     lifecycle=LC.CLOUD_PRODUCT, scope_keys=("field", "filt"),
     subdir=_nircam_field_filter_dir, suffix=None, legacy_prefix=None,
 ))
+# Web-ready dark PNG render of the expmap (``expmap_<field>_<filter>.png``),
+# sibling of the expmap FITS in the filter dir. Prefix-dispatched like the FITS
+# (``expmap_``); the ``.png`` extension tells the two apart in the bijection, so
+# ``suffix`` stays None (there is no clean filename suffix to dispatch on).
+_register(ProductSpec(
+    name="nircam_expmap_plot", instrument=NC, tree="products", bucket="data",
+    lifecycle=LC.CLOUD_PRODUCT, scope_keys=("field", "filt"),
+    subdir=_nircam_field_filter_dir, suffix=None, legacy_prefix=None,
+))
+# Per-mosaic science thumbnail (``mosaic_..._thumb.png``), sibling of the mosaic
+# FITS. Suffix-dispatched on ``_thumb.png`` (matched before the ``mosaic`` prefix).
+_register(ProductSpec(
+    name="nircam_mosaic_thumbnail", instrument=NC, tree="products", bucket="data",
+    lifecycle=LC.CLOUD_PRODUCT, scope_keys=("field", "filt"),
+    subdir=_nircam_field_filter_dir, suffix="_thumb.png", legacy_prefix=None,
+))
+# Field layout plot (``<field>_layout.png``): stacked-filter coverage + tile
+# outlines. Field-scoped, in the field root beside nircam_rgb; the landing-page
+# preview. Suffix-dispatched on ``_layout.png``.
+_register(ProductSpec(
+    name="nircam_layout", instrument=NC, tree="products", bucket="data",
+    lifecycle=LC.CLOUD_PRODUCT, scope_keys=("field",), subdir=_nircam_field_dir,
+    suffix="_layout.png", legacy_prefix=None,
+))
 
 # --- Map tiles (separate 'tiles' bucket, scheme-invariant, stays on R2) ---------
 

--- a/layout/conformance/layout_golden.json
+++ b/layout/conformance/layout_golden.json
@@ -132,6 +132,36 @@
       "tree_class": "cloud-backed-product"
     },
     {
+      "product_type": "nircam_expmap_plot",
+      "scope": {"field": "cosmos", "filt": "f444w"},
+      "filename": "expmap_cosmos_f444w.png",
+      "relpath": "products/nircam/cosmos/f444w/expmap_cosmos_f444w.png",
+      "key_legacy": null,
+      "key_canonical": "data/products/nircam/cosmos/f444w/expmap_cosmos_f444w.png",
+      "bucket": "data",
+      "tree_class": "cloud-backed-product"
+    },
+    {
+      "product_type": "nircam_mosaic_thumbnail",
+      "scope": {"field": "cosmos", "filt": "f444w"},
+      "filename": "mosaic_cosmos_f444w_30mas_thumb.png",
+      "relpath": "products/nircam/cosmos/f444w/mosaic_cosmos_f444w_30mas_thumb.png",
+      "key_legacy": null,
+      "key_canonical": "data/products/nircam/cosmos/f444w/mosaic_cosmos_f444w_30mas_thumb.png",
+      "bucket": "data",
+      "tree_class": "cloud-backed-product"
+    },
+    {
+      "product_type": "nircam_layout",
+      "scope": {"field": "cosmos"},
+      "filename": "cosmos_layout.png",
+      "relpath": "products/nircam/cosmos/cosmos_layout.png",
+      "key_legacy": null,
+      "key_canonical": "data/products/nircam/cosmos/cosmos_layout.png",
+      "bucket": "data",
+      "tree_class": "cloud-backed-product"
+    },
+    {
       "product_type": "tile",
       "scope": {"field": "cosmos", "filt": "f444w", "zoom": 3, "x": 1, "y": 2},
       "filename": null,
@@ -303,7 +333,10 @@
     "nircam/exposures/cosmos/f444w/jw01727028001_04101_00003_nrcalong_preview.png",
     "photometry/cosmos/12345_pz.json",
     "data/products/nirspec/ember_egs_p1/jw07076020001_04101_00003_nrs1_15182.fits",
-    "data/products/nirspec/ember_egs_p1/jw07076020001_04101_00003_nrs1_rate.fits"
+    "data/products/nirspec/ember_egs_p1/jw07076020001_04101_00003_nrs1_rate.fits",
+    "data/products/nircam/cosmos/f444w/expmap_cosmos_f444w.png",
+    "data/products/nircam/cosmos/f444w/mosaic_cosmos_f444w_30mas_thumb.png",
+    "data/products/nircam/cosmos/cosmos_layout.png"
   ],
   "unknown_keys": [
     "spectra/../etc/passwd",

--- a/web/lib/layout.ts
+++ b/web/lib/layout.ts
@@ -86,6 +86,9 @@ reg(spec({ name: 'nircam_exposure_full', tree: 'products', bucket: 'data', scope
 reg(spec({ name: 'nircam_mosaic', tree: 'products', bucket: 'data', scopeKeys: ['field', 'filt'], subdir: nircamFieldFilter, suffix: null }));
 reg(spec({ name: 'nircam_rgb', tree: 'products', bucket: 'data', scopeKeys: ['field'], subdir: (s) => `nircam/${s.field}`, suffix: '_rgb.png' }));
 reg(spec({ name: 'nircam_expmap', tree: 'products', bucket: 'data', scopeKeys: ['field', 'filt'], subdir: nircamFieldFilter, suffix: null }));
+reg(spec({ name: 'nircam_expmap_plot', tree: 'products', bucket: 'data', scopeKeys: ['field', 'filt'], subdir: nircamFieldFilter, suffix: null }));
+reg(spec({ name: 'nircam_mosaic_thumbnail', tree: 'products', bucket: 'data', scopeKeys: ['field', 'filt'], subdir: nircamFieldFilter, suffix: '_thumb.png' }));
+reg(spec({ name: 'nircam_layout', tree: 'products', bucket: 'data', scopeKeys: ['field'], subdir: (s) => `nircam/${s.field}`, suffix: '_layout.png' }));
 
 // --- Map tiles (separate bucket, scheme-invariant) ---
 reg(spec({
@@ -195,6 +198,7 @@ const NIRSPEC_OBS_SUFFIXES: [string, string][] = [
 const NIRCAM_FILTER_SUFFIXES: [string, string][] = [
   ['_preview.png', 'nircam_exposure_preview'],
   ['_full.png', 'nircam_exposure_full'],
+  ['_thumb.png', 'nircam_mosaic_thumbnail'], // before the 'mosaic' prefix check
 ];
 const TILE_RE = /^([^/]+)\/([^/]+)\/(\d+)\/(\d+)\/(\d+)\.png$/;
 
@@ -228,13 +232,15 @@ export function parseRelpath(relpath: string): ParsedKey {
   if (tree === 'products' && seg.length >= 4 && seg[1] === 'nircam') {
     const field = seg[2];
     if (seg.length === 4 && seg[3].endsWith('_rgb.png')) return { productType: 'nircam_rgb', scope: { field }, filename: seg[3] };
+    if (seg.length === 4 && seg[3].endsWith('_layout.png')) return { productType: 'nircam_layout', scope: { field }, filename: seg[3] };
     if (seg.length === 5) {
       const filt = seg[3];
       const fname = seg[4];
       const pt = dispatch(fname, NIRCAM_FILTER_SUFFIXES);
       if (pt) return { productType: pt, scope: { field, filt }, filename: fname };
       if (fname.startsWith('mosaic')) return { productType: 'nircam_mosaic', scope: { field, filt }, filename: fname };
-      if (fname.startsWith('expmap')) return { productType: 'nircam_expmap', scope: { field, filt }, filename: fname };
+      // '.png' is the dark web plot; '.fits' is the coverage map.
+      if (fname.startsWith('expmap')) return { productType: fname.endsWith('.png') ? 'nircam_expmap_plot' : 'nircam_expmap', scope: { field, filt }, filename: fname };
       if (fname.endsWith('.fits')) return { productType: 'nircam_exposure', scope: { field, filt }, filename: fname };
     }
   }


### PR DESCRIPTION
**PR 2 of 5** in the NIRCam page redesign stack. **Stacked on #373** (base branch `feat/nircam-redesign-p1-pipeline`).

Registers the three new deployable NIRCam artifacts introduced in PR 1 into the `campfire-layout` key/path contract, so PR 3 (deploy) can build canonical keys + `storage_objects` rows for them.

## New products (reserved keys — canonical only, no legacy)
| product_type | filename | scope |
|---|---|---|
| `nircam_expmap_plot` | `expmap_<field>_<filter>.png` | field·filter |
| `nircam_mosaic_thumbnail` | `mosaic_*_thumb.png` | field·filter |
| `nircam_layout` | `<field>_layout.png` | field |

## Bijection
- Mosaic thumbnails + the field layout dispatch on their `_thumb.png` / `_layout.png` suffixes.
- The expmap plot shares the `expmap` filename prefix with the FITS, so reverse dispatch now **branches on the extension** (`.png` → plot, `.fits` → coverage map) — the collision the plan called out.

## Mirroring + tests
- Mirrored in `web/lib/layout.ts` (the TS arm of the contract).
- Three new rows in the shared golden fixture (`layout/conformance/layout_golden.json`) + three `known_keys`.
- Both conformance arms pass: **Python `test_layout.py` 38**, **vitest `layout.test.ts` 102** (incl. the completeness guard that every registered product has a golden case).

No `pipeline/**` change → no pipeline changelog. The only web change is the `layout.ts` mirror (validated by vitest); the full `npm run build` gate lands with the UI in PR 5.

## Stack
1. #373 — pipeline plots + area
2. **This PR** — layout contract
3. Deploy (register the 3 product types; read layout area)
4. DB RPCs
5. Web routes

Generated with Claude Code