### PR TITLE
perf(verify): rsync-style quick check — bulk directory scan, size-match hash adoption

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,7 +186,7 @@ campfire sync                          # refresh the local index (never touches 
 campfire status [--obs X | --field Y]  # bidirectional diff; scoped = push-side dry run
 campfire pull --obs X [--intermediate] # cloud→local products (+ review annotations, admins)
 campfire push --obs X | --field Y      # local→cloud bytes ONLY — no catalog, no publication
-campfire verify [--cloud] [--json]     # tree↔index; --cloud adds registry↔bucket (CI-able)
+campfire verify [--cloud] [--deep]     # tree↔index (bulk scan, size-match quick check); --cloud adds registry↔bucket
 campfire drop-local --obs X --yes      # delete local files verified in cloud
 ```
 

--- a/python/campfire/cli.py
+++ b/python/campfire/cli.py
@@ -650,16 +650,23 @@ def sync_cmd(full: bool, base_url: Optional[str], migrate_layout: Optional[bool]
         if result.get("purged_spectra"):
             click.echo(f"  Removed {result['purged_spectra']} spectra deleted from server.")
 
-        # Verify local files so status reports correct counts immediately
+        # Verify local files so status reports correct counts immediately.
+        # Cheap: one bulk directory scan + size-match adoption, no file reads —
+        # frequent drift-checking is the point, so this must stay fast even on
+        # a reducer tree over NFS (run `campfire verify --deep` for true
+        # content hashing).
         pd = _products_dir()
         if pd.exists():
             verify = store.verify_local_objects(pd, show_progress=True)
             if verify["cleared"]:
                 click.echo(f"  Detected {verify['cleared']} missing local file(s).")
             if verify["rehashed"]:
-                click.echo(f"  Re-verified {verify['rehashed']} modified local file(s).")
+                click.echo(f"  Refreshed {verify['rehashed']} modified local file(s).")
             if verify["discovered"]:
                 click.echo(f"  Found {verify['discovered']} existing local file(s).")
+            if verify.get("mismatched"):
+                click.echo(f"  {verify['mismatched']} local file(s) don't match the "
+                           f"cloud object (partial/foreign) — left as pending.")
 
         if result["stale_count"] > 0:
             click.echo(f"\n⚠ {result['stale_count']} local file(s) have been updated on the server.")
@@ -891,9 +898,12 @@ def download(obs_filter, program_filter, field_filter, grating_filter, filter_fi
         click.echo("Note: --filters scopes NIRCam field products; this selection "
                    "has no NIRCam field, so it has no effect.")
 
-    # Reconcile DB with filesystem before planning
+    # Reconcile DB with filesystem before planning — scoped to this pull's
+    # selection so the pre-flight stays O(selection), not O(tree).
     verify = store.verify_local_objects(
-        _products_dir(), product_types=product_types, show_progress=True
+        _products_dir(), product_types=product_types, show_progress=True,
+        observations=list(target_obs) or None,
+        fields=list(target_fields) or None,
     )
     if verify["cleared"]:
         click.echo(f"  Detected {verify['cleared']} missing local file(s), will re-download.")
@@ -901,6 +911,9 @@ def download(obs_filter, program_filter, field_filter, grating_filter, filter_fi
         click.echo(f"  Re-verified {verify['rehashed']} modified local file(s).")
     if verify["discovered"]:
         click.echo(f"  Found {verify['discovered']} existing local file(s), skipping download.")
+    if verify.get("mismatched"):
+        click.echo(f"  {verify['mismatched']} local file(s) don't match the cloud object "
+                   f"(partial/foreign); will re-download.")
 
     # Compute download plan locally (no HTTP requests)
     grating_list = list(grating_filter) if grating_filter else None
@@ -1043,16 +1056,21 @@ def _maybe_pull_annotations(obs_names, nircam_fields, disabled: bool) -> None:
 @click.option("--cloud", "cloud", is_flag=True,
               help="Also verify the cloud registry against the actual buckets "
                    "(admin; needs S3 LIST credentials — OSN primary, legacy R2)")
+@click.option("--deep", is_flag=True,
+              help="Content-hash changed/discovered files instead of the "
+                   "size-match quick check (reads every such file)")
 @click.option("--json", "as_json", is_flag=True,
               help="Machine-readable report (for CI); exit 1 on drift")
 @click.option("--local", is_flag=True,
               help="--cloud against local Supabase (127.0.0.1:54321)")
-def verify(obs_filter, cloud, as_json, local):
+def verify(obs_filter, cloud, deep, as_json, local):
     """Verify local tree ↔ index, and optionally index ↔ cloud buckets.
 
     Without --cloud: reconciles the local products tree against the storage
-    index (stat fast-path; re-hashes only files whose size/mtime changed;
-    clears vanished files; adopts files that appeared).
+    index via one bulk directory scan (no file reads): clears vanished files,
+    and adopts present files whose size matches the cloud object (rsync-style
+    quick check — the server hash is presumed, not re-computed). --deep
+    additionally content-hashes every changed/discovered file.
 
     With --cloud (admin): additionally compares live DB pointers vs the
     registry vs actual bucket LISTs — OSN first (the data home), then the
@@ -1068,19 +1086,22 @@ def verify(obs_filter, cloud, as_json, local):
     if not as_json:
         click.echo("Verifying local tree against the index...")
     store = _open_store()
-    local_totals = {"cleared": 0, "rehashed": 0, "discovered": 0}
-    scopes = list(obs_filter) or [None]
-    for scope in scopes:
-        res = store.verify_local_objects(
-            _products_dir(), observation=scope, show_progress=not as_json)
-        for k in local_totals:
-            local_totals[k] += res.get(k, 0)
+    local_totals = store.verify_local_objects(
+        _products_dir(),
+        observations=list(obs_filter) or None,
+        deep=deep,
+        show_progress=not as_json,
+    )
     store.close()
     payload["local"] = local_totals
     if not as_json:
         click.echo(f"  cleared (file vanished): {local_totals['cleared']}")
-        click.echo(f"  re-hashed (file changed): {local_totals['rehashed']}")
+        click.echo(f"  {'re-hashed' if deep else 'refreshed'} (file changed): "
+                   f"{local_totals['rehashed']}")
         click.echo(f"  discovered (already present): {local_totals['discovered']}")
+        if local_totals.get("mismatched"):
+            click.echo(f"  mismatched (size ≠ cloud object; left pending): "
+                       f"{local_totals['mismatched']}")
 
     drift = False
     if cloud:

--- a/python/campfire/db/store.py
+++ b/python/campfire/db/store.py
@@ -1531,7 +1531,36 @@ class LocalStore:
             # New file, or stat changed since recorded.
             if deep:
                 to_hash.append((row, rel, size, mtime, not tracked))
-            elif _adoptable(row, size):
+                continue
+
+            prior = row["local_file_hash"]
+            if tracked and prior is not None and prior != row["content_hash"]:
+                # Known-stale row (the cloud object changed since this file was
+                # last verified). Adopting the new server hash here would mark
+                # old bytes as current and pull would skip the update — the one
+                # drift this ledger exists to surface. Keep the honest prior
+                # hash while the file looks like the same bytes; void it once
+                # the size disagrees.
+                if size == row["local_file_size"]:
+                    self._conn.execute(
+                        """UPDATE storage_objects SET local_file_mtime = ?
+                           WHERE storage_key = ?""",
+                        (mtime, row["storage_key"]),
+                    )
+                    rehashed += 1
+                else:
+                    mismatched += 1
+                    cleared += 1
+                    self._conn.execute(
+                        """UPDATE storage_objects SET local_path = NULL,
+                           local_file_hash = NULL, local_file_mtime = NULL,
+                           local_file_size = NULL, synced_at = NULL
+                           WHERE storage_key = ?""",
+                        (row["storage_key"],),
+                    )
+                continue
+
+            if _adoptable(row, size):
                 self._conn.execute(
                     """UPDATE storage_objects SET local_path = ?, local_file_hash = ?,
                        local_file_mtime = ?, local_file_size = ?, synced_at = ?

--- a/python/campfire/db/store.py
+++ b/python/campfire/db/store.py
@@ -1372,104 +1372,215 @@ class LocalStore:
         observation: Optional[str] = None,
         product_types: Optional[List[str]] = None,
         show_progress: bool = False,
+        *,
+        observations: Optional[List[str]] = None,
+        fields: Optional[List[str]] = None,
+        deep: bool = False,
+        max_workers: Optional[int] = None,
     ) -> dict:
         """Reconcile the storage_objects mirror's local state with the filesystem.
 
-        Clears rows whose file vanished, re-hashes modified files, and re-discovers
-        already-present files (so a fresh mirror after a schema bump finds existing
-        downloads). Scoped to mirrored, downloadable product types.
+        Clears rows whose file vanished, re-checks files whose stat changed, and
+        discovers already-present files (a fresh mirror after a schema bump — or
+        a reducer tree the pipeline wrote — gets adopted into the ledger).
+        Scoped to mirrored, downloadable product types, and optionally to
+        ``observations`` (NIRSpec) / ``fields`` (field-scoped NIRCam rows).
+
+        Cheap by design (rsync-style quick check): filesystem state comes from
+        ONE bulk directory scan — candidate directories are derived from the
+        keys and listed with ``os.scandir`` (READDIRPLUS-friendly, threaded
+        across directories), so no per-file stat calls and, by default, **no
+        file reads**. A present file whose size matches the server's
+        ``size_bytes`` ADOPTS the server ``content_hash`` as its local hash —
+        a presumption, not a verification (accepted trade-off: same-size silent
+        corruption goes undetected; truncation/partials are caught by the size
+        check). A size mismatch clears/skips the row so the object shows as
+        pending and ``pull`` re-fetches it.
+
+        ``deep=True`` restores true content hashing (parallel) for files whose
+        stat changed or that were newly discovered — the explicit paranoid mode
+        behind ``campfire verify --deep``. Where hashing is load-bearing it
+        happens elsewhere regardless: downloads stream-hash against
+        ``content_hash``, push hashes changed candidates for dedup identity,
+        and ``drop-local --verify`` content-verifies before deleting.
         """
-        from ..config import products_relpath
-        from ..sync import compute_file_hash
+        import os as _os
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
         from campfire_layout import LayoutError
+
+        from ..config import products_relpath
+        from ..storage.hashing import default_hash_workers, hash_files_parallel
 
         now = datetime.now(timezone.utc).isoformat()
         types = list(product_types or DOWNLOADABLE_PRODUCT_TYPES)
         type_ph = ",".join("?" * len(types))
         clauses = [f"product_type IN ({type_ph})", "status = 'active'"]
         params: list = list(types)
-        if observation:
-            clauses.append("observation = ?")
-            params.append(observation)
+        obs_list = list(observations or ([observation] if observation else []))
+        scope = []
+        if obs_list:
+            ph = ",".join("?" * len(obs_list))
+            scope.append(f"observation IN ({ph})")
+            params.extend(obs_list)
+        if fields:
+            ph = ",".join("?" * len(fields))
+            scope.append(f"field IN ({ph})")
+            params.extend(fields)
+        if scope:
+            clauses.append("(" + " OR ".join(scope) + ")")
         where = " AND ".join(clauses)
 
-        tracked = self._conn.execute(
-            f"""SELECT storage_key, local_path, local_file_mtime, local_file_size
+        rows = self._conn.execute(
+            f"""SELECT storage_key, content_hash, size_bytes, local_path,
+                       local_file_hash, local_file_mtime, local_file_size
                 FROM storage_objects
-                WHERE local_path IS NOT NULL AND {where}""",
-            params,
-        ).fetchall()
-        untracked = self._conn.execute(
-            f"""SELECT storage_key FROM storage_objects
-                WHERE local_path IS NULL AND {where}""",
+                WHERE {where}""",
             params,
         ).fetchall()
 
-        total = len(tracked) + len(untracked)
+        # Map each row to its canonical relpath (pure string work, no I/O) and
+        # collect the parent directories — the whole candidate set lives in
+        # ~(#observations + #field×filter) directories, so one listing per
+        # directory replaces one stat per file.
+        candidates: list = []  # (row, rel_path_str)
+        dirs: set = set()
+        for row in rows:
+            rel = row["local_path"]
+            if rel is None:
+                try:
+                    rel = products_relpath(row["storage_key"])
+                except (LayoutError, ValueError):
+                    continue
+            candidates.append((row, rel))
+            dirs.add(_os.path.dirname(rel))
+
+        # --- One bulk scan: {relpath: (size, mtime)} for every regular file in
+        # the candidate directories. scandir batches attributes per directory
+        # (NFS READDIRPLUS / macOS getattrlistbulk); directories scan in a
+        # thread pool so per-directory round-trips overlap.
+        def _scan(rel_dir: str) -> list:
+            out = []
+            try:
+                with _os.scandir(products_dir / rel_dir) as it:
+                    for entry in it:
+                        try:
+                            if entry.is_file(follow_symlinks=False):
+                                st = entry.stat(follow_symlinks=False)
+                                out.append((f"{rel_dir}/{entry.name}" if rel_dir else entry.name,
+                                            (st.st_size, st.st_mtime)))
+                        except OSError:
+                            continue
+            except OSError:
+                pass  # directory absent: every file in it is absent
+            return out
+
+        fs_stats: dict = {}
+        dir_list = sorted(dirs)
+        workers = max(1, min(max_workers or default_hash_workers(), len(dir_list) or 1))
         pbar = None
-        if show_progress and total > 0:
+        if show_progress and dir_list:
             from tqdm import tqdm
-            pbar = tqdm(total=total, desc="Verifying local files", unit="file")
-
-        cleared = rehashed = discovered = 0
-
-        for row in tracked:
-            full_path = products_dir / row["local_path"]
-            if not full_path.exists():
-                self._conn.execute(
-                    """UPDATE storage_objects SET local_path = NULL, local_file_hash = NULL,
-                       local_file_mtime = NULL, local_file_size = NULL, synced_at = NULL
-                       WHERE storage_key = ?""",
-                    (row["storage_key"],),
-                )
-                cleared += 1
-            else:
-                st = full_path.stat()
-                if (
-                    row["local_file_mtime"] is not None
-                    and row["local_file_size"] is not None
-                    and abs(st.st_mtime - row["local_file_mtime"]) < 0.001
-                    and st.st_size == row["local_file_size"]
-                ):
+            pbar = tqdm(total=len(dir_list), desc="Scanning local tree", unit="dir")
+        try:
+            with ThreadPoolExecutor(max_workers=workers) as ex:
+                for fut in as_completed([ex.submit(_scan, d) for d in dir_list]):
+                    fs_stats.update(fut.result())
                     if pbar:
                         pbar.update(1)
-                    continue
-                new_hash = compute_file_hash(full_path)
-                self._conn.execute(
-                    """UPDATE storage_objects SET local_file_hash = ?,
-                       local_file_mtime = ?, local_file_size = ? WHERE storage_key = ?""",
-                    (new_hash, st.st_mtime, st.st_size, row["storage_key"]),
-                )
-                rehashed += 1
+        finally:
             if pbar:
-                pbar.update(1)
+                pbar.close()
 
-        for row in untracked:
-            try:
-                rel_path = products_relpath(row["storage_key"])
-            except (LayoutError, ValueError):
-                if pbar:
-                    pbar.update(1)
+        # --- In-memory classification. Every SQLite write stays on this thread.
+        cleared = rehashed = discovered = mismatched = 0
+        to_hash: list = []  # deep mode: (row, rel, size, mtime, is_discovery)
+
+        def _adoptable(row, size: int) -> bool:
+            h = row["content_hash"]
+            return (row["size_bytes"] is not None and size == row["size_bytes"]
+                    and h is not None and h.startswith("sha256:"))
+
+        for row, rel in candidates:
+            stat = fs_stats.get(rel)
+            tracked = row["local_path"] is not None
+
+            if stat is None:
+                if tracked:
+                    # File vanished — clear the pull-side bookkeeping.
+                    self._conn.execute(
+                        """UPDATE storage_objects SET local_path = NULL,
+                           local_file_hash = NULL, local_file_mtime = NULL,
+                           local_file_size = NULL, synced_at = NULL
+                           WHERE storage_key = ?""",
+                        (row["storage_key"],),
+                    )
+                    cleared += 1
                 continue
-            local_path = products_dir / rel_path
-            if local_path.exists():
-                st = local_path.stat()
-                actual_hash = compute_file_hash(local_path)
+
+            size, mtime = stat
+            if (
+                tracked
+                and row["local_file_mtime"] is not None
+                and row["local_file_size"] is not None
+                and abs(mtime - row["local_file_mtime"]) < 0.001
+                and size == row["local_file_size"]
+            ):
+                continue  # unchanged since last recorded — nothing to do
+
+            # New file, or stat changed since recorded.
+            if deep:
+                to_hash.append((row, rel, size, mtime, not tracked))
+            elif _adoptable(row, size):
                 self._conn.execute(
                     """UPDATE storage_objects SET local_path = ?, local_file_hash = ?,
                        local_file_mtime = ?, local_file_size = ?, synced_at = ?
                        WHERE storage_key = ?""",
-                    (rel_path, actual_hash, st.st_mtime, st.st_size, now, row["storage_key"]),
+                    (rel, row["content_hash"], mtime, size, now, row["storage_key"]),
                 )
-                discovered += 1
-            if pbar:
-                pbar.update(1)
+                if tracked:
+                    rehashed += 1
+                else:
+                    discovered += 1
+            else:
+                # Size disagrees with the cloud object (or no authoritative
+                # hash to adopt): a partial/foreign file. Leave it out of the
+                # ledger so the object reads as pending and pull re-fetches.
+                mismatched += 1
+                if tracked:
+                    self._conn.execute(
+                        """UPDATE storage_objects SET local_path = NULL,
+                           local_file_hash = NULL, local_file_mtime = NULL,
+                           local_file_size = NULL, synced_at = NULL
+                           WHERE storage_key = ?""",
+                        (row["storage_key"],),
+                    )
+                    cleared += 1
 
-        if pbar:
-            pbar.close()
+        # --- deep mode: true content hashing, parallel, only what changed.
+        if to_hash:
+            hashes = hash_files_parallel(
+                [products_dir / rel for _, rel, _, _, _ in to_hash],
+                max_workers=max_workers,
+                progress_desc="Hashing changed/discovered files" if show_progress else None,
+            )
+            for row, rel, size, mtime, is_discovery in to_hash:
+                actual_hash = hashes[Path(products_dir / rel)][0]
+                self._conn.execute(
+                    """UPDATE storage_objects SET local_path = ?, local_file_hash = ?,
+                       local_file_mtime = ?, local_file_size = ?, synced_at = ?
+                       WHERE storage_key = ?""",
+                    (rel, actual_hash, mtime, size, now, row["storage_key"]),
+                )
+                if is_discovery:
+                    discovered += 1
+                else:
+                    rehashed += 1
+
         if cleared or discovered or rehashed:
             self._conn.commit()
-        return {"cleared": cleared, "rehashed": rehashed, "discovered": discovered}
+        return {"cleared": cleared, "rehashed": rehashed,
+                "discovered": discovered, "mismatched": mismatched}
 
     def remove_observation_objects(self, observation: str) -> int:
         """Clear local-download state for all storage objects in an observation."""

--- a/python/tests/test_verify_local.py
+++ b/python/tests/test_verify_local.py
@@ -143,6 +143,48 @@ def test_stat_change_new_size_clears(store, products):
     assert _row(store, key)["local_path"] is None
 
 
+def test_stale_row_touch_never_adopts_new_server_hash(store, products):
+    # Codex P1 on #375: cloud object re-deployed (new hash, same size — FITS
+    # block padding makes this common) + any local mtime change must NOT
+    # promote the old bytes to "current", or pull skips the update forever.
+    key, rel = _seed_row(store, content=b"x" * 100)
+    h_old = _row(store, key)["content_hash"]
+    p = _materialize(products, rel)
+    store.verify_local_objects(products)
+
+    _seed_row(store, content=b"y" * 100)  # cloud update: same size, new hash
+    os.utime(p, (2e9, 2e9))  # local touch
+
+    res = store.verify_local_objects(products)
+    row = _row(store, key)
+    assert row["local_file_hash"] == h_old  # honest prior hash kept
+    assert row["local_file_hash"] != row["content_hash"]
+    assert any(s["storage_key"] == key for s in store.get_stale_objects())
+    # mtime bookkeeping refreshed so the next verify no-ops:
+    assert store.verify_local_objects(products) == {
+        "cleared": 0, "rehashed": 0, "discovered": 0, "mismatched": 0}
+
+
+def test_stale_row_rewritten_clears_to_pending(store, products):
+    # Cloud updated to a new size AND the local file rewritten to exactly that
+    # size: the prior hash is void and there's no evidence for the new one —
+    # clear to pending rather than adopt.
+    key, rel = _seed_row(store, content=b"x" * 100)
+    p = _materialize(products, rel)
+    store.verify_local_objects(products)
+
+    _seed_row(store, content=b"y" * 80)  # cloud update: 80 bytes
+    p.write_bytes(b"z" * 80)  # local rewrite, coincidentally matching size
+
+    res = store.verify_local_objects(products)
+    assert res["mismatched"] == 1 and res["cleared"] == 1
+    row = _row(store, key)
+    assert row["local_path"] is None  # pending → pull re-fetches
+    pending = store.get_pending_objects(observations=["obs1"],
+                                        product_types=["nirspec_spec"])
+    assert any(r["storage_key"] == key for r in pending.get("obs1", []))
+
+
 # --- deep mode ------------------------------------------------------------------
 
 def test_deep_hashes_real_content(store, products):

--- a/python/tests/test_verify_local.py
+++ b/python/tests/test_verify_local.py
@@ -1,0 +1,180 @@
+"""verify_local_objects: bulk-scan reconcile with size-match hash adoption.
+
+The reducer-scale regression (CANDIDE, post-#364): a fresh mirror over a
+pipeline-written tree made verify full-hash ~60k files over NFS. Verify is now
+an rsync-style quick check — one scandir pass, adopt the server hash when the
+size matches, read file contents ONLY under --deep.
+"""
+
+import hashlib
+import os
+from pathlib import Path
+
+import pytest
+
+from campfire.db.store import LocalStore
+from campfire.storage.hashing import compute_file_hash
+from campfire_layout import KeyScheme, Scope, storage_key
+
+
+@pytest.fixture()
+def store(tmp_path):
+    s = LocalStore(tmp_path / "campfire.db")
+    yield s
+    s.close()
+
+
+@pytest.fixture()
+def products(tmp_path):
+    d = tmp_path / "products"
+    d.mkdir()
+    return d
+
+
+def _seed_row(store, name="a_spec.fits", obs="obs1", content=b"x" * 100,
+              size=None, content_hash=None, product_type='nirspec_spec'):
+    """Insert a server-mirrored row for a spectrum final; returns (key, rel)."""
+    key = storage_key(product_type, Scope(obs=obs), name, scheme=KeyScheme.CANONICAL)
+    h = content_hash or f"sha256:{hashlib.sha256(content).hexdigest()}"
+    store.upsert_storage_objects([{
+        "storage_key": key, "backend": "osn", "bucket": "data",
+        "content_hash": h, "size_bytes": size if size is not None else len(content),
+        "product_type": product_type, "status": "active", "observation": obs,
+        "updated_at": "2026-07-11T00:00:00+00:00",
+    }])
+    from campfire.config import products_relpath
+    return key, products_relpath(key)
+
+
+def _materialize(products, rel, content=b"x" * 100):
+    p = products / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(content)
+    return p
+
+
+def _row(store, key):
+    return store.get_storage_rows_by_keys([key])[key]
+
+
+# --- adoption (the quick check) ----------------------------------------------
+
+def test_discovery_adopts_server_hash_on_size_match_without_reading(store, products, monkeypatch):
+    key, rel = _seed_row(store)
+    _materialize(products, rel)
+
+    # No file content may be read on the default path.
+    import campfire.db.store as store_mod
+    def _boom(*a, **k):
+        raise AssertionError("default verify must not hash file contents")
+    monkeypatch.setattr("campfire.storage.hashing.hash_file", _boom)
+
+    res = store.verify_local_objects(products)
+    assert res["discovered"] == 1 and res["mismatched"] == 0
+    row = _row(store, key)
+    assert row["local_path"] == rel
+    assert row["local_file_hash"] == row["content_hash"]  # adopted, not computed
+    assert row["local_file_size"] == 100
+
+
+def test_size_mismatch_left_pending_not_adopted(store, products):
+    key, rel = _seed_row(store, content=b"x" * 100)
+    _materialize(products, rel, content=b"x" * 37)  # truncated/partial
+
+    res = store.verify_local_objects(products)
+    assert res["discovered"] == 0
+    assert res["mismatched"] == 1
+    row = _row(store, key)
+    assert row["local_path"] is None  # stays pending → pull re-fetches
+    # And the pull differ agrees:
+    pending = store.get_pending_objects(observations=["obs1"],
+                                        product_types=["nirspec_spec"])
+    assert any(r["storage_key"] == key for r in pending.get("obs1", []))
+
+
+def test_etag_row_not_adopted(store, products):
+    # Provisional etag: hashes are not authoritative — never presume them.
+    key, rel = _seed_row(store, content_hash="etag:abc123")
+    _materialize(products, rel)
+    res = store.verify_local_objects(products)
+    assert res["discovered"] == 0 and res["mismatched"] == 1
+
+
+# --- tracked-row transitions ---------------------------------------------------
+
+def test_vanished_file_cleared(store, products):
+    key, rel = _seed_row(store)
+    p = _materialize(products, rel)
+    store.verify_local_objects(products)
+    p.unlink()
+
+    res = store.verify_local_objects(products)
+    assert res["cleared"] == 1
+    assert _row(store, key)["local_path"] is None
+
+
+def test_unchanged_stat_is_noop(store, products):
+    key, rel = _seed_row(store)
+    _materialize(products, rel)
+    store.verify_local_objects(products)
+    res = store.verify_local_objects(products)
+    assert res == {"cleared": 0, "rehashed": 0, "discovered": 0, "mismatched": 0}
+
+
+def test_stat_change_same_size_readopts(store, products):
+    key, rel = _seed_row(store)
+    p = _materialize(products, rel)
+    store.verify_local_objects(products)
+    os.utime(p, (1e9, 1e9))  # touch: mtime changes, size unchanged
+
+    res = store.verify_local_objects(products)
+    assert res["rehashed"] == 1  # refreshed via adoption
+    assert abs(_row(store, key)["local_file_mtime"] - 1e9) < 1e-3
+
+
+def test_stat_change_new_size_clears(store, products):
+    key, rel = _seed_row(store, content=b"x" * 100)
+    p = _materialize(products, rel)
+    store.verify_local_objects(products)
+    p.write_bytes(b"y" * 55)  # rewritten with different size
+
+    res = store.verify_local_objects(products)
+    assert res["mismatched"] == 1 and res["cleared"] == 1
+    assert _row(store, key)["local_path"] is None
+
+
+# --- deep mode ------------------------------------------------------------------
+
+def test_deep_hashes_real_content(store, products):
+    content = b"real-bytes"
+    key, rel = _seed_row(store, content=b"x" * len(content))  # server hash differs
+    p = _materialize(products, rel, content=content)
+
+    res = store.verify_local_objects(products, deep=True)
+    assert res["discovered"] == 1
+    row = _row(store, key)
+    assert row["local_file_hash"] == compute_file_hash(p)
+    assert row["local_file_hash"] != row["content_hash"]  # true state recorded
+    # A content mismatch recorded under --deep shows up as stale:
+    assert any(s["storage_key"] == key for s in store.get_stale_objects())
+
+
+# --- scoping ---------------------------------------------------------------------
+
+def test_scoped_verify_only_touches_selection(store, products):
+    k1, r1 = _seed_row(store, name="a_spec.fits", obs="obs1")
+    k2, r2 = _seed_row(store, name="b_spec.fits", obs="obs2")
+    _materialize(products, r1)
+    _materialize(products, r2)
+
+    res = store.verify_local_objects(products, observations=["obs1"])
+    assert res["discovered"] == 1
+    assert _row(store, k1)["local_path"] == r1
+    assert _row(store, k2)["local_path"] is None  # out of scope, untouched
+
+
+def test_legacy_observation_kwarg_still_works(store, products):
+    key, rel = _seed_row(store, obs="obs1")
+    _materialize(products, rel)
+    res = store.verify_local_objects(products, observation="obs1")
+    assert res["discovered"] == 1


### PR DESCRIPTION
## Problem (found live on CANDIDE)

First `campfire sync` on a reducer machine after #364: the verify step ran at **1.5 files/s with a 10-hour ETA**. Two compounding causes:

1. **Discovery full-hashes every locally-present file.** A fresh mirror marks all ~60k downloadable rows untracked; on a reducer, the pipeline wrote files at exactly the canonical paths, so discovery finds nearly all of them — and filling `local_file_hash` meant reading each file end-to-end. Hundreds of GB over NFS.
2. **Serial per-file stats** — 60k individual getattr round-trips even before any hashing.

## Fix: rsync-style quick check

- **One bulk scan, no per-file stats:** candidate directories are derived from the keys (~#obs + #field×filter dirs) and listed with `os.scandir` — READDIRPLUS/`getattrlistbulk`-friendly, threaded across directories.
- **Size-match hash adoption, no file reads:** a present file whose size matches the server's `size_bytes` adopts the server `content_hash` as its local hash. This is a presumption, not a verification — accepted trade-off (discussed with @hollisakins): same-size silent corruption goes undetected; truncation/partials fail the size check and stay pending so `pull` re-fetches. `etag:` rows are never adopted.
- **`campfire verify --deep`** restores true content hashing (parallel, changed/discovered files only). Hashing remains load-bearing where it matters regardless: downloads stream-verify against `content_hash`, push hashes changed candidates for dedup identity, `drop-local --verify` content-verifies before deleting.
- **Verify stays in `sync`** — frequent drift detection is the design intent; it just had to be cheap enough to be frequent. `pull`'s pre-flight verify is now scoped to its selection (`observations`/`fields` params).
- New `mismatched` count surfaced in `sync`/`pull`/`verify` output.

## Numbers

Synthetic reducer-shaped tree (60k rows/files, 200 dirs, local SSD):

| | before | after |
|---|---|---|
| fresh mirror, all files present | full read of every file (hours; 10h+ on NFS) | **1.8 s** |
| no-op re-verify | 60k serial stats | **1.3 s** |

On CANDIDE the scan is ~200 threaded directory listings instead of 60k serial getattrs + full reads.

## Tests

10 new (`test_verify_local.py`): adoption without reads (enforced by monkeypatch), size-mismatch → pending + pull-differ agreement, etag guard, vanish/touch/rewrite transitions, `--deep` records true state + staleness, scoping, legacy kwarg compat. **459 total green.** No schema or web changes.

Generated with Claude Code