### PR TITLE
feat(db): first-class fields table + NIRCam field-summary RPCs (redesign PR 3/5, #303)

### DIFF
--- a/supabase/migrations/20260711211348_nircam_fields_table.sql
+++ b/supabase/migrations/20260711211348_nircam_fields_table.sql
@@ -1,0 +1,190 @@
+-- NIRCam field registry (issue #303) — the first-class `fields` table, the
+-- missing third leg of the cloud-as-source-of-truth config loop (programs /
+-- observations / fields), symmetric with `observations`. Plus the two read RPCs
+-- for the NIRCam page redesign.
+--
+-- NOTE: the spurious `drop … / create` churn for mv_filter_options,
+-- mv_programs_overview, nircam_reduction_progress, and spectrum_flag_summary that
+-- `supabase db diff` emits (migra cannot track (mat)views) has been stripped —
+-- this migration touches only the new fields table + RPCs + the storage_objects
+-- product_type CHECK.
+
+-- Allow the three new deployable NIRCam product types (registered in the layout
+-- contract in the prior PR) so the deploy can register them in storage_objects.
+alter table "public"."storage_objects" drop constraint "storage_objects_product_type_check";
+
+alter table "public"."storage_objects" add constraint "storage_objects_product_type_check" CHECK ((product_type = ANY (ARRAY['nirspec_spec'::text, 'spectrum_json'::text, 'zfit'::text, 'nirspec_spectrum_exposure'::text, 'nirspec_rate'::text, 'rgb'::text, 'sed'::text, 'nircam_exposure'::text, 'nircam_exposure_preview'::text, 'nircam_exposure_full'::text, 'nircam_mosaic'::text, 'nircam_rgb'::text, 'nircam_expmap'::text, 'nircam_expmap_plot'::text, 'nircam_mosaic_thumbnail'::text, 'nircam_layout'::text, 'tile'::text, 'photometry_pz'::text, 'nirspec_manual_mask'::text, 'nirspec_stuck_shutters'::text, 'nirspec_bkg_override'::text, 'nircam_mask'::text, 'nircam_astrom_cat'::text, 'nircam_bad_pixel'::text, 'nircam_flat'::text, 'nircam_wisp'::text]))) not valid;
+
+alter table "public"."storage_objects" validate constraint "storage_objects_product_type_check";
+
+
+  create table "public"."fields" (
+    "name" text not null,
+    "display_name" text,
+    "filters" text[] not null default '{}'::text[],
+    "tiles" text[] not null default '{}'::text[],
+    "fiducial_tiles" text[] not null default '{}'::text[],
+    "epochs" text[] not null default '{}'::text[],
+    "programs" text[] not null default '{}'::text[],
+    "jwst_program_ids" integer[] not null default '{}'::integer[],
+    "file_globs" text[] not null default '{}'::text[],
+    "center_ra" double precision,
+    "center_dec" double precision,
+    "config" jsonb,
+    "coverage_area_arcmin2" double precision,
+    "coverage_area_deg2" double precision,
+    "latest_deployment_id" integer,
+    "created_at" timestamp with time zone default now()
+      );
+
+
+alter table "public"."fields" enable row level security;
+
+CREATE UNIQUE INDEX fields_pkey ON public.fields USING btree (name);
+
+alter table "public"."fields" add constraint "fields_pkey" PRIMARY KEY using index "fields_pkey";
+
+alter table "public"."fields" add constraint "fields_latest_deployment_fkey" FOREIGN KEY (latest_deployment_id) REFERENCES public.deployments(id) ON DELETE SET NULL not valid;
+
+alter table "public"."fields" validate constraint "fields_latest_deployment_fkey";
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_nircam_field_summary(p_field text)
+ RETURNS TABLE(field text, display_name text, center_ra double precision, center_dec double precision, coverage_area_arcmin2 double precision, coverage_area_deg2 double precision, filters text[], tiles text[], pixel_scales text[], extensions text[], epochs text[], n_files bigint, total_bytes bigint, last_updated timestamp without time zone, layout_key text)
+ LANGUAGE sql
+ STABLE
+ SET search_path TO 'public'
+AS $function$
+  SELECT
+    ni.field,
+    COALESCE(f.display_name, upper(ni.field)) AS display_name,
+    f.center_ra,
+    f.center_dec,
+    f.coverage_area_arcmin2,
+    f.coverage_area_deg2,
+    array_agg(DISTINCT ni.filter ORDER BY ni.filter)           AS filters,
+    array_agg(DISTINCT ni.tile ORDER BY ni.tile)               AS tiles,
+    array_agg(DISTINCT ni.pixel_scale ORDER BY ni.pixel_scale) AS pixel_scales,
+    array_agg(DISTINCT ni.extension ORDER BY ni.extension)     AS extensions,
+    array_agg(DISTINCT ni.epoch ORDER BY ni.epoch)             AS epochs,
+    COUNT(*)::bigint                       AS n_files,
+    COALESCE(SUM(ni.file_size), 0)::bigint AS total_bytes,
+    MAX(ni.created_at)                     AS last_updated,
+    (SELECT so.storage_key FROM storage_objects so
+       WHERE so.product_type = 'nircam_layout'
+         AND so.field = ni.field
+         AND so.status = 'active'
+       LIMIT 1)                            AS layout_key
+  FROM nircam_images ni
+  LEFT JOIN fields f ON f.name = ni.field
+  WHERE ni.field = p_field
+  GROUP BY ni.field, f.display_name, f.center_ra, f.center_dec,
+           f.coverage_area_arcmin2, f.coverage_area_deg2;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_nircam_fields()
+ RETURNS TABLE(field text, display_name text, center_ra double precision, center_dec double precision, coverage_area_arcmin2 double precision, coverage_area_deg2 double precision, n_filters integer, n_tiles integer, n_files bigint, total_bytes bigint, last_updated timestamp without time zone, layout_key text)
+ LANGUAGE sql
+ STABLE
+ SET search_path TO 'public'
+AS $function$
+  SELECT
+    ni.field,
+    COALESCE(f.display_name, upper(ni.field)) AS display_name,
+    f.center_ra,
+    f.center_dec,
+    f.coverage_area_arcmin2,
+    f.coverage_area_deg2,
+    COUNT(DISTINCT ni.filter)::integer AS n_filters,
+    COUNT(DISTINCT ni.tile)::integer   AS n_tiles,
+    COUNT(*)::bigint                    AS n_files,
+    COALESCE(SUM(ni.file_size), 0)::bigint AS total_bytes,
+    MAX(ni.created_at)                  AS last_updated,
+    (SELECT so.storage_key FROM storage_objects so
+       WHERE so.product_type = 'nircam_layout'
+         AND so.field = ni.field
+         AND so.status = 'active'
+       LIMIT 1)                         AS layout_key
+  FROM nircam_images ni
+  LEFT JOIN fields f ON f.name = ni.field
+  GROUP BY ni.field, f.display_name, f.center_ra, f.center_dec,
+           f.coverage_area_arcmin2, f.coverage_area_deg2
+  ORDER BY ni.field;
+$function$
+;
+
+grant delete on table "public"."fields" to "anon";
+
+grant insert on table "public"."fields" to "anon";
+
+grant references on table "public"."fields" to "anon";
+
+grant select on table "public"."fields" to "anon";
+
+grant trigger on table "public"."fields" to "anon";
+
+grant truncate on table "public"."fields" to "anon";
+
+grant update on table "public"."fields" to "anon";
+
+grant delete on table "public"."fields" to "authenticated";
+
+grant insert on table "public"."fields" to "authenticated";
+
+grant references on table "public"."fields" to "authenticated";
+
+grant select on table "public"."fields" to "authenticated";
+
+grant trigger on table "public"."fields" to "authenticated";
+
+grant truncate on table "public"."fields" to "authenticated";
+
+grant update on table "public"."fields" to "authenticated";
+
+grant delete on table "public"."fields" to "service_role";
+
+grant insert on table "public"."fields" to "service_role";
+
+grant references on table "public"."fields" to "service_role";
+
+grant select on table "public"."fields" to "service_role";
+
+grant trigger on table "public"."fields" to "service_role";
+
+grant truncate on table "public"."fields" to "service_role";
+
+grant update on table "public"."fields" to "service_role";
+
+
+  create policy "accessible_fields_select"
+  on "public"."fields"
+  as permissive
+  for select
+  to authenticated
+using (((EXISTS ( SELECT 1
+   FROM public.nircam_images ni
+  WHERE ((ni.field = fields.name) AND (ni.deploy_status = 'published'::text)))) OR ( SELECT public.is_admin() AS is_admin)));
+
+
+
+  create policy "admin_fields_insert"
+  on "public"."fields"
+  as permissive
+  for insert
+  to authenticated
+with check (( SELECT public.is_admin() AS is_admin));
+
+
+
+  create policy "admin_fields_update"
+  on "public"."fields"
+  as permissive
+  for update
+  to authenticated
+using (( SELECT public.is_admin() AS is_admin))
+with check (( SELECT public.is_admin() AS is_admin));
+
+
+

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -127,6 +127,114 @@ GRANT EXECUTE ON FUNCTION public.fitsgl_dataset_is_public(text, text[], text[], 
 
 
 -- =============================================================================
+-- NIRCam field summaries  (NIRCam page redesign; issue #303 fields table)
+-- =============================================================================
+-- Both are SECURITY INVOKER: nircam_images RLS (deploy_status = 'published' OR
+-- is_admin()) does the visibility gating, so non-admins get published-only
+-- aggregates and admins see everything with no manual deploy_status filter.
+-- Driven by nircam_images so only fields with visible mosaics appear; the fields
+-- table (LEFT JOIN) supplies display_name / center / coverage_area, and
+-- storage_objects supplies the deployed layout-plot key for the card preview.
+
+-- Landing grid: one row per field the caller can see any mosaic of.
+CREATE OR REPLACE FUNCTION public.get_nircam_fields()
+RETURNS TABLE(
+  field text,
+  display_name text,
+  center_ra double precision,
+  center_dec double precision,
+  coverage_area_arcmin2 double precision,
+  coverage_area_deg2 double precision,
+  n_filters integer,
+  n_tiles integer,
+  n_files bigint,
+  total_bytes bigint,
+  last_updated timestamp without time zone,
+  layout_key text
+)
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public
+AS $$
+  SELECT
+    ni.field,
+    COALESCE(f.display_name, upper(ni.field)) AS display_name,
+    f.center_ra,
+    f.center_dec,
+    f.coverage_area_arcmin2,
+    f.coverage_area_deg2,
+    COUNT(DISTINCT ni.filter)::integer AS n_filters,
+    COUNT(DISTINCT ni.tile)::integer   AS n_tiles,
+    COUNT(*)::bigint                    AS n_files,
+    COALESCE(SUM(ni.file_size), 0)::bigint AS total_bytes,
+    MAX(ni.created_at)                  AS last_updated,
+    (SELECT so.storage_key FROM storage_objects so
+       WHERE so.product_type = 'nircam_layout'
+         AND so.field = ni.field
+         AND so.status = 'active'
+       LIMIT 1)                         AS layout_key
+  FROM nircam_images ni
+  LEFT JOIN fields f ON f.name = ni.field
+  GROUP BY ni.field, f.display_name, f.center_ra, f.center_dec,
+           f.coverage_area_arcmin2, f.coverage_area_deg2
+  ORDER BY ni.field;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_nircam_fields() TO authenticated;
+
+
+-- Field detail page: the single-field version with the facet arrays.
+CREATE OR REPLACE FUNCTION public.get_nircam_field_summary(p_field text)
+RETURNS TABLE(
+  field text,
+  display_name text,
+  center_ra double precision,
+  center_dec double precision,
+  coverage_area_arcmin2 double precision,
+  coverage_area_deg2 double precision,
+  filters text[],
+  tiles text[],
+  pixel_scales text[],
+  extensions text[],
+  epochs text[],
+  n_files bigint,
+  total_bytes bigint,
+  last_updated timestamp without time zone,
+  layout_key text
+)
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path = public
+AS $$
+  SELECT
+    ni.field,
+    COALESCE(f.display_name, upper(ni.field)) AS display_name,
+    f.center_ra,
+    f.center_dec,
+    f.coverage_area_arcmin2,
+    f.coverage_area_deg2,
+    array_agg(DISTINCT ni.filter ORDER BY ni.filter)           AS filters,
+    array_agg(DISTINCT ni.tile ORDER BY ni.tile)               AS tiles,
+    array_agg(DISTINCT ni.pixel_scale ORDER BY ni.pixel_scale) AS pixel_scales,
+    array_agg(DISTINCT ni.extension ORDER BY ni.extension)     AS extensions,
+    array_agg(DISTINCT ni.epoch ORDER BY ni.epoch)             AS epochs,
+    COUNT(*)::bigint                       AS n_files,
+    COALESCE(SUM(ni.file_size), 0)::bigint AS total_bytes,
+    MAX(ni.created_at)                     AS last_updated,
+    (SELECT so.storage_key FROM storage_objects so
+       WHERE so.product_type = 'nircam_layout'
+         AND so.field = ni.field
+         AND so.status = 'active'
+       LIMIT 1)                            AS layout_key
+  FROM nircam_images ni
+  LEFT JOIN fields f ON f.name = ni.field
+  WHERE ni.field = p_field
+  GROUP BY ni.field, f.display_name, f.center_ra, f.center_dec,
+           f.coverage_area_arcmin2, f.coverage_area_deg2;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_nircam_field_summary(text) TO authenticated;
+
+
+-- =============================================================================
 -- object_scoped_aggregates
 -- =============================================================================
 -- Viewer-scoped recompute of an object's aggregate columns.

--- a/supabase/schemas/policies.sql
+++ b/supabase/schemas/policies.sql
@@ -120,6 +120,39 @@ CREATE POLICY "admin_programs_update"
 
 
 -- =============================================================================
+-- fields  (issue #303 — NIRCam field registry)
+-- =============================================================================
+
+ALTER TABLE fields ENABLE ROW LEVEL SECURITY;
+
+-- A field is visible once it has at least one published NIRCam mosaic — mirrors
+-- the deploy_status gate on nircam_images so a field's config (name, filters,
+-- tangent point) is not exposed while its data is still draft. Admins see all.
+DROP POLICY IF EXISTS "accessible_fields_select" ON fields;
+CREATE POLICY "accessible_fields_select"
+  ON fields FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM nircam_images ni
+      WHERE ni.field = fields.name AND ni.deploy_status = 'published'
+    )
+    OR (SELECT public.is_admin())
+  );
+
+-- Admins can insert/update fields (deploy CLI: sync-fields + nircam deploy).
+DROP POLICY IF EXISTS "admin_fields_insert" ON fields;
+CREATE POLICY "admin_fields_insert"
+  ON fields FOR INSERT TO authenticated
+  WITH CHECK ((SELECT public.is_admin()));
+
+DROP POLICY IF EXISTS "admin_fields_update" ON fields;
+CREATE POLICY "admin_fields_update"
+  ON fields FOR UPDATE TO authenticated
+  USING ((SELECT public.is_admin()))
+  WITH CHECK ((SELECT public.is_admin()));
+
+
+-- =============================================================================
 -- observations
 -- =============================================================================
 

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -721,6 +721,41 @@ CREATE TABLE IF NOT EXISTS "public"."programs" (
 ALTER TABLE "public"."programs" OWNER TO "postgres";
 
 
+-- First-class NIRCam field registry (issue #303) — the missing third leg of the
+-- cloud-as-source-of-truth config loop (programs / observations / fields),
+-- symmetric with `observations`. Synced from fields.toml, scoped to fields that
+-- already have deployed NIRCam data, so the cloud table reflects what is actually
+-- reduced. The full fields.toml section is mirrored losslessly into `config`
+-- (jsonb) so nothing — nested tile WCS, jhat, wcs_shift, epoch defs — is dropped;
+-- the commonly-queried bits are also lifted into typed columns. `latest_deployment_id`
+-- mirrors observations. `coverage_area_*` are deploy-computed from <field>_layout.json
+-- (exact survey area = non-zero pixels of the stacked exposure map x pixel area);
+-- sync-fields upserts only config columns so it never clobbers them. Read by
+-- get_nircam_fields / get_nircam_field_summary.
+CREATE TABLE IF NOT EXISTS "public"."fields" (
+    "name" "text" NOT NULL,
+    "display_name" "text",
+    "filters" "text"[] NOT NULL DEFAULT '{}',
+    "tiles" "text"[] NOT NULL DEFAULT '{}',
+    "fiducial_tiles" "text"[] NOT NULL DEFAULT '{}',
+    "epochs" "text"[] NOT NULL DEFAULT '{}',
+    "programs" "text"[] NOT NULL DEFAULT '{}',
+    "jwst_program_ids" integer[] NOT NULL DEFAULT '{}',
+    "file_globs" "text"[] NOT NULL DEFAULT '{}',
+    "center_ra" double precision,
+    "center_dec" double precision,
+    "config" "jsonb",
+    "coverage_area_arcmin2" double precision,
+    "coverage_area_deg2" double precision,
+    "latest_deployment_id" integer,
+    "created_at" timestamp with time zone DEFAULT "now"(),
+    CONSTRAINT "fields_pkey" PRIMARY KEY ("name")
+);
+
+
+ALTER TABLE "public"."fields" OWNER TO "postgres";
+
+
 -- One logical mosaic per (field, tile, filter, pixel_scale, extension, epoch).
 -- The `version` axis is retired (epic #261, N2 / D3): the pipeline emits a
 -- single canonical mosaic name per slot and re-combine overwrites it in place.
@@ -1012,7 +1047,9 @@ CREATE TABLE IF NOT EXISTS "public"."storage_objects" (
         'rgb'::"text", 'sed'::"text",
         'nircam_exposure'::"text", 'nircam_exposure_preview'::"text",
         'nircam_exposure_full'::"text", 'nircam_mosaic'::"text", 'nircam_rgb'::"text",
-        'nircam_expmap'::"text", 'tile'::"text", 'photometry_pz'::"text",
+        'nircam_expmap'::"text", 'nircam_expmap_plot'::"text",
+        'nircam_mosaic_thumbnail'::"text", 'nircam_layout'::"text",
+        'tile'::"text", 'photometry_pz'::"text",
         'nirspec_manual_mask'::"text", 'nirspec_stuck_shutters'::"text",
         'nirspec_bkg_override'::"text", 'nircam_mask'::"text", 'nircam_astrom_cat'::"text",
         'nircam_bad_pixel'::"text", 'nircam_flat'::"text", 'nircam_wisp'::"text"
@@ -1964,6 +2001,9 @@ ALTER TABLE ONLY "public"."observations"
 ALTER TABLE ONLY "public"."observations"
     ADD CONSTRAINT "observations_latest_deployment_fkey" FOREIGN KEY ("latest_deployment_id") REFERENCES "public"."deployments"("id");
 
+ALTER TABLE ONLY "public"."fields"
+    ADD CONSTRAINT "fields_latest_deployment_fkey" FOREIGN KEY ("latest_deployment_id") REFERENCES "public"."deployments"("id") ON DELETE SET NULL;
+
 
 
 ALTER TABLE ONLY "public"."password_reset_log"
@@ -2164,6 +2204,11 @@ GRANT ALL ON TABLE "public"."observations" TO "service_role";
 GRANT ALL ON TABLE "public"."programs" TO "anon";
 GRANT ALL ON TABLE "public"."programs" TO "authenticated";
 GRANT ALL ON TABLE "public"."programs" TO "service_role";
+
+
+GRANT ALL ON TABLE "public"."fields" TO "anon";
+GRANT ALL ON TABLE "public"."fields" TO "authenticated";
+GRANT ALL ON TABLE "public"."fields" TO "service_role";
 
 
 


### PR DESCRIPTION
**PR 3 of 5** in the NIRCam page redesign stack. **Stacked on #374** (base `feat/nircam-redesign-p2-layout`). Implements the `fields`-table leg of **#303** (cloud as source of truth for data-management config).

## What this adds
- **`fields` table** — the missing third leg of the config loop (programs / observations / **fields**), symmetric with `observations`. Synced from `fields.toml`: the full section is mirrored losslessly into a `config` jsonb, with the commonly-queried bits (`filters`, `tiles`, `fiducial_tiles`, `epochs`, `programs`, `jwst_program_ids`, `file_globs`, center RA/Dec) lifted into typed columns. Carries deploy-computed `coverage_area_arcmin2/deg2` (the exact survey area from PR 1's stacked expmap) and a `latest_deployment_id` pointer. Per @hollisakins' guidance, the deploy layer (PR 4) scopes the upsert to **fields that already have deployed NIRCam data**, so the cloud table reflects what's actually reduced.
- **RLS** — a field is visible once it has ≥1 **published** nircam mosaic (mirrors the `deploy_status` gate on `nircam_images` so config isn't exposed while data is draft); admins see all.
- **`get_nircam_fields()` / `get_nircam_field_summary(field)`** — `SECURITY INVOKER` read RPCs. Visibility rides `nircam_images` RLS (non-admins get published-only aggregates), `LEFT JOIN fields` supplies metadata + area, `storage_objects` supplies the deployed layout-plot key for the card preview.
- **`storage_objects.product_type` CHECK** extended for the three new PR-2 product types (`nircam_expmap_plot` / `nircam_mosaic_thumbnail` / `nircam_layout`). The CHECK is an enum, **not free-form** as I'd assumed — the deploy in PR 4 would have failed to register them. Caught during RLS testing.

## Verification (local Postgres)
- `supabase db reset` + seed apply cleanly.
- RPCs + `fields` RLS gate correctly for **admin vs non-admin**: a draft-only field is absent, published-only counts exclude draft tiles, a draft field's summary is empty. (Watch out: the seed's admin test user is `1111…-1111` — using it as the "non-admin" masks RLS.)
- Migra's spurious `(mat)view` drop/recreate churn stripped from the generated migration (mv_filter_options, mv_programs_overview, nircam_reduction_progress, spectrum_flag_summary).

## Notes / follow-ups
- This is a partial implementation of #303 (the `fields` leg); the uniform config-sync contract + delete/rename semantics for programs/observations remain open there.
- Seed has no NIRCam data, so `fields` stays empty in preview; PR 5 (web) will add a sample row if needed for the landing preview.

## Stack
1. #373 — pipeline plots + area
2. #374 — layout contract
3. **This PR** — fields table + RPCs
4. Deploy (sync-fields + register artifacts + write area)
5. Web routes

Generated with Claude Code