### PR TITLE
feat(deploy): ship expmap/thumbnail/layout artifacts + sync fields table (redesign PR 4/5, #303)

### DIFF
--- a/python/campfire/deploy/cli.py
+++ b/python/campfire/deploy/cli.py
@@ -1338,6 +1338,42 @@ def sync_programs(ctx, config_path, dry_run, local):
 
 
 # ---------------------------------------------------------------------------
+# sync-fields subcommand  (issue #303)
+# ---------------------------------------------------------------------------
+
+@deploy_group.command('sync-fields')
+@click.option('--config', 'config_path', default=None, help='Path to deploy config TOML.')
+@click.option('--field', default=None,
+              help='Sync a single field (default: every field with deployed data).')
+@click.option('--dry-run', is_flag=True, help='Show what would happen without making changes.')
+@click.option('--local', is_flag=True,
+              help='Use local Supabase (127.0.0.1:54321).')
+@click.pass_context
+def sync_fields_cmd(ctx, config_path, field, dry_run, local):
+    """Upsert fields.toml config into the cloud `fields` table (issue #303).
+
+    Scoped to fields that already have deployed NIRCam data (or a single
+    ``--field``). Only the config columns are written — the deploy-computed
+    coverage area and latest_deployment_id (owned by ``campfire deploy --field``)
+    are left untouched.
+    """
+    from campfire.deploy.fields import load_fields_toml, sync_fields
+
+    if not load_fields_toml():
+        print("No fields.toml found (or empty) at $CAMPFIRE_ROOT/config/.")
+        return
+
+    config = load_config(config_path, local=_resolve_local(ctx, local))
+    sb = get_supabase_client(config)
+
+    field_names = [field] if field else None
+    print("Syncing fields.toml -> fields table"
+          + (f" (field={field})" if field else " (all deployed fields)"))
+    n = sync_fields(sb, field_names, dry_run=dry_run)
+    print("\nDry run — no changes made." if dry_run else f"\nDone. Synced {n} field(s).")
+
+
+# ---------------------------------------------------------------------------
 # fetch-config subcommand
 # ---------------------------------------------------------------------------
 

--- a/python/campfire/deploy/fields.py
+++ b/python/campfire/deploy/fields.py
@@ -1,0 +1,152 @@
+"""fields.toml -> the cloud `fields` table (issue #303).
+
+The NIRCam field registry: the third leg of the cloud-as-source-of-truth config
+loop (programs / observations / fields). The full fields.toml section is mirrored
+losslessly into the `config` jsonb column; the commonly-queried bits are lifted
+into typed columns.
+
+`coverage_area_*` and `latest_deployment_id` are **deploy-owned** — written by
+`deploy_nircam` from `<field>_layout.json` — so `sync_fields` never sends them and
+the upsert leaves them untouched on existing rows (PostgREST merge-duplicates only
+updates the columns present in the payload).
+
+Scoped to fields that already have deployed NIRCam data, so the cloud table
+reflects what is actually reduced, not every field defined locally.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+
+from .config import _load_toml
+
+# JWST rootname program id: jwPPPPP... (the leading 5-digit program number).
+_PID_RE = re.compile(r"jw(\d{5})")
+
+
+def _fields_toml_path() -> Path:
+    root = os.environ.get("CAMPFIRE_ROOT")
+    if not root:
+        raise RuntimeError("$CAMPFIRE_ROOT is not set")
+    return Path(root) / "config" / "fields.toml"
+
+
+def load_fields_toml() -> dict:
+    """Full parsed fields.toml (``{}`` if the file is absent)."""
+    path = _fields_toml_path()
+    return _load_toml(path) if path.exists() else {}
+
+
+def _as_list(value) -> list:
+    if value is None:
+        return []
+    return [value] if isinstance(value, str) else list(value)
+
+
+def field_config_row(field: str, section: dict) -> dict:
+    """Map a fields.toml ``[<field>]`` section to the `fields` config columns.
+
+    Lossless: the whole section rides in ``config`` (jsonb); the rest are lifted
+    for querying. Tile names are the section's dict-valued sub-tables minus the
+    reserved ``epochs`` table. Program ids are the 5-digit ids embedded in the
+    ``files`` globs (``jwPPPPP*``). Program *slugs* are left empty — programs.toml
+    carries no program-id map, so slug resolution is deferred (issue #303).
+    """
+    tp = _as_list(section.get("tangent_point"))
+    globs = _as_list(section.get("files"))
+    pids = sorted({int(m.group(1)) for g in globs
+                   for m in [_PID_RE.search(g)] if m})
+    tiles = sorted(k for k, v in section.items()
+                   if isinstance(v, dict) and k != "epochs")
+    epochs = sorted((section.get("epochs") or {}).keys())
+    return {
+        "name": field,
+        "display_name": section.get("display_name"),  # None -> RPC derives upper()
+        "filters": _as_list(section.get("filters")),
+        "tiles": tiles,
+        "fiducial_tiles": _as_list(section.get("fiducial_tiles")),
+        "epochs": epochs,
+        "programs": [],  # slug resolution deferred (no program-id map in programs.toml)
+        "jwst_program_ids": pids,
+        "file_globs": globs,
+        "center_ra": tp[0] if len(tp) > 0 else None,
+        "center_dec": tp[1] if len(tp) > 1 else None,
+        "config": section,
+    }
+
+
+def read_layout_coverage(products_dir, field: str) -> dict | None:
+    """Parse ``<field>_layout.json`` (the deploy-computed survey area), or None."""
+    path = Path(products_dir) / f"{field}_layout.json"
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def upsert_field(client, row: dict) -> None:
+    """Upsert one `fields` row (on conflict = name). Only the keys present in
+    ``row`` are written, so a config-only sync leaves the deploy-owned columns
+    (coverage_area_*, latest_deployment_id) untouched on existing rows."""
+    client.table("fields").upsert(row, on_conflict="name").execute()
+
+
+def upsert_field_on_deploy(client, products_dir, field: str,
+                           deployment_id: int | None) -> bool:
+    """Ride ``deploy_nircam``: sync the field's fields.toml config AND write the
+    deploy-owned columns (coverage area from ``<field>_layout.json``,
+    latest_deployment_id). Returns True if a row was upserted."""
+    section = load_fields_toml().get(field)
+    if section is None:
+        print(f"  fields: '{field}' not in fields.toml — skipping registry upsert")
+        return False
+    row = field_config_row(field, section)
+    if deployment_id is not None:
+        row["latest_deployment_id"] = deployment_id
+    coverage = read_layout_coverage(products_dir, field)
+    area_msg = ""
+    if coverage and coverage.get("coverage_area_arcmin2") is not None:
+        row["coverage_area_arcmin2"] = coverage["coverage_area_arcmin2"]
+        row["coverage_area_deg2"] = coverage.get("coverage_area_deg2")
+        area_msg = f", area {coverage['coverage_area_arcmin2']:.1f} arcmin2"
+    upsert_field(client, row)
+    print(f"  fields: upserted '{field}' "
+          f"({len(row['filters'])} filters, {len(row['tiles'])} tiles{area_msg})")
+    return True
+
+
+def deployed_field_names(client) -> list[str]:
+    """Field names that already have a deployment — the scope for sync-fields."""
+    resp = client.table("deployments").select("field").execute()
+    return sorted({r["field"] for r in (resp.data or []) if r.get("field")})
+
+
+def sync_fields(client, field_names=None, *, dry_run=False) -> int:
+    """Upsert the fields.toml **config** (only) for the given fields — or, when
+    ``field_names`` is None, for every field that already has deployed data.
+    Never touches the deploy-owned coverage/deployment columns. Returns the count
+    upserted."""
+    toml = load_fields_toml()
+    if field_names is None:
+        field_names = deployed_field_names(client)
+    n = 0
+    for name in field_names:
+        section = toml.get(name)
+        if section is None:
+            print(f"  ! {name}: not in fields.toml — skipping")
+            continue
+        row = field_config_row(name, section)
+        if dry_run:
+            print(f"  would sync {name} "
+                  f"({len(row['filters'])} filters, {len(row['tiles'])} tiles, "
+                  f"pids {row['jwst_program_ids']})")
+            continue
+        upsert_field(client, row)
+        print(f"  + {name}")
+        n += 1
+    return n

--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -53,6 +53,7 @@ from campfire.deploy.supabase import (
 # also land here under canonical keys (served via presigned OSN GET URLs).
 _CANONICAL_BACKEND = 'osn'
 _FITS_CONTENT_TYPE = 'application/fits'
+_PNG_CONTENT_TYPE = 'image/png'
 
 
 # ---------------------------------------------------------------------------
@@ -356,20 +357,31 @@ def build_fits_upload_tasks(field, exposures):
 # raw quick-look, and ``_canonical`` is the pre-rename legacy name for what is now
 # the undecorated fiducial (a stale copy may still sit on a reducer's disk). Deploy
 # ships only the fiducial map so users download a single, unqualified exposure map.
-_EXPMAP_NONFIDUCIAL_SUFFIXES = ('_uncal.fits', '_canonical.fits')
+# Reducer-only quick-look / pre-rename leftovers, keyed on the filename *stem*
+# so the check covers both the .fits map and its .png plot.
+_EXPMAP_NONFIDUCIAL_STEMS = ('_uncal', '_canonical')
+
+# The per-filter expmap products deployed together: the coverage FITS and the
+# dark web plot PNG (NIRCam page redesign). product_type is key-derived at
+# registration, so each just needs its canonical key + content type.
+_EXPMAP_DEPLOY = (
+    ('expmap_*.fits', 'nircam_expmap', _FITS_CONTENT_TYPE),
+    ('expmap_*.png', 'nircam_expmap_plot', _PNG_CONTENT_TYPE),
+)
 
 
 def discover_expmap_tasks(dirs, field, filters):
-    """Build canonical-key OSN upload tasks for the per-filter fiducial expmap files.
+    """Build canonical-key OSN upload tasks for the per-filter fiducial expmaps.
 
     Expmaps are per-``(field, filter)`` coverage maps written into the canonical
-    filter directory (``products/nircam/<field>/<filter>/expmap_*.fits``),
-    alongside the mosaics/exposures. Only the **fiducial** map
-    (``expmap_<field>_<filter>.fits``, no stage suffix) is deployed; the reducer-only
-    ``_uncal`` quick-look (and any pre-rename ``_canonical`` leftover) is skipped so a
-    user downloads a single, unqualified exposure map. They are produced at combine
-    time, so a process-only field may have none yet — deploy is idempotent and picks
-    them up on a later run. Returns a list of ``UploadTask`` (empty if none found).
+    filter directory (``products/nircam/<field>/<filter>/expmap_*``), alongside the
+    mosaics/exposures. Deploys both the coverage **FITS** and its dark web **PNG**
+    plot; only the **fiducial** map (``expmap_<field>_<filter>.{fits,png}``, no stage
+    suffix) is shipped — the reducer-only ``_uncal`` quick-look (and any pre-rename
+    ``_canonical`` leftover) is skipped so a user gets a single, unqualified map. The
+    light-mode ``.pdf`` diagnostic stays local. Produced at combine time, so a
+    process-only field may have none yet — deploy is idempotent and picks them up on
+    a later run. Returns a list of ``UploadTask`` (empty if none found).
     """
     products = dirs['products']
     tasks = []
@@ -377,14 +389,32 @@ def discover_expmap_tasks(dirs, field, filters):
         filter_dir = products / filtname
         if not filter_dir.exists():
             continue
-        for path in sorted(filter_dir.glob('expmap_*.fits')):
-            if path.name.endswith(_EXPMAP_NONFIDUCIAL_SUFFIXES):
-                continue
-            key = storage_key('nircam_expmap', Scope(field=field, filt=filtname),
-                              path.name, scheme=KeyScheme.CANONICAL)
-            tasks.append(UploadTask(local_path=path, r2_key=key,
-                                    content_type=_FITS_CONTENT_TYPE))
+        for pattern, ptype, content_type in _EXPMAP_DEPLOY:
+            for path in sorted(filter_dir.glob(pattern)):
+                if path.stem.endswith(_EXPMAP_NONFIDUCIAL_STEMS):
+                    continue
+                key = storage_key(ptype, Scope(field=field, filt=filtname),
+                                  path.name, scheme=KeyScheme.CANONICAL)
+                tasks.append(UploadTask(local_path=path, r2_key=key,
+                                        content_type=content_type))
     return tasks
+
+
+def discover_layout_tasks(dirs, field):
+    """Canonical-key OSN upload task for the field layout plot, if present.
+
+    ``<field>_layout.png`` (stacked-filter coverage + tile outlines) lives at the
+    per-field products root and is the landing-page card preview. Only the fiducial
+    (undecorated) plot is deployed; the ``_uncal`` quick-look and the ``.json``
+    coverage sidecar (read locally by the field-registry upsert) stay off OSN.
+    """
+    path = dirs['products'] / f'{field}_layout.png'
+    if not path.exists():
+        return []
+    key = storage_key('nircam_layout', Scope(field=field), path.name,
+                      scheme=KeyScheme.CANONICAL)
+    return [UploadTask(local_path=path, r2_key=key,
+                       content_type=_PNG_CONTENT_TYPE)]
 
 
 # ---------------------------------------------------------------------------
@@ -489,13 +519,15 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
 
     exposures = discover_exposures(dirs, filters)
     expmap_tasks = discover_expmap_tasks(dirs, field, filters)
+    layout_tasks = discover_layout_tasks(dirs, field)
     n_mosaics = len(discover_mosaics(dirs, field, filters))
     print(f"Discovered {len(exposures)} canonical exposure(s), "
-          f"{len(expmap_tasks)} expmap(s), {n_mosaics} mosaic(s)")
+          f"{len(expmap_tasks)} expmap file(s), {n_mosaics} mosaic(s), "
+          f"{len(layout_tasks)} layout plot(s)")
     # Deploy whatever the field has — mosaics/expmaps are independent of the
     # per-exposure FITS (a field can keep its science mosaics after the large cal
     # exposures are pruned). Only bail if there is genuinely nothing to ship.
-    if not exposures and not expmap_tasks and not n_mosaics:
+    if not exposures and not expmap_tasks and not n_mosaics and not layout_tasks:
         print("Nothing to deploy for this field.")
         return
 
@@ -554,8 +586,10 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
             print(f"  with masks: {mask_count}")
         print(f"\nWould record a {'draft' if draft else 'published'} field "
               f"deployment and upload {len(fits_tasks)} canonical FITS + "
-              f"{len(expmap_tasks)} expmap(s) + {n_mosaics} mosaic(s) to OSN "
-              f"(subject to content-hash dedup), and {len(png_tasks)} preview PNG(s) to OSN.")
+              f"{len(expmap_tasks)} expmap file(s) + {n_mosaics} mosaic(s) + "
+              f"{len(layout_tasks)} layout plot(s) to OSN (subject to content-hash "
+              f"dedup), and {len(png_tasks)} preview PNG(s) to OSN, then upsert the "
+              f"fields registry row for '{field}'.")
         print("Dry run — no changes made.")
         return
 
@@ -595,7 +629,7 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
     # without reading a byte — so an unchanged re-deploy no longer pays the
     # "hash every exposure" pause before uploading.
     png_upload_list = [t[0] for t in png_tasks]
-    osn_tasks = fits_tasks + expmap_tasks + png_upload_list
+    osn_tasks = fits_tasks + expmap_tasks + png_upload_list + layout_tasks
     store = open_reducer_store()
     plan, _server_rows = plan_remote_push(
         client, store, osn_tasks, backend=_CANONICAL_BACKEND)
@@ -655,6 +689,17 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
     # --- Mosaics: deploy under the same field deployment (epic #261, N2) ----
     mosaic_stats = _deploy_field_mosaics(dirs, field, config, client, filters,
                                          deployment_id, draft, user_id, store=store)
+
+    # --- Field registry: upsert the fields.toml config + deploy-computed survey
+    # area (issue #303). Rides the deploy so a field row exists exactly for fields
+    # with deployed data; coverage_area comes from <field>_layout.json, and
+    # latest_deployment_id points at this deployment. Best-effort — a missing
+    # fields.toml section or layout.json never fails the deploy.
+    try:
+        from campfire.deploy.fields import upsert_field_on_deploy
+        upsert_field_on_deploy(client, dirs['products'], field, deployment_id)
+    except Exception as e:  # noqa: BLE001 - registry upsert must never sink a deploy
+        print(f"  fields: registry upsert skipped ({e})")
 
     # --- Multi-reducer scope claim + audit (epic #210, B4 / D12) -----------
     claim = claim_deploy_scope(client, 'field', field, scope_version, actor=user_id)
@@ -852,8 +897,37 @@ def discover_mosaics(dirs, field, filters):
                     'path': fpath, 'filter': mfilter, 'tile': tile,
                     'pixel_scale': pixel_scale, 'epoch': epoch,
                     'extension': ext, 'storage_key': key,
+                    'mosaic_name': base,
                 })
     return out
+
+
+def discover_mosaic_thumbnail_tasks(mosaics, field):
+    """One ``nircam_mosaic_thumbnail`` upload task per mosaic base.
+
+    The pipeline writes a single ``<base>_thumb.png`` per mosaic (derived from the
+    i2d), so this dedups the per-extension ``mosaics`` list to one task per base
+    and only emits it when the thumbnail exists. The scope filter is the mosaic's
+    own directory name, so the thumbnail key sits beside its mosaic FITS. Returns
+    ``[]`` when no thumbnails are present (a field reduced before thumbnails).
+    """
+    tasks = []
+    seen = set()
+    for m in mosaics:
+        filt = m['path'].parent.name
+        key_id = (filt, m['mosaic_name'])
+        if key_id in seen:
+            continue
+        seen.add(key_id)
+        thumb_path = m['path'].parent / f"{m['mosaic_name']}_thumb.png"
+        if thumb_path.exists():
+            tasks.append(UploadTask(
+                local_path=thumb_path,
+                r2_key=storage_key('nircam_mosaic_thumbnail',
+                                   Scope(field=field, filt=filt),
+                                   thumb_path.name, scheme=KeyScheme.CANONICAL),
+                content_type=_PNG_CONTENT_TYPE))
+    return tasks
 
 
 def _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
@@ -887,8 +961,17 @@ def _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
 
     mosaic_tasks = [UploadTask(local_path=m['path'], r2_key=m['storage_key'],
                                content_type=_FITS_CONTENT_TYPE) for m in mosaics]
+
+    # Per-mosaic science thumbnails ride the same plan/registration (see
+    # discover_mosaic_thumbnail_tasks): they get a nircam_mosaic_thumbnail
+    # storage_objects row (key-derived product_type) but NO nircam_images row —
+    # the web shows them on the sci extension row.
+    thumb_tasks = discover_mosaic_thumbnail_tasks(mosaics, field)
+    if thumb_tasks:
+        print(f"  Thumbnails: {len(thumb_tasks)}")
+
     plan, server_rows = plan_remote_push(
-        client, store, mosaic_tasks, backend=_CANONICAL_BACKEND)
+        client, store, mosaic_tasks + thumb_tasks, backend=_CANONICAL_BACKEND)
     unchanged_keys = {t.r2_key for t in plan.unchanged}
     print(f"  Plan: {plan.summary()}")
 
@@ -932,7 +1015,11 @@ def _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
     } for m in mosaics if m['storage_key'] in indexable]
     n_img = _upsert_nircam_images(client, img_rows)
     print(f"  Indexed {n_img} nircam_images row(s) ({img_status})")
-    n_failed = len(present) - len(img_rows) if not draft else 0
+    # Only mosaic FITS get nircam_images rows — thumbnails (also in `present`) do
+    # not, so count failures against mosaic keys alone or every thumb reads as a
+    # non-indexed mosaic.
+    mosaic_keys = {m['storage_key'] for m in mosaics}
+    n_failed = len(present & mosaic_keys) - len(img_rows) if not draft else 0
     if n_failed:
         print(f"  ({n_failed} mosaic(s) not indexed — upload failed; re-run to retry)")
 

--- a/python/tests/test_deploy_fields.py
+++ b/python/tests/test_deploy_fields.py
@@ -1,0 +1,232 @@
+"""Tests for the NIRCam page-redesign deploy layer:
+
+- the `fields.toml -> fields` sync (issue #303): section parsing, deploy-time
+  upsert (config + area + deployment), and the deployed-only scoping of
+  `sync_fields` — all with a fake Supabase client;
+- discovery of the three new deployable artifacts (expmap PNG, field layout PNG,
+  mosaic thumbnails) with canonical keys.
+
+Pure/local — no network, no real Supabase.
+"""
+
+import json
+import textwrap
+import types
+
+import pytest
+
+from campfire.deploy import fields as F
+from campfire.deploy import nircam as nc
+from campfire.deploy.r2 import UploadTask
+
+
+# --- fake Supabase client ---------------------------------------------------
+
+class _FakeTable:
+    def __init__(self, store, name):
+        self.store, self.name = store, name
+
+    def select(self, _cols):
+        return self
+
+    def upsert(self, row, on_conflict=None):
+        self.store["upserts"].append((self.name, on_conflict, row))
+        return self
+
+    def execute(self):
+        if self.name == "deployments":
+            return types.SimpleNamespace(data=self.store.get("deployments", []))
+        return types.SimpleNamespace(data=[])
+
+
+class _FakeClient:
+    def __init__(self, deployments=None):
+        self.store = {"upserts": [], "deployments": deployments or []}
+
+    def table(self, name):
+        return _FakeTable(self.store, name)
+
+
+_FIELDS_TOML = """
+    [cosmos]
+    filters = ["f115w", "f444w"]
+    files = ["jw01727*", "jw05893*"]
+    tangent_point = [150.1163, 2.2009]
+    fiducial_tiles = ["A1", "A2"]
+
+    [cosmos.A1]
+    "30mas" = { crpix = [1000, 1000], naxis = [2000, 2000] }
+    [cosmos.A2]
+    rotation = 20
+    "30mas" = { crpix = [3000, 1000], naxis = [2000, 2000] }
+    [cosmos.epochs.CW]
+    files = ["jw05893*"]
+
+    [uds]
+    filters = ["f444w"]
+    files = ["jw01837*"]
+    tangent_point = [34.4, -5.2]
+"""
+
+
+def _write_root(tmp_path, monkeypatch, toml=_FIELDS_TOML):
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "fields.toml").write_text(textwrap.dedent(toml))
+    monkeypatch.setenv("CAMPFIRE_ROOT", str(tmp_path))
+    return tmp_path
+
+
+# --- field_config_row -------------------------------------------------------
+
+def test_field_config_row_lifts_and_is_lossless():
+    section = F.load_fields_toml  # noqa: F841 (ensure import wired)
+    import tomllib
+    cfg = tomllib.loads(textwrap.dedent(_FIELDS_TOML))["cosmos"]
+    row = F.field_config_row("cosmos", cfg)
+    assert row["name"] == "cosmos"
+    assert row["filters"] == ["f115w", "f444w"]
+    assert row["tiles"] == ["A1", "A2"]               # dict sub-tables, minus epochs
+    assert row["fiducial_tiles"] == ["A1", "A2"]
+    assert row["epochs"] == ["CW"]
+    assert row["jwst_program_ids"] == [1727, 5893]    # from the files globs
+    assert row["file_globs"] == ["jw01727*", "jw05893*"]
+    assert row["center_ra"] == pytest.approx(150.1163)
+    assert row["center_dec"] == pytest.approx(2.2009)
+    assert row["programs"] == []                       # slug resolution deferred
+    assert row["display_name"] is None                 # RPC derives upper()
+    # config is the whole section, verbatim (lossless).
+    assert row["config"] == cfg
+
+
+def test_field_config_row_coerces_string_scalars():
+    row = F.field_config_row("x", {"filters": "f444w", "fiducial_tiles": "A1",
+                                    "files": "jw01727*"})
+    assert row["filters"] == ["f444w"]
+    assert row["fiducial_tiles"] == ["A1"]
+    assert row["jwst_program_ids"] == [1727]
+    assert row["center_ra"] is None and row["center_dec"] is None
+
+
+# --- read_layout_coverage ---------------------------------------------------
+
+def test_read_layout_coverage(tmp_path):
+    (tmp_path / "cosmos_layout.json").write_text(
+        json.dumps({"coverage_area_arcmin2": 1944.0, "coverage_area_deg2": 0.54}))
+    cov = F.read_layout_coverage(tmp_path, "cosmos")
+    assert cov["coverage_area_arcmin2"] == 1944.0
+    assert F.read_layout_coverage(tmp_path, "absent") is None
+
+
+# --- upsert_field_on_deploy -------------------------------------------------
+
+def test_upsert_field_on_deploy_writes_config_area_and_deployment(tmp_path, monkeypatch):
+    _write_root(tmp_path, monkeypatch)
+    products = tmp_path / "products"
+    products.mkdir()
+    (products / "cosmos_layout.json").write_text(
+        json.dumps({"coverage_area_arcmin2": 1944.0, "coverage_area_deg2": 0.54}))
+    client = _FakeClient()
+    assert F.upsert_field_on_deploy(client, products, "cosmos", 42) is True
+    (name, on_conflict, row), = client.store["upserts"]
+    assert name == "fields" and on_conflict == "name"
+    assert row["latest_deployment_id"] == 42
+    assert row["coverage_area_arcmin2"] == 1944.0
+    assert row["coverage_area_deg2"] == 0.54
+    assert row["filters"] == ["f115w", "f444w"]
+
+
+def test_upsert_field_on_deploy_skips_unknown_field(tmp_path, monkeypatch):
+    _write_root(tmp_path, monkeypatch)
+    client = _FakeClient()
+    assert F.upsert_field_on_deploy(client, tmp_path, "not_a_field", 1) is False
+    assert client.store["upserts"] == []
+
+
+# --- sync_fields scoping ----------------------------------------------------
+
+def test_sync_fields_scopes_to_deployed_fields(tmp_path, monkeypatch):
+    _write_root(tmp_path, monkeypatch)
+    # Only cosmos has a deployment; uds is defined in fields.toml but not deployed.
+    client = _FakeClient(deployments=[{"field": "cosmos"}, {"field": None},
+                                      {"field": "cosmos"}])
+    n = F.sync_fields(client)  # field_names=None -> deployed only
+    assert n == 1
+    names = [row["name"] for (_t, _c, row) in client.store["upserts"]]
+    assert names == ["cosmos"]
+    # config-only sync never sends the deploy-owned columns.
+    (_t, _c, row), = client.store["upserts"]
+    assert "coverage_area_arcmin2" not in row
+    assert "latest_deployment_id" not in row
+
+
+def test_sync_fields_single_field(tmp_path, monkeypatch):
+    _write_root(tmp_path, monkeypatch)
+    client = _FakeClient()
+    n = F.sync_fields(client, ["uds"])
+    assert n == 1
+    assert client.store["upserts"][0][2]["name"] == "uds"
+
+
+def test_sync_fields_dry_run_writes_nothing(tmp_path, monkeypatch):
+    _write_root(tmp_path, monkeypatch)
+    client = _FakeClient(deployments=[{"field": "cosmos"}])
+    n = F.sync_fields(client, dry_run=True)
+    assert n == 0
+    assert client.store["upserts"] == []
+
+
+# --- new artifact discovery -------------------------------------------------
+
+def test_discover_expmap_tasks_includes_png(tmp_path):
+    products = tmp_path / "products" / "nircam" / "cosmos"
+    (products / "f444w").mkdir(parents=True)
+    fdir = products / "f444w"
+    (fdir / "expmap_cosmos_f444w.fits").write_bytes(b"\x00")
+    (fdir / "expmap_cosmos_f444w.png").write_bytes(b"\x00")
+    (fdir / "expmap_cosmos_f444w_uncal.png").write_bytes(b"\x00")  # excluded
+    tasks = nc.discover_expmap_tasks({"products": products}, "cosmos", ["f444w"])
+    keys = sorted(t.r2_key for t in tasks)
+    assert keys == [
+        "data/products/nircam/cosmos/f444w/expmap_cosmos_f444w.fits",
+        "data/products/nircam/cosmos/f444w/expmap_cosmos_f444w.png",
+    ]
+    png = next(t for t in tasks if t.r2_key.endswith(".png"))
+    assert png.content_type == "image/png"
+
+
+def test_discover_layout_tasks(tmp_path):
+    products = tmp_path / "products" / "nircam" / "cosmos"
+    products.mkdir(parents=True)
+    assert nc.discover_layout_tasks({"products": products}, "cosmos") == []
+    (products / "cosmos_layout.png").write_bytes(b"\x00")
+    (products / "cosmos_layout_uncal.png").write_bytes(b"\x00")  # not deployed
+    tasks = nc.discover_layout_tasks({"products": products}, "cosmos")
+    assert [t.r2_key for t in tasks] == [
+        "data/products/nircam/cosmos/cosmos_layout.png"]
+    assert tasks[0].content_type == "image/png"
+
+
+def test_discover_mosaic_thumbnail_tasks(tmp_path):
+    fdir = tmp_path / "products" / "nircam" / "cosmos" / "f444w"
+    fdir.mkdir(parents=True)
+    base = "mosaic_nircam_f444w_cosmos_30mas_A1"
+    (fdir / f"{base}_i2d.fits").write_bytes(b"\x00")
+    (fdir / f"{base}_thumb.png").write_bytes(b"\x00")
+    # two extensions of the same mosaic base -> still ONE thumbnail task
+    mosaics = [
+        {"path": fdir / f"{base}_i2d.fits", "mosaic_name": base},
+        {"path": fdir / f"{base}_sci.fits", "mosaic_name": base},
+    ]
+    tasks = nc.discover_mosaic_thumbnail_tasks(mosaics, "cosmos")
+    assert [t.r2_key for t in tasks] == [
+        f"data/products/nircam/cosmos/f444w/{base}_thumb.png"]
+    assert tasks[0].content_type == "image/png"
+
+
+def test_discover_mosaic_thumbnail_tasks_empty_when_absent(tmp_path):
+    fdir = tmp_path / "products" / "nircam" / "cosmos" / "f444w"
+    fdir.mkdir(parents=True)
+    base = "mosaic_nircam_f444w_cosmos_30mas_A1"
+    (fdir / f"{base}_i2d.fits").write_bytes(b"\x00")  # no _thumb.png
+    mosaics = [{"path": fdir / f"{base}_i2d.fits", "mosaic_name": base}]
+    assert nc.discover_mosaic_thumbnail_tasks(mosaics, "cosmos") == []


### PR DESCRIPTION
**PR 4 of 5** in the NIRCam page redesign stack. **Stacked on #376** (base `feat/nircam-redesign-p3-fields-db`). The deploy layer — ships PR 1's new artifacts and populates PR 3's `fields` table.

## New artifacts shipped by `deploy_nircam`
- **Expmap PNG** — `discover_expmap_tasks` now ships the dark web plot alongside the coverage FITS (the light `.pdf` stays local).
- **Field layout PNG** — new `discover_layout_tasks` ships `<field>_layout.png` (the landing-card preview).
- **Mosaic thumbnails** — `discover_mosaic_thumbnail_tasks` ships one `<base>_thumb.png` per mosaic base; they ride the mosaic plan but get **no** `nircam_images` row (the web shows them on the sci row).

`product_type` is key-derived at registration (via the PR-2 bijection), so each artifact only needs its canonical key + content type. **Bug fixed:** thumbnails are in the plan's `present` set but not indexed, so the mosaic `n_failed` count is now measured against mosaic keys only — otherwise every thumbnail read as a non-indexed mosaic.

## Field registry (issue #303)
- **`campfire/deploy/fields.py`** — `fields.toml` → a `fields` row: the full section mirrored losslessly into `config` (jsonb) + typed columns; program **ids** from the file globs (slugs deferred — `programs.toml` has no id map).
- **`upsert_field_on_deploy`** rides `deploy_nircam`: writes the config **plus** the deploy-owned columns (coverage area from `<field>_layout.json`, `latest_deployment_id`). Best-effort — a missing section/JSON never fails the deploy.
- **`campfire deploy sync-fields`** (mirrors `sync-programs`) — scoped to fields that already have deployed data; writes **only** config columns, so the deploy-computed area is never clobbered.

## Verification
- 12 new unit tests (section parsing, scoping, artifact discovery) + existing `test_nircam_deploy` / CLI tests green.
- **Live against local Supabase**: `upsert_field` round-trips arrays + jsonb `config` losslessly, and a config-only re-sync **preserves** the deploy-computed area (confirms the PostgREST merge-duplicates behavior the design relies on).

python-only — no changelog. Program-slug resolution for `fields.programs` is a follow-up (needs a program-id map; part of #303's broader config-sync work).

## Stack
1. #373 pipeline · 2. #374 layout · 3. #376 fields DB · **4. this — deploy** · 5. web

Generated with Claude Code