### PR TITLE
Remove Updates navigation link

### DIFF
--- a/web/components/layout/Navigation.tsx
+++ b/web/components/layout/Navigation.tsx
@@ -87,7 +87,6 @@ export const Navigation: React.FC = () => {
     },
     { href: '/map', label: 'Map' },
     { href: '/cutouts', label: 'Cutouts' },
-    { href: '/updates', label: 'Updates' },
     { href: '/docs', label: 'Docs' },
   ];
 


### PR DESCRIPTION
## Summary
Removed the "Updates" navigation link from the main navigation menu.

## Changes
- Removed the `/updates` navigation route from the Navigation component

## Details
The Updates link has been removed from the navigation menu structure. This appears to be a cleanup of an unused or deprecated navigation item.

https://claude.ai/code/session_01H2w6YudH4U5xNa8L4xjwna