### PR TITLE
Filter i2d mosaics from cloud deployment paths

### DIFF
--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -435,13 +435,17 @@ def _provenance_from_header(path):
 def _read_field_provenance(dirs, field, filters):
     """Best-effort ``(cfpipe_version, jwst_version, crds_context)`` for a field.
 
-    Prefer a deployed mosaic's ``i2d`` header (the combined science product);
-    fall back to any canonical exposure header. Both now carry the CAMPFIRE
-    ``CMPFRVER`` — the mosaic from ``resample.py``, the exposure from
-    ``detector1`` at creation — plus the jwst-native ``CAL_VER`` / ``CRDS_CTX``.
-    So a mid-reduction ``--draft`` exposure deploy (no mosaic yet) now records
-    real provenance instead of NULL (audit B2). Returns ``(None, None, None)``
-    only when the field has neither a mosaic nor a readable exposure.
+    Prefer the local ``i2d`` mosaic header (the combined science product) — the
+    i2d is no longer uploaded to the cloud, but ``discover_mosaics`` still
+    surfaces it locally, and it is the only mosaic product that carries the
+    provenance cards (the split ``_sci/_err/_wht`` extensions inherit the SCI
+    *extension* header and carry none). Fall back to any canonical exposure
+    header. Both carry the CAMPFIRE ``CMPFRVER`` — the mosaic from
+    ``resample.py``, the exposure from ``detector1`` at creation — plus the
+    jwst-native ``CAL_VER`` / ``CRDS_CTX``. So a mid-reduction ``--draft``
+    exposure deploy (no mosaic yet) now records real provenance instead of NULL
+    (audit B2). Returns ``(None, None, None)`` only when the field has neither a
+    readable i2d nor a readable exposure.
     """
     try:
         mosaics = discover_mosaics(dirs, field, filters)
@@ -520,7 +524,7 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
     exposures = discover_exposures(dirs, filters)
     expmap_tasks = discover_expmap_tasks(dirs, field, filters)
     layout_tasks = discover_layout_tasks(dirs, field)
-    n_mosaics = len(discover_mosaics(dirs, field, filters))
+    n_mosaics = len(deployable_mosaics(discover_mosaics(dirs, field, filters)))
     print(f"Discovered {len(exposures)} canonical exposure(s), "
           f"{len(expmap_tasks)} expmap file(s), {n_mosaics} mosaic(s), "
           f"{len(layout_tasks)} layout plot(s)")
@@ -837,9 +841,38 @@ _MOSAIC_EXTENSIONS = (
     ('_srcmask.fits', 'srcmask'),
 )
 
+# The i2d cube is the multi-extension science product the split _sci/_err/_wht
+# extensions are carved from — heavy, and redundant for users, who download the
+# split extensions. It stays *discovered* (discover_mosaics still returns it)
+# because local consumers depend on it: the deployment provenance stamp reads its
+# primary-header CMPFRVER/CAL_VER/CRDS_CTX cards (the split extensions inherit
+# only the SCI *extension* header and carry none of them — see resample.py), and
+# the FitsGL map pyramid falls back to it when a tile has no split sci. It is
+# simply never uploaded to the cloud or indexed in nircam_images. Every
+# cloud-bound path runs discovered mosaics through `deployable_mosaics` first.
+_UNDEPLOYED_MOSAIC_EXTENSIONS = frozenset({'i2d'})
+
+
+def deployable_mosaics(mosaics):
+    """Discovered mosaics minus the extensions we don't ship to the cloud (i2d).
+
+    ``discover_mosaics`` intentionally returns every extension on disk because
+    local consumers need i2d (provenance stamping, the FitsGL pyramid fallback);
+    the deploy and ``campfire deploy push`` paths run its output through this
+    filter so i2d bytes never leave the reducer and no ``nircam_images`` i2d row
+    is written.
+    """
+    return [m for m in mosaics
+            if m['extension'] not in _UNDEPLOYED_MOSAIC_EXTENSIONS]
+
 
 def discover_mosaics(dirs, field, filters):
-    """Discover deployable mosaic products via their manifests.
+    """Discover mosaic products via their manifests.
+
+    Returns every extension present on disk, including the ``i2d`` cube — local
+    consumers (deployment provenance, the FitsGL pyramid) read it. The cloud
+    upload/index paths drop i2d via :func:`deployable_mosaics`; discovery itself
+    stays complete.
 
     Each ``mosaic_*_manifest.json`` (written by the resample step) carries the
     authoritative ``(mosaic_name, filter, tile, pixel_scale, epoch)`` — read from
@@ -935,8 +968,9 @@ def _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
     """Deploy this field's mosaics under the field deployment (epic #261, N2).
 
     Called from :func:`deploy_nircam` so ``campfire deploy --field`` ships exposures
-    and mosaics as one field deployment. Uploads each mosaic product (the ``_i2d``
-    cube + any split ``_sci/_err/_wht/_srcmask`` extensions) to OSN under canonical
+    and mosaics as one field deployment. Uploads each deployable mosaic product (the
+    split ``_sci/_err/_wht/_srcmask`` extensions — the heavy ``_i2d`` cube is
+    discovered but filtered out by :func:`deployable_mosaics`) to OSN under canonical
     keys — whole-file content-hash deduped via the push planner (with the pushed_*
     stat fast path, so an unchanged multi-GB mosaic is skipped without re-hashing)
     — upserts one ``nircam_images`` row per
@@ -951,7 +985,9 @@ def _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
     )
     from campfire.deploy.registry import set_active_deployment
 
-    mosaics = discover_mosaics(dirs, field, filters)
+    # discover_mosaics returns i2d too (provenance / FitsGL read it locally); the
+    # cloud deploy ships only the deployable extensions, so filter it out here.
+    mosaics = deployable_mosaics(discover_mosaics(dirs, field, filters))
     if not mosaics:
         return None
     print(f"\nMosaics: {len(mosaics)} product(s)")

--- a/python/campfire/deploy/push.py
+++ b/python/campfire/deploy/push.py
@@ -374,8 +374,8 @@ def push_field(
     """
     from campfire.deploy.nircam import (
         _discover_filters, _resolve_nircam_dirs, build_fits_upload_tasks,
-        build_upload_tasks, discover_expmap_tasks, discover_exposures,
-        discover_mosaics, _read_field_provenance,
+        build_upload_tasks, deployable_mosaics, discover_expmap_tasks,
+        discover_exposures, discover_mosaics, _read_field_provenance,
     )
     from campfire.deploy.supabase import get_supabase_client, get_user_id_from_token
 
@@ -405,7 +405,7 @@ def push_field(
     tasks += list(discover_expmap_tasks(dirs, field, filters))
     tasks += [t[0] for t in build_upload_tasks(dirs, field, filters)]
     tasks += [UploadTask(m['path'], m['storage_key'], 'application/fits')
-              for m in discover_mosaics(dirs, field, filters)]
+              for m in deployable_mosaics(discover_mosaics(dirs, field, filters))]
 
     print(f"Field: {field}")
     print(f"  Filters: {', '.join(filters)}")

--- a/python/tests/test_nircam_deploy.py
+++ b/python/tests/test_nircam_deploy.py
@@ -239,6 +239,30 @@ def test_discover_mosaics_manifest_based_version_free_keys(tmp_path):
     assert row["field"] == "cosmos"
 
 
+def test_deployable_mosaics_drops_i2d(tmp_path):
+    # i2d stays *discoverable* — provenance stamping and the FitsGL pyramid read
+    # it locally — but it must never reach the cloud upload / nircam_images index
+    # set. deployable_mosaics is the filter every cloud-bound path applies.
+    fdir = tmp_path / "products" / "nircam" / "cosmos" / "f444w"
+    fdir.mkdir(parents=True)
+    base = "mosaic_nircam_f444w_cosmos_30mas_A1"
+    _write_manifest(fdir, base, field="cosmos", filt="f444w", tile="A1", scale="30mas")
+    for suffix in ("_i2d.fits", "_sci.fits", "_err.fits", "_wht.fits"):
+        (fdir / f"{base}{suffix}").write_bytes(b"\x00")
+
+    dirs = {"products": tmp_path / "products" / "nircam" / "cosmos"}
+    found = nc.discover_mosaics(dirs, "cosmos", ["f444w"])
+    # discovery still surfaces i2d (local consumers depend on it)...
+    assert "i2d" in {m["extension"] for m in found}
+    # ...but the deploy set excludes it, keeping the split extensions.
+    deployable = nc.deployable_mosaics(found)
+    assert sorted(m["extension"] for m in deployable) == ["err", "sci", "wht"]
+    assert all(m["extension"] != "i2d" for m in deployable)
+    # a mosaic with only an i2d on disk deploys nothing (no split science product)
+    assert nc.deployable_mosaics(
+        [{"extension": "i2d", "path": "x", "storage_key": "k"}]) == []
+
+
 def test_discover_mosaics_skips_stale_versioned_manifest(tmp_path):
     # A field re-reduced after N2 keeps its pre-N2 `..._v0_1_..._manifest.json`
     # on disk next to the new version-free one. discover_mosaics must accept ONLY


### PR DESCRIPTION
## Summary

The i2d mosaic cube is a heavy, redundant product that should never be uploaded to the cloud or indexed in `nircam_images`. However, it must remain discoverable locally because deployment provenance stamping and the FitsGL pyramid fallback depend on reading its headers. This change introduces a filter function to exclude i2d from all cloud-bound paths while keeping it in local discovery.

## Key Changes

- **New `deployable_mosaics()` function**: Filters discovered mosaics to exclude the i2d extension, which is applied to all cloud upload and indexing paths
- **Updated `discover_mosaics()` docstring**: Clarifies that discovery intentionally returns all extensions (including i2d) for local consumers, and that cloud paths must filter via `deployable_mosaics()`
- **Applied filter in three locations**:
  - `deploy_nircam()`: Count only deployable mosaics in discovery summary
  - `_deploy_field_mosaics()`: Filter before uploading and indexing mosaics
  - `push_field()`: Filter before building upload tasks for cloud push
- **Updated docstrings**: Clarified why i2d is discovered but not deployed, and updated `_read_field_provenance()` and `_deploy_field_mosaics()` documentation to reflect the new behavior
- **Added test**: `test_deployable_mosaics_drops_i2d()` verifies that i2d is discoverable but filtered from deployment, and that mosaics with only i2d deploy nothing

## Implementation Details

The i2d cube is the multi-extension science product that the split `_sci/_err/_wht` extensions are carved from. It stays discovered because:
- Deployment provenance stamping reads its primary-header CMPFRVER/CAL_VER/CRDS_CTX cards (split extensions inherit only the SCI extension header)
- The FitsGL map pyramid falls back to it when a tile has no split sci

By filtering at the deployment boundary rather than in discovery, we maintain a single source of truth for what products exist locally while cleanly separating local and cloud concerns.

https://claude.ai/code/session_016fCVTnhprFeyeEsqG6GmVa