### PR TITLE
Add admin write policies for nircam_images table

### DIFF
--- a/supabase/migrations/20260712170059_nircam_images_admin_write_policies.sql
+++ b/supabase/migrations/20260712170059_nircam_images_admin_write_policies.sql
@@ -1,0 +1,28 @@
+-- nircam_images admin write policies (deploy RLS gap).
+--
+-- nircam_images had RLS enabled with only a SELECT policy. Since the deploy-auth
+-- epic (#250) made `login` mode (which operates through RLS) the default deploy
+-- path, the NIRCam mosaic deploy's _upsert_nircam_images (an upsert =
+-- INSERT ... ON CONFLICT DO UPDATE) had no permissive INSERT/UPDATE policy to
+-- satisfy and failed with 42501 "new row violates row-level security policy for
+-- table nircam_images". Previously deploys ran under service_role (RLS bypassed),
+-- so the gap was invisible. This mirrors the admin write policies already present
+-- on nircam_exposures and fields. (Publish/revoke is unaffected: it flips
+-- deploy_status via the SECURITY DEFINER set_deployment_status RPC, which
+-- bypasses RLS.)
+
+  create policy "admin_insert_nircam"
+  on "public"."nircam_images"
+  as permissive
+  for insert
+  to authenticated
+with check (( SELECT public.is_admin() AS is_admin));
+
+
+  create policy "admin_update_nircam"
+  on "public"."nircam_images"
+  as permissive
+  for update
+  to authenticated
+using (( SELECT public.is_admin() AS is_admin))
+with check (( SELECT public.is_admin() AS is_admin));

--- a/supabase/schemas/policies.sql
+++ b/supabase/schemas/policies.sql
@@ -682,6 +682,23 @@ CREATE POLICY "authenticated_select_nircam"
   ON nircam_images FOR SELECT TO authenticated
   USING (deploy_status = 'published' OR (SELECT public.is_admin()));
 
+-- Admins write the mosaic index. The NIRCam mosaic deploy (`campfire deploy
+-- --field`) runs in login mode through RLS and upserts these rows
+-- (_upsert_nircam_images = INSERT ... ON CONFLICT DO UPDATE), so BOTH an INSERT
+-- and an UPDATE policy are required. Mirrors nircam_exposures / fields. Publish
+-- and revoke flip deploy_status via the SECURITY DEFINER set_deployment_status
+-- RPC, which bypasses RLS and so is unaffected.
+DROP POLICY IF EXISTS "admin_insert_nircam" ON nircam_images;
+CREATE POLICY "admin_insert_nircam"
+  ON nircam_images FOR INSERT TO authenticated
+  WITH CHECK ((SELECT public.is_admin()));
+
+DROP POLICY IF EXISTS "admin_update_nircam" ON nircam_images;
+CREATE POLICY "admin_update_nircam"
+  ON nircam_images FOR UPDATE TO authenticated
+  USING ((SELECT public.is_admin()))
+  WITH CHECK ((SELECT public.is_admin()));
+
 
 -- =============================================================================
 -- nircam_exposures (admin-only)


### PR DESCRIPTION
## Summary
Adds INSERT and UPDATE row-level security (RLS) policies to the `nircam_images` table to allow authenticated admin users to write data. This fixes a deployment failure that occurred after the deploy-auth epic made login mode (which operates through RLS) the default deployment path.

## Changes
- **Migration**: Added new migration file creating `admin_insert_nircam` and `admin_update_nircam` policies for the `nircam_images` table
- **Policies schema**: Consolidated the policies into the main policies.sql file with improved documentation, including DROP IF EXISTS statements to handle idempotency

## Details
The NIRCam mosaic deploy performs an upsert operation (`_upsert_nircam_images`) that requires both INSERT and UPDATE permissions. Previously, deploys ran under `service_role` which bypassed RLS, masking the missing policies. With login mode now as the default, the operation failed with error 42501 (row-level security policy violation).

These new policies mirror the existing admin write policies on `nircam_exposures` and `fields` tables. The publish/revoke operations remain unaffected as they use the SECURITY DEFINER `set_deployment_status` RPC which bypasses RLS.

https://claude.ai/code/session_01NYEMicBn5owq1Q6FAUnTBG