### PR TITLE
feat(nircam): two-size mosaic thumbnail pair (table thumb + popup quicklook)

### DIFF
--- a/layout/campfire_layout/bijection.py
+++ b/layout/campfire_layout/bijection.py
@@ -45,6 +45,7 @@ _NIRCAM_FILTER_SUFFIXES = (
     ("_preview.png", "nircam_exposure_preview"),
     ("_full.png", "nircam_exposure_full"),
     ("_thumb.png", "nircam_mosaic_thumbnail"),  # before the 'mosaic' prefix check
+    ("_quicklook.png", "nircam_mosaic_quicklook"),
 )
 _EXPOSURE_RE = re.compile(r"_nrs[12]_\d+\.fits$")
 _TILE_RE = re.compile(r"^(?P<field>[^/]+)/(?P<filt>[^/]+)/(?P<z>\d+)/(?P<x>\d+)/(?P<y>\d+)\.png$")

--- a/layout/campfire_layout/products.py
+++ b/layout/campfire_layout/products.py
@@ -210,6 +210,15 @@ _register(ProductSpec(
     lifecycle=LC.CLOUD_PRODUCT, scope_keys=("field", "filt"),
     subdir=_nircam_field_filter_dir, suffix="_thumb.png", legacy_prefix=None,
 ))
+# Mosaic quick-look (``<mosaic>_quicklook.png``): the larger rendition of the
+# thumbnail pair (long side ~4k, for the web popup). A distinct suffix on
+# purpose — ``_preview.png``/``_full.png`` in this directory already mean the
+# per-exposure triage PNGs.
+_register(ProductSpec(
+    name="nircam_mosaic_quicklook", instrument=NC, tree="products", bucket="data",
+    lifecycle=LC.CLOUD_PRODUCT, scope_keys=("field", "filt"),
+    subdir=_nircam_field_filter_dir, suffix="_quicklook.png", legacy_prefix=None,
+))
 # Field layout plot (``<field>_layout.png``): stacked-filter coverage + tile
 # outlines. Field-scoped, in the field root beside nircam_rgb; the landing-page
 # preview. Suffix-dispatched on ``_layout.png``.

--- a/layout/conformance/layout_golden.json
+++ b/layout/conformance/layout_golden.json
@@ -3,7 +3,9 @@
   "cases": [
     {
       "product_type": "nirspec_spec",
-      "scope": {"obs": "ember_egs_p1"},
+      "scope": {
+        "obs": "ember_egs_p1"
+      },
       "filename": "ember_egs_p1_prism_clear_15182_spec.fits",
       "relpath": "products/nirspec/ember_egs_p1/ember_egs_p1_prism_clear_15182_spec.fits",
       "key_legacy": "spectra/ember_egs_p1/ember_egs_p1_prism_clear_15182_spec.fits",
@@ -13,7 +15,9 @@
     },
     {
       "product_type": "spectrum_json",
-      "scope": {"obs": "ember_egs_p1"},
+      "scope": {
+        "obs": "ember_egs_p1"
+      },
       "filename": "ember_egs_p1_prism_clear_15182_spec.json",
       "relpath": "products/nirspec/ember_egs_p1/ember_egs_p1_prism_clear_15182_spec.json",
       "key_legacy": "spectra/ember_egs_p1/ember_egs_p1_prism_clear_15182_spec.json",
@@ -23,7 +27,9 @@
     },
     {
       "product_type": "zfit",
-      "scope": {"obs": "ember_egs_p1"},
+      "scope": {
+        "obs": "ember_egs_p1"
+      },
       "filename": "ember_egs_p1_prism_clear_15182_zfit.json",
       "relpath": "products/nirspec/ember_egs_p1/ember_egs_p1_prism_clear_15182_zfit.json",
       "key_legacy": "spectra/ember_egs_p1/ember_egs_p1_prism_clear_15182_zfit.json",
@@ -33,7 +39,9 @@
     },
     {
       "product_type": "nirspec_spectrum_exposure",
-      "scope": {"obs": "ember_egs_p1"},
+      "scope": {
+        "obs": "ember_egs_p1"
+      },
       "filename": "jw07076020001_04101_00003_nrs1_15182.fits",
       "relpath": "products/nirspec/ember_egs_p1/jw07076020001_04101_00003_nrs1_15182.fits",
       "key_legacy": null,
@@ -43,7 +51,9 @@
     },
     {
       "product_type": "nirspec_rate",
-      "scope": {"obs": "ember_egs_p1"},
+      "scope": {
+        "obs": "ember_egs_p1"
+      },
       "filename": "jw07076020001_04101_00003_nrs1_rate.fits",
       "relpath": "products/nirspec/ember_egs_p1/jw07076020001_04101_00003_nrs1_rate.fits",
       "key_legacy": null,
@@ -53,7 +63,9 @@
     },
     {
       "product_type": "rgb",
-      "scope": {"obs": "ember_egs_p1"},
+      "scope": {
+        "obs": "ember_egs_p1"
+      },
       "filename": "ember_egs_p1_15182_rgb.png",
       "relpath": "products/nirspec/ember_egs_p1/ember_egs_p1_15182_rgb.png",
       "key_legacy": "rgb/ember_egs_p1/ember_egs_p1_15182_rgb.png",
@@ -63,7 +75,9 @@
     },
     {
       "product_type": "sed",
-      "scope": {"obs": "ember_egs_p1"},
+      "scope": {
+        "obs": "ember_egs_p1"
+      },
       "filename": "ember_egs_p1_15182_sed.pdf",
       "relpath": "products/nirspec/ember_egs_p1/ember_egs_p1_15182_sed.pdf",
       "key_legacy": "sed/ember_egs_p1/ember_egs_p1_15182_sed.pdf",
@@ -73,7 +87,10 @@
     },
     {
       "product_type": "nircam_exposure",
-      "scope": {"field": "cosmos", "filt": "f444w"},
+      "scope": {
+        "field": "cosmos",
+        "filt": "f444w"
+      },
       "filename": "jw01727028001_04101_00003_nrcalong.fits",
       "relpath": "products/nircam/cosmos/f444w/jw01727028001_04101_00003_nrcalong.fits",
       "key_legacy": null,
@@ -83,7 +100,10 @@
     },
     {
       "product_type": "nircam_exposure_preview",
-      "scope": {"field": "cosmos", "filt": "f444w"},
+      "scope": {
+        "field": "cosmos",
+        "filt": "f444w"
+      },
       "filename": "jw01727028001_04101_00003_nrcalong_preview.png",
       "relpath": "products/nircam/cosmos/f444w/jw01727028001_04101_00003_nrcalong_preview.png",
       "key_legacy": "nircam/exposures/cosmos/f444w/jw01727028001_04101_00003_nrcalong_preview.png",
@@ -93,7 +113,10 @@
     },
     {
       "product_type": "nircam_exposure_full",
-      "scope": {"field": "cosmos", "filt": "f444w"},
+      "scope": {
+        "field": "cosmos",
+        "filt": "f444w"
+      },
       "filename": "jw01727028001_04101_00003_nrcalong_full.png",
       "relpath": "products/nircam/cosmos/f444w/jw01727028001_04101_00003_nrcalong_full.png",
       "key_legacy": "nircam/exposures/cosmos/f444w/jw01727028001_04101_00003_nrcalong_full.png",
@@ -103,7 +126,9 @@
     },
     {
       "product_type": "nircam_rgb",
-      "scope": {"field": "cosmos"},
+      "scope": {
+        "field": "cosmos"
+      },
       "filename": "A1_30mas_rgb.png",
       "relpath": "products/nircam/cosmos/A1_30mas_rgb.png",
       "key_legacy": null,
@@ -113,7 +138,10 @@
     },
     {
       "product_type": "nircam_expmap",
-      "scope": {"field": "cosmos", "filt": "f444w"},
+      "scope": {
+        "field": "cosmos",
+        "filt": "f444w"
+      },
       "filename": "expmap_cosmos_f444w.fits",
       "relpath": "products/nircam/cosmos/f444w/expmap_cosmos_f444w.fits",
       "key_legacy": null,
@@ -123,7 +151,10 @@
     },
     {
       "product_type": "nircam_mosaic",
-      "scope": {"field": "cosmos", "filt": "f444w"},
+      "scope": {
+        "field": "cosmos",
+        "filt": "f444w"
+      },
       "filename": "mosaic_cosmos_f444w_30mas_sci.fits",
       "relpath": "products/nircam/cosmos/f444w/mosaic_cosmos_f444w_30mas_sci.fits",
       "key_legacy": null,
@@ -133,7 +164,10 @@
     },
     {
       "product_type": "nircam_expmap_plot",
-      "scope": {"field": "cosmos", "filt": "f444w"},
+      "scope": {
+        "field": "cosmos",
+        "filt": "f444w"
+      },
       "filename": "expmap_cosmos_f444w.png",
       "relpath": "products/nircam/cosmos/f444w/expmap_cosmos_f444w.png",
       "key_legacy": null,
@@ -143,7 +177,10 @@
     },
     {
       "product_type": "nircam_mosaic_thumbnail",
-      "scope": {"field": "cosmos", "filt": "f444w"},
+      "scope": {
+        "field": "cosmos",
+        "filt": "f444w"
+      },
       "filename": "mosaic_cosmos_f444w_30mas_thumb.png",
       "relpath": "products/nircam/cosmos/f444w/mosaic_cosmos_f444w_30mas_thumb.png",
       "key_legacy": null,
@@ -152,8 +189,23 @@
       "tree_class": "cloud-backed-product"
     },
     {
+      "product_type": "nircam_mosaic_quicklook",
+      "scope": {
+        "field": "cosmos",
+        "filt": "f444w"
+      },
+      "filename": "mosaic_cosmos_f444w_30mas_quicklook.png",
+      "relpath": "products/nircam/cosmos/f444w/mosaic_cosmos_f444w_30mas_quicklook.png",
+      "key_legacy": null,
+      "key_canonical": "data/products/nircam/cosmos/f444w/mosaic_cosmos_f444w_30mas_quicklook.png",
+      "bucket": "data",
+      "tree_class": "cloud-backed-product"
+    },
+    {
       "product_type": "nircam_layout",
-      "scope": {"field": "cosmos"},
+      "scope": {
+        "field": "cosmos"
+      },
       "filename": "cosmos_layout.png",
       "relpath": "products/nircam/cosmos/cosmos_layout.png",
       "key_legacy": null,
@@ -163,7 +215,13 @@
     },
     {
       "product_type": "tile",
-      "scope": {"field": "cosmos", "filt": "f444w", "zoom": 3, "x": 1, "y": 2},
+      "scope": {
+        "field": "cosmos",
+        "filt": "f444w",
+        "zoom": 3,
+        "x": 1,
+        "y": 2
+      },
       "filename": null,
       "relpath": "tiles/cosmos/f444w/3/1/2.png",
       "key_legacy": "cosmos/f444w/3/1/2.png",
@@ -173,7 +231,10 @@
     },
     {
       "product_type": "photometry_pz",
-      "scope": {"field": "cosmos", "object_id": "12345"},
+      "scope": {
+        "field": "cosmos",
+        "object_id": "12345"
+      },
       "filename": null,
       "relpath": null,
       "key_legacy": "photometry/cosmos/12345_pz.json",
@@ -183,7 +244,9 @@
     },
     {
       "product_type": "nirspec_manual_mask",
-      "scope": {"obs": "ember_egs_p1"},
+      "scope": {
+        "obs": "ember_egs_p1"
+      },
       "filename": "jw07076020001_04101_00003_nrs1_rate.reg",
       "relpath": "products/nirspec/ember_egs_p1/manual_masks/jw07076020001_04101_00003_nrs1_rate.reg",
       "key_legacy": null,
@@ -193,7 +256,9 @@
     },
     {
       "product_type": "nirspec_stuck_shutters",
-      "scope": {"obs": "ember_egs_p1"},
+      "scope": {
+        "obs": "ember_egs_p1"
+      },
       "filename": null,
       "relpath": "reference/nirspec/ember_egs_p1/stuck_closed_shutters.toml",
       "key_legacy": null,
@@ -203,7 +268,9 @@
     },
     {
       "product_type": "nirspec_bkg_override",
-      "scope": {"obs": "ember_egs_p1"},
+      "scope": {
+        "obs": "ember_egs_p1"
+      },
       "filename": null,
       "relpath": "reference/nirspec/ember_egs_p1/nodded_background_overrides.toml",
       "key_legacy": null,
@@ -233,7 +300,9 @@
     },
     {
       "product_type": "nircam_mask",
-      "scope": {"field": "cosmos"},
+      "scope": {
+        "field": "cosmos"
+      },
       "filename": "cosmos_f444w_mask.reg",
       "relpath": "reference/nircam/cosmos/masks/cosmos_f444w_mask.reg",
       "key_legacy": null,
@@ -243,7 +312,9 @@
     },
     {
       "product_type": "nircam_astrom_cat",
-      "scope": {"field": "cosmos"},
+      "scope": {
+        "field": "cosmos"
+      },
       "filename": "gaia_cosmos.fits",
       "relpath": "reference/nircam/cosmos/astrom_cats/gaia_cosmos.fits",
       "key_legacy": null,
@@ -253,7 +324,9 @@
     },
     {
       "product_type": "nircam_bad_pixel",
-      "scope": {"field": "cosmos"},
+      "scope": {
+        "field": "cosmos"
+      },
       "filename": "badpix_nrcalong.fits",
       "relpath": "reference/nircam/cosmos/bad_pixels/badpix_nrcalong.fits",
       "key_legacy": null,
@@ -263,7 +336,9 @@
     },
     {
       "product_type": "raw_nirspec",
-      "scope": {"data_subdir": "7076"},
+      "scope": {
+        "data_subdir": "7076"
+      },
       "filename": "jw07076020001_04101_00003_nrs1_uncal.fits",
       "relpath": "raw/nirspec/7076/jw07076020001_04101_00003_nrs1_uncal.fits",
       "key_legacy": null,
@@ -273,7 +348,10 @@
     },
     {
       "product_type": "raw_nircam",
-      "scope": {"pid": "1727", "filt": "f444w"},
+      "scope": {
+        "pid": "1727",
+        "filt": "f444w"
+      },
       "filename": "jw01727028001_04101_00003_nrcalong_uncal.fits",
       "relpath": "raw/nircam/1727/f444w/jw01727028001_04101_00003_nrcalong_uncal.fits",
       "key_legacy": null,
@@ -283,7 +361,9 @@
     },
     {
       "product_type": "summary",
-      "scope": {"obs": "ember_egs_p1"},
+      "scope": {
+        "obs": "ember_egs_p1"
+      },
       "filename": null,
       "relpath": "products/nirspec/ember_egs_p1/ember_egs_p1_summary.ecsv",
       "key_legacy": null,
@@ -293,7 +373,9 @@
     },
     {
       "product_type": "pointings",
-      "scope": {"obs": "ember_egs_p1"},
+      "scope": {
+        "obs": "ember_egs_p1"
+      },
       "filename": null,
       "relpath": "products/nirspec/ember_egs_p1/ember_egs_p1_pointings.ecsv",
       "key_legacy": null,
@@ -303,7 +385,9 @@
     },
     {
       "product_type": "shutters",
-      "scope": {"obs": "ember_egs_p1"},
+      "scope": {
+        "obs": "ember_egs_p1"
+      },
       "filename": null,
       "relpath": "products/nirspec/ember_egs_p1/ember_egs_p1_shutters.ecsv",
       "key_legacy": null,
@@ -313,7 +397,9 @@
     },
     {
       "product_type": "nirspec_config",
-      "scope": {"obs": "ember_egs_p1"},
+      "scope": {
+        "obs": "ember_egs_p1"
+      },
       "filename": null,
       "relpath": "products/nirspec/ember_egs_p1/ember_egs_p1_config.toml",
       "key_legacy": null,
@@ -323,9 +409,21 @@
     }
   ],
   "siblings": [
-    {"from": "spectra/ember_egs_p1/ember_egs_p1_prism_clear_15182_spec.fits", "to": "zfit", "expect": "spectra/ember_egs_p1/ember_egs_p1_prism_clear_15182_zfit.json"},
-    {"from": "spectra/ember_egs_p1/ember_egs_p1_prism_clear_15182_spec.fits", "to": "spectrum_json", "expect": "spectra/ember_egs_p1/ember_egs_p1_prism_clear_15182_spec.json"},
-    {"from": "data/products/nirspec/ember_egs_p1/ember_egs_p1_prism_clear_15182_spec.fits", "to": "zfit", "expect": "data/products/nirspec/ember_egs_p1/ember_egs_p1_prism_clear_15182_zfit.json"}
+    {
+      "from": "spectra/ember_egs_p1/ember_egs_p1_prism_clear_15182_spec.fits",
+      "to": "zfit",
+      "expect": "spectra/ember_egs_p1/ember_egs_p1_prism_clear_15182_zfit.json"
+    },
+    {
+      "from": "spectra/ember_egs_p1/ember_egs_p1_prism_clear_15182_spec.fits",
+      "to": "spectrum_json",
+      "expect": "spectra/ember_egs_p1/ember_egs_p1_prism_clear_15182_spec.json"
+    },
+    {
+      "from": "data/products/nirspec/ember_egs_p1/ember_egs_p1_prism_clear_15182_spec.fits",
+      "to": "zfit",
+      "expect": "data/products/nirspec/ember_egs_p1/ember_egs_p1_prism_clear_15182_zfit.json"
+    }
   ],
   "known_keys": [
     "spectra/ember_egs_p1/ember_egs_p1_prism_clear_15182_spec.fits",
@@ -336,6 +434,7 @@
     "data/products/nirspec/ember_egs_p1/jw07076020001_04101_00003_nrs1_rate.fits",
     "data/products/nircam/cosmos/f444w/expmap_cosmos_f444w.png",
     "data/products/nircam/cosmos/f444w/mosaic_cosmos_f444w_30mas_thumb.png",
+    "data/products/nircam/cosmos/f444w/mosaic_cosmos_f444w_30mas_quicklook.png",
     "data/products/nircam/cosmos/f444w/mosaic_cosmos_f444w_30mas_sci.fits.gz",
     "data/products/nircam/cosmos/cosmos_layout.png"
   ],

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -29,15 +29,19 @@ Release procedure: edit the `## Unreleased` section below, then run
 ## Unreleased
 
 ### Infrastructure
-- NIRCam mosaic thumbnails (`*_thumb.png`) are now size-capped: the long side
-  of the PNG is at most `thumbnail_max_dim` pixels (default 1024; new
-  `[nircam.resample]` config key). The previous fixed /4 downsample scaled
-  with the mosaic — a wide 30 mas strip produced a ~10k-px, tens-of-MB
-  "thumbnail", which the NIRCam web page then served as a table preview. The
-  factor is raised only when needed, so small mosaics are byte-identical to
-  before; quick-look PNG only, no change to FITS pixel values
-  (`nircam/steps/_plots.py`, `nircam/steps/resample.py`,
-  `data/config_default.toml`).
+- NIRCam mosaics now get a size-capped **thumbnail pair** instead of one
+  fixed-/4-downsampled PNG: `<base>_thumb.png` (long side ≤
+  `thumbnail_max_dim`, default 500 px — the web table rendition) and a new
+  `<base>_quicklook.png` (long side ≤ `quicklook_max_dim`, default 4096 px —
+  the click-to-enlarge popup). The fixed /4 factor scaled with the mosaic (a
+  wide 30 mas strip produced a ~10k-px, tens-of-MB "thumbnail"); the caps
+  bound both renditions regardless of field geometry, and mosaics smaller
+  than a cap are saved at native size. Named `quicklook` (not
+  `_preview`/`_full`) because those suffixes already mean the per-exposure
+  triage PNGs in the same directory. Display PNGs only, no change to FITS
+  pixel values (`nircam/steps/_plots.py`, `nircam/steps/resample.py`,
+  `data/config_default.toml`; layout contract + deploy + `storage_objects`
+  CHECK gain the `nircam_mosaic_quicklook` product type).
 - NIRCam expmap/layout plot styling: the deployable dark PNGs (per-filter
   `expmap_*.png` and `<field>_layout.png`) no longer carry a title — the web
   page embedding them already labels field/filter, so it was duplicated

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -29,6 +29,15 @@ Release procedure: edit the `## Unreleased` section below, then run
 ## Unreleased
 
 ### Infrastructure
+- NIRCam mosaic thumbnails (`*_thumb.png`) are now size-capped: the long side
+  of the PNG is at most `thumbnail_max_dim` pixels (default 1024; new
+  `[nircam.resample]` config key). The previous fixed /4 downsample scaled
+  with the mosaic — a wide 30 mas strip produced a ~10k-px, tens-of-MB
+  "thumbnail", which the NIRCam web page then served as a table preview. The
+  factor is raised only when needed, so small mosaics are byte-identical to
+  before; quick-look PNG only, no change to FITS pixel values
+  (`nircam/steps/_plots.py`, `nircam/steps/resample.py`,
+  `data/config_default.toml`).
 - NIRCam expmap/layout plot styling: the deployable dark PNGs (per-filter
   `expmap_*.png` and `<field>_layout.png`) no longer carry a title — the web
   page embedding them already labels field/filter, so it was duplicated

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -471,3 +471,4 @@
     split_extensions = true
     plot = true
     plot_downsample = 4
+    thumbnail_max_dim = 1024  # cap the thumbnail PNG's long side (px)

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -471,4 +471,5 @@
     split_extensions = true
     plot = true
     plot_downsample = 4
-    thumbnail_max_dim = 1024  # cap the thumbnail PNG's long side (px)
+    thumbnail_max_dim = 500   # table thumbnail PNG: long-side cap (px)
+    quicklook_max_dim = 4096  # popup quick-look PNG: long-side cap (px)

--- a/pipeline/campfire_pipeline/nircam/steps/_plots.py
+++ b/pipeline/campfire_pipeline/nircam/steps/_plots.py
@@ -191,15 +191,26 @@ def _block_reduce(arr, block_size):
         return block_reduce(arr, block_size=block_size, func=np.nanmean)
 
 
-def plot_mosaic_thumbnail(sci, save_file, downsample=4, cmap='Greys'):
+def plot_mosaic_thumbnail(sci, save_file, downsample=4, cmap='Greys',
+                          max_dim=1024):
     """Save a downsampled PNG of a mosaic SCI with no axes/borders.
 
     Uses ``plt.imsave`` so the output PNG has exactly the downsampled
-    array's pixel dimensions — small files at native resolution, no
-    matplotlib decoration to scale.
+    array's pixel dimensions — no matplotlib decoration to scale.
+
+    ``downsample`` is a floor, not the final factor: it is raised so the
+    output's long side is at most ``max_dim`` pixels. A fixed /4 alone
+    scales with the mosaic — a wide 30 mas strip came out ~10k px / tens
+    of MB, which the web page then pulled into a 32 px thumbnail. 1024 px
+    stays crisp in the table's click-to-enlarge popup at ~1/100 the bytes.
+    Pass ``max_dim=None`` for the old fixed-factor behavior.
     """
+    import math
+
     import matplotlib.pyplot as plt
 
+    if max_dim:
+        downsample = max(downsample, math.ceil(max(sci.shape) / max_dim))
     thumb = _block_reduce(sci, downsample)
     vmin, vmax = _zscale_limits(thumb)
     plt.imsave(save_file, thumb, cmap=cmap, vmin=vmin, vmax=vmax,

--- a/pipeline/campfire_pipeline/nircam/steps/_plots.py
+++ b/pipeline/campfire_pipeline/nircam/steps/_plots.py
@@ -191,26 +191,25 @@ def _block_reduce(arr, block_size):
         return block_reduce(arr, block_size=block_size, func=np.nanmean)
 
 
-def plot_mosaic_thumbnail(sci, save_file, downsample=4, cmap='Greys',
-                          max_dim=1024):
-    """Save a downsampled PNG of a mosaic SCI with no axes/borders.
+def plot_mosaic_thumbnail(sci, save_file, max_dim=500, cmap='Greys'):
+    """Save a size-capped PNG rendering of a mosaic SCI, no axes/borders.
 
-    Uses ``plt.imsave`` so the output PNG has exactly the downsampled
-    array's pixel dimensions — no matplotlib decoration to scale.
+    Block-mean downsampled so the output's long side is at most ``max_dim``
+    pixels (a mosaic already smaller than that is saved at native size).
+    Uses ``plt.imsave`` so the PNG has exactly the downsampled array's pixel
+    dimensions — no matplotlib decoration to scale.
 
-    ``downsample`` is a floor, not the final factor: it is raised so the
-    output's long side is at most ``max_dim`` pixels. A fixed /4 alone
-    scales with the mosaic — a wide 30 mas strip came out ~10k px / tens
-    of MB, which the web page then pulled into a 32 px thumbnail. 1024 px
-    stays crisp in the table's click-to-enlarge popup at ~1/100 the bytes.
-    Pass ``max_dim=None`` for the old fixed-factor behavior.
+    Written twice per mosaic with different caps: a small ``_thumb.png`` for
+    table rendering and a large ``_quicklook.png`` for the click-to-enlarge
+    popup. A fixed downsample factor is deliberately NOT used — it scales
+    with the mosaic (a wide 30 mas strip at /4 came out ~10k px / tens of
+    MB).
     """
     import math
 
     import matplotlib.pyplot as plt
 
-    if max_dim:
-        downsample = max(downsample, math.ceil(max(sci.shape) / max_dim))
+    downsample = max(1, math.ceil(max(sci.shape) / max_dim))
     thumb = _block_reduce(sci, downsample)
     vmin, vmax = _zscale_limits(thumb)
     plt.imsave(save_file, thumb, cmap=cmap, vmin=vmin, vmax=vmax,

--- a/pipeline/campfire_pipeline/nircam/steps/resample.py
+++ b/pipeline/campfire_pipeline/nircam/steps/resample.py
@@ -432,7 +432,10 @@ def resample_step(filtname, exposure_files, field, step_config,
             downsample = int(step_config.get('plot_downsample', 4))
 
             thumb_png = mosaic_file.replace('_i2d.fits', '_thumb.png')
-            plot_mosaic_thumbnail(sci, thumb_png, downsample=downsample)
+            plot_mosaic_thumbnail(
+                sci, thumb_png, downsample=downsample,
+                max_dim=int(step_config.get('thumbnail_max_dim', 1024)),
+            )
             log(f"  saved {os.path.basename(thumb_png)}")
 
             if step_config.get('background_subtract', True):

--- a/pipeline/campfire_pipeline/nircam/steps/resample.py
+++ b/pipeline/campfire_pipeline/nircam/steps/resample.py
@@ -431,12 +431,21 @@ def resample_step(filtname, exposure_files, field, step_config,
             )
             downsample = int(step_config.get('plot_downsample', 4))
 
+            # Thumbnail pair: a small table rendition + a large quick-look
+            # for the web popup, both size-capped (see plot_mosaic_thumbnail).
             thumb_png = mosaic_file.replace('_i2d.fits', '_thumb.png')
             plot_mosaic_thumbnail(
-                sci, thumb_png, downsample=downsample,
-                max_dim=int(step_config.get('thumbnail_max_dim', 1024)),
+                sci, thumb_png,
+                max_dim=int(step_config.get('thumbnail_max_dim', 500)),
             )
             log(f"  saved {os.path.basename(thumb_png)}")
+
+            quicklook_png = mosaic_file.replace('_i2d.fits', '_quicklook.png')
+            plot_mosaic_thumbnail(
+                sci, quicklook_png,
+                max_dim=int(step_config.get('quicklook_max_dim', 4096)),
+            )
+            log(f"  saved {os.path.basename(quicklook_png)}")
 
             if step_config.get('background_subtract', True):
                 pre_bkg_path = mosaic_file.replace(

--- a/pipeline/tests/test_mosaic_thumbnail.py
+++ b/pipeline/tests/test_mosaic_thumbnail.py
@@ -1,6 +1,9 @@
-"""Mosaic thumbnail size cap: a fixed /4 downsample scaled with the mosaic
-(a wide 30 mas strip produced ~10k-px, tens-of-MB "thumbnails"); the long
-side is now capped at ``max_dim`` while small mosaics keep the old behavior.
+"""Mosaic thumbnail pair: size-capped PNG renditions of a mosaic SCI.
+
+A fixed /4 downsample scaled with the mosaic (a wide 30 mas strip produced
+~10k-px, tens-of-MB "thumbnails"), so the render is capped by target long
+side instead — written twice per mosaic: a small ``_thumb.png`` for the web
+table and a large ``_quicklook.png`` for the click-to-enlarge popup.
 """
 
 import matplotlib
@@ -18,26 +21,27 @@ def _dims(path):
     return img.shape[1], img.shape[0]  # (w, h)
 
 
-def test_large_mosaic_is_capped(tmp_path):
+def test_table_thumbnail_cap(tmp_path):
     sci = np.random.default_rng(0).normal(size=(2200, 5000)).astype(np.float32)
     out = tmp_path / 'thumb.png'
-    plot_mosaic_thumbnail(sci, str(out), downsample=4, max_dim=1024)
+    plot_mosaic_thumbnail(sci, str(out), max_dim=500)
     w, h = _dims(out)
-    assert max(w, h) <= 1024
-    # near the cap, not over-shrunk (ceil(5000/1024)=5 -> 1000 px)
-    assert max(w, h) == 1000
-    assert out.stat().st_size < 5 * 1024 * 1024
+    assert max(w, h) <= 500
+    assert max(w, h) == 500  # ceil(5000/500)=10 -> exactly at the cap
+    assert out.stat().st_size < 1024 * 1024
 
 
-def test_small_mosaic_keeps_fixed_downsample(tmp_path):
-    sci = np.random.default_rng(1).normal(size=(400, 800)).astype(np.float32)
+def test_quicklook_cap(tmp_path):
+    sci = np.random.default_rng(1).normal(size=(2200, 5000)).astype(np.float32)
+    out = tmp_path / 'quicklook.png'
+    plot_mosaic_thumbnail(sci, str(out), max_dim=4096)
+    w, h = _dims(out)
+    assert max(w, h) <= 4096
+    assert max(w, h) == 2500  # ceil(5000/4096)=2 -> half size
+
+
+def test_small_mosaic_saved_at_native_size(tmp_path):
+    sci = np.random.default_rng(2).normal(size=(200, 300)).astype(np.float32)
     out = tmp_path / 'thumb.png'
-    plot_mosaic_thumbnail(sci, str(out), downsample=4, max_dim=1024)
-    assert _dims(out) == (200, 100)  # exactly /4, cap not engaged
-
-
-def test_max_dim_none_restores_old_behavior(tmp_path):
-    sci = np.random.default_rng(2).normal(size=(512, 8192)).astype(np.float32)
-    out = tmp_path / 'thumb.png'
-    plot_mosaic_thumbnail(sci, str(out), downsample=4, max_dim=None)
-    assert _dims(out) == (2048, 128)  # fixed /4, uncapped
+    plot_mosaic_thumbnail(sci, str(out), max_dim=500)
+    assert _dims(out) == (300, 200)  # under the cap: factor 1, no upsampling

--- a/pipeline/tests/test_mosaic_thumbnail.py
+++ b/pipeline/tests/test_mosaic_thumbnail.py
@@ -1,0 +1,43 @@
+"""Mosaic thumbnail size cap: a fixed /4 downsample scaled with the mosaic
+(a wide 30 mas strip produced ~10k-px, tens-of-MB "thumbnails"); the long
+side is now capped at ``max_dim`` while small mosaics keep the old behavior.
+"""
+
+import matplotlib
+
+matplotlib.use('Agg')
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from campfire_pipeline.nircam.steps._plots import plot_mosaic_thumbnail
+
+
+def _dims(path):
+    img = plt.imread(str(path))
+    return img.shape[1], img.shape[0]  # (w, h)
+
+
+def test_large_mosaic_is_capped(tmp_path):
+    sci = np.random.default_rng(0).normal(size=(2200, 5000)).astype(np.float32)
+    out = tmp_path / 'thumb.png'
+    plot_mosaic_thumbnail(sci, str(out), downsample=4, max_dim=1024)
+    w, h = _dims(out)
+    assert max(w, h) <= 1024
+    # near the cap, not over-shrunk (ceil(5000/1024)=5 -> 1000 px)
+    assert max(w, h) == 1000
+    assert out.stat().st_size < 5 * 1024 * 1024
+
+
+def test_small_mosaic_keeps_fixed_downsample(tmp_path):
+    sci = np.random.default_rng(1).normal(size=(400, 800)).astype(np.float32)
+    out = tmp_path / 'thumb.png'
+    plot_mosaic_thumbnail(sci, str(out), downsample=4, max_dim=1024)
+    assert _dims(out) == (200, 100)  # exactly /4, cap not engaged
+
+
+def test_max_dim_none_restores_old_behavior(tmp_path):
+    sci = np.random.default_rng(2).normal(size=(512, 8192)).astype(np.float32)
+    out = tmp_path / 'thumb.png'
+    plot_mosaic_thumbnail(sci, str(out), downsample=4, max_dim=None)
+    assert _dims(out) == (2048, 128)  # fixed /4, uncapped

--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -938,14 +938,23 @@ def discover_mosaics(dirs, field, filters):
     return out
 
 
-def discover_mosaic_thumbnail_tasks(mosaics, field):
-    """One ``nircam_mosaic_thumbnail`` upload task per mosaic base.
+# The thumbnail pair the pipeline writes per mosaic base (derived from the
+# i2d): a small table rendition + a large quick-look for the web popup.
+_MOSAIC_PNG_RENDITIONS = (
+    ('_thumb.png', 'nircam_mosaic_thumbnail'),
+    ('_quicklook.png', 'nircam_mosaic_quicklook'),
+)
 
-    The pipeline writes a single ``<base>_thumb.png`` per mosaic (derived from the
-    i2d), so this dedups the per-extension ``mosaics`` list to one task per base
-    and only emits it when the thumbnail exists. The scope filter is the mosaic's
-    own directory name, so the thumbnail key sits beside its mosaic FITS. Returns
-    ``[]`` when no thumbnails are present (a field reduced before thumbnails).
+
+def discover_mosaic_thumbnail_tasks(mosaics, field):
+    """Upload tasks for each mosaic base's PNG renditions (thumbnail pair).
+
+    The pipeline writes ``<base>_thumb.png`` (small, table) and
+    ``<base>_quicklook.png`` (large, popup) per mosaic, so this dedups the
+    per-extension ``mosaics`` list to one pass per base and emits a task per
+    rendition that exists on disk. The scope filter is the mosaic's own
+    directory name, so the keys sit beside their mosaic FITS. Fields reduced
+    before a rendition existed simply skip it.
     """
     tasks = []
     seen = set()
@@ -955,14 +964,15 @@ def discover_mosaic_thumbnail_tasks(mosaics, field):
         if key_id in seen:
             continue
         seen.add(key_id)
-        thumb_path = m['path'].parent / f"{m['mosaic_name']}_thumb.png"
-        if thumb_path.exists():
-            tasks.append(UploadTask(
-                local_path=thumb_path,
-                r2_key=storage_key('nircam_mosaic_thumbnail',
-                                   Scope(field=field, filt=filt),
-                                   thumb_path.name, scheme=KeyScheme.CANONICAL),
-                content_type=_PNG_CONTENT_TYPE))
+        for suffix, product in _MOSAIC_PNG_RENDITIONS:
+            png_path = m['path'].parent / f"{m['mosaic_name']}{suffix}"
+            if png_path.exists():
+                tasks.append(UploadTask(
+                    local_path=png_path,
+                    r2_key=storage_key(product,
+                                       Scope(field=field, filt=filt),
+                                       png_path.name, scheme=KeyScheme.CANONICAL),
+                    content_type=_PNG_CONTENT_TYPE))
     return tasks
 
 

--- a/python/tests/test_deploy_fields.py
+++ b/python/tests/test_deploy_fields.py
@@ -212,15 +212,30 @@ def test_discover_mosaic_thumbnail_tasks(tmp_path):
     base = "mosaic_nircam_f444w_cosmos_30mas_A1"
     (fdir / f"{base}_i2d.fits").write_bytes(b"\x00")
     (fdir / f"{base}_thumb.png").write_bytes(b"\x00")
-    # two extensions of the same mosaic base -> still ONE thumbnail task
+    (fdir / f"{base}_quicklook.png").write_bytes(b"\x00")
+    # two extensions of the same mosaic base -> still ONE task per rendition
     mosaics = [
         {"path": fdir / f"{base}_i2d.fits", "mosaic_name": base},
         {"path": fdir / f"{base}_sci.fits", "mosaic_name": base},
     ]
     tasks = nc.discover_mosaic_thumbnail_tasks(mosaics, "cosmos")
     assert [t.r2_key for t in tasks] == [
+        f"data/products/nircam/cosmos/f444w/{base}_thumb.png",
+        f"data/products/nircam/cosmos/f444w/{base}_quicklook.png"]
+    assert all(t.content_type == "image/png" for t in tasks)
+
+
+def test_discover_mosaic_thumbnail_tasks_thumb_only(tmp_path):
+    # A field reduced before the quicklook existed ships just the thumbnail.
+    fdir = tmp_path / "products" / "nircam" / "cosmos" / "f444w"
+    fdir.mkdir(parents=True)
+    base = "mosaic_nircam_f444w_cosmos_30mas_A1"
+    (fdir / f"{base}_i2d.fits").write_bytes(b"\x00")
+    (fdir / f"{base}_thumb.png").write_bytes(b"\x00")
+    mosaics = [{"path": fdir / f"{base}_i2d.fits", "mosaic_name": base}]
+    tasks = nc.discover_mosaic_thumbnail_tasks(mosaics, "cosmos")
+    assert [t.r2_key for t in tasks] == [
         f"data/products/nircam/cosmos/f444w/{base}_thumb.png"]
-    assert tasks[0].content_type == "image/png"
 
 
 def test_discover_mosaic_thumbnail_tasks_empty_when_absent(tmp_path):

--- a/supabase/migrations/20260712182144_add_nircam_mosaic_quicklook.sql
+++ b/supabase/migrations/20260712182144_add_nircam_mosaic_quicklook.sql
@@ -1,0 +1,16 @@
+-- Add 'nircam_mosaic_quicklook' to the storage_objects product-type CHECK:
+-- the larger rendition of the mosaic thumbnail pair (long side ~4k px, for
+-- the NIRCam page's click-to-enlarge popup; `_thumb.png` stays the small
+-- table rendition). Named "quicklook" because `_preview.png`/`_full.png` in
+-- the same directory already mean the per-exposure triage PNGs.
+--
+-- NOTE: the generated diff also contained the usual spurious migra
+-- drop/recreate churn for mv_filter_options, mv_programs_overview,
+-- nircam_reduction_progress and spectrum_flag_summary (migra cannot track
+-- (mat)views); stripped here, only the intended CHECK change kept.
+
+alter table "public"."storage_objects" drop constraint "storage_objects_product_type_check";
+
+alter table "public"."storage_objects" add constraint "storage_objects_product_type_check" CHECK ((product_type = ANY (ARRAY['nirspec_spec'::text, 'spectrum_json'::text, 'zfit'::text, 'nirspec_spectrum_exposure'::text, 'nirspec_rate'::text, 'rgb'::text, 'sed'::text, 'nircam_exposure'::text, 'nircam_exposure_preview'::text, 'nircam_exposure_full'::text, 'nircam_mosaic'::text, 'nircam_rgb'::text, 'nircam_expmap'::text, 'nircam_expmap_plot'::text, 'nircam_mosaic_thumbnail'::text, 'nircam_mosaic_quicklook'::text, 'nircam_layout'::text, 'tile'::text, 'photometry_pz'::text, 'nirspec_manual_mask'::text, 'nirspec_stuck_shutters'::text, 'nirspec_bkg_override'::text, 'nircam_mask'::text, 'nircam_astrom_cat'::text, 'nircam_bad_pixel'::text, 'nircam_flat'::text, 'nircam_wisp'::text]))) not valid;
+
+alter table "public"."storage_objects" validate constraint "storage_objects_product_type_check";

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -1048,7 +1048,7 @@ CREATE TABLE IF NOT EXISTS "public"."storage_objects" (
         'nircam_exposure'::"text", 'nircam_exposure_preview'::"text",
         'nircam_exposure_full'::"text", 'nircam_mosaic'::"text", 'nircam_rgb'::"text",
         'nircam_expmap'::"text", 'nircam_expmap_plot'::"text",
-        'nircam_mosaic_thumbnail'::"text", 'nircam_layout'::"text",
+        'nircam_mosaic_thumbnail'::"text", 'nircam_mosaic_quicklook'::"text", 'nircam_layout'::"text",
         'tile'::"text", 'photometry_pz'::"text",
         'nirspec_manual_mask'::"text", 'nirspec_stuck_shutters'::"text",
         'nirspec_bkg_override'::"text", 'nircam_mask'::"text", 'nircam_astrom_cat'::"text",

--- a/web/lib/layout.ts
+++ b/web/lib/layout.ts
@@ -90,6 +90,7 @@ reg(spec({ name: 'nircam_rgb', tree: 'products', bucket: 'data', scopeKeys: ['fi
 reg(spec({ name: 'nircam_expmap', tree: 'products', bucket: 'data', scopeKeys: ['field', 'filt'], subdir: nircamFieldFilter, suffix: null }));
 reg(spec({ name: 'nircam_expmap_plot', tree: 'products', bucket: 'data', scopeKeys: ['field', 'filt'], subdir: nircamFieldFilter, suffix: null }));
 reg(spec({ name: 'nircam_mosaic_thumbnail', tree: 'products', bucket: 'data', scopeKeys: ['field', 'filt'], subdir: nircamFieldFilter, suffix: '_thumb.png' }));
+reg(spec({ name: 'nircam_mosaic_quicklook', tree: 'products', bucket: 'data', scopeKeys: ['field', 'filt'], subdir: nircamFieldFilter, suffix: '_quicklook.png' }));
 reg(spec({ name: 'nircam_layout', tree: 'products', bucket: 'data', scopeKeys: ['field'], subdir: (s) => `nircam/${s.field}`, suffix: '_layout.png' }));
 
 // --- Map tiles (separate bucket, scheme-invariant) ---
@@ -205,6 +206,7 @@ const NIRCAM_FILTER_SUFFIXES: [string, string][] = [
   ['_preview.png', 'nircam_exposure_preview'],
   ['_full.png', 'nircam_exposure_full'],
   ['_thumb.png', 'nircam_mosaic_thumbnail'], // before the 'mosaic' prefix check
+  ['_quicklook.png', 'nircam_mosaic_quicklook'],
 ];
 const TILE_RE = /^([^/]+)\/([^/]+)\/(\d+)\/(\d+)\/(\d+)\.png$/;
 


### PR DESCRIPTION
**Reworked per review** — instead of one capped thumbnail, the pipeline writes a **pair** per mosaic (found via the EGS test deploy, where the fixed `/4` downsample produced 49–65 MB "thumbnails" from 30 mas strips):

| Rendition | Cap (config key) | Consumer |
|---|---|---|
| `<base>_thumb.png` | 500 px (`thumbnail_max_dim`) | table preview on `/nircam/[field]` |
| `<base>_quicklook.png` **(new)** | 4096 px (`quicklook_max_dim`) | click-to-enlarge popup |

Mosaics smaller than a cap save at native size (never upsampled). Named `quicklook` deliberately: `_preview.png` / `_full.png` in the same `<field>/<filter>/` directory already dispatch to the **per-exposure triage PNG** product types in the layout contract, so those suffixes would collide.

## Scope (full backend slice)
- **pipeline** — `plot_mosaic_thumbnail(max_dim)`, both renditions written in the resample plot phase, config keys, 3 tests, changelog (Infrastructure/PATCH; display PNGs only, no FITS pixel change)
- **layout contract** — `nircam_mosaic_quicklook` spec + suffix dispatch (python + TS mirror + golden case); conformance green both arms (py 39 / vitest 108)
- **db** — `storage_objects_product_type_check` gains the type (schema + migration, migra matview churn stripped; verified via `db reset` + live insert)
- **deploy** — `discover_mosaic_thumbnail_tasks` emits one task per rendition present; a field reduced before quicklooks existed still ships its thumb; tests updated (13 pass)

Web consumption (table uses thumb, popup prefers quicklook with thumb fallback) lands on #379.

## Post-merge
Regenerate the EGS renditions (renders from the existing `_sci` FITS in the resample plot phase — no re-drizzle) + redeploy; dedup re-uploads only the changed/new PNGs.

Generated with Claude Code