### PR TITLE
feat(deploy): record stored (gzipped) byte count in the registry

### DIFF
--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -1029,16 +1029,19 @@ def _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
         m['size'] = plan.stats.get(m['storage_key'], (None, None))[1]
 
     uploaded: set[str] = set()
+    # Gzipped mosaic uploads report the bytes actually PUT; the flusher writes
+    # them to registry.stored_size_bytes (size_bytes stays the logical size).
+    stored_sizes: dict[str, int] = {}
     flusher = registration_flusher(
         client, store, plan, backend=_CANONICAL_BACKEND,
         deployment_id=deployment_id, uploaded_by=user_id,
-        max_workers=_upload_workers())
+        max_workers=_upload_workers(), stored_sizes=stored_sizes)
     if plan.to_upload:
         print(f"  Uploading {len(plan.to_upload)} mosaic file(s) to OSN...")
         success, failed, failures = upload_files_parallel(
             config, plan.to_upload, desc='OSN mosaic uploads', max_workers=_upload_workers(),
             succeeded_out=uploaded, backend=_CANONICAL_BACKEND,
-            on_success=flusher.add)
+            on_success=flusher.add, stored_sizes_out=stored_sizes)
         flusher.flush()
         print(f"  Uploaded: {success}, Failed: {failed}")
         for msg in failures:

--- a/python/campfire/deploy/push.py
+++ b/python/campfire/deploy/push.py
@@ -328,9 +328,15 @@ def push_observation(
                 'skipped': len(plan.unchanged)}
 
     user_id = get_user_id_from_token(config)
+    # Transport-compressed uploads (gzipped mosaics) report their stored byte
+    # count; the flusher writes it to registry.stored_size_bytes. Wired here as
+    # well as in deploy so the slow-link workflow (push heavy bytes first, then
+    # deploy dedup-skips them) records it too — deploy never re-uploads.
+    stored_sizes: dict[str, int] = {}
     flusher = registration_flusher(
         client, store, plan, backend='osn', deployment_id=None,
-        uploaded_by=user_id, cfpipe_version=cfpipe_version)
+        uploaded_by=user_id, cfpipe_version=cfpipe_version,
+        stored_sizes=stored_sizes)
 
     upload_workers = workers or default_upload_workers()
     total_bytes = sum(plan.stats[t.r2_key][1] for t in plan.to_upload
@@ -339,7 +345,8 @@ def push_observation(
           f"({total_bytes / 1e9:.2f} GB) to OSN...")
     success, failed, failures = upload_files_parallel(
         config, plan.to_upload, desc='Pushing to OSN',
-        max_workers=upload_workers, backend='osn', on_success=flusher.add)
+        max_workers=upload_workers, backend='osn', on_success=flusher.add,
+        stored_sizes_out=stored_sizes)
     flusher.flush()
 
     print(f"  Pushed: {success}, Failed: {failed}, "
@@ -430,9 +437,15 @@ def push_field(
 
     cfpipe_version, _jwst, _crds = _read_field_provenance(dirs, field, filters)
     user_id = get_user_id_from_token(config)
+    # Transport-compressed uploads (gzipped mosaics) report their stored byte
+    # count; the flusher writes it to registry.stored_size_bytes. Wired here as
+    # well as in deploy so the slow-link workflow (push heavy bytes first, then
+    # deploy dedup-skips them) records it too — deploy never re-uploads.
+    stored_sizes: dict[str, int] = {}
     flusher = registration_flusher(
         client, store, plan, backend='osn', deployment_id=None,
-        uploaded_by=user_id, cfpipe_version=cfpipe_version)
+        uploaded_by=user_id, cfpipe_version=cfpipe_version,
+        stored_sizes=stored_sizes)
 
     upload_workers = workers or default_upload_workers()
     total_bytes = sum(plan.stats[t.r2_key][1] for t in plan.to_upload
@@ -441,7 +454,8 @@ def push_field(
           f"({total_bytes / 1e9:.2f} GB) to OSN...")
     success, failed, failures = upload_files_parallel(
         config, plan.to_upload, desc='Pushing to OSN',
-        max_workers=upload_workers, backend='osn', on_success=flusher.add)
+        max_workers=upload_workers, backend='osn', on_success=flusher.add,
+        stored_sizes_out=stored_sizes)
     flusher.flush()
 
     print(f"  Pushed: {success}, Failed: {failed}, "

--- a/python/campfire/deploy/push.py
+++ b/python/campfire/deploy/push.py
@@ -169,6 +169,7 @@ def registration_flusher(
     cfpipe_version: Optional[str] = None,
     max_workers: Optional[int] = None,
     batch_size: int = REGISTRATION_BATCH,
+    stored_sizes: Optional[dict[str, int]] = None,
 ) -> BatchFlusher:
     """Build the per-batch registration hook for an upload pass.
 
@@ -209,7 +210,7 @@ def registration_flusher(
             batch, backend=backend, deployment_id=deployment_id,
             uploaded_by=uploaded_by, cfpipe_version=cfpipe_version,
             sci_dq_hashes=sci_dq, precomputed=plan.whole_file,
-            max_workers=max_workers,
+            max_workers=max_workers, stored_sizes=stored_sizes,
         )
         upsert_storage_objects(client, rows)
 

--- a/python/campfire/deploy/r2.py
+++ b/python/campfire/deploy/r2.py
@@ -219,7 +219,7 @@ def _assert_presigned_backend_osn(urls: dict[str, str]) -> None:
 
 def _upload_to_presigned_url(
     session, url: str, local_path: Path, content_type: str, *, compress: bool = False,
-) -> None:
+) -> Optional[int]:
     """Upload a single file to a presigned PutObject URL via a pooled session.
 
     The shared session gives each worker a persistent connection (one TCP+TLS
@@ -229,8 +229,13 @@ def _upload_to_presigned_url(
     ``compress`` gzips the body first (compressed products only); the presign was
     minted for the ``.fits.gz`` key with a matching ``application/gzip``
     Content-Type, so the header stays consistent with the signed request.
+
+    Returns the **stored** byte count for a compressed upload (the gzipped
+    body actually PUT — the registry's ``stored_size_bytes``), or None for a
+    verbatim upload (stored bytes == the logical ``size_bytes``).
     """
     with _upload_body(local_path, compress=compress) as body:
+        stored_size = body.stat().st_size if compress else None
         with open(body, 'rb') as f:
             resp = session.put(
                 url,
@@ -239,6 +244,7 @@ def _upload_to_presigned_url(
                 timeout=300,
             )
             resp.raise_for_status()
+    return stored_size
 
 
 def upload_files_presigned(
@@ -250,6 +256,7 @@ def upload_files_presigned(
     *,
     session=None,
     on_success: Optional[Callable[[UploadTask], None]] = None,
+    stored_sizes_out: Optional[dict[str, int]] = None,
 ) -> tuple[int, int, list[str]]:
     """
     Upload files using presigned URLs.
@@ -289,7 +296,11 @@ def upload_files_presigned(
     if session is None:
         session = create_transfer_session(max_workers, methods=("GET", "PUT"))
 
-    def _success(task: UploadTask, _result) -> None:
+    def _success(task: UploadTask, result) -> None:
+        # Stored-byte capture must precede on_success: the registration
+        # flusher may build this task's registry row inside that callback.
+        if stored_sizes_out is not None and result is not None:
+            stored_sizes_out[task.r2_key] = result
         if succeeded_out is not None:
             succeeded_out.add(task.r2_key)
         if on_success is not None:
@@ -343,11 +354,12 @@ def upload_to_r2(
     cache_control: str | None = None,
     *,
     compress: bool = False,
-) -> None:
+) -> Optional[int]:
     """Upload a single file via boto3 (any S3-compatible backend).
 
     ``compress`` gzips the body first (compressed products only); the caller's
-    ``content_type`` should already be ``application/gzip`` for those.
+    ``content_type`` should already be ``application/gzip`` for those. Returns
+    the stored (gzipped) byte count for a compressed upload, else None.
     """
     extra_args = {}
     if content_type:
@@ -356,12 +368,14 @@ def upload_to_r2(
         extra_args['CacheControl'] = cache_control
 
     with _upload_body(local_path, compress=compress) as body:
+        stored_size = body.stat().st_size if compress else None
         client.upload_file(
             str(body),
             bucket,
             r2_key,
             ExtraArgs=extra_args or None,
         )
+    return stored_size
 
 
 def upload_files_direct(
@@ -374,6 +388,7 @@ def upload_files_direct(
     *,
     cache_control: Optional[str] = None,
     on_success: Optional[Callable[[UploadTask], None]] = None,
+    stored_sizes_out: Optional[dict[str, int]] = None,
 ) -> tuple[int, int, list[str]]:
     """
     Upload multiple files via boto3 in parallel with progress bar.
@@ -389,7 +404,9 @@ def upload_files_direct(
     if not tasks:
         return 0, 0, []
 
-    def _success(task: UploadTask, _result) -> None:
+    def _success(task: UploadTask, result) -> None:
+        if stored_sizes_out is not None and result is not None:
+            stored_sizes_out[task.r2_key] = result
         if succeeded_out is not None:
             succeeded_out.add(task.r2_key)
         if on_success is not None:
@@ -423,6 +440,7 @@ def upload_files_parallel(
     *,
     backend: str,
     on_success: Optional[Callable[[UploadTask], None]] = None,
+    stored_sizes_out: Optional[dict[str, int]] = None,
 ) -> tuple[int, int, list[str]]:
     """
     Upload files to the object store, dispatching on the resolved deploy auth mode.
@@ -503,6 +521,7 @@ def upload_files_parallel(
             s, f, msgs = upload_files_presigned(
                 urls, batch, max_workers=max_workers, desc=desc,
                 succeeded_out=succeeded_out, session=session, on_success=on_success,
+                stored_sizes_out=stored_sizes_out,
             )
             total_success += s
             total_failed += f
@@ -535,5 +554,5 @@ def upload_files_parallel(
     return upload_files_direct(
         client, backend_cfg.bucket, tasks, max_workers=max_workers, desc=desc,
         succeeded_out=succeeded_out, cache_control=cache_control,
-        on_success=on_success,
+        on_success=on_success, stored_sizes_out=stored_sizes_out,
     )

--- a/python/campfire/deploy/registry.py
+++ b/python/campfire/deploy/registry.py
@@ -152,6 +152,7 @@ def row_for_key(
     status: str = 'active',
     bucket: Optional[str] = None,
     sci_dq_hash: Optional[str] = None,
+    stored_size_bytes: Optional[int] = None,
 ) -> dict | None:
     """Build one ``storage_objects`` row dict from a storage key + integrity info.
 
@@ -191,6 +192,11 @@ def row_for_key(
         # canonical exposures carry one today; None leaves the column NULL.
         'sci_dq_hash': sci_dq_hash,
         'size_bytes': int(size_bytes),
+        # Bytes as stored in the bucket for transport-compressed products
+        # (gzipped mosaic FITS); NULL = stored verbatim (== size_bytes, which
+        # stays the LOGICAL uncompressed size the sync engine's dedup and stat
+        # fast-path compare against local plain files).
+        'stored_size_bytes': stored_size_bytes,
         'content_type': content_type,
         'product_type': product_type,
         'instrument': instrument,
@@ -224,6 +230,7 @@ def build_registry_rows(
     sci_dq_hashes: Optional[dict[str, str]] = None,
     max_workers: Optional[int] = None,
     precomputed: Optional[dict[str, tuple[str, int]]] = None,
+    stored_sizes: Optional[dict[str, int]] = None,
 ) -> list[dict]:
     """Build ``storage_objects`` rows for the objects an upload actually landed.
 
@@ -246,6 +253,7 @@ def build_registry_rows(
     """
     sci_dq_hashes = sci_dq_hashes or {}
     precomputed = precomputed or {}
+    stored_sizes = stored_sizes or {}
     selected: list[tuple[UploadTask, Path]] = []
     for task in tasks:
         if succeeded_keys is not None and task.r2_key not in succeeded_keys:
@@ -273,6 +281,7 @@ def build_registry_rows(
             uploaded_by=uploaded_by,
             cfpipe_version=cfpipe_version,
             sci_dq_hash=sci_dq_hashes.get(task.r2_key),
+            stored_size_bytes=stored_sizes.get(task.r2_key),
         )
         if row is not None:
             rows.append(row)

--- a/python/tests/test_mosaic_compression.py
+++ b/python/tests/test_mosaic_compression.py
@@ -87,3 +87,78 @@ def test_upload_body_cleans_up_temp_on_error(tmp_path):
     assert leaked is not None and not leaked.exists()  # finally-unlinked
     # no stray .gz.tmp left in the dir
     assert not any(f.name.endswith(".gz.tmp") for f in tmp_path.iterdir())
+
+
+# --- stored_size_bytes capture (registry transport-size column) -------------
+
+class _FakeS3:
+    """Captures upload_file calls; records the staged body's size."""
+    def __init__(self):
+        self.calls = []
+
+    def upload_file(self, filename, bucket, key, ExtraArgs=None):
+        self.calls.append((Path(filename).stat().st_size, bucket, key))
+
+
+def test_upload_to_r2_returns_stored_gz_size(tmp_path):
+    from campfire.deploy.r2 import upload_to_r2
+    src = tmp_path / "mosaic_x_sci.fits"
+    src.write_bytes(b"\x00" * 100_000)  # highly compressible
+
+    fake = _FakeS3()
+    stored = upload_to_r2(fake, "bucket", src, _key("mosaic_x_sci.fits"),
+                          "application/gzip", compress=True)
+    # returned value == the gz body actually PUT, and much smaller than source
+    assert stored == fake.calls[0][0]
+    assert 0 < stored < 100_000
+
+    # verbatim upload: no stored size (stored bytes == logical size_bytes)
+    assert upload_to_r2(fake, "bucket", src, "data/x.fits",
+                        "application/fits", compress=False) is None
+
+
+def test_direct_wrapper_collects_stored_sizes(tmp_path):
+    from campfire.deploy.r2 import UploadTask, upload_files_direct
+    fits = tmp_path / "mosaic_x_sci.fits"
+    fits.write_bytes(b"\x00" * 50_000)
+    png = tmp_path / "mosaic_x_thumb.png"
+    png.write_bytes(b"\x01" * 500)
+
+    gz_key = _key("mosaic_x_sci.fits")  # .fits.gz -> compressed
+    png_key = _key("mosaic_x_thumb.png", product="nircam_mosaic_thumbnail")
+
+    stored: dict[str, int] = {}
+    ok, failed, _ = upload_files_direct(
+        _FakeS3(), "bucket",
+        [UploadTask(fits, gz_key, "application/gzip"),
+         UploadTask(png, png_key, "image/png")],
+        max_workers=2, stored_sizes_out=stored)
+    assert (ok, failed) == (2, 0)
+    assert set(stored) == {gz_key}          # only the compressed product
+    assert 0 < stored[gz_key] < 50_000
+
+
+def test_registry_row_carries_stored_size_bytes(tmp_path):
+    from campfire.deploy.r2 import UploadTask
+    from campfire.deploy.registry import build_registry_rows, row_for_key
+
+    row = row_for_key(_key("mosaic_x_sci.fits"), backend="osn",
+                      content_hash="sha256:0", size_bytes=100,
+                      content_type="application/gzip", stored_size_bytes=42)
+    assert row["stored_size_bytes"] == 42
+    assert row["size_bytes"] == 100  # logical size untouched
+
+    # default: NULL (stored verbatim)
+    row = row_for_key(_key("mosaic_x_sci.fits"), backend="osn",
+                      content_hash="sha256:0", size_bytes=100,
+                      content_type="application/gzip")
+    assert row["stored_size_bytes"] is None
+
+    # build_registry_rows threads the per-key map through
+    fits = tmp_path / "mosaic_x_sci.fits"
+    fits.write_bytes(b"\x00" * 10)
+    gz_key = _key("mosaic_x_sci.fits")
+    rows = build_registry_rows(
+        [UploadTask(fits, gz_key, "application/gzip")],
+        backend="osn", stored_sizes={gz_key: 7})
+    assert rows[0]["stored_size_bytes"] == 7

--- a/python/tests/test_mosaic_compression.py
+++ b/python/tests/test_mosaic_compression.py
@@ -162,3 +162,17 @@ def test_registry_row_carries_stored_size_bytes(tmp_path):
         [UploadTask(fits, gz_key, "application/gzip")],
         backend="osn", stored_sizes={gz_key: 7})
     assert rows[0]["stored_size_bytes"] == 7
+
+
+def test_push_paths_wire_stored_sizes(monkeypatch):
+    """The slow-link workflow (`campfire push` first; deploy dedup-skips) must
+    record stored_size_bytes too — deploy never re-uploads those bytes, so a
+    push-side registration is the only chance (Codex review on #386)."""
+    import inspect
+
+    from campfire.deploy import push as push_mod
+
+    for fn in (push_mod.push_observation, push_mod.push_field):
+        src = inspect.getsource(fn)
+        assert 'stored_sizes=stored_sizes' in src, fn.__name__
+        assert 'stored_sizes_out=stored_sizes' in src, fn.__name__

--- a/supabase/migrations/20260712192241_add_stored_size_bytes.sql
+++ b/supabase/migrations/20260712192241_add_stored_size_bytes.sql
@@ -1,0 +1,11 @@
+-- storage_objects.stored_size_bytes: bytes as stored in the bucket for
+-- transport-compressed products (gzipped mosaic FITS, PR #383); NULL = stored
+-- verbatim. size_bytes stays the LOGICAL (uncompressed) size that client-side
+-- dedup and the stat fast-path compare against local plain files.
+--
+-- NOTE: the generated diff also contained the usual spurious migra
+-- drop/recreate churn for mv_filter_options, mv_programs_overview,
+-- nircam_reduction_progress and spectrum_flag_summary (migra cannot track
+-- (mat)views); stripped here, only the intended column kept.
+
+alter table "public"."storage_objects" add column "stored_size_bytes" bigint;

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -1013,6 +1013,11 @@ CREATE TABLE IF NOT EXISTS "public"."storage_objects" (
     -- no partial digest (everything except nircam_exposure today).
     "sci_dq_hash" "text",
     "size_bytes" bigint NOT NULL,
+    -- Bytes as stored in the bucket for transport-compressed products (gzipped
+    -- mosaic FITS, epic #261 / PR #383); NULL = stored verbatim. size_bytes
+    -- stays the LOGICAL (uncompressed) size that client-side dedup and the
+    -- stat fast-path compare against local plain files.
+    "stored_size_bytes" bigint,
     "content_type" "text" NOT NULL,
     "product_type" "text" NOT NULL,
     "instrument" "text",


### PR DESCRIPTION
Backend half of showing compressed sizes on the NIRCam page (the web half rides #379).

#383 gzips mosaic FITS at upload, but deliberately keeps `storage_objects.size_bytes` as the **logical** (uncompressed) size — client dedup and the stat fast-path compare it against local plain files. The compressed byte count was measured transiently at upload and dropped, so it existed nowhere in the DB (verified on the live EGS rows: `size_bytes` = uncompressed stat, sci/err/wht byte-identical per tile).

## Change
- **`storage_objects.stored_size_bytes bigint NULL`** — bytes as stored in the bucket; NULL = stored verbatim. Additive migration (migra matview churn stripped). Beyond the UI, this lets `verify --cloud` / budget accounting reconcile actual bucket bytes.
- **Capture:** the single-file uploaders (presigned PUT + boto3) return the staged gz body size; the parallel wrappers collect into an opt-in `stored_sizes_out` dict — recorded **before** `on_success` fires, so the per-batch registration flusher sees the value when it builds the row. `row_for_key` → `build_registry_rows` → `registration_flusher` thread it through; the NIRCam mosaic deploy wires the dict end-to-end. All params optional — every other call site is behaviorally unchanged.

## Verification
- 3 new tests in `test_mosaic_compression.py` (uploader return, wrapper collection incl. mixed compressed/verbatim batch, registry-row threading); full python suite 489 green.
- Local `db reset` clean; column present.

## Post-merge
- The 12 already-deployed EGS mosaics upload-dedup-skip, so a re-deploy won't fill them — one-time HEAD backfill script goes to Hollis alongside.
- Web display (`Size (compressed)` column, transfer-estimate totals) lands on #379.

Generated with Claude Code