### PR TITLE
Add tile outlines and squared panels to expmap plots

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -29,6 +29,14 @@ Release procedure: edit the `## Unreleased` section below, then run
 ## Unreleased
 
 ### Infrastructure
+- NIRCam expmap plots gain tile footprints + a squared, in-ticked panel: the
+  per-filter maps (`expmap_*.png`/`.pdf`) now overlay the same tile outlines as
+  `<field>_layout.png`, so a single filter's coverage reads against the tile
+  grid; the main panel of every expmap/layout plot is forced square (predictable
+  web layout, WCS aspect preserved so a non-square field pads rather than
+  stretches), its tick marks point inward (colorbar unchanged), and the imshow
+  sits behind the axes so grid, ticks, and outlines render on top. Plots only;
+  no change to FITS pixel values or filenames (`nircam/expmap.py`).
 - NIRCam mosaics now get a size-capped **thumbnail pair** instead of one
   fixed-/4-downsampled PNG: `<base>_thumb.png` (long side ≤
   `thumbnail_max_dim`, default 500 px — the web table rendition) and a new

--- a/pipeline/campfire_pipeline/nircam/expmap.py
+++ b/pipeline/campfire_pipeline/nircam/expmap.py
@@ -20,8 +20,8 @@ exposure map — while the reducer-only ``uncal`` quick-look keeps an explicit
 ``_uncal`` suffix (shown below as ``[_uncal]``):
 
     <filter>/expmap_{field}_{filter}[_uncal].fits   float32, ``BUNIT='s'``, ``AREA`` header, WCS
-    <filter>/expmap_{field}_{filter}[_uncal].pdf    light diagnostic (RA/Dec grid + colorbar)
-    <filter>/expmap_{field}_{filter}[_uncal].png    dark web plot (same view, deployable)
+    <filter>/expmap_{field}_{filter}[_uncal].pdf    light diagnostic (RA/Dec grid + tiles + colorbar)
+    <filter>/expmap_{field}_{filter}[_uncal].png    dark web plot (same view + tiles, deployable)
     {field}_layout[_uncal].png                      stacked-filter coverage + tile outlines (dark)
     {field}_layout[_uncal].json                     coverage summary: exact area, per-filter areas
     footprints[_uncal].reg                          ds9 fk5 polygons across all filters
@@ -36,10 +36,13 @@ union of nonzero pixels) so the plots show the same colour scale — easy to
 tab through. The PDF carries a title (stage labelled only for ``uncal``);
 the deployable PNGs carry no title at all, since the web page embedding
 them already labels field/filter. The dark PNG matches CAMPFIRE's data
-wells, which stay dark in both app themes. The ``{field}_layout`` plot stacks every per-filter
-expmap (total exposure across filters) and overlays the tile footprints; the
-companion ``.json`` records the exact survey area (non-zero pixels of the
-stack × pixel area) for the deploy/DB layer.
+wells, which stay dark in both app themes. Every plot — per-filter and layout
+— has a square main panel (predictable web layout, WCS aspect preserved),
+tick marks pointing inward, and the tile footprints overlaid so a single
+filter's coverage reads against the tile grid. The ``{field}_layout`` plot
+stacks every per-filter expmap (total exposure across filters) with the same
+tile footprints; the companion ``.json`` records the exact survey area
+(non-zero pixels of the stack × pixel area) for the deploy/DB layer.
 
 The .reg file only contains polygons for filters that were (re)built in this
 invocation. To regenerate a combined .reg after up-to-date FITS already exist,
@@ -243,14 +246,24 @@ def _render_expmap_figure(path, data, wcs, *, title, cbar_label,
     ax.set_facecolor(bg)
     cmap = mpl.colormaps['magma'].copy()
     cmap.set_bad(bg if dark else 'w')
+    # zorder behind the axes so the grid, in-pointing ticks, frame, and tile
+    # outlines all render on top of the map rather than being covered by it.
     im = ax.imshow(masked, origin='lower', cmap=cmap, norm=norm,
-                   interpolation='nearest')
+                   interpolation='nearest', zorder=-1)
+    # Force the main panel square regardless of field geometry so the deployed
+    # web layout stays predictable. The WCS aspect stays equal (no stretching);
+    # a non-square field simply pads with background above/below or left/right.
+    ax.set_box_aspect(1)
 
     ax.coords[0].set_major_formatter('hh:mm:ss')
     ax.coords[1].set_major_formatter('dd:mm:ss')
     ax.coords[0].set_axislabel('RA', color=fg)
     ax.coords[1].set_axislabel('Dec', color=fg)
     ax.grid(color=grid_c, lw=0.4, alpha=0.6)
+    # Tick direction 'in' on the main panel only — the colorbar keeps its
+    # default outward ticks.
+    for coord in ax.coords:
+        coord.set_ticks(direction='in')
     if dark:
         for coord in ax.coords:
             coord.set_ticklabel(color=fg)
@@ -519,7 +532,7 @@ def _accumulate_filter(args):
 
 
 def _render_filter_plots(field_name, filter_name, stage, metas, fits_path,
-                         out_dir, wcs, vmin, vmax):
+                         out_dir, wcs, vmin, vmax, tile_outlines=None):
     """Re-read the filter FITS and render the light PDF + dark PNG.
 
     Both share the invocation-wide ``vmin``/``vmax`` so tabbing through
@@ -527,7 +540,9 @@ def _render_filter_plots(field_name, filter_name, stage, metas, fits_path,
     (kept) and carries a title; the fiducial canonical stage is undecorated
     there too, so only the reducer-only ``uncal`` quick-look labels its
     stage. The PNG is the deployable web plot and carries no title at all —
-    the web page it's embedded in already says field/filter.
+    the web page it's embedded in already says field/filter. ``tile_outlines``
+    (the same footprints drawn on ``<field>_layout.png``) are overlaid on both
+    so a single filter's coverage can be read against the tile grid.
     """
     _, pdf_path, png_path = _expmap_paths(out_dir, field_name, filter_name,
                                           stage)
@@ -538,10 +553,12 @@ def _render_filter_plots(field_name, filter_name, stage, metas, fits_path,
         title = f'{field_name} · {filter_name.upper()} · {stage} · N={len(metas)}'
     _render_expmap_figure(pdf_path, expmap, wcs, title=title,
                           cbar_label='Exposure time [s]',
-                          vmin=vmin, vmax=vmax, dark=False)
+                          vmin=vmin, vmax=vmax, dark=False,
+                          tile_outlines=tile_outlines)
     _render_expmap_figure(png_path, expmap, wcs, title=None,
                           cbar_label='Exposure time [s]',
-                          vmin=vmin, vmax=vmax, dark=True)
+                          vmin=vmin, vmax=vmax, dark=True,
+                          tile_outlines=tile_outlines)
     log(f'[{filter_name}] wrote {os.path.basename(pdf_path)} + '
         f'{os.path.basename(png_path)}')
     return pdf_path
@@ -559,6 +576,22 @@ def _layout_paths(base_dir, field_name, stage):
         stem += f'_{stage}'
     base = os.path.join(base_dir, stem)
     return base + '.png', base + '.json'
+
+
+def _collect_tile_outlines(field):
+    """Tile footprints as ``[(name, corners), ...]`` for the plot overlays.
+
+    Decorative and best-effort: a bad or missing ``[tiles]`` entry never blocks
+    a plot, so a broken tile is logged and skipped rather than raised. Fields
+    without a ``[tiles]`` block yield an empty list (coverage only).
+    """
+    tile_outlines = []
+    for tname in (getattr(field, 'tiles', None) or {}):
+        try:
+            tile_outlines.append((tname, field.get_tile_corners(tname)))
+        except Exception as e:  # noqa: BLE001 - decorative overlay, never fatal
+            log(f'  expmap: skipping tile {tname} outline ({e})')
+    return tile_outlines
 
 
 def _render_layout(out_dir, field, stage, results, wcs, pixel_scale,
@@ -734,6 +767,12 @@ def run_expmap(
     else:
         global_vmin = global_vmax = None
 
+    # Tile footprints overlaid on every plot (per-filter maps + the layout),
+    # matching how the layout draws them. Collected once, up front, so a
+    # partial-filter rerun still shows tiles on the per-filter maps even though
+    # it skips the full-field layout below.
+    tile_outlines = _collect_tile_outlines(field)
+
     # Phase 3c: per-filter plots (light PDF + dark PNG). Always regenerated
     # (cheap; the shared norm is invocation-dependent so a cached plot from a
     # prior run with a different filter set would not match the colorbar).
@@ -741,7 +780,8 @@ def run_expmap(
         if fits_path is None or not metas:
             continue
         _render_filter_plots(field.name, filter_name, stage, metas, fits_path,
-                             out_dir, wcs, global_vmin, global_vmax)
+                             out_dir, wcs, global_vmin, global_vmax,
+                             tile_outlines=tile_outlines)
 
     # Phase 3d: field layout — stack of every per-filter expmap with tile
     # outlines + the exact survey area (non-zero pixels of the stack). Only a
@@ -749,14 +789,6 @@ def run_expmap(
     # filtered rerun stacks a subset and would publish an under-reported survey
     # area over the complete one, so partial runs skip the layout entirely.
     if set(filter_list) >= set(field.filters):
-        # Tile outlines are decorative and a bad/missing tile config never
-        # blocks the plot; fields without a [tiles] block get coverage only.
-        tile_outlines = []
-        for tname in (getattr(field, 'tiles', None) or {}):
-            try:
-                tile_outlines.append((tname, field.get_tile_corners(tname)))
-            except Exception as e:  # noqa: BLE001 - decorative overlay, never fatal
-                log(f'  layout: skipping tile {tname} outline ({e})')
         _render_layout(out_dir, field, stage, results, wcs, pixel_scale,
                        tile_outlines, float(sum(m.xposure for m in all_metas)))
     else:

--- a/pipeline/tests/test_expmap_plots.py
+++ b/pipeline/tests/test_expmap_plots.py
@@ -93,6 +93,97 @@ def test_render_figure_no_title(tmp_path):
     assert out.exists() and out.stat().st_size > 0
 
 
+def test_render_figure_square_inticks_and_zorder(tmp_path, monkeypatch):
+    # Change set: the main panel is forced square (predictable web layout),
+    # its ticks point inward, and the imshow sits behind the axes so the grid,
+    # ticks, and tile outlines render on top of the map. Capture the figure
+    # before it is closed and introspect it.
+    import warnings
+
+    import matplotlib.pyplot as plt
+
+    captured = {}
+    real_close = plt.close
+    monkeypatch.setattr(plt, 'close', lambda fig: captured.setdefault('fig', fig))
+
+    _metas, wcs, _shape, arr = _synthetic_expmap()
+    out = tmp_path / 'sq.png'
+    ok = em._render_expmap_figure(str(out), arr, wcs, title=None,
+                                  cbar_label='Exposure time [s]', dark=True)
+    assert ok is True
+
+    fig = captured['fig']
+    ax = fig.axes[0]                       # main panel; colorbar is a later axes
+    assert ax.get_box_aspect() == 1.0      # forced square
+    images = ax.get_images()
+    assert images and all(im.get_zorder() < 0 for im in images)  # behind axes
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')    # .ticks accessor is deprecated
+        # get_tick_out() is False for direction='in'; both RA and Dec.
+        assert ax.coords[0].ticks.get_tick_out() is False
+        assert ax.coords[1].ticks.get_tick_out() is False
+    real_close(fig)
+
+
+def test_render_filter_plots_forward_tiles(tmp_path, monkeypatch):
+    # Per-filter maps now carry the tile outlines too (both the light PDF and
+    # the dark PNG), matching the layout plot.
+    metas, wcs, _shape, arr = _synthetic_expmap()
+    fdir = tmp_path / 'f444w'
+    fdir.mkdir()
+    fp = fdir / 'expmap_cosmos_f444w.fits'
+    em._write_fits(str(fp), arr, wcs, field_name='cosmos',
+                   filter_name='f444w', stage='canonical', metas=metas)
+
+    calls = []
+
+    def _fake_render(path, data, wcs_, *, title, cbar_label, vmin=None,
+                     vmax=None, dark=False, tile_outlines=None):
+        calls.append((dark, tile_outlines))
+        return True
+
+    monkeypatch.setattr(em, '_render_expmap_figure', _fake_render)
+    tiles = [('A1', [[150.0, 2.0], [150.01, 2.0],
+                     [150.01, 2.01], [150.0, 2.01]])]
+    em._render_filter_plots('cosmos', 'f444w', 'canonical', metas, str(fp),
+                            str(tmp_path), wcs, 1.0, 10.0, tile_outlines=tiles)
+
+    # both renders (light PDF dark=False, dark PNG dark=True) get the tiles
+    assert len(calls) == 2
+    assert sorted(dark for dark, _ in calls) == [False, True]
+    assert all(passed == tiles for _, passed in calls)
+
+
+def test_run_expmap_passes_tiles_to_filter_plots(tmp_path, monkeypatch):
+    # End-to-end: the field's tile (A1) flows through _collect_tile_outlines
+    # into every per-filter render, even though this stubs out the heavy work.
+    metas, wcs, shape, _arr = _synthetic_expmap()
+
+    ff = tmp_path / 'fields.toml'
+    ff.write_text(textwrap.dedent(_FIELDS_TOML))    # cosmos has tile A1
+    field = Field.load('cosmos', fields_file=str(ff))
+
+    monkeypatch.setattr(em, '_load_metadata_cache', lambda *a, **k: {})
+    monkeypatch.setattr(em, '_save_metadata_cache', lambda *a, **k: None)
+    monkeypatch.setattr(em, '_collect_metas',
+                        lambda field, filt, stage, cache=None: [metas[0]])
+    monkeypatch.setattr(em, '_auto_wcs', lambda ms, ps, pad: (wcs, shape))
+    monkeypatch.setattr(em, '_accumulate_filter',
+                        lambda w: (w[1], w[5], f'/fake/{w[1]}.fits', 1.0, 10.0))
+    monkeypatch.setattr(em, '_render_layout', lambda *a, **k: None)
+    monkeypatch.setattr(em, '_write_region_file', lambda *a, **k: None)
+
+    captured = []
+    monkeypatch.setattr(em, '_render_filter_plots',
+                        lambda *a, **k: captured.append(k.get('tile_outlines')))
+
+    em.run_expmap(field, filters=['f200w', 'f444w'], out_dir=str(tmp_path))
+
+    assert captured                                 # per-filter plots rendered
+    for tiles in captured:
+        assert [name for name, _ in tiles] == ['A1']
+
+
 def test_render_figure_all_zero_writes_nothing(tmp_path):
     _metas, wcs, shape, _arr = _synthetic_expmap()
     out = tmp_path / 'zero.png'


### PR DESCRIPTION
## Summary
Enhances NIRCam exposure map visualizations by overlaying tile footprints on per-filter maps and standardizing plot layout with squared panels and inward-pointing ticks.

## Key Changes
- **Tile outline overlays**: Per-filter expmap plots (`expmap_*.png`/`.pdf`) now display the same tile footprints as the field layout plot, allowing single-filter coverage to be read against the tile grid
- **Squared main panels**: All expmap plots (per-filter and layout) have their main panel forced to square aspect ratio for predictable web layout, while preserving WCS aspect (non-square fields pad rather than stretch)
- **Inward-pointing ticks**: Tick marks on the main panel point inward; colorbar ticks remain outward (default)
- **Z-order adjustment**: The imshow layer sits behind axes (zorder=-1) so grid lines, ticks, frame, and tile outlines render on top of the map
- **Tile collection refactoring**: Extracted `_collect_tile_outlines()` helper to gather tile footprints once at the start of `run_expmap()`, ensuring per-filter reruns still display tiles even when skipping the full-field layout

## Implementation Details
- `_render_expmap_figure()` now accepts optional `tile_outlines` parameter and applies `set_box_aspect(1)` and `set_ticks(direction='in')` to the main axes
- `_render_filter_plots()` forwards tile outlines to both PDF and PNG renders
- `_collect_tile_outlines()` handles missing/broken tile configurations gracefully (logs and skips rather than raising)
- Tile outlines are collected once before the filter loop, enabling partial-filter reruns to show tiles on per-filter maps
- Documentation updated to reflect tile overlays on all plots and squared panel behavior

No changes to FITS pixel values or filenames.

https://claude.ai/code/session_01S23KLDirswBeJgaSAE6jjn