### PR TITLE
fix(deploy): scope NIRCam mosaic discovery to the current fields.toml

### DIFF
--- a/python/campfire/deploy/fields.py
+++ b/python/campfire/deploy/fields.py
@@ -26,6 +26,45 @@ from .config import _load_toml
 # JWST rootname program id: jwPPPPP... (the leading 5-digit program number).
 _PID_RE = re.compile(r"jw(\d{5})")
 
+# A pixel-scale WCS subsection key, e.g. ``30mas``.
+_PIXEL_SCALE_RE = re.compile(r"^\d+mas$")
+
+
+def _is_tile_section(value: dict) -> bool:
+    """True if a ``[<field>.<key>]`` sub-table is a tile definition.
+
+    Mirrors the pipeline's tile gate (``campfire_pipeline.nircam.field``): a tile
+    declares explicit sky ``corners`` or at least one ``<N>mas`` subsection with
+    ``crpix``+``naxis``. Deploy must not import the pipeline, so the gate is
+    reproduced here. This is what distinguishes a real tile from a step-override
+    table (``[<field>.jhat]``, ``[<field>.align]``, …), which are also dicts but
+    carry no WCS — so those are *not* tiles.
+    """
+    if not isinstance(value, dict):
+        return False
+    if "corners" in value:
+        return True
+    return any(
+        _PIXEL_SCALE_RE.match(k) and isinstance(v, dict)
+        and "crpix" in v and "naxis" in v
+        for k, v in value.items()
+    )
+
+
+def declared_tiles_and_epochs(section: dict) -> tuple[set[str], set[str]]:
+    """The tile + epoch names a fields.toml ``[<field>]`` section declares.
+
+    The single authority for "what did the *current* config ask the pipeline to
+    produce" — used both to lift the `fields` registry columns and to scope
+    mosaic discovery at deploy time (drop stray on-disk products from a former
+    config). Tiles pass :func:`_is_tile_section` (so step-override tables are
+    excluded); epochs are the ``[<field>.epochs.<name>]`` sub-tables.
+    """
+    tiles = {k for k, v in section.items()
+             if k != "epochs" and _is_tile_section(v)}
+    epochs = set((section.get("epochs") or {}).keys())
+    return tiles, epochs
+
 
 def _fields_toml_path() -> Path:
     root = os.environ.get("CAMPFIRE_ROOT")
@@ -50,25 +89,24 @@ def field_config_row(field: str, section: dict) -> dict:
     """Map a fields.toml ``[<field>]`` section to the `fields` config columns.
 
     Lossless: the whole section rides in ``config`` (jsonb); the rest are lifted
-    for querying. Tile names are the section's dict-valued sub-tables minus the
-    reserved ``epochs`` table. Program ids are the 5-digit ids embedded in the
-    ``files`` globs (``jwPPPPP*``). Program *slugs* are left empty — programs.toml
-    carries no program-id map, so slug resolution is deferred (issue #303).
+    for querying. Tile names come from :func:`declared_tiles_and_epochs` (WCS-bearing
+    sub-tables only — step-override tables like ``jhat``/``align`` are excluded).
+    Program ids are the 5-digit ids embedded in the ``files`` globs (``jwPPPPP*``).
+    Program *slugs* are left empty — programs.toml carries no program-id map, so
+    slug resolution is deferred (issue #303).
     """
     tp = _as_list(section.get("tangent_point"))
     globs = _as_list(section.get("files"))
     pids = sorted({int(m.group(1)) for g in globs
                    for m in [_PID_RE.search(g)] if m})
-    tiles = sorted(k for k, v in section.items()
-                   if isinstance(v, dict) and k != "epochs")
-    epochs = sorted((section.get("epochs") or {}).keys())
+    tiles, epochs = declared_tiles_and_epochs(section)
     return {
         "name": field,
         "display_name": section.get("display_name"),  # None -> RPC derives upper()
         "filters": _as_list(section.get("filters")),
-        "tiles": tiles,
+        "tiles": sorted(tiles),
         "fiducial_tiles": _as_list(section.get("fiducial_tiles")),
-        "epochs": epochs,
+        "epochs": sorted(epochs),
         "programs": [],  # slug resolution deferred (no program-id map in programs.toml)
         "jwst_program_ids": pids,
         "file_globs": globs,

--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -525,7 +525,16 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
     exposures = discover_exposures(dirs, filters)
     expmap_tasks = discover_expmap_tasks(dirs, field, filters)
     layout_tasks = discover_layout_tasks(dirs, field)
-    n_mosaics = len(deployable_mosaics(discover_mosaics(dirs, field, filters)))
+    # Scope mosaic discovery to what the current fields.toml declares — a stray
+    # on-disk tile/epoch from a former config must not ride into the cloud (this is
+    # the guard; the count + the actual upload both use this same scoped list).
+    try:
+        mosaics_to_deploy = scope_mosaics_to_fields_toml(
+            deployable_mosaics(discover_mosaics(dirs, field, filters)), field)
+    except ValueError as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+    n_mosaics = len(mosaics_to_deploy)
     print(f"Discovered {len(exposures)} canonical exposure(s), "
           f"{len(expmap_tasks)} expmap file(s), {n_mosaics} mosaic(s), "
           f"{len(layout_tasks)} layout plot(s)")
@@ -692,8 +701,11 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
     n_skipped = sum(1 for t in plan.unchanged if t.r2_key in _fits_keys)
 
     # --- Mosaics: deploy under the same field deployment (epic #261, N2) ----
+    # Reuse the fields.toml-scoped list computed up front (single discovery +
+    # single skip-log; stray tiles/epochs were already filtered out above).
     mosaic_stats = _deploy_field_mosaics(dirs, field, config, client, filters,
-                                         deployment_id, draft, user_id, store=store)
+                                         deployment_id, draft, user_id, store=store,
+                                         mosaics=mosaics_to_deploy)
 
     # --- Field registry: upsert the fields.toml config + deploy-computed survey
     # area (issue #303). Rides the deploy so a field row exists exactly for fields
@@ -938,6 +950,48 @@ def discover_mosaics(dirs, field, filters):
     return out
 
 
+def scope_mosaics_to_fields_toml(mosaics, field):
+    """Drop discovered mosaics whose ``(tile, epoch)`` the current fields.toml
+    does not declare for ``field``.
+
+    ``discover_mosaics`` walks the products tree and returns whatever mosaic
+    manifests are physically present — including stray products left over from a
+    former config (a commented-out tile, a renamed or removed epoch). fields.toml
+    is the source of truth for what the *current* config asks the pipeline to
+    build, so the cloud-bound paths (``campfire deploy --field`` / ``campfire
+    push``) run discovery through this filter: a mosaic whose tile isn't a declared
+    tile — or whose epoch isn't a declared epoch — is skipped (logged, not silently
+    dropped) and never uploaded to OSN or indexed in ``nircam_images``.
+
+    Raises ``ValueError`` if the field has mosaics on disk but no ``[<field>]``
+    section in fields.toml: we can't tell declared from stray, so refuse to deploy
+    unscoped rather than blindly ship the tree (that is exactly the footgun this
+    guards against).
+    """
+    if not mosaics:
+        return mosaics
+    from campfire.deploy.fields import declared_tiles_and_epochs, load_fields_toml
+    section = load_fields_toml().get(field)
+    if section is None:
+        raise ValueError(
+            f"field '{field}' has {len(mosaics)} mosaic product(s) on disk but no "
+            f"[{field}] section in fields.toml — refusing to deploy unscoped. Add "
+            f"the [{field}] section, or remove the stray products from the tree.")
+    tiles, epochs = declared_tiles_and_epochs(section)
+    kept, dropped = [], []
+    for m in mosaics:
+        tile_ok = m['tile'] in tiles
+        epoch_ok = (not m.get('epoch')) or m['epoch'] in epochs
+        (kept if tile_ok and epoch_ok else dropped).append(m)
+    for tile, epoch in sorted({(m['tile'], m.get('epoch') or '') for m in dropped}):
+        why = ("tile not declared" if tile not in tiles
+               else f"epoch '{epoch}' not declared")
+        label = f"tile '{tile}'" + (f" epoch '{epoch}'" if epoch else "")
+        print(f"  mosaics: skipping {label} — {why} in fields.toml "
+              f"(stray on-disk product, not deployed)")
+    return kept
+
+
 def discover_mosaic_thumbnail_tasks(mosaics, field):
     """One ``nircam_mosaic_thumbnail`` upload task per mosaic base.
 
@@ -967,7 +1021,7 @@ def discover_mosaic_thumbnail_tasks(mosaics, field):
 
 
 def _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
-                          draft, user_id, store=None):
+                          draft, user_id, store=None, mosaics=None):
     """Deploy this field's mosaics under the field deployment (epic #261, N2).
 
     Called from :func:`deploy_nircam` so ``campfire deploy --field`` ships exposures
@@ -989,8 +1043,12 @@ def _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
     from campfire.deploy.registry import set_active_deployment
 
     # discover_mosaics returns i2d too (provenance / FitsGL read it locally); the
-    # cloud deploy ships only the deployable extensions, so filter it out here.
-    mosaics = deployable_mosaics(discover_mosaics(dirs, field, filters))
+    # cloud deploy ships only the deployable extensions AND only the tiles/epochs
+    # the current fields.toml declares. deploy_nircam passes that scoped list in;
+    # fall back to computing it here for any direct caller.
+    if mosaics is None:
+        mosaics = scope_mosaics_to_fields_toml(
+            deployable_mosaics(discover_mosaics(dirs, field, filters)), field)
     if not mosaics:
         return None
     print(f"\nMosaics: {len(mosaics)} product(s)")

--- a/python/campfire/deploy/push.py
+++ b/python/campfire/deploy/push.py
@@ -375,7 +375,8 @@ def push_field(
     from campfire.deploy.nircam import (
         _discover_filters, _resolve_nircam_dirs, build_fits_upload_tasks,
         build_upload_tasks, deployable_mosaics, discover_expmap_tasks,
-        discover_exposures, discover_mosaics, _read_field_provenance,
+        discover_exposures, discover_mosaics, scope_mosaics_to_fields_toml,
+        _read_field_provenance,
     )
     from campfire.deploy.supabase import get_supabase_client, get_user_id_from_token
 
@@ -404,8 +405,16 @@ def push_field(
     tasks: list[UploadTask] = list(build_fits_upload_tasks(field, exposures))
     tasks += list(discover_expmap_tasks(dirs, field, filters))
     tasks += [t[0] for t in build_upload_tasks(dirs, field, filters)]
+    # Scope mosaics to the current fields.toml — a stray on-disk tile/epoch must
+    # not have its bytes pushed to OSN (they would sit orphaned, un-indexed).
+    try:
+        scoped_mosaics = scope_mosaics_to_fields_toml(
+            deployable_mosaics(discover_mosaics(dirs, field, filters)), field)
+    except ValueError as e:
+        print(f"Error: {e}")
+        return {'planned': 0, 'pushed': 0, 'failed': 0, 'skipped': 0}
     tasks += [UploadTask(m['path'], m['storage_key'], m['content_type'])
-              for m in deployable_mosaics(discover_mosaics(dirs, field, filters))]
+              for m in scoped_mosaics]
 
     print(f"Field: {field}")
     print(f"  Filters: {', '.join(filters)}")

--- a/python/tests/test_deploy_fields.py
+++ b/python/tests/test_deploy_fields.py
@@ -107,6 +107,69 @@ def test_field_config_row_coerces_string_scalars():
     assert row["center_ra"] is None and row["center_dec"] is None
 
 
+def test_field_config_row_excludes_step_override_tables():
+    # Step-override sub-tables (jhat/align/…) are dicts but carry no WCS, so they
+    # must NOT be counted as tiles. Only NE (a `<N>mas` WCS table) is a tile.
+    section = {
+        "filters": "f444w", "files": "jw01345*",
+        "jhat": {"refcat": "egs_ref.ecsv"},
+        "align": {"enabled": True, "refcat": "egs_ref.ecsv"},
+        "NE": {"rotation": -49.7, "30mas": {"crpix": [1, 2], "naxis": [3, 4]}},
+        "epochs": {"spam": {"files": ["jw08559*"]}},
+    }
+    row = F.field_config_row("egs", section)
+    assert row["tiles"] == ["NE"]
+    assert row["epochs"] == ["spam"]
+
+
+# --- declared_tiles_and_epochs ----------------------------------------------
+
+def test_declared_tiles_and_epochs():
+    section = {
+        "jhat": {"refcat": "x"},                          # step table -> not a tile
+        "A1": {"30mas": {"crpix": [1, 1], "naxis": [2, 2]}},   # WCS tile
+        "legacy": {"corners": [[0, 0], [1, 1]]},               # explicit-corners tile
+        "epochs": {"cy1": {"files": ["jw01*"]}, "spam": {"files": ["jw08*"]}},
+    }
+    tiles, epochs = F.declared_tiles_and_epochs(section)
+    assert tiles == {"A1", "legacy"}
+    assert epochs == {"cy1", "spam"}
+
+
+# --- scope_mosaics_to_fields_toml -------------------------------------------
+
+def _mos(tile, epoch=""):
+    return {"tile": tile, "epoch": epoch, "storage_key": f"k/{tile}/{epoch}"}
+
+
+def test_scope_mosaics_keeps_declared_drops_stray(tmp_path, monkeypatch, capsys):
+    _write_root(tmp_path, monkeypatch)   # cosmos declares tiles A1, A2 + epoch CW
+    mosaics = [
+        _mos("A1"), _mos("A2"),          # declared full-field tiles -> kept
+        _mos("A1", "CW"),                # declared tile + declared epoch -> kept
+        _mos("full"),                    # stray tile -> dropped
+        _mos("A2", "bogus"),             # declared tile, undeclared epoch -> dropped
+    ]
+    kept = nc.scope_mosaics_to_fields_toml(mosaics, "cosmos")
+    assert sorted((m["tile"], m["epoch"]) for m in kept) == [
+        ("A1", ""), ("A1", "CW"), ("A2", "")]
+    out = capsys.readouterr().out
+    assert "tile 'full'" in out and "tile not declared" in out
+    assert "epoch 'bogus'" in out
+
+
+def test_scope_mosaics_raises_when_field_absent(tmp_path, monkeypatch):
+    _write_root(tmp_path, monkeypatch)
+    with pytest.raises(ValueError, match="no \\[ghost\\] section in fields.toml"):
+        nc.scope_mosaics_to_fields_toml([_mos("t1")], "ghost")
+
+
+def test_scope_mosaics_empty_is_noop_without_fields_toml(tmp_path, monkeypatch):
+    # No mosaics -> nothing to scope, so a missing section never bites.
+    _write_root(tmp_path, monkeypatch)
+    assert nc.scope_mosaics_to_fields_toml([], "ghost") == []
+
+
 # --- read_layout_coverage ---------------------------------------------------
 
 def test_read_layout_coverage(tmp_path):


### PR DESCRIPTION
## Problem

`campfire deploy --field` and `campfire push` discovered NIRCam mosaics by globbing the products tree, so any stray mosaic left on disk from a former config (a commented-out tile, a renamed/removed epoch) rode straight into OSN + `nircam_images`. This is how EGS repeatedly shipped `tile='full'` and `tile='ceers2'` mosaics that its `fields.toml` no longer declares (~32 GB of stray products on OSN + 18 stray DB rows, twice).

## Fix

- **`scope_mosaics_to_fields_toml()`** (`deploy/nircam.py`): drops (and logs) any discovered mosaic whose `tile`/`epoch` the current `fields.toml` doesn't declare, before anything reaches the cloud. Wired into both `deploy_nircam` (scoped list computed once, threaded into `_deploy_field_mosaics`) and `campfire push`. A field with mosaics on disk but **no** `[<field>]` section hard-refuses rather than shipping unscoped.
- **`declared_tiles_and_epochs()`** (`deploy/fields.py`): the single authority for "what does the current config declare", mirroring the pipeline's tile gate (a tile has `corners` or a `<N>mas` WCS subsection). Reusing it in `field_config_row()` also fixes a latent bug where step-override tables (`[<field>.jhat]`/`[.align]`) were miscounted as tiles in the `fields` registry column.

FitsGL tile generation was checked and is **not** affected — its build/deploy paths already constrain discovery to an explicit tile allowlist (`fiducial_tiles`, or `--tile`), never globbing the tree.

## Tests

Added coverage for the authority, the step-table exclusion, and the keep/drop/raise/empty scoping paths. Full `python/` suite: **490 passed, 1 skipped**.

python-only; no pipeline changelog entry required.

Generated with Claude Code