### PR TITLE
Surface server error details in tiles-credentials fetch

### DIFF
--- a/python/campfire/fitsgl/deploy.py
+++ b/python/campfire/fitsgl/deploy.py
@@ -146,8 +146,34 @@ def resolve_tiles_creds(config):
     }
 
 
+def _server_error_detail(resp):
+    """Best-effort human-readable detail from a web-API error response body.
+
+    The deploy routes answer errors as ``{"error": ..., "error_description": ...}``.
+    Falls back to a trimmed raw body when the response isn't that JSON (e.g. an HTML
+    502 from a proxy), so a non-JSON failure still yields *something* actionable rather
+    than being silently dropped. Returns ``None`` when there's nothing usable.
+    """
+    try:
+        body = resp.json()
+    except ValueError:
+        text = (resp.text or '').strip()
+        return text[:200] if text else None
+    if isinstance(body, dict):
+        return body.get('error_description') or body.get('error')
+    return None
+
+
 def fetch_tiles_credentials(config):
-    """GET the R2 tiles creds from the admin-gated web endpoint (login mode)."""
+    """GET the R2 tiles creds from the admin-gated web endpoint (login mode).
+
+    Surfaces the server's own error text on failure (the deploy routes return a JSON
+    ``error_description``) instead of a bare ``raise_for_status`` traceback, and — for a
+    5xx, which for this endpoint means the web app's tiles storage isn't configured —
+    points at the ``--service-role`` / ``--local`` fallback that reads local
+    ``CAMPFIRE_S3_TILES_*`` creds directly. Raises ``click.ClickException`` so the CLI
+    prints a clean ``Error: …`` line, never a stack trace.
+    """
     import requests
     from campfire.api.session import resolve_base_url
     from campfire.auth.tokens import TokenManager
@@ -155,25 +181,44 @@ def fetch_tiles_credentials(config):
     base_url = resolve_base_url()
     tm = TokenManager(base_url=base_url)
     if not tm.is_oauth():
-        raise RuntimeError(
+        raise click.ClickException(
             "not logged in — run `campfire login` (or use --service-role with "
             "CAMPFIRE_S3_TILES_* for unattended deploys)."
         )
     token = tm.get_valid_token()
     if not token:
-        raise RuntimeError("login session expired — run `campfire login`.")
-    resp = requests.get(
-        f"{base_url}/deploy/tiles-credentials",
-        headers={'Authorization': f'Bearer {token}'}, timeout=30,
-    )
+        raise click.ClickException("login session expired — run `campfire login`.")
+    try:
+        resp = requests.get(
+            f"{base_url}/deploy/tiles-credentials",
+            headers={'Authorization': f'Bearer {token}'}, timeout=30,
+        )
+    except requests.RequestException as e:
+        raise click.ClickException(
+            f"could not reach the tiles-credentials endpoint at {base_url}: {e}"
+        )
     if resp.status_code == 403:
-        raise RuntimeError("tiles credentials require admin access.")
+        raise click.ClickException("tiles credentials require admin access.")
     if resp.status_code == 404:
-        raise RuntimeError(
+        raise click.ClickException(
             "tiles-credentials endpoint not found — the web app may predate Phase 3; "
             "use --service-role with CAMPFIRE_S3_TILES_* instead."
         )
-    resp.raise_for_status()
+    if not resp.ok:
+        detail = _server_error_detail(resp)
+        # A 5xx here is a server misconfiguration, not a client error: the endpoint
+        # returns 500 when the web app can't resolve its tiles bucket (missing/partial
+        # S3_TILES_*/R2_TILES_* on the server). The deployer can't fix the server's env
+        # from here, so point them at the local-creds path that skips this endpoint.
+        hint = (
+            " The web app's tiles storage may not be configured (server-side "
+            "S3_TILES_*/R2_TILES_* env). Configure it, or deploy with --service-role "
+            "(or --local) using local CAMPFIRE_S3_TILES_* credentials."
+        ) if resp.status_code >= 500 else ""
+        raise click.ClickException(
+            f"tiles-credentials endpoint returned HTTP {resp.status_code}"
+            f"{f': {detail}' if detail else ''}.{hint}"
+        )
     return resp.json()
 
 

--- a/python/tests/test_fitsgl_deploy.py
+++ b/python/tests/test_fitsgl_deploy.py
@@ -8,6 +8,7 @@ without the FitsGL producer installed, a live bucket, or Supabase.
 
 import os
 
+import click
 import pytest
 
 from campfire.fitsgl.deploy import (
@@ -17,6 +18,7 @@ from campfire.fitsgl.deploy import (
     dataset_name,
     dataset_prefix,
     dataset_row,
+    fetch_tiles_credentials,
     fitsgl_json_url,
 )
 
@@ -144,3 +146,101 @@ def test_pure_layer_imports_without_fitsgl():
     import importlib
     mod = importlib.import_module("campfire.fitsgl.deploy")
     assert hasattr(mod, "run_deploy") and hasattr(mod, "suggest_fitsgl_rebuild")
+
+
+# --- server-error surfacing (fetch_tiles_credentials) -----------------------
+#
+# The login-mode credential fetch must turn a failed web-API response into a clean,
+# actionable message instead of a bare `raise_for_status` traceback — this is the bug
+# behind the opaque "500 Server Error: Internal Server Error" the deployer hit.
+
+class _FakeResp:
+    def __init__(self, status_code, *, json_body=None, text=''):
+        self.status_code = status_code
+        self.ok = 200 <= status_code < 300
+        self._json = json_body
+        self.text = text
+
+    def json(self):
+        if self._json is None:
+            raise ValueError("no json")
+        return self._json
+
+
+def _patch_login(monkeypatch, resp):
+    """Make fetch_tiles_credentials believe it's a logged-in admin and return `resp`."""
+    import requests
+
+    import campfire.api.session as session
+    import campfire.auth.tokens as tokens
+
+    monkeypatch.setattr(session, "resolve_base_url", lambda *a, **k: "https://x/api/v1")
+
+    class _TM:
+        def __init__(self, *a, **k):
+            pass
+
+        def is_oauth(self):
+            return True
+
+        def get_valid_token(self):
+            return "tok"
+
+    monkeypatch.setattr(tokens, "TokenManager", _TM)
+    monkeypatch.setattr(requests, "get", lambda *a, **k: resp)
+
+
+def test_fetch_tiles_credentials_returns_json_on_success(monkeypatch):
+    creds = {"bucket": "campfire-tiles", "endpoint": "https://e", "access_key_id": "k",
+             "secret_access_key": "s", "public_url_base": "https://cdn"}
+    _patch_login(monkeypatch, _FakeResp(200, json_body=creds))
+    assert fetch_tiles_credentials({}) == creds
+
+
+def test_fetch_tiles_credentials_500_surfaces_server_detail_and_fallback(monkeypatch):
+    _patch_login(monkeypatch, _FakeResp(
+        500, json_body={"error": "server_error",
+                        "error_description": "Tiles storage not configured on the server: "
+                                             "Storage \"tiles\" credentials not configured"}))
+    with pytest.raises(click.ClickException) as exc:
+        fetch_tiles_credentials({})
+    msg = exc.value.message
+    assert "500" in msg
+    assert "Tiles storage not configured on the server" in msg   # server detail surfaced
+    assert "--service-role" in msg                                # actionable fallback
+    assert "raise_for_status" not in msg
+
+
+def test_fetch_tiles_credentials_500_without_json_body_still_actionable(monkeypatch):
+    # A proxy 502/HTML body (no JSON) must not crash the detail extractor.
+    _patch_login(monkeypatch, _FakeResp(502, text="<html>Bad Gateway</html>"))
+    with pytest.raises(click.ClickException) as exc:
+        fetch_tiles_credentials({})
+    assert "502" in exc.value.message
+    assert "--service-role" in exc.value.message
+
+
+def test_fetch_tiles_credentials_403_is_admin_message(monkeypatch):
+    _patch_login(monkeypatch, _FakeResp(403, json_body={"error": "forbidden"}))
+    with pytest.raises(click.ClickException) as exc:
+        fetch_tiles_credentials({})
+    assert "admin" in exc.value.message.lower()
+
+
+def test_fetch_tiles_credentials_requires_login(monkeypatch):
+    import campfire.api.session as session
+    import campfire.auth.tokens as tokens
+
+    monkeypatch.setattr(session, "resolve_base_url", lambda *a, **k: "https://x/api/v1")
+
+    class _TM:
+        def __init__(self, *a, **k):
+            pass
+
+        def is_oauth(self):
+            return False
+
+    monkeypatch.setattr(tokens, "TokenManager", _TM)
+    with pytest.raises(click.ClickException) as exc:
+        fetch_tiles_credentials({})
+    assert "campfire login" in exc.value.message

--- a/web/app/api/v1/deploy/tiles-credentials/route.ts
+++ b/web/app/api/v1/deploy/tiles-credentials/route.ts
@@ -44,13 +44,22 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Resolve the tiles-bucket backend from the server's S3_TILES_* env.
+    // Resolve the tiles-bucket backend from the server's S3_TILES_* env. Surface the
+    // underlying reason (which env var is missing / unresolvable) so the admin-gated
+    // caller — and Vercel logs — can tell *what* to configure. `resolveBackend` only
+    // reports missing/unresolvable config here, never secret values, so this is safe to
+    // return to the (admin-only) client.
     let b;
     try {
       b = resolveBackend('tiles');
-    } catch {
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : String(e);
+      console.error('tiles-credentials: resolveBackend("tiles") failed:', reason);
       return NextResponse.json(
-        { error: 'server_error', error_description: 'Tiles storage credentials not configured' },
+        {
+          error: 'server_error',
+          error_description: `Tiles storage not configured on the server: ${reason}`,
+        },
         { status: 500 }
       );
     }


### PR DESCRIPTION
## Summary
Improve error handling in the tiles-credentials endpoint to surface actionable server error details to deployers instead of opaque HTTP status tracebacks. This addresses a bug where deployers received bare "500 Server Error" messages without understanding what was misconfigured on the server.

## Key Changes

- **Python (`deploy.py`)**:
  - Added `_server_error_detail()` helper to extract human-readable error information from API responses (JSON `error_description` field, or fallback to raw text for non-JSON responses like HTML 502s)
  - Refactored `fetch_tiles_credentials()` to:
    - Replace `RuntimeError` with `click.ClickException` for clean CLI error output (no stack traces)
    - Replace bare `raise_for_status()` with explicit error handling that surfaces server details
    - Add specific guidance for 5xx errors (pointing to `--service-role`/`--local` fallback when server-side tiles storage isn't configured)
    - Handle network request failures gracefully
  - Updated docstring to document the improved error surfacing behavior

- **Web API (`route.ts`)**:
  - Enhanced error response from `resolveBackend('tiles')` to include the underlying reason (which env var is missing/unresolvable) in the `error_description` field
  - Added console logging for debugging
  - Ensured sensitive values are never exposed (only configuration issues are reported)

- **Tests (`test_fitsgl_deploy.py`)**:
  - Added comprehensive test suite for `fetch_tiles_credentials()` covering:
    - Successful credential fetch
    - 500 errors with JSON body (surfaces server detail + actionable fallback)
    - 502 errors without JSON body (graceful fallback)
    - 403 forbidden (admin access required)
    - Missing login session (requires `campfire login`)

## Implementation Details

The solution uses a three-layer approach:
1. **Server-side**: Return detailed error descriptions in the JSON response
2. **Client-side**: Extract and format these details for display
3. **CLI-side**: Use `click.ClickException` to present clean error messages without tracebacks

For 5xx errors specifically, the deployer is directed to either configure the server's `S3_TILES_*`/`R2_TILES_*` environment variables or use the `--service-role`/`--local` flags to provide credentials locally.

https://claude.ai/code/session_01UG7FqGXU4eAf3i9ezz7s8C