### PR TITLE
fix(deploy): drop redundant masking column across exposure tables

### DIFF
--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -240,16 +240,6 @@ def _read_exposure_metadata(path):
     return info
 
 
-def _detect_masking(dirs, basename, filtname):
-    """Return 'done' if a .reg mask file exists, else None.
-
-    Pipeline reads masks from ``masks/<filter>/<rootname>.reg`` (no ``_cal``
-    suffix in the new canonical layout).
-    """
-    reg_path = dirs['masks'] / filtname / f'{basename}.reg'
-    return 'done' if reg_path.exists() else None
-
-
 # ---------------------------------------------------------------------------
 # Preview PNG discovery
 # ---------------------------------------------------------------------------
@@ -568,7 +558,6 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
 
     records = []
     for (filtname, basename), info in sorted(exposures.items()):
-        masking = _detect_masking(dirs, basename, filtname)
         dims = full_dims.get((filtname, basename))
         record = {
             'field': field,
@@ -585,8 +574,6 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
             'image_width': dims[0] if dims else None,
             'image_height': dims[1] if dims else None,
         }
-        if masking:
-            record['masking'] = masking
         records.append(record)
 
     if dry_run:
@@ -595,9 +582,6 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
         for _, stage in _CFP_TO_STAGE:
             if stage in stage_counts:
                 print(f"  {stage}: {stage_counts[stage]}")
-        mask_count = sum(1 for r in records if r.get('masking') == 'done')
-        if mask_count:
-            print(f"  with masks: {mask_count}")
         print(f"\nWould record a {'draft' if draft else 'published'} field "
               f"deployment and upload {len(fits_tasks)} canonical FITS + "
               f"{len(expmap_tasks)} expmap file(s) + {n_mosaics} mosaic(s) + "
@@ -762,11 +746,10 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
 def _upsert_exposures(client, records, batch_size=500):
     """Upsert exposure records, preserving web-triage fields for existing rows.
 
-    New rows get default ``review_status='pending'``, ``masking='none'``,
-    ``correction='none'``. Existing rows: update pipeline-derived columns
-    only (``stage``, ``png_path``, metadata, ``masking='done'`` when a
-    ``.reg`` file is present). Preserve ``review_status``, ``correction``,
-    ``notes``.
+    New rows get default ``review_status='pending'``, ``correction='none'``.
+    Existing rows: update pipeline-derived columns only (``stage``,
+    ``png_path``, metadata). Preserve web-owned ``review_status``,
+    ``correction``, ``mask_regions``, ``notes``.
     """
     if not records:
         return
@@ -813,8 +796,6 @@ def _upsert_exposures(client, records, batch_size=500):
                 update['ra_center'] = r['ra_center']
             if r.get('dec_center') is not None:
                 update['dec_center'] = r['dec_center']
-            if r.get('masking') == 'done':
-                update['masking'] = 'done'
             update_records.append(update)
         else:
             new = {
@@ -824,8 +805,6 @@ def _upsert_exposures(client, records, batch_size=500):
                 'created_at': now,
                 'updated_at': now,
             }
-            if 'masking' not in new:
-                new['masking'] = 'none'
             new_records.append(new)
 
     for i in range(0, len(new_records), batch_size):

--- a/python/campfire/deploy/nircam_masks.py
+++ b/python/campfire/deploy/nircam_masks.py
@@ -185,7 +185,7 @@ def import_masks(field, config, dry_run=False):
 
         payload = {'version': 1, 'polygons': polygons}
         resp = (client.table('nircam_exposures')
-                .update({'mask_regions': payload, 'masking': 'done'})
+                .update({'mask_regions': payload})
                 .eq('field', field)
                 .eq('filter', filtname)
                 .eq('filename', basename)

--- a/python/campfire/deploy/rate_exposures.py
+++ b/python/campfire/deploy/rate_exposures.py
@@ -3,11 +3,9 @@
 Populates the ``nirspec_rate_exposures`` table — the detector-grain analogue of
 ``nircam_exposures`` — from the rate files ``discover_rate_files`` finds. Split
 ownership mirrors ``nircam._upsert_exposures``: a re-deploy UPDATE writes ONLY the
-identity/render columns and OMITS ``review_status``/``masking``/``mask_regions``/
-``notes`` so it never clobbers web triage; new rows seed ``review_status='pending'``,
-``masking='none'``. Unlike NIRCam, deploy has no ``.reg`` knowledge here (the
-mask-pull is P3b), so ``masking`` is entirely web-owned and never set to ``'done'``
-by deploy.
+identity/render columns and OMITS ``review_status``/``mask_regions``/``notes`` so
+it never clobbers web triage; new rows seed ``review_status='pending'``. Mask state
+is entirely web-owned — it lives in ``mask_regions`` and deploy never touches it.
 
 Pure helpers (``parse_rate_filename``, ``partition_rate_records``) are unit-tested
 without a DB; the full insert/upsert round-trip is exercised live against local
@@ -91,9 +89,9 @@ def partition_rate_records(
 ) -> tuple[list[dict], list[dict]]:
     """Split into (new_rows, update_rows) with split ownership.
 
-    New rows seed ``review_status='pending'``/``masking='none'``. Update rows carry
-    ONLY identity + non-null render columns (+ ``updated_at``) — never the
-    web-owned triage columns — so a re-deploy leaves reviewer decisions intact.
+    New rows seed ``review_status='pending'``. Update rows carry ONLY identity +
+    non-null render columns (+ ``updated_at``) — never the web-owned triage
+    columns — so a re-deploy leaves reviewer decisions intact.
     """
     new_records, update_records = [], []
     for r in records:
@@ -109,7 +107,6 @@ def partition_rate_records(
             new_records.append({
                 **r,
                 "review_status": "pending",
-                "masking": "none",
                 "created_at": now,
                 "updated_at": now,
             })

--- a/python/campfire/deploy/spectrum_grid.py
+++ b/python/campfire/deploy/spectrum_grid.py
@@ -9,8 +9,8 @@ reconstructed here — it depends on the whole exposure set's dither pattern).
 
 Split ownership mirrors ``rate_exposures`` / ``nircam._upsert_exposures``: a
 re-deploy UPDATE writes ONLY identity/render columns and OMITS
-``review_status``/``masking``/``notes`` so web triage is never clobbered; new rows
-seed ``review_status='pending'``, ``masking='none'``.
+``review_status``/``notes`` so web triage is never clobbered; new rows
+seed ``review_status='pending'``.
 
 Terminology note: ``spectrum_exposures.exposure_root`` is the pipeline's 2-token
 root (``jw07076020001_04101``) with the exposure token broken out as ``nod`` — this
@@ -117,9 +117,9 @@ def partition_spectrum_records(
 ) -> tuple[list[dict], list[dict]]:
     """Split into (new_rows, update_rows) with split ownership.
 
-    New rows seed ``review_status='pending'``/``masking='none'``. Update rows carry
-    ONLY identity + non-null render columns (+ ``updated_at``) — never the web-owned
-    triage columns — so a re-deploy leaves reviewer decisions intact.
+    New rows seed ``review_status='pending'``. Update rows carry ONLY identity +
+    non-null render columns (+ ``updated_at``) — never the web-owned triage
+    columns — so a re-deploy leaves reviewer decisions intact.
     """
     new_records, update_records = [], []
     for r in records:
@@ -135,7 +135,6 @@ def partition_spectrum_records(
             new_records.append({
                 **r,
                 "review_status": "pending",
-                "masking": "none",
                 "created_at": now,
                 "updated_at": now,
             })

--- a/python/tests/test_rate_exposures.py
+++ b/python/tests/test_rate_exposures.py
@@ -73,12 +73,11 @@ def _record(**over):
     return base
 
 
-def test_partition_new_row_seeds_pending_and_none():
+def test_partition_new_row_seeds_pending():
     new, upd = partition_rate_records([_record()], existing_keys=set(), now="T")
     assert upd == []
     assert len(new) == 1
     assert new[0]["review_status"] == "pending"
-    assert new[0]["masking"] == "none"
     assert new[0]["created_at"] == "T" and new[0]["updated_at"] == "T"
 
 
@@ -89,8 +88,7 @@ def test_partition_existing_row_omits_web_owned_columns():
     assert len(upd) == 1
     update = upd[0]
     # split ownership: the UPDATE must NOT carry any web-owned triage column
-    for web_col in ("review_status", "masking", "mask_regions", "notes",
-                    "created_at"):
+    for web_col in ("review_status", "mask_regions", "notes", "created_at"):
         assert web_col not in update, web_col
     # it DOES carry identity + render + updated_at
     assert update["updated_at"] == "T"

--- a/python/tests/test_spectrum_grid.py
+++ b/python/tests/test_spectrum_grid.py
@@ -81,12 +81,11 @@ def _record(**over):
     return base
 
 
-def test_partition_new_row_seeds_pending_and_none():
+def test_partition_new_row_seeds_pending():
     new, upd = partition_spectrum_records([_record()], existing_keys=set(), now="T")
     assert upd == []
     assert len(new) == 1
     assert new[0]["review_status"] == "pending"
-    assert new[0]["masking"] == "none"
     assert new[0]["created_at"] == "T" and new[0]["updated_at"] == "T"
 
 
@@ -96,7 +95,7 @@ def test_partition_existing_row_omits_web_owned_columns():
     assert new == []
     assert len(upd) == 1
     update = upd[0]
-    for web_col in ("review_status", "masking", "notes", "created_at"):
+    for web_col in ("review_status", "notes", "created_at"):
         assert web_col not in update, web_col
     assert update["updated_at"] == "T"
     for col in ("observation", "exposure_root", "nod", "detector", "source_id",

--- a/supabase/migrations/20260712200000_drop_masking_column.sql
+++ b/supabase/migrations/20260712200000_drop_masking_column.sql
@@ -1,0 +1,233 @@
+-- Drop the redundant `masking` triage column across the three admin exposure
+-- tables (nircam_exposures, nirspec_rate_exposures, spectrum_exposures).
+--
+-- "Masking done" is fully derivable from `mask_regions`: the web already set
+-- `masking = (polygons present ? 'done' : 'none')` on every mask save, so the
+-- column was duplicate state that could drift out of sync (a NULL slipping into
+-- a heterogeneous deploy upsert batch is exactly how it surfaced). The only
+-- non-derivable value, 'needed', and its "Needs masking" dashboard aggregate
+-- (`nircam_reduction_progress.needs_masking`) are retired with it. The sibling
+-- `correction` column (no backing data — a genuine manual flag) is unaffected.
+--
+-- migra would not generate the function/view recreations cleanly (plpgsql
+-- bodies and views aren't tracked the way column drops are), so this migration
+-- is hand-authored: drop the dependent view, drop the columns, recreate the
+-- view, then drop + recreate the two admin RPCs (signature change; the first
+-- also changes its RETURNS TABLE, so CREATE OR REPLACE alone cannot do it).
+
+-- 1. nircam_reduction_progress aggregates `masking`; drop it before the column.
+DROP VIEW IF EXISTS public.nircam_reduction_progress;
+
+-- 2. Drop the column from all three tables.
+ALTER TABLE "public"."nircam_exposures"      DROP COLUMN IF EXISTS "masking";
+ALTER TABLE "public"."nirspec_rate_exposures" DROP COLUMN IF EXISTS "masking";
+ALTER TABLE "public"."spectrum_exposures"     DROP COLUMN IF EXISTS "masking";
+
+-- 3. Recreate the reduction-progress view without needs_masking.
+CREATE VIEW public.nircam_reduction_progress
+WITH (security_invoker = true) AS
+SELECT
+    field,
+    filter,
+    count(*) AS total,
+    count(*) FILTER (WHERE stage = 'uncal')         AS at_uncal,
+    count(*) FILTER (WHERE stage = 'detector1')     AS at_detector1,
+    count(*) FILTER (WHERE stage = 'persistence')   AS at_persistence,
+    count(*) FILTER (WHERE stage = 'wisp')          AS at_wisp,
+    count(*) FILTER (WHERE stage = 'image2')        AS at_image2,
+    count(*) FILTER (WHERE stage = 'edge')          AS at_edge,
+    count(*) FILTER (WHERE stage = 'bkg')           AS at_bkg,
+    count(*) FILTER (WHERE stage = 'diag_striping') AS at_diag_striping,
+    count(*) FILTER (WHERE stage = 'wcs_shift')     AS at_wcs_shift,
+    count(*) FILTER (WHERE stage = 'preview')       AS at_preview,
+    count(*) FILTER (WHERE stage = 'jhat')          AS at_jhat,
+    count(*) FILTER (WHERE stage = 'apply_mask')    AS at_apply_mask,
+    count(*) FILTER (WHERE stage = 'bad_pixel')     AS at_bad_pixel,
+    count(*) FILTER (WHERE stage = 'outlier')       AS at_outlier,
+    count(*) FILTER (WHERE review_status = 'pending')  AS pending_review,
+    count(*) FILTER (WHERE review_status = 'approved') AS approved,
+    count(*) FILTER (WHERE review_status = 'excluded') AS excluded,
+    count(*) FILTER (WHERE correction = 'needed')      AS needs_correction
+FROM public.nircam_exposures
+GROUP BY field, filter;
+
+GRANT SELECT ON public.nircam_reduction_progress TO authenticated;
+
+-- 4. The two admin RPCs filtered on / returned `masking`. Drop the old
+-- signatures (both lose the p_masking parameter; get_admin_exposures also
+-- changes its RETURNS TABLE) before recreating without it.
+DROP FUNCTION IF EXISTS public.get_admin_exposures(text, text, text, text, text, text, text, text, text, integer, integer);
+DROP FUNCTION IF EXISTS public.get_admin_exposure_neighbors(integer, text, text, text, text, text, text, text, text, text, integer);
+
+CREATE OR REPLACE FUNCTION public.get_admin_exposures(
+  p_field text DEFAULT NULL,
+  p_filter text DEFAULT NULL,
+  p_detector text DEFAULT NULL,
+  p_review_status text DEFAULT NULL,
+  p_stage text DEFAULT NULL,
+  p_correction text DEFAULT NULL,
+  p_sort_column text DEFAULT 'filename',   -- 'filename' = the compound (field, filter, filename) list order
+  p_sort_direction text DEFAULT 'asc',
+  p_page integer DEFAULT 1,
+  p_page_size integer DEFAULT 50
+)
+RETURNS TABLE (
+  id integer,
+  field text,
+  filter text,
+  detector text,
+  filename text,
+  visit text,
+  date_obs timestamp without time zone,
+  ra_center double precision,
+  dec_center double precision,
+  stage text,
+  review_status text,
+  correction text,
+  png_path text,
+  full_png_path text,
+  image_width integer,
+  image_height integer,
+  mask_regions jsonb,
+  notes text,
+  created_at timestamp without time zone,
+  updated_at timestamp without time zone,
+  total_count bigint
+)
+LANGUAGE plpgsql STABLE
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_limit integer := LEAST(GREATEST(COALESCE(p_page_size, 50), 1), 200);
+  v_offset integer := GREATEST(COALESCE(p_page, 1) - 1, 0) * LEAST(GREATEST(COALESCE(p_page_size, 50), 1), 200);
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
+  IF p_sort_column NOT IN ('filename', 'field', 'filter', 'detector', 'stage',
+                           'review_status', 'date_obs', 'updated_at') THEN
+    p_sort_column := 'filename';
+  END IF;
+
+  RETURN QUERY
+  SELECT e.id, e.field, e.filter, e.detector, e.filename, e.visit, e.date_obs,
+         e.ra_center, e.dec_center, e.stage, e.review_status,
+         e.correction, e.png_path, e.full_png_path, e.image_width,
+         e.image_height, e.mask_regions, e.notes, e.created_at, e.updated_at,
+         count(*) OVER ()
+  FROM nircam_exposures e
+  WHERE (p_field IS NULL OR e.field = p_field)
+    AND (p_filter IS NULL OR e.filter = p_filter)
+    AND (p_detector IS NULL OR e.detector = p_detector)
+    AND (p_review_status IS NULL OR e.review_status = p_review_status)
+    AND (p_stage IS NULL OR e.stage = p_stage)
+    AND (p_correction IS NULL OR e.correction = p_correction)
+  ORDER BY
+    -- Keep in lockstep with get_admin_exposure_neighbors.
+    CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'asc'  THEN e.field END ASC,
+    CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'asc'  THEN e.filter END ASC,
+    CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'asc'  THEN e.filename END ASC,
+    CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'desc' THEN e.field END DESC,
+    CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'desc' THEN e.filter END DESC,
+    CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'desc' THEN e.filename END DESC,
+    CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc'  THEN e.field END ASC,
+    CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN e.field END DESC,
+    CASE WHEN p_sort_column = 'filter' AND p_sort_direction = 'asc'  THEN e.filter END ASC,
+    CASE WHEN p_sort_column = 'filter' AND p_sort_direction = 'desc' THEN e.filter END DESC,
+    CASE WHEN p_sort_column = 'detector' AND p_sort_direction = 'asc'  THEN e.detector END ASC,
+    CASE WHEN p_sort_column = 'detector' AND p_sort_direction = 'desc' THEN e.detector END DESC,
+    CASE WHEN p_sort_column = 'stage' AND p_sort_direction = 'asc'  THEN e.stage END ASC,
+    CASE WHEN p_sort_column = 'stage' AND p_sort_direction = 'desc' THEN e.stage END DESC,
+    CASE WHEN p_sort_column = 'review_status' AND p_sort_direction = 'asc'  THEN e.review_status END ASC,
+    CASE WHEN p_sort_column = 'review_status' AND p_sort_direction = 'desc' THEN e.review_status END DESC,
+    CASE WHEN p_sort_column = 'date_obs' AND p_sort_direction = 'asc'  THEN e.date_obs END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'date_obs' AND p_sort_direction = 'desc' THEN e.date_obs END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'updated_at' AND p_sort_direction = 'asc'  THEN e.updated_at END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'updated_at' AND p_sort_direction = 'desc' THEN e.updated_at END DESC NULLS LAST,
+    e.id ASC
+  OFFSET v_offset LIMIT v_limit;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_admin_exposures TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.get_admin_exposure_neighbors(
+  p_current_id integer,
+  p_field text DEFAULT NULL,
+  p_filter text DEFAULT NULL,
+  p_detector text DEFAULT NULL,
+  p_review_status text DEFAULT NULL,
+  p_stage text DEFAULT NULL,
+  p_correction text DEFAULT NULL,
+  p_sort_column text DEFAULT 'filename',
+  p_sort_direction text DEFAULT 'asc',
+  p_window integer DEFAULT 3
+)
+RETURNS TABLE (
+  id integer,
+  nav_position bigint,   -- 1-based rank in the filtered set ("position" is reserved)
+  total_count bigint
+)
+LANGUAGE plpgsql STABLE
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_window integer := LEAST(GREATEST(COALESCE(p_window, 3), 1), 25);
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
+  IF p_sort_column NOT IN ('filename', 'field', 'filter', 'detector', 'stage',
+                           'review_status', 'date_obs', 'updated_at') THEN
+    p_sort_column := 'filename';
+  END IF;
+
+  RETURN QUERY
+  WITH ranked AS (
+    SELECT e.id AS exp_id,
+           row_number() OVER (ORDER BY
+             -- Keep in lockstep with get_admin_exposures.
+             CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'asc'  THEN e.field END ASC,
+             CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'asc'  THEN e.filter END ASC,
+             CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'asc'  THEN e.filename END ASC,
+             CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'desc' THEN e.field END DESC,
+             CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'desc' THEN e.filter END DESC,
+             CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'desc' THEN e.filename END DESC,
+             CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc'  THEN e.field END ASC,
+             CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN e.field END DESC,
+             CASE WHEN p_sort_column = 'filter' AND p_sort_direction = 'asc'  THEN e.filter END ASC,
+             CASE WHEN p_sort_column = 'filter' AND p_sort_direction = 'desc' THEN e.filter END DESC,
+             CASE WHEN p_sort_column = 'detector' AND p_sort_direction = 'asc'  THEN e.detector END ASC,
+             CASE WHEN p_sort_column = 'detector' AND p_sort_direction = 'desc' THEN e.detector END DESC,
+             CASE WHEN p_sort_column = 'stage' AND p_sort_direction = 'asc'  THEN e.stage END ASC,
+             CASE WHEN p_sort_column = 'stage' AND p_sort_direction = 'desc' THEN e.stage END DESC,
+             CASE WHEN p_sort_column = 'review_status' AND p_sort_direction = 'asc'  THEN e.review_status END ASC,
+             CASE WHEN p_sort_column = 'review_status' AND p_sort_direction = 'desc' THEN e.review_status END DESC,
+             CASE WHEN p_sort_column = 'date_obs' AND p_sort_direction = 'asc'  THEN e.date_obs END ASC NULLS LAST,
+             CASE WHEN p_sort_column = 'date_obs' AND p_sort_direction = 'desc' THEN e.date_obs END DESC NULLS LAST,
+             CASE WHEN p_sort_column = 'updated_at' AND p_sort_direction = 'asc'  THEN e.updated_at END ASC NULLS LAST,
+             CASE WHEN p_sort_column = 'updated_at' AND p_sort_direction = 'desc' THEN e.updated_at END DESC NULLS LAST,
+             e.id ASC
+           ) AS rn,
+           count(*) OVER () AS n
+    FROM nircam_exposures e
+    WHERE (p_field IS NULL OR e.field = p_field)
+      AND (p_filter IS NULL OR e.filter = p_filter)
+      AND (p_detector IS NULL OR e.detector = p_detector)
+      AND (p_review_status IS NULL OR e.review_status = p_review_status)
+      AND (p_stage IS NULL OR e.stage = p_stage)
+      AND (p_correction IS NULL OR e.correction = p_correction)
+  ),
+  cur AS (
+    SELECT r.rn AS rn0 FROM ranked r WHERE r.exp_id = p_current_id
+  )
+  SELECT r.exp_id, r.rn, r.n
+  FROM ranked r, cur
+  WHERE r.rn BETWEEN cur.rn0 - v_window AND cur.rn0 + v_window
+  ORDER BY r.rn;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_admin_exposure_neighbors TO authenticated;

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -3656,7 +3656,6 @@ CREATE OR REPLACE FUNCTION public.get_admin_exposures(
   p_detector text DEFAULT NULL,
   p_review_status text DEFAULT NULL,
   p_stage text DEFAULT NULL,
-  p_masking text DEFAULT NULL,
   p_correction text DEFAULT NULL,
   p_sort_column text DEFAULT 'filename',   -- 'filename' = the compound (field, filter, filename) list order
   p_sort_direction text DEFAULT 'asc',
@@ -3675,7 +3674,6 @@ RETURNS TABLE (
   dec_center double precision,
   stage text,
   review_status text,
-  masking text,
   correction text,
   png_path text,
   full_png_path text,
@@ -3705,7 +3703,7 @@ BEGIN
 
   RETURN QUERY
   SELECT e.id, e.field, e.filter, e.detector, e.filename, e.visit, e.date_obs,
-         e.ra_center, e.dec_center, e.stage, e.review_status, e.masking,
+         e.ra_center, e.dec_center, e.stage, e.review_status,
          e.correction, e.png_path, e.full_png_path, e.image_width,
          e.image_height, e.mask_regions, e.notes, e.created_at, e.updated_at,
          count(*) OVER ()
@@ -3715,7 +3713,6 @@ BEGIN
     AND (p_detector IS NULL OR e.detector = p_detector)
     AND (p_review_status IS NULL OR e.review_status = p_review_status)
     AND (p_stage IS NULL OR e.stage = p_stage)
-    AND (p_masking IS NULL OR e.masking = p_masking)
     AND (p_correction IS NULL OR e.correction = p_correction)
   ORDER BY
     -- Keep in lockstep with get_admin_exposure_neighbors.
@@ -3758,7 +3755,6 @@ CREATE OR REPLACE FUNCTION public.get_admin_exposure_neighbors(
   p_detector text DEFAULT NULL,
   p_review_status text DEFAULT NULL,
   p_stage text DEFAULT NULL,
-  p_masking text DEFAULT NULL,
   p_correction text DEFAULT NULL,
   p_sort_column text DEFAULT 'filename',
   p_sort_direction text DEFAULT 'asc',
@@ -3818,8 +3814,7 @@ BEGIN
       AND (p_detector IS NULL OR e.detector = p_detector)
       AND (p_review_status IS NULL OR e.review_status = p_review_status)
       AND (p_stage IS NULL OR e.stage = p_stage)
-      AND (p_masking IS NULL OR e.masking = p_masking)
-      AND (p_correction IS NULL OR e.correction = p_correction)
+        AND (p_correction IS NULL OR e.correction = p_correction)
   ),
   cur AS (
     SELECT r.rn AS rn0 FROM ranked r WHERE r.exp_id = p_current_id

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -814,7 +814,6 @@ CREATE TABLE IF NOT EXISTS "public"."nircam_exposures" (
     "dec_center" double precision,
     "stage" "text" NOT NULL DEFAULT 'uncal'::"text",
     "review_status" "text" NOT NULL DEFAULT 'pending'::"text",
-    "masking" "text" NOT NULL DEFAULT 'none'::"text",
     "correction" "text" NOT NULL DEFAULT 'none'::"text",
     "png_path" "text",
     "full_png_path" "text",
@@ -860,7 +859,6 @@ CREATE TABLE IF NOT EXISTS "public"."nirspec_rate_exposures" (
     "storage_key" "text",
     "stage" "text" NOT NULL DEFAULT 'rate'::"text",
     "review_status" "text" NOT NULL DEFAULT 'pending'::"text",
-    "masking" "text" NOT NULL DEFAULT 'none'::"text",
     "mask_regions" "jsonb",
     "notes" "text",
     "created_at" timestamp with time zone NOT NULL DEFAULT "now"(),
@@ -898,7 +896,7 @@ ALTER SEQUENCE "public"."nirspec_rate_exposures_id_seq" OWNED BY "public"."nirsp
 -- header stamp. Admin-only: reduction intermediates, never user-facing science. The
 -- physical object (key/hash/size/backend) lives in storage_objects (product_type
 -- 'nirspec_spectrum_exposure'); this table owns render columns + reviewer lifecycle
--- state (review_status, masking, notes — the last two set by the web, not deploy).
+-- state (review_status, notes — set by the web, not deploy).
 CREATE TABLE IF NOT EXISTS "public"."spectrum_exposures" (
     "id" integer NOT NULL,
     "observation" "text" NOT NULL,
@@ -914,7 +912,6 @@ CREATE TABLE IF NOT EXISTS "public"."spectrum_exposures" (
     "image_height" integer,
     "stage" "text" NOT NULL DEFAULT 'cal'::"text",
     "review_status" "text" NOT NULL DEFAULT 'pending'::"text",
-    "masking" "text" NOT NULL DEFAULT 'none'::"text",
     "notes" "text",
     "created_at" timestamp with time zone DEFAULT "now"() NOT NULL,
     "updated_at" timestamp with time zone DEFAULT "now"() NOT NULL

--- a/supabase/schemas/views.sql
+++ b/supabase/schemas/views.sql
@@ -169,7 +169,6 @@ SELECT
     count(*) FILTER (WHERE review_status = 'pending')  AS pending_review,
     count(*) FILTER (WHERE review_status = 'approved') AS approved,
     count(*) FILTER (WHERE review_status = 'excluded') AS excluded,
-    count(*) FILTER (WHERE masking = 'needed')         AS needs_masking,
     count(*) FILTER (WHERE correction = 'needed')      AS needs_correction
 FROM public.nircam_exposures
 GROUP BY field, filter;

--- a/web/app/admin/nircam/[id]/page.tsx
+++ b/web/app/admin/nircam/[id]/page.tsx
@@ -60,7 +60,6 @@ function ExposureDetailPageInner() {
 
   // Editable fields
   const [reviewStatus, setReviewStatus] = useState<string>('pending');
-  const [masking, setMasking] = useState<string>('none');
   const [correction, setCorrection] = useState<string>('none');
   const [notes, setNotes] = useState<string>('');
 
@@ -98,7 +97,6 @@ function ExposureDetailPageInner() {
     setExposureForId(id);
     setExposure(cached);
     setReviewStatus(cached?.review_status || 'pending');
-    setMasking(cached?.masking || 'none');
     setCorrection(cached?.correction || 'none');
     setNotes(cached?.notes || '');
     setLoading(!cached);
@@ -123,7 +121,6 @@ function ExposureDetailPageInner() {
         setCachedExposure(result.exposure);
         setExposure(result.exposure);
         setReviewStatus(result.exposure.review_status);
-        setMasking(result.exposure.masking);
         setCorrection(result.exposure.correction);
         setNotes(result.exposure.notes || '');
       }
@@ -193,14 +190,13 @@ function ExposureDetailPageInner() {
 
   const hasChanges = !!(exposure && (
     reviewStatus !== exposure.review_status ||
-    masking !== exposure.masking ||
     correction !== exposure.correction ||
     notes !== (exposure.notes || '')
   ));
 
   // Latest-state ref so the keyboard handler doesn't capture stale closures.
-  const stateRef = useRef({ reviewStatus, masking, correction, notes, hasChanges });
-  stateRef.current = { reviewStatus, masking, correction, notes, hasChanges };
+  const stateRef = useRef({ reviewStatus, correction, notes, hasChanges });
+  stateRef.current = { reviewStatus, correction, notes, hasChanges };
 
   const handleSave = useCallback(async (): Promise<{ ok: boolean }> => {
     const s = stateRef.current;
@@ -209,7 +205,6 @@ function ExposureDetailPageInner() {
     setError(null);
     const result = await updateExposureReview(id, {
       review_status: s.reviewStatus as NircamExposure['review_status'],
-      masking: s.masking as NircamExposure['masking'],
       correction: s.correction as NircamExposure['correction'],
       notes: s.notes || undefined,
     });
@@ -535,21 +530,6 @@ function ExposureDetailPageInner() {
                   <option value="pending">Pending</option>
                   <option value="approved">Approved</option>
                   <option value="excluded">Excluded</option>
-                </select>
-              </div>
-
-              <div>
-                <label className="block text-xs font-medium text-text-secondary mb-1">
-                  Masking
-                </label>
-                <select
-                  value={masking}
-                  onChange={(e) => setMasking(e.target.value)}
-                  className="w-full text-sm border border-border rounded-lg px-3 py-2 bg-card text-text-primary"
-                >
-                  <option value="none">None</option>
-                  <option value="needed">Needed</option>
-                  <option value="done">Done</option>
                 </select>
               </div>
 

--- a/web/app/admin/nircam/page.tsx
+++ b/web/app/admin/nircam/page.tsx
@@ -58,6 +58,20 @@ function ActionBadge({ status, label }: { status: string; label: string }) {
   );
 }
 
+// "Masked" is derived state — a non-empty mask_regions is the sole signal
+// (the redundant `masking` status column was dropped). Read-only: masks are
+// drawn in the exposure detail view, not toggled here.
+function MaskedBadge({ regions }: { regions: NircamExposure['mask_regions'] }) {
+  if ((regions?.polygons?.length ?? 0) === 0) {
+    return <span className="text-xs text-text-secondary">&mdash;</span>;
+  }
+  return (
+    <span className="inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-300">
+      masked
+    </span>
+  );
+}
+
 function StageBadge({ stage }: { stage: string }) {
   return (
     <span className={`inline-flex px-2 py-0.5 text-xs font-medium rounded-full font-mono ${stageBadgeClasses(stage)}`}>
@@ -119,7 +133,6 @@ function ProgressTable({ progress }: { progress: ReductionProgress[] }) {
             <th className="px-3 py-2 text-right text-xs font-medium text-text-secondary uppercase">Total</th>
             <th className="px-3 py-2 text-left text-xs font-medium text-text-secondary uppercase w-1/3">Stage distribution</th>
             <th className="px-3 py-2 text-right text-xs font-medium text-text-secondary uppercase">Pending</th>
-            <th className="px-3 py-2 text-right text-xs font-medium text-text-secondary uppercase">Masking</th>
             <th className="px-3 py-2 text-right text-xs font-medium text-text-secondary uppercase">Correction</th>
           </tr>
         </thead>
@@ -139,18 +152,6 @@ function ProgressTable({ progress }: { progress: ReductionProgress[] }) {
                     className="text-yellow-600 dark:text-yellow-400 font-medium hover:underline"
                   >
                     {row.pending_review}
-                  </Link>
-                ) : (
-                  <span className="text-text-secondary">0</span>
-                )}
-              </td>
-              <td className="px-3 py-2 text-right">
-                {row.needs_masking > 0 ? (
-                  <Link
-                    href={`/admin/nircam?field=${encodeURIComponent(row.field)}&filter=${encodeURIComponent(row.filter)}&masking=needed`}
-                    className="text-orange-600 dark:text-orange-400 font-medium hover:underline"
-                  >
-                    {row.needs_masking}
                   </Link>
                 ) : (
                   <span className="text-text-secondary">0</span>
@@ -254,7 +255,7 @@ function ExcludedPanel({ excluded }: { excluded: ExcludedExposure[] }) {
 // see lib/nircam-exposure-nav.ts.
 // ---------------------------------------------------------------------------
 
-const FILTER_KEYS = ['field', 'filter', 'detector', 'review', 'stage', 'masking', 'correction'] as const;
+const FILTER_KEYS = ['field', 'filter', 'detector', 'review', 'stage', 'correction'] as const;
 const codec = flatFilterCodec(FILTER_KEYS);
 const DEFAULT_SORT: SortState = { column: 'filename', direction: 'asc' };
 
@@ -294,7 +295,6 @@ function AdminNircamPageInner() {
         detector: f.detector || undefined,
         reviewStatus: f.review || undefined,
         stage: f.stage || undefined,
-        masking: f.masking || undefined,
         correction: f.correction || undefined,
         sortColumn: state.sort.column,
         sortDirection: state.sort.direction,
@@ -374,9 +374,9 @@ function AdminNircamPageInner() {
       meta: { sortKey: 'review_status' },
     },
     {
-      id: 'masking',
-      header: 'Masking',
-      cell: ({ row }) => <ActionBadge status={row.original.masking} label="mask" />,
+      id: 'masked',
+      header: 'Masked',
+      cell: ({ row }) => <MaskedBadge regions={row.original.mask_regions} />,
     },
     {
       id: 'correction',
@@ -440,7 +440,6 @@ function AdminNircamPageInner() {
             options: NIRCAM_STAGES.map((s) => ({ value: s, label: s })),
           },
           { kind: 'select', key: 'review', label: 'Review', options: REVIEW_OPTIONS },
-          { kind: 'select', key: 'masking', label: 'Masking', options: ACTION_STATE_OPTIONS },
           { kind: 'select', key: 'correction', label: 'Correction', options: ACTION_STATE_OPTIONS },
         ]}
         values={state.filters}

--- a/web/app/admin/nirspec/rate/[id]/page.tsx
+++ b/web/app/admin/nirspec/rate/[id]/page.tsx
@@ -44,7 +44,6 @@ function RateDetailPageInner() {
 
   // Editable triage fields
   const [reviewStatus, setReviewStatus] = useState<string>('pending');
-  const [masking, setMasking] = useState<string>('none');
   const [notes, setNotes] = useState<string>('');
 
   const [nav, setNav] = useState<RateNeighbors | null>(null);
@@ -67,7 +66,6 @@ function RateDetailPageInner() {
     setExposureForId(id);
     setExposure(cached);
     setReviewStatus(cached?.review_status || 'pending');
-    setMasking(cached?.masking || 'none');
     setNotes(cached?.notes || '');
     setLoading(!cached);
     setError(null);
@@ -89,7 +87,6 @@ function RateDetailPageInner() {
         setCachedRate(result.exposure);
         setExposure(result.exposure);
         setReviewStatus(result.exposure.review_status);
-        setMasking(result.exposure.masking);
         setNotes(result.exposure.notes || '');
       }
       setLoading(false);
@@ -110,12 +107,11 @@ function RateDetailPageInner() {
 
   const hasChanges = !!(exposure && (
     reviewStatus !== exposure.review_status ||
-    masking !== exposure.masking ||
     notes !== (exposure.notes || '')
   ));
 
-  const stateRef = useRef({ reviewStatus, masking, notes, hasChanges });
-  stateRef.current = { reviewStatus, masking, notes, hasChanges };
+  const stateRef = useRef({ reviewStatus, notes, hasChanges });
+  stateRef.current = { reviewStatus, notes, hasChanges };
 
   const handleSave = useCallback(async (): Promise<{ ok: boolean }> => {
     const s = stateRef.current;
@@ -124,7 +120,6 @@ function RateDetailPageInner() {
     setError(null);
     const result = await updateNirspecRateReview(id, {
       review_status: s.reviewStatus as NirspecRateExposure['review_status'],
-      masking: s.masking as NirspecRateExposure['masking'],
       notes: s.notes || undefined,
     });
     setSaving(false);
@@ -373,21 +368,6 @@ function RateDetailPageInner() {
                   <option value="pending">Pending</option>
                   <option value="approved">Approved</option>
                   <option value="excluded">Excluded</option>
-                </select>
-              </div>
-
-              <div>
-                <label className="block text-xs font-medium text-text-secondary mb-1">
-                  Masking
-                </label>
-                <select
-                  value={masking}
-                  onChange={(e) => setMasking(e.target.value)}
-                  className="w-full text-sm border border-border rounded-lg px-3 py-2 bg-card text-text-primary"
-                >
-                  <option value="none">None</option>
-                  <option value="needed">Needed</option>
-                  <option value="done">Done</option>
                 </select>
               </div>
 

--- a/web/app/admin/nirspec/rate/page.tsx
+++ b/web/app/admin/nirspec/rate/page.tsx
@@ -34,15 +34,16 @@ function ReviewBadge({ status }: { status: string }) {
   );
 }
 
-function ActionBadge({ status, label }: { status: string; label: string }) {
-  if (status === 'none') return <span className="text-xs text-text-secondary">&mdash;</span>;
-  const colors: Record<string, string> = {
-    needed: 'bg-orange-100 dark:bg-orange-900 text-orange-800 dark:text-orange-300',
-    done: 'bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-300',
-  };
+// "Masked" is derived state — a non-empty mask_regions is the sole signal
+// (the redundant `masking` status column was dropped). Read-only: masks are
+// drawn in the rate detail view, not toggled here.
+function MaskedBadge({ regions }: { regions: NirspecRateExposure['mask_regions'] }) {
+  if ((regions?.polygons?.length ?? 0) === 0) {
+    return <span className="text-xs text-text-secondary">&mdash;</span>;
+  }
   return (
-    <span className={`inline-flex px-2 py-0.5 text-xs font-medium rounded-full ${colors[status] || ''}`}>
-      {label}: {status}
+    <span className="inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-300">
+      masked
     </span>
   );
 }
@@ -53,7 +54,7 @@ function ActionBadge({ status, label }: { status: string; label: string }) {
 // see lib/nirspec-rate-nav.ts.
 // ---------------------------------------------------------------------------
 
-const FILTER_KEYS = ['observation', 'detector', 'review', 'masking', 'grating'] as const;
+const FILTER_KEYS = ['observation', 'detector', 'review', 'grating'] as const;
 const codec = flatFilterCodec(FILTER_KEYS);
 const DEFAULT_SORT: SortState = { column: 'filename', direction: 'asc' };
 
@@ -61,11 +62,6 @@ const REVIEW_OPTIONS = [
   { value: 'pending', label: 'Pending' },
   { value: 'approved', label: 'Approved' },
   { value: 'excluded', label: 'Excluded' },
-];
-const ACTION_STATE_OPTIONS = [
-  { value: 'needed', label: 'Needed' },
-  { value: 'done', label: 'Done' },
-  { value: 'none', label: 'None' },
 ];
 const DETECTOR_OPTIONS = [
   { value: 'nrs1', label: 'nrs1' },
@@ -91,7 +87,6 @@ function AdminNirspecRatePageInner() {
         observation: f.observation || undefined,
         detector: f.detector || undefined,
         reviewStatus: f.review || undefined,
-        masking: f.masking || undefined,
         grating: f.grating || undefined,
         sortColumn: state.sort.column,
         sortDirection: state.sort.direction,
@@ -161,9 +156,9 @@ function AdminNirspecRatePageInner() {
       meta: { sortKey: 'review_status' },
     },
     {
-      id: 'masking',
-      header: 'Masking',
-      cell: ({ row }) => <ActionBadge status={row.original.masking} label="mask" />,
+      id: 'masked',
+      header: 'Masked',
+      cell: ({ row }) => <MaskedBadge regions={row.original.mask_regions} />,
     },
     {
       id: 'open',
@@ -203,7 +198,6 @@ function AdminNirspecRatePageInner() {
             options: (facets?.gratings ?? []).map((g) => ({ value: g, label: g })),
           },
           { kind: 'select', key: 'review', label: 'Review', options: REVIEW_OPTIONS },
-          { kind: 'select', key: 'masking', label: 'Masking', options: ACTION_STATE_OPTIONS },
         ]}
         values={state.filters}
         onChange={(key, value) => state.setFilters({ ...state.filters, [key]: value })}

--- a/web/app/admin/page.tsx
+++ b/web/app/admin/page.tsx
@@ -98,7 +98,6 @@ export default function AdminDashboardPage() {
 
   const progress = progressResult?.progress ?? [];
   const pendingReview = progress.reduce((s, r) => s + (r.pending_review ?? 0), 0);
-  const needsMasking = progress.reduce((s, r) => s + (r.needs_masking ?? 0), 0);
   const needsCorrection = progress.reduce((s, r) => s + (r.needs_correction ?? 0), 0);
   const attention = progress.filter((r) => r.pending_review > 0);
 
@@ -123,13 +122,6 @@ export default function AdminDashboardPage() {
           label="Exposures pending review"
           value={pendingReview}
           accent={pendingReview > 0}
-        />
-        <StatTile
-          href="/admin/nircam?masking=needed"
-          icon={Camera}
-          label="Needs masking"
-          value={needsMasking}
-          accent={needsMasking > 0}
         />
         <StatTile
           href="/admin/nircam?correction=needed"

--- a/web/lib/actions/nircam-exposures.ts
+++ b/web/lib/actions/nircam-exposures.ts
@@ -46,7 +46,6 @@ export interface ExposureFilters {
   detector?: string;
   reviewStatus?: string;
   stage?: string;
-  masking?: string;
   correction?: string;
 }
 
@@ -66,7 +65,6 @@ function rpcExposureParams(params?: ExposureFilters & ExposureSort) {
     p_detector: params?.detector ?? null,
     p_review_status: params?.reviewStatus ?? null,
     p_stage: params?.stage ?? null,
-    p_masking: params?.masking ?? null,
     p_correction: params?.correction ?? null,
     p_sort_column: params?.sortColumn ?? 'filename',
     p_sort_direction: params?.sortDirection ?? 'asc',
@@ -274,7 +272,6 @@ export async function updateExposureReview(
   id: number,
   updates: {
     review_status?: 'pending' | 'approved' | 'excluded';
-    masking?: 'none' | 'needed' | 'done';
     correction?: 'none' | 'needed' | 'done';
     notes?: string;
   },
@@ -314,9 +311,8 @@ export async function updateExposureReview(
  *
  * Vertices are stored as DS9 ``image`` 1-indexed coords so the same payload
  * round-trips through ``campfire deploy pull-masks`` and ``apply_masks_step``
- * without any further transform. ``masking`` is flipped to ``'done'`` iff
- * at least one polygon is present, mirroring the local-file-exists semantic
- * that the deploy code uses.
+ * without any further transform. "Masked" is derived state: a non-empty
+ * ``mask_regions`` is the sole signal; clearing all polygons nulls it.
  */
 export async function saveExposureMaskRegions(
   id: number,
@@ -330,7 +326,6 @@ export async function saveExposureMaskRegions(
       .from('nircam_exposures')
       .update({
         mask_regions: hasPolygons ? regions : null,
-        masking: hasPolygons ? 'done' : 'none',
         updated_at: new Date().toISOString(),
       })
       .eq('id', id)
@@ -377,7 +372,6 @@ export interface ReductionProgress {
   pending_review: number;
   approved: number;
   excluded: number;
-  needs_masking: number;
   needs_correction: number;
 }
 

--- a/web/lib/actions/nirspec-rate.ts
+++ b/web/lib/actions/nirspec-rate.ts
@@ -27,7 +27,6 @@ export interface RateFilters {
   observation?: string;
   detector?: string;
   reviewStatus?: string;
-  masking?: string;
   grating?: string;
 }
 
@@ -66,7 +65,6 @@ function applyRateFilters(query: any, f: RateFilters) {
   if (f.observation) query = query.eq('observation', f.observation);
   if (f.detector) query = query.eq('detector', f.detector);
   if (f.reviewStatus) query = query.eq('review_status', f.reviewStatus);
-  if (f.masking) query = query.eq('masking', f.masking);
   if (f.grating) query = query.eq('grating', f.grating);
   return query;
 }
@@ -201,7 +199,6 @@ export async function updateNirspecRateReview(
   id: number,
   updates: {
     review_status?: 'pending' | 'approved' | 'excluded';
-    masking?: 'none' | 'needed' | 'done';
     notes?: string;
   },
 ): Promise<{ exposure: NirspecRateExposure | null; error?: string }> {
@@ -228,8 +225,8 @@ export async function updateNirspecRateReview(
  *
  * Vertices are stored as DS9 ``image`` 1-indexed coords so the payload round-trips
  * through ``campfire deploy nirspec pull-rate-masks`` (P3b) and ``apply_mask_dq``
- * without further transform. ``masking`` flips to ``'done'`` iff ≥1 polygon,
- * mirroring the local-file-exists semantic the deploy code uses.
+ * without further transform. "Masked" is derived state: a non-empty
+ * ``mask_regions`` is the sole signal; clearing all polygons nulls it.
  */
 export async function saveRateMaskRegions(
   id: number,
@@ -242,7 +239,6 @@ export async function saveRateMaskRegions(
       .from('nirspec_rate_exposures')
       .update({
         mask_regions: hasPolygons ? regions : null,
-        masking: hasPolygons ? 'done' : 'none',
         updated_at: new Date().toISOString(),
       })
       .eq('id', id)

--- a/web/lib/nircam-exposure-nav.ts
+++ b/web/lib/nircam-exposure-nav.ts
@@ -9,7 +9,7 @@ import type { ExposureFilters, ExposureSort } from '@/lib/actions/nircam-exposur
 import { EXPOSURE_SORT_KEYS } from '@/lib/admin/sort-keys';
 
 export const EXPOSURE_FILTER_PARAM_KEYS = [
-  'field', 'filter', 'detector', 'review', 'stage', 'masking', 'correction',
+  'field', 'filter', 'detector', 'review', 'stage', 'correction',
 ] as const;
 
 export type ExposureFilterParams = Record<
@@ -29,7 +29,6 @@ export function parseExposureNavParams(
     detector: sp.get('detector') || undefined,
     reviewStatus: sp.get('review') || undefined,
     stage: sp.get('stage') || undefined,
-    masking: sp.get('masking') || undefined,
     correction: sp.get('correction') || undefined,
     sortColumn:
       sort && (EXPOSURE_SORT_KEYS as readonly string[]).includes(sort) ? sort : undefined,

--- a/web/lib/nirspec-nods.test.ts
+++ b/web/lib/nirspec-nods.test.ts
@@ -11,7 +11,7 @@ function row(over: Partial<SpectrumExposure>): SpectrumExposure {
     nod: '00001', detector: 'nrs1', source_id: 117757, exp_group: 0, grating: 'PRISM',
     filename: 'x.fits', storage_key: 'data/products/nirspec/o/x.fits',
     image_width: 40, image_height: 400, stage: 'cal', review_status: 'pending',
-    masking: 'none', notes: null, created_at: '', updated_at: '', ...over,
+    notes: null, created_at: '', updated_at: '', ...over,
   };
 }
 

--- a/web/lib/nirspec-rate-nav.ts
+++ b/web/lib/nirspec-rate-nav.ts
@@ -8,7 +8,7 @@ import type { RateFilters, RateSort } from '@/lib/actions/nirspec-rate';
 import { NIRSPEC_RATE_SORT_KEYS } from '@/lib/admin/sort-keys';
 
 export const RATE_FILTER_PARAM_KEYS = [
-  'observation', 'detector', 'review', 'masking', 'grating',
+  'observation', 'detector', 'review', 'grating',
 ] as const;
 
 export type RateFilterParams = Record<
@@ -26,7 +26,6 @@ export function parseRateNavParams(
     observation: sp.get('observation') || undefined,
     detector: sp.get('detector') || undefined,
     reviewStatus: sp.get('review') || undefined,
-    masking: sp.get('masking') || undefined,
     grating: sp.get('grating') || undefined,
     sortColumn:
       sort && (NIRSPEC_RATE_SORT_KEYS as readonly string[]).includes(sort) ? sort : undefined,

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -352,7 +352,6 @@ export interface NircamExposure {
   dec_center: number | null;
   stage: NircamStage;
   review_status: 'pending' | 'approved' | 'excluded';
-  masking: 'none' | 'needed' | 'done';
   correction: 'none' | 'needed' | 'done';
   png_path: string | null;
   full_png_path: string | null;
@@ -379,7 +378,6 @@ export interface NirspecRateExposure {
   storage_key: string | null;     // canonical nirspec_rate key for the FITS proxy
   stage: string;
   review_status: 'pending' | 'approved' | 'excluded';
-  masking: 'none' | 'needed' | 'done';
   mask_regions: MaskRegionsPayload | null;
   notes: string | null;
   created_at: string;
@@ -406,7 +404,6 @@ export interface SpectrumExposure {
   image_height: number | null;
   stage: string;
   review_status: 'pending' | 'approved' | 'excluded';
-  masking: 'none' | 'needed' | 'done';
   notes: string | null;
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## Problem

`campfire deploy --field egs --filter f277w` uploaded all 578 files successfully, then aborted on the Supabase upsert:

```
postgrest.exceptions.APIError: null value in column "masking" of relation
"nircam_exposures" violates not-null constraint (code 23502)
```

**Root cause.** NIRCam's re-deploy update path added `masking='done'` *only* for exposures that have a `.reg` mask file, so a batch was heterogeneous — a few rows carried the `masking` key, most didn't. PostgREST bulk-upsert takes the union of keys across the batch and null-fills the rows that omit one, so the maskless rows were sent `masking = NULL`, violating the `NOT NULL` constraint. (The sibling nirspec deploy path never hits this because it treats masking as strictly web-owned and never writes it.)

## Fix: drop the `masking` column

The column duplicated state already implied by `mask_regions`: the web set `masking = polygons ? 'done' : 'none'` on every mask save, so "done" is just "`mask_regions` is non-empty." Rather than paper over the upsert, this removes the redundant column across the board and derives the display state from the regions.

The only non-derivable value, `'needed'` (a manual "this needs a mask" flag), and its **"Needs masking"** dashboard aggregate are retired. The sibling `correction` column has no backing data — a genuine manual flag — and is left untouched.

## Changes

**Database** (`supabase/schemas/` + migration `20260712200000_drop_masking_column.sql`)
- Drop `masking` from `nircam_exposures`, `nirspec_rate_exposures`, `spectrum_exposures`
- Recreate `nircam_reduction_progress` without `needs_masking`
- Drop + recreate `get_admin_exposures` / `get_admin_exposure_neighbors` without `p_masking` (`get_admin_exposures` also drops it from `RETURNS TABLE`, so `CREATE OR REPLACE` alone can't do it)
- Hand-authored migration — migra doesn't diff function/view recreations cleanly. `DROP FUNCTION` signatures verified against the prior definition.

**Python** (`campfire/deploy/`) — this is what unblocks the deploy
- Remove `_detect_masking` and every masking write from the nircam / rate / spectrum deploy paths and the `.reg` mask-import round-trip
- Update `test_rate_exposures.py` / `test_spectrum_grid.py`

**Web**
- Drop `masking` from types, filters, URL nav, and the two detail-page dropdowns
- Replace the "Masking" table column with a read-only **`masked`** badge derived from `mask_regions`; remove the "Needs masking" dashboard tile

## Verification
- Python partition logic exercised standalone: new rows no longer seed `masking`, update rows stay web-column-free; all edited Python files `py_compile` clean
- `tsc --noEmit` clean; `next build` compiles and typechecks (fails only at the `/login` prerender, which needs Supabase env vars — same on `main`)
- `seed.sql` doesn't touch these tables; no `pipeline/**` changes, so no CHANGELOG entry needed

## Note
Dropping the column discards existing `'needed'` flags in production — unavoidable given the redundancy, flagging it explicitly. On merge, the migration drops the column from production via the Supabase integration.

Generated with Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqiQyodbtNTx3boktS3udf)_