### PR TITLE
fix(web): address #379 review findings (deep-linked band + stale-fetch race)

### DIFF
--- a/web/app/nircam/[field]/NircamFieldPageContent.tsx
+++ b/web/app/nircam/[field]/NircamFieldPageContent.tsx
@@ -108,13 +108,20 @@ export function NircamFieldPageContent({ field }: NircamFieldPageContentProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchData = useCallback(async () => {
+  // Field-scoped fetch. The dropdown switches fields on the SAME mounted
+  // component (prop change, no remount), so the effect guards against a
+  // stale response: a slower field-A reply resolving after field-B must not
+  // overwrite B's rendered state (claude-review on #379).
+  useEffect(() => {
     if (authLoading) return;
-    setLoading(true);
-    setError(null);
-    setFilters(DEFAULT_NIRCAM_FILTERS);
+    let stale = false;
 
-    try {
+    const fetchData = async () => {
+      setLoading(true);
+      setError(null);
+      setFilters(DEFAULT_NIRCAM_FILTERS);
+
+      try {
       const [summaryRes, imagesRes, expmapsRes, imagesUrlsRes, fieldsRes, fitsglDatasets] =
         await Promise.all([
           getNircamFieldSummary(field),
@@ -124,6 +131,7 @@ export function NircamFieldPageContent({ field }: NircamFieldPageContentProps) {
           getNircamFields(),
           getFitsglDatasets(field).catch(() => []),
         ]);
+      if (stale) return;
 
       if (summaryRes.error) {
         setError(summaryRes.error);
@@ -171,17 +179,20 @@ export function NircamFieldPageContent({ field }: NircamFieldPageContentProps) {
       }
       setViewableFilters(bands);
       setHasCutouts(fitsglDatasets.some((ds) => ds.kind === 'field'));
-    } catch (err) {
-      setError('Failed to fetch data');
-      console.error(err);
-    } finally {
-      setLoading(false);
-    }
-  }, [authLoading, field]);
+      } catch (err) {
+        if (stale) return;
+        setError('Failed to fetch data');
+        console.error(err);
+      } finally {
+        if (!stale) setLoading(false);
+      }
+    };
 
-  useEffect(() => {
     fetchData();
-  }, [fetchData, user]);
+    return () => {
+      stale = true;
+    };
+  }, [authLoading, field, user]);
 
   const handleSelectionChange = useCallback((selected: NircamProductRow[]) => {
     setSelectedProducts(selected);

--- a/web/components/map/FitsGLMapSurface.tsx
+++ b/web/components/map/FitsGLMapSurface.tsx
@@ -78,6 +78,9 @@ interface FitsGLMapSurfaceProps {
   markerFilter?: (marker: MapObjectMarker) => boolean;
   initialCenter?: { ra: number; dec: number };
   initialZoom?: number;
+  /** Band to open on (e.g. from /map?filter=...); falls back to the dataset
+   *  default view when absent or not in the band inventory. */
+  initialBand?: string;
   /** Field switcher (shared across the Leaflet + FitsGL surfaces). */
   fields: string[];
   selectedField: string;
@@ -223,6 +226,7 @@ export function FitsGLMapSurface({
   markerFilter,
   initialCenter,
   initialZoom,
+  initialBand,
   fields,
   selectedField,
   onFieldChange,
@@ -263,6 +267,7 @@ export function FitsGLMapSurface({
   // on a dataset reload (field switch), so it must see the CURRENT initial props.
   const initialCenterRef = useRef(initialCenter);
   const initialZoomRef = useRef(initialZoom);
+  const initialBandRef = useRef(initialBand);
   useEffect(() => { initialCenterRef.current = initialCenter; }, [initialCenter]);
   useEffect(() => { initialZoomRef.current = initialZoom; }, [initialZoom]);
   const lastCursorSky = useRef<{ ra: number; dec: number } | null>(null);
@@ -315,7 +320,16 @@ export function FitsGLMapSurface({
         setBands(b);
         // north-up forced on (decision 4); colormap pinned to 'gray' so it is driven
         // imperatively (useColormap) rather than through the config.
-        setViewState({ ...defaultExplorerState(b, dv), northUp: true, colormap: 'gray' });
+        let state: ExplorerState = { ...defaultExplorerState(b, dv), northUp: true, colormap: 'gray' };
+        // Deep link: /map?filter=<band> opens single-band on that band instead
+        // of the dataset default (which may be RGB or a different band).
+        const wanted = initialBandRef.current?.toLowerCase();
+        const match = wanted ? b.find((bb) => bb.name.toLowerCase() === wanted) : undefined;
+        if (match) {
+          state = { ...state, mode: 'single', band: match.name,
+                    stretch: state.stretch === 'trilogy' ? 'asinh' : state.stretch };
+        }
+        setViewState(state);
         setColormapName(dv.colormap ?? 'gray');
         setColormapReversed(false);
       })

--- a/web/components/map/FitsGLMapSurface.tsx
+++ b/web/components/map/FitsGLMapSurface.tsx
@@ -270,6 +270,7 @@ export function FitsGLMapSurface({
   const initialBandRef = useRef(initialBand);
   useEffect(() => { initialCenterRef.current = initialCenter; }, [initialCenter]);
   useEffect(() => { initialZoomRef.current = initialZoom; }, [initialZoom]);
+  useEffect(() => { initialBandRef.current = initialBand; }, [initialBand]);
   const lastCursorSky = useRef<{ ra: number; dec: number } | null>(null);
   const initialApplied = useRef(false);
   // Popup: the clicked marker + its world position (repositioned every frame).

--- a/web/components/map/MapViewer.tsx
+++ b/web/components/map/MapViewer.tsx
@@ -398,6 +398,13 @@ export function MapViewer({
       <div ref={mapWrapperRef} className="relative h-full w-full">
         <FitsGLMapSurface
           dataset={activeDataset}
+          initialBand={
+            // Honor ?filter= for the deep-linked field only (same rule as
+            // initialCenter): a manual field switch starts from the default.
+            !initialField || initialField === selectedField
+              ? initialFilter
+              : undefined
+          }
           markers={markers}
           showMarkers={showMarkers}
           highlightObjectId={highlightObjectId}


### PR DESCRIPTION
The two review findings on #379 that were never addressed before its merge:

## 1. `↗ View` didn't honor the filter on the FitsGL map (Codex P2)
`/map?field=X&filter=f444w` — the Leaflet branch consumed `initialFilter`, but the FitsGL branch never passed it down, so View on an F444W row opened the dataset default band / RGB composite. `FitsGLMapSurface` gains `initialBand`, applied when the config loads: single-band mode on the matching band (case-insensitive against `ExplorerBand.name`, trilogy coerced to asinh exactly like the band-rail switch). Honored only for the deep-linked field — a manual field switch starts from the dataset default, the same rule `initialCenter`/`initialZoom` follow. Unknown band ⇒ silent fallback to the default view.

## 2. Stale-response race on field switch (claude-review)
`FieldSelectorDropdown` switches fields on the same mounted `NircamFieldPageContent` (prop change, no remount); the fetch effect had no cancellation, so a slow field-A response resolving after field-B's overwrote B's rendered state. The fetch now lives inside the effect with a `stale` flag flipped in cleanup, checked after the `Promise.all` and in catch/finally.

## Verification
- Build + tsc green; dropdown switch renders the target field's data locally.
- The band deep-link needs a live pyramid: on prod, click **View** on an EGS sci row and confirm the map opens on that band rather than the default.

Generated with Claude Code