### PR TITLE
Hide footer on map route to prevent layout shift

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -6,7 +6,7 @@ import { AuthProvider } from '@/lib/contexts/AuthContext';
 import { ThemeProvider } from '@/lib/contexts/ThemeContext';
 import { PreferencesProvider } from '@/lib/contexts/PreferencesContext';
 import { QueryProvider } from '@/lib/providers/QueryProvider';
-import { Footer } from '@/components/layout/Footer';
+import { ConditionalFooter } from '@/components/layout/ConditionalFooter';
 import { Analytics } from '@vercel/analytics/next';
 
 // Direction 2 (Ember & Dusk): Inter for UI, JetBrains Mono for data/code.
@@ -57,7 +57,7 @@ export default function RootLayout({
               <PreferencesProvider>
                 <Navigation />
                 <main className="flex-1">{children}</main>
-                <Footer />
+                <ConditionalFooter />
               </PreferencesProvider>
             </ThemeProvider>
           </AuthProvider>

--- a/web/components/layout/ConditionalFooter.tsx
+++ b/web/components/layout/ConditionalFooter.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { Footer } from '@/components/layout/Footer';
+
+// The map viewer fills the viewport (100vh minus the nav), so the footer would
+// only push it into a scroll. Hide the footer on the map route.
+export function ConditionalFooter() {
+  const pathname = usePathname();
+
+  if (pathname === '/map') return null;
+
+  return <Footer />;
+}


### PR DESCRIPTION
## Summary
Hide the footer component on the `/map` route to prevent it from pushing the full-viewport map viewer into a scrollable state.

## Changes
- Created new `ConditionalFooter` component that conditionally renders the `Footer` based on the current pathname
- Updated root layout to use `ConditionalFooter` instead of directly rendering `Footer`
- Footer is now hidden when on the `/map` route, allowing the map viewer to fill the available viewport space

## Implementation Details
The `ConditionalFooter` component uses the `usePathname` hook from Next.js navigation to check if the current route is `/map`. Since the map viewer is designed to fill 100vh minus the navigation height, rendering the footer would cause unwanted scrolling behavior. This solution keeps the footer visible on all other routes while cleanly hiding it on the map route.

https://claude.ai/code/session_012YG1g8HcQU1mmKryK1nTD6