### PR TITLE
Refactor RGB channel config to prefer fields.toml over imaging.toml

### DIFF
--- a/docs/design-fitsgl-integration.md
+++ b/docs/design-fitsgl-integration.md
@@ -194,8 +194,10 @@ Remaining prerequisite before the first render:
 1. Gather the field's per-filter mosaic FITS (native grid; a single FITS or a pre-tiled
    list/glob per band).
 2. Generate a `fitsgl.toml` programmatically — bands from deployed mosaics, `[viewer]`
-   RGB roles + stretch mirrored from CAMPFIRE's existing `get_rgb_configs`, catalog from a
-   NIRSpec export. **CAMPFIRE controls the FitsGL config; scientists never hand-edit toml.**
+   RGB roles + stretch from fields.toml `[<field>.rgb]` (the same block `cfpipe nircam rgb`
+   uses; pure TOML, no dependency on local mosaic paths — legacy imaging.toml is a
+   fallback), catalog from a NIRSpec export. **CAMPFIRE controls the FitsGL config;
+   scientists never hand-edit toml.**
 3. Call `build.build_dataset` → dataset dir under a scratch/out root.
 
 No `reproject_interp` / `OutputGrid` — the slowest current stage is gone, and skipping the

--- a/docs/design-fitsgl-map-ux.md
+++ b/docs/design-fitsgl-map-ux.md
@@ -87,10 +87,10 @@ disclosure (only the slim spine is always visible; panels collapse), group by fu
 ## 4. Component spec
 
 ### Band rail (top-center pill)
-- `[<field> ▾] | [F090W][F115W]…[F444W]  [RGB]`. Field `<select>` merged in.
-- A band chip → `{mode:'single', band}` (always leaves RGB); the `RGB` toggle →
-  composite mode, tuned in the Display panel (revised decision 1).
-- Hidden entirely when the field has a single band.
+- `[<field> ▾] | [band ▾]` — two dropdowns, nothing else. `RGB` is the FIRST
+  option of the band dropdown: picking it enters composite mode (tuned in the
+  Display panel, revised decision 1); picking a band name → `{mode:'single', band}`.
+- The band dropdown is hidden when the field has a single band.
 
 ### Display panel (docked-right, collapsible)
 - **Single mode**: stretch chips (asinh / log / sqrt / linear), limit presets
@@ -102,10 +102,12 @@ disclosure (only the slim spine is always visible; panels collapse), group by fu
     deliberately no per-band stretch, so relative channel brightness stays
     physical), **contrast** (scales the shared limits about their midpoint) and
     **saturation** (the viewer's post-stretch composite uniform) sliders.
-  - **trilogy**: `@fitsgl/core/react`'s `TrilogyWeightMatrix` (per-band R/G/B
-    weight knobs + Rainbow) and `TrilogyControls` (noiselum / saturate % /
-    noise σ / black σ), embedded under the `fgl-embed` token class; levels derive
-    live from each band's `stats.trilogy` + the knobs.
+  - **trilogy**: campfire's `TrilogyWeights` matrix (per-band R/G/B weight
+    `Knob`s + Rainbow; **minimized by default** to the participating bands, a
+    single `+`/`−` button expands to the full co-gridded group with
+    participation checkboxes) and `@fitsgl/core/react`'s `TrilogyControls`
+    (noiselum / saturate % / noise σ / black σ) under the `fgl-embed` token
+    class; levels derive live from each band's `stats.trilogy` + the knobs.
 - **Histogram fine-adjust** (FitsExplorer-style): draw the band's `stats.histogram`
   (128 bins, `lo`/`hi`) with **draggable black/white handles**; live-drives the stretch.
 - No north-up control (forced true).

--- a/docs/design-fitsgl-map-ux.md
+++ b/docs/design-fitsgl-map-ux.md
@@ -58,10 +58,17 @@ disclosure (only the slim spine is always visible; panels collapse), group by fu
 
 ## 3. Locked design decisions (Hollis, 2026-07-10)
 
-1. **No `Single | RGB` toggle.** Mode is implicit from band selection. RGB channel
-   assignment lives **in the band rail** (single chip → single mode; an `RGB` affordance
-   → three R/G/B band-pickers + a "rainbow" auto-assign). The Display panel is *only*
-   stretch + histogram + colormap.
+1. **The band rail stays simple; ALL RGB construction lives in the Display panel.**
+   *(Revised 2026-07-13 — the map-RGB-defaults follow-up; originally RGB channel
+   assignment lived in the rail.)* The rail is one chip per band + an `RGB` toggle:
+   a band chip → single mode on that band; `RGB` → composite mode. The Display
+   panel owns channel assignment and splits RGB into two sub-modes:
+   **simple** (three band pickers, ONE shared limit range — no per-band stretch —
+   a shared transfer curve, contrast + color-saturation sliders) and **trilogy**
+   (FitsGL's weighted matrix: per-band R/G/B knobs + rainbow, plus
+   noiselum / saturate % / noise σ / black σ sliders over precomputed stats).
+   The dataset's `fitsgl.json` defaultView opens the map on the weighted trilogy
+   composite when the producer shipped one.
 2. **Field selector merged into the band rail**; drop the FitsGL badge.
 3. **Colormap = a dropdown** (not a swatch row).
 4. **North-up = always on, not exposed.** `config.northUp: true` always; no control.
@@ -81,18 +88,26 @@ disclosure (only the slim spine is always visible; panels collapse), group by fu
 
 ### Band rail (top-center pill)
 - `[<field> ▾] | [F090W][F115W]…[F444W]  [RGB]`. Field `<select>` merged in.
-- Single mode: click a band chip → `config.view = {mode:'single', band}`.
-- RGB mode: `RGB` toggle flips the rail to three channel pickers (R/G/B → band dropdowns)
-  + a **Rainbow** button (auto-assign blue→red by `pivotUm`). `config.view = {mode:'rgb', r,g,b}`.
-  Default interaction chosen by us; iterate on sight. Cross-grid bands greyed via
-  `isBandSelectableForRgb`.
+- A band chip → `{mode:'single', band}` (always leaves RGB); the `RGB` toggle →
+  composite mode, tuned in the Display panel (revised decision 1).
 - Hidden entirely when the field has a single band.
 
 ### Display panel (docked-right, collapsible)
-- **Stretch mode** chips: asinh / log / sqrt / linear / zscale (+ trilogy in RGB).
+- **Single mode**: stretch chips (asinh / log / sqrt / linear), limit presets
+  (auto / zscale / minmax / 99.5%), the histogram fine-adjust, colormap dropdown.
+- **RGB mode**: a `simple | trilogy` sub-mode toggle (trilogy disabled without
+  precomputed stats).
+  - **simple**: three R/G/B band `<select>`s, stretch chips, limit presets +
+    ONE shared histogram control (one `[min,max]` pushed to all three channels —
+    deliberately no per-band stretch, so relative channel brightness stays
+    physical), **contrast** (scales the shared limits about their midpoint) and
+    **saturation** (the viewer's post-stretch composite uniform) sliders.
+  - **trilogy**: `@fitsgl/core/react`'s `TrilogyWeightMatrix` (per-band R/G/B
+    weight knobs + Rainbow) and `TrilogyControls` (noiselum / saturate % /
+    noise σ / black σ), embedded under the `fgl-embed` token class; levels derive
+    live from each band's `stats.trilogy` + the knobs.
 - **Histogram fine-adjust** (FitsExplorer-style): draw the band's `stats.histogram`
   (128 bins, `lo`/`hi`) with **draggable black/white handles**; live-drives the stretch.
-- **Colormap dropdown** (gray / viridis / magma / … ).
 - No north-up control (forced true).
 
 ### Layers panel (docked-right, collapsible)

--- a/python/campfire/fitsgl/build.py
+++ b/python/campfire/fitsgl/build.py
@@ -113,28 +113,40 @@ def group_bands(mosaics, *, single_tile):
     return bands
 
 
-def derive_viewer(rgb_channels, band_filters):
+def derive_viewer(rgb_channels, band_filters, trilogy=None):
     """Derive the fitsgl.toml ``[viewer]`` default from CAMPFIRE's RGB config.
 
-    ``rgb_channels`` maps filter → (r, g, b) color weights (from
-    ``get_rgb_configs``), or ``None`` when no imaging config is available.
-    ``band_filters`` is the list of filters that became bands. When ≥3 of the RGB
-    config's filters are present, the default is an RGB view with ``stretch =
-    "trilogy"`` and r/g/b assigned to the filter carrying the most weight in each
-    channel (mirroring the roles, not the exact trilogy normalization — the live
-    viewer restretches). Otherwise a single-band view on the reddest present filter.
-    Every filter is a band regardless; this only sets the initial view.
+    ``rgb_channels`` maps filter → (r, g, b) color weights (from fields.toml
+    ``[<field>.rgb.channels]`` or legacy imaging.toml), or ``None`` when no RGB
+    config is available. ``band_filters`` is the list of filters that became
+    bands. When ≥3 of the RGB config's filters are present, the default is an RGB
+    view with ``stretch = "trilogy"``, r/g/b roles assigned to the filter carrying
+    the most weight in each channel, and the FULL per-filter weight table emitted
+    as ``[viewer.weights]`` — so the viewer opens on the faithful weighted
+    composite that mirrors the old PNG tiles, not just a 3-band triple. Weights
+    are rescaled by the global max so they land in the knob UI's [0, 1] range
+    (only channel ratios matter — the composite normalizes by the weight sum).
+    ``trilogy`` (optional dict of noiselum/satpercent/noisesig/noisesig0) passes
+    through as ``[viewer.trilogy]``. Otherwise a single-band view on the reddest
+    present filter. Every filter is a band regardless; this only sets the
+    initial view. Nested tables are placed last so the TOML serializes cleanly.
     """
     usable = [f for f in band_filters if rgb_channels and f in rgb_channels]
     if len(usable) >= 3:
         pick = lambda ch: max(usable, key=lambda f: rgb_channels[f][ch])
-        return {
+        peak = max((w for f in usable for w in rgb_channels[f]), default=1.0)
+        scale = peak if peak > 1.0 else 1.0
+        viewer = {
             'default': 'rgb',
             'r': pick(0),
             'g': pick(1),
             'b': pick(2),
             'stretch': 'trilogy',
+            'weights': {f: [w / scale for w in rgb_channels[f]] for f in usable},
         }
+        if trilogy:
+            viewer['trilogy'] = dict(trilogy)
+        return viewer
     if not band_filters:
         return {'default': 'single', 'stretch': 'asinh'}
     return {
@@ -261,19 +273,37 @@ def _fiducial_tiles_from_toml(field):
     return list(raw) if isinstance(raw, list) else []
 
 
-def _rgb_channels_from_fields_toml(field):
-    """Filter → (r,g,b) weights from fields.toml ``[<field>.rgb.channels]``, or ``None``.
+# fields.toml [<field>.rgb] stretch keys → fitsgl [viewer.trilogy] knobs. Same
+# names pass through; campfire's legacy `noisesig` (black-point multiplier in the
+# old PNG stretch) maps onto fitsgl's `noisesig` — the algorithms are cousins,
+# not twins, so treat the value as a starting point and tune in fields.toml.
+_TRILOGY_KNOBS = ('noiselum', 'satpercent', 'noisesig', 'noisesig0')
 
-    The same block ``cfpipe nircam rgb`` consumes; only the color weights matter
-    for the default view (the stretch tunables wait on defaultView support in the
-    fitsgl.json contract). Pure TOML — no mosaic files are resolved, so this works
-    on any machine that can see fields.toml. Filter keys are lowercased to match
-    the discovered band names; malformed weight entries are skipped.
+
+def _knobs_from_block(block):
+    """The trilogy knob dict carried by an rgb config block, or ``None``."""
+    knobs = {}
+    for key in _TRILOGY_KNOBS:
+        v = block.get(key)
+        if isinstance(v, (int, float)) and not isinstance(v, bool):
+            knobs[key] = float(v)
+    return knobs or None
+
+
+def _rgb_config_from_fields_toml(field):
+    """``(channels, knobs)`` from fields.toml ``[<field>.rgb]``, or ``(None, None)``.
+
+    The same block ``cfpipe nircam rgb`` consumes: ``channels`` (filter → [r,g,b]
+    weights) plus the stretch knobs (noiselum/satpercent/noisesig[0]). Pure TOML —
+    no mosaic files are resolved, so this works on any machine that can see
+    fields.toml. Filter keys are lowercased to match the discovered band names;
+    malformed weight entries are skipped.
     """
     table = _fields_toml_table(field)
-    raw = ((table or {}).get('rgb') or {}).get('channels')
+    block = (table or {}).get('rgb') or {}
+    raw = block.get('channels')
     if not isinstance(raw, dict):
-        return None
+        return None, None
     out = {}
     for filt, weights in raw.items():
         try:
@@ -285,11 +315,13 @@ def _rgb_channels_from_fields_toml(field):
             )
             continue
         out[str(filt).lower()] = (r, g, b)
-    return out or None
+    if not out:
+        return None, None
+    return out, _knobs_from_block(block)
 
 
-def _rgb_channels_from_imaging_toml(field):
-    """Legacy: filter → (r,g,b) weights via imaging.toml, or ``None`` if unavailable.
+def _rgb_config_from_imaging_toml(field):
+    """Legacy: ``(channels, knobs)`` via imaging.toml, or ``(None, None)``.
 
     PNG-tile-era path kept for fields not yet migrated to fields.toml. Note
     ``get_rgb_configs`` resolves mosaic file globs on the local filesystem and
@@ -302,47 +334,53 @@ def _rgb_channels_from_imaging_toml(field):
 
         path = resolve_imaging_config()
         if path is None:
-            return None
+            return None, None
         rgbs = get_rgb_configs(load_imaging_config(path), fields=[field])
         if not rgbs:
-            return None
-        return {
+            return None, None
+        channels = {
             filt: tuple(float(x) for x in info['color'])
             for filt, info in rgbs[0].filter_channels.items()
         }
+        knobs = _knobs_from_block({
+            'noiselum': rgbs[0].noiselum,
+            'satpercent': rgbs[0].satpercent,
+            'noisesig': rgbs[0].noisesig,
+        })
+        return channels, knobs
     except Exception:
-        return None
+        return None, None
 
 
-def _load_rgb_channels(field):
-    """Filter → (r,g,b) color weights for the default view, or ``None``.
+def _load_rgb_config(field):
+    """``(channels, knobs)`` for the default view, or ``(None, None)``.
 
-    Sources, in order: fields.toml ``[<field>.rgb.channels]`` (preferred), then
-    the legacy imaging.toml. Always says which source won — or why none did — so
-    a single-band fallback is never silent (the failure mode that shipped EGS
+    Sources, in order: fields.toml ``[<field>.rgb]`` (preferred), then the legacy
+    imaging.toml. Always says which source won — or why none did — so a
+    single-band fallback is never silent (the failure mode that shipped EGS
     with a single-band default).
     """
-    channels = _rgb_channels_from_fields_toml(field)
+    channels, knobs = _rgb_config_from_fields_toml(field)
     if channels:
         click.echo(
             f"RGB default view from fields.toml [{field}.rgb]: "
             f"{len(channels)} filter(s)."
         )
-        return channels
-    channels = _rgb_channels_from_imaging_toml(field)
+        return channels, knobs
+    channels, knobs = _rgb_config_from_imaging_toml(field)
     if channels:
         click.echo(
             f"RGB default view from legacy imaging.toml [{field}.rgb]: "
             f"{len(channels)} filter(s). Consider moving this block to "
             f"fields.toml [{field}.rgb]."
         )
-        return channels
+        return channels, knobs
     click.echo(
         f"Note: no RGB config for '{field}' — the dataset will open in a "
         f"single-band view. Add [{field}.rgb.channels] (filter → [r,g,b] "
         f"weights) to $CAMPFIRE_ROOT/config/fields.toml to set an RGB default."
     )
-    return None
+    return None, None
 
 
 def run_build(field, *, pixel_scale='30mas', tile=None, processes=None,
@@ -396,8 +434,8 @@ def run_build(field, *, pixel_scale='30mas', tile=None, processes=None,
         f"'{field}' at {pixel_scale}: {len(bands)} band(s) / {n_inputs} mosaic(s)."
     )
 
-    rgb_channels = _load_rgb_channels(field)
-    viewer = derive_viewer(rgb_channels, list(bands))
+    rgb_channels, trilogy_knobs = _load_rgb_config(field)
+    viewer = derive_viewer(rgb_channels, list(bands), trilogy=trilogy_knobs)
     if rgb_channels and viewer.get('default') != 'rgb':
         usable = sorted(f for f in bands if f in rgb_channels)
         click.echo(

--- a/python/campfire/fitsgl/build.py
+++ b/python/campfire/fitsgl/build.py
@@ -132,6 +132,19 @@ def derive_viewer(rgb_channels, band_filters, trilogy=None):
     initial view. Nested tables are placed last so the TOML serializes cleanly.
     """
     usable = [f for f in band_filters if rgb_channels and f in rgb_channels]
+    if len(usable) > _MAX_COMPOSITE_BANDS:
+        # FitsGL caps a composite at 12 bands and its parser rejects a longer
+        # [viewer.weights]; keep the strongest contributors (by total weight),
+        # preserving wavelength order for the survivors.
+        keep = set(sorted(usable, key=lambda f: sum(rgb_channels[f]), reverse=True)
+                   [:_MAX_COMPOSITE_BANDS])
+        dropped = [f for f in usable if f not in keep]
+        usable = [f for f in usable if f in keep]
+        click.echo(
+            f"Note: the RGB config lists {len(usable) + len(dropped)} filters; "
+            f"FitsGL composites cap at {_MAX_COMPOSITE_BANDS} — dropping the "
+            f"lowest-weight: {', '.join(dropped)}."
+        )
     if len(usable) >= 3:
         pick = lambda ch: max(usable, key=lambda f: rgb_channels[f][ch])
         peak = max((w for f in usable for w in rgb_channels[f]), default=1.0)
@@ -278,6 +291,10 @@ def _fiducial_tiles_from_toml(field):
 # old PNG stretch) maps onto fitsgl's `noisesig` — the algorithms are cousins,
 # not twins, so treat the value as a starting point and tune in fields.toml.
 _TRILOGY_KNOBS = ('noiselum', 'satpercent', 'noisesig', 'noisesig0')
+
+# FitsGL's composite cap (fitsgl-core MAX_BANDS / fitsgl-py MAX_COMPOSITE_BANDS):
+# a longer [viewer.weights] is rejected by the producer's parser.
+_MAX_COMPOSITE_BANDS = 12
 
 
 def _knobs_from_block(block):

--- a/python/campfire/fitsgl/build.py
+++ b/python/campfire/fitsgl/build.py
@@ -235,31 +235,66 @@ def resolve_fiducial_tiles(field, *, pixel_scale='30mas'):
     return Field.load(field).fiducial_tile_set(pixel_scale=pixel_scale)
 
 
-def _fiducial_tiles_from_toml(field):
-    """Fallback: read ``[<field>].fiducial_tiles`` straight from fields.toml (no WCS check)."""
+def _fields_toml_table(field):
+    """The ``[<field>]`` table from ``$CAMPFIRE_ROOT/config/fields.toml``, or ``None``."""
     try:
         import tomllib
     except ModuleNotFoundError:  # pragma: no cover - py<3.11
         import tomli as tomllib  # type: ignore
     root = os.environ.get('CAMPFIRE_ROOT')
     if not root:
-        return []
+        return None
     path = Path(root) / 'config' / 'fields.toml'
     if not path.is_file():
-        return []
+        return None
     with path.open('rb') as f:
         data = tomllib.load(f)
-    raw = (data.get(field) or {}).get('fiducial_tiles', [])
+    table = data.get(field)
+    return table if isinstance(table, dict) else None
+
+
+def _fiducial_tiles_from_toml(field):
+    """Fallback: read ``[<field>].fiducial_tiles`` straight from fields.toml (no WCS check)."""
+    raw = (_fields_toml_table(field) or {}).get('fiducial_tiles', [])
     if isinstance(raw, str):
         raw = [raw]
     return list(raw) if isinstance(raw, list) else []
 
 
-def _load_rgb_channels(field):
-    """Filter → (r,g,b) color weights from imaging.toml, or ``None`` if unavailable.
+def _rgb_channels_from_fields_toml(field):
+    """Filter → (r,g,b) weights from fields.toml ``[<field>.rgb.channels]``, or ``None``.
 
-    Best-effort: any missing config / parse error yields ``None`` so the build
-    proceeds with a single-band default view rather than failing.
+    The same block ``cfpipe nircam rgb`` consumes; only the color weights matter
+    for the default view (the stretch tunables wait on defaultView support in the
+    fitsgl.json contract). Pure TOML — no mosaic files are resolved, so this works
+    on any machine that can see fields.toml. Filter keys are lowercased to match
+    the discovered band names; malformed weight entries are skipped.
+    """
+    table = _fields_toml_table(field)
+    raw = ((table or {}).get('rgb') or {}).get('channels')
+    if not isinstance(raw, dict):
+        return None
+    out = {}
+    for filt, weights in raw.items():
+        try:
+            r, g, b = (float(x) for x in weights)
+        except (TypeError, ValueError):
+            click.echo(
+                f"Warning: [{field}.rgb.channels.{filt}] is not a 3-element "
+                f"[r,g,b] list — skipping that filter."
+            )
+            continue
+        out[str(filt).lower()] = (r, g, b)
+    return out or None
+
+
+def _rgb_channels_from_imaging_toml(field):
+    """Legacy: filter → (r,g,b) weights via imaging.toml, or ``None`` if unavailable.
+
+    PNG-tile-era path kept for fields not yet migrated to fields.toml. Note
+    ``get_rgb_configs`` resolves mosaic file globs on the local filesystem and
+    drops filters whose files are missing — prefer ``[<field>.rgb]`` in
+    fields.toml, which has no filesystem dependency.
     """
     try:
         from campfire.deploy.config import resolve_imaging_config
@@ -277,6 +312,37 @@ def _load_rgb_channels(field):
         }
     except Exception:
         return None
+
+
+def _load_rgb_channels(field):
+    """Filter → (r,g,b) color weights for the default view, or ``None``.
+
+    Sources, in order: fields.toml ``[<field>.rgb.channels]`` (preferred), then
+    the legacy imaging.toml. Always says which source won — or why none did — so
+    a single-band fallback is never silent (the failure mode that shipped EGS
+    with a single-band default).
+    """
+    channels = _rgb_channels_from_fields_toml(field)
+    if channels:
+        click.echo(
+            f"RGB default view from fields.toml [{field}.rgb]: "
+            f"{len(channels)} filter(s)."
+        )
+        return channels
+    channels = _rgb_channels_from_imaging_toml(field)
+    if channels:
+        click.echo(
+            f"RGB default view from legacy imaging.toml [{field}.rgb]: "
+            f"{len(channels)} filter(s). Consider moving this block to "
+            f"fields.toml [{field}.rgb]."
+        )
+        return channels
+    click.echo(
+        f"Note: no RGB config for '{field}' — the dataset will open in a "
+        f"single-band view. Add [{field}.rgb.channels] (filter → [r,g,b] "
+        f"weights) to $CAMPFIRE_ROOT/config/fields.toml to set an RGB default."
+    )
+    return None
 
 
 def run_build(field, *, pixel_scale='30mas', tile=None, processes=None,
@@ -330,7 +396,14 @@ def run_build(field, *, pixel_scale='30mas', tile=None, processes=None,
         f"'{field}' at {pixel_scale}: {len(bands)} band(s) / {n_inputs} mosaic(s)."
     )
 
-    viewer = derive_viewer(_load_rgb_channels(field), list(bands))
+    rgb_channels = _load_rgb_channels(field)
+    viewer = derive_viewer(rgb_channels, list(bands))
+    if rgb_channels and viewer.get('default') != 'rgb':
+        usable = sorted(f for f in bands if f in rgb_channels)
+        click.echo(
+            f"Note: only {len(usable)} of the RGB config's filters are among the "
+            f"built bands (need 3) — defaulting to single-band {viewer.get('band')}."
+        )
     toml_dict = build_fitsgl_toml(
         field, bands=bands, viewer=viewer, pixel_scale=pixel_scale,
         single_tile=single_tile, tile=tile,

--- a/python/tests/test_fitsgl_build.py
+++ b/python/tests/test_fitsgl_build.py
@@ -314,3 +314,17 @@ def test_generated_viewer_block_parses_through_fitsgl(tmp_path):
         "f444w": (1.0, 0.0, 0.0),
     }
     assert cfg.viewer.trilogy == {"noiselum": 0.12, "satpercent": 0.01}
+
+
+def test_derive_viewer_caps_weights_at_fitsgl_composite_max(capsys):
+    """>12 usable filters: keep the strongest by total weight (FitsGL rejects a
+    longer [viewer.weights]), preserve wavelength order, and say what dropped."""
+    filters = [f"f{100 + 10 * i}w" for i in range(14)]  # wavelength-ordered
+    # total weight rises with wavelength, so the two bluest are the weakest
+    rgb = {f: (0.1 * (i + 1), 0.0, 0.0) for i, f in enumerate(filters)}
+    v = derive_viewer(rgb, filters)
+    assert v["default"] == "rgb"
+    assert len(v["weights"]) == 12
+    assert list(v["weights"]) == filters[2:]  # weakest two dropped, order kept
+    out = capsys.readouterr().out
+    assert "cap at 12" in out and "f100w" in out and "f110w" in out

--- a/python/tests/test_fitsgl_build.py
+++ b/python/tests/test_fitsgl_build.py
@@ -11,6 +11,8 @@ import json
 import toml
 
 from campfire.fitsgl.build import (
+    _load_rgb_channels,
+    _rgb_channels_from_fields_toml,
     build_fitsgl_toml,
     derive_viewer,
     group_bands,
@@ -88,6 +90,89 @@ def test_derive_viewer_single_when_fewer_than_three_rgb_filters():
 def test_derive_viewer_empty_bands():
     v = derive_viewer(None, [])
     assert v["default"] == "single" and "band" not in v
+
+
+# --- _rgb_channels_from_fields_toml / _load_rgb_channels ---------------------
+
+def _write_fields_toml(tmp_path, monkeypatch, body):
+    """A $CAMPFIRE_ROOT with config/fields.toml containing ``body``."""
+    (tmp_path / "config").mkdir()
+    (tmp_path / "config" / "fields.toml").write_text(body)
+    monkeypatch.setenv("CAMPFIRE_ROOT", str(tmp_path))
+
+
+def test_rgb_channels_from_fields_toml(tmp_path, monkeypatch):
+    _write_fields_toml(tmp_path, monkeypatch, """
+[egs]
+fiducial_tiles = ["A1"]
+
+[egs.rgb]
+noiselum = 0.12
+
+[egs.rgb.channels]
+f115w = [0.0, 0.0, 1.0]
+F444W = [1.0, 0.0, 0.0]
+f277w = [0.0, 1.0, 0.0]
+""")
+    ch = _rgb_channels_from_fields_toml("egs")
+    # weights parsed as float tuples; filter keys lowercased to match band names
+    assert ch == {
+        "f115w": (0.0, 0.0, 1.0),
+        "f444w": (1.0, 0.0, 0.0),
+        "f277w": (0.0, 1.0, 0.0),
+    }
+    # end-to-end: this is exactly what derive_viewer needs for an RGB default
+    v = derive_viewer(ch, ["f115w", "f277w", "f444w"])
+    assert v["default"] == "rgb" and v["stretch"] == "trilogy"
+
+
+def test_rgb_channels_from_fields_toml_skips_malformed_entries(tmp_path, monkeypatch):
+    _write_fields_toml(tmp_path, monkeypatch, """
+[egs.rgb.channels]
+f115w = [0.0, 0.0, 1.0]
+f277w = [0.0, 1.0]
+f444w = "red"
+""")
+    assert _rgb_channels_from_fields_toml("egs") == {"f115w": (0.0, 0.0, 1.0)}
+
+
+def test_rgb_channels_from_fields_toml_missing(tmp_path, monkeypatch):
+    # no rgb block at all
+    _write_fields_toml(tmp_path, monkeypatch, "[egs]\nfiducial_tiles = ['A1']\n")
+    assert _rgb_channels_from_fields_toml("egs") is None
+    # no field table
+    assert _rgb_channels_from_fields_toml("cosmos") is None
+    # no CAMPFIRE_ROOT
+    monkeypatch.delenv("CAMPFIRE_ROOT")
+    assert _rgb_channels_from_fields_toml("egs") is None
+
+
+def test_load_rgb_channels_prefers_fields_toml(tmp_path, monkeypatch):
+    """fields.toml wins without ever touching the legacy imaging.toml path."""
+    _write_fields_toml(tmp_path, monkeypatch, """
+[egs.rgb.channels]
+f115w = [0.0, 0.0, 1.0]
+f277w = [0.0, 1.0, 0.0]
+f444w = [1.0, 0.0, 0.0]
+""")
+
+    def boom(field):
+        raise AssertionError("legacy imaging.toml path must not be consulted")
+
+    monkeypatch.setattr("campfire.fitsgl.build._rgb_channels_from_imaging_toml", boom)
+    ch = _load_rgb_channels("egs")
+    assert set(ch) == {"f115w", "f277w", "f444w"}
+
+
+def test_load_rgb_channels_none_when_no_config(tmp_path, monkeypatch, capsys):
+    """No fields.toml block and no imaging.toml → None, but never silent."""
+    _write_fields_toml(tmp_path, monkeypatch, "[egs]\n")
+    monkeypatch.setattr(
+        "campfire.fitsgl.build._rgb_channels_from_imaging_toml", lambda field: None
+    )
+    assert _load_rgb_channels("egs") is None
+    out = capsys.readouterr().out
+    assert "no RGB config" in out and "[egs.rgb.channels]" in out
 
 
 # --- select_mosaics / group_bands (real discover_mosaics on a fake tree) -----

--- a/python/tests/test_fitsgl_build.py
+++ b/python/tests/test_fitsgl_build.py
@@ -11,8 +11,8 @@ import json
 import toml
 
 from campfire.fitsgl.build import (
-    _load_rgb_channels,
-    _rgb_channels_from_fields_toml,
+    _load_rgb_config,
+    _rgb_config_from_fields_toml,
     build_fitsgl_toml,
     derive_viewer,
     group_bands,
@@ -72,6 +72,28 @@ def test_derive_viewer_rgb_from_color_weights():
     assert v["default"] == "rgb"
     assert v["r"] == "f444w" and v["g"] == "f277w" and v["b"] == "f150w"
     assert v["stretch"] == "trilogy"
+    # the FULL weight table ships (faithful weighted composite), band order kept
+    assert v["weights"] == {
+        "f150w": [0.0, 0.0, 1.0],
+        "f277w": [0.0, 1.0, 0.0],
+        "f444w": [1.0, 0.0, 0.0],
+    }
+    assert "trilogy" not in v  # no knobs -> viewer defaults
+
+
+def test_derive_viewer_rescales_weights_and_passes_trilogy_knobs():
+    rgb = {"f444w": (2.0, 0.0, 0.0), "f277w": (0.0, 1.0, 0.0), "f150w": (0.0, 0.0, 1.0)}
+    v = derive_viewer(rgb, ["f150w", "f277w", "f444w"],
+                      trilogy={"noiselum": 0.12, "satpercent": 0.01, "noisesig": 2.0})
+    # global max 2.0 rescales everything into the knob UI's [0,1]
+    assert v["weights"]["f444w"] == [1.0, 0.0, 0.0]
+    assert v["weights"]["f277w"] == [0.0, 0.5, 0.0]
+    assert v["trilogy"] == {"noiselum": 0.12, "satpercent": 0.01, "noisesig": 2.0}
+    # nested tables land AFTER the scalar keys so the serialized TOML is valid
+    keys = list(v)
+    assert keys.index("weights") > keys.index("stretch")
+    reparsed = toml.loads(toml.dumps({"viewer": v}))
+    assert reparsed["viewer"]["trilogy"]["noiselum"] == 0.12
 
 
 def test_derive_viewer_single_band_fallback_without_rgb():
@@ -114,16 +136,18 @@ f115w = [0.0, 0.0, 1.0]
 F444W = [1.0, 0.0, 0.0]
 f277w = [0.0, 1.0, 0.0]
 """)
-    ch = _rgb_channels_from_fields_toml("egs")
+    ch, knobs = _rgb_config_from_fields_toml("egs")
     # weights parsed as float tuples; filter keys lowercased to match band names
     assert ch == {
         "f115w": (0.0, 0.0, 1.0),
         "f444w": (1.0, 0.0, 0.0),
         "f277w": (0.0, 1.0, 0.0),
     }
+    assert knobs == {"noiselum": 0.12}
     # end-to-end: this is exactly what derive_viewer needs for an RGB default
-    v = derive_viewer(ch, ["f115w", "f277w", "f444w"])
+    v = derive_viewer(ch, ["f115w", "f277w", "f444w"], trilogy=knobs)
     assert v["default"] == "rgb" and v["stretch"] == "trilogy"
+    assert v["trilogy"] == {"noiselum": 0.12}
 
 
 def test_rgb_channels_from_fields_toml_skips_malformed_entries(tmp_path, monkeypatch):
@@ -133,18 +157,18 @@ f115w = [0.0, 0.0, 1.0]
 f277w = [0.0, 1.0]
 f444w = "red"
 """)
-    assert _rgb_channels_from_fields_toml("egs") == {"f115w": (0.0, 0.0, 1.0)}
+    assert _rgb_config_from_fields_toml("egs") == ({"f115w": (0.0, 0.0, 1.0)}, None)
 
 
 def test_rgb_channels_from_fields_toml_missing(tmp_path, monkeypatch):
     # no rgb block at all
     _write_fields_toml(tmp_path, monkeypatch, "[egs]\nfiducial_tiles = ['A1']\n")
-    assert _rgb_channels_from_fields_toml("egs") is None
+    assert _rgb_config_from_fields_toml("egs") == (None, None)
     # no field table
-    assert _rgb_channels_from_fields_toml("cosmos") is None
+    assert _rgb_config_from_fields_toml("cosmos") == (None, None)
     # no CAMPFIRE_ROOT
     monkeypatch.delenv("CAMPFIRE_ROOT")
-    assert _rgb_channels_from_fields_toml("egs") is None
+    assert _rgb_config_from_fields_toml("egs") == (None, None)
 
 
 def test_load_rgb_channels_prefers_fields_toml(tmp_path, monkeypatch):
@@ -159,8 +183,8 @@ f444w = [1.0, 0.0, 0.0]
     def boom(field):
         raise AssertionError("legacy imaging.toml path must not be consulted")
 
-    monkeypatch.setattr("campfire.fitsgl.build._rgb_channels_from_imaging_toml", boom)
-    ch = _load_rgb_channels("egs")
+    monkeypatch.setattr("campfire.fitsgl.build._rgb_config_from_imaging_toml", boom)
+    ch, _knobs = _load_rgb_config("egs")
     assert set(ch) == {"f115w", "f277w", "f444w"}
 
 
@@ -168,9 +192,9 @@ def test_load_rgb_channels_none_when_no_config(tmp_path, monkeypatch, capsys):
     """No fields.toml block and no imaging.toml → None, but never silent."""
     _write_fields_toml(tmp_path, monkeypatch, "[egs]\n")
     monkeypatch.setattr(
-        "campfire.fitsgl.build._rgb_channels_from_imaging_toml", lambda field: None
+        "campfire.fitsgl.build._rgb_config_from_imaging_toml", lambda field: (None, None)
     )
-    assert _load_rgb_channels("egs") is None
+    assert _load_rgb_config("egs") == (None, None)
     out = capsys.readouterr().out
     assert "no RGB config" in out and "[egs.rgb.channels]" in out
 
@@ -262,3 +286,31 @@ def test_group_bands_single_tile_scalar_path(tmp_path):
     bands = group_bands(picked, single_tile=True)
     assert set(bands) == {"f444w"}
     assert not isinstance(bands["f444w"], list)  # single path, not a list
+
+
+def test_generated_viewer_block_parses_through_fitsgl(tmp_path):
+    """The [viewer] dict derive_viewer emits must survive toml serialization AND
+    fitsgl's own load_config validation (the real producer-contract seam)."""
+    import pytest
+    fitsgl_config = pytest.importorskip("fitsgl.config")
+
+    for n in ("f115w", "f277w", "f444w"):
+        (tmp_path / f"{n}.fits").write_bytes(b"\x00")
+    rgb = {"f444w": (1.0, 0.0, 0.0), "f277w": (0.0, 1.0, 0.0), "f115w": (0.0, 0.0, 1.0)}
+    viewer = derive_viewer(rgb, ["f115w", "f277w", "f444w"],
+                           trilogy={"noiselum": 0.12, "satpercent": 0.01})
+    d = build_fitsgl_toml(
+        "egs",
+        bands={n: [tmp_path / f"{n}.fits"] for n in ("f115w", "f277w", "f444w")},
+        viewer=viewer, pixel_scale="30mas", single_tile=False,
+    )
+    p = tmp_path / "egs.toml"
+    p.write_text(toml.dumps(d))
+    cfg = fitsgl_config.load_config(p)
+    assert cfg.viewer.mode == "rgb" and cfg.viewer.stretch == "trilogy"
+    assert cfg.viewer.weights == {
+        "f115w": (0.0, 0.0, 1.0),
+        "f277w": (0.0, 1.0, 0.0),
+        "f444w": (1.0, 0.0, 0.0),
+    }
+    assert cfg.viewer.trilogy == {"noiselum": 0.12, "satpercent": 0.01}

--- a/web/components/map/FitsGLMapSurface.tsx
+++ b/web/components/map/FitsGLMapSurface.tsx
@@ -586,7 +586,7 @@ export function FitsGLMapSurface({
   }
 
   return (
-    <div ref={rootRef} className="fitsgl-chrome relative h-full w-full" onContextMenu={handleContextMenu}>
+    <div ref={rootRef} className="fitsgl-chrome relative h-full w-full overflow-hidden" onContextMenu={handleContextMenu}>
       {viewerConfig && (
         <FitsViewer
           config={viewerConfig}
@@ -645,10 +645,16 @@ export function FitsGLMapSurface({
         />
       )}
 
-      {/* Right control dock — Display panel (+ objects toggle placeholder until the
-          Layers panel lands in chunk 3). Collapsible via the edge chevron. */}
-      {viewState && dockOpen && (
-        <div className={`absolute right-0 top-16 bottom-16 z-[500] w-72 overflow-y-auto rounded-l-xl ${GLASS} p-3`}>
+      {/* Right control dock — Display + Layers panels. Height hugs the content
+          (up to the old fixed extent, then scrolls); collapse slides it off the
+          right edge (kept mounted so the panel state survives + animates). */}
+      {viewState && (
+        <div
+          className={`absolute right-0 top-16 z-[500] max-h-[calc(100%-8rem)] w-[13.5rem] overflow-y-auto rounded-l-xl ${GLASS} p-3 transition-transform duration-200 ease-out ${
+            dockOpen ? 'translate-x-0' : 'pointer-events-none translate-x-full'
+          }`}
+          aria-hidden={!dockOpen}
+        >
           <DisplayPanel
             state={viewState}
             bands={bands}
@@ -693,8 +699,8 @@ export function FitsGLMapSurface({
         <button
           type="button"
           onClick={() => setDockOpen((o) => !o)}
-          className={`absolute top-20 z-[501] flex h-11 w-4 items-center justify-center rounded-l-lg ${GLASS} text-text-tertiary hover:text-text-primary`}
-          style={{ right: dockOpen ? '18rem' : 0 }}
+          className={`absolute top-20 z-[501] flex h-11 w-4 items-center justify-center rounded-l-lg ${GLASS} text-text-tertiary transition-[right] duration-200 ease-out hover:text-text-primary`}
+          style={{ right: dockOpen ? '13.5rem' : 0 }}
           aria-label={dockOpen ? 'Collapse controls' : 'Expand controls'}
           title={dockOpen ? 'Collapse controls' : 'Expand controls'}
         >
@@ -713,6 +719,7 @@ export function FitsGLMapSurface({
           bandLabel={viewState.mode === 'rgb' ? 'RGB' : viewState.band}
           stretch={viewState.stretch}
           ruler={tool === 'ruler' ? rulerMeasure : null}
+          showValue={!(viewState.mode === 'rgb' && viewState.stretch === 'trilogy')}
         />
       )}
 

--- a/web/components/map/FitsGLMapSurface.tsx
+++ b/web/components/map/FitsGLMapSurface.tsx
@@ -25,6 +25,8 @@ import {
   defaultViewFromConfig,
   defaultExplorerState,
   loadFitsglConfig,
+  rainbowAction,
+  rgbActiveGroup,
   type FitsViewerHandle,
   type ExplorerBand,
   type ExplorerState,
@@ -33,6 +35,7 @@ import {
 import {
   pixToSky,
   skyToPix,
+  type BandWeight,
   type ColormapName,
   type StretchMode,
   type CursorInfo,
@@ -40,6 +43,7 @@ import {
   type MarkerInput,
   type RegionInput,
   type ResolvedRegion,
+  type TrilogyParams,
   type ViewerConfig,
   type ViewerFrameInfo,
 } from '@fitsgl/core';
@@ -53,7 +57,7 @@ import { LayersPanel } from './fitsgl/LayersPanel';
 import { ToolRail } from './fitsgl/ToolRail';
 import { StatusPill } from './fitsgl/StatusPill';
 import { FitsglOverlays, type FitsglOverlaysHandle } from './fitsgl/FitsglOverlays';
-import { useDisplayStretch, type ChannelKey } from './fitsgl/useDisplayStretch';
+import { useDisplayStretch, type ChannelKey, type LimitPreset } from './fitsgl/useDisplayStretch';
 import { useColormap } from './fitsgl/useColormap';
 import type { RulerMeasurement } from './fitsgl/ruler';
 import { GLASS } from './fitsgl/glass';
@@ -121,21 +125,6 @@ function updateMapUrl(params: Record<string, string | undefined>) {
   window.history.replaceState(null, '', url.toString());
 }
 
-/** Strict-3 rainbow: reddest→R, bluest→B, middle→G by pivot wavelength (falls back
- *  to declaration order when wavelengths are absent). The >3-band weighted-trilogy
- *  rainbow is a later refinement (needs the core trilogy-weight primitives). */
-function rainbowRgb(bands: ExplorerBand[]): { r: string; g: string; b: string } | null {
-  if (bands.length < 3) return null;
-  const withWl = bands.filter((b) => b.wavelengthMicron != null);
-  const pool = withWl.length >= 3
-    ? [...withWl].sort((a, b) => a.wavelengthMicron! - b.wavelengthMicron!)
-    : bands;
-  return {
-    b: pool[0].name,
-    g: pool[Math.floor((pool.length - 1) / 2)].name,
-    r: pool[pool.length - 1].name,
-  };
-}
 
 /**
  * The four sky corners (ICRS deg) of a shutter, from its centre + position angle +
@@ -252,6 +241,14 @@ export function FitsGLMapSurface({
   // pinned to 'gray' to keep deriveViewerConfig off the colormap path).
   const [colormapName, setColormapName] = useState<ColormapName>('gray');
   const [colormapReversed, setColormapReversed] = useState(false);
+  // Simple-RGB color tuning, driven imperatively like the colormap: contrast
+  // narrows/widens the shared limits about their midpoint; saturation is the
+  // viewer's post-stretch composite uniform. Both reset on a source change.
+  const [contrast, setContrast] = useState(1);
+  const [saturation, setSaturation] = useState(1);
+  // The contrast=1 baseline the slider scales from (null ⇒ the hook's current
+  // shared range, i.e. whatever the last preset/auto-stretch produced).
+  const rgbBaseRef = useRef<{ min: number; max: number } | null>(null);
   // Layers + cursor tools + live readouts (status pill).
   const [graticule, setGraticule] = useState(false);
   const [tool, setTool] = useState<'pan' | 'ruler'>('pan');
@@ -333,6 +330,9 @@ export function FitsGLMapSurface({
         setViewState(state);
         setColormapName(dv.colormap ?? 'gray');
         setColormapReversed(false);
+        setContrast(1);
+        setSaturation(1);
+        rgbBaseRef.current = null;
       })
       .catch((e) => { if (!cancelled) setLoadError(String(e?.message ?? e)); });
     return () => { cancelled = true; };
@@ -497,20 +497,64 @@ export function FitsGLMapSurface({
       const mode = s.mode === 'rgb' ? 'single' : 'rgb';
       return { ...s, mode, stretch: mode === 'single' ? leaveTrilogy(s.stretch) : s.stretch };
     }), []);
+  // Display-panel intent handlers. RGB construction lives entirely in the panel
+  // (revised decision 1): channel assignment, simple|trilogy sub-mode, weights,
+  // trilogy knobs, and the simple-mode shared range / contrast / saturation.
   const onSetRgbRole = useCallback((role: 'r' | 'g' | 'b', band: string) =>
     setViewState((s) => (s ? { ...s, rgb: { ...s.rgb, [role]: band } } : s)), []);
-  const onRainbow = useCallback(() =>
-    setViewState((s) => {
-      if (!s) return s;
-      const rgb = rainbowRgb(bands);
-      return rgb ? { ...s, mode: 'rgb', rgb } : s;
-    }), [bands]);
-
-  // Display-panel intent handlers.
   const onSetStretch = useCallback((mode: StretchMode) =>
     setViewState((s) => (s ? { ...s, stretch: mode } : s)), []);
+  const onSetRgbSubMode = useCallback((m: 'simple' | 'trilogy') =>
+    setViewState((s) => {
+      if (!s) return s;
+      const stretch = m === 'trilogy' ? 'trilogy' : leaveTrilogy(s.stretch);
+      return stretch === s.stretch ? s : { ...s, stretch };
+    }), []);
+  const onApplyWeights = useCallback((entries: Array<{ band: string; weight: BandWeight }>) =>
+    setViewState((s) => {
+      if (!s) return s;
+      const weights: Record<string, BandWeight> = {};
+      for (const e of entries) weights[e.band] = e.weight;
+      return { ...s, weights, weightBands: entries.map((e) => e.band) };
+    }), []);
+  const onRainbowWeights = useCallback(() =>
+    setViewState((s) => (s ? { ...s, ...rainbowAction(bands, rgbActiveGroup(bands, s.rgb)) } : s)), [bands]);
+  const onSetTrilogyParams = useCallback((patch: Partial<TrilogyParams>) =>
+    setViewState((s) => (s ? { ...s, trilogyParams: { ...s.trilogyParams, ...patch } } : s)), []);
   const onSetHandle = useCallback((key: ChannelKey, min: number, max: number) =>
     display.setHandle(key, min, max), [display]);
+
+  // Simple-RGB shared range + contrast + saturation. Dragging the shared handles
+  // establishes a new contrast=1 baseline; the contrast slider then scales the
+  // limits about their midpoint; presets reset both to the fresh envelope.
+  const onSetSharedRange = useCallback((min: number, max: number) => {
+    rgbBaseRef.current = { min, max };
+    setContrast(1);
+    display.setSharedHandle(min, max);
+  }, [display]);
+  const onSetContrast = useCallback((c: number) => {
+    setContrast(c);
+    const base = rgbBaseRef.current ?? display.sharedRange;
+    if (!base) return;
+    const mid = (base.min + base.max) / 2;
+    const half = (base.max - base.min) / 2 / Math.max(c, 1e-6);
+    display.setSharedHandle(mid - half, mid + half);
+  }, [display]);
+  const onApplyPreset = useCallback(async (preset: LimitPreset) => {
+    await display.applyPreset(preset);
+    rgbBaseRef.current = null; // next contrast change scales the fresh envelope
+    setContrast(1);
+  }, [display]);
+  // Saturation is a live viewer uniform (identity for single-band); re-pushed
+  // after every viewer (re)ready since a rebuilt viewer starts at 1.
+  useEffect(() => {
+    handleRef.current?.getViewer()?.setSaturation(saturation);
+  }, [saturation, readyTick]);
+  // A source-identity change invalidates the simple-RGB tuning baseline.
+  useEffect(() => {
+    rgbBaseRef.current = null;
+    setContrast(1);
+  }, [sourceKey]);
 
   // Tool-rail actions.
   const onFit = useCallback(() => handleRef.current?.fitToImage(), []);
@@ -600,8 +644,6 @@ export function FitsGLMapSurface({
           canComposite={canComposite}
           onSelectBand={onSelectBand}
           onToggleRgb={onToggleRgb}
-          onSetRgbRole={onSetRgbRole}
-          onRainbow={onRainbow}
         />
       )}
 
@@ -611,16 +653,28 @@ export function FitsGLMapSurface({
         <div className={`absolute right-0 top-16 bottom-16 z-[500] w-72 overflow-y-auto rounded-l-xl ${GLASS} p-3`}>
           <DisplayPanel
             state={viewState}
+            bands={bands}
             channels={display.channels}
             hasZscale={display.hasZscale}
             hasTrilogy={display.hasTrilogy}
             colormap={colormapName}
             colormapReversed={colormapReversed}
+            sharedRange={display.sharedRange}
+            contrast={contrast}
+            saturation={saturation}
             onSetStretch={onSetStretch}
+            onSetRgbSubMode={onSetRgbSubMode}
+            onSetRgbRole={onSetRgbRole}
+            onApplyWeights={onApplyWeights}
+            onRainbowWeights={onRainbowWeights}
+            onSetTrilogyParams={onSetTrilogyParams}
             onSetColormap={setColormapName}
             onToggleReverseColormap={setColormapReversed}
             onSetHandle={onSetHandle}
-            onApplyPreset={display.applyPreset}
+            onSetSharedRange={onSetSharedRange}
+            onSetContrast={onSetContrast}
+            onSetSaturation={setSaturation}
+            onApplyPreset={onApplyPreset}
           />
           <div className="mt-3 border-t border-border pt-3">
             <LayersPanel

--- a/web/components/map/FitsGLMapSurface.tsx
+++ b/web/components/map/FitsGLMapSurface.tsx
@@ -51,7 +51,7 @@ import type { FitsglDataset, MapObjectMarker, SlitRegion, Shutter } from '@/lib/
 import { MARKER_QUALITY_COLORS, QUALITY_LABELS } from '@/lib/types';
 import { makeFitsglWorker } from '@/lib/fits/fitsglWorker';
 import { getObservationColor } from './observation-colors';
-import { BandRail } from './fitsgl/BandRail';
+import { BandRail, RGB_OPTION } from './fitsgl/BandRail';
 import { DisplayPanel } from './fitsgl/DisplayPanel';
 import { LayersPanel } from './fitsgl/LayersPanel';
 import { ToolRail } from './fitsgl/ToolRail';
@@ -485,17 +485,16 @@ export function FitsGLMapSurface({
     });
   }, []);
 
-  // Band-rail intent handlers (all pure state updates → deriveViewerConfig).
-  // trilogy is RGB-only, so leaving RGB coerces the curve back to a single-band one.
+  // Band-rail intent handler (a pure state update → deriveViewerConfig): the
+  // band dropdown's RGB_OPTION enters composite mode, a band name drops to
+  // single mode on it. trilogy is RGB-only, so leaving RGB coerces the curve.
   const canComposite = bands.length >= 2;
   const leaveTrilogy = (stretch: StretchMode): StretchMode => (stretch === 'trilogy' ? 'asinh' : stretch);
-  const onSelectBand = useCallback((name: string) =>
-    setViewState((s) => (s ? { ...s, mode: 'single', band: name, stretch: leaveTrilogy(s.stretch) } : s)), []);
-  const onToggleRgb = useCallback(() =>
+  const onSelectDisplay = useCallback((value: string) =>
     setViewState((s) => {
       if (!s) return s;
-      const mode = s.mode === 'rgb' ? 'single' : 'rgb';
-      return { ...s, mode, stretch: mode === 'single' ? leaveTrilogy(s.stretch) : s.stretch };
+      if (value === RGB_OPTION) return s.mode === 'rgb' ? s : { ...s, mode: 'rgb' };
+      return { ...s, mode: 'single', band: value, stretch: leaveTrilogy(s.stretch) };
     }), []);
   // Display-panel intent handlers. RGB construction lives entirely in the panel
   // (revised decision 1): channel assignment, simple|trilogy sub-mode, weights,
@@ -642,8 +641,7 @@ export function FitsGLMapSurface({
           bands={bands}
           state={viewState}
           canComposite={canComposite}
-          onSelectBand={onSelectBand}
-          onToggleRgb={onToggleRgb}
+          onSelectDisplay={onSelectDisplay}
         />
       )}
 

--- a/web/components/map/fitsgl/BandRail.tsx
+++ b/web/components/map/fitsgl/BandRail.tsx
@@ -2,10 +2,11 @@
 
 /**
  * Band rail (epic #337, Phase 4.5) — the top-center glass pill that merges the
- * field selector with band selection (`docs/design-fitsgl-map-ux.md` §4). Mode is
- * implicit in the selection (locked decision 1): a single band chip → single mode;
- * the `RGB` affordance → three R/G/B channel pickers + a rainbow auto-assign. There
- * is no `Single | RGB` segmented toggle.
+ * field selector with band selection (`docs/design-fitsgl-map-ux.md` §4). The
+ * rail stays deliberately simple (revised decision 1): one chip per band plus an
+ * `RGB` toggle. Clicking a band chip always selects single-band mode on that
+ * band; everything about *how* an RGB composite is built (channel assignment,
+ * simple vs trilogy, weights, stretch) lives in the Display panel.
  *
  * Purely presentational — the parent owns the `ExplorerState` and derives the
  * `ViewerConfig`; this only renders the model and calls back on intent.
@@ -13,11 +14,6 @@
 
 import type { ExplorerBand, ExplorerState } from '@fitsgl/core/react';
 import { GLASS_PILL, chipClass, INSET } from './glass';
-
-type RgbRole = 'r' | 'g' | 'b';
-const RGB_ROLES: readonly RgbRole[] = ['r', 'g', 'b'];
-const ROLE_LABEL: Record<RgbRole, string> = { r: 'R', g: 'G', b: 'B' };
-const ROLE_DOT: Record<RgbRole, string> = { r: '#ef4444', g: '#22c55e', b: '#3b82f6' };
 
 interface BandRailProps {
   fields: string[];
@@ -29,9 +25,6 @@ interface BandRailProps {
   canComposite: boolean;
   onSelectBand: (name: string) => void;
   onToggleRgb: () => void;
-  onSetRgbRole: (role: RgbRole, band: string) => void;
-  /** Auto-assign R/G/B by pivot wavelength (reddest→R, bluest→B). */
-  onRainbow: () => void;
 }
 
 export function BandRail({
@@ -43,8 +36,6 @@ export function BandRail({
   canComposite,
   onSelectBand,
   onToggleRgb,
-  onSetRgbRole,
-  onRainbow,
 }: BandRailProps) {
   const rgb = state.mode === 'rgb';
   const showBands = bands.length > 1;
@@ -73,52 +64,20 @@ export function BandRail({
         <>
           <span className="mx-0.5 h-5 w-px bg-border" aria-hidden />
 
-          {rgb ? (
-            // RGB mode: three channel pickers + rainbow.
-            <div className="flex items-center gap-1">
-              {RGB_ROLES.map((role) => (
-                <label key={role} className="flex items-center gap-1" title={`${ROLE_LABEL[role]} channel`}>
-                  <span
-                    className="inline-block h-2.5 w-2.5 rounded-sm"
-                    style={{ background: ROLE_DOT[role] }}
-                    aria-hidden
-                  />
-                  <select
-                    value={state.rgb[role]}
-                    onChange={(e) => onSetRgbRole(role, e.target.value)}
-                    className={`${INSET} font-mono`}
-                    aria-label={`${ROLE_LABEL[role]} channel band`}
-                  >
-                    {bands.map((b) => (
-                      <option key={b.name} value={b.name}>{b.label ?? b.name}</option>
-                    ))}
-                  </select>
-                </label>
-              ))}
+          {/* One chip per band — a chip is active only in single mode; clicking
+              one always drops out of RGB onto that band. */}
+          <div className="flex flex-wrap items-center gap-1">
+            {bands.map((b) => (
               <button
+                key={b.name}
                 type="button"
-                onClick={onRainbow}
-                className={chipClass(false)}
-                title="Auto-assign channels by wavelength (reddest→R, bluest→B)"
+                onClick={() => onSelectBand(b.name)}
+                className={`${chipClass(!rgb && state.band === b.name)} font-mono`}
               >
-                ✦ rainbow
+                {b.label ?? b.name}
               </button>
-            </div>
-          ) : (
-            // Single mode: one chip per band.
-            <div className="flex flex-wrap items-center gap-1">
-              {bands.map((b) => (
-                <button
-                  key={b.name}
-                  type="button"
-                  onClick={() => onSelectBand(b.name)}
-                  className={`${chipClass(state.band === b.name)} font-mono`}
-                >
-                  {b.label ?? b.name}
-                </button>
-              ))}
-            </div>
-          )}
+            ))}
+          </div>
 
           {canComposite && (
             <>
@@ -127,7 +86,7 @@ export function BandRail({
                 type="button"
                 onClick={onToggleRgb}
                 className={chipClass(rgb)}
-                title={rgb ? 'Back to single-band' : 'Compose an RGB image'}
+                title={rgb ? 'Back to single-band' : 'Compose an RGB image (tune it in the Display panel)'}
               >
                 RGB
               </button>

--- a/web/components/map/fitsgl/BandRail.tsx
+++ b/web/components/map/fitsgl/BandRail.tsx
@@ -1,19 +1,20 @@
 'use client';
 
 /**
- * Band rail (epic #337, Phase 4.5) — the top-center glass pill that merges the
- * field selector with band selection (`docs/design-fitsgl-map-ux.md` §4). The
- * rail stays deliberately simple (revised decision 1): one chip per band plus an
- * `RGB` toggle. Clicking a band chip always selects single-band mode on that
- * band; everything about *how* an RGB composite is built (channel assignment,
- * simple vs trilogy, weights, stretch) lives in the Display panel.
+ * Band rail (epic #337, Phase 4.5) — the top-center glass pill: a field dropdown
+ * and a band dropdown, nothing else (revised decision 1). `RGB` rides as the
+ * FIRST option of the band dropdown; picking it enters composite mode (tuned in
+ * the Display panel), picking a band name drops to single-band mode on it.
  *
  * Purely presentational — the parent owns the `ExplorerState` and derives the
  * `ViewerConfig`; this only renders the model and calls back on intent.
  */
 
 import type { ExplorerBand, ExplorerState } from '@fitsgl/core/react';
-import { GLASS_PILL, chipClass, INSET } from './glass';
+import { GLASS_PILL, INSET } from './glass';
+
+/** Sentinel option value for the composite entry (no band may collide with it). */
+export const RGB_OPTION = '__rgb__';
 
 interface BandRailProps {
   fields: string[];
@@ -23,8 +24,8 @@ interface BandRailProps {
   state: ExplorerState;
   /** Whether an RGB composite is possible (≥2 co-gridded bands). */
   canComposite: boolean;
-  onSelectBand: (name: string) => void;
-  onToggleRgb: () => void;
+  /** `RGB_OPTION` → composite mode; a band name → single mode on that band. */
+  onSelectDisplay: (value: string) => void;
 }
 
 export function BandRail({
@@ -34,10 +35,9 @@ export function BandRail({
   bands,
   state,
   canComposite,
-  onSelectBand,
-  onToggleRgb,
+  onSelectDisplay,
 }: BandRailProps) {
-  const rgb = state.mode === 'rgb';
+  const value = state.mode === 'rgb' ? RGB_OPTION : state.band;
   const showBands = bands.length > 1;
 
   return (
@@ -63,35 +63,17 @@ export function BandRail({
       {showBands && (
         <>
           <span className="mx-0.5 h-5 w-px bg-border" aria-hidden />
-
-          {/* One chip per band — a chip is active only in single mode; clicking
-              one always drops out of RGB onto that band. */}
-          <div className="flex flex-wrap items-center gap-1">
+          <select
+            value={value}
+            onChange={(e) => onSelectDisplay(e.target.value)}
+            className={`${INSET} font-mono`}
+            aria-label="Band"
+          >
+            {canComposite && <option value={RGB_OPTION}>RGB</option>}
             {bands.map((b) => (
-              <button
-                key={b.name}
-                type="button"
-                onClick={() => onSelectBand(b.name)}
-                className={`${chipClass(!rgb && state.band === b.name)} font-mono`}
-              >
-                {b.label ?? b.name}
-              </button>
+              <option key={b.name} value={b.name}>{b.label ?? b.name}</option>
             ))}
-          </div>
-
-          {canComposite && (
-            <>
-              <span className="mx-0.5 h-5 w-px bg-border" aria-hidden />
-              <button
-                type="button"
-                onClick={onToggleRgb}
-                className={chipClass(rgb)}
-                title={rgb ? 'Back to single-band' : 'Compose an RGB image (tune it in the Display panel)'}
-              >
-                RGB
-              </button>
-            </>
-          )}
+          </select>
         </>
       )}
     </div>

--- a/web/components/map/fitsgl/DisplayPanel.tsx
+++ b/web/components/map/fitsgl/DisplayPanel.tsx
@@ -1,144 +1,304 @@
 'use client';
 
 /**
- * Display panel (epic #337, Phase 4.5) — the docked-right control for how the
- * imagery is rendered (`docs/design-fitsgl-map-ux.md` §4). Scale (transfer curve)
- * + Limits (black/white presets) + the fine-adjust histogram + a colormap dropdown
- * (locked decision 3: a dropdown, not a swatch row). No north-up control — it is
- * forced on (decision 4). RGB channel *assignment* lives in the band rail, not
- * here (decision 1); this panel only styles whatever the active view is.
+ * Display panel (epic #337, Phase 4.5; RGB rework per the map-RGB-defaults
+ * follow-up) — the docked-right control for how the imagery is rendered
+ * (`docs/design-fitsgl-map-ux.md` §4). ALL RGB construction lives here (revised
+ * decision 1 — the band rail stays a simple band/RGB switch):
  *
- * Controlled: stretch mode + colormap flow up to the parent's `ExplorerState`
- * (→ `deriveViewerConfig`); the histogram/preset black-white points are pushed
- * imperatively by `useDisplayStretch` (see that hook).
+ *  - **single mode**: Scale chips + Limits presets/histogram + colormap dropdown
+ *    (locked decision 3: a dropdown, not a swatch row).
+ *  - **RGB · simple**: pick the three channel bands, one SHARED limit range
+ *    (bands share flux units, so shared cuts keep the composite interpretable —
+ *    deliberately no per-band stretch), a shared transfer curve, plus contrast
+ *    and color-saturation sliders.
+ *  - **RGB · trilogy**: the faithful weighted composite — FitsGL's own weight
+ *    matrix (per-band R/G/B knobs + rainbow) and trilogy tuning sliders
+ *    (noiselum / saturate % / noise σ / black σ), levels derived live from the
+ *    precomputed per-band stats.
+ *
+ * No north-up control — it is forced on (decision 4). Controlled: stretch mode,
+ * channel assignment, weights and trilogy params flow up to the parent's
+ * `ExplorerState` (→ `deriveViewerConfig`); black/white points, contrast and
+ * saturation are pushed imperatively (see `useDisplayStretch`).
  */
 
-import { COLORMAP_NAMES, type ColormapName, type StretchMode } from '@fitsgl/core';
-import type { ExplorerState } from '@fitsgl/core/react';
+import { COLORMAP_NAMES, type BandWeight, type ColormapName, type StretchMode, type TrilogyParams } from '@fitsgl/core';
+import { TrilogyControls, TrilogyWeightMatrix } from '@fitsgl/core/react';
+import type { ExplorerBand, ExplorerState } from '@fitsgl/core/react';
 import { StretchHistogram } from './StretchHistogram';
 import { ColormapControl } from './ColormapControl';
-import { PANEL_CAP, chipClass } from './glass';
-import type { DisplayChannel, LimitPreset, ChannelKey } from './useDisplayStretch';
+import { PANEL_CAP, chipClass, INSET } from './glass';
+import type { DisplayChannel, LimitPreset } from './useDisplayStretch';
 
-/** Transfer curves offered as chips (zscale is a *limit* preset, not a curve). */
+/** Transfer curves offered as chips (zscale is a *limit* preset, not a curve;
+ *  trilogy is the RGB sub-mode toggle, not a chip). */
 const SCALE_MODES: StretchMode[] = ['asinh', 'log', 'sqrt', 'linear'];
-const ROLE_LABEL: Record<ChannelKey, string> = { single: '', r: 'R', g: 'G', b: 'B' };
+
+type RgbRole = 'r' | 'g' | 'b';
+const RGB_ROLES: readonly RgbRole[] = ['r', 'g', 'b'];
+const ROLE_LABEL: Record<RgbRole, string> = { r: 'R', g: 'G', b: 'B' };
+const ROLE_DOT: Record<RgbRole, string> = { r: '#ef4444', g: '#22c55e', b: '#3b82f6' };
 
 interface DisplayPanelProps {
   state: ExplorerState;
+  bands: ExplorerBand[];
   channels: DisplayChannel[];
   hasZscale: boolean;
   hasTrilogy: boolean;
   colormap: ColormapName;
   colormapReversed: boolean;
+  /** Simple-RGB shared black/white points (null outside RGB mode). */
+  sharedRange: { min: number; max: number } | null;
+  /** Simple-RGB contrast about the shared midpoint (1 = neutral). */
+  contrast: number;
+  /** Composite color saturation (1 = neutral, 0 = grayscale). */
+  saturation: number;
   onSetStretch: (mode: StretchMode) => void;
+  /** Switch between the simple 3-band composite and the weighted trilogy. */
+  onSetRgbSubMode: (mode: 'simple' | 'trilogy') => void;
+  onSetRgbRole: (role: RgbRole, band: string) => void;
+  onApplyWeights: (entries: Array<{ band: string; weight: BandWeight }>) => void;
+  onRainbowWeights: () => void;
+  onSetTrilogyParams: (patch: Partial<TrilogyParams>) => void;
   onSetColormap: (name: ColormapName) => void;
   onToggleReverseColormap: (reversed: boolean) => void;
-  onSetHandle: (key: ChannelKey, min: number, max: number) => void;
+  onSetHandle: (key: DisplayChannel['key'], min: number, max: number) => void;
+  onSetSharedRange: (min: number, max: number) => void;
+  onSetContrast: (contrast: number) => void;
+  onSetSaturation: (saturation: number) => void;
   onApplyPreset: (preset: LimitPreset) => void;
+}
+
+/** A labeled slider row in campfire chrome (contrast / saturation). */
+function SliderRow({
+  label,
+  value,
+  min,
+  max,
+  step,
+  neutral,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  /** Double-click resets to this. */
+  neutral: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <label className="flex items-center gap-2">
+      <span className="w-16 shrink-0 font-mono text-[10px] text-text-tertiary">{label}</span>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        onDoubleClick={() => onChange(neutral)}
+        className="h-1 flex-1 accent-[var(--primary)]"
+        title={`${label} (double-click to reset)`}
+      />
+      <span className="w-9 shrink-0 text-right font-mono text-[10px] tabular-nums text-text-secondary">
+        {value.toFixed(2)}
+      </span>
+    </label>
+  );
 }
 
 export function DisplayPanel({
   state,
+  bands,
   channels,
   hasZscale,
   hasTrilogy,
   colormap,
   colormapReversed,
+  sharedRange,
+  contrast,
+  saturation,
   onSetStretch,
+  onSetRgbSubMode,
+  onSetRgbRole,
+  onApplyWeights,
+  onRainbowWeights,
+  onSetTrilogyParams,
   onSetColormap,
   onToggleReverseColormap,
   onSetHandle,
+  onSetSharedRange,
+  onSetContrast,
+  onSetSaturation,
   onApplyPreset,
 }: DisplayPanelProps) {
-  const trilogy = state.stretch === 'trilogy';
   const single = state.mode === 'single';
+  const trilogy = !single && state.stretch === 'trilogy';
+
+  // The shared simple-RGB histogram backdrop: the middle (G) channel is the most
+  // representative single band; the handles carry the SHARED range regardless.
+  const sharedHist = channels.find((c) => c.key === 'g')?.histogram ?? channels[0]?.histogram;
+
+  const presetRow = (
+    <div className="flex items-center justify-between">
+      <span className={PANEL_CAP}>Limits</span>
+      <div className="flex gap-1">
+        <button type="button" onClick={() => onApplyPreset('auto')} className={chipClass(false)} title="Auto-stretch to the data in view">auto</button>
+        {hasZscale && (
+          <button type="button" onClick={() => onApplyPreset('zscale')} className={chipClass(false)} title="Whole-image DS9/IRAF zscale cuts">zscale</button>
+        )}
+        <button type="button" onClick={() => onApplyPreset('minmax')} className={chipClass(false)} title="Full data min–max in view">minmax</button>
+        <button type="button" onClick={() => onApplyPreset('p995')} className={chipClass(false)} title="0.25–99.75% in view">99.5%</button>
+      </div>
+    </div>
+  );
+
+  const scaleRow = (
+    <div className="space-y-1.5">
+      <span className={PANEL_CAP}>Scale</span>
+      <div className="flex flex-wrap gap-1">
+        {SCALE_MODES.map((m) => (
+          <button key={m} type="button" onClick={() => onSetStretch(m)} className={chipClass(state.stretch === m)}>
+            {m}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
 
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
         <h4 className={PANEL_CAP}>Display</h4>
         <span className="font-mono text-[10px] text-text-tertiary">
-          {single ? state.band : 'RGB'} · {state.stretch}
+          {single ? state.band : trilogy ? 'RGB · trilogy' : 'RGB · simple'}
+          {trilogy ? '' : ` · ${state.stretch}`}
         </span>
       </div>
 
-      {/* Scale (transfer curve). */}
-      <div className="space-y-1.5">
-        <span className={PANEL_CAP}>Scale</span>
-        <div className="flex flex-wrap gap-1">
-          {SCALE_MODES.map((m) => (
-            <button key={m} type="button" onClick={() => onSetStretch(m)} className={chipClass(state.stretch === m)}>
-              {m}
-            </button>
-          ))}
-          {/* Trilogy is the RGB weighted composite — not offered in single-band. */}
-          {!single && hasTrilogy && (
-            <button
-              type="button"
-              onClick={() => onSetStretch('trilogy')}
-              className={chipClass(trilogy)}
-              title="Faithful colour-preserving trilogy stretch (precomputed levels)"
-            >
-              trilogy
-            </button>
-          )}
+      {/* RGB sub-mode: simple 3-band composite vs faithful weighted trilogy. */}
+      {!single && (
+        <div className="flex gap-1">
+          <button
+            type="button"
+            onClick={() => onSetRgbSubMode('simple')}
+            className={`${chipClass(!trilogy)} flex-1`}
+            title="Three bands, one shared stretch — easy to read quantitatively"
+          >
+            simple
+          </button>
+          <button
+            type="button"
+            onClick={() => onSetRgbSubMode('trilogy')}
+            disabled={!hasTrilogy}
+            className={`${chipClass(trilogy)} flex-1 disabled:cursor-not-allowed disabled:opacity-40`}
+            title={
+              hasTrilogy
+                ? 'Weighted multi-band trilogy — the publication-style composite'
+                : 'Needs precomputed trilogy stats (rebuild the dataset)'
+            }
+          >
+            trilogy
+          </button>
         </div>
-      </div>
+      )}
 
-      {/* Limits + fine adjust. Trilogy sets its levels from precomputed stats. */}
-      {trilogy ? (
-        <p className="text-[11px] italic text-text-tertiary">
-          Levels set from precomputed trilogy stats.
-        </p>
-      ) : (
-        <div className="space-y-2">
-          <div className="flex items-center justify-between">
-            <span className={PANEL_CAP}>Limits</span>
-            <div className="flex gap-1">
-              <button type="button" onClick={() => onApplyPreset('auto')} className={chipClass(false)} title="Auto-stretch to the data in view">auto</button>
-              {hasZscale && (
-                <button type="button" onClick={() => onApplyPreset('zscale')} className={chipClass(false)} title="Whole-image DS9/IRAF zscale cuts">zscale</button>
-              )}
-              <button type="button" onClick={() => onApplyPreset('minmax')} className={chipClass(false)} title="Full data min–max in view">minmax</button>
-              <button type="button" onClick={() => onApplyPreset('p995')} className={chipClass(false)} title="0.25–99.75% in view">99.5%</button>
-            </div>
-          </div>
-
-          {channels.map((c) =>
-            c.histogram ? (
-              <div key={c.key} className="space-y-0.5">
-                {!single && (
-                  <div className="flex items-center gap-1.5 text-[10px] font-mono text-text-tertiary">
-                    <span className="inline-block h-2 w-2 rounded-sm" style={{ background: c.color }} aria-hidden />
-                    {ROLE_LABEL[c.key]} · {c.band.label ?? c.band.name}
-                  </div>
-                )}
+      {single ? (
+        <>
+          {scaleRow}
+          <div className="space-y-2">
+            {presetRow}
+            {channels.map((c) =>
+              c.histogram ? (
                 <StretchHistogram
+                  key={c.key}
                   histogram={c.histogram}
                   min={c.min}
                   max={c.max}
                   color={c.color}
                   onChange={(min, max) => onSetHandle(c.key, min, max)}
                 />
-              </div>
-            ) : null,
-          )}
-        </div>
-      )}
-
-      {/* Colormap — single mode only (an RGB composite carries its own colour). */}
-      {single && !trilogy && (
-        <div className="space-y-1.5">
-          <span className={PANEL_CAP}>Colormap</span>
-          <ColormapControl
-            names={COLORMAP_NAMES}
-            value={colormap}
-            reversed={colormapReversed}
-            onChange={onSetColormap}
-            onToggleReverse={onToggleReverseColormap}
+              ) : null,
+            )}
+          </div>
+          <div className="space-y-1.5">
+            <span className={PANEL_CAP}>Colormap</span>
+            <ColormapControl
+              names={COLORMAP_NAMES}
+              value={colormap}
+              reversed={colormapReversed}
+              onChange={onSetColormap}
+              onToggleReverse={onToggleReverseColormap}
+            />
+          </div>
+        </>
+      ) : trilogy ? (
+        /* RGB · trilogy — FitsGL's own weight matrix + tuning sliders, embedded
+           in campfire chrome (`fgl-embed` carries the explorer design tokens). */
+        <div className="fgl-embed space-y-1">
+          <TrilogyWeightMatrix
+            bands={bands}
+            state={state}
+            onApply={onApplyWeights}
+            onRainbow={onRainbowWeights}
           />
+          <TrilogyControls params={state.trilogyParams} missing={!hasTrilogy} onChange={onSetTrilogyParams} />
         </div>
+      ) : (
+        /* RGB · simple — 3 channel picks + ONE shared stretch. */
+        <>
+          <div className="space-y-1.5">
+            <span className={PANEL_CAP}>Channels</span>
+            <div className="space-y-1">
+              {RGB_ROLES.map((role) => (
+                <label key={role} className="flex items-center gap-1.5" title={`${ROLE_LABEL[role]} channel`}>
+                  <span
+                    className="inline-block h-2.5 w-2.5 shrink-0 rounded-sm"
+                    style={{ background: ROLE_DOT[role] }}
+                    aria-hidden
+                  />
+                  <select
+                    value={state.rgb[role]}
+                    onChange={(e) => onSetRgbRole(role, e.target.value)}
+                    className={`${INSET} w-full font-mono`}
+                    aria-label={`${ROLE_LABEL[role]} channel band`}
+                  >
+                    {bands.map((b) => (
+                      <option key={b.name} value={b.name}>{b.label ?? b.name}</option>
+                    ))}
+                  </select>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {scaleRow}
+
+          <div className="space-y-2">
+            {presetRow}
+            {sharedHist && sharedRange && (
+              <StretchHistogram
+                histogram={sharedHist}
+                min={sharedRange.min}
+                max={sharedRange.max}
+                onChange={onSetSharedRange}
+              />
+            )}
+            <p className="text-[10px] italic leading-snug text-text-tertiary">
+              One shared range for all three bands — relative channel brightness
+              stays physical.
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <span className={PANEL_CAP}>Color</span>
+            <SliderRow label="Contrast" value={contrast} min={0.25} max={4} step={0.05} neutral={1} onChange={onSetContrast} />
+            <SliderRow label="Saturation" value={saturation} min={0} max={2} step={0.05} neutral={1} onChange={onSetSaturation} />
+          </div>
+        </>
       )}
     </div>
   );

--- a/web/components/map/fitsgl/DisplayPanel.tsx
+++ b/web/components/map/fitsgl/DisplayPanel.tsx
@@ -92,7 +92,7 @@ function SliderRow({
 }) {
   return (
     <label className="flex items-center gap-2">
-      <span className="w-16 shrink-0 font-mono text-[10px] text-text-tertiary">{label}</span>
+      <span className="w-14 shrink-0 font-mono text-[10px] text-text-tertiary">{label}</span>
       <input
         type="range"
         min={min}
@@ -101,10 +101,10 @@ function SliderRow({
         value={value}
         onChange={(e) => onChange(Number(e.target.value))}
         onDoubleClick={() => onChange(neutral)}
-        className="h-1 flex-1 accent-[var(--primary)]"
+        className="h-1 min-w-0 flex-1 accent-[var(--primary)]"
         title={`${label} (double-click to reset)`}
       />
-      <span className="w-9 shrink-0 text-right font-mono text-[10px] tabular-nums text-text-secondary">
+      <span className="w-8 shrink-0 text-right font-mono text-[10px] tabular-nums text-text-secondary">
         {value.toFixed(2)}
       </span>
     </label>
@@ -144,9 +144,9 @@ export function DisplayPanel({
   const sharedHist = channels.find((c) => c.key === 'g')?.histogram ?? channels[0]?.histogram;
 
   const presetRow = (
-    <div className="flex items-center justify-between">
+    <div className="space-y-1.5">
       <span className={PANEL_CAP}>Limits</span>
-      <div className="flex gap-1">
+      <div className="flex flex-wrap gap-1">
         <button type="button" onClick={() => onApplyPreset('auto')} className={chipClass(false)} title="Auto-stretch to the data in view">auto</button>
         {hasZscale && (
           <button type="button" onClick={() => onApplyPreset('zscale')} className={chipClass(false)} title="Whole-image DS9/IRAF zscale cuts">zscale</button>
@@ -246,7 +246,9 @@ export function DisplayPanel({
             onApply={onApplyWeights}
             onRainbow={onRainbowWeights}
           />
-          <div className="fgl-embed">
+          {/* Range inputs carry an intrinsic ~129px minimum; let them shrink to
+              the narrow dock, and trim the fgl label/value reserves to match. */}
+          <div className="fgl-embed [&_.fgl-tri-lbl]:min-w-[52px] [&_.fgl-tri-range]:w-full [&_.fgl-tri-range]:min-w-0 [&_.fgl-tri-val]:min-w-[34px]">
             <TrilogyControls params={state.trilogyParams} missing={!hasTrilogy} onChange={onSetTrilogyParams} />
           </div>
         </div>

--- a/web/components/map/fitsgl/DisplayPanel.tsx
+++ b/web/components/map/fitsgl/DisplayPanel.tsx
@@ -24,9 +24,10 @@
  */
 
 import { COLORMAP_NAMES, type BandWeight, type ColormapName, type StretchMode, type TrilogyParams } from '@fitsgl/core';
-import { TrilogyControls, TrilogyWeightMatrix } from '@fitsgl/core/react';
+import { TrilogyControls } from '@fitsgl/core/react';
 import type { ExplorerBand, ExplorerState } from '@fitsgl/core/react';
 import { StretchHistogram } from './StretchHistogram';
+import { TrilogyWeights } from './TrilogyWeights';
 import { ColormapControl } from './ColormapControl';
 import { PANEL_CAP, chipClass, INSET } from './glass';
 import type { DisplayChannel, LimitPreset } from './useDisplayStretch';
@@ -236,16 +237,18 @@ export function DisplayPanel({
           </div>
         </>
       ) : trilogy ? (
-        /* RGB · trilogy — FitsGL's own weight matrix + tuning sliders, embedded
-           in campfire chrome (`fgl-embed` carries the explorer design tokens). */
-        <div className="fgl-embed space-y-1">
-          <TrilogyWeightMatrix
+        /* RGB · trilogy — campfire's weight matrix (minimized to active bands by
+           default) + FitsGL's tuning sliders (`fgl-embed` carries their tokens). */
+        <div className="space-y-2">
+          <TrilogyWeights
             bands={bands}
             state={state}
             onApply={onApplyWeights}
             onRainbow={onRainbowWeights}
           />
-          <TrilogyControls params={state.trilogyParams} missing={!hasTrilogy} onChange={onSetTrilogyParams} />
+          <div className="fgl-embed">
+            <TrilogyControls params={state.trilogyParams} missing={!hasTrilogy} onChange={onSetTrilogyParams} />
+          </div>
         </div>
       ) : (
         /* RGB · simple — 3 channel picks + ONE shared stretch. */
@@ -287,10 +290,6 @@ export function DisplayPanel({
                 onChange={onSetSharedRange}
               />
             )}
-            <p className="text-[10px] italic leading-snug text-text-tertiary">
-              One shared range for all three bands — relative channel brightness
-              stays physical.
-            </p>
           </div>
 
           <div className="space-y-1.5">

--- a/web/components/map/fitsgl/StatusPill.tsx
+++ b/web/components/map/fitsgl/StatusPill.tsx
@@ -22,6 +22,8 @@ interface StatusPillProps {
   bandLabel: string;
   stretch: string;
   ruler: RulerMeasurement | null;
+  /** Hide the per-band pixel value readout (e.g. a many-band trilogy composite). */
+  showValue?: boolean;
 }
 
 function fmtVal(v: number | null): string {
@@ -40,7 +42,7 @@ function Item({ k, children }: { k: string; children: React.ReactNode }) {
   );
 }
 
-export function StatusPill({ ra, dec, values, native, zoom, bandLabel, stretch, ruler }: StatusPillProps) {
+export function StatusPill({ ra, dec, values, native, zoom, bandLabel, stretch, ruler, showValue = true }: StatusPillProps) {
   const hasVal = !!values && values.some((v) => v !== null && Number.isFinite(v));
   const valStr = hasVal ? values!.map(fmtVal).join(' ') + (native ? '' : '*') : '—';
   return (
@@ -53,7 +55,7 @@ export function StatusPill({ ra, dec, values, native, zoom, bandLabel, stretch, 
         {ra !== null && dec !== null ? `(${ra.toFixed(5)}, ${dec.toFixed(5)})` : ''}
       </span>
       <span className="h-3.5 w-px bg-border" aria-hidden />
-      <Item k="val">{valStr}</Item>
+      {showValue && <Item k="val">{valStr}</Item>}
       <Item k="zoom">{zoom !== null ? `${zoom.toFixed(2)}×` : '—'}</Item>
       <span className="text-text-tertiary">{bandLabel} · {stretch}</span>
       {ruler && (

--- a/web/components/map/fitsgl/TrilogyWeights.tsx
+++ b/web/components/map/fitsgl/TrilogyWeights.tsx
@@ -71,13 +71,13 @@ export function TrilogyWeights({ bands, state, onApply, onRainbow }: TrilogyWeig
 
   return (
     <div className="space-y-1">
-      <div className="flex items-center justify-between">
-        <span className={PANEL_CAP}>Band weights</span>
-        <div className="flex gap-1">
+      <div className="flex items-center justify-between gap-1">
+        <span className={PANEL_CAP}>Weights</span>
+        <div className="flex shrink-0 gap-1">
           <button
             type="button"
             onClick={onRainbow}
-            className={chipClass(false)}
+            className={`${chipClass(false)} whitespace-nowrap`}
             title="Spread the group's bands blue→red across B→R"
           >
             ✦ rainbow

--- a/web/components/map/fitsgl/TrilogyWeights.tsx
+++ b/web/components/map/fitsgl/TrilogyWeights.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+/**
+ * TrilogyWeights — campfire-chrome per-band weight matrix for the trilogy
+ * composite (replaces the embedded `@fitsgl/core/react` TrilogyWeightMatrix so
+ * the copy, minimize behavior, and styling are ours). Each participating band
+ * gets three rotary `Knob`s (its R/G/B contribution); the matrix is MINIMIZED
+ * by default — only active (participating) bands show — and a single +/− button
+ * expands it to reveal the rest of the co-gridded group with participation
+ * checkboxes. Pure logic (composite/toggle/cap) comes from the core helpers, so
+ * this stays a thin view over the same `ExplorerState` the viewer renders.
+ */
+
+import { useState } from 'react';
+import { MAX_BANDS, type BandWeight } from '@fitsgl/core';
+import {
+  Knob,
+  groupBands,
+  rgbActiveGroup,
+  trilogyComposite,
+  type ExplorerBand,
+  type ExplorerState,
+} from '@fitsgl/core/react';
+import { PANEL_CAP, chipClass } from './glass';
+
+const CH_COLOR = { r: '#ef4444', g: '#22c55e', b: '#3b82f6' } as const;
+
+/** CSS `rgb(...)` for a band's (R,G,B) weight — the row swatch shows its tint. */
+function weightSwatch(w: BandWeight): string {
+  const c = (x: number): number => Math.round(Math.min(1, Math.max(0, x)) * 255);
+  return `rgb(${c(w[0])},${c(w[1])},${c(w[2])})`;
+}
+
+interface TrilogyWeightsProps {
+  bands: ExplorerBand[];
+  state: ExplorerState;
+  onApply: (entries: Array<{ band: string; weight: BandWeight }>) => void;
+  onRainbow: () => void;
+}
+
+export function TrilogyWeights({ bands, state, onApply, onRainbow }: TrilogyWeightsProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const activeGroup = rgbActiveGroup(bands, state.rgb);
+  const rows = groupBands(bands, activeGroup);
+  const comp = new Map(trilogyComposite(state).map((e) => [e.band, e.weight] as const));
+  const atCap = comp.size >= MAX_BANDS;
+  const visible = expanded ? rows : rows.filter((b) => comp.has(b.name));
+  const hiddenCount = rows.length - visible.length;
+
+  const toggle = (name: string): void => {
+    const cur = trilogyComposite(state);
+    const has = cur.some((e) => e.band === name);
+    if (!has && cur.length >= MAX_BANDS) return; // cap: checkbox is disabled anyway
+    onApply(
+      has
+        ? cur.filter((e) => e.band !== name)
+        : [...cur, { band: name, weight: state.weights[name] ?? ([1, 1, 1] as BandWeight) }],
+    );
+  };
+
+  const editWeight = (name: string, ch: 0 | 1 | 2, value: number): void => {
+    const v = Number.isFinite(value) ? Math.min(1, Math.max(0, value)) : 0;
+    const cur = trilogyComposite(state);
+    const idx = cur.findIndex((e) => e.band === name);
+    const prev = idx >= 0 ? cur[idx].weight : state.weights[name] ?? ([0, 0, 0] as BandWeight);
+    const w: BandWeight = ch === 0 ? [v, prev[1], prev[2]] : ch === 1 ? [prev[0], v, prev[2]] : [prev[0], prev[1], v];
+    if (idx < 0 && atCap) return;
+    onApply(idx >= 0 ? cur.map((e, i) => (i === idx ? { band: name, weight: w } : e)) : [...cur, { band: name, weight: w }]);
+  };
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between">
+        <span className={PANEL_CAP}>Band weights</span>
+        <div className="flex gap-1">
+          <button
+            type="button"
+            onClick={onRainbow}
+            className={chipClass(false)}
+            title="Spread the group's bands blue→red across B→R"
+          >
+            ✦ rainbow
+          </button>
+          {hiddenCount > 0 || expanded ? (
+            <button
+              type="button"
+              onClick={() => setExpanded((e) => !e)}
+              className={chipClass(expanded)}
+              aria-expanded={expanded}
+              aria-label={expanded ? 'Show active bands only' : 'Show all bands'}
+              title={expanded ? 'Show active bands only' : `Show all bands (${hiddenCount} hidden)`}
+            >
+              {expanded ? '−' : '+'}
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      {/* Column header aligned with the knob triplets. */}
+      <div className="flex items-center justify-end gap-1 pr-0.5">
+        {(['r', 'g', 'b'] as const).map((c) => (
+          <span
+            key={c}
+            className="w-[30px] text-center font-mono text-[9px] font-semibold"
+            style={{ color: CH_COLOR[c] }}
+          >
+            {c.toUpperCase()}
+          </span>
+        ))}
+      </div>
+
+      <div className="space-y-0.5">
+        {visible.map((b) => {
+          const on = comp.has(b.name);
+          const w = comp.get(b.name) ?? ([0, 0, 0] as BandWeight);
+          return (
+            <div key={b.name} className={`flex items-center gap-1.5 ${on ? '' : 'opacity-50'}`}>
+              {expanded && (
+                <input
+                  type="checkbox"
+                  checked={on}
+                  disabled={!on && atCap}
+                  aria-label={`include ${b.label ?? b.name}`}
+                  title={!on && atCap ? `Composite is capped at ${MAX_BANDS} bands` : undefined}
+                  onChange={() => toggle(b.name)}
+                  className="h-3 w-3 shrink-0 accent-[var(--primary)]"
+                />
+              )}
+              <span className="flex min-w-0 flex-1 items-center gap-1.5 font-mono text-[10px] text-text-secondary">
+                <span
+                  className="inline-block h-2 w-2 shrink-0 rounded-sm border border-border"
+                  style={{ background: weightSwatch(w) }}
+                  aria-hidden
+                />
+                <span className="truncate">{b.label ?? b.name}</span>
+              </span>
+              {/* Knobs are core components; the fgl-embed wrapper carries their tokens. */}
+              <span className="fgl-embed flex shrink-0 gap-1">
+                {([0, 1, 2] as const).map((ch) => (
+                  <Knob
+                    key={ch}
+                    value={w[ch]}
+                    color={CH_COLOR[(['r', 'g', 'b'] as const)[ch]]}
+                    label={`${b.label ?? b.name} ${'RGB'[ch]} weight`}
+                    onChange={(next) => editWeight(b.name, ch, next)}
+                  />
+                ))}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/components/map/fitsgl/useDisplayStretch.ts
+++ b/web/components/map/fitsgl/useDisplayStretch.ts
@@ -18,6 +18,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { isTrilogyComposite, trilogyComposite } from '@fitsgl/core/react';
 import type { ExplorerBand, ExplorerState, FitsViewerHandle } from '@fitsgl/core/react';
 
 export type ChannelKey = 'single' | 'r' | 'g' | 'b';
@@ -118,17 +119,29 @@ export function useDisplayStretch({ handleRef, bands, state, readyTick }: UseDis
     }
   }, [handleRef, trilogy]);
 
-  // Apply precomputed trilogy levels when the trilogy curve is active.
+  // Apply precomputed trilogy levels (with the live knobs) when the trilogy
+  // curve is active. A weighted composite takes one stats per participating
+  // band, in `trilogyComposite` order — the same order `deriveViewerConfig`
+  // builds the multiband view from, so it matches the viewer's band managers.
+  // The try/catch absorbs the one-frame race where the viewer's source hasn't
+  // caught up with the state yet (the readyTick pass re-applies).
   useEffect(() => {
     if (!trilogy || !state) return;
     const v = handleRef.current?.getViewer();
     if (!v) return;
-    if (state.mode === 'rgb') {
-      const stats = (['r', 'g', 'b'] as const).map((role) => bandByName.get(state.rgb[role])?.trilogy);
-      if (stats.every((s): s is NonNullable<typeof s> => !!s)) v.applyTrilogy(stats);
-    } else {
-      const stat = bandByName.get(state.band)?.trilogy;
-      if (stat) v.applyTrilogy(stat);
+    try {
+      if (isTrilogyComposite(state)) {
+        const comp = trilogyComposite(state);
+        const stats = comp.map((e) => bandByName.get(e.band)?.trilogy);
+        if (stats.every((s): s is NonNullable<typeof s> => !!s)) {
+          v.applyTrilogy(stats, state.trilogyParams);
+        }
+      } else {
+        const stat = bandByName.get(state.band)?.trilogy;
+        if (stat) v.applyTrilogy(stat, state.trilogyParams);
+      }
+    } catch {
+      // source/state transient mismatch — the next ready/frame pass re-applies
     }
   }, [trilogy, state, bandByName, handleRef, readyTick]);
 
@@ -144,22 +157,58 @@ export function useDisplayStretch({ handleRef, bands, state, readyTick }: UseDis
     [handleRef],
   );
 
+  /** Simple-RGB shared limits: one [min, max] pushed to all three channels — no
+   *  independent per-band stretch (that's what keeps a simple composite
+   *  interpretable; the bands share flux units, so shared cuts are physical). */
+  const setSharedHandle = useCallback(
+    (min: number, max: number) => {
+      const v = handleRef.current?.getViewer();
+      if (!v) return;
+      for (const role of ['r', 'g', 'b'] as const) v.setChannelStretch(role, min, max);
+      setRanges((prev) => ({
+        ...prev,
+        r: { min, max },
+        g: { min, max },
+        b: { min, max },
+      }));
+    },
+    [handleRef],
+  );
+
+  /** The one range shown by the simple-RGB shared control: after any shared op
+   *  all channels agree; before one (fresh source auto-stretch), merge to the
+   *  envelope (min of mins / max of maxes) so every band's data stays visible. */
+  const sharedRange = useMemo<{ min: number; max: number } | null>(() => {
+    if (!state || state.mode !== 'rgb') return null;
+    const rs = (['r', 'g', 'b'] as const).map(
+      (role) => ranges[role] ?? fallbackRange(bandByName.get(state.rgb[role]) ?? bands[0]),
+    );
+    return {
+      min: Math.min(...rs.map((r) => r.min)),
+      max: Math.max(...rs.map((r) => r.max)),
+    };
+  }, [state, ranges, bandByName, bands]);
+
   const applyPreset = useCallback(
     async (preset: LimitPreset) => {
       const h = handleRef.current;
       const v = h?.getViewer();
       if (!h || !v || !state) return;
+      // Simple RGB shares one range across channels; merge per-channel results
+      // to their envelope so no band's data is cut off.
+      const shareRgb = (per: Array<{ min: number; max: number } | undefined>): void => {
+        const got = per.filter((r): r is { min: number; max: number } => !!r);
+        if (got.length === 0) return;
+        setSharedHandle(Math.min(...got.map((r) => r.min)), Math.max(...got.map((r) => r.max)));
+      };
       if (preset === 'zscale') {
         if (state.mode === 'rgb') {
-          const next: Partial<Record<ChannelKey, { min: number; max: number }>> = {};
-          for (const role of ['r', 'g', 'b'] as const) {
-            const z = bandByName.get(state.rgb[role])?.zscale;
-            if (z) {
-              v.setChannelStretch(role, z[0], z[1]);
-              next[role] = { min: z[0], max: z[1] };
-            }
-          }
-          setRanges((prev) => ({ ...prev, ...next }));
+          shareRgb(
+            (['r', 'g', 'b'] as const).map((role) => {
+              const z = bandByName.get(state.rgb[role])?.zscale;
+              return z ? { min: z[0], max: z[1] } : undefined;
+            }),
+          );
         } else {
           const z = bandByName.get(state.band)?.zscale;
           if (z) {
@@ -179,18 +228,27 @@ export function useDisplayStretch({ handleRef, bands, state, readyTick }: UseDis
       const res = await v.autoStretch(pLo, pHi);
       if (!res) return;
       if (res.mode === 'rgb') {
-        const next: Partial<Record<ChannelKey, { min: number; max: number }>> = {};
-        for (const role of ['r', 'g', 'b'] as const) {
-          const r = res[role];
-          if (r) next[role] = { min: r[0], max: r[1] };
-        }
-        setRanges((prev) => ({ ...prev, ...next }));
+        shareRgb(
+          (['r', 'g', 'b'] as const).map((role) => {
+            const r = res[role];
+            return r ? { min: r[0], max: r[1] } : undefined;
+          }),
+        );
       } else {
         setRanges((prev) => ({ ...prev, single: { min: res.min, max: res.max } }));
       }
     },
-    [handleRef, state, bandByName],
+    [handleRef, state, bandByName, setSharedHandle],
   );
 
-  return { channels, hasZscale, hasTrilogy, setHandle, applyPreset, seedFromFrame };
+  return {
+    channels,
+    hasZscale,
+    hasTrilogy,
+    sharedRange,
+    setHandle,
+    setSharedHandle,
+    applyPreset,
+    seedFromFrame,
+  };
 }

--- a/web/lib/cutout/display.ts
+++ b/web/lib/cutout/display.ts
@@ -24,10 +24,19 @@ export async function renderDisplayCutoutPng(
   src: FieldCutoutSource,
   args: DisplayCutoutArgs,
 ): Promise<Buffer> {
+  // The producer's default stretch (trilogy levels solved from precomputed
+  // stats + knobs upstream in `displayDefaults`) — so the cutout opens on the
+  // same transfer the map does; absent ⇒ the engine default (asinh + auto).
+  const display = src.display;
   const cutout = await renderCutout(src.bands, {
     center: [args.ra, args.dec],
     fovArcsec: args.fovArcsec,
     outputSize: args.outputSize,
+    ...(display !== null && {
+      stretch: display.stretch,
+      ...(display.limits !== undefined && { limits: display.limits }),
+      ...(display.trilogyK !== undefined && { trilogyK: display.trilogyK }),
+    }),
   });
   // No-coverage (NaN) pixels render transparent; flatten onto black like the
   // legacy compositor's opaque canvas.

--- a/web/lib/cutout/index.ts
+++ b/web/lib/cutout/index.ts
@@ -38,6 +38,9 @@ export interface CutoutRequest {
   colormap?: ColormapName;
   /** Display limits: `'auto'` (per-band percentile) or explicit per band. */
   limits?: 'auto' | Limits | Limits[];
+  /** Trilogy softening `k`: one shared value or per-band, aligned with `bands`
+   *  (used when `stretch` is `'trilogy'`; solved from stats + knobs upstream). */
+  trilogyK?: number | number[];
 }
 
 export interface CutoutRGBA {
@@ -83,11 +86,13 @@ export async function renderCutout(bands: BandSource[], req: CutoutRequest): Pro
       limits: limitFor(0),
       stretch,
       colormap: req.colormap ?? 'gray',
+      trilogyK: typeof req.trilogyK === 'number' ? req.trilogyK : req.trilogyK?.[0],
     });
   } else {
     rgba = renderRGB([outs[0].data, outs[1].data, outs[2].data], width, height, {
       limits: [limitFor(0), limitFor(1), limitFor(2)],
       stretch,
+      trilogyK: req.trilogyK,
     });
   }
   return { rgba, width, height, outputWcsHeader };

--- a/web/lib/cutout/render.test.ts
+++ b/web/lib/cutout/render.test.ts
@@ -39,6 +39,43 @@ describe('renderSingleBand', () => {
 });
 
 describe('renderRGB', () => {
+  it('applies per-channel trilogy softening k (each band its own curve)', () => {
+    // One pixel, all channels the same mid-scale value: a large k lifts the
+    // output far above linear; k = 0 stays linear. Distinct per-channel ks
+    // must produce distinct channel outputs from identical inputs.
+    const half = new Float32Array([0.5]);
+    const rgba = renderRGB([half, half, half], 1, 1, {
+      limits: [
+        { lo: 0, hi: 1 },
+        { lo: 0, hi: 1 },
+        { lo: 0, hi: 1 },
+      ],
+      stretch: 'trilogy',
+      trilogyK: [100, 0, 100],
+    });
+    const [r, g, b] = px(rgba, 0, 0, 1);
+    expect(r).toBe(b); // same k, same output
+    expect(g).toBe(128); // k = 0 → linear (0.5 * 255 rounded)
+    expect(r).toBeGreaterThan(200); // strong softening lifts the faint end
+  });
+
+  it('a scalar trilogyK still applies to every channel', () => {
+    const half = new Float32Array([0.5]);
+    const rgba = renderRGB([half, half, half], 1, 1, {
+      limits: [
+        { lo: 0, hi: 1 },
+        { lo: 0, hi: 1 },
+        { lo: 0, hi: 1 },
+      ],
+      stretch: 'trilogy',
+      trilogyK: 100,
+    });
+    const [r, g, b] = px(rgba, 0, 0, 1);
+    expect(r).toBe(g);
+    expect(g).toBe(b);
+    expect(r).toBeGreaterThan(200);
+  });
+
   it('flips rows and maps channels R/G/B in the flipped order', () => {
     // 1×2 column: south px has r=0, north px has r=1 (g/b constant 0)
     const r = new Float32Array([0, 1]);

--- a/web/lib/cutout/render.ts
+++ b/web/lib/cutout/render.ts
@@ -76,9 +76,17 @@ export function renderRGB(
   channels: readonly [Float32Array, Float32Array, Float32Array],
   width: number,
   height: number,
-  opts: { limits: readonly [Limits, Limits, Limits]; stretch: StretchMode; trilogyK?: number },
+  opts: {
+    limits: readonly [Limits, Limits, Limits];
+    stretch: StretchMode;
+    /** Trilogy softening: one shared `k`, or per-channel `[kR, kG, kB]` (each
+     *  band's levels solve its own `k`, matching the viewer's applyTrilogy). */
+    trilogyK?: number | readonly number[];
+  },
 ): Uint8ClampedArray {
   const { limits, stretch, trilogyK } = opts;
+  const kFor = (c: number): number | undefined =>
+    typeof trilogyK === 'number' ? trilogyK : trilogyK?.[c];
   const rgba = new Uint8ClampedArray(width * height * 4);
   for (let y = 0; y < height; y++) {
     const src = y * width;
@@ -90,7 +98,7 @@ export function renderRGB(
         const v = channels[c][src + x];
         if (Number.isNaN(v)) continue;
         any = true;
-        rgba[o + c] = Math.round(scaleValue(v, limits[c].lo, limits[c].hi, stretch, trilogyK) * 255);
+        rgba[o + c] = Math.round(scaleValue(v, limits[c].lo, limits[c].hi, stretch, kFor(c)) * 255);
       }
       if (any) rgba[o + 3] = 255; // opaque where at least one band has data
     }

--- a/web/lib/cutout/source.test.ts
+++ b/web/lib/cutout/source.test.ts
@@ -1,0 +1,80 @@
+// displayDefaults (epic #337 / map-RGB-defaults): the producer's default stretch,
+// resolved server-side so cutouts open on the same transfer the map does. Trilogy
+// levels derive from precomputed per-band stats + the producer's knobs via
+// @fitsgl/core's own trilogyLevels — the same math the viewer's applyTrilogy runs.
+
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_TRILOGY_PARAMS, trilogyLevels, type FitsglConfig } from '@fitsgl/core';
+import { displayDefaults } from './source';
+
+const TRI_STATS = {
+  mean: 0.001,
+  sigma: 0.005,
+  tail: { p99: 0.08, p99_9: 0.76, p99_99: 4.0, p99_999: 15.0 },
+};
+
+function config(overrides: {
+  stretch?: { mode?: 'linear' | 'log' | 'asinh' | 'trilogy' | 'sqrt' };
+  trilogy?: Record<string, number>;
+  dropStatsOn?: string;
+}): FitsglConfig {
+  const bands = ['r', 'g', 'b'].map((name) => ({
+    name,
+    tiles: [`https://cdn/${name}/manifest.json`],
+    grid: { group: 0 },
+    ...(overrides.dropStatsOn === name
+      ? {}
+      : { stats: { histogram: { counts: [1], lo: 0, hi: 1 }, trilogy: TRI_STATS } }),
+  }));
+  return {
+    schemaVersion: 1,
+    dataset: { name: 'x', bands },
+    defaultView: {
+      mode: 'rgb',
+      r: 'r',
+      g: 'g',
+      b: 'b',
+      ...(overrides.stretch !== undefined && { stretch: overrides.stretch }),
+      // `trilogy` knobs are a @fitsgl/core ≥ 0.3.0 contract field; simulate a
+      // parsed config carrying them (0.2.0's validator strips the key).
+      ...(overrides.trilogy !== undefined && { trilogy: overrides.trilogy }),
+    } as FitsglConfig['defaultView'],
+  };
+}
+
+const chosen = (c: FitsglConfig) => c.dataset.bands;
+
+describe('displayDefaults', () => {
+  it('returns null when the producer declares no stretch (engine default)', () => {
+    expect(displayDefaults(config({}), chosen(config({})))).toBeNull();
+  });
+
+  it('passes a non-trilogy stretch through without limits (auto percentile)', () => {
+    const c = config({ stretch: { mode: 'log' } });
+    expect(displayDefaults(c, chosen(c))).toEqual({ stretch: 'log' });
+  });
+
+  it('solves per-band trilogy levels from stats with default knobs', () => {
+    const c = config({ stretch: { mode: 'trilogy' } });
+    const d = displayDefaults(c, chosen(c));
+    const expected = trilogyLevels(TRI_STATS, DEFAULT_TRILOGY_PARAMS);
+    expect(d?.stretch).toBe('trilogy');
+    expect(d?.limits).toHaveLength(3);
+    expect(d?.limits?.[0]).toEqual({ lo: expected.x0, hi: expected.x2 });
+    expect(d?.trilogyK?.[0]).toBeCloseTo(expected.k, 10);
+  });
+
+  it('honors producer knobs when the config carries them (core ≥ 0.3.0)', () => {
+    const knobs = { noiselum: 0.12, satpercent: 0.01 };
+    const c = config({ stretch: { mode: 'trilogy' }, trilogy: knobs });
+    const d = displayDefaults(c, chosen(c));
+    const expected = trilogyLevels(TRI_STATS, { ...DEFAULT_TRILOGY_PARAMS, ...knobs });
+    expect(d?.trilogyK?.[0]).toBeCloseTo(expected.k, 10);
+    expect(d?.limits?.[0].hi).toBeCloseTo(expected.x2, 10);
+  });
+
+  it('falls back to null when any chosen band lacks trilogy stats', () => {
+    const c = config({ stretch: { mode: 'trilogy' }, dropStatsOn: 'g' });
+    expect(displayDefaults(c, chosen(c))).toBeNull();
+  });
+});

--- a/web/lib/cutout/source.ts
+++ b/web/lib/cutout/source.ts
@@ -7,12 +7,31 @@
 // Kept free of `sharp`/route coupling so the science-FITS route can share it;
 // PNG-flattening display helpers live in `./display`.
 
-import { loadFitsglConfig, type FitsglConfig } from '@fitsgl/core';
+import {
+  DEFAULT_TRILOGY_PARAMS,
+  loadFitsglConfig,
+  trilogyLevels,
+  type FitsglConfig,
+  type StretchMode,
+  type TrilogyParams,
+} from '@fitsgl/core';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { loadManifest } from './manifest';
 import type { BandSource } from './index';
+import type { Limits } from './render';
 
 type FitsglBand = FitsglConfig['dataset']['bands'][number];
+
+/** The producer's default stretch, resolved for the chosen display bands so a
+ *  server cutout opens on the same transfer the map does. */
+export interface DisplayStretchDefaults {
+  stretch: StretchMode;
+  /** Per-band display interval, aligned with the chosen bands (trilogy only:
+   *  `[x0, x2]` from the precomputed stats + knobs). Absent ⇒ auto percentile. */
+  limits?: Limits[];
+  /** Per-band trilogy softening `k`, aligned with `limits` (trilogy only). */
+  trilogyK?: number[];
+}
 
 export interface FieldCutoutSource {
   /** 1 band (single-band colormap) or 3 ordered `[R, G, B]` (composite). */
@@ -21,6 +40,8 @@ export interface FieldCutoutSource {
   bandNames: string[];
   /** Native (finest-level) pixel scale in arcsec/px, for native-size defaults. */
   nativeScaleArcsec: number;
+  /** Producer default stretch for `bands`, or `null` (engine default: asinh + auto). */
+  display: DisplayStretchDefaults | null;
   /** Whether every backing mosaic is published (`fitsgl_dataset_is_public`).
    *  `false` ⇒ this render is admin-only: the response must NOT be
    *  shared-cacheable (`private, no-store`), or a CDN keyed only on the URL
@@ -64,6 +85,36 @@ function chooseBands(config: FitsglConfig): FitsglBand[] {
 
   const single = (dv.band && bands.find((b) => b.name === dv.band)) || bands[0];
   return [single];
+}
+
+/**
+ * Resolve the producer's default stretch for the chosen bands (exported for
+ * tests). Trilogy needs precomputed `stats.trilogy` on EVERY chosen band —
+ * levels derive server-side from those stats + the producer's knobs, exactly
+ * as the map's `applyTrilogy` does, so cutout and map match by construction.
+ * Any band missing stats ⇒ `null` (engine default: asinh + auto percentile),
+ * matching the viewer's own fallback. Producer knobs (`defaultView.trilogy`)
+ * arrive with @fitsgl/core ≥ 0.3.0 — an older validator strips the key and we
+ * fall back to the library defaults.
+ */
+export function displayDefaults(
+  config: FitsglConfig,
+  chosen: FitsglBand[],
+): DisplayStretchDefaults | null {
+  const dv = config.defaultView;
+  const mode = dv.stretch?.mode;
+  if (mode === undefined) return null;
+  if (mode !== 'trilogy') return { stretch: mode };
+  const stats = chosen.map((b) => b.stats?.trilogy);
+  if (stats.some((s) => s === undefined)) return null;
+  const knobs = (dv as { trilogy?: Partial<TrilogyParams> }).trilogy;
+  const params: TrilogyParams = { ...DEFAULT_TRILOGY_PARAMS, ...knobs };
+  const levels = stats.map((s) => trilogyLevels(s!, params));
+  return {
+    stretch: 'trilogy',
+    limits: levels.map((l) => ({ lo: l.x0, hi: l.x2 })),
+    trilogyK: levels.map((l) => l.k),
+  };
 }
 
 /**
@@ -136,6 +187,7 @@ export async function resolveFieldCutoutSource(
       bands,
       bandNames: chosen.map((b) => b.name),
       nativeScaleArcsec: bands[0].manifest.levels[0].pixelScaleArcsec,
+      display: displayDefaults(ds.config, chosen),
       isPublic: ds.isPublic,
     };
   } catch (err) {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.932.0",
         "@aws-sdk/s3-request-presigner": "^3.932.0",
-        "@fitsgl/core": "^0.2.0",
+        "@fitsgl/core": "^0.3.0",
         "@supabase/ssr": "^0.7.0",
         "@supabase/supabase-js": "^2.81.1",
         "@tanstack/react-query": "^5.90.12",
@@ -2103,9 +2103,9 @@
       }
     },
     "node_modules/@fitsgl/core": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@fitsgl/core/-/core-0.2.0.tgz",
-      "integrity": "sha512-irufmLerlJ8dszFXYpWD1M2W2mFEolvCaU53sqsKumOI5NqeAKWQykVq4BOdzBesP4osx7GYvwlHKtxZqoYtwA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@fitsgl/core/-/core-0.3.0.tgz",
+      "integrity": "sha512-1e/0yHKXGhZuDXU/6J5g0gPzJDoL3GDv2k+oztb1UOIuQ1joPfOKGZ2ppXCZCm/8FW9OBMEdpMKHUEYR6JEcLA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": ">=18.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.932.0",
     "@aws-sdk/s3-request-presigner": "^3.932.0",
-    "@fitsgl/core": "^0.2.0",
+    "@fitsgl/core": "^0.3.0",
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.81.1",
     "@tanstack/react-query": "^5.90.12",


### PR DESCRIPTION
## Summary
Refactors the RGB channel configuration loading to prioritize `fields.toml` over the legacy `imaging.toml`, with improved user feedback and better separation of concerns. The new approach is pure TOML (no filesystem dependencies) and aligns with the `cfpipe nircam rgb` workflow.

## Key Changes

- **Extract `_fields_toml_table(field)`**: New helper to load the `[<field>]` table from `$CAMPFIRE_ROOT/config/fields.toml`, returning `None` if unavailable. Replaces inline TOML parsing in `_fiducial_tiles_from_toml`.

- **Add `_rgb_channels_from_fields_toml(field)`**: New function to read RGB channel weights from `[<field>.rgb.channels]` in fields.toml. Parses filter → `[r,g,b]` weight lists, lowercases filter keys to match discovered band names, and skips malformed entries with warnings.

- **Rename and refactor `_load_rgb_channels`**: Now orchestrates two sources in priority order:
  1. `_rgb_channels_from_fields_toml` (preferred, pure TOML, no filesystem dependency)
  2. `_rgb_channels_from_imaging_toml` (legacy fallback for unmigrated fields)
  
  Always logs which source was used (or why none were available), eliminating silent single-band fallbacks.

- **Add diagnostic logging in `run_build`**: When RGB config exists but fewer than 3 filters are available in the built bands, explicitly note which filters are usable and why single-band was chosen.

- **Update documentation**: Clarify that `[<field>.rgb]` in fields.toml is the preferred source, matching the `cfpipe nircam rgb` block, with imaging.toml as a legacy fallback.

## Implementation Details

- Filter keys are normalized to lowercase to match discovered band names (e.g., `F115W` → `f115w`).
- Malformed weight entries (non-3-element lists, non-numeric values) are skipped with a warning rather than failing the build.
- The refactoring maintains backward compatibility: fields without fields.toml RGB config still fall back to imaging.toml.
- All changes are covered by new unit tests validating parsing, fallback behavior, and end-to-end integration with `derive_viewer`.

https://claude.ai/code/session_01EoEqGrD9VdF8SWLDKz4ccR