### PR TITLE
Improve marker visualization and popup interaction

### DIFF
--- a/web/components/map/CanvasMarkerLayer.tsx
+++ b/web/components/map/CanvasMarkerLayer.tsx
@@ -18,7 +18,6 @@ const QUALITY_DRAW_ORDER = [0, 1, 2, 3, 4];
 interface PreparedMarker {
   marker: MapObjectMarker;
   latLng: L.LatLng;
-  color: string;
   isHighlighted: boolean;
 }
 
@@ -37,6 +36,8 @@ export interface CanvasMarkerLayerProps {
   highlightObjectId?: string;
   markerFilter?: (marker: MapObjectMarker) => boolean;
   onMarkerClick: (marker: MapObjectMarker, latLng: L.LatLng) => void;
+  /** Click that hit no marker (used to dismiss an open popup). */
+  onBackgroundClick?: () => void;
 }
 
 // ============================================
@@ -58,6 +59,7 @@ export function CanvasMarkerLayer({
   highlightObjectId,
   markerFilter,
   onMarkerClick,
+  onBackgroundClick,
 }: CanvasMarkerLayerProps) {
   const map = useMap();
 
@@ -69,7 +71,6 @@ export function CanvasMarkerLayer({
       return {
         marker: m,
         latLng: L.latLng(y, x), // Leaflet: lat=y, lng=x
-        color: QUALITY_COLORS[m.redshift_quality] || QUALITY_COLORS[0],
         isHighlighted: m.object_id === highlightObjectId,
       };
     });
@@ -81,6 +82,9 @@ export function CanvasMarkerLayer({
 
   const onMarkerClickRef = useRef(onMarkerClick);
   onMarkerClickRef.current = onMarkerClick;
+
+  const onBackgroundClickRef = useRef(onBackgroundClick);
+  onBackgroundClickRef.current = onBackgroundClick;
 
   const visibleRef = useRef(visible);
   visibleRef.current = visible;
@@ -204,22 +208,12 @@ export function CanvasMarkerLayer({
         group.push(pt);
       }
 
-      // Batch draw in quality order (not inspected on bottom, secure on top)
+      // Batch draw in quality order (not inspected on bottom, secure on top).
+      // Hollow rings — no fill — so the object itself stays visible.
       for (const q of QUALITY_DRAW_ORDER) {
         const points = groups.get(q);
         if (!points) continue;
         const color = QUALITY_COLORS[q] || QUALITY_COLORS[0];
-        // Fill pass
-        ctx!.beginPath();
-        for (const pt of points) {
-          ctx!.moveTo(pt.x + 6, pt.y);
-          ctx!.arc(pt.x, pt.y, 6, 0, Math.PI * 2);
-        }
-        ctx!.fillStyle = color;
-        ctx!.globalAlpha = 0.1;
-        ctx!.fill();
-
-        // Stroke pass
         ctx!.beginPath();
         for (const pt of points) {
           ctx!.moveTo(pt.x + 6, pt.y);
@@ -231,15 +225,10 @@ export function CanvasMarkerLayer({
         ctx!.stroke();
       }
 
-      // Draw highlighted marker last (on top)
+      // Draw highlighted marker last (on top) — a larger white ring, unfilled
+      // so the highlighted object itself stays visible.
       if (highlightItem) {
-        const { point: pt, prepared: item } = highlightItem;
-
-        ctx!.beginPath();
-        ctx!.arc(pt.x, pt.y, 10, 0, Math.PI * 2);
-        ctx!.fillStyle = item.color;
-        ctx!.globalAlpha = 0.5;
-        ctx!.fill();
+        const { point: pt } = highlightItem;
 
         ctx!.beginPath();
         ctx!.arc(pt.x, pt.y, 10, 0, Math.PI * 2);
@@ -306,6 +295,8 @@ export function CanvasMarkerLayer({
       const hit = hitTest(e.layerPoint);
       if (hit) {
         onMarkerClickRef.current(hit.marker, hit.latLng);
+      } else {
+        onBackgroundClickRef.current?.();
       }
     }
 

--- a/web/components/map/FitsGLMapSurface.tsx
+++ b/web/components/map/FitsGLMapSurface.tsx
@@ -343,24 +343,33 @@ export function FitsGLMapSurface({
     [bands, viewState],
   );
 
-  // Marker inputs (sky-positioned; FitsGL projects via the manifest WCS). A filter
-  // dims non-matching objects rather than hiding them; the highlighted object gets
-  // a larger white glyph, matching the Leaflet layer's emphasis.
+  // Marker inputs (sky-positioned; FitsGL projects via the manifest WCS). Hollow
+  // circles — an unfilled ring keeps the object itself visible — with the border
+  // colored by redshift quality. A filter dims non-matching objects rather than
+  // hiding them; the highlighted object gets a larger white ring, matching the
+  // Leaflet layer's emphasis. FitsGL draws (and hit-tests topmost) in input order,
+  // so sort dimmed non-matches to the bottom, then ascending quality (secure on
+  // top), with the highlighted object above everything.
   const markerInputs = useMemo<MarkerInput[]>(() => {
-    return markers.map((m) => {
+    const entries = markers.map((m) => {
       const matches = !markerFilter || markerFilter(m);
       const highlighted = m.object_id === highlightObjectId;
       const base = MARKER_QUALITY_COLORS[m.redshift_quality] ?? MARKER_QUALITY_COLORS[0];
-      return {
+      const input: MarkerInput = {
         id: m.object_id,
         ra: m.ra,
         dec: m.dec,
-        shape: 'point',
+        shape: 'circle',
         size: highlighted ? 16 : matches ? 10 : 6,
+        edgeWidth: highlighted ? 2.5 : 1.5,
         color: highlighted ? '#ffffff' : matches ? base : hexToRgba(base, 0.25),
         data: { objectId: m.object_id },
       };
+      const zOrder = highlighted ? 100 : (matches ? 10 : 0) + m.redshift_quality;
+      return { input, zOrder };
     });
+    entries.sort((a, b) => a.zOrder - b.zOrder);
+    return entries.map((e) => e.input);
   }, [markers, markerFilter, highlightObjectId]);
 
   // Push markers whenever they (or the toggle) change and the viewer is ready.
@@ -459,10 +468,16 @@ export function FitsGLMapSurface({
     }, 300);
   }, []);
 
+  // FitsGL fires onMarkerClick on mouseup; the browser then delivers the DOM
+  // `click` for the same gesture to the root handler, which must not close the
+  // popup it just opened. Consumed (or overwritten) by the very next click.
+  const suppressNextRootClick = useRef(false);
+
   const onMarkerClick = useCallback((e: MarkerEvent) => {
     const objectId = e.marker.data?.objectId as string | undefined;
     const marker = objectId ? markerById.get(objectId) : undefined;
     if (!marker) return;
+    suppressNextRootClick.current = true;
     popupWorld.current = { worldX: e.worldX, worldY: e.worldY };
     setPopup({ marker, x: e.screenX, y: e.screenY });
   }, [markerById]);
@@ -471,6 +486,29 @@ export function FitsGLMapSurface({
     popupWorld.current = null;
     setPopup(null);
   }, []);
+
+  // Pointer cursor over a clickable marker (the canvas only sets its own cursor
+  // for modal tools, so the root style shows through in pan mode).
+  const onMarkerHover = useCallback((e: MarkerEvent | null) => {
+    const root = rootRef.current;
+    if (root) root.style.cursor = e ? 'pointer' : '';
+  }, []);
+
+  // Click anywhere (that isn't the marker click that opened it, and isn't the
+  // tail end of a pan drag) dismisses the popup.
+  const pointerDownPos = useRef<{ x: number; y: number } | null>(null);
+  const handleRootPointerDown = useCallback((ev: React.PointerEvent<HTMLDivElement>) => {
+    pointerDownPos.current = { x: ev.clientX, y: ev.clientY };
+  }, []);
+  const handleRootClick = useCallback((ev: React.MouseEvent<HTMLDivElement>) => {
+    if (suppressNextRootClick.current) {
+      suppressNextRootClick.current = false;
+      return;
+    }
+    const down = pointerDownPos.current;
+    if (down && Math.hypot(ev.clientX - down.x, ev.clientY - down.y) > 5) return;
+    closePopup();
+  }, [closePopup]);
 
   // Right-click → context menu at the cursor's sky position. Passes ABSOLUTE
   // client coords; the parent (MapViewer.handleContextMenu) subtracts the map
@@ -586,7 +624,13 @@ export function FitsGLMapSurface({
   }
 
   return (
-    <div ref={rootRef} className="fitsgl-chrome relative h-full w-full overflow-hidden" onContextMenu={handleContextMenu}>
+    <div
+      ref={rootRef}
+      className="fitsgl-chrome relative h-full w-full overflow-hidden"
+      onContextMenu={handleContextMenu}
+      onPointerDown={handleRootPointerDown}
+      onClick={handleRootClick}
+    >
       {viewerConfig && (
         <FitsViewer
           config={viewerConfig}
@@ -595,6 +639,7 @@ export function FitsGLMapSurface({
           onCursor={onCursor}
           onFrame={onFrame}
           onMarkerClick={onMarkerClick}
+          onMarkerHover={onMarkerHover}
           regionTooltip={regionTooltip}
           onError={(err) => setLoadError(String((err as Error)?.message ?? err))}
           className="h-full w-full"
@@ -728,8 +773,11 @@ export function FitsGLMapSurface({
         const q = QUALITY_LABELS.find((l) => l.value === popup.marker.redshift_quality);
         return (
           <div
-            className="absolute z-[600] min-w-[200px] -translate-x-1/2 -translate-y-full rounded-lg border border-border bg-card p-3 text-sm shadow-lg"
+            // text-text-primary is explicit (not inherited): the chrome's card is
+            // pinned dark in both themes, but the inherited body color is not.
+            className="absolute z-[600] min-w-[200px] -translate-x-1/2 -translate-y-full rounded-lg border border-border bg-card p-3 text-sm text-text-primary shadow-lg"
             style={{ left: popup.x, top: popup.y - 12 }}
+            onClick={(ev) => ev.stopPropagation()}
           >
             <button
               onClick={closePopup}

--- a/web/components/map/MapViewer.tsx
+++ b/web/components/map/MapViewer.tsx
@@ -53,6 +53,14 @@ const mapChromeStyle = `
 .leaflet-popup-close-button:hover {
   color: var(--text-primary) !important;
 }
+/* Leaflet's stock ".leaflet-container a" blue outranks the Tailwind color
+   utilities on popup links; re-theme it onto the design tokens. */
+.leaflet-container .leaflet-popup-content a {
+  color: var(--primary-text);
+}
+.leaflet-container .leaflet-popup-content a:hover {
+  color: var(--primary);
+}
 .leaflet-bar a,
 .leaflet-bar a:hover {
   background: var(--card);
@@ -516,6 +524,7 @@ export function MapViewer({
           highlightObjectId={highlightObjectId}
           markerFilter={markerFilter}
           onMarkerClick={(marker, latLng) => setPopupState({ marker, latLng })}
+          onBackgroundClick={() => setPopupState(null)}
         />
 
         {/* Popup for clicked marker (standalone, rendered by React) */}


### PR DESCRIPTION
## Summary
Enhanced the marker display and popup interaction patterns across both FitsGL and Leaflet map implementations. Markers now use hollow ring glyphs colored by redshift quality, with improved visual hierarchy and interaction feedback.

## Key Changes

**FitsGL Map Surface (`FitsGLMapSurface.tsx`)**
- Changed marker shape from points to hollow circles (unfilled rings) to keep objects visible beneath the marker glyph
- Added edge width styling to markers (1.5px for normal, 2.5px for highlighted)
- Implemented z-order sorting for markers: dimmed non-matches at bottom, then ascending by redshift quality, with highlighted marker on top
- Added marker hover detection with pointer cursor feedback
- Implemented popup dismissal logic that distinguishes between marker clicks (which open popups) and background clicks (which close them)
- Added pan drag detection to prevent closing popups during drag operations
- Enhanced popup styling with explicit text color and click propagation prevention
- Updated marker comments to document the new hollow ring design and sorting strategy

**Canvas Marker Layer (`CanvasMarkerLayer.tsx`)**
- Removed fill pass from marker rendering, keeping only the stroke (hollow rings)
- Simplified highlighted marker rendering to use only stroke (larger white ring)
- Added `onBackgroundClick` callback prop to notify parent when background is clicked
- Updated comments to clarify the hollow ring design rationale

**Map Viewer (`MapViewer.tsx`)**
- Added CSS theming for Leaflet popup links to use design tokens instead of default blue
- Connected `onBackgroundClick` handler to dismiss popup state

## Implementation Details
- Marker z-order calculation: `highlighted ? 100 : (matches ? 10 : 0) + m.redshift_quality` ensures proper layering
- Pan drag detection uses a 5px threshold to distinguish clicks from drags
- Popup dismissal uses a ref flag to prevent the marker click event from immediately closing the popup it just opened
- Both map implementations now support hollow ring markers with consistent visual treatment

https://claude.ai/code/session_01BbB9n5KTV6wsNKg2JEHTv6