### PR TITLE
Guard against MAST /list_products returning empty 200 for existing filesets

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -29,6 +29,15 @@ Release procedure: edit the `## Unreleased` section below, then run
 ## Unreleased
 
 ### Infrastructure
+- `cfpipe download` no longer silently reports "No matching files found" when
+  MAST's `/list_products` returns an empty `200` for filesets the search just
+  matched. Under load (large programs whose product lists take ~30s to build),
+  MAST intermittently answers `200` with an empty `products` array instead of a
+  429/5xx; the batch was counted as a success and the run exited claiming zero
+  products. `list_products_batched` now raises a re-run-hint `RuntimeError` when
+  a non-empty set of filesets yields zero products, and the `download` CLI
+  catches `RuntimeError` to print it cleanly (this also fixes the pre-existing
+  "batches kept timing out" `RuntimeError` dumping a bare traceback).
 - Dependency declarations now match actual imports (#330): added `requests`,
   `h5py`, and `Pillow` (previously satisfied only transitively) plus the
   directly-imported JWST-stack packages (`crds`, `asdf`, `stdatamodels`,

--- a/pipeline/campfire_pipeline/cli.py
+++ b/pipeline/campfire_pipeline/cli.py
@@ -239,6 +239,11 @@ def download(program, instrument, obs_ids, filters, targets, radius, radius_unit
                 "is rejected by MAST's resolver."
             )
         raise click.ClickException(msg)
+    except RuntimeError as e:
+        # Transient MAST /list_products failures (batches that never stopped
+        # timing out, or an empty 200 for filesets that exist) surface as
+        # RuntimeError with a re-run hint — show it cleanly, not as a traceback.
+        raise click.ClickException(str(e))
     except KeyboardInterrupt:
         click.echo("\n\nInterrupted. Re-run to resume (existing files will be skipped).")
         sys.exit(130)

--- a/pipeline/campfire_pipeline/common/query.py
+++ b/pipeline/campfire_pipeline/common/query.py
@@ -292,6 +292,22 @@ def list_products_batched(filesets, batch_size=25, token=None, workers=4,
             f"the download command, or wait and retry when MAST is less loaded."
         )
 
+    # Every batch reported success (HTTP 200), yet not one product came back
+    # for filesets that the search just confirmed exist. That's not a genuine
+    # "no products" result — a fileset always has products — so MAST returned
+    # 200 with an empty `products` list, which it does intermittently when the
+    # endpoint is loaded (large programs whose product lists take ~30s to
+    # build). Treat it as the transient failure it is rather than silently
+    # reporting "no matching files."
+    if not all_products:
+        raise RuntimeError(
+            f"MAST /list_products returned 0 products for {len(fileset_names)} "
+            f"fileset(s) that the search matched — a fileset always has "
+            f"products, so this is a transient MAST failure (an empty 200 "
+            f"response), not an empty result. Try re-running the download "
+            f"command, or wait and retry when MAST is less loaded."
+        )
+
     return all_products
 
 


### PR DESCRIPTION
## Problem

`cfpipe download` intermittently reported `No matching files found. Exiting.` for data that exists on MAST. Repro from a real run:

```
cfpipe download --instrument nircam --program 1176 --obs-id 221
Found 16 filesets
  Retrieving product lists for 16 filesets (1 batches of up to 25, 1 parallel)...
  batches: 100%|██████████| 1/1 [00:30<00:00, 30.43s/batch]
  0 total products across 16 filesets
Selected 0 uncal files (0 B total)
No matching files found. Exiting.
```

The search found 16 real filesets, but `/list_products` returned 0 products for them — a logical impossibility, since a fileset always has products.

## Root cause

Program 1176 obs 221 is large — one `/list_products` batch pulls ~4928 products and takes ~30s server-side. Under load, MAST intermittently answers **HTTP 200 with an empty `products` array** instead of a proper 429/5xx. `_list_products_request` only retries on 429/5xx and network errors, so the empty 200 sailed through, the batch counted as a success (`1/1` progress bar), and the run exited claiming zero products. Re-running works — it's transient.

## Change

- `list_products_batched`: after the retry rounds complete, raise a re-run-hint `RuntimeError` when a **non-empty** set of filesets yields **zero** products. A legitimately-empty search (zero filesets) still short-circuits to `[]` at the top of the function, so it's unaffected. Guard is after-all-rounds only (no per-batch check).
- `download` CLI: catch `RuntimeError` and surface it as a clean `ClickException`. This also fixes a pre-existing rough edge — the "batches kept timing out" `RuntimeError` was previously escaping as a bare traceback.

Now the transient failure produces a clear, actionable message instead of a silent wrong-looking success.

## Testing

- Empty 200 for existing filesets → raises `RuntimeError` with re-run hint ✅
- Non-empty batch → returns products, no error ✅
- Empty input (no filesets) → returns `[]` without raising ✅
- Verified the live query for program 1176 obs 221 returns 16 filesets → 4928 products → 160 uncal files (the underlying data is fine).

## Changelog

Added an Infrastructure entry under `## Unreleased` (PATCH — no scientific-output change).

Generated with Claude Code