### PR TITLE
Push multiband trilogy weights imperatively to GPU

### DIFF
--- a/web/components/map/fitsgl/useDisplayStretch.ts
+++ b/web/components/map/fitsgl/useDisplayStretch.ts
@@ -145,6 +145,26 @@ export function useDisplayStretch({ handleRef, bands, state, readyTick }: UseDis
     }
   }, [trilogy, state, bandByName, handleRef, readyTick]);
 
+  // Push per-band trilogy weights imperatively (like the stretch handles). The
+  // viewer deliberately EXCLUDES the multiband weights from its source-rebuild
+  // signature (`viewSignature` in @fitsgl/core) — only a change to the *set* of
+  // bands forces a `setSource` — so a pure weight tweak on the same band set never
+  // reaches the GPU through the controlled `deriveViewerConfig` config. Mirror
+  // FitsGL's own <FitsExplorer> shell and re-push the weights here. `setBandWeights`
+  // requires the count to match the resident band set, so guard on the `multiband`
+  // source mode and absorb the one-frame race where a band-set change hasn't
+  // rebuilt the source yet (that pending `setSource` then carries the new weights).
+  useEffect(() => {
+    if (!state || !isTrilogyComposite(state)) return;
+    const v = handleRef.current?.getViewer();
+    if (!v || v.sourceMode !== 'multiband') return;
+    try {
+      v.setBandWeights(trilogyComposite(state).map((e) => e.weight));
+    } catch {
+      // band set mid-rebuild — the pending source swap carries the right weights
+    }
+  }, [state, handleRef, readyTick]);
+
   /** Fine-adjust: push one channel's black/white point to the GPU + store it. */
   const setHandle = useCallback(
     (key: ChannelKey, min: number, max: number) => {


### PR DESCRIPTION
## Summary
Add imperative weight synchronization for multiband trilogy composites to ensure GPU-side band weights stay in sync with UI state changes, mirroring the existing stretch handle behavior.

## Key Changes
- Added a new `useEffect` hook that imperatively pushes per-band trilogy weights to the viewer via `setBandWeights()`
- The effect guards on multiband source mode and handles the race condition where a band-set change hasn't yet rebuilt the source
- Weights are extracted from the trilogy composite state and pushed on each state or readyTick change
- Gracefully absorbs errors during band set rebuilds, relying on the pending source swap to carry the correct weights

## Implementation Details
The viewer deliberately excludes multiband weights from its source-rebuild signature, meaning weight-only changes on the same band set don't trigger GPU updates through the normal controlled config path. This mirrors FitsGL's own `<FitsExplorer>` shell by re-pushing weights imperatively, similar to how stretch handles are already managed. The implementation includes proper guards to ensure `setBandWeights()` is only called when the band count matches the resident band set.

https://claude.ai/code/session_01KcXi8Lds9RRUHW6SDJhEF9