### PR TITLE
fix(web): inspection color fix, plot shortcuts, download docs

### DIFF
--- a/web/components/spectra/SpectrumPlot.tsx
+++ b/web/components/spectra/SpectrumPlot.tsx
@@ -120,6 +120,11 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
   const [redshift, setRedshift] = useState(initialRedshift ?? 0);
   const [colorMin, setColorMin] = useState(spectrumPreferences.snrMin);
   const [colorMax, setColorMax] = useState(spectrumPreferences.snrMax);
+  // Auto-scale the 1D y-axis to real spectral features (computeYRange). On by
+  // default; toggling it off falls back to Plotly's full autorange so noise
+  // spikes and the full flux range are visible. The 'y' key toggles it in
+  // inspection mode (issue #245).
+  const [autoStretch, setAutoStretch] = useState(true);
 
   // Track observed wavelength range for rest-frame axis tick computation
   // null = full range (autorange), [min, max] = user-zoomed range in μm
@@ -142,6 +147,27 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
       setRedshift(initialRedshift);
     }
   }, [initialRedshift]);
+
+  // Inspection-mode plot shortcuts (issue #245): 'f' toggles flux units
+  // (fν ↔ fλ), 'y' toggles the 1D y-axis auto-stretch. Only wired in
+  // inspection mode, where exactly one SpectrumPlot is mounted; the remaining
+  // inspection shortcuts live in InspectionModeOverlay.
+  useEffect(() => {
+    if (!inspectionMode) return;
+    const handler = (e: KeyboardEvent) => {
+      const el = e.target as HTMLElement;
+      if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT') return;
+      if (e.key === 'f' || e.key === 'F') {
+        e.preventDefault();
+        setFluxUnit(prev => (prev === 'fnu' ? 'flambda' : 'fnu'));
+      } else if (e.key === 'y' || e.key === 'Y') {
+        e.preventDefault();
+        setAutoStretch(prev => !prev);
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [inspectionMode]);
 
   // Get current plot colors based on theme
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -516,8 +542,13 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
         exponentformat: 'e' as const,
         domain: [0, 0.7],
         anchor: 'x' as const,
-        uirevision: 'constant',
-        ...(yAxisRange && { range: yAxisRange }),
+        // Tie the y-axis uirevision to autoStretch so toggling it forces Plotly
+        // to re-apply the range/autorange below. A stable uirevision would
+        // otherwise preserve the user's current y-zoom and ignore the change.
+        uirevision: autoStretch ? 'y-auto' : 'y-full',
+        ...(autoStretch && yAxisRange
+          ? { range: yAxisRange, autorange: false as const }
+          : { autorange: true as const }),
       },
       // Y-axis for 2D heatmap (top-left)
       yaxis2: {
@@ -569,7 +600,7 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
     };
 
     return { traces, layout };
-  }, [data, processedData, fluxUnit, colorscale, colorMin, colorMax, accentColorHex, plotColors, showEmissionLines, redshift, grating, showModel, obsRange]);
+  }, [data, processedData, fluxUnit, colorscale, colorMin, colorMax, accentColorHex, plotColors, showEmissionLines, redshift, grating, showModel, obsRange, autoStretch]);
 
   // χ²(z) panel data — only built when the user toggles the Model overlay on.
   const chi2PlotData = useMemo(() => {
@@ -797,6 +828,22 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
               className="w-4 h-4 rounded border-border dark:border-border-strong text-primary focus:ring-primary"
             />
             <span className="text-sm text-text-secondary">Model</span>
+          </label>
+        </div>
+
+        {/* y-axis auto-stretch toggle (inspection shortcut: y) */}
+        <div className="flex items-center gap-2">
+          <label
+            className="flex items-center gap-2 cursor-pointer"
+            title="Auto-scale the y-axis to real spectral features; off shows the full flux range (press y in inspection mode)"
+          >
+            <input
+              type="checkbox"
+              checked={autoStretch}
+              onChange={(e) => setAutoStretch(e.target.checked)}
+              className="w-4 h-4 rounded border-border dark:border-border-strong text-primary focus:ring-primary"
+            />
+            <span className="text-sm text-text-secondary">Auto-y</span>
           </label>
         </div>
 

--- a/web/components/spectra/SpectrumPlot.tsx
+++ b/web/components/spectra/SpectrumPlot.tsx
@@ -157,6 +157,9 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
     const handler = (e: KeyboardEvent) => {
       const el = e.target as HTMLElement;
       if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.tagName === 'SELECT') return;
+      // Only plain F/Y are ours; let modifier combos (Ctrl/Cmd+F browser find,
+      // Cmd+Y, etc.) through untouched.
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
       if (e.key === 'f' || e.key === 'F') {
         e.preventDefault();
         setFluxUnit(prev => (prev === 'fnu' ? 'flambda' : 'fnu'));

--- a/web/components/spectra/inspection/KeyboardShortcutSheet.tsx
+++ b/web/components/spectra/inspection/KeyboardShortcutSheet.tsx
@@ -13,6 +13,8 @@ const SHORTCUTS = [
   { key: 'S', action: 'Save without advancing' },
   { key: 'Z', action: 'Focus redshift input' },
   { key: 'G', action: 'Cycle grating' },
+  { key: 'F', action: 'Toggle flux units (fν / fλ)' },
+  { key: 'Y', action: 'Toggle y-axis auto-stretch' },
   { key: 'Escape', action: 'Exit inspection mode' },
   { key: '?', action: 'Toggle this help' },
 ];

--- a/web/lib/docs/content/api/getting-started.md
+++ b/web/lib/docs/content/api/getting-started.md
@@ -70,6 +70,14 @@ Synced 146 observations, 3072 objects, 47340 spectra
 
 Re-running `cf.sync()` is fast and safe — it updates inspection results, redshifts, tags, and any new spectra. If files have been reprocessed on the server, you'll see a stale-count warning; re-fetch them with `cf.download(stale_only=True)`.
 
+To bulk-download FITS from the shell — rather than lazily on first access (see §7) — use `campfire download` (alias `campfire pull`):
+
+```bash
+campfire download --obs ember_uds_p4   # or --program / --field / --all, plus --grating / --stale / --dry-run
+```
+
+The full flag list lives in the [CLI Reference](/docs/api/cli#downloading-fits-files).
+
 ---
 
 ## 4. The mental model

--- a/web/lib/docs/content/api/index.md
+++ b/web/lib/docs/content/api/index.md
@@ -35,7 +35,10 @@ pip install \
 ```bash
 campfire login                    # browser-based OAuth
 campfire sync                     # pulls full catalog (metadata only, ~seconds)
+campfire download --obs ember_uds_p4   # bulk-fetch a selection's FITS (--program / --field / --all also work)
 ```
+
+`campfire download` (alias `campfire pull`) grabs FITS in bulk up front; the `Campfire` client below also downloads lazily on first access, so the bulk step is optional. See the [CLI Reference](/docs/api/cli#downloading-fits-files) for every filter and option.
 
 ```python
 from campfire import Campfire

--- a/web/lib/flags.ts
+++ b/web/lib/flags.ts
@@ -27,8 +27,8 @@ export interface QualityDef {
 export const REDSHIFT_QUALITY: QualityDef[] = [
   { value: 0, label: 'Not Inspected', short: 'None', icon: '⚪', color: '#e0e0e0', description: 'Not yet visually inspected' },
   { value: 1, label: 'Impossible', short: 'Bad', icon: '🔴', color: '#dc3545', description: 'Impossible to determine redshift from available data' },
-  { value: 2, label: 'Tentative', short: 'Tent.', icon: '🟠', color: '#ffc107', description: 'Redshift uncertain but plausible (~50% confidence)' },
-  { value: 3, label: 'Probable', short: 'Prob.', icon: '🟡', color: '#ff9800', description: 'Redshift likely correct (~80% confidence)' },
+  { value: 2, label: 'Tentative', short: 'Tent.', icon: '🟠', color: '#ff9800', description: 'Redshift uncertain but plausible (~50% confidence)' },
+  { value: 3, label: 'Probable', short: 'Prob.', icon: '🟡', color: '#ffc107', description: 'Redshift likely correct (~80% confidence)' },
   { value: 4, label: 'Secure', short: 'Secure', icon: '🟢', color: '#28a745', description: 'Redshift definitely correct (>95% confidence)' },
 ];
 


### PR DESCRIPTION
Address three low-hanging-fruit issues:

- #246: Swap the Tentative/Probable quality colors so they match the
  icon convention used everywhere else in the UI (Tentative orange,
  Probable yellow). The `color` hexes were reversed relative to the
  🟠/🟡 icons, so inspection-mode quality buttons and the list badge
  showed the wrong colors.

- #245: Add inspection-mode plot keyboard shortcuts — `f` toggles flux
  units (fν/fλ) and `y` toggles the 1D y-axis auto-stretch. `z` stays
  bound to "focus redshift input", so auto-stretch uses `y` instead of
  the originally-suggested `z`. Adds a visible "Auto-y" toggle for
  discoverability and documents both keys in the shortcut sheet.

- #350: Document the `campfire download` command (alias of `campfire
  pull`) in the Programmatic Access walkthrough pages, which previously
  showed login + sync and jumped straight to the Python client.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WZcCbFVkLjPDEXKJHcroq5