### PR TITLE
NIRCam outlier grow: deblend release, negative growth, edge-seed guards, two-color diagnostics

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -90,7 +90,36 @@ Release procedure: edit the `## Unreleased` section below, then run
   mosaic A/B shows arc contributions removed at their per-dither sky
   positions with only local one-dither depth cost). Wired in both outlier
   implementations; growth stats stamped into `CFP_OUT`. Additive: default
-  off leaves existing outputs unchanged.
+  off leaves existing outputs unchanged. Two follow-up guards (both on by
+  default when growth is enabled): **deblend release**
+  (`grow_deblend`) — each expanded region is photutils-deblended
+  (multi-threshold watershed on the smoothed residual) and children that
+  contain no seed pixels *and* peak >2x above the seeded artifact are
+  released, so a neighbouring galaxy whose isophotes touch the artifact's
+  wings keeps its depth (the peak-ratio criterion keeps the artifact's own
+  noise-split wing chunks masked); and **negative growth**
+  (`grow_negative`) — seeds sitting on negative residuals (oversubtracted
+  wisp/background regions; the base detection thresholds `|sci − blot|`,
+  so both signs seed) expand through connected pixels *below*
+  −`grow_expand_nsigma`·σ instead of above, rejecting oversubtraction
+  wings the same way positive artifact wings are. Self-limiting: if every
+  dither is oversubtracted identically the median matches them and no
+  seed forms. Additionally, growth seeds now form only from
+  weight-carrying pixels: OUTLIER pixels that were already DO_NOT_USE
+  before detection (exposure-edge trim) are excluded from seeding —
+  detection flags near-contiguous strips along the trimmed frame edges
+  (blot/median mismatch), and on rj0911 f200w those weightless strips
+  were seeding floods into real galaxies touching the exposure edges.
+  A geometric companion guard, `grow_edge_buffer` (default 50 px),
+  additionally stops any OUTLIER pixel that close to the frame edge from
+  seeding — saturated star cores falling near the edge are
+  detection-flagged on weight-carrying pixels and would otherwise flood
+  the star's own PSF wings (per-pixel exclusion, so a large artifact
+  reaching the edge still seeds from its deeper interior part).
+  The `*_outlier.pdf` diagnostics now draw waterfall-grown
+  pixels as a separate magenta overlay (detections stay yellow) with both
+  counts in the panel title — the campfire implementation previously
+  omitted grown pixels from the plot entirely.
 
 ### Infrastructure
 - Dependency declarations now match actual imports (#330): added `requests`,

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -501,11 +501,38 @@
     # own PSF wings) fall back to a plain grow_radius px dilation of the
     # seed. Grown px are flagged OUTLIER|DO_NOT_USE; depth cost is one
     # dither, confined to artifact neighbourhoods (<1% of frame).
+    #
+    # grow_deblend: photutils-deblend each expanded region (multi-threshold
+    # watershed on the smoothed residual) and release deblended children
+    # that contain no seed pixels AND peak >2x above the seeded artifact —
+    # neighbouring galaxies whose isophotes touch the artifact's wings keep
+    # their depth instead of being masked. The peak-ratio guard keeps the
+    # artifact's own noise-split wing chunks masked (watershed alone
+    # over-segments flat-topped elongated artifacts).
+    #
+    # grow_negative: seeds sitting on negative residuals (oversubtracted
+    # wisp/background regions — the base detection thresholds |sci-blot|,
+    # so both signs seed) expand through connected pixels *below*
+    # -grow_expand_nsigma sigma instead of above. Self-limiting: if every
+    # dither is oversubtracted identically the median matches them and no
+    # seed forms, so only exposures that disagree with the ensemble are
+    # rejected.
+    # grow_edge_buffer: OUTLIER pixels within this many px of the frame
+    # edge never seed growth (per-pixel; a large artifact reaching the
+    # edge still seeds from its deeper interior part). Detection flags
+    # near-contiguous strips along trimmed exposure edges and the
+    # saturated cores of stars falling near the edge — both would
+    # otherwise seed floods into real sources at the frame boundary.
+    # (Weightless pixels — already DO_NOT_USE before detection — are
+    # additionally always excluded from seeding, no knob.)
     grow_large_regions = false
     grow_min_area = 100
     grow_expand_nsigma = 1.5
     grow_max_factor = 40
     grow_radius = 12
+    grow_deblend = true
+    grow_negative = true
+    grow_edge_buffer = 50
     # implementation = "jwst" routes outlier detection through
     # `jwst.pipeline.calwebb_image3.Image3Pipeline` per visit (with
     # intra-program cross-visit overlap padding). "campfire" runs the

--- a/pipeline/campfire_pipeline/nircam/outlier_detect.py
+++ b/pipeline/campfire_pipeline/nircam/outlier_detect.py
@@ -194,6 +194,9 @@ def outlier_detect_for_visit(
             continue  # only flag and save the visit's own files
         with ImageModel(crf, memmap=False) as model:
             dq_before = (model.dq & OUTLIER_BIT) != 0
+            # weight-carrying state before detection: grow seeds must not
+            # form on pixels that were already DO_NOT_USE (edge trim)
+            dnu_before = (model.dq & pixel_flags['DO_NOT_USE']) != 0
             sci_for_plot = model.data.copy() if plot else None
             # Match jwst.outlier_detection.imaging.detect_outliers: pass
             # only median_sci. flag_resampled_model_crs falls back to the
@@ -213,13 +216,14 @@ def outlier_detect_for_visit(
 
             rootname = os.path.basename(crf).removesuffix('.fits')
             cfp_val = None
+            grow_added = None
             if grow is not None:
                 # lazy import: steps.outlier imports this module
                 from campfire_pipeline.nircam.steps.outlier import (
                     grow_outlier_regions,
                 )
-                n_large, n_added = grow_outlier_regions(
-                    model.data, model.dq, **grow)
+                n_large, n_added, grow_added = grow_outlier_regions(
+                    model.data, model.dq, preexisting_dnu=dnu_before, **grow)
                 cfp_val = (f'grow_large_regions: {n_large} regions, '
                            f'+{n_added} px')
                 if n_large:
@@ -233,12 +237,14 @@ def outlier_detect_for_visit(
 
             if plot:
                 from campfire_pipeline.nircam.steps._plots import plot_outlier
+                # dq_after was snapshotted before the grow, so new_outlier
+                # is detections only; grown pixels ride the second overlay
                 new_outlier = dq_after & ~dq_before
                 out_pdf = os.path.join(
                     os.path.dirname(crf), f'{rootname}_outlier.pdf',
                 )
                 plot_outlier(
-                    sci_for_plot, new_outlier,
+                    sci_for_plot, new_outlier, grown=grow_added,
                     save_file=out_pdf,
                     title=f'{rootname}: outlier (campfire)',
                 )

--- a/pipeline/campfire_pipeline/nircam/steps/_plots.py
+++ b/pipeline/campfire_pipeline/nircam/steps/_plots.py
@@ -134,7 +134,7 @@ def plot_diag_striping(sci_before, diag_model, residual_model, sci_after,
     plt.close(fig)
 
 
-def plot_outlier(sci, new_outlier, save_file=None, title=None):
+def plot_outlier(sci, new_outlier, grown=None, save_file=None, title=None):
     """Outlier-step diagnostic: SCI plus a side-panel with newly flagged pixels.
 
     Parameters
@@ -143,13 +143,17 @@ def plot_outlier(sci, new_outlier, save_file=None, title=None):
         SCI snapshot taken before outlier flagging (the array itself is
         unchanged by the step; only DQ is updated).
     new_outlier : 2D bool array
-        ``(DQ_after & OUTLIER) & ~(DQ_before & OUTLIER)`` — pixels this
-        run flagged that weren't already marked as outliers.
+        Pixels flagged by outlier *detection* this run (excludes ``grown``)
+        that weren't already marked as outliers.
+    grown : 2D bool array, optional
+        Pixels added by waterfall growth (``grow_outlier_regions``), drawn
+        in a different color (magenta) from the detections (yellow).
     """
     import matplotlib.pyplot as plt
 
     norm = ImageNormalize(sci, interval=ZScaleInterval())
     n_new = int(new_outlier.sum())
+    n_grown = 0 if grown is None else int(grown.sum())
 
     fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 5), tight_layout=True)
     ax1.imshow(sci, origin='lower', interpolation='none',
@@ -163,7 +167,13 @@ def plot_outlier(sci, new_outlier, save_file=None, title=None):
                                  np.ones_like(sci, dtype=float))
     ax2.imshow(overlay, origin='lower', interpolation='none',
                cmap='autumn', vmin=0, vmax=1, alpha=0.9)
-    ax2.set_title(f'New outliers ({n_new:,})')
+    panel_title = f'New outliers ({n_new:,})'
+    if grown is not None:
+        g = np.ma.masked_where(~grown, np.ones_like(sci, dtype=float))
+        ax2.imshow(g, origin='lower', interpolation='none',
+                   cmap='cool', vmin=0, vmax=1, alpha=0.9)
+        panel_title += f' + grown ({n_grown:,})'
+    ax2.set_title(panel_title)
     ax2.axis('off')
 
     if save_file is not None:

--- a/pipeline/campfire_pipeline/nircam/steps/outlier.py
+++ b/pipeline/campfire_pipeline/nircam/steps/outlier.py
@@ -56,9 +56,96 @@ from campfire_pipeline.nircam.manifest import (
 EXTRA_EXT_NAMES = ('SRCMASK', 'CFMASK')
 
 
+def _release_unseeded_children(work, expanded, seeds, npixels=25,
+                               nlevels=32, contrast=0.001, peak_ratio=2.0):
+    """Deblend expanded components and release distinct-source children.
+
+    Photutils multi-threshold watershed deblending on the (one-sign,
+    smoothed) residual: a neighbouring galaxy whose isophotes touch the
+    artifact's wings gets its own deblended child and is dropped from the
+    mask, while the artifact — whose peak owns the seed — is kept.
+
+    Watershed alone over-segments flat-topped elongated artifacts (noise
+    dips along a ridge create saddles), so unseeded children are NOT
+    released on segmentation alone: a child is released only when its peak
+    also exceeds ``peak_ratio`` x the brightest seeded child of the same
+    parent component. Artifact-wing chunks share the artifact's surface
+    brightness and stay masked; a distinct galaxy sticks out well above it
+    and is released. A galaxy fainter than the artifact stays masked — the
+    conservative direction (it was buried in the artifact anyway).
+    """
+    from scipy import ndimage
+
+    elab, en = ndimage.label(expanded)
+    if en == 0:
+        return expanded
+    data = np.where(expanded, np.maximum(work, 0.0), 0.0)
+    try:
+        from photutils.segmentation import SegmentationImage, deblend_sources
+        deb = deblend_sources(
+            data, SegmentationImage(elab), npixels=npixels, nlevels=nlevels,
+            contrast=contrast, mode='linear', progress_bar=False,
+        )
+    except Exception as exc:  # never let a deblend hiccup kill the step
+        log(f"  outlier grow: deblend failed ({exc}); keeping full expansion")
+        return expanded
+
+    child_ids = np.arange(1, deb.max_label + 1)
+    peaks = np.atleast_1d(ndimage.maximum(data, deb.data, child_ids))
+    # children partition parents, so elab is constant over each child
+    parent_of = np.atleast_1d(
+        ndimage.maximum(elab, deb.data, child_ids)).astype(int)
+    seeded = np.zeros(deb.max_label + 1, dtype=bool)
+    seeded[np.unique(deb.data[seeds & (deb.data > 0)])] = True
+
+    ref_peak = {}  # parent id -> brightest seeded-child peak
+    for i, cid in enumerate(child_ids):
+        if seeded[cid]:
+            p = parent_of[i]
+            ref_peak[p] = max(ref_peak.get(p, 0.0), peaks[i])
+
+    keep = seeded.copy()
+    for i, cid in enumerate(child_ids):
+        if not seeded[cid] and \
+                peaks[i] <= peak_ratio * ref_peak.get(parent_of[i], np.inf):
+            keep[cid] = True
+    return keep[deb.data]
+
+
+def _expand_seeds(work, sig, seeds, expand_nsigma, max_factor,
+                  fallback_radius, deblend):
+    """One-sign waterfall expansion with deblend release and growth cap.
+
+    Floods ``seeds`` through connected pixels of ``work`` above
+    ``expand_nsigma``·``sig`` (callers pass ``-work`` for negative seeds),
+    optionally releases deblended children that contain no seed pixels,
+    then applies the per-component ``max_factor`` growth cap with the
+    ``fallback_radius`` EDT-dilation fallback.
+    """
+    from scipy.ndimage import binary_propagation, distance_transform_edt, label
+
+    above = (work > expand_nsigma * sig) | seeds
+    expanded = binary_propagation(seeds, mask=above)
+    if deblend:
+        expanded = _release_unseeded_children(work, expanded, seeds)
+
+    elab, en = label(expanded)
+    final = np.zeros_like(expanded)
+    for cid in range(1, en + 1):
+        comp = elab == cid
+        seed_area = np.count_nonzero(comp & seeds)
+        if seed_area == 0:
+            continue
+        if np.count_nonzero(comp) > max_factor * seed_area:
+            comp = distance_transform_edt(~(comp & seeds)) <= fallback_radius
+        final |= comp
+    return final
+
+
 def grow_outlier_regions(sci, dq, min_area=100, expand_nsigma=1.5,
                          max_factor=40, fallback_radius=12.0, smooth=2.0,
-                         skirt=2.0):
+                         skirt=2.0, negative=True, deblend=True,
+                         preexisting_dnu=None, edge_buffer=50):
     """Waterfall (hysteresis) expansion of large OUTLIER DQ regions.
 
     Detector-fixed artifacts (scattered-light arcs, glints) move on-sky
@@ -74,8 +161,21 @@ def grow_outlier_regions(sci, dq, min_area=100, expand_nsigma=1.5,
     Requires a flat background (the bkg step's conditioning/applied chain
     provides it), since the expansion threshold is global.
 
-    Two guards:
+    Seeds are split by the sign of the smoothed residual they sit on (the
+    base detection thresholds ``|sci - blot|``, so both signs seed): positive
+    seeds (scattered light, glints) expand through pixels *above*
+    +``expand_nsigma``·sigma, and — when ``negative`` is on — negative seeds
+    (oversubtracted wisp/background regions) expand through pixels *below*
+    −``expand_nsigma``·sigma. With ``negative=False`` all seeds expand on
+    the positive side (the pre-sign-split behavior).
 
+    Three guards:
+
+    * **Deblend release** (``deblend``) — each expanded component is
+      photutils-deblended on the smoothed residual; children that contain
+      no seed pixels *and* peak clearly above the seeded artifact
+      (neighbouring galaxies picked up by the flood) are released from the
+      mask. See ``_release_unseeded_children``.
     * **Growth cap** — a seed on a bright star floods the star's own PSF
       halo. Any expanded component larger than ``max_factor`` x its seed
       area is discarded and replaced by a plain EDT dilation of the seed by
@@ -84,47 +184,75 @@ def grow_outlier_regions(sci, dq, min_area=100, expand_nsigma=1.5,
     * **Skirt** — a final ``skirt`` px dilation covers the sub-threshold
       edge of the expansion.
 
+    ``preexisting_dnu`` (boolean mask) marks pixels that were DO_NOT_USE
+    *before* outlier detection ran (exposure-edge trim, bad pixels). Those
+    pixels carry no weight in the drizzle, so flagging them as OUTLIER
+    changes nothing in the mosaic — and they must not drive expansion:
+    outlier detection flags near-contiguous strips along the trimmed
+    exposure edges (blot/median mismatch at the frame boundary), and
+    without this exclusion any strip over ``min_area`` seeds a flood into
+    whatever real galaxy touches the frame edge. Seeds are therefore
+    formed only from weight-carrying OUTLIER pixels; a genuine artifact
+    overlapping the trim still seeds from its interior bulk, and its
+    flood can re-enter the trimmed zone through above-threshold wings.
+
+    ``edge_buffer`` extends the same idea geometrically: OUTLIER pixels
+    within ``edge_buffer`` px of the frame edge never seed. Saturated
+    star cores falling near the exposure edge get detection-flagged
+    (saturation is unstable between dithers) on weight-carrying pixels
+    the DNU exclusion can't catch, and would otherwise flood the star's
+    own PSF wings. Exclusion is per-pixel, so a large artifact reaching
+    the edge still seeds from the part of it deeper than the buffer.
+
     Grown pixels are flagged OUTLIER|DO_NOT_USE in ``dq`` (in place).
-    Returns ``(n_large_seeds, n_added_px)``.
+    Returns ``(n_large_seeds, n_added_px, added_mask)`` where ``added_mask``
+    is the boolean array of newly flagged pixels (None when no large seeds).
     """
     from astropy.stats import mad_std
     from jwst.datamodels.dqflags import pixel as pf
-    from scipy.ndimage import (binary_propagation, distance_transform_edt,
-                               gaussian_filter, label)
+    from scipy.ndimage import distance_transform_edt, gaussian_filter, label
 
     outlier = (dq & pf['OUTLIER']) != 0
-    lab, nlab = label(outlier)
+    seedable = outlier if preexisting_dnu is None \
+        else outlier & ~preexisting_dnu
+    if edge_buffer > 0:
+        b = int(edge_buffer)
+        interior = np.zeros_like(outlier)
+        interior[b:-b, b:-b] = True
+        seedable = seedable & interior
+    lab, nlab = label(seedable)
     if nlab == 0:
-        return 0, 0
+        return 0, 0, None
     areas = np.bincount(lab.ravel())[1:]
     large_ids = np.flatnonzero(areas >= min_area) + 1
     if large_ids.size == 0:
-        return 0, 0
-    seeds = np.isin(lab, large_ids)
+        return 0, 0, None
 
     work = gaussian_filter(
         np.nan_to_num(sci - np.nanmedian(sci), nan=0.0), smooth)
     sig = mad_std(work, ignore_nan=True)
-    above = (work > expand_nsigma * sig) | seeds
-    expanded = binary_propagation(seeds, mask=above)
 
-    # per-component growth cap
-    elab, en = label(expanded)
-    final = np.zeros_like(expanded)
-    for cid in range(1, en + 1):
-        comp = elab == cid
-        seed_area = np.count_nonzero(comp & seeds)
-        if seed_area == 0:
-            continue
-        if np.count_nonzero(comp) > max_factor * seed_area:
-            comp = distance_transform_edt(~(comp & seeds)) <= fallback_radius
-        final |= comp
+    pos_seeds = np.zeros_like(outlier)
+    neg_seeds = np.zeros_like(outlier)
+    for cid in large_ids:
+        comp = lab == cid
+        if negative and np.median(work[comp]) < 0:
+            neg_seeds |= comp
+        else:
+            pos_seeds |= comp
+
+    final = np.zeros_like(outlier)
+    for w, seeds in ((work, pos_seeds), (-work, neg_seeds)):
+        if seeds.any():
+            final |= _expand_seeds(w, sig, seeds, expand_nsigma,
+                                   max_factor, fallback_radius, deblend)
+
     if skirt > 0:
         final = distance_transform_edt(~final) <= skirt
 
     added = final & ~outlier
     dq[added] |= (pf['OUTLIER'] | pf['DO_NOT_USE'])
-    return int(large_ids.size), int(added.sum())
+    return int(large_ids.size), int(added.sum()), added
 
 
 def _grow_kwargs(step_config):
@@ -134,6 +262,9 @@ def _grow_kwargs(step_config):
         expand_nsigma=float(step_config.get('grow_expand_nsigma', 1.5)),
         max_factor=float(step_config.get('grow_max_factor', 40)),
         fallback_radius=float(step_config.get('grow_radius', 12)),
+        negative=bool(step_config.get('grow_negative', True)),
+        deblend=bool(step_config.get('grow_deblend', True)),
+        edge_buffer=int(step_config.get('grow_edge_buffer', 50)),
     )
 
 
@@ -391,9 +522,19 @@ def outlier_step(visit, visit_files, filter_files, sregions,
 
             with ImageModel(scratch_out) as model:
                 cfp_val = None
+                grow_added = None
                 if step_config.get('grow_large_regions', False):
-                    n_large, n_added = grow_outlier_regions(
-                        model.data, model.dq, **_grow_kwargs(step_config))
+                    # canonical on disk is still pre-outlier here: its DQ
+                    # gives the weight-carrying state before detection, so
+                    # grow seeds skip pixels already DO_NOT_USE (edge trim)
+                    from jwst.datamodels.dqflags import pixel as pf
+                    dnu_before = (
+                        (fits.getdata(canonical, 'DQ') & pf['DO_NOT_USE'])
+                        != 0
+                    )
+                    n_large, n_added, grow_added = grow_outlier_regions(
+                        model.data, model.dq, preexisting_dnu=dnu_before,
+                        **_grow_kwargs(step_config))
                     cfp_val = (f'grow_large_regions: {n_large} regions, '
                                f'+{n_added} px')
                     if n_large:
@@ -414,11 +555,13 @@ def outlier_step(visit, visit_files, filter_files, sregions,
                     ((dq_after & OUTLIER_BIT) != 0)
                     & ~((dq_before & OUTLIER_BIT) != 0)
                 )
+                if grow_added is not None:
+                    new_outlier &= ~grow_added
                 out_pdf = os.path.join(
                     os.path.dirname(canonical), f'{rootname}_outlier.pdf',
                 )
                 plot_outlier(
-                    sci_before, new_outlier,
+                    sci_before, new_outlier, grown=grow_added,
                     save_file=out_pdf,
                     title=f'{rootname}: outlier (jwst)',
                 )

--- a/pipeline/tests/test_nircam_outlier_grow.py
+++ b/pipeline/tests/test_nircam_outlier_grow.py
@@ -37,10 +37,11 @@ def test_waterfall_follows_ridge_and_ignores_crs():
         y, x = rng.integers(0, 512, 2)
         dq[y, x] |= pf['OUTLIER']
 
-    n_large, n_added = grow_outlier_regions(sci, dq, min_area=100,
-                                            expand_nsigma=1.5)
+    n_large, n_added, added = grow_outlier_regions(sci, dq, min_area=100,
+                                                   expand_nsigma=1.5)
     assert n_large == 1
     assert n_added > 0
+    assert added is not None and int(added.sum()) == n_added
     masked = (dq & pf['DO_NOT_USE']) != 0
     # the expansion escapes the seed and covers most of the bright ridge...
     assert masked[ridge_bright].mean() > 0.6
@@ -78,6 +79,190 @@ def test_noop_without_large_components():
     for _ in range(300):
         y, x = rng.integers(0, 512, 2)
         dq[y, x] |= pf['OUTLIER']
-    n_large, n_added = grow_outlier_regions(sci, dq, min_area=100)
-    assert n_large == 0 and n_added == 0
+    n_large, n_added, added = grow_outlier_regions(sci, dq, min_area=100)
+    assert n_large == 0 and n_added == 0 and added is None
     assert ((dq & pf['DO_NOT_USE']) != 0).sum() == 0
+
+
+def test_deblend_releases_touching_galaxy():
+    """A galaxy whose isophotes touch the artifact's above-threshold wings
+    must be released by deblending, not swallowed by the flood."""
+    sci, dq, _ = _scene(3)
+    yy, xx = np.mgrid[0:512, 0:512]
+    # artifact: horizontal ridge; its above-threshold corridor overlaps the
+    # galaxy's outer isophotes (connected flood path through faint wings,
+    # with a genuine saddle between ridge and galaxy peaks)
+    ridge = 4 * SIG * np.exp(-0.5 * ((yy - 256.0) / 6.0) ** 2) \
+        * ((xx > 100) & (xx < 235))
+    # galaxy: compact source offset from the ridge axis, clearly brighter
+    # than the artifact (peak-ratio release criterion)
+    rr2_gal = (yy - 277.0) ** 2 + (xx - 200.0) ** 2
+    gal = 15 * SIG * np.exp(-0.5 * rr2_gal / 6.0 ** 2)
+    sci += ridge + gal
+
+    seed = (xx > 110) & (xx < 150) & (np.abs(yy - 256) < 4)
+    assert seed.sum() >= 100
+
+    gal_core = rr2_gal <= 4 ** 2
+    ridge_bright = ridge > 2 * SIG
+
+    # without the deblend guard the flood swallows the galaxy
+    dq_off = dq.copy()
+    dq_off[seed] |= pf['OUTLIER']
+    grow_outlier_regions(sci, dq_off, min_area=100, expand_nsigma=1.5,
+                         deblend=False)
+    masked_off = (dq_off & pf['DO_NOT_USE']) != 0
+    assert masked_off[gal_core].mean() > 0.9
+
+    # with it, the galaxy's deblended child is released; ridge still masked
+    dq[seed] |= pf['OUTLIER']
+    grow_outlier_regions(sci, dq, min_area=100, expand_nsigma=1.5,
+                         deblend=True)
+    masked = (dq & pf['DO_NOT_USE']) != 0
+    assert masked[gal_core].mean() < 0.1
+    assert masked[ridge_bright].mean() > 0.6
+
+
+def test_negative_seed_expands_through_negative_wings():
+    """A large seed on an oversubtracted (negative) region expands through
+    the negative wings; with negative=False it stays confined to the seed."""
+    sci, dq, _ = _scene(4)
+    yy, xx = np.mgrid[0:512, 0:512]
+    hole_flux = -4 * SIG * np.exp(
+        -0.5 * (((yy - 256.0) / 30.0) ** 2 + ((xx - 256.0) / 12.0) ** 2))
+    sci += hole_flux
+    deep = hole_flux < -2 * SIG
+
+    seed = (np.abs(yy - 256) < 20) & (np.abs(xx - 256) < 8)
+    dq[seed] |= pf['OUTLIER']
+    assert seed.sum() >= 100
+
+    dq_off = dq.copy()
+    n_large, n_added, added = grow_outlier_regions(sci, dq, min_area=100,
+                                                   expand_nsigma=1.5)
+    assert n_large == 1 and n_added > 0
+    masked = (dq & pf['DO_NOT_USE']) != 0
+    assert masked[deep].mean() > 0.6
+
+    _, n_added_off, _ = grow_outlier_regions(sci, dq_off, min_area=100,
+                                             expand_nsigma=1.5,
+                                             negative=False)
+    assert n_added_off < n_added / 10
+
+
+def test_edge_strip_does_not_seed():
+    """OUTLIER strips on already-DO_NOT_USE exposure edges (blot/median
+    mismatch at the frame boundary) must not seed expansion into real
+    galaxies touching the edge — rj0911 f200w regression."""
+    sci, dq, _ = _scene(5)
+    yy, xx = np.mgrid[0:512, 0:512]
+    # bright galaxy touching the left edge (isophotes cross the trim zone)
+    rr2_gal = (yy - 256.0) ** 2 + (xx - 12.0) ** 2
+    sci += 20 * SIG * np.exp(-0.5 * rr2_gal / 8.0 ** 2)
+    gal_core = rr2_gal <= 5 ** 2
+
+    # edge trim: outer 4 px are DO_NOT_USE before outlier detection
+    trim = np.zeros((512, 512), bool)
+    trim[:4, :] = trim[-4:, :] = trim[:, :4] = trim[:, -4:] = True
+    # detection flags a contiguous strip along the trimmed left edge
+    strip = (xx < 2)
+    dq[strip] |= pf['OUTLIER']
+    assert strip.sum() >= 100
+
+    # without either guard the strip seeds and floods the galaxy
+    # (edge_buffer=0 isolates the DNU exclusion from the geometric buffer)
+    dq_bug = dq.copy()
+    n_bug, _, _ = grow_outlier_regions(sci, dq_bug, min_area=100,
+                                       expand_nsigma=1.5, edge_buffer=0)
+    assert n_bug >= 1
+    assert (((dq_bug & pf['DO_NOT_USE']) != 0)[gal_core]).mean() > 0.9
+
+    # with it, the weightless strip cannot seed: nothing grows
+    n_large, n_added, added = grow_outlier_regions(
+        sci, dq, min_area=100, expand_nsigma=1.5, preexisting_dnu=trim,
+        edge_buffer=0)
+    assert n_large == 0 and n_added == 0 and added is None
+    assert (((dq & pf['DO_NOT_USE']) != 0)[gal_core]).sum() == 0
+
+
+def test_edge_buffer_excludes_near_edge_seeds():
+    """A saturated star core flagged near the frame edge (weight-carrying,
+    so the DNU exclusion can't catch it) must not seed a flood into the
+    star's own PSF wings; interior artifacts in the same frame still grow."""
+    sci, dq, _ = _scene(7)
+    yy, xx = np.mgrid[0:512, 0:512]
+    # bright star whose core sits 30 px from the top edge
+    rr2_star = (yy - 482.0) ** 2 + (xx - 256.0) ** 2
+    sci += 100 * SIG * np.exp(-0.5 * rr2_star / 25.0 ** 2)
+    star_seed = rr2_star <= 12 ** 2
+    dq[star_seed] |= pf['OUTLIER']
+    assert star_seed.sum() >= 100
+
+    # interior artifact ridge, far from the star
+    ridge_flux = 4 * SIG * np.exp(-0.5 * ((yy - 150.0) / 6.0) ** 2) \
+        * ((xx > 100) & (xx < 400))
+    sci += ridge_flux
+    ridge_seed = (xx > 150) & (xx < 190) & (np.abs(yy - 150) < 4)
+    dq[ridge_seed] |= pf['OUTLIER']
+    assert ridge_seed.sum() >= 100
+
+    n_large, n_added, _ = grow_outlier_regions(sci, dq, min_area=100,
+                                               expand_nsigma=1.5)
+    masked = (dq & pf['DO_NOT_USE']) != 0
+    # star wings untouched (only the pre-flagged core stays OUTLIER)
+    star_wings = (rr2_star <= 60 ** 2) & ~star_seed
+    assert n_large == 1
+    assert masked[star_wings].mean() < 0.05
+    assert masked[ridge_flux > 2 * SIG].mean() > 0.6
+
+    # with the buffer off, the star seed floods its own PSF wings
+    dq2 = np.zeros_like(dq)
+    dq2[star_seed] |= pf['OUTLIER']
+    grow_outlier_regions(sci, dq2, min_area=100, expand_nsigma=1.5,
+                         edge_buffer=0)
+    assert (((dq2 & pf['DO_NOT_USE']) != 0)[star_wings]).mean() > 0.3
+
+
+def test_interior_artifact_still_seeds_with_dnu_trim():
+    """The DNU-seed exclusion must not disable growth for genuine interior
+    artifacts (with an edge trim present, as in production)."""
+    sci, dq, _ = _scene(6)
+    yy, xx = np.mgrid[0:512, 0:512]
+    ridge_flux = 4 * SIG * np.exp(-0.5 * ((yy - 256.0) / 6.0) ** 2) \
+        * ((xx > 100) & (xx < 400))
+    sci += ridge_flux
+
+    trim = np.zeros((512, 512), bool)
+    trim[:4, :] = trim[-4:, :] = trim[:, :4] = trim[:, -4:] = True
+
+    seed = (xx > 150) & (xx < 190) & (np.abs(yy - 256) < 4)
+    dq[seed] |= pf['OUTLIER']
+    assert seed.sum() >= 100
+
+    n_large, n_added, _ = grow_outlier_regions(
+        sci, dq, min_area=100, expand_nsigma=1.5, preexisting_dnu=trim)
+    assert n_large == 1 and n_added > 0
+    masked = (dq & pf['DO_NOT_USE']) != 0
+    assert masked[ridge_flux > 2 * SIG].mean() > 0.6
+
+
+def test_plot_outlier_grown_overlay(tmp_path):
+    """plot_outlier renders detected + grown overlays without error."""
+    import matplotlib
+    matplotlib.use('Agg')
+    from campfire_pipeline.nircam.steps._plots import plot_outlier
+
+    rng = np.random.default_rng(5)
+    sci = rng.normal(0, SIG, (64, 64))
+    detected = np.zeros((64, 64), bool)
+    detected[10:14, 10:14] = True
+    grown = np.zeros((64, 64), bool)
+    grown[14:20, 10:14] = True
+
+    out = tmp_path / 'outlier.pdf'
+    plot_outlier(sci, detected, grown=grown, save_file=str(out), title='t')
+    assert out.exists() and out.stat().st_size > 0
+    # grown=None keeps the pre-grow single-overlay behavior
+    out2 = tmp_path / 'outlier2.pdf'
+    plot_outlier(sci, detected, save_file=str(out2))
+    assert out2.exists() and out2.stat().st_size > 0


### PR DESCRIPTION
Follow-ups to the waterfall expansion of large OUTLIER regions (#404), plus two guards fixing seeding bugs found during validation — both present in #404 as merged.

## Features

- **Two-color `outlier.pdf` diagnostics** — waterfall-grown pixels are drawn as a magenta overlay distinct from the yellow detections, with both counts in the panel title. Also fixes a bug where the campfire implementation snapshotted DQ *before* the grow ran, so grown pixels never appeared in its plots at all.
- **Deblend release** (`grow_deblend`, default on) — each expanded region is photutils-deblended (multi-threshold watershed on the smoothed residual); children containing no seed pixels **and** peaking >2× above the seeded child are released, so a neighbouring galaxy whose isophotes touch the artifact's wings keeps its depth. The peak-ratio criterion is load-bearing: watershed alone over-segments flat-topped elongated artifacts at noise saddles and would release the artifact's own wing chunks.
- **Negative growth** (`grow_negative`, default on) — seeds are split by the sign of the smoothed residual they sit on (the base stcal detection already thresholds `|sci − blot|`, so both signs seed); negative seeds (oversubtracted wisp/background regions) expand through pixels *below* −nσ. Self-limiting: identically-oversubtracted dithers match the median and never seed.

## Guards (bug fixes)

- **Weight-carrying seeds only** — outlier detection flags near-contiguous strips along the trimmed exposure edges (blot/median mismatch at the frame boundary; 38% of the 2-px border on rj0911 f200w, 100% `DO_NOT_USE` pre-detection). Those weightless strips exceeded `grow_min_area` and were seeding floods into **every real galaxy touching a frame edge, on all 32 f200w exposures**. Seeds now form only from pixels that were not already `DO_NOT_USE` before detection (`preexisting_dnu` plumbed through both implementations).
- **`grow_edge_buffer`** (default 50 px) — OUTLIER pixels within the buffer of the frame edge never seed. Catches saturated star cores falling near the edge: they're flagged on weight-carrying pixels (so the DNU guard can't see them) and were flooding the star's own PSF wings. Per-pixel exclusion, so a large artifact reaching the edge still seeds from its interior bulk.

## Validation (rj0911 f200w, full combine A/B)

- Grow now fires on **4/32 exposures** (was 32/32): the four nrcb2 dithers carrying the genuine transient glint streak, with per-exposure masked-pixel counts unchanged by the guards. Detection itself byte-identical (734,700 px).
- Mosaic A/B vs the pre-fix baseline: **413,724 px regained >25% weight** (released edge galaxies + star wings, ~1% of the field), **zero pixels lost >25%, zero new zero-weight holes**, median weight ratio 1.0000.
- `grow_negative` never fired on this field — the mild NMF wisp oversubtraction visible on nrcb4 stays below the detection seed threshold (seed starvation). Needs a strong-oversubtraction field for a real test.
- Tests: 6 new (deblend release, negative growth, both guards in isolation, plot smoke test); full pipeline suite 420/420.

## Notes

- Changelog: extends the existing `## Unreleased` Algorithm entry from #404 (not yet tagged).
- All defaults only take effect where `grow_large_regions` is enabled (still off by default); rj0911 has it on in fields.toml.
- Deploy caveat: any grow-enabled filter already reduced with #404 (e.g. the rj0911 F444W validation mosaic) has edge galaxies masked in single dithers and should be recombined with this fix before deploy.

Generated with Claude Code