### PR TITLE
Onboarding hardening: secure access-code redemption + UX/API/CLI fixes

### DIFF
--- a/python/campfire/cli.py
+++ b/python/campfire/cli.py
@@ -6,9 +6,8 @@ Provides commands for authentication, catalog sync, and FITS downloading:
 - campfire logout: Remove stored credentials
 - campfire whoami: Show current authenticated user
 - campfire status: Check credentials, catalog, and download status
-- campfire observations: List available observations
 - campfire sync: Sync the full object catalog (metadata only)
-- campfire download: Download FITS spectrum files
+- campfire pull: Download FITS spectrum files (`download` is a back-compat alias)
 """
 
 import shutil
@@ -157,13 +156,20 @@ def _check_client_version(base_url: str) -> None:
         latest = Version(data.get("latest", __version__))
         minimum = Version(data.get("minimum", "0.0.0"))
 
+        # campfire-layout isn't on PyPI, so the upgrade command must supply it
+        # alongside the client or pip fails to resolve the dependency.
+        upgrade_cmd = (
+            "  pip install -U "
+            '"campfire-layout @ git+https://github.com/hollisakins/campfire.git#subdirectory=layout" '
+            '"campfire @ git+https://github.com/hollisakins/campfire.git#subdirectory=python"'
+        )
         if current < minimum:
             click.echo(f"\n⚠ campfire v{__version__} is no longer supported "
                         f"(minimum: v{minimum}). Please update:")
-            click.echo("  pip install -U git+https://github.com/hollisakins/campfire.git#subdirectory=python")
+            click.echo(upgrade_cmd)
         elif current < latest:
             click.echo(f"\n  Update available: v{__version__} → v{latest}")
-            click.echo("  pip install -U git+https://github.com/hollisakins/campfire.git#subdirectory=python")
+            click.echo(upgrade_cmd)
     except Exception:
         pass  # Never block sync for a version check failure
 
@@ -258,6 +264,13 @@ def login(browser: Optional[bool], base_url: Optional[str]):
 
     # Determine authentication method
     if browser is None:
+        if not sys.stdin.isatty():
+            raise click.ClickException(
+                "No interactive terminal to choose an authentication method. "
+                "Run 'campfire login --browser' (device flow; works over SSH — "
+                "open the printed URL on any machine) or "
+                "'campfire login --api-key' to paste an API key."
+            )
         click.echo("\nHow would you like to authenticate?")
         click.echo("  1. Login with web browser (recommended)")
         click.echo("  2. Paste an API key")
@@ -670,7 +683,7 @@ def sync_cmd(full: bool, base_url: Optional[str], migrate_layout: Optional[bool]
 
         if result["stale_count"] > 0:
             click.echo(f"\n⚠ {result['stale_count']} local file(s) have been updated on the server.")
-            click.echo("  Run: campfire download --stale")
+            click.echo("  Run: campfire pull --stale")
 
         # Check for client updates (non-blocking)
         _check_client_version(base_url)

--- a/python/campfire/cli.py
+++ b/python/campfire/cli.py
@@ -156,20 +156,23 @@ def _check_client_version(base_url: str) -> None:
         latest = Version(data.get("latest", __version__))
         minimum = Version(data.get("minimum", "0.0.0"))
 
-        # campfire-layout isn't on PyPI, so the upgrade command must supply it
-        # alongside the client or pip fails to resolve the dependency.
-        upgrade_cmd = (
-            "  pip install -U "
+        # Two supported install paths, and the CLI can't tell which one it came
+        # from: a repo checkout updates via install.py, while a pip-from-git
+        # install must supply campfire-layout alongside the client (it isn't on
+        # PyPI, so the single-package form can never resolve).
+        upgrade_lines = (
+            "  repo checkout:  git pull && python3 install.py\n"
+            "  pip install:    pip install -U "
             '"campfire-layout @ git+https://github.com/hollisakins/campfire.git#subdirectory=layout" '
             '"campfire @ git+https://github.com/hollisakins/campfire.git#subdirectory=python"'
         )
         if current < minimum:
             click.echo(f"\n⚠ campfire v{__version__} is no longer supported "
                         f"(minimum: v{minimum}). Please update:")
-            click.echo(upgrade_cmd)
+            click.echo(upgrade_lines)
         elif current < latest:
             click.echo(f"\n  Update available: v{__version__} → v{latest}")
-            click.echo(upgrade_cmd)
+            click.echo(upgrade_lines)
     except Exception:
         pass  # Never block sync for a version check failure
 

--- a/python/campfire/config.py
+++ b/python/campfire/config.py
@@ -5,8 +5,8 @@ Data directory resolution order:
   2. ``~/campfire``
 
 Layout within the data directory:
-  - ``products/<obs>/``  — FITS files (mirrors pipeline structure)
-  - ``meta/``            — campfire.db, objects.csv, spectra.csv
+  - ``products/nirspec/<obs>/``  — FITS files (mirrors pipeline structure)
+  - ``meta/``  — campfire.db, objects.csv, spectra.csv, photometry.csv
 
 Credentials are stored separately in ``~/.campfire/credentials``.
 """

--- a/python/campfire/plotting.py
+++ b/python/campfire/plotting.py
@@ -13,8 +13,9 @@ try:
     from plotly.subplots import make_subplots
 except ImportError:
     raise ImportError(
-        "Plotting functionality requires plotly. "
-        "Install with: pip install plotly"
+        "Interactive plotting requires the [plotting] extra. "
+        "Install with: pip install 'campfire[plotting]' (or: pip install plotly). "
+        "For a quick matplotlib plot without plotly, use SpectrumData.plot()."
     )
 
 
@@ -277,7 +278,7 @@ def plot_spectrum(
     >>> from campfire.plotting import plot_spectrum
     >>>
     >>> cf = Campfire()
-    >>> data = cf.get_spectrum_data('ember_uds_p4_123456', 'PRISM')
+    >>> data = cf.get_spectrum_data('ember_uds_p4_123456')
     >>> fig = plot_spectrum(data, redshift=2.5, show_emission_lines=True)
     >>> fig.show()
     """

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -46,10 +46,6 @@ dependencies = [
     "photutils>=1.13",
     "reproject",
     "Pillow>=10.0",
-    # Deploy DB operations
-    "supabase>=2.0",
-    # Deploy R2 uploads (will be replaced by presigned URLs in future)
-    "boto3>=1.28",
 ]
 
 [project.scripts]
@@ -72,6 +68,12 @@ deploy = [
     # it locally. See the repo-root install.py, which installs this profile in
     # the right order.
     "campfire-pipeline",
+    # Deploy DB operations. Base-install code paths that touch these (e.g. the
+    # annotation half of `campfire pull`) already degrade gracefully when the
+    # import fails, so consumers never need them.
+    "supabase>=2.0",
+    # Deploy R2 uploads (will be replaced by presigned URLs in future)
+    "boto3>=1.28",
     # calibration.py prefers spectres for flux-conserving resampling (falls back
     # to interpolation without it); deploy-side stacking should have the real thing.
     "spectres>=2.2",

--- a/supabase/migrations/20260719120000_secure_access_code_redemption.sql
+++ b/supabase/migrations/20260719120000_secure_access_code_redemption.sql
@@ -13,6 +13,18 @@
 
 drop policy if exists "Anyone can read active codes" on "public"."access_codes";
 
+-- Users can still read codes they have already redeemed (the profile page's
+-- redemption history embeds access_codes via code_redemptions). Redeeming
+-- required knowing the code, so this reveals nothing new; unredeemed codes
+-- stay invisible to non-admins.
+CREATE POLICY "Users can read own redeemed codes"
+  ON "public"."access_codes" FOR SELECT
+  USING (EXISTS (
+    SELECT 1 FROM code_redemptions
+    WHERE code_redemptions.code_id = access_codes.id
+      AND code_redemptions.user_id = (SELECT auth.uid())
+  ));
+
 CREATE OR REPLACE FUNCTION public.redeem_access_code(p_code text)
 RETURNS jsonb
 LANGUAGE plpgsql SECURITY DEFINER

--- a/supabase/migrations/20260719120000_secure_access_code_redemption.sql
+++ b/supabase/migrations/20260719120000_secure_access_code_redemption.sql
@@ -1,0 +1,90 @@
+-- Secure access-code redemption.
+--
+-- 1. Drop the world-readable SELECT policy on access_codes: it allowed any
+--    caller (including anon) to enumerate every active code and its granted
+--    programs, bypassing the invitation model entirely.
+-- 2. Add redeem_access_code(p_code): a SECURITY DEFINER RPC that performs the
+--    whole redemption (validate, grant, record, increment) in one transaction
+--    with a row lock, so max_uses is enforced correctly under concurrent
+--    redemptions and codes never need to be readable by non-admins.
+--
+-- NOTE: hand-authored (no local Supabase available to run `supabase db diff`);
+-- mirrors supabase/schemas/{policies,functions}.sql exactly.
+
+drop policy if exists "Anyone can read active codes" on "public"."access_codes";
+
+CREATE OR REPLACE FUNCTION public.redeem_access_code(p_code text)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_uid uuid := auth.uid();
+  v_code access_codes%ROWTYPE;
+  v_slugs text[];
+BEGIN
+  IF v_uid IS NULL THEN
+    RETURN jsonb_build_object('status', 'unauthenticated');
+  END IF;
+
+  IF public.is_group_account() THEN
+    RETURN jsonb_build_object('status', 'group_account');
+  END IF;
+
+  SELECT * INTO v_code
+  FROM access_codes
+  WHERE code = p_code AND is_active = true
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('status', 'invalid');
+  END IF;
+
+  IF v_code.expires_at IS NOT NULL AND v_code.expires_at < NOW() THEN
+    RETURN jsonb_build_object('status', 'expired');
+  END IF;
+
+  IF v_code.max_uses IS NOT NULL AND v_code.use_count >= v_code.max_uses THEN
+    RETURN jsonb_build_object('status', 'exhausted');
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM code_redemptions
+    WHERE code_id = v_code.id AND user_id = v_uid
+  ) THEN
+    RETURN jsonb_build_object('status', 'already_redeemed');
+  END IF;
+
+  IF v_code.grants_all_programs THEN
+    SELECT array_agg(slug) INTO v_slugs FROM programs;
+  ELSE
+    v_slugs := v_code.program_slugs;
+  END IF;
+
+  IF v_slugs IS NULL OR array_length(v_slugs, 1) IS NULL THEN
+    RETURN jsonb_build_object('status', 'no_programs');
+  END IF;
+
+  INSERT INTO user_program_access (user_id, program_slug, granted_by)
+  SELECT v_uid, slug, v_code.created_by
+  FROM unnest(v_slugs) AS slug
+  ON CONFLICT (user_id, program_slug) DO NOTHING;
+
+  INSERT INTO code_redemptions (code_id, user_id)
+  VALUES (v_code.id, v_uid);
+
+  UPDATE access_codes
+  SET use_count = use_count + 1
+  WHERE id = v_code.id;
+
+  RETURN jsonb_build_object(
+    'status', 'ok',
+    'grants_all_programs', v_code.grants_all_programs,
+    'programs_granted', COALESCE(array_length(v_slugs, 1), 0)
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.redeem_access_code(text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.redeem_access_code(text) FROM anon;
+GRANT EXECUTE ON FUNCTION public.redeem_access_code(text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.redeem_access_code(text) TO service_role;

--- a/supabase/migrations/20260719120000_secure_access_code_redemption.sql
+++ b/supabase/migrations/20260719120000_secure_access_code_redemption.sql
@@ -28,6 +28,7 @@ CREATE POLICY "Users can read own redeemed codes"
 CREATE OR REPLACE FUNCTION public.redeem_access_code(p_code text)
 RETURNS jsonb
 LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp
 AS $$
 DECLARE
   v_uid uuid := auth.uid();

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -386,6 +386,94 @@ GRANT ALL ON FUNCTION public.check_device_code_status(text) TO service_role;
 
 
 -- =============================================================================
+-- Access Code Redemption
+-- =============================================================================
+
+-- Redeems an access code for the calling user in a single transaction.
+-- SECURITY DEFINER so codes never need to be readable by non-admins (the
+-- access_codes SELECT policy is admin-only); the row lock (FOR UPDATE) makes
+-- the max_uses check + use_count increment atomic under concurrent redemptions.
+-- Returns a jsonb object whose 'status' key the API route maps to HTTP codes.
+CREATE OR REPLACE FUNCTION public.redeem_access_code(p_code text)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+AS $$
+DECLARE
+  v_uid uuid := auth.uid();
+  v_code access_codes%ROWTYPE;
+  v_slugs text[];
+BEGIN
+  IF v_uid IS NULL THEN
+    RETURN jsonb_build_object('status', 'unauthenticated');
+  END IF;
+
+  IF public.is_group_account() THEN
+    RETURN jsonb_build_object('status', 'group_account');
+  END IF;
+
+  SELECT * INTO v_code
+  FROM access_codes
+  WHERE code = p_code AND is_active = true
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('status', 'invalid');
+  END IF;
+
+  IF v_code.expires_at IS NOT NULL AND v_code.expires_at < NOW() THEN
+    RETURN jsonb_build_object('status', 'expired');
+  END IF;
+
+  IF v_code.max_uses IS NOT NULL AND v_code.use_count >= v_code.max_uses THEN
+    RETURN jsonb_build_object('status', 'exhausted');
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM code_redemptions
+    WHERE code_id = v_code.id AND user_id = v_uid
+  ) THEN
+    RETURN jsonb_build_object('status', 'already_redeemed');
+  END IF;
+
+  IF v_code.grants_all_programs THEN
+    SELECT array_agg(slug) INTO v_slugs FROM programs;
+  ELSE
+    v_slugs := v_code.program_slugs;
+  END IF;
+
+  IF v_slugs IS NULL OR array_length(v_slugs, 1) IS NULL THEN
+    RETURN jsonb_build_object('status', 'no_programs');
+  END IF;
+
+  INSERT INTO user_program_access (user_id, program_slug, granted_by)
+  SELECT v_uid, slug, v_code.created_by
+  FROM unnest(v_slugs) AS slug
+  ON CONFLICT (user_id, program_slug) DO NOTHING;
+
+  INSERT INTO code_redemptions (code_id, user_id)
+  VALUES (v_code.id, v_uid);
+
+  UPDATE access_codes
+  SET use_count = use_count + 1
+  WHERE id = v_code.id;
+
+  RETURN jsonb_build_object(
+    'status', 'ok',
+    'grants_all_programs', v_code.grants_all_programs,
+    'programs_granted', COALESCE(array_length(v_slugs, 1), 0)
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.redeem_access_code(text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.redeem_access_code(text) FROM anon;
+GRANT EXECUTE ON FUNCTION public.redeem_access_code(text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.redeem_access_code(text) TO service_role;
+
+
+
+
+-- =============================================================================
 -- get_objects_for_sync
 -- (lightweight bulk fetch for Python client objects catalog sync)
 -- =============================================================================

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -397,6 +397,7 @@ GRANT ALL ON FUNCTION public.check_device_code_status(text) TO service_role;
 CREATE OR REPLACE FUNCTION public.redeem_access_code(p_code text)
 RETURNS jsonb
 LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public, pg_temp
 AS $$
 DECLARE
   v_uid uuid := auth.uid();

--- a/supabase/schemas/policies.sql
+++ b/supabase/schemas/policies.sql
@@ -1128,6 +1128,19 @@ CREATE POLICY "admin_manage_codes"
   ON access_codes
   USING ((SELECT public.is_admin()));
 
+-- Users can read codes they have already redeemed (the profile page's
+-- redemption history embeds access_codes via code_redemptions). Redeeming
+-- required knowing the code, so this reveals nothing new; unredeemed codes
+-- stay invisible to non-admins.
+DROP POLICY IF EXISTS "Users can read own redeemed codes" ON access_codes;
+CREATE POLICY "Users can read own redeemed codes"
+  ON access_codes FOR SELECT
+  USING (EXISTS (
+    SELECT 1 FROM code_redemptions
+    WHERE code_redemptions.code_id = access_codes.id
+      AND code_redemptions.user_id = (SELECT auth.uid())
+  ));
+
 
 -- =============================================================================
 -- code_redemptions

--- a/supabase/schemas/policies.sql
+++ b/supabase/schemas/policies.sql
@@ -1119,17 +1119,14 @@ CREATE POLICY "admin_delete_invites"
 
 ALTER TABLE access_codes ENABLE ROW LEVEL SECURITY;
 
--- Admins can manage all access codes (all operations).
+-- Admins can manage all access codes (all operations). Codes are secrets:
+-- there is deliberately NO broader SELECT policy — redemption goes through the
+-- SECURITY DEFINER redeem_access_code() RPC, so non-admins can never enumerate
+-- codes (a public "read active codes" policy previously allowed exactly that).
 DROP POLICY IF EXISTS "admin_manage_codes" ON access_codes;
 CREATE POLICY "admin_manage_codes"
   ON access_codes
   USING ((SELECT public.is_admin()));
-
--- Anyone can read active codes (for code redemption flow).
-DROP POLICY IF EXISTS "Anyone can read active codes" ON access_codes;
-CREATE POLICY "Anyone can read active codes"
-  ON access_codes FOR SELECT
-  USING (is_active = true);
 
 
 -- =============================================================================

--- a/web/app/api/admin/inspection-requests/[id]/route.ts
+++ b/web/app/api/admin/inspection-requests/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient, createServiceClient } from '@/lib/supabase/server';
+import { sendInspectionDecisionNotification } from '@/lib/email/resend';
 
 /**
  * PATCH /api/admin/inspection-requests/[id]
@@ -78,6 +79,32 @@ export async function PATCH(
   if (updateError) {
     console.error('Error updating inspection request:', updateError);
     return NextResponse.json({ error: 'Failed to update request' }, { status: 500 });
+  }
+
+  // Tell the requester the outcome (the profile page promises this email).
+  // Best-effort: a failed email never fails the review itself.
+  try {
+    const [{ data: requesterProfile }, { data: requesterAuth }] = await Promise.all([
+      serviceClient
+        .from('user_profiles')
+        .select('full_name')
+        .eq('user_id', req.user_id)
+        .single(),
+      serviceClient.auth.admin.getUserById(req.user_id),
+    ]);
+
+    const requesterEmail = requesterAuth?.user?.email;
+    if (requesterEmail) {
+      await sendInspectionDecisionNotification({
+        email: requesterEmail,
+        full_name: requesterProfile?.full_name || 'there',
+        approved: action === 'approve',
+      });
+    } else {
+      console.warn('No email found for inspection requester', req.user_id);
+    }
+  } catch (err) {
+    console.error('Error sending inspection decision notification:', err);
   }
 
   return NextResponse.json({ success: true });

--- a/web/app/api/codes/redeem/route.ts
+++ b/web/app/api/codes/redeem/route.ts
@@ -1,12 +1,28 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient, createServiceClient } from '@/lib/supabase/server';
+import { createClient } from '@/lib/supabase/server';
 
 /**
  * POST /api/codes/redeem
  *
  * Redeems an access code for the current user.
  * Body: { code: string }
+ *
+ * The entire redemption (validation, program grants, redemption record,
+ * use_count increment) runs inside the redeem_access_code() SECURITY DEFINER
+ * RPC, so access codes are never readable by non-admins and max_uses holds
+ * under concurrent redemptions.
  */
+
+const STATUS_RESPONSES: Record<string, { error: string; http: number }> = {
+  unauthenticated: { error: 'Authentication required', http: 401 },
+  group_account: { error: 'Group accounts cannot redeem access codes', http: 403 },
+  invalid: { error: 'Invalid access code', http: 404 },
+  expired: { error: 'This access code has expired', http: 410 },
+  exhausted: { error: 'This access code has reached its maximum uses', http: 410 },
+  already_redeemed: { error: 'You have already redeemed this code', http: 409 },
+  no_programs: { error: 'This code does not grant access to any programs', http: 400 },
+};
+
 export async function POST(request: NextRequest) {
   const supabase = await createClient();
 
@@ -17,20 +33,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(
       { error: 'Authentication required' },
       { status: 401 }
-    );
-  }
-
-  // Check if user is a group account
-  const { data: profile } = await supabase
-    .from('user_profiles')
-    .select('is_group_account')
-    .eq('user_id', user.id)
-    .single();
-
-  if (profile?.is_group_account) {
-    return NextResponse.json(
-      { error: 'Group accounts cannot redeem access codes' },
-      { status: 403 }
     );
   }
 
@@ -48,130 +50,37 @@ export async function POST(request: NextRequest) {
     // Normalize code (uppercase, trim)
     const normalizedCode = code.trim().toUpperCase();
 
-    // Find the access code
-    const { data: accessCode, error: codeError } = await supabase
-      .from('access_codes')
-      .select('*')
-      .eq('code', normalizedCode)
-      .eq('is_active', true)
-      .single();
+    const { data: result, error: rpcError } = await supabase.rpc(
+      'redeem_access_code',
+      { p_code: normalizedCode }
+    );
 
-    if (codeError || !accessCode) {
+    if (rpcError || !result?.status) {
+      console.error('Error redeeming code:', rpcError);
       return NextResponse.json(
-        { error: 'Invalid access code' },
-        { status: 404 }
+        { error: 'Failed to redeem access code' },
+        { status: 500 }
       );
     }
 
-    // Check if expired
-    if (accessCode.expires_at && new Date(accessCode.expires_at) < new Date()) {
-      return NextResponse.json(
-        { error: 'This access code has expired' },
-        { status: 410 }
-      );
-    }
-
-    // Check if max uses reached
-    if (accessCode.max_uses && accessCode.use_count >= accessCode.max_uses) {
-      return NextResponse.json(
-        { error: 'This access code has reached its maximum uses' },
-        { status: 410 }
-      );
-    }
-
-    // Check if user already redeemed this code
-    const { data: existingRedemption } = await supabase
-      .from('code_redemptions')
-      .select('id')
-      .eq('code_id', accessCode.id)
-      .eq('user_id', user.id)
-      .single();
-
-    if (existingRedemption) {
-      return NextResponse.json(
-        { error: 'You have already redeemed this code' },
-        { status: 409 }
-      );
-    }
-
-    // Determine which programs to grant
-    let programSlugs: string[] = [];
-
-    if (accessCode.grants_all_programs) {
-      // Get all program slugs
-      const { data: programs } = await supabase
-        .from('programs')
-        .select('slug');
-
-      programSlugs = (programs || []).map(p => p.slug);
-    } else if (accessCode.program_slugs && accessCode.program_slugs.length > 0) {
-      programSlugs = accessCode.program_slugs;
-    }
-
-    // Validate that code grants at least one program
-    if (programSlugs.length === 0) {
-      return NextResponse.json(
-        { error: 'This code does not grant access to any programs' },
-        { status: 400 }
-      );
-    }
-
-    // Use service client for system operations (granting access, incrementing counters)
-    const serviceClient = createServiceClient();
-
-    // Grant program access
-    if (programSlugs.length > 0) {
-      const accessRecords = programSlugs.map(programSlug => ({
-        user_id: user.id,
-        program_slug: programSlug,
-        granted_by: accessCode.created_by,
-      }));
-
-      // Use upsert to avoid duplicates
-      const { error: accessError } = await serviceClient
-        .from('user_program_access')
-        .upsert(accessRecords, {
-          onConflict: 'user_id,program_slug',
-          ignoreDuplicates: true
-        });
-
-      if (accessError) {
-        console.error('Error granting program access:', accessError);
+    if (result.status !== 'ok') {
+      const mapped = STATUS_RESPONSES[result.status];
+      if (!mapped) {
+        console.error('Unexpected redemption status:', result.status);
         return NextResponse.json(
-          { error: 'Failed to grant program access' },
+          { error: 'Failed to redeem access code' },
           { status: 500 }
         );
       }
-    }
-
-    // Record the redemption
-    const { error: redemptionError } = await supabase
-      .from('code_redemptions')
-      .insert({
-        code_id: accessCode.id,
-        user_id: user.id,
-      });
-
-    if (redemptionError) {
-      console.error('Error recording redemption:', redemptionError);
-      // Don't fail - access was already granted
-    }
-    const { error: incrementError } = await serviceClient
-      .from('access_codes')
-      .update({ use_count: accessCode.use_count + 1 })
-      .eq('id', accessCode.id);
-
-    if (incrementError) {
-      console.error('Error incrementing use count:', incrementError);
-      // Don't fail - access was already granted
+      return NextResponse.json({ error: mapped.error }, { status: mapped.http });
     }
 
     return NextResponse.json({
       success: true,
-      message: accessCode.grants_all_programs
+      message: result.grants_all_programs
         ? 'Access granted to all programs'
-        : `Access granted to ${programSlugs.length} program(s)`,
-      programs_granted: programSlugs.length,
+        : `Access granted to ${result.programs_granted} program(s)`,
+      programs_granted: result.programs_granted,
     });
 
   } catch (error) {

--- a/web/app/api/invites/accept/route.ts
+++ b/web/app/api/invites/accept/route.ts
@@ -38,9 +38,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (!password || typeof password !== 'string' || password.length < 6) {
+    if (!password || typeof password !== 'string' || password.length < 8) {
       return NextResponse.json(
-        { error: 'Password must be at least 6 characters' },
+        { error: 'Password must be at least 8 characters' },
         { status: 400 }
       );
     }

--- a/web/app/api/v1/objects/route.ts
+++ b/web/app/api/v1/objects/route.ts
@@ -76,9 +76,16 @@ export async function GET(request: NextRequest) {
       ? hasPhotometryParam.toLowerCase() === 'true'
       : null;
 
-    // Pagination
+    // Pagination (limit 1..10000 so limit=0 can't produce NaN pages and a
+    // single request can't ask for an unbounded page)
     const limit = parseInt(searchParams.get('limit') || '1000', 10);
     const offset = parseInt(searchParams.get('offset') || '0', 10);
+    if (!Number.isFinite(limit) || limit < 1 || limit > 10000 || !Number.isFinite(offset) || offset < 0) {
+      return NextResponse.json(
+        { error: 'Invalid pagination: limit must be 1-10000 and offset must be >= 0' },
+        { status: 400 }
+      );
+    }
     const page = Math.floor(offset / limit) + 1;
 
     // Sort

--- a/web/app/api/v1/spectra/list/route.ts
+++ b/web/app/api/v1/spectra/list/route.ts
@@ -88,8 +88,16 @@ export async function GET(request: NextRequest) {
 
     const dq = parseFlagMode(searchParams, 'dq_flags');
 
+    // Pagination (limit 1..10000 so limit=0 can't produce NaN pages and a
+    // single request can't ask for an unbounded page)
     const limit = parseInt(searchParams.get('limit') || '1000', 10);
     const offset = parseInt(searchParams.get('offset') || '0', 10);
+    if (!Number.isFinite(limit) || limit < 1 || limit > 10000 || !Number.isFinite(offset) || offset < 0) {
+      return NextResponse.json(
+        { error: 'Invalid pagination: limit must be 1-10000 and offset must be >= 0' },
+        { status: 400 }
+      );
+    }
     const page = Math.floor(offset / limit) + 1;
 
     const validSortColumns = [

--- a/web/app/profile/page.tsx
+++ b/web/app/profile/page.tsx
@@ -454,9 +454,9 @@ export default function ProfilePage() {
                   >
                     <div>
                       <span className="font-mono text-sm text-text-primary">
-                        {redemption.access_codes.code}
+                        {redemption.access_codes?.code ?? '(code unavailable)'}
                       </span>
-                      {redemption.access_codes.description && (
+                      {redemption.access_codes?.description && (
                         <span className="text-sm text-text-secondary ml-2">
                           ({redemption.access_codes.description})
                         </span>

--- a/web/app/welcome/page.tsx
+++ b/web/app/welcome/page.tsx
@@ -107,8 +107,8 @@ export default function WelcomePage() {
       return;
     }
 
-    if (password.length < 6) {
-      setError('Password must be at least 6 characters');
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters');
       return;
     }
 
@@ -294,8 +294,8 @@ export default function WelcomePage() {
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 className="w-full px-4 py-2 bg-background text-text-primary placeholder:text-text-tertiary border border-border-strong rounded-lg focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary"
-                placeholder="Enter a password (min. 6 characters)"
-                minLength={6}
+                placeholder="Enter a password (min. 8 characters)"
+                minLength={8}
                 required
                 disabled={saving}
               />
@@ -316,7 +316,7 @@ export default function WelcomePage() {
                 onChange={(e) => setConfirmPassword(e.target.value)}
                 className="w-full px-4 py-2 bg-background text-text-primary placeholder:text-text-tertiary border border-border-strong rounded-lg focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary"
                 placeholder="Confirm your password"
-                minLength={6}
+                minLength={8}
                 required
                 disabled={saving}
               />

--- a/web/components/auth/AccessCodePrompt.tsx
+++ b/web/components/auth/AccessCodePrompt.tsx
@@ -127,7 +127,7 @@ export const AccessCodePrompt: React.FC<AccessCodePromptProps> = ({ onSuccess })
         <p className="text-sm text-text-secondary text-center mt-6">
           Don&apos;t have a code? Contact your PI or{' '}
           <a
-            href="mailto:campfire@example.com"
+            href="mailto:hollis.akins@gmail.com"
             className="text-primary hover:underline"
           >
             request access via email

--- a/web/components/auth/SignupForm.tsx
+++ b/web/components/auth/SignupForm.tsx
@@ -31,9 +31,14 @@ export const SignupForm: React.FC = () => {
     setLoading(true);
 
     try {
-      const { error } = await signUp(email.trim(), password, fullName.trim());
+      const { error, existingAccount } = await signUp(email.trim(), password, fullName.trim());
       if (error) {
         setError(error.message);
+      } else if (existingAccount) {
+        setError(
+          'An account with this email already exists. Sign in instead — or use ' +
+          '"Forgot password?" on the sign-in page if you need to reset it.'
+        );
       } else {
         // Email confirmation is required, so there is no session yet.
         setSubmitted(true);
@@ -143,17 +148,17 @@ export const SignupForm: React.FC = () => {
             className="w-full px-4 py-2 bg-background text-text-primary placeholder:text-text-tertiary border border-border-strong rounded-lg focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary"
             placeholder="••••••••"
             required
-            minLength={6}
+            minLength={8}
             disabled={loading}
           />
-          <p className="text-xs text-text-secondary mt-1">At least 6 characters.</p>
+          <p className="text-xs text-text-secondary mt-1">At least 8 characters.</p>
         </div>
 
         <Button
           type="submit"
           variant="primary"
           className="w-full mt-6"
-          disabled={loading || !email.trim() || !fullName.trim() || password.length < 6}
+          disabled={loading || !email.trim() || !fullName.trim() || password.length < 8}
         >
           {loading ? 'Creating account...' : 'Create Account'}
         </Button>

--- a/web/components/layout/Footer.tsx
+++ b/web/components/layout/Footer.tsx
@@ -6,7 +6,7 @@ export function Footer() {
   return (
     <footer className="border-t border-border">
       <div className="container mx-auto px-4 py-4 flex flex-col sm:flex-row items-center justify-between gap-2 text-sm text-text-secondary">
-        <span>&copy; 2025 Hollis Akins &middot; MIT License</span>
+        <span>&copy; {new Date().getFullYear()} Hollis Akins &middot; MIT License</span>
         <div className="flex items-center gap-4">
           <a
             href={GITHUB_REPO}

--- a/web/components/layout/Navigation.tsx
+++ b/web/components/layout/Navigation.tsx
@@ -4,7 +4,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import Link from 'next/link';
 import { SignInLink } from '@/components/auth/SignInLink';
 import { usePathname, useRouter } from 'next/navigation';
-import { LogOut, User, Shield, Sun, Moon, Monitor, ChevronDown, Github } from 'lucide-react';
+import { LogOut, User, Shield, Sun, Moon, Monitor, ChevronDown, Github, Menu, X } from 'lucide-react';
 import { Logo } from '@/components/brand/Logo';
 import { useAuth } from '@/lib/contexts/AuthContext';
 import { useTheme } from '@/lib/contexts/ThemeContext';
@@ -61,6 +61,12 @@ export const Navigation: React.FC = () => {
   const router = useRouter();
   const { user, userProfile, signOut } = useAuth();
   const { theme, setTheme } = useTheme();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  // Close the mobile menu on navigation.
+  useEffect(() => {
+    setMobileOpen(false);
+  }, [pathname]);
 
   const cycleTheme = () => {
     const themes: Array<'light' | 'dark' | 'system'> = ['light', 'system', 'dark'];
@@ -95,6 +101,14 @@ export const Navigation: React.FC = () => {
     router.push('/login');
   };
 
+  const mobileLinkClass = (active: boolean) => `
+    block px-3 py-2 rounded-lg text-sm font-medium transition-colors
+    ${active
+      ? 'text-header-foreground bg-header-hover'
+      : 'text-header-muted hover:text-header-foreground hover:bg-header-hover'
+    }
+  `;
+
   return (
     <nav data-slot="app-header" className="bg-header text-header-foreground shadow-md">
       <div className="container mx-auto px-4 py-4">
@@ -105,8 +119,8 @@ export const Navigation: React.FC = () => {
             <span className="text-xl font-bold">CAMPFIRE</span>
           </Link>
 
-          {/* Navigation Links */}
-          <div className="flex items-center space-x-8">
+          {/* Navigation Links (desktop) */}
+          <div className="hidden md:flex items-center space-x-8">
             {navLinks.map((link) =>
               link.children ? (
                 <NavDropdown key={link.href} link={link} isActive={isActive(link.href)} />
@@ -184,7 +198,82 @@ export const Navigation: React.FC = () => {
               </SignInLink>
             )}
           </div>
+
+          {/* Mobile controls */}
+          <div className="flex md:hidden items-center space-x-3">
+            <button
+              onClick={cycleTheme}
+              className="flex items-center text-header-muted hover:text-header-foreground transition-colors"
+              aria-label={`Current theme: ${theme}. Click to change.`}
+              title={`Theme: ${theme}`}
+            >
+              <ThemeIcon className="w-5 h-5" />
+            </button>
+            <button
+              onClick={() => setMobileOpen(!mobileOpen)}
+              className="flex items-center text-header-muted hover:text-header-foreground transition-colors"
+              aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
+              aria-expanded={mobileOpen}
+            >
+              {mobileOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
+            </button>
+          </div>
         </div>
+
+        {/* Mobile menu */}
+        {mobileOpen && (
+          <div className="md:hidden mt-4 pt-4 border-t border-header-border space-y-1">
+            {navLinks.map((link) =>
+              link.children ? (
+                <div key={link.href}>
+                  {link.children.map((child, i) => (
+                    <Link
+                      key={child.href}
+                      href={child.href}
+                      className={mobileLinkClass(isActive(link.href) && i === 0)}
+                    >
+                      {i === 0 ? link.label : `${link.label} · ${child.label}`}
+                    </Link>
+                  ))}
+                </div>
+              ) : (
+                <Link key={link.href} href={link.href} className={mobileLinkClass(isActive(link.href))}>
+                  {link.label}
+                </Link>
+              )
+            )}
+
+            <div className="pt-2 mt-2 border-t border-header-border space-y-1">
+              {user ? (
+                <>
+                  {userProfile?.is_admin && (
+                    <Link href="/admin" className={mobileLinkClass(isActive('/admin'))}>
+                      <span className="flex items-center gap-2"><Shield className="w-4 h-4" /> Admin</span>
+                    </Link>
+                  )}
+                  <Link href="/profile" className={mobileLinkClass(isActive('/profile'))}>
+                    <span className="flex items-center gap-2">
+                      <User className="w-4 h-4" /> {userProfile?.full_name || user.email}
+                    </span>
+                  </Link>
+                  <button onClick={handleSignOut} className={`w-full text-left ${mobileLinkClass(false)}`}>
+                    <span className="flex items-center gap-2"><LogOut className="w-4 h-4" /> Sign out</span>
+                  </button>
+                </>
+              ) : (
+                <SignInLink className={mobileLinkClass(false)}>Sign In</SignInLink>
+              )}
+              <a
+                href="https://github.com/hollisakins/campfire"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={mobileLinkClass(false)}
+              >
+                <span className="flex items-center gap-2"><Github className="w-4 h-4" /> GitHub</span>
+              </a>
+            </div>
+          </div>
+        )}
       </div>
     </nav>
   );

--- a/web/components/spectra/inspection/InspectionModeOverlay.tsx
+++ b/web/components/spectra/inspection/InspectionModeOverlay.tsx
@@ -435,6 +435,16 @@ export const InspectionModeOverlay: React.FC<InspectionModeOverlayProps> = ({
         </div>
       )}
 
+      {/* Non-inspectors can browse but not submit; without this banner the
+          disabled controls read as broken rather than restricted. */}
+      {!canEdit && queueReady && !queue.isEmpty && (
+        <div className="absolute top-14 left-1/2 -translate-x-1/2 px-4 py-2 bg-amber-100 dark:bg-amber-900 text-amber-800 dark:text-amber-200 text-sm rounded-lg shadow-lg z-10">
+          Read-only: your account doesn&apos;t have inspection access, so ratings and
+          flags are disabled. Request access from your{' '}
+          <a href="/profile" className="underline hover:no-underline">profile page</a>.
+        </div>
+      )}
+
       {queueReady && inspectionState.versionConflict && inspectionState.conflictInfo && (
         <div className="absolute top-14 left-1/2 -translate-x-1/2 w-[640px] max-w-[calc(100vw-2rem)] z-20">
           <ConflictBanner

--- a/web/lib/contexts/AuthContext.tsx
+++ b/web/lib/contexts/AuthContext.tsx
@@ -21,7 +21,11 @@ interface AuthContextType {
   needsAccessCode: boolean; // True if user has no proprietary program access
   programAccess: ProgramAccessInfo | null;
   signIn: (email: string, password: string) => Promise<{ error: Error | null }>;
-  signUp: (email: string, password: string, fullName: string) => Promise<{ error: Error | null }>;
+  signUp: (
+    email: string,
+    password: string,
+    fullName: string
+  ) => Promise<{ error: Error | null; existingAccount?: boolean }>;
   signOut: () => Promise<void>;
   refreshProfile: () => Promise<void>; // Manually refresh profile after setup
   checkProgramAccess: () => Promise<void>; // Refresh program access state
@@ -161,7 +165,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         return !!existing;
       });
 
-      const { error } = await supabase.auth.signUp({
+      const { data, error } = await supabase.auth.signUp({
         email,
         password,
         options: {
@@ -182,7 +186,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       if (error) throw error;
 
-      return { error: null };
+      // With email confirmation enabled, Supabase obfuscates duplicate-email
+      // signups: it returns a fake user with no identities instead of an error.
+      // No confirmation email will arrive, so surface it rather than showing a
+      // false "check your inbox" success.
+      const existingAccount = !!data.user && (data.user.identities?.length ?? 0) === 0;
+
+      return { error: null, existingAccount };
     } catch (error) {
       return { error: error as Error };
     }

--- a/web/lib/email/resend.ts
+++ b/web/lib/email/resend.ts
@@ -104,3 +104,91 @@ ${appUrl}/admin/inspection-requests
     return { success: false, error: err instanceof Error ? err.message : 'Unknown error' };
   }
 }
+
+interface InspectionDecisionNotification {
+  email: string;
+  full_name: string;
+  approved: boolean;
+}
+
+/**
+ * Notify a user that their inspection-access request was reviewed. Best-effort:
+ * never fails the review action if email isn't configured. (The profile page
+ * promises users an email once an admin has reviewed their request.)
+ */
+export async function sendInspectionDecisionNotification(
+  decision: InspectionDecisionNotification
+): Promise<{ success: boolean; error?: string }> {
+  const resendApiKey = process.env.RESEND_API_KEY;
+
+  if (!resendApiKey) {
+    console.warn('RESEND_API_KEY not set, skipping decision notification');
+    return { success: true };
+  }
+
+  const resend = new Resend(resendApiKey);
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+  const { email, full_name, approved } = decision;
+
+  const bodyText = approved
+    ? 'Your request for inspection access has been approved. You can now submit redshift assessments, quality ratings, and flags from any spectrum page.'
+    : 'Your request for inspection access was not approved at this time. If you think this is a mistake, reply to this email or reach out to the CAMPFIRE team.';
+  const ctaLabel = approved ? 'Start Inspecting' : 'Open CAMPFIRE';
+  const ctaUrl = approved ? `${appUrl}/nirspec` : appUrl;
+
+  try {
+    const { data, error } = await resend.emails.send({
+      from: 'CAMPFIRE <team@campfire.hollisakins.com>',
+      to: email,
+      subject: approved
+        ? 'Your CAMPFIRE inspection access request was approved'
+        : 'Update on your CAMPFIRE inspection access request',
+      html: `
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        </head>
+        <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+          <div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); padding: 30px; border-radius: 10px 10px 0 0;">
+            <h1 style="color: white; margin: 0; font-size: 24px;">Inspection Access ${approved ? 'Approved' : 'Request Reviewed'}</h1>
+          </div>
+
+          <div style="background: #f9fafb; padding: 30px; border: 1px solid #e5e7eb; border-top: none; border-radius: 0 0 10px 10px;">
+            <p style="margin-top: 0;">Hi ${full_name},</p>
+            <p>${bodyText}</p>
+
+            <a href="${ctaUrl}"
+               style="display: inline-block; background: #667eea; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: 500; margin-top: 10px;">
+              ${ctaLabel}
+            </a>
+
+            <p style="color: #6b7280; font-size: 14px; margin-top: 30px; margin-bottom: 0;">
+              This email was sent automatically by CAMPFIRE.
+            </p>
+          </div>
+        </body>
+        </html>
+      `,
+      text: `
+Hi ${full_name},
+
+${bodyText}
+
+${ctaUrl}
+      `.trim(),
+    });
+
+    if (error) {
+      console.error('Failed to send inspection decision notification:', error);
+      return { success: false, error: error.message };
+    }
+
+    console.log('Inspection decision notification sent:', { id: data?.id, to: email });
+    return { success: true };
+  } catch (err) {
+    console.error('Error sending inspection decision notification:', err);
+    return { success: false, error: err instanceof Error ? err.message : 'Unknown error' };
+  }
+}


### PR DESCRIPTION
Self-contained fixes from the pre-onboarding audit of the user-facing surface. Docs-content edits (`web/lib/docs/content/**`) are deliberately **not** included — those are deferred to a separate pass.

## Security

- **Access codes are no longer world-readable.** The `"Anyone can read active codes"` RLS policy (`FOR SELECT USING (is_active = true)`, no role restriction) let any caller — including anonymous visitors with the public anon key — enumerate every active code and its granted programs, then self-grant proprietary access. The policy is dropped; redemption now goes through a new `redeem_access_code(p_code)` `SECURITY DEFINER` RPC.
- **`max_uses` now holds under concurrency.** The RPC performs the whole redemption (validate → grant → record → increment) in one transaction with a `FOR UPDATE` row lock, replacing the route's three non-transactional writes and read-modify-write counter.
- Side effect worth noting: `grants_all_programs` codes now grant *all* programs. Previously the program list was read through the redeeming user's RLS, so "all programs" silently meant "programs the user could already see."
- Migration `20260719120000_secure_access_code_redemption.sql` was **hand-authored** (no local Supabase in this environment to run `supabase db diff`); it mirrors the schema-file changes exactly, but please sanity-check with `supabase db reset` + `supabase db diff` locally before merge.

## Web

- **Signup duplicate-email trap**: Supabase obfuscates duplicate-email signups as a success with an empty `identities` array; the form now detects that and tells the user to sign in / reset instead of showing a false "confirm your email" screen.
- **Inspection-request decision emails**: the profile page promised "we'll email you once an administrator has had a chance to look," but no such email existed. Approve/reject now sends one (best-effort, never fails the review).
- **Mobile navigation**: the header was a single flex row with no breakpoints (overflowed on phones). Desktop layout is unchanged; below `md` there's now a hamburger menu with all nav links, profile/admin/sign-out, and the theme toggle.
- **Read-only `/inspect` explanation**: non-inspectors deep-linking into inspection mode saw silently disabled controls; there's now a banner explaining the account lacks inspection access, linking to the profile page. (Writes were already enforced server-side.)
- **API pagination validation** on `/api/v1/objects` and `/api/v1/spectra/list`: `limit=0` previously produced NaN pages passed to the RPC; now a clean 400, with `limit` capped at 10000.
- Small fixes: password minimum standardized at 8 characters across signup/welcome/invite-accept (the reset form already required 8, so users could be forced into a stricter rule than they signed up under); dead `mailto:campfire@example.com` replaced; footer year made dynamic.

## Python client

- **`supabase` + `boto3` moved from base dependencies to the `[deploy]` extra.** All import sites are already lazy and degrade gracefully (deploy CLI commands stub with an install hint; the annotation half of `campfire pull` skips silently), so consumer installs get a meaningfully lighter dependency tree.
- The in-CLI upgrade hint printed a single-line `pip install` that can never resolve (it omits `campfire-layout`, which isn't on PyPI); it now prints the two-package form.
- Stale-file hints unified on `campfire pull --stale` (one path said `pull`, another said `download`).
- Bare `campfire login` with no TTY now raises an actionable error pointing at `--browser`/`--api-key` instead of aborting at an invisible prompt.
- `plotting` ImportError now points at `pip install 'campfire[plotting]'` and mentions the matplotlib fallback (`SpectrumData.plot()`); stale module docstrings corrected (`products/nirspec/<obs>/` layout, phantom `campfire observations` command, two-arg `get_spectrum_data` example).

## Verification

- `cd web && npm run build` passes (with placeholder Supabase env vars; this container has no `.env.local`).
- Edited Python files compile; no `pipeline/**` changes, so no changelog entry is required.
- The RPC + migration SQL could not be executed here (no local Supabase) — flagging again as the one piece needing a local `supabase db reset` check.

Generated with Claude Code

https://claude.ai/code/session_01FTSehUwR87ZL4V8z6skEXV

---
_Generated by [Claude Code](https://claude.ai/code/session_01FTSehUwR87ZL4V8z6skEXV)_