### PR TITLE
ci: enable inline PR review comments in claude-code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -54,9 +54,26 @@ jobs:
             the background. Run every sub-agent synchronously (run_in_background:
             false) and complete the entire review — posting all inline comments —
             before you end your turn.
-          # Strip the interactive-only tools the model reaches for in headless runs
-          # (anthropics/claude-code-action#1462) so it cannot defer work off-turn.
-          claude_args: '--disallowedTools "ScheduleWakeup,SendMessage,Monitor"'
+          # Tool configuration for the headless review run:
+          #
+          # --allowedTools enables inline PR review comments. Because this step
+          # passes an explicit `prompt`, the action runs in "agent mode", and in
+          # agent mode it only installs its `github_inline_comment` MCP server when
+          # an allowed tool matching `mcp__github_inline_comment__*` is present in
+          # claude_args (see install-mcp-server.ts + modes/agent/index.ts in
+          # anthropics/claude-code-action — the decision reads claude_args, NOT
+          # .claude/settings.json). Without this entry the server is never
+          # connected, the /code-review plugin can't call
+          # mcp__github_inline_comment__create_inline_comment, and it falls back to
+          # a single regular PR comment ("inline review comments aren't available
+          # from this session..."). Listing the tool here is what wires it up.
+          #
+          # --disallowedTools strips the interactive-only tools the model reaches
+          # for in headless runs (anthropics/claude-code-action#1462) so it cannot
+          # defer work off-turn.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment"
+            --disallowedTools "ScheduleWakeup,SendMessage,Monitor"
           # Post a single updating summary comment in addition to inline comments,
           # so the PR always gets visible feedback even when the review has no
           # line-specific inline nits to buffer.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -74,10 +74,10 @@ jobs:
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment"
             --disallowedTools "ScheduleWakeup,SendMessage,Monitor"
-          # Post a single updating summary comment in addition to inline comments,
-          # so the PR always gets visible feedback even when the review has no
-          # line-specific inline nits to buffer.
-          use_sticky_comment: true
+          # Note: use_sticky_comment only takes effect in tag mode; in agent mode
+          # (this step, which passes an explicit `prompt`) the action never creates
+          # a tracking comment, so it was a no-op. The /code-review plugin posts its
+          # own top-level summary via `gh pr comment` when there are no inline nits.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
The Claude Code review action runs in agent mode (an explicit `prompt` is
provided). In agent mode, claude-code-action only installs its
github_inline_comment MCP server when an allowed tool matching
mcp__github_inline_comment__* is present in claude_args — the decision reads
claude_args, not .claude/settings.json.

The workflow passed only --disallowedTools, so the server was never
connected, the code-review plugin couldn't call
mcp__github_inline_comment__create_inline_comment, and every run fell back to
a single regular PR comment ("inline review comments aren't available from
this session...").

Add --allowedTools "mcp__github_inline_comment__create_inline_comment" to
claude_args (mirroring the action's own pr-review-comprehensive.yml example)
so the inline-comment server is installed and the review posts line-level
comments instead of the fallback.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0155ztPRahBkMKsQ7z7zv7os