### PR TITLE
Fix objects-table row aggregates being scoped to the program filter

### DIFF
--- a/supabase/migrations/20260719204502_unscope_object_row_aggregates_from_program_filter.sql
+++ b/supabase/migrations/20260719204502_unscope_object_row_aggregates_from_program_filter.sql
@@ -1,0 +1,426 @@
+-- Fix: with a program filter active, the objects table scoped each row's
+-- displayed programs / # observations / gratings aggregates to only the
+-- selected program(s). The filter should choose which rows appear (objects
+-- whose programs *include* a selected program — unchanged overlap test), while
+-- per-row aggregates and member_targets stay scoped to the viewer's full
+-- accessible program set (p_program_slugs), not the filter-narrowed array.
+-- Hand-authored (CREATE OR REPLACE, signature unchanged): no local Docker for
+-- `supabase db diff`. Matches supabase/schemas/functions.sql.
+CREATE OR REPLACE FUNCTION public.get_filtered_objects_paginated(
+  p_program_slugs TEXT[],
+  p_filter_programs TEXT[] DEFAULT NULL,
+  p_fields TEXT[] DEFAULT NULL,
+  p_gratings TEXT[] DEFAULT NULL,
+  p_gratings_mode TEXT DEFAULT 'any',
+  p_observations TEXT[] DEFAULT NULL,
+  p_redshift_quality INTEGER[] DEFAULT NULL,
+  p_redshift_min DOUBLE PRECISION DEFAULT NULL,
+  p_redshift_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_snr_min DOUBLE PRECISION DEFAULT NULL,
+  p_max_snr_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_exposure_time_min DOUBLE PRECISION DEFAULT NULL,
+  p_max_exposure_time_max DOUBLE PRECISION DEFAULT NULL,
+  p_search TEXT DEFAULT NULL,
+  p_inspected_only BOOLEAN DEFAULT NULL,
+  p_needs_review BOOLEAN DEFAULT NULL,
+  p_list_ids INTEGER[] DEFAULT NULL,
+  p_coord_ra DOUBLE PRECISION DEFAULT NULL,
+  p_coord_dec DOUBLE PRECISION DEFAULT NULL,
+  p_radius_degrees DOUBLE PRECISION DEFAULT NULL,
+  p_has_photometry BOOLEAN DEFAULT NULL,
+  p_photo_z_min DOUBLE PRECISION DEFAULT NULL,
+  p_photo_z_max DOUBLE PRECISION DEFAULT NULL,
+  p_comment_search TEXT DEFAULT NULL,
+  p_comment_search_scope TEXT DEFAULT NULL,
+  p_comment_user_id UUID DEFAULT NULL,
+  p_sort_column TEXT DEFAULT 'object_id',
+  p_sort_direction TEXT DEFAULT 'asc',
+  p_page INTEGER DEFAULT 1,
+  p_page_size INTEGER DEFAULT 50,
+  p_include_unpublished BOOLEAN DEFAULT false
+)
+RETURNS TABLE(targets JSONB, total_count BIGINT, page INTEGER, page_size INTEGER)
+LANGUAGE plpgsql STABLE
+SET plan_cache_mode = 'force_custom_plan'
+AS $$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_offset INTEGER;
+  v_total_count BIGINT;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
+    v_gratings_mode := 'any';
+  END IF;
+
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN
+    p_sort_direction := 'asc';
+  END IF;
+
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time', 'photo_z'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+
+  IF v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN
+    p_sort_column := 'distance';
+  END IF;
+
+  v_offset := (COALESCE(p_page, 1) - 1) * COALESCE(p_page_size, 50);
+
+  -- Intersect user-accessible programs with filter selection
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(
+      SELECT unnest(p_program_slugs)
+      INTERSECT
+      SELECT unnest(p_filter_programs)
+    ) INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN QUERY SELECT '[]'::jsonb, 0::BIGINT, p_page, p_page_size;
+    RETURN;
+  END IF;
+
+  -- Step 1: count
+  SELECT COUNT(*) INTO v_total_count
+  FROM objects o
+  WHERE
+    -- Access control: object must have at least one accessible program
+    o.programs && v_filtered_program_slugs
+    AND o.is_active = true
+    -- B1: hide objects with no published spectrum (fail-closed).
+    AND (p_include_unpublished OR o.has_published_spectrum)
+    AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+    AND (
+      NOT v_grating_filter_active
+      OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+      OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+      OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+    )
+    AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+    AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+    AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+    AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+    AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+    AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+    AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+    AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+    AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
+    AND (
+      p_inspected_only IS NULL
+      OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+      OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+    )
+    AND (
+      p_needs_review IS NULL
+      OR (p_needs_review = TRUE
+          AND o.staleness_reason IS NOT NULL
+          AND o.last_inspected_at IS NOT NULL
+          AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+      OR (p_needs_review = FALSE
+          AND (o.staleness_reason IS NULL
+               OR o.last_inspected_at IS NULL
+               OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+    )
+    AND (
+      NOT v_coord_search_active
+      OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+        AND 2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) <= p_radius_degrees
+      )
+    )
+    AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+        SELECT olm.object_id FROM object_list_members olm
+        WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+    ))
+    AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+    AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+    AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+    AND (
+      NOT v_comment_search_active
+      -- Uncorrelated semijoin: collect the object_ids that have a matching
+      -- comment ONCE (object-level comments directly + target-level comments
+      -- mapped through their parent object), then probe o.id IN (...). The old
+      -- correlated EXISTS-inside-OR re-ran a per-object targets subquery for
+      -- every (object x matching-comment) pair -> 271k subplan executions /
+      -- ~870ms here, multi-second on broad terms or cold cache.
+      OR o.id IN (
+        SELECT c.object_id FROM comments c
+        WHERE c.object_id IS NOT NULL
+          AND c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (
+            p_comment_search_scope = 'everyone'
+            OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+          )
+        UNION
+        SELECT t.object_id FROM comments c
+        JOIN targets t ON t.id = c.target_id
+        WHERE c.target_id IS NOT NULL
+          AND c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (
+            p_comment_search_scope = 'everyone'
+            OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+          )
+      )
+    );
+
+  -- Step 2: fetch page
+  RETURN QUERY
+  WITH filtered_objects AS (
+    SELECT
+      o.id,
+      o.object_id,
+      o.field,
+      o.ra,
+      o.dec,
+      o.n_targets,
+      o.n_spectra,
+      o.programs,
+      o.gratings,
+      o.max_snr,
+      o.max_exposure_time,
+      o.redshift,
+      o.redshift_quality,
+      o.redshift_inspected,
+      o.redshift_auto,
+      o.inspected_used_auto,
+      o.last_inspected_at,
+      o.last_inspected_by,
+      o.last_data_change_at,
+      o.staleness_reason,
+      o.version,
+      o.is_active,
+      o.photo_z,
+      o.has_photometry,
+      o.created_at,
+      CASE
+        WHEN v_coord_search_active THEN
+          2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+            POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+          )))
+        ELSE NULL
+      END AS distance
+    FROM objects o
+    WHERE
+      o.programs && v_filtered_program_slugs
+      AND o.is_active = true
+      AND (p_include_unpublished OR o.has_published_spectrum)
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+        OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+        OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+      )
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
+      AND (
+        p_inspected_only IS NULL
+        OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+        OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+      )
+      AND (
+        p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+      )
+      AND (
+        NOT v_coord_search_active
+        OR (
+          o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+          AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+          AND 2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+            POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+          ))) <= p_radius_degrees
+        )
+      )
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+      AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+      AND (
+        NOT v_comment_search_active
+        -- Uncorrelated semijoin; see the count query above for the rationale.
+        OR o.id IN (
+          SELECT c.object_id FROM comments c
+          WHERE c.object_id IS NOT NULL
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+          UNION
+          SELECT t.object_id FROM comments c
+          JOIN targets t ON t.id = c.target_id
+          WHERE c.target_id IS NOT NULL
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+        )
+      )
+    ORDER BY
+      CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN
+        2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN
+        2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN o.object_id END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'desc' THEN o.object_id END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN o.field END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN o.field END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN o.ra END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN o.ra END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN o.dec END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN o.dec END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN o.redshift END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN o.redshift END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN o.redshift_quality END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN o.redshift_quality END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'asc' THEN o.n_targets END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'desc' THEN o.n_targets END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'asc' THEN o.n_spectra END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'desc' THEN o.n_spectra END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN o.max_snr END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN o.max_snr END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN o.max_exposure_time END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN o.max_exposure_time END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'asc' THEN o.photo_z END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'desc' THEN o.photo_z END DESC NULLS LAST,
+      o.object_id ASC
+    LIMIT p_page_size OFFSET v_offset
+  ),
+  with_members AS (
+    SELECT
+      jsonb_build_object(
+        'id', fo.id,
+        'object_id', fo.object_id,
+        'field', fo.field,
+        'ra', fo.ra,
+        'dec', fo.dec,
+        -- Aggregates scoped to the viewer's accessible programs so mixed-program
+        -- objects don't leak proprietary member metadata. Deliberately NOT
+        -- narrowed by p_filter_programs: a program filter selects which objects
+        -- appear (overlap test above), but each row still shows the object's
+        -- full accessible programs/observations. Filter and sort above run on
+        -- the global o.* columns; the substitution happens only on the
+        -- paginated result set.
+        'n_targets', sa.n_targets,
+        'n_spectra', sa.n_spectra,
+        'programs', sa.programs,
+        'gratings', sa.gratings,
+        'max_snr', sa.max_snr,
+        'max_exposure_time', sa.max_exposure_time,
+        'redshift', fo.redshift,
+        'redshift_quality', fo.redshift_quality,
+        'redshift_inspected', fo.redshift_inspected,
+        'redshift_auto', fo.redshift_auto,
+        'inspected_used_auto', fo.inspected_used_auto,
+        'last_inspected_at', fo.last_inspected_at,
+        'last_inspected_by', fo.last_inspected_by,
+        'last_data_change_at', fo.last_data_change_at,
+        'staleness_reason', fo.staleness_reason,
+        'version', fo.version,
+        'is_active', fo.is_active,
+        'photo_z', fo.photo_z,
+        'has_photometry', fo.has_photometry,
+        'created_at', fo.created_at,
+        'distance', fo.distance,
+        -- Phase D: member_targets becomes provenance only (target_id, program,
+        -- observation). Inspection state lives on the object now; redshift_auto
+        -- on targets is retained for transitional UI display until Phase E.
+        'member_targets', COALESCE(
+          (SELECT jsonb_agg(
+            jsonb_build_object(
+              'target_id', t.target_id,
+              'program_slug', t.program_slug,
+              'observation', t.observation,
+              'redshift_auto', t.redshift_auto
+            )
+          )
+          FROM targets t
+          WHERE t.object_id = fo.id
+            AND t.program_slug = ANY(p_program_slugs)
+          ),
+          '[]'::jsonb
+        ),
+        'lists', COALESCE(
+          (SELECT jsonb_agg(
+            jsonb_build_object(
+              'id', ol.id,
+              'name', ol.name,
+              'slug', ol.slug,
+              'icon', ol.icon,
+              'color', ol.color
+            ) ORDER BY ol.name
+          )
+          FROM object_list_members olm
+          JOIN object_lists ol ON ol.id = olm.list_id
+          WHERE olm.object_id = fo.id),
+          '[]'::jsonb
+        )
+      ) AS obj_json
+    FROM filtered_objects fo
+    LEFT JOIN LATERAL public.object_scoped_aggregates(fo.id, p_program_slugs, p_include_unpublished) sa ON true
+  )
+  SELECT
+    COALESCE(jsonb_agg(wm.obj_json), '[]'::jsonb),
+    v_total_count,
+    p_page,
+    p_page_size
+  FROM with_members wm;
+END;
+$$;

--- a/supabase/migrations/20260719213602_member_targets_publication_gate.sql
+++ b/supabase/migrations/20260719213602_member_targets_publication_gate.sql
@@ -1,0 +1,428 @@
+-- Codex review follow-up (PR #410): gate member_targets on
+-- has_published_spectrum, matching object_scoped_aggregates. The RPC is
+-- reached via the service-role client (/api/v1/objects) which bypasses RLS,
+-- so without this predicate draft-only targets in accessible programs leaked
+-- target_id / observation / redshift_auto when p_include_unpublished = false.
+-- Pre-existing gap; the previous migration widened it to filtered queries.
+CREATE OR REPLACE FUNCTION public.get_filtered_objects_paginated(
+  p_program_slugs TEXT[],
+  p_filter_programs TEXT[] DEFAULT NULL,
+  p_fields TEXT[] DEFAULT NULL,
+  p_gratings TEXT[] DEFAULT NULL,
+  p_gratings_mode TEXT DEFAULT 'any',
+  p_observations TEXT[] DEFAULT NULL,
+  p_redshift_quality INTEGER[] DEFAULT NULL,
+  p_redshift_min DOUBLE PRECISION DEFAULT NULL,
+  p_redshift_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_snr_min DOUBLE PRECISION DEFAULT NULL,
+  p_max_snr_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_exposure_time_min DOUBLE PRECISION DEFAULT NULL,
+  p_max_exposure_time_max DOUBLE PRECISION DEFAULT NULL,
+  p_search TEXT DEFAULT NULL,
+  p_inspected_only BOOLEAN DEFAULT NULL,
+  p_needs_review BOOLEAN DEFAULT NULL,
+  p_list_ids INTEGER[] DEFAULT NULL,
+  p_coord_ra DOUBLE PRECISION DEFAULT NULL,
+  p_coord_dec DOUBLE PRECISION DEFAULT NULL,
+  p_radius_degrees DOUBLE PRECISION DEFAULT NULL,
+  p_has_photometry BOOLEAN DEFAULT NULL,
+  p_photo_z_min DOUBLE PRECISION DEFAULT NULL,
+  p_photo_z_max DOUBLE PRECISION DEFAULT NULL,
+  p_comment_search TEXT DEFAULT NULL,
+  p_comment_search_scope TEXT DEFAULT NULL,
+  p_comment_user_id UUID DEFAULT NULL,
+  p_sort_column TEXT DEFAULT 'object_id',
+  p_sort_direction TEXT DEFAULT 'asc',
+  p_page INTEGER DEFAULT 1,
+  p_page_size INTEGER DEFAULT 50,
+  p_include_unpublished BOOLEAN DEFAULT false
+)
+RETURNS TABLE(targets JSONB, total_count BIGINT, page INTEGER, page_size INTEGER)
+LANGUAGE plpgsql STABLE
+SET plan_cache_mode = 'force_custom_plan'
+AS $$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_offset INTEGER;
+  v_total_count BIGINT;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
+    v_gratings_mode := 'any';
+  END IF;
+
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN
+    p_sort_direction := 'asc';
+  END IF;
+
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time', 'photo_z'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+
+  IF v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN
+    p_sort_column := 'distance';
+  END IF;
+
+  v_offset := (COALESCE(p_page, 1) - 1) * COALESCE(p_page_size, 50);
+
+  -- Intersect user-accessible programs with filter selection
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(
+      SELECT unnest(p_program_slugs)
+      INTERSECT
+      SELECT unnest(p_filter_programs)
+    ) INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN QUERY SELECT '[]'::jsonb, 0::BIGINT, p_page, p_page_size;
+    RETURN;
+  END IF;
+
+  -- Step 1: count
+  SELECT COUNT(*) INTO v_total_count
+  FROM objects o
+  WHERE
+    -- Access control: object must have at least one accessible program
+    o.programs && v_filtered_program_slugs
+    AND o.is_active = true
+    -- B1: hide objects with no published spectrum (fail-closed).
+    AND (p_include_unpublished OR o.has_published_spectrum)
+    AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+    AND (
+      NOT v_grating_filter_active
+      OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+      OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+      OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+    )
+    AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+    AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+    AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+    AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+    AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+    AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+    AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+    AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+    AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
+    AND (
+      p_inspected_only IS NULL
+      OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+      OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+    )
+    AND (
+      p_needs_review IS NULL
+      OR (p_needs_review = TRUE
+          AND o.staleness_reason IS NOT NULL
+          AND o.last_inspected_at IS NOT NULL
+          AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+      OR (p_needs_review = FALSE
+          AND (o.staleness_reason IS NULL
+               OR o.last_inspected_at IS NULL
+               OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+    )
+    AND (
+      NOT v_coord_search_active
+      OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+        AND 2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) <= p_radius_degrees
+      )
+    )
+    AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+        SELECT olm.object_id FROM object_list_members olm
+        WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+    ))
+    AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+    AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+    AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+    AND (
+      NOT v_comment_search_active
+      -- Uncorrelated semijoin: collect the object_ids that have a matching
+      -- comment ONCE (object-level comments directly + target-level comments
+      -- mapped through their parent object), then probe o.id IN (...). The old
+      -- correlated EXISTS-inside-OR re-ran a per-object targets subquery for
+      -- every (object x matching-comment) pair -> 271k subplan executions /
+      -- ~870ms here, multi-second on broad terms or cold cache.
+      OR o.id IN (
+        SELECT c.object_id FROM comments c
+        WHERE c.object_id IS NOT NULL
+          AND c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (
+            p_comment_search_scope = 'everyone'
+            OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+          )
+        UNION
+        SELECT t.object_id FROM comments c
+        JOIN targets t ON t.id = c.target_id
+        WHERE c.target_id IS NOT NULL
+          AND c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (
+            p_comment_search_scope = 'everyone'
+            OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+          )
+      )
+    );
+
+  -- Step 2: fetch page
+  RETURN QUERY
+  WITH filtered_objects AS (
+    SELECT
+      o.id,
+      o.object_id,
+      o.field,
+      o.ra,
+      o.dec,
+      o.n_targets,
+      o.n_spectra,
+      o.programs,
+      o.gratings,
+      o.max_snr,
+      o.max_exposure_time,
+      o.redshift,
+      o.redshift_quality,
+      o.redshift_inspected,
+      o.redshift_auto,
+      o.inspected_used_auto,
+      o.last_inspected_at,
+      o.last_inspected_by,
+      o.last_data_change_at,
+      o.staleness_reason,
+      o.version,
+      o.is_active,
+      o.photo_z,
+      o.has_photometry,
+      o.created_at,
+      CASE
+        WHEN v_coord_search_active THEN
+          2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+            POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+          )))
+        ELSE NULL
+      END AS distance
+    FROM objects o
+    WHERE
+      o.programs && v_filtered_program_slugs
+      AND o.is_active = true
+      AND (p_include_unpublished OR o.has_published_spectrum)
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+        OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+        OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+      )
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
+      AND (
+        p_inspected_only IS NULL
+        OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+        OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+      )
+      AND (
+        p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+      )
+      AND (
+        NOT v_coord_search_active
+        OR (
+          o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+          AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+          AND 2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+            POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+          ))) <= p_radius_degrees
+        )
+      )
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+      AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+      AND (
+        NOT v_comment_search_active
+        -- Uncorrelated semijoin; see the count query above for the rationale.
+        OR o.id IN (
+          SELECT c.object_id FROM comments c
+          WHERE c.object_id IS NOT NULL
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+          UNION
+          SELECT t.object_id FROM comments c
+          JOIN targets t ON t.id = c.target_id
+          WHERE c.target_id IS NOT NULL
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+        )
+      )
+    ORDER BY
+      CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN
+        2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN
+        2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN o.object_id END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'desc' THEN o.object_id END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN o.field END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN o.field END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN o.ra END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN o.ra END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN o.dec END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN o.dec END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN o.redshift END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN o.redshift END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN o.redshift_quality END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN o.redshift_quality END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'asc' THEN o.n_targets END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'desc' THEN o.n_targets END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'asc' THEN o.n_spectra END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'desc' THEN o.n_spectra END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN o.max_snr END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN o.max_snr END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN o.max_exposure_time END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN o.max_exposure_time END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'asc' THEN o.photo_z END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'desc' THEN o.photo_z END DESC NULLS LAST,
+      o.object_id ASC
+    LIMIT p_page_size OFFSET v_offset
+  ),
+  with_members AS (
+    SELECT
+      jsonb_build_object(
+        'id', fo.id,
+        'object_id', fo.object_id,
+        'field', fo.field,
+        'ra', fo.ra,
+        'dec', fo.dec,
+        -- Aggregates scoped to the viewer's accessible programs so mixed-program
+        -- objects don't leak proprietary member metadata. Deliberately NOT
+        -- narrowed by p_filter_programs: a program filter selects which objects
+        -- appear (overlap test above), but each row still shows the object's
+        -- full accessible programs/observations. Filter and sort above run on
+        -- the global o.* columns; the substitution happens only on the
+        -- paginated result set.
+        'n_targets', sa.n_targets,
+        'n_spectra', sa.n_spectra,
+        'programs', sa.programs,
+        'gratings', sa.gratings,
+        'max_snr', sa.max_snr,
+        'max_exposure_time', sa.max_exposure_time,
+        'redshift', fo.redshift,
+        'redshift_quality', fo.redshift_quality,
+        'redshift_inspected', fo.redshift_inspected,
+        'redshift_auto', fo.redshift_auto,
+        'inspected_used_auto', fo.inspected_used_auto,
+        'last_inspected_at', fo.last_inspected_at,
+        'last_inspected_by', fo.last_inspected_by,
+        'last_data_change_at', fo.last_data_change_at,
+        'staleness_reason', fo.staleness_reason,
+        'version', fo.version,
+        'is_active', fo.is_active,
+        'photo_z', fo.photo_z,
+        'has_photometry', fo.has_photometry,
+        'created_at', fo.created_at,
+        'distance', fo.distance,
+        -- Phase D: member_targets becomes provenance only (target_id, program,
+        -- observation). Inspection state lives on the object now; redshift_auto
+        -- on targets is retained for transitional UI display until Phase E.
+        'member_targets', COALESCE(
+          (SELECT jsonb_agg(
+            jsonb_build_object(
+              'target_id', t.target_id,
+              'program_slug', t.program_slug,
+              'observation', t.observation,
+              'redshift_auto', t.redshift_auto
+            )
+          )
+          FROM targets t
+          WHERE t.object_id = fo.id
+            AND t.program_slug = ANY(p_program_slugs)
+            -- Same publication gate as object_scoped_aggregates: the RPC is
+            -- reached via the service-role client (/api/v1/objects), so RLS
+            -- won't hide draft-only members here.
+            AND (p_include_unpublished OR t.has_published_spectrum)
+          ),
+          '[]'::jsonb
+        ),
+        'lists', COALESCE(
+          (SELECT jsonb_agg(
+            jsonb_build_object(
+              'id', ol.id,
+              'name', ol.name,
+              'slug', ol.slug,
+              'icon', ol.icon,
+              'color', ol.color
+            ) ORDER BY ol.name
+          )
+          FROM object_list_members olm
+          JOIN object_lists ol ON ol.id = olm.list_id
+          WHERE olm.object_id = fo.id),
+          '[]'::jsonb
+        )
+      ) AS obj_json
+    FROM filtered_objects fo
+    LEFT JOIN LATERAL public.object_scoped_aggregates(fo.id, p_program_slugs, p_include_unpublished) sa ON true
+  )
+  SELECT
+    COALESCE(jsonb_agg(wm.obj_json), '[]'::jsonb),
+    v_total_count,
+    p_page,
+    p_page_size
+  FROM with_members wm;
+END;
+$$;

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -1626,6 +1626,10 @@ BEGIN
           FROM targets t
           WHERE t.object_id = fo.id
             AND t.program_slug = ANY(p_program_slugs)
+            -- Same publication gate as object_scoped_aggregates: the RPC is
+            -- reached via the service-role client (/api/v1/objects), so RLS
+            -- won't hide draft-only members here.
+            AND (p_include_unpublished OR t.has_published_spectrum)
           ),
           '[]'::jsonb
         ),

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -1583,10 +1583,13 @@ BEGIN
         'field', fo.field,
         'ra', fo.ra,
         'dec', fo.dec,
-        -- Aggregates scoped to the viewer's accessible (+ filtered) programs so
-        -- mixed-program objects don't leak proprietary member metadata. Filter
-        -- and sort above still run on the global o.* columns (display-only
-        -- scoping); the substitution happens only on the paginated result set.
+        -- Aggregates scoped to the viewer's accessible programs so mixed-program
+        -- objects don't leak proprietary member metadata. Deliberately NOT
+        -- narrowed by p_filter_programs: a program filter selects which objects
+        -- appear (overlap test above), but each row still shows the object's
+        -- full accessible programs/observations. Filter and sort above run on
+        -- the global o.* columns; the substitution happens only on the
+        -- paginated result set.
         'n_targets', sa.n_targets,
         'n_spectra', sa.n_spectra,
         'programs', sa.programs,
@@ -1622,7 +1625,7 @@ BEGIN
           )
           FROM targets t
           WHERE t.object_id = fo.id
-            AND t.program_slug = ANY(v_filtered_program_slugs)
+            AND t.program_slug = ANY(p_program_slugs)
           ),
           '[]'::jsonb
         ),
@@ -1643,7 +1646,7 @@ BEGIN
         )
       ) AS obj_json
     FROM filtered_objects fo
-    LEFT JOIN LATERAL public.object_scoped_aggregates(fo.id, v_filtered_program_slugs, p_include_unpublished) sa ON true
+    LEFT JOIN LATERAL public.object_scoped_aggregates(fo.id, p_program_slugs, p_include_unpublished) sa ON true
   )
   SELECT
     COALESCE(jsonb_agg(wm.obj_json), '[]'::jsonb),


### PR DESCRIPTION
## Summary

Bug: in the NIRSpec objects table, filtering by program rescoped each row's **Programs** and **# Observations** columns to only the selected program, instead of showing the object's full program membership.

Root cause: `get_filtered_objects_paginated` intersects the user's program filter into the accessible-programs array (`v_filtered_program_slugs`) and passed that same narrowed array into the `object_scoped_aggregates` LATERAL that recomputes the displayed per-row aggregates. Row *selection* was already correct — the `o.programs && v_filtered_program_slugs` overlap test selects every object whose programs include the chosen one — only the displayed aggregates were wrongly narrowed.

## Changes

- `supabase/schemas/functions.sql` — in `get_filtered_objects_paginated`, the aggregates LATERAL and the `member_targets` subquery now use `p_program_slugs` (the viewer's full accessible set) instead of the filter-narrowed array. The anti-leak scoping this substitution was built for is preserved: aggregates remain capped to programs the viewer can access. Row filtering, total count, and sort are untouched.
- `supabase/migrations/20260719204502_unscope_object_row_aggregates_from_program_filter.sql` — hand-authored `CREATE OR REPLACE` (Docker unavailable locally for `supabase db diff`; same signature so grants persist), diff-verified byte-identical to the schema-file definition.

## Verification

Read-only check against production data: object `J021703.04-051008.1` (programs `[mom, rubies]`, 2 observations). `object_scoped_aggregates` with the filter-narrowed array returns `[mom]` / 1 (the bug); with the access-scoped array it returns `[mom, rubies]` / 2 (correct). Preview branch will exercise the migration.

Side effect: passing the full accessible set lets most objects hit the function's stored-aggregate fast path (`o.programs <@ p_program_slugs`) instead of recomputing per row.

Generated with Claude Code