### PR TITLE
NIRCam align: JHAT-parity matcher + SEP-segmentation detection + residual backstop

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -47,17 +47,21 @@ Release procedure: edit the `## Unreleased` section below, then run
   f444w) that JHAT solved at 100%. Pooling is preserved and strengthened:
   all of a pool's detectors accumulate into one shared offset histogram. The
   pool is gated to `NOT_ALIGNED` unless enough one-to-one matches span enough
-  sky to condition a rotation, then each over-tolerance detector gets a fine
-  fit down a `general→rshift→shift→coarse` ladder (default ceiling `rshift`,
-  = jhat's per-detector geometry), fit on its own mutual-NN pairs as a
-  pre-matched list (`match=None` — jhat's `already_matched` design; no
-  `XYXYMatch` remains anywhere in align). Detection magnitudes are calibrated
-  AB whenever the frame carries `BUNIT=MJy/sr` + `PIXAR_SR` (Kron photometry
-  + jhat's zeropoint convention; see the SEP-detection entry below), making
-  jhat's `objmag_lim` and pair-level `delta_mag_lim` cuts available with
-  their COSMOS values (`[19, 28]` / `[-3, 4]`; both default-off,
-  `objmag_lim` is skipped loudly on zeropoint-less frames instead of cutting
-  on instrumental mags). Retires the pooled cross-filter joint
+  sky to condition a rotation, then EVERY detector with enough verified
+  matches gets a fine fit down a `general→rshift→shift→coarse` ladder
+  (default ceiling `rshift`, = jhat's per-detector geometry; jhat fits every
+  detector, always, so `tolerance` is a QA flag, not a gate — a sub-tolerance
+  systematic SIAF offset no longer survives), fit on its own mutual-NN pairs
+  as a pre-matched list (`match=None` — jhat's `already_matched` design; no
+  `XYXYMatch` remains anywhere in align; `fine_min_shift` floor = jhat's
+  `minobj` = 3, the guard against noise-chasing per-detector fits).
+  Detection magnitudes are calibrated AB whenever the frame carries
+  `BUNIT=MJy/sr` + `PIXAR_SR` (Kron photometry + jhat's zeropoint
+  convention; see the SEP-detection entry below), making jhat's `objmag_lim`
+  and pair-level `delta_mag_lim` cuts available with their COSMOS values
+  (`[19, 28]` / `[-3, 4]`; both default-off, `objmag_lim` is skipped loudly
+  on zeropoint-less frames instead of cutting on instrumental mags). Retires
+  the pooled cross-filter joint
   solve, the bootstrap triangle matcher, and the **`tristars` dependency**
   (`matcher.py` removed). `CFP_ALGN` now records the refcat content hash
   (`rc=`) so a changed refcat re-solves instead of silently keeping a stale

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -52,17 +52,39 @@ Release procedure: edit the `## Unreleased` section below, then run
   = jhat's per-detector geometry), fit on its own mutual-NN pairs as a
   pre-matched list (`match=None` — jhat's `already_matched` design; no
   `XYXYMatch` remains anywhere in align). Detection magnitudes are calibrated
-  AB whenever the frame carries `BUNIT=MJy/sr` + `PIXAR_SR` (annulus-free
-  2×FWHM aperture photometry — jhat's zeropoint convention, minus the sky
-  annulus that breaks on sky-subtracted frames), making jhat's `objmag_lim`
-  and pair-level `delta_mag_lim` cuts available with their COSMOS values
-  (`[19, 28]` / `[-3, 4]`; both default-off, `objmag_lim` is skipped loudly
-  on zeropoint-less frames instead of cutting on instrumental mags). Retires the pooled cross-filter joint
+  AB whenever the frame carries `BUNIT=MJy/sr` + `PIXAR_SR` (Kron photometry
+  + jhat's zeropoint convention; see the SEP-detection entry below), making
+  jhat's `objmag_lim` and pair-level `delta_mag_lim` cuts available with
+  their COSMOS values (`[19, 28]` / `[-3, 4]`; both default-off,
+  `objmag_lim` is skipped loudly on zeropoint-less frames instead of cutting
+  on instrumental mags). Retires the pooled cross-filter joint
   solve, the bootstrap triangle matcher, and the **`tristars` dependency**
   (`matcher.py` removed). `CFP_ALGN` now records the refcat content hash
   (`rc=`) so a changed refcat re-solves instead of silently keeping a stale
   WCS. `campfire_pipeline/nircam/align/`, `association.py`, `orchestrate.py`,
   `config_default.toml`.
+- NIRCam `align` per-exposure detection swapped from point-source
+  (`DAOStarFinder`) to **SEP segmentation of the SNR map**, sharing the refcat
+  build's exact recipe (`refcat/extract.py::sep_extract_sources`, factored out
+  as a common core) so image-side detections correspond to refcat entries by
+  construction. Fixes the COSMOS A2/A3 f277w misregistration: over a bright
+  extended galaxy the point-source finder returned thousands of bright
+  substructure peaks tracing the same galaxy clustering as the refcat, and the
+  coarse gross-shift 2-D offset histogram locked onto a clustering-scale peak
+  ~37" from the true offset, dragging 13 well-pointed exposures 25–40"
+  (doubled sources in the A2/A3 mosaics). Validated on all 13 affected + 10
+  clean exposures (`scripts/claude/repro_batch.py`): 13/13 recover (0,0),
+  10/10 unchanged, refcat-match fraction up in every case (22–31% → 87–91% on
+  the bad ones). Detection knobs change accordingly
+  (`snr_thresh`/`minarea`/`deblend_*`/`fwhm` = matched-filter kernel;
+  `snr_min` is now the integrated flux SNR; calibrated mags are Kron-based,
+  `aper_radius_px` is gone). Also adds a **residual backstop**
+  (`max_residual_arcsec`, default 0.1"): any detector whose final one-to-one
+  residual exceeds it is individually rejected to `NOT_ALIGNED` (WCS
+  preserved, quarantined from combine), so a plausible-but-wrong solution can
+  never reach a mosaic again — the healthy population sits at ~0.02–0.03",
+  the A2/A3 failures sat at 0.20–0.24". `campfire_pipeline/nircam/align/`,
+  `refcat/extract.py`, `config_default.toml`.
 - NIRCam `wcs_shift` now invalidates downstream alignment state whenever it
   rewrites a WCS: the `CFP_JHAT`/`CFP_ALGN` stamps and align's `ALGN_BAK`
   baseline are scrubbed in the same atomic write, so re-applying a retuned

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -35,17 +35,26 @@ Release procedure: edit the `## Unreleased` section below, then run
   default off), so existing jhat reductions are unchanged. Per filter (= per
   channel), each exposure is split into module pools (`pool_modules`, default
   per-module); each pool is footprint-clipped and tied to the field's shared
-  Gaia-tied refcat with one rigid `rshift` matched by `tweakwcs.XYXYMatch`'s
-  2-D-histogram (iterated to convergence — recovers offsets to tens of arcsec
-  and roll to ~1°; validated in `scripts/align_matcher_bakeoff.py`), gated to
-  `NOT_ALIGNED` unless enough one-to-one matches span enough sky to condition a
-  rotation, then each over-tolerance detector gets a fine fit down a
-  `general→rshift→shift→coarse` ladder (default ceiling `rshift`, = jhat's
-  per-detector geometry). Retires the pooled cross-filter joint solve, the
-  bootstrap triangle matcher, and the **`tristars` dependency** (`matcher.py`
-  removed). `CFP_ALGN` now records the refcat content hash (`rc=`) so a changed
-  refcat re-solves instead of silently keeping a stale WCS. `campfire_pipeline/
-  nircam/align/`, `association.py`, `orchestrate.py`, `config_default.toml`.
+  Gaia-tied refcat with one rigid `rshift` matched by the **JHAT-ported
+  offset-histogram matcher** (`align/histmatch.py`): a 2-D-histogram
+  gross-shift stage (recovers acquisition offsets to tens of arcsec), then
+  unbounded 1-NN pairing whose true correspondences are selected by JHAT's
+  per-axis offset-histogram consensus (rotation-slope scan + sigma clip),
+  iterated to convergence. The consensus matcher replaces `tweakwcs.XYXYMatch`
+  in the coarse path: XYXYMatch's pair *enumeration* sizes output by the
+  detection count and died with `MatchSourceConfusionError` on clustered
+  extragalactic catalogs — 39% of COSMOS LW exposures (48/124 in tile A1
+  f444w) that JHAT solved at 100%. Pooling is preserved and strengthened:
+  all of a pool's detectors accumulate into one shared offset histogram. The
+  pool is gated to `NOT_ALIGNED` unless enough one-to-one matches span enough
+  sky to condition a rotation, then each over-tolerance detector gets a fine
+  fit down a `general→rshift→shift→coarse` ladder (default ceiling `rshift`,
+  = jhat's per-detector geometry). Retires the pooled cross-filter joint
+  solve, the bootstrap triangle matcher, and the **`tristars` dependency**
+  (`matcher.py` removed). `CFP_ALGN` now records the refcat content hash
+  (`rc=`) so a changed refcat re-solves instead of silently keeping a stale
+  WCS. `campfire_pipeline/nircam/align/`, `association.py`, `orchestrate.py`,
+  `config_default.toml`.
 - NIRCam `wcs_shift` now invalidates downstream alignment state whenever it
   rewrites a WCS: the `CFP_JHAT`/`CFP_ALGN` stamps and align's `ALGN_BAK`
   baseline are scrubbed in the same atomic write, so re-applying a retuned
@@ -61,7 +70,6 @@ Release procedure: edit the `## Unreleased` section below, then run
   epoch is no longer silently read as a Julian year), and warns when a merge
   discards proper motions because the PM catalog wasn't listed first.
   `campfire_pipeline/nircam/refcat/{motion,merge}.py`.
-### Calibration
 - NIRCam wisp subtraction now defaults to the multi-component non-negative
   matrix factorization model of Wu et al. 2026 (JADES DR5, arXiv:2601.15958),
   via the new `nmfwisp` dependency (templates ship in the wheel). Per-exposure

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -49,7 +49,15 @@ Release procedure: edit the `## Unreleased` section below, then run
   pool is gated to `NOT_ALIGNED` unless enough one-to-one matches span enough
   sky to condition a rotation, then each over-tolerance detector gets a fine
   fit down a `general→rshift→shift→coarse` ladder (default ceiling `rshift`,
-  = jhat's per-detector geometry). Retires the pooled cross-filter joint
+  = jhat's per-detector geometry), fit on its own mutual-NN pairs as a
+  pre-matched list (`match=None` — jhat's `already_matched` design; no
+  `XYXYMatch` remains anywhere in align). Detection magnitudes are calibrated
+  AB whenever the frame carries `BUNIT=MJy/sr` + `PIXAR_SR` (annulus-free
+  2×FWHM aperture photometry — jhat's zeropoint convention, minus the sky
+  annulus that breaks on sky-subtracted frames), making jhat's `objmag_lim`
+  and pair-level `delta_mag_lim` cuts available with their COSMOS values
+  (`[19, 28]` / `[-3, 4]`; both default-off, `objmag_lim` is skipped loudly
+  on zeropoint-less frames instead of cutting on instrumental mags). Retires the pooled cross-filter joint
   solve, the bootstrap triangle matcher, and the **`tristars` dependency**
   (`matcher.py` removed). `CFP_ALGN` now records the refcat content hash
   (`rc=`) so a changed refcat re-solves instead of silently keeping a stale

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -431,19 +431,36 @@
     enabled = false
     # --- Coarse: pooled per-module (or per-channel) shift+rotation --------------
     # One rshift is fit from all of a module's detectors at once (SIAF fixed),
-    # matched to the refcat by tweakwcs' 2-D pairwise-offset histogram
-    # (XYXYMatch, use2dhist) then iterated to convergence. The bake-off
-    # (scripts/align_matcher_bakeoff.py) showed this recovers offsets to tens of
-    # arcsec and roll to ~1 deg at 97-100% in realistic (contaminated) fields;
-    # a rotation-scan wrapper was worse and 17x slower and the stimage triangle
-    # matcher hard-crashes on sparse input, so both — and tristars — are retired.
+    # matched to the refcat by the JHAT-ported OffsetHistogramMatch: a 2-D
+    # pairwise-offset histogram grabs the gross translation (pass 0 only),
+    # then every image source is 1-NN-paired to the refcat and the TRUE pairs
+    # are selected by consensus — they pile into one narrow peak of the
+    # per-axis offset histogram (rotation-slope scan + sigma clip) while false
+    # pairs scatter. Nothing is pair-enumerated, so the matcher cannot hit
+    # tweakwcs/stimage's MatchSourceConfusionError on clustered extragalactic
+    # catalogs (39% of COSMOS LW exposures under the previous XYXYMatch).
+    # All detectors of a pool share ONE offset histogram, so pooling makes the
+    # consensus peak stronger, not weaker.
     pool_modules      = false   # false: coarse fit per module (A, B separate);
                                 # true: pool both modules into one coarse fit
-    coarse_searchrad  = 70.0    # arcsec; 2-D-hist search radius (>= max acquisition
-                                # offset to recover; 70" covers 60" shifts)
-    coarse_tolerance  = 2.0     # arcsec; coarse pair-accept tolerance
-    coarse_separation = 1.0     # arcsec; min in-catalog source separation
+    coarse_searchrad  = 70.0    # arcsec; gross-shift 2-D-hist radius (>= max
+                                # acquisition offset to recover; 70" covers 60")
     refine_niter      = 3       # coarse match->fit->rematch iters (recovers roll)
+    # Histogram-consensus knobs (JHAT names/values — the validated COSMOS
+    # [nircam.jhat] configuration). *_px values are IMAGE PIXELS, converted to
+    # tangent-plane arcsec per pool, so SW/LW each get physical values.
+    d2d_max           = 1.5     # arcsec; drop 1-NN pairs farther than this
+                                # (after the gross shift)
+    binsize_px        = 0.02    # offset-histogram bin (px)
+    gaussian_sigma_px = 0.2     # histogram smoothing sigma (px)
+    rough_cut_px_min  = 2.5     # clamp on the rough cut around the peak (px);
+    rough_cut_px_max  = 2.5     # min = max = 2.5 pins it, as JHAT ran on COSMOS
+    nfwhm             = 2.5     # rough cut = nfwhm * peak FWHM before clamping
+    hist_nsigma       = 3.0     # sigma-clip of the de-rotated offsets
+    histocut_order    = "dxdy"  # cut dx-vs-y first ("dxdy") or dy-vs-x ("dydx")
+    slope_max         = 0.0048828125  # rotation-scan half-range, dimensionless
+                                      # (= JHAT's 10px/2048px ~ 0.28 deg)
+    slope_nsteps      = 200     # rotation-scan steps across [-slope_max, +]
     # --- Fine: gated per-detector fit on top of the coarse ---------------------
     # fine_fitgeom is the CEILING dof; each detector falls down the ladder
     # (general -> rshift -> shift -> keep-coarse) by its unique-match count. jhat

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -461,6 +461,14 @@
     slope_max         = 0.0048828125  # rotation-scan half-range, dimensionless
                                       # (= JHAT's 10px/2048px ~ 0.28 deg)
     slope_nsteps      = 200     # rotation-scan steps across [-slope_max, +]
+    # delta_mag_lim = [-3.0, 4.0]   # keep a 1-NN pair only if image_mag -
+                                # refcat_mag lies in this window (JHAT's COSMOS
+                                # value). Needs calibrated detection mags (auto
+                                # when frames are MJy/sr) AND a refcat whose
+                                # 'mag' zeropoint is trustworthy — refcat mags
+                                # are heterogeneous across build backends, so
+                                # this stays off by default. Pairs missing
+                                # either mag are never cut.
     # --- Fine: gated per-detector fit on top of the coarse ---------------------
     # fine_fitgeom is the CEILING dof; each detector falls down the ladder
     # (general -> rshift -> shift -> keep-coarse) by its unique-match count. jhat
@@ -474,12 +482,22 @@
     min_matched       = 6         # per-pool reject-to-NOT_ALIGNED floor (1-to-1)
     min_coverage_arcsec = 5.0     # matched sources must span >= this (conditions rot)
     ref_border_arcmin = 1.2     # refcat footprint margin (>= coarse_searchrad); arcmin
-    # Detection quality selection (per detector, no count cap):
+    # Detection quality selection (per detector, no count cap). Detection
+    # magnitudes are CALIBRATED AB whenever the frame is MJy/sr with PIXAR_SR
+    # (annulus-free aperture photometry, radius 2 x fwhm, JHAT's zeropoint
+    # convention) — so objmag_lim takes real AB values; on a frame with no
+    # zeropoint the cut is skipped loudly rather than applied to instrumental
+    # mags.
     nsigma = 5.0                # detection threshold (convolved background sigma)
     snr_min = 5.0               # drop detections below this peak SNR (peak/bkg-rms)
     fwhm = 2.5                  # fallback detection PSF FWHM (px); per-filter
                                 # override below
     edge = 8                    # drop detections within this many px of a border
+    # objmag_lim = [19.0, 28.0] # keep only this AB-mag window (JHAT's COSMOS
+                                # value); off by default — DQ saturation
+                                # masking already guards the bright end
+    # aper_radius_px = 5.0      # aperture radius for calibrated mags;
+                                # default 2 x fwhm
 
     # Per-filter detection PSF FWHM (detector pixels). NIRCam's PSF core runs
     # from ~F070W to ~F480M, so one fwhm is wrong across the SW+LW channels; the

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -482,28 +482,44 @@
     min_matched       = 6         # per-pool reject-to-NOT_ALIGNED floor (1-to-1)
     min_coverage_arcsec = 5.0     # matched sources must span >= this (conditions rot)
     ref_border_arcmin = 1.2     # refcat footprint margin (>= coarse_searchrad); arcmin
-    # Detection quality selection (per detector, no count cap). Detection
-    # magnitudes are CALIBRATED AB whenever the frame is MJy/sr with PIXAR_SR
-    # (annulus-free aperture photometry, radius 2 x fwhm, JHAT's zeropoint
+    # Backstop residual gate: any detector whose final 1-to-1 residual exceeds
+    # this (arcsec) is individually rejected to NOT_ALIGNED (WCS preserved,
+    # quarantined from combine) — no plausible-but-wrong solution may reach a
+    # mosaic. Healthy solves sit at ~0.02-0.03"; the COSMOS A2/A3
+    # misregistrations this guards against sat at 0.20-0.24".
+    max_residual_arcsec = 0.1
+    # --- Detection (per detector, no count cap) --------------------------------
+    # SEP segmentation of the SNR map (sci/err), mirroring the refcat build
+    # (refcat/extract.py) so image-side detections correspond to refcat
+    # entries. Point-source (DAOStarFinder) detection is retired: over bright
+    # extended galaxies it found thousands of *bright* substructure peaks
+    # tracing the same galaxy clustering as the refcat, and the coarse
+    # gross-shift 2-D offset histogram grew clustering-scale peaks that could
+    # beat the true offset — dragging well-pointed exposures tens of arcsec
+    # (COSMOS A2/A3 f277w). Detection magnitudes are CALIBRATED AB whenever
+    # the frame is MJy/sr with PIXAR_SR (Kron photometry + JHAT's zeropoint
     # convention) — so objmag_lim takes real AB values; on a frame with no
     # zeropoint the cut is skipped loudly rather than applied to instrumental
     # mags.
-    nsigma = 5.0                # detection threshold (convolved background sigma)
-    snr_min = 5.0               # drop detections below this peak SNR (peak/bkg-rms)
-    fwhm = 2.5                  # fallback detection PSF FWHM (px); per-filter
-                                # override below
+    snr_thresh = 3.0            # per-pixel detection threshold on the SNR map
+    minarea = 15                # min connected pixels above snr_thresh
+    deblend_nthresh = 32        # SEP deblender: number of thresholds
+    deblend_cont = 0.001        # SEP deblender: min contrast
+    snr_min = 10.0              # drop sources below this integrated flux SNR
+                                # (flux/fluxerr; same cut as the refcat build)
     edge = 8                    # drop detections within this many px of a border
+    fwhm = 1.5                  # fallback matched-filter kernel FWHM (px);
+                                # per-filter override below
     # objmag_lim = [19.0, 28.0] # keep only this AB-mag window (JHAT's COSMOS
                                 # value); off by default — DQ saturation
                                 # masking already guards the bright end
-    # aper_radius_px = 5.0      # aperture radius for calibrated mags;
-                                # default 2 x fwhm
 
-    # Per-filter detection PSF FWHM (detector pixels). NIRCam's PSF core runs
-    # from ~F070W to ~F480M, so one fwhm is wrong across the SW+LW channels; the
-    # align worker keys detection off each member's filter, falling back to the
-    # scalar `fwhm` above for any filter not listed. Values ≈ PSF-core FWHM /
-    # pixel-scale — approximate; tune per field on real data.
+    # Per-filter matched-filter kernel FWHM (detector pixels) — the kernel
+    # should track the PSF core, which runs from ~F070W to ~F480M, so one fwhm
+    # is wrong across the SW+LW channels; the align worker keys detection off
+    # each member's filter, falling back to the scalar `fwhm` above for any
+    # filter not listed. Values ≈ PSF-core FWHM / pixel-scale — approximate;
+    # tune per field on real data.
     [nircam.align.psf_fwhm_by_filter]
         f070w = 1.5
         f090w = 1.6

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -469,15 +469,22 @@
                                 # are heterogeneous across build backends, so
                                 # this stays off by default. Pairs missing
                                 # either mag are never cut.
-    # --- Fine: gated per-detector fit on top of the coarse ---------------------
-    # fine_fitgeom is the CEILING dof; each detector falls down the ladder
-    # (general -> rshift -> shift -> keep-coarse) by its unique-match count. jhat
-    # only ever fits rshift per detector, so rshift is the default ceiling.
+    # --- Fine: per-detector fit on top of the coarse ---------------------------
+    # EVERY detector with enough verified (mutual-NN) matches gets an
+    # individual fit on its pre-matched pairs — jhat fits every detector,
+    # always, and a sub-tolerance systematic SIAF offset must not survive just
+    # because it is small. fine_fitgeom is the CEILING dof; each detector
+    # falls down the ladder (general -> rshift -> shift -> keep-coarse) by its
+    # match count; the floors are the guard against noise-chasing fits
+    # (fine_min_shift = jhat's own minobj = 3). jhat only ever fits rshift per
+    # detector, so rshift is the default ceiling.
     fine_fitgeom      = "rshift"  # "general" | "rshift" | "shift"
     fine_min_general  = 10        # >= this many 1-to-1 matches -> allow general
     fine_min_rshift   = 4         # >= this -> allow rshift
-    fine_min_shift    = 2         # >= this -> allow shift; below -> keep coarse
-    tolerance         = 0.05      # arcsec; a fine fit must beat this to read "within"
+    fine_min_shift    = 3         # >= this -> allow shift; below -> keep coarse
+                                  # (= jhat's tweakreg minobj)
+    tolerance         = 0.05      # arcsec; QA/reporting only — flags a detector
+                                  # as within tolerance; gates nothing
     match_radius      = 0.5       # arcsec; 1-to-1 NN radius for residuals + fine match
     min_matched       = 6         # per-pool reject-to-NOT_ALIGNED floor (1-to-1)
     min_coverage_arcsec = 5.0     # matched sources must span >= this (conditions rot)

--- a/pipeline/campfire_pipeline/nircam/align/DESIGN.md
+++ b/pipeline/campfire_pipeline/nircam/align/DESIGN.md
@@ -88,9 +88,10 @@ per FILTER (one channel), per EXPOSURE (build_exposure_groups)
 │  1. FOOTPRINT-CLIP the field refcat to this pool's detector union +    │
 │     border (footprint.py, gnomonic tangent plane).                     │
 │  2. COARSE — ONE pooled rigid `rshift`, all the pool's detectors on one │
-│     group_id, matched by tweakwcs XYXYMatch(use2dhist=True) 2-D        │
-│     pairwise-offset histogram, iterated match→fit→rematch to converge  │
-│     (pass 0 grabs the gross translation; later passes peel off roll).  │
+│     group_id, matched by the JHAT-ported OffsetHistogramMatch          │
+│     (histmatch.py): gross 2-D-hist shift (pass 0), then unbounded 1-NN │
+│     + offset-histogram consensus; iterated match→fit→rematch to        │
+│     converge (later passes peel off roll).                             │
 │  3. GROUP GATE — recompute one-to-one (mutual-NN) matches DIRECTLY;    │
 │     accept the pool only if ≥ min_matched matches AND they span        │
 │     ≥ min_coverage_arcsec of sky; else → NOT_ALIGNED (WCS preserved).  │
@@ -137,15 +138,52 @@ Mechanically: all of a pool's detectors get one `group_id`, so `tweakwcs`
 `align_wcs` fits and applies one rigid transform to them; distinct per-pool
 `group_id`s + a static refcat + `expand_refcat=False` keep pools independent.
 
-### 3.2 Coarse solve (`solve._coarse`)
+### 3.2 Coarse solve (`solve._coarse` + `histmatch.OffsetHistogramMatch`)
 
-Pass 0 uses `XYXYMatch(use2dhist=True, searchrad=coarse_searchrad, ...)` — a 2-D
-pairwise-offset histogram that grabs the gross translation over the full search
-radius. Later passes start from the corrected WCS, match by nearest neighbour
-(`use2dhist=False`) around the now-small residual, and the rigid `rshift` peels
-off the roll; the loop stops when a pass moves the WCS by < 0.01″ (well below a
-NIRCam pixel) or after `refine_niter` passes. A matcher/fit crash degrades the
-pool to NOT_ALIGNED — it never aborts the worker or the field.
+The coarse matcher is a **faithful port of JHAT's matching algorithm**
+(`find_good_refcat_matches` + `histogram_cut`), which is structurally different
+from `tweakwcs.XYXYMatch`:
+
+- **Why not XYXYMatch.** `XYXYMatch` *enumerates* candidate pairs
+  (`stsci.stimage.xyxymatch`) and sizes its output array by the detection
+  count. On real extragalactic catalogs — where detections and refcat rows are
+  the same clustered galaxies and the refcat resolves substructure (several
+  reference rows within the match tolerance of one detection) — the number of
+  reference sources finding a partner exceeds the detection count and the
+  matcher dies with `MatchSourceConfusionError`. This killed **39% of COSMOS
+  LW exposures** (48/124 in tile A1 f444w) that JHAT solved at 100%.
+- **What JHAT does instead.** Pair **every** image source with its single
+  nearest reference (unbounded 1-NN — most pairs are wrong *by design*), then
+  find the true correspondence by **consensus**: true pairs pile into one
+  narrow peak of the pairwise-offset histogram while false pairs scatter
+  ~uniformly. Per axis (dx vs y first, then dy vs x — `histocut_order`), a
+  rotation-slope scan (`slope_max`, `slope_nsteps`) de-rotates the offsets, the
+  Gaussian-smoothed histogram peak is located, survivors of a rough cut around
+  the peak (`nfwhm`·FWHM clamped to `[rough_cut_px_min, rough_cut_px_max]`)
+  are sigma-clipped (`hist_nsigma`). Nothing is enumerated; nothing can
+  overflow. The `*_px` knobs are image pixels (converted per pool via the
+  `tweakwcs` `tp_pscale`), so the validated JHAT COSMOS configuration carries
+  over verbatim.
+- **Pooling is native, and stronger.** The matcher sees the tangent-plane
+  catalogs *after* `tweakwcs` concatenates the pool (shared `group_id`), so
+  every detector's pairs accumulate into ONE shared offset histogram — more
+  detectors mean a taller consensus peak. The port strengthens the pooled
+  design rather than trading it away.
+- **Gross-shift stage (pass 0 only).** JHAT's 1-NN assumes the WCS error is
+  below the local source spacing (true for normal JWST pointing). To keep
+  acquisition-failure recovery, pass 0 first locates the gross translation as
+  the peak of the 2-D pairwise-offset histogram within `coarse_searchrad` —
+  the same idea `XYXYMatch(use2dhist=True)` used for its initial estimate
+  (bake-off-validated), but accumulated directly into the histogram so no pair
+  list is ever materialized.
+
+Later passes start from the corrected WCS and re-match with the same consensus
+matcher minus the gross stage (JHAT's `iterate_with_xyshifts`, generalized:
+the re-pairing starts from the *fitted* WCS, not just a median shift); the
+rigid `rshift` peels off the roll. The loop stops when a pass moves the WCS by
+< 0.01″ (well below a NIRCam pixel) or after `refine_niter` passes. A
+matcher/fit crash degrades the pool to NOT_ALIGNED — it never aborts the
+worker or the field.
 
 Provenance: pass 0's fit is the gross shift/rot the input WCS was off by (stored
 for logging); the converged pass's RMSE is the reported quality.
@@ -305,10 +343,17 @@ All knobs live in `config_default.toml`; per-field overrides go in
 | `enabled` | `false` | Opt-in; off ⇒ the JHAT path runs unchanged |
 | `refcat` | — | Field's Gaia-tied refcat filename (required when enabled; set in `fields.toml`) |
 | `pool_modules` | `false` | `false`: coarse fit per module (A, B separate); `true`: pool both modules |
-| `coarse_searchrad` | `70.0` | arcsec — 2-D-hist search radius (≥ max acquisition offset) |
-| `coarse_tolerance` | `2.0` | arcsec — coarse pair-accept tolerance |
-| `coarse_separation` | `1.0` | arcsec — min in-catalog source separation |
+| `coarse_searchrad` | `70.0` | arcsec — gross-shift 2-D-hist radius (≥ max acquisition offset) |
 | `refine_niter` | `3` | coarse match→fit→rematch iterations (recovers roll) |
+| `d2d_max` | `1.5` | arcsec — drop 1-NN pairs farther than this (post gross shift) |
+| `binsize_px` | `0.02` | offset-histogram bin (image px, JHAT value) |
+| `gaussian_sigma_px` | `0.2` | histogram smoothing sigma (image px) |
+| `rough_cut_px_min` / `_max` | `2.5` / `2.5` | clamp on the rough cut around the peak (px); min = max pins it (COSMOS config) |
+| `nfwhm` | `2.5` | rough cut = `nfwhm` × peak FWHM before clamping |
+| `hist_nsigma` | `3.0` | sigma-clip of the de-rotated offsets |
+| `histocut_order` | `"dxdy"` | cut dx-vs-y first, or `"dydx"` |
+| `slope_max` | `10/2048` | rotation-scan half-range, dimensionless (≈ ±0.28°) |
+| `slope_nsteps` | `200` | rotation-scan steps |
 | `fine_fitgeom` | `"rshift"` | per-detector fine ceiling: `general` \| `rshift` \| `shift` |
 | `fine_min_general` | `10` | ≥ this many 1-to-1 matches ⇒ allow `general` |
 | `fine_min_rshift` | `4` | ≥ this ⇒ allow `rshift` |
@@ -332,8 +377,18 @@ All knobs live in `config_default.toml`; per-field overrides go in
 
 - **jhat's automatic solve.** Replaced by `align` for opted-in fields; jhat's
   linear per-detector `rshift` behavior is reproduced (`fine_fitgeom="rshift"`
-  default), and its `to_fits_sip` GWCS serialization is preserved via
+  default), its **matching algorithm is ported outright** (`histmatch.py`, §3.2),
+  and its `to_fits_sip` GWCS serialization is preserved via
   `update_fits_wcsinfo`.
+- **`tweakwcs.XYXYMatch` in the coarse path — retired.** Its pair enumeration
+  (`stsci.stimage.xyxymatch`) sizes output by the detection count and dies with
+  `MatchSourceConfusionError` on clustered extragalactic catalogs (39% of
+  COSMOS LW exposures; JHAT solved 100%). The 2-D-histogram *initial-offset*
+  idea it validated in the bake-off survives as the matcher's gross-shift
+  stage; the enumeration does not. `XYXYMatch` remains only in the fine
+  per-detector refit, where the local refcat is a subset of that detector's
+  own one-to-one matches, so the overflow condition (#refs finding a partner >
+  #detections) is impossible by construction.
 - **The triangle matcher (`tristars`) — retired.** The earlier `align` drafts
   bootstrapped correspondences with a `tristars` triangle/asterism matcher
   (`matcher.py`); the coarse-matcher bake-off (`scripts/align_matcher_bakeoff.py`)
@@ -365,6 +420,17 @@ All knobs live in `config_default.toml`; per-field overrides go in
   (COSMOS/CEERS broad-band pairs, an F070W/F090W field, a crowded stellar field, a
   nebulous star-forming region, a narrow/medium LW pairing, tile-edge and
   missing-detector cases), `align` stays opt-in.
+- **Magnitude cuts are NOT at JHAT parity — known, deliberate.** JHAT's
+  validated COSMOS config also used `objmag_lim = [19, 28]` (calibrated AB, from
+  aperture photometry + zeropoint) and `delta_mag_lim = [-3, 4]` (pair-level
+  image-vs-refcat brightness agreement). align's `objmag_lim` is an
+  **uncalibrated** DAOStarFinder kernel magnitude (`detect.py`) so the JHAT
+  values do not transfer, and `delta_mag_lim` has no align equivalent at all
+  (no calibrated image magnitudes to compare against the refcat). The
+  histogram-consensus matcher is what makes JHAT robust — the mag cuts only
+  thin its false-pair floor — so parity was not blocked on them; if real-data
+  validation shows the floor matters, calibrating detection magnitudes
+  (zeropoint from the SCI header units + pixel area) is the follow-up.
 - **Per-detector distortion fitting — deliberately not built.** A genuine SIP
   distortion solve (`fit_wcs_from_points(sip_degree=…)`) was considered and
   rejected: jhat doesn't do it (its SIP is a serialization, not a fit, §1), and a

--- a/pipeline/campfire_pipeline/nircam/align/DESIGN.md
+++ b/pipeline/campfire_pipeline/nircam/align/DESIGN.md
@@ -96,7 +96,7 @@ per FILTER (one channel), per EXPOSURE (build_exposure_groups)
 │  3. GROUP GATE — recompute one-to-one (mutual-NN) matches DIRECTLY;    │
 │     accept the pool only if ≥ min_matched matches AND they span        │
 │     ≥ min_coverage_arcsec of sky; else → NOT_ALIGNED (WCS preserved).  │
-│  4. FINE — each detector over `tolerance` gets an individual fit down  │
+│  4. FINE — every detector with ≥ fine_min matches gets a fit down      │
 │     the ladder general → rshift → shift → keep-coarse, geometry chosen │
 │     by its unique-match count + coverage, ACCEPTED only if it reduces  │
 │     the residual.                                                      │
@@ -206,11 +206,19 @@ rotation you don't trust. This is the substantive fix over the old count-only ga
 
 ### 3.4 Fine per-detector ladder (`solve._choose_fitgeom`, `solve._fine_fit`)
 
-Only detectors whose one-to-one residual exceeds `tolerance` are refit. Each picks
-a geometry down the ladder `general → rshift → shift → keep-coarse`, starting from
-the `fine_fitgeom` **ceiling** and dropping when it has too few unique matches for
-the current geometry, skipping rotating geometries (`general`, `rshift`) when its
-own matched sources don't span `min_coverage_arcsec` (an unconditioned rotation).
+**Every** detector with enough verified matches is refit — jhat fits every
+detector, always, and a sub-tolerance systematic SIAF placement error (tens of
+mas — over an SW pixel) must not survive just because it is under a threshold;
+`tolerance` is a QA/reporting flag (`within_tolerance`), not a gate. Each
+detector picks a geometry down the ladder `general → rshift → shift →
+keep-coarse`, starting from the `fine_fitgeom` **ceiling** and dropping when it
+has too few unique matches for the current geometry, skipping rotating
+geometries (`general`, `rshift`) when its own matched sources don't span
+`min_coverage_arcsec` (an unconditioned rotation). These ladder floors are the
+real guard against noise-chasing: the residual-improvement acceptance below is
+nearly tautological (the fit minimizes the very pairs it is judged on), so
+`fine_min_shift = 3` — jhat's own `tweakreg.minobj` — is the line below which
+the pooled attitude is trusted as the better estimate.
 The default ceiling is `rshift` — **exactly what jhat fits per detector**. The
 refit consumes the detector's own mutual-NN pairs *as a pre-matched list*: the
 row-aligned pair catalogs go to `align_wcs` with `match=None` — precisely
@@ -394,8 +402,8 @@ All knobs live in `config_default.toml`; per-field overrides go in
 | `fine_fitgeom` | `"rshift"` | per-detector fine ceiling: `general` \| `rshift` \| `shift` |
 | `fine_min_general` | `10` | ≥ this many 1-to-1 matches ⇒ allow `general` |
 | `fine_min_rshift` | `4` | ≥ this ⇒ allow `rshift` |
-| `fine_min_shift` | `2` | ≥ this ⇒ allow `shift`; below ⇒ keep coarse |
-| `tolerance` | `0.05` | arcsec — a fine fit must beat this to read "within" |
+| `fine_min_shift` | `3` | ≥ this ⇒ allow `shift`; below ⇒ keep coarse (= jhat's `minobj`) |
+| `tolerance` | `0.05` | arcsec — QA/reporting only (`within_tolerance` flag); gates nothing |
 | `match_radius` | `0.5` | arcsec — 1-to-1 NN radius for residuals + fine match |
 | `min_matched` | `6` | per-pool reject-to-NOT_ALIGNED floor (1-to-1 count) |
 | `min_coverage_arcsec` | `5.0` | matched sources must span ≥ this (conditions rotation) |

--- a/pipeline/campfire_pipeline/nircam/align/DESIGN.md
+++ b/pipeline/campfire_pipeline/nircam/align/DESIGN.md
@@ -78,9 +78,10 @@ per FILTER (one channel), per EXPOSURE (build_exposure_groups)
         ▼                pool_modules=true  → both modules are one pool
 ┌──────────────────────────────────────────────────────────────────────┐
 │ PER DETECTOR (detect.py)                                               │
-│  • DAOStarFinder centroids on the SCI image (0-indexed px), per-filter │
-│    PSF fwhm; DQ mask = DO_NOT_USE | SATURATED | NO_LIN_CORR; snr_min,  │
-│    objmag_lim, shape + edge cuts. mag rides along only as a rank proxy.│
+│  • SEP segmentation of the SNR map (sci/err, 0-indexed px) — the SAME  │
+│    recipe as the refcat build (refcat/extract.py shared core) — with a │
+│    per-filter matched-filter fwhm; DQ mask = DO_NOT_USE | SATURATED |  │
+│    NO_LIN_CORR; integrated snr_min, calibrated-AB objmag_lim, edge cut.│
 └──────────────────────────────────────────────────────────────────────┘
         ▼
 ┌──────────────────────────────────────────────────────────────────────┐
@@ -99,6 +100,9 @@ per FILTER (one channel), per EXPOSURE (build_exposure_groups)
 │     the ladder general → rshift → shift → keep-coarse, geometry chosen │
 │     by its unique-match count + coverage, ACCEPTED only if it reduces  │
 │     the residual.                                                      │
+│  5. RESIDUAL GATE — any detector whose final 1-to-1 residual still     │
+│     exceeds `max_residual_arcsec` is individually rejected to          │
+│     NOT_ALIGNED (backstop: no bad solution may reach a mosaic).        │
 └──────────────────────────────────────────────────────────────────────┘
         ▼
    ACCEPTED → write corrected gwcs + CFP_ALGN + WCS_BAK (apply.py)
@@ -221,36 +225,46 @@ recorded per detector as the `dof` (`coarse` | `shift` | `rshift` | `general` |
 
 ## 4. Detection (`detect.py`)
 
-`detect_star_centroids` runs `photutils.DAOStarFinder` on the SCI image and
-returns `(x, y)` centroids (0-indexed detector pixels, the gwcs / `tweakwcs`
-convention) plus **calibrated AB magnitudes** whenever the frame carries an AB
-zeropoint (`BUNIT = MJy/sr` + `PIXAR_SR`, i.e. every jwst cal product):
-annulus-free circular-aperture photometry (radius `2×FWHM`, jhat's
-`radii_Nfwhm=[2.0]`) on the median-subtracted frame, with
+`detect_sources` runs **SEP segmentation on the SNR map** (`sci/err`) with a
+matched-filter Gaussian kernel — the *same recipe as the refcat build*, via the
+shared `refcat/extract.py::sep_extract_sources` core — and returns windowed
+`(x, y)` positions (0-indexed detector pixels, the gwcs / `tweakwcs`
+convention) plus Kron `flux`/`fluxerr` and **calibrated AB magnitudes**
+whenever the frame carries an AB zeropoint (`BUNIT = MJy/sr` + `PIXAR_SR`,
+i.e. every jwst cal product): `mag = ZP − 2.5·log10(flux)` with
 `ZP = −2.5·log10(PIXAR_SR·1e6/3631)` — the same surface-brightness ×
-pixel-area conversion jhat uses. **No sky annulus, deliberately**: jhat's
-annulus on CAMPFIRE's already sky-subtracted frames averages negative and
-trips a `-99.99` sentinel that floods the matcher — the annulus is exactly the
-piece of jhat photometry that must not be ported. No aperture correction
-either (a ~0.2–0.4 mag point-source constant, irrelevant to the wide mag
-windows, ill-defined for galaxies). `table.meta['mag_calibrated']` records
-which regime a catalog is in; without a zeropoint, `mag` falls back to the
-uncalibrated DAO kernel estimate.
+pixel-area conversion jhat uses. No aperture correction (irrelevant to the
+wide mag windows, ill-defined for galaxies). `table.meta['mag_calibrated']`
+records which regime a catalog is in; without a zeropoint, `mag` falls back to
+the uncalibrated `−2.5·log10(flux)`.
 
-- **Per-filter PSF FWHM.** NIRCam's core width runs from ~F070W to ~F480M, so one
-  `fwhm` is wrong across an exposure's SW+LW channels; `apply.py` keys detection
-  off each member's filter via `psf_fwhm_by_filter`, falling back to the scalar
-  `fwhm`.
+**Why segmentation, not point sources.** The refcat is galaxy-based (SEP
+segmentation of a mosaic), and the coarse gross-shift stage histograms *all*
+image-side detections against it. A point-source finder (DAOStarFinder, the
+original implementation) over a bright extended galaxy returns thousands of
+*bright* spurious peaks — star-forming clumps and substructure — that trace
+the same galaxy clustering as the refcat, so the 2-D offset histogram grows
+clustering-scale peaks that can beat the true (0,0) peak inside
+`coarse_searchrad`, dragging a well-pointed exposure tens of arcsec (the
+COSMOS A2/A3 f277w misregistration: 13 exposures moved ~25–40″ onto a wrong
+clustering peak). Detecting with the refcat's own recipe makes image-side
+detections correspond to refcat entries by construction (refcat-match
+fraction on the affected exposures: 22–31% → 87–91%; validated in
+`scripts/claude/repro_batch.py`, 13/13 bad fixed, 10/10 good unchanged).
+
+- **Per-filter kernel FWHM.** The matched filter should track the PSF core,
+  which runs from ~F070W to ~F480M, so one `fwhm` is wrong across an exposure's
+  SW+LW channels; `apply.py` keys detection off each member's filter via
+  `psf_fwhm_by_filter`, falling back to the scalar `fwhm`.
 - **DQ masking, not a magnitude guess.** `DETECT_DQ_BITS = DO_NOT_USE | SATURATED
   | NO_LIN_CORR` are masked before detection — a saturated or nonlinearity-
-  uncorrected core corrupts both the centroid and the kernel flux, and those are
+  uncorrected core corrupts both the position and the flux, and those are
   exactly the bright-star failures a magnitude cut can't catch.
-- **Quality cuts:** `snr_min` (peak / background RMS, above the kernel `nsigma`
-  threshold), `objmag_lim` (**calibrated AB window**, jhat's COSMOS value
+- **Quality cuts:** `snr_min` (integrated `flux/fluxerr`, the refcat's own
+  cut), `objmag_lim` (**calibrated AB window**, jhat's COSMOS value
   `[19, 28]`; skipped loudly when the frame has no zeropoint — an AB window on
-  instrumental mags would cut everything), sharpness/roundness windows, and an
-  `edge` reject. No `brightest` count cap on the align path — the full
-  quality-selected catalog reaches the solve.
+  instrumental mags would cut everything), and an `edge` reject. No count cap
+  on the align path — the full quality-selected catalog reaches the solve.
 - **Pair-level brightness agreement** (`delta_mag_lim`, jhat's COSMOS value
   `[-3, 4]`): the matcher can additionally drop 1-NN pairs whose
   `image_mag − refcat_mag` falls outside the window. `tweakwcs` drops
@@ -377,7 +391,6 @@ All knobs live in `config_default.toml`; per-field overrides go in
 | `slope_nsteps` | `200` | rotation-scan steps |
 | `delta_mag_lim` | unset | pair cut: keep `image_mag − refcat_mag` in this AB window (jhat COSMOS: `[-3, 4]`) |
 | `objmag_lim` | unset | detection cut: keep this calibrated AB window (jhat COSMOS: `[19, 28]`) |
-| `aper_radius_px` | `2×fwhm` | aperture radius for calibrated detection mags |
 | `fine_fitgeom` | `"rshift"` | per-detector fine ceiling: `general` \| `rshift` \| `shift` |
 | `fine_min_general` | `10` | ≥ this many 1-to-1 matches ⇒ allow `general` |
 | `fine_min_rshift` | `4` | ≥ this ⇒ allow `rshift` |
@@ -387,11 +400,15 @@ All knobs live in `config_default.toml`; per-field overrides go in
 | `min_matched` | `6` | per-pool reject-to-NOT_ALIGNED floor (1-to-1 count) |
 | `min_coverage_arcsec` | `5.0` | matched sources must span ≥ this (conditions rotation) |
 | `ref_border_arcmin` | `1.2` | refcat footprint margin (≥ `coarse_searchrad`); arcmin |
-| `nsigma` | `5.0` | detection threshold (convolved-background σ) |
-| `snr_min` | `5.0` | drop detections below this peak SNR |
-| `fwhm` | `2.5` | fallback detection PSF FWHM (px) |
+| `max_residual_arcsec` | `0.1` | backstop: reject any detector whose final residual exceeds this |
+| `snr_thresh` | `3.0` | per-pixel detection threshold on the SNR map |
+| `minarea` | `15` | min connected pixels above `snr_thresh` |
+| `deblend_nthresh` | `32` | SEP deblender: number of thresholds |
+| `deblend_cont` | `0.001` | SEP deblender: min contrast |
+| `snr_min` | `10.0` | drop sources below this integrated flux SNR (`flux/fluxerr`) |
+| `fwhm` | `1.5` | fallback matched-filter kernel FWHM (px) |
 | `edge` | `8` | drop detections within this many px of a border |
-| `psf_fwhm_by_filter` | table | per-filter detection PSF FWHM (F070W→F480M) |
+| `psf_fwhm_by_filter` | table | per-filter matched-filter kernel FWHM (F070W→F480M) |
 
 (`nclip=3`, `sigma=3.0` are the σ-clip params passed through to `tweakwcs`.)
 

--- a/pipeline/campfire_pipeline/nircam/align/DESIGN.md
+++ b/pipeline/campfire_pipeline/nircam/align/DESIGN.md
@@ -208,11 +208,14 @@ the `fine_fitgeom` **ceiling** and dropping when it has too few unique matches f
 the current geometry, skipping rotating geometries (`general`, `rshift`) when its
 own matched sources don't span `min_coverage_arcsec` (an unconditioned rotation).
 The default ceiling is `rshift` — **exactly what jhat fits per detector**. The
-detector is refit against a *distractor-free local refcat* (only the references it
-matched), on a deep-copied corrector so a rejected trial never touches the shared
-solution, and the new WCS is **accepted only if it measurably reduces** the
-one-to-one residual. The chosen geometry is recorded per detector as the `dof`
-(`coarse` | `shift` | `rshift` | `general` | `identity`).
+refit consumes the detector's own mutual-NN pairs *as a pre-matched list*: the
+row-aligned pair catalogs go to `align_wcs` with `match=None` — precisely
+JHAT's `already_matched=True` design (no matcher runs in the fit; the
+sigma-clipped fit alone decides) — on a deep-copied corrector so a rejected
+trial never touches the shared solution, and the new WCS is **accepted only if
+it measurably reduces** the one-to-one residual. The chosen geometry is
+recorded per detector as the `dof` (`coarse` | `shift` | `rshift` | `general` |
+`identity`). No `tweakwcs.XYXYMatch` remains anywhere in `align`.
 
 ---
 
@@ -220,11 +223,19 @@ one-to-one residual. The chosen geometry is recorded per detector as the `dof`
 
 `detect_star_centroids` runs `photutils.DAOStarFinder` on the SCI image and
 returns `(x, y)` centroids (0-indexed detector pixels, the gwcs / `tweakwcs`
-convention) plus a `mag = -2.5·log10(flux)` **rank proxy** — used only to order
-sources, never as a match constraint. Deliberately centroid-only, no aperture
-photometry: jhat's aperture annulus on CAMPFIRE's sky-subtracted frames averages
-negative and trips a `-99.99` sentinel that floods the matcher; a PSF-fit finder
-has no sky annulus and structurally cannot hit that bug.
+convention) plus **calibrated AB magnitudes** whenever the frame carries an AB
+zeropoint (`BUNIT = MJy/sr` + `PIXAR_SR`, i.e. every jwst cal product):
+annulus-free circular-aperture photometry (radius `2×FWHM`, jhat's
+`radii_Nfwhm=[2.0]`) on the median-subtracted frame, with
+`ZP = −2.5·log10(PIXAR_SR·1e6/3631)` — the same surface-brightness ×
+pixel-area conversion jhat uses. **No sky annulus, deliberately**: jhat's
+annulus on CAMPFIRE's already sky-subtracted frames averages negative and
+trips a `-99.99` sentinel that floods the matcher — the annulus is exactly the
+piece of jhat photometry that must not be ported. No aperture correction
+either (a ~0.2–0.4 mag point-source constant, irrelevant to the wide mag
+windows, ill-defined for galaxies). `table.meta['mag_calibrated']` records
+which regime a catalog is in; without a zeropoint, `mag` falls back to the
+uncalibrated DAO kernel estimate.
 
 - **Per-filter PSF FWHM.** NIRCam's core width runs from ~F070W to ~F480M, so one
   `fwhm` is wrong across an exposure's SW+LW channels; `apply.py` keys detection
@@ -235,9 +246,19 @@ has no sky annulus and structurally cannot hit that bug.
   uncorrected core corrupts both the centroid and the kernel flux, and those are
   exactly the bright-star failures a magnitude cut can't catch.
 - **Quality cuts:** `snr_min` (peak / background RMS, above the kernel `nsigma`
-  threshold), `objmag_lim` (a coarse per-run trim, not a calibrated cut),
-  sharpness/roundness windows, and an `edge` reject. No `brightest` count cap on
-  the align path — the full quality-selected catalog reaches the solve.
+  threshold), `objmag_lim` (**calibrated AB window**, jhat's COSMOS value
+  `[19, 28]`; skipped loudly when the frame has no zeropoint — an AB window on
+  instrumental mags would cut everything), sharpness/roundness windows, and an
+  `edge` reject. No `brightest` count cap on the align path — the full
+  quality-selected catalog reaches the solve.
+- **Pair-level brightness agreement** (`delta_mag_lim`, jhat's COSMOS value
+  `[-3, 4]`): the matcher can additionally drop 1-NN pairs whose
+  `image_mag − refcat_mag` falls outside the window. `tweakwcs` drops
+  brightness columns when pooling, so image mags ride the surviving `id`
+  column through an id→mag lookup the solve builds from calibrated catalogs.
+  Pairs missing either mag are never punished. Off by default: refcat `mag`
+  zeropoints are heterogeneous across build backends — enable per field when
+  the refcat's photometry is trusted.
 
 ---
 
@@ -354,6 +375,9 @@ All knobs live in `config_default.toml`; per-field overrides go in
 | `histocut_order` | `"dxdy"` | cut dx-vs-y first, or `"dydx"` |
 | `slope_max` | `10/2048` | rotation-scan half-range, dimensionless (≈ ±0.28°) |
 | `slope_nsteps` | `200` | rotation-scan steps |
+| `delta_mag_lim` | unset | pair cut: keep `image_mag − refcat_mag` in this AB window (jhat COSMOS: `[-3, 4]`) |
+| `objmag_lim` | unset | detection cut: keep this calibrated AB window (jhat COSMOS: `[19, 28]`) |
+| `aper_radius_px` | `2×fwhm` | aperture radius for calibrated detection mags |
 | `fine_fitgeom` | `"rshift"` | per-detector fine ceiling: `general` \| `rshift` \| `shift` |
 | `fine_min_general` | `10` | ≥ this many 1-to-1 matches ⇒ allow `general` |
 | `fine_min_rshift` | `4` | ≥ this ⇒ allow `rshift` |
@@ -420,17 +444,13 @@ All knobs live in `config_default.toml`; per-field overrides go in
   (COSMOS/CEERS broad-band pairs, an F070W/F090W field, a crowded stellar field, a
   nebulous star-forming region, a narrow/medium LW pairing, tile-edge and
   missing-detector cases), `align` stays opt-in.
-- **Magnitude cuts are NOT at JHAT parity — known, deliberate.** JHAT's
-  validated COSMOS config also used `objmag_lim = [19, 28]` (calibrated AB, from
-  aperture photometry + zeropoint) and `delta_mag_lim = [-3, 4]` (pair-level
-  image-vs-refcat brightness agreement). align's `objmag_lim` is an
-  **uncalibrated** DAOStarFinder kernel magnitude (`detect.py`) so the JHAT
-  values do not transfer, and `delta_mag_lim` has no align equivalent at all
-  (no calibrated image magnitudes to compare against the refcat). The
-  histogram-consensus matcher is what makes JHAT robust — the mag cuts only
-  thin its false-pair floor — so parity was not blocked on them; if real-data
-  validation shows the floor matters, calibrating detection magnitudes
-  (zeropoint from the SCI header units + pixel area) is the follow-up.
+- **Magnitude-cut parity is implemented but default-off.** Detection mags are
+  calibrated AB (§4), so jhat's `objmag_lim = [19, 28]` and
+  `delta_mag_lim = [-3, 4]` transfer directly — but both default unset:
+  DQ saturation masking already guards the bright end, and refcat `mag`
+  zeropoints are heterogeneous across build backends. Enable them per field
+  (e.g. COSMOS) where the refcat photometry is trusted; the consensus matcher,
+  not the mag cuts, is what carries jhat's robustness either way.
 - **Per-detector distortion fitting — deliberately not built.** A genuine SIP
   distortion solve (`fit_wcs_from_points(sip_degree=…)`) was considered and
   rejected: jhat doesn't do it (its SIP is a serialization, not a fit, §1), and a

--- a/pipeline/campfire_pipeline/nircam/align/__init__.py
+++ b/pipeline/campfire_pipeline/nircam/align/__init__.py
@@ -1,21 +1,21 @@
 """NIRCam astrometric ``align`` subsystem.
 
 The field-level alignment algorithm that replaces the JHAT-based ``jhat`` /
-``wcs_shift`` steps: triangle-matches a pooled per-exposure source catalog to a
-Gaia-tied reference catalog and fits one shared shift+rotation per exposure via
-``tweakwcs`` (SIAF distortion fixed), freeing a per-detector shift only where
-residuals demand it. See ``pipeline/ASTROMETRY_ALIGN_HANDOFF.md``.
+``wcs_shift`` steps: matches a pooled per-exposure source catalog (SEP
+segmentation, mirroring the refcat build) to a Gaia-tied reference catalog via
+the JHAT-ported offset-histogram consensus matcher (``histmatch.py``) and fits
+one shared shift+rotation per pool via ``tweakwcs`` (SIAF distortion fixed),
+freeing a per-detector fit only where residuals demand it.
 
-Modules are added phase by phase; this package currently exports the source
-detector, the triangle matcher, and the per-exposure solve. The
-exposure-grouping layer lives at ``nircam/association.py`` (a general primitive,
-not align-specific).
+This package exports the source detector, the per-pool solve, and the exposure
+I/O layer. The exposure-grouping layer lives at ``nircam/association.py`` (a
+general primitive, not align-specific).
 """
 
 from campfire_pipeline.nircam.align.apply import align_exposure_group
 from campfire_pipeline.nircam.align.detect import (
     detect_in_exposure,
-    detect_star_centroids,
+    detect_sources,
 )
 from campfire_pipeline.nircam.align.solve import (
     DetectorInput,
@@ -25,7 +25,7 @@ from campfire_pipeline.nircam.align.solve import (
 )
 
 __all__ = [
-    'detect_star_centroids',
+    'detect_sources',
     'detect_in_exposure',
     'solve_exposure_group',
     'DetectorInput',

--- a/pipeline/campfire_pipeline/nircam/align/apply.py
+++ b/pipeline/campfire_pipeline/nircam/align/apply.py
@@ -55,8 +55,11 @@ NOT_ALIGNED_SENTINEL = cfp.NOT_ALIGNED
 # (``psf_fwhm_by_filter``) is resolved per member below, not passed through
 # these keys. ``pool_modules`` is an orchestration key (it decides how detectors
 # are pooled before the solve is called), so it is deliberately NOT a solve key.
-_SOLVE_KEYS = ('coarse_searchrad', 'coarse_tolerance', 'coarse_separation',
-               'refine_niter', 'fine_fitgeom', 'fine_min_general',
+_SOLVE_KEYS = ('coarse_searchrad', 'refine_niter',
+               'd2d_max', 'binsize_px', 'gaussian_sigma_px',
+               'rough_cut_px_min', 'rough_cut_px_max', 'nfwhm', 'hist_nsigma',
+               'histocut_order', 'slope_max', 'slope_nsteps',
+               'fine_fitgeom', 'fine_min_general',
                'fine_min_rshift', 'fine_min_shift', 'tolerance', 'match_radius',
                'min_matched', 'min_coverage_arcsec', 'ref_border_arcmin',
                'nclip', 'sigma')

--- a/pipeline/campfire_pipeline/nircam/align/apply.py
+++ b/pipeline/campfire_pipeline/nircam/align/apply.py
@@ -33,7 +33,7 @@ from campfire_pipeline.common.io import atomic_save, log
 from campfire_pipeline.nircam.align.detect import (
     DETECT_DQ_BITS,
     ab_zeropoint_from_sci_header,
-    detect_star_centroids,
+    detect_sources,
 )
 from campfire_pipeline.nircam.align.solve import (
     DetectorInput,
@@ -63,9 +63,9 @@ _SOLVE_KEYS = ('coarse_searchrad', 'refine_niter',
                'fine_fitgeom', 'fine_min_general',
                'fine_min_rshift', 'fine_min_shift', 'tolerance', 'match_radius',
                'min_matched', 'min_coverage_arcsec', 'ref_border_arcmin',
-               'nclip', 'sigma')
-_DETECT_KEYS = ('fwhm', 'nsigma', 'edge', 'snr_min', 'objmag_lim',
-                'aper_radius_px', 'sharplo', 'sharphi', 'roundlo', 'roundhi')
+               'nclip', 'sigma', 'max_residual_arcsec')
+_DETECT_KEYS = ('fwhm', 'snr_thresh', 'minarea', 'deblend_nthresh',
+                'deblend_cont', 'edge', 'snr_min', 'objmag_lim')
 
 
 # --- gwcs <-> ASDF-in-FITS backup (technique shared with steps/wcs_shift.py) --
@@ -183,9 +183,11 @@ def _load_detector(path, detector, detect_cfg, ImageModel):
         wcsinfo = {'v2_ref': wi['v2_ref'], 'v3_ref': wi['v3_ref'],
                    'roll_ref': wi['roll_ref']}
         orig_wcs = model.meta.wcs
-        cat = detect_star_centroids(np.asarray(model.data, dtype=float),
-                                    mask=_detect_mask(model),
-                                    zeropoint=zeropoint, **detect_cfg)
+        err = (np.asarray(model.err, dtype=float)
+               if getattr(model, 'err', None) is not None else None)
+        cat = detect_sources(np.asarray(model.data, dtype=float), err,
+                             mask=_detect_mask(model),
+                             zeropoint=zeropoint, **detect_cfg)
     finally:
         model.close()
 
@@ -305,12 +307,13 @@ def align_exposure_group(members, refcat, *, key=None, config=None,
     solve_cfg = {k: config[k] for k in _SOLVE_KEYS if k in config}
     detect_cfg = {k: config[k] for k in _DETECT_KEYS if k in config}
 
-    # Per-filter detection PSF FWHM: NIRCam's core width runs from ~F070W to
-    # ~F480M, so a single fwhm is wrong across the exposure's SW+LW channels.
-    # Key it off each member's filter, falling back to the scalar `fwhm`.
+    # Per-filter matched-filter kernel FWHM: the kernel should track the PSF
+    # core, whose width runs from ~F070W to ~F480M, so a single fwhm is wrong
+    # across the exposure's SW+LW channels. Key it off each member's filter,
+    # falling back to the scalar `fwhm`.
     psf_by_filter = {str(k).lower(): float(v)
                      for k, v in (config.get('psf_fwhm_by_filter') or {}).items()}
-    default_fwhm = detect_cfg.get('fwhm', 2.5)
+    default_fwhm = detect_cfg.get('fwhm', 1.5)
 
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
@@ -345,7 +348,11 @@ def align_exposure_group(members, refcat, *, key=None, config=None,
     by_detector = {d.detector: d for d in solution.detectors}
     for m in members:
         det_sol = by_detector.get(m.detector)
-        if solution.status == 'SOLVED' and det_sol is not None:
+        # ``aligned=False`` marks a per-detector residual-gate reject inside an
+        # otherwise SOLVED pool — that detector is stamped NOT_ALIGNED (WCS
+        # preserved, quarantined from combine) like a failed pool.
+        if (solution.status == 'SOLVED' and det_sol is not None
+                and getattr(det_sol, 'aligned', True)):
             _write_solution(m.path, det_sol.wcs,
                             _format_algn_value(det_sol, refcat_hash),
                             ImageModel, update_fits_wcsinfo)

--- a/pipeline/campfire_pipeline/nircam/align/apply.py
+++ b/pipeline/campfire_pipeline/nircam/align/apply.py
@@ -32,6 +32,7 @@ from campfire_pipeline.common import cfp
 from campfire_pipeline.common.io import atomic_save, log
 from campfire_pipeline.nircam.align.detect import (
     DETECT_DQ_BITS,
+    ab_zeropoint_from_sci_header,
     detect_star_centroids,
 )
 from campfire_pipeline.nircam.align.solve import (
@@ -58,13 +59,13 @@ NOT_ALIGNED_SENTINEL = cfp.NOT_ALIGNED
 _SOLVE_KEYS = ('coarse_searchrad', 'refine_niter',
                'd2d_max', 'binsize_px', 'gaussian_sigma_px',
                'rough_cut_px_min', 'rough_cut_px_max', 'nfwhm', 'hist_nsigma',
-               'histocut_order', 'slope_max', 'slope_nsteps',
+               'histocut_order', 'slope_max', 'slope_nsteps', 'delta_mag_lim',
                'fine_fitgeom', 'fine_min_general',
                'fine_min_rshift', 'fine_min_shift', 'tolerance', 'match_radius',
                'min_matched', 'min_coverage_arcsec', 'ref_border_arcmin',
                'nclip', 'sigma')
 _DETECT_KEYS = ('fwhm', 'nsigma', 'edge', 'snr_min', 'objmag_lim',
-                'sharplo', 'sharphi', 'roundlo', 'roundhi')
+                'aper_radius_px', 'sharplo', 'sharphi', 'roundlo', 'roundhi')
 
 
 # --- gwcs <-> ASDF-in-FITS backup (technique shared with steps/wcs_shift.py) --
@@ -171,6 +172,11 @@ def _detect_mask(model):
 def _load_detector(path, detector, detect_cfg, ImageModel):
     """Open a canonical, pick the pre-align gwcs (from ALGN_BAK if this file was
     aligned before), detect sources, and return a :class:`DetectorInput`."""
+    # AB zeropoint for calibrated detection magnitudes (None -> uncalibrated
+    # fallback, objmag_lim skipped loudly) — read cheaply before the datamodel.
+    with fits.open(path, memmap=False) as hdul:
+        zeropoint = ab_zeropoint_from_sci_header(hdul['SCI'].header)
+
     model = ImageModel(path, memmap=False)
     try:
         wi = model.meta.wcsinfo.instance
@@ -178,7 +184,8 @@ def _load_detector(path, detector, detect_cfg, ImageModel):
                    'roll_ref': wi['roll_ref']}
         orig_wcs = model.meta.wcs
         cat = detect_star_centroids(np.asarray(model.data, dtype=float),
-                                    mask=_detect_mask(model), **detect_cfg)
+                                    mask=_detect_mask(model),
+                                    zeropoint=zeropoint, **detect_cfg)
     finally:
         model.close()
 

--- a/pipeline/campfire_pipeline/nircam/align/detect.py
+++ b/pipeline/campfire_pipeline/nircam/align/detect.py
@@ -1,22 +1,30 @@
-"""Centroid-only point-source detection for the NIRCam ``align`` phase.
+"""Point-source detection + calibrated magnitudes for the NIRCam ``align`` phase.
 
-Produces ``(x, y)`` star centroids plus a brightness proxy for a detector image
-— the image-side catalog that the align solve worker projects to the tangent
-plane and triangle-matches against the Gaia-tied reference catalog.
+Produces ``(x, y)`` star centroids plus magnitudes for a detector image — the
+image-side catalog that the align solve worker projects to the tangent plane
+and matches against the Gaia-tied reference catalog.
 
-**Centroids only, no aperture photometry.** JHAT's aperture annulus, run on
-CAMPFIRE's already sky-subtracted frames, averages *negative* for ~46% of
-detections and trips a ``-99.99`` sky sentinel, producing a spurious constant
-magnitude that floods the matcher (handoff §2a). A peak / PSF-fit finder
-(``photutils.DAOStarFinder``) has no sky annulus and structurally cannot hit
-that bug — its ``flux``/``mag`` come from the PSF fit, not a background-
-subtracted aperture.
+**Annulus-free aperture photometry.** JHAT's sky *annulus*, run on CAMPFIRE's
+already sky-subtracted frames, averages *negative* for ~46% of detections and
+trips a ``-99.99`` sky sentinel, producing a spurious constant magnitude that
+floods the matcher (handoff §2a). Detection is ``photutils.DAOStarFinder``
+(no annulus, structurally immune), and when a *zeropoint* is supplied the
+magnitudes come from a plain circular-aperture sum (default radius 2×FWHM,
+JHAT's ``radii_Nfwhm=[2.0]``) on the median-subtracted frame with **no local
+annulus** — the frames are already sky-flat, so the annulus is exactly the
+piece of JHAT photometry that must NOT be ported. No aperture correction is
+applied (a ~0.2–0.4 mag point-source offset, irrelevant to the wide
+``objmag_lim``/``delta_mag_lim`` windows, and ill-defined for galaxies).
+
+``mag`` is **calibrated AB** when *zeropoint* is given (for the MJy/sr cal
+frames: ``ZP = -2.5·log10(PIXAR_SR · 1e6 / 3631)``, the same surface-brightness
+× pixel-area conversion JHAT uses); otherwise it falls back to the uncalibrated
+DAOStarFinder kernel estimate and the ``objmag_lim`` cut is *skipped loudly*
+(an AB window applied to instrumental mags would cut everything).
 
 Coordinates are **0-indexed** detector pixels (the ``DAOStarFinder`` and gwcs
-convention — what the ``tweakwcs`` corrector's ``det_to_world`` / ``det_to_tanp``
-expect). ``mag = -2.5·log10(flux)`` (smaller = brighter) rides along **only**
-to rank the bootstrap triangle-vertex cap (``matcher.py``), never as a match
-constraint.
+convention — what the ``tweakwcs`` corrector's ``det_to_world`` /
+``det_to_tanp`` expect).
 
 Import-light and ``jwst``-free: detection is WCS-free (works in detector
 pixels), so it reads SCI/ERR/DQ via plain ``astropy.io.fits`` rather than a
@@ -45,25 +53,34 @@ _SATURATED = np.uint32(2)
 _NO_LIN_CORR = np.uint32(1 << 20)          # 1048576
 DETECT_DQ_BITS = _DO_NOT_USE | _SATURATED | _NO_LIN_CORR
 
-_FLOAT_COLUMNS = ('x', 'y', 'flux', 'mag', 'sharpness',
+_FLOAT_COLUMNS = ('x', 'y', 'flux', 'mag', 'aper_flux', 'sharpness',
                   'roundness1', 'roundness2', 'peak')
 
+# Warn at most once per process when an objmag_lim is configured but the frame
+# provided no AB zeropoint (the cut would be nonsense on instrumental mags).
+_UNCAL_OBJMAG_WARNED = False
 
-def _empty_catalog():
+
+def _empty_catalog(mag_calibrated=False):
     cols = {c: np.array([], dtype=float) for c in _FLOAT_COLUMNS}
     cols['npix'] = np.array([], dtype=int)
-    return Table(cols)
+    t = Table(cols)
+    t.meta['mag_calibrated'] = bool(mag_calibrated)
+    return t
 
 
 def detect_star_centroids(data, *, mask=None, fwhm=2.5, nsigma=5.0,
                           sharplo=0.2, sharphi=1.0, roundlo=-1.0, roundhi=1.0,
                           edge=8, snr_min=None, objmag_lim=None, brightest=None,
+                          zeropoint=None, aper_radius_px=None,
                           sigma=3.0, maxiters=5):
     """Detect point-source centroids on a detector image.
 
-    Returns an astropy ``Table`` with columns ``x, y, flux, mag, sharpness,
-    roundness1, roundness2, peak, npix`` (0-indexed pixels), sorted by ``flux``
-    descending; an empty (but typed) Table when nothing is found.
+    Returns an astropy ``Table`` with columns ``x, y, flux, mag, aper_flux,
+    sharpness, roundness1, roundness2, peak, npix`` (0-indexed pixels), sorted
+    by ``flux`` descending; an empty (but typed) Table when nothing is found.
+    ``table.meta['mag_calibrated']`` records whether ``mag`` is calibrated AB
+    (aperture sum + *zeropoint*) or the uncalibrated DAO kernel estimate.
 
     Parameters
     ----------
@@ -88,16 +105,24 @@ def detect_star_centroids(data, *, mask=None, fwhm=2.5, nsigma=5.0,
         filter detection can trip ``nsigma`` on a noise peak whose real SNR is
         marginal.
     objmag_lim : (float, float), optional
-        Keep only ``bright <= mag <= faint``. ``mag = -2.5·log10(flux)`` is the
-        DAOStarFinder kernel estimate — **uncalibrated** (no zeropoint), so this
-        is a coarse per-run trim (drop the saturated-bright and the faint junk),
-        not a physical magnitude cut; prefer ``snr_min`` + DQ saturation masking
-        for physically meaningful cuts.
+        Keep only ``bright <= mag <= faint`` in **calibrated AB mag** (JHAT's
+        ``objmag_lim``; its validated COSMOS window is ``[19, 28]``). Applied
+        only when *zeropoint* is available — on an uncalibrated frame the cut
+        is skipped with a loud (once-per-process) log, because an AB window on
+        instrumental mags would cut everything.
     brightest : int, optional
         Keep only the ``brightest`` sources (by flux) after all cuts. The align
-        path leaves this unset — the triangle-vertex cap is applied later, on
-        the bootstrap only (see ``matcher.py``) — so the full quality-selected
-        catalog reaches the all-source refine.
+        path leaves this unset so the full quality-selected catalog reaches the
+        solve.
+    zeropoint : float, optional
+        AB zeropoint for one image unit in an aperture sum: ``mag = zeropoint
+        - 2.5·log10(aperture_sum)``. For jwst cal frames in MJy/sr,
+        ``zeropoint = -2.5·log10(PIXAR_SR · 1e6 / 3631)`` (see
+        :func:`ab_zeropoint_from_sci_header`). When given, ``mag`` is measured
+        by annulus-free circular-aperture photometry (module docstring).
+    aper_radius_px : float, optional
+        Aperture radius (pixels) for the calibrated photometry; default
+        ``2 × fwhm`` (JHAT's ``radii_Nfwhm = [2.0]``).
     """
     data = np.asarray(data, dtype=float)
     mask = np.zeros(data.shape, dtype=bool) if mask is None else np.asarray(mask, dtype=bool)
@@ -125,19 +150,40 @@ def detect_star_centroids(data, *, mask=None, fwhm=2.5, nsigma=5.0,
     keep = ((x >= edge) & (x <= nx - 1 - edge) &
             (y >= edge) & (y <= ny - 1 - edge))
 
+    calibrated = zeropoint is not None
     out = Table({
         'x': x[keep],
         'y': y[keep],
         'flux': np.asarray(sources['flux'], dtype=float)[keep],
         'mag': np.asarray(sources['mag'], dtype=float)[keep],
+        'aper_flux': np.full(int(np.count_nonzero(keep)), np.nan),
         'sharpness': np.asarray(sources['sharpness'], dtype=float)[keep],
         'roundness1': np.asarray(sources['roundness1'], dtype=float)[keep],
         'roundness2': np.asarray(sources['roundness2'], dtype=float)[keep],
         'peak': np.asarray(sources['peak'], dtype=float)[keep],
         'npix': np.asarray(sources['npix'], dtype=int)[keep],
     })
+    out.meta['mag_calibrated'] = calibrated
     if len(out) == 0:
-        return _empty_catalog()
+        return _empty_catalog(calibrated)
+
+    if calibrated:
+        # Annulus-free aperture photometry on the median-subtracted frame
+        # (module docstring); non-positive sums -> NaN mag (dropped by an
+        # objmag_lim cut, passed through otherwise).
+        from photutils.aperture import CircularAperture, aperture_photometry
+        radius = float(aper_radius_px) if aper_radius_px else 2.0 * float(fwhm)
+        aper = CircularAperture(
+            np.column_stack([np.asarray(out['x']), np.asarray(out['y'])]),
+            r=radius)
+        phot = aperture_photometry(data - median, aper, method='exact',
+                                   mask=mask)
+        aper_sum = np.asarray(phot['aperture_sum'], dtype=float)
+        out['aper_flux'] = aper_sum
+        with np.errstate(divide='ignore', invalid='ignore'):
+            out['mag'] = np.where(
+                aper_sum > 0,
+                float(zeropoint) - 2.5 * np.log10(aper_sum), np.nan)
 
     # Quality cuts. sharpness/roundness are already applied inside DAOStarFinder;
     # snr_min and objmag_lim trim what the kernel threshold alone can't.
@@ -145,17 +191,51 @@ def detect_star_centroids(data, *, mask=None, fwhm=2.5, nsigma=5.0,
     if snr_min is not None:
         quality &= (np.asarray(out['peak'], dtype=float) / std) >= float(snr_min)
     if objmag_lim is not None:
-        bright, faint = float(objmag_lim[0]), float(objmag_lim[1])
-        mag = np.asarray(out['mag'], dtype=float)
-        quality &= np.isfinite(mag) & (mag >= bright) & (mag <= faint)
+        if calibrated:
+            bright, faint = float(objmag_lim[0]), float(objmag_lim[1])
+            mag = np.asarray(out['mag'], dtype=float)
+            quality &= np.isfinite(mag) & (mag >= bright) & (mag <= faint)
+        else:
+            _warn_uncalibrated_objmag()
     out = out[quality]
     if len(out) == 0:
-        return _empty_catalog()
+        return _empty_catalog(calibrated)
 
     out.sort('flux', reverse=True)
     if brightest is not None and len(out) > brightest:
         out = out[:int(brightest)]
     return out
+
+
+def _warn_uncalibrated_objmag():
+    """Log (once per process) that objmag_lim was skipped for lack of an AB
+    zeropoint — applying an AB window to instrumental mags would cut all
+    sources, which is worse than not cutting."""
+    global _UNCAL_OBJMAG_WARNED
+    if _UNCAL_OBJMAG_WARNED:
+        return
+    _UNCAL_OBJMAG_WARNED = True
+    log("detect: objmag_lim is set but no AB zeropoint is available "
+        "(missing/unknown PIXAR_SR or BUNIT != MJy/sr); SKIPPING the "
+        "magnitude cut. Logged once per process.")
+
+
+def ab_zeropoint_from_sci_header(header):
+    """AB zeropoint for a jwst cal SCI extension header, or ``None``.
+
+    Requires ``BUNIT = MJy/sr`` and a positive ``PIXAR_SR``; then one image
+    unit summed over pixels is ``PIXAR_SR·1e6`` Jy, so
+    ``ZP = -2.5·log10(PIXAR_SR · 1e6 / 3631)`` (JHAT's surface-brightness ×
+    pixel-area conversion, ~26.5 for the 0.063" LW pixel).
+    """
+    bunit = str(header.get('BUNIT', '')).replace(' ', '').lower()
+    pixar_sr = header.get('PIXAR_SR')
+    if bunit != 'mjy/sr' or pixar_sr is None:
+        return None
+    pixar_sr = float(pixar_sr)
+    if not np.isfinite(pixar_sr) or pixar_sr <= 0:
+        return None
+    return -2.5 * np.log10(pixar_sr * 1.0e6 / 3631.0)
 
 
 def detect_in_exposure(path, *, fwhm=2.5, nsigma=5.0, **kwargs):
@@ -166,11 +246,14 @@ def detect_in_exposure(path, *, fwhm=2.5, nsigma=5.0, **kwargs):
     pixels (non-finite ERR) and the ``DETECT_DQ_BITS`` DQ pixels (DO_NOT_USE +
     SATURATED + NO_LIN_CORR — unusable, saturated, or nonlinearity-uncorrected;
     JUMP_DET etc. are already-corrected and kept). ERR/DQ are read defensively
-    (skipped if absent). Extra keyword arguments pass through to
-    :func:`detect_star_centroids`.
+    (skipped if absent). The AB zeropoint is resolved from the SCI header
+    (:func:`ab_zeropoint_from_sci_header`) unless the caller passes one. Extra
+    keyword arguments pass through to :func:`detect_star_centroids`.
     """
     with fits.open(path, memmap=False) as hdul:
         sci = np.asarray(hdul['SCI'].data, dtype=float)
+        kwargs.setdefault('zeropoint',
+                          ab_zeropoint_from_sci_header(hdul['SCI'].header))
         mask = ~np.isfinite(sci)
         if 'ERR' in hdul and hdul['ERR'].data is not None:
             mask |= ~np.isfinite(np.asarray(hdul['ERR'].data, dtype=float))

--- a/pipeline/campfire_pipeline/nircam/align/detect.py
+++ b/pipeline/campfire_pipeline/nircam/align/detect.py
@@ -1,51 +1,53 @@
-"""Point-source detection + calibrated magnitudes for the NIRCam ``align`` phase.
+"""SEP segmentation detection + calibrated magnitudes for the NIRCam ``align``
+phase.
 
-Produces ``(x, y)`` star centroids plus magnitudes for a detector image — the
-image-side catalog that the align solve worker projects to the tangent plane
-and matches against the Gaia-tied reference catalog.
+Produces ``(x, y)`` source positions plus Kron photometry for a detector image
+— the image-side catalog that the align solve worker projects to the tangent
+plane and matches against the reference catalog.
 
-**Annulus-free aperture photometry.** JHAT's sky *annulus*, run on CAMPFIRE's
-already sky-subtracted frames, averages *negative* for ~46% of detections and
-trips a ``-99.99`` sky sentinel, producing a spurious constant magnitude that
-floods the matcher (handoff §2a). Detection is ``photutils.DAOStarFinder``
-(no annulus, structurally immune), and when a *zeropoint* is supplied the
-magnitudes come from a plain circular-aperture sum (default radius 2×FWHM,
-JHAT's ``radii_Nfwhm=[2.0]``) on the median-subtracted frame with **no local
-annulus** — the frames are already sky-flat, so the annulus is exactly the
-piece of JHAT photometry that must NOT be ported. No aperture correction is
-applied (a ~0.2–0.4 mag point-source offset, irrelevant to the wide
-``objmag_lim``/``delta_mag_lim`` windows, and ill-defined for galaxies).
+**Same recipe as the refcat, deliberately.** Detection mirrors the refcat
+build's SEP-on-SNR segmentation (``refcat/extract.py``) via the shared
+:func:`~campfire_pipeline.nircam.refcat.extract.sep_extract_sources` core, so
+image-side detections correspond to refcat entries by construction. The
+previous point-source finder (``DAOStarFinder``) was retired after the COSMOS
+A2/A3 misregistration: over a bright extended galaxy it returned thousands of
+*bright* spurious peaks (star-forming clumps, substructure) that trace the same
+galaxy clustering as the refcat, and the coarse gross-shift 2-D offset
+histogram then grew clustering-scale peaks that out-voted the true (0,0) peak
+inside ``coarse_searchrad`` — dragging well-pointed exposures tens of arcsec.
+Segmentation detects the galaxies themselves (one detection per refcat-like
+object), which removes the mismatch at the source rather than capping the
+search radius.
 
-``mag`` is **calibrated AB** when *zeropoint* is given (for the MJy/sr cal
-frames: ``ZP = -2.5·log10(PIXAR_SR · 1e6 / 3631)``, the same surface-brightness
-× pixel-area conversion JHAT uses); otherwise it falls back to the uncalibrated
-DAOStarFinder kernel estimate and the ``objmag_lim`` cut is *skipped loudly*
-(an AB window applied to instrumental mags would cut everything).
+``mag`` is **calibrated AB** (Kron flux + the JHAT zeropoint convention: for
+MJy/sr cal frames ``ZP = -2.5·log10(PIXAR_SR · 1e6 / 3631)``) when a
+*zeropoint* is given; otherwise it falls back to the uncalibrated
+``-2.5·log10(flux)`` and the ``objmag_lim`` cut is *skipped loudly* (an AB
+window applied to instrumental mags would cut everything).
+``table.meta['mag_calibrated']`` records which, and the solve's
+``delta_mag_lim`` pair cut only ever consumes calibrated mags. No aperture
+correction is applied (irrelevant to the wide ``objmag_lim``/``delta_mag_lim``
+windows, and ill-defined for galaxies).
 
-Coordinates are **0-indexed** detector pixels (the ``DAOStarFinder`` and gwcs
-convention — what the ``tweakwcs`` corrector's ``det_to_world`` /
-``det_to_tanp`` expect).
+Coordinates are **0-indexed** detector pixels (SEP's, windowed positions — the
+gwcs convention ``tweakwcs``'s ``det_to_world`` / ``det_to_tanp`` expect).
 
 Import-light and ``jwst``-free: detection is WCS-free (works in detector
 pixels), so it reads SCI/ERR/DQ via plain ``astropy.io.fits`` rather than a
-jwst ``ImageModel``.
+jwst ``ImageModel``; ``sep`` is imported lazily inside the shared core.
 """
-
-import warnings
 
 import numpy as np
 from astropy.io import fits
 from astropy.stats import sigma_clipped_stats
 from astropy.table import Table
-from photutils.detection import DAOStarFinder
-from photutils.utils.exceptions import NoDetectionsWarning
 
 from campfire_pipeline.common.io import log
 
 # jwst.datamodels.dqflags.pixel bit values, hardcoded to keep this module free
-# of the jwst/CRDS import chain (cf. field.py's _DO_NOT_USE). Centroiding must
+# of the jwst/CRDS import chain (cf. field.py's _DO_NOT_USE). Detection must
 # skip pixels that are unusable (DO_NOT_USE), saturated (a saturated core
-# corrupts both the centroid and the kernel flux), or lack a valid nonlinearity
+# corrupts both the position and the flux), or lack a valid nonlinearity
 # correction (NO_LIN_CORR) — the latter two are exactly the bright-star failure
 # modes a magnitude cut can't catch because the measured flux is already wrong.
 _DO_NOT_USE = np.uint32(1)
@@ -53,8 +55,7 @@ _SATURATED = np.uint32(2)
 _NO_LIN_CORR = np.uint32(1 << 20)          # 1048576
 DETECT_DQ_BITS = _DO_NOT_USE | _SATURATED | _NO_LIN_CORR
 
-_FLOAT_COLUMNS = ('x', 'y', 'flux', 'mag', 'aper_flux', 'sharpness',
-                  'roundness1', 'roundness2', 'peak')
+_FLOAT_COLUMNS = ('x', 'y', 'flux', 'fluxerr', 'mag', 'snr')
 
 # Warn at most once per process when an objmag_lim is configured but the frame
 # provided no AB zeropoint (the cut would be nonsense on instrumental mags).
@@ -69,141 +70,114 @@ def _empty_catalog(mag_calibrated=False):
     return t
 
 
-def detect_star_centroids(data, *, mask=None, fwhm=2.5, nsigma=5.0,
-                          sharplo=0.2, sharphi=1.0, roundlo=-1.0, roundhi=1.0,
-                          edge=8, snr_min=None, objmag_lim=None, brightest=None,
-                          zeropoint=None, aper_radius_px=None,
-                          sigma=3.0, maxiters=5):
-    """Detect point-source centroids on a detector image.
+def detect_sources(sci, err=None, *, mask=None, fwhm=1.5, snr_thresh=3.0,
+                   minarea=15, deblend_nthresh=32, deblend_cont=0.001,
+                   edge=8, snr_min=10.0, objmag_lim=None, zeropoint=None):
+    """Detect sources on a detector image by SEP segmentation of the SNR map.
 
-    Returns an astropy ``Table`` with columns ``x, y, flux, mag, aper_flux,
-    sharpness, roundness1, roundness2, peak, npix`` (0-indexed pixels), sorted
-    by ``flux`` descending; an empty (but typed) Table when nothing is found.
+    Returns an astropy ``Table`` with columns ``x, y, flux, fluxerr, mag, snr,
+    npix`` (0-indexed pixels, windowed positions), sorted by ``flux``
+    descending; an empty (but typed) Table when nothing is found.
     ``table.meta['mag_calibrated']`` records whether ``mag`` is calibrated AB
-    (aperture sum + *zeropoint*) or the uncalibrated DAO kernel estimate.
+    (Kron flux + *zeropoint*) or the uncalibrated ``-2.5·log10(flux)``.
 
     Parameters
     ----------
-    data : 2-D array
-        Detector SCI image (any residual smooth background is removed by the
-        scalar median subtraction below; DAOStarFinder's kernel suppresses the
-        rest).
+    sci : 2-D array
+        Detector SCI image.
+    err : 2-D array, optional
+        Per-pixel 1-sigma error map; detection thresholds the ``sci/err`` SNR
+        map. When absent (or carrying no positive pixels), a sigma-clipped
+        global RMS of ``sci`` stands in as a constant error — degraded but
+        functional.
     mask : 2-D bool array, optional
-        Pixels to ignore (bad pixels, off-detector). Non-finite ``data`` pixels
-        are always added to the mask.
+        Pixels to ignore (bad pixels, off-detector). Non-finite ``sci``/``err``
+        pixels are always excluded.
     fwhm : float
-        PSF FWHM in pixels. NIRCam's PSF core is filter-dependent (F070W→F480M),
-        so the align worker keys this off the exposure's filter
-        (``psf_fwhm_by_filter``) rather than using one value.
-    nsigma : float
-        Detection threshold in units of the sigma-clipped background RMS.
+        Matched-filter Gaussian kernel FWHM in pixels — should track the PSF
+        core, which is filter-dependent, so the align worker keys this off the
+        exposure's filter (``psf_fwhm_by_filter``) rather than one value.
+    snr_thresh : float
+        Per-pixel detection threshold on the SNR map.
+    minarea : int
+        Minimum number of connected pixels above ``snr_thresh``.
+    deblend_nthresh, deblend_cont : int, float
+        SEP deblender knobs.
     edge : int
-        Reject centroids within this many pixels of any border (unreliable).
+        Reject detections within this many pixels of any border (unreliable).
     snr_min : float, optional
-        Drop detections below this peak SNR (``peak / background_rms``). Raises
-        the effective floor above the kernel ``nsigma`` threshold; a matched-
-        filter detection can trip ``nsigma`` on a noise peak whose real SNR is
-        marginal.
+        Drop sources whose *integrated* flux SNR (``flux/fluxerr``) is below
+        this — the refcat build applies the same cut, keeping the two catalogs
+        selection-matched. ``None`` disables.
     objmag_lim : (float, float), optional
         Keep only ``bright <= mag <= faint`` in **calibrated AB mag** (JHAT's
         ``objmag_lim``; its validated COSMOS window is ``[19, 28]``). Applied
         only when *zeropoint* is available — on an uncalibrated frame the cut
         is skipped with a loud (once-per-process) log, because an AB window on
         instrumental mags would cut everything.
-    brightest : int, optional
-        Keep only the ``brightest`` sources (by flux) after all cuts. The align
-        path leaves this unset so the full quality-selected catalog reaches the
-        solve.
     zeropoint : float, optional
-        AB zeropoint for one image unit in an aperture sum: ``mag = zeropoint
-        - 2.5·log10(aperture_sum)``. For jwst cal frames in MJy/sr,
-        ``zeropoint = -2.5·log10(PIXAR_SR · 1e6 / 3631)`` (see
-        :func:`ab_zeropoint_from_sci_header`). When given, ``mag`` is measured
-        by annulus-free circular-aperture photometry (module docstring).
-    aper_radius_px : float, optional
-        Aperture radius (pixels) for the calibrated photometry; default
-        ``2 × fwhm`` (JHAT's ``radii_Nfwhm = [2.0]``).
+        AB zeropoint for one image unit of integrated flux: ``mag = zeropoint
+        - 2.5·log10(flux)``. For jwst cal frames in MJy/sr, ``zeropoint =
+        -2.5·log10(PIXAR_SR · 1e6 / 3631)`` (see
+        :func:`ab_zeropoint_from_sci_header`).
     """
-    data = np.asarray(data, dtype=float)
-    mask = np.zeros(data.shape, dtype=bool) if mask is None else np.asarray(mask, dtype=bool)
-    mask = mask | ~np.isfinite(data)
+    from campfire_pipeline.nircam.refcat.extract import sep_extract_sources
 
-    mean, median, std = sigma_clipped_stats(data, mask=mask, sigma=sigma,
-                                            maxiters=maxiters)
-    if not np.isfinite(std) or std <= 0:
-        log("detect: non-finite/zero background noise; skipping detection.")
-        return _empty_catalog()
-
-    finder = DAOStarFinder(threshold=nsigma * float(std), fwhm=fwhm,
-                           sharplo=sharplo, sharphi=sharphi,
-                           roundlo=roundlo, roundhi=roundhi)
-    with warnings.catch_warnings():
-        # A starved detector legitimately finds nothing — not worth a warning.
-        warnings.simplefilter('ignore', NoDetectionsWarning)
-        sources = finder(data - median, mask=mask)
-    if sources is None or len(sources) == 0:
-        return _empty_catalog()
-
-    x = np.asarray(sources['xcentroid'], dtype=float)
-    y = np.asarray(sources['ycentroid'], dtype=float)
-    ny, nx = data.shape
-    keep = ((x >= edge) & (x <= nx - 1 - edge) &
-            (y >= edge) & (y <= ny - 1 - edge))
-
+    sci = np.asarray(sci, dtype=float)
+    if mask is not None:
+        mask = np.asarray(mask, dtype=bool)
     calibrated = zeropoint is not None
+
+    if err is None or not np.any(np.isfinite(err) & (np.asarray(err) > 0)):
+        _, _, std = sigma_clipped_stats(sci, mask=mask, sigma=3.0, maxiters=5)
+        if not np.isfinite(std) or std <= 0:
+            log("detect: no usable ERR and non-finite/zero background noise; "
+                "skipping detection.")
+            return _empty_catalog(calibrated)
+        log("detect: no usable ERR map; using a constant sigma-clipped "
+            f"RMS ({std:.4g}) as the error map.")
+        err = np.full(sci.shape, float(std))
+
+    cat = sep_extract_sources(sci, err, mask=mask, snr_thresh=snr_thresh,
+                              minarea=minarea, deblend_nthresh=deblend_nthresh,
+                              deblend_cont=deblend_cont, filter_fwhm=fwhm)
+    if len(cat) == 0:
+        return _empty_catalog(calibrated)
+
+    x = np.asarray(cat['x'], dtype=float)
+    y = np.asarray(cat['y'], dtype=float)
+    flux = np.asarray(cat['flux'], dtype=float)
+    fluxerr = np.asarray(cat['fluxerr'], dtype=float)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        snr = flux / fluxerr
+        mag = np.where(flux > 0, -2.5 * np.log10(np.abs(flux)), np.nan)
+        if calibrated:
+            mag = mag + float(zeropoint)
+
+    ny, nx = sci.shape
+    keep = (np.isfinite(x) & np.isfinite(y) &
+            (x >= edge) & (x <= nx - 1 - edge) &
+            (y >= edge) & (y <= ny - 1 - edge))
+    if snr_min is not None:
+        keep &= np.isfinite(snr) & (snr >= float(snr_min))
+    if objmag_lim is not None:
+        if calibrated:
+            bright, faint = float(objmag_lim[0]), float(objmag_lim[1])
+            keep &= np.isfinite(mag) & (mag >= bright) & (mag <= faint)
+        else:
+            _warn_uncalibrated_objmag()
+
     out = Table({
-        'x': x[keep],
-        'y': y[keep],
-        'flux': np.asarray(sources['flux'], dtype=float)[keep],
-        'mag': np.asarray(sources['mag'], dtype=float)[keep],
-        'aper_flux': np.full(int(np.count_nonzero(keep)), np.nan),
-        'sharpness': np.asarray(sources['sharpness'], dtype=float)[keep],
-        'roundness1': np.asarray(sources['roundness1'], dtype=float)[keep],
-        'roundness2': np.asarray(sources['roundness2'], dtype=float)[keep],
-        'peak': np.asarray(sources['peak'], dtype=float)[keep],
-        'npix': np.asarray(sources['npix'], dtype=int)[keep],
+        'x': x[keep], 'y': y[keep],
+        'flux': flux[keep], 'fluxerr': fluxerr[keep],
+        'mag': np.asarray(mag, dtype=float)[keep],
+        'snr': np.asarray(snr, dtype=float)[keep],
+        'npix': np.asarray(cat['npix'], dtype=int)[keep],
     })
     out.meta['mag_calibrated'] = calibrated
     if len(out) == 0:
         return _empty_catalog(calibrated)
-
-    if calibrated:
-        # Annulus-free aperture photometry on the median-subtracted frame
-        # (module docstring); non-positive sums -> NaN mag (dropped by an
-        # objmag_lim cut, passed through otherwise).
-        from photutils.aperture import CircularAperture, aperture_photometry
-        radius = float(aper_radius_px) if aper_radius_px else 2.0 * float(fwhm)
-        aper = CircularAperture(
-            np.column_stack([np.asarray(out['x']), np.asarray(out['y'])]),
-            r=radius)
-        phot = aperture_photometry(data - median, aper, method='exact',
-                                   mask=mask)
-        aper_sum = np.asarray(phot['aperture_sum'], dtype=float)
-        out['aper_flux'] = aper_sum
-        with np.errstate(divide='ignore', invalid='ignore'):
-            out['mag'] = np.where(
-                aper_sum > 0,
-                float(zeropoint) - 2.5 * np.log10(aper_sum), np.nan)
-
-    # Quality cuts. sharpness/roundness are already applied inside DAOStarFinder;
-    # snr_min and objmag_lim trim what the kernel threshold alone can't.
-    quality = np.ones(len(out), dtype=bool)
-    if snr_min is not None:
-        quality &= (np.asarray(out['peak'], dtype=float) / std) >= float(snr_min)
-    if objmag_lim is not None:
-        if calibrated:
-            bright, faint = float(objmag_lim[0]), float(objmag_lim[1])
-            mag = np.asarray(out['mag'], dtype=float)
-            quality &= np.isfinite(mag) & (mag >= bright) & (mag <= faint)
-        else:
-            _warn_uncalibrated_objmag()
-    out = out[quality]
-    if len(out) == 0:
-        return _empty_catalog(calibrated)
-
     out.sort('flux', reverse=True)
-    if brightest is not None and len(out) > brightest:
-        out = out[:int(brightest)]
     return out
 
 
@@ -238,8 +212,8 @@ def ab_zeropoint_from_sci_header(header):
     return -2.5 * np.log10(pixar_sr * 1.0e6 / 3631.0)
 
 
-def detect_in_exposure(path, *, fwhm=2.5, nsigma=5.0, **kwargs):
-    """Detect star centroids on a canonical NIRCam exposure's SCI image.
+def detect_in_exposure(path, **kwargs):
+    """Detect sources on a canonical NIRCam exposure's SCI image.
 
     Reads SCI/ERR/DQ via ``astropy.io.fits`` (no jwst datamodel needed —
     detection is WCS-free and works in detector pixels). Masks off-detector
@@ -248,17 +222,18 @@ def detect_in_exposure(path, *, fwhm=2.5, nsigma=5.0, **kwargs):
     JUMP_DET etc. are already-corrected and kept). ERR/DQ are read defensively
     (skipped if absent). The AB zeropoint is resolved from the SCI header
     (:func:`ab_zeropoint_from_sci_header`) unless the caller passes one. Extra
-    keyword arguments pass through to :func:`detect_star_centroids`.
+    keyword arguments pass through to :func:`detect_sources`.
     """
     with fits.open(path, memmap=False) as hdul:
         sci = np.asarray(hdul['SCI'].data, dtype=float)
         kwargs.setdefault('zeropoint',
                           ab_zeropoint_from_sci_header(hdul['SCI'].header))
         mask = ~np.isfinite(sci)
+        err = None
         if 'ERR' in hdul and hdul['ERR'].data is not None:
-            mask |= ~np.isfinite(np.asarray(hdul['ERR'].data, dtype=float))
+            err = np.asarray(hdul['ERR'].data, dtype=float)
+            mask |= ~np.isfinite(err)
         if 'DQ' in hdul and hdul['DQ'].data is not None:
             dq = np.asarray(hdul['DQ'].data).astype(np.uint32)
             mask |= (dq & DETECT_DQ_BITS) != 0
-    return detect_star_centroids(sci, mask=mask, fwhm=fwhm, nsigma=nsigma,
-                                 **kwargs)
+    return detect_sources(sci, err, mask=mask, **kwargs)

--- a/pipeline/campfire_pipeline/nircam/align/histmatch.py
+++ b/pipeline/campfire_pipeline/nircam/align/histmatch.py
@@ -191,13 +191,26 @@ class OffsetHistogramMatch(MatchCatalogs):
         ``10/2048`` px/px ≈ ±0.28°.
     slope_nsteps : int
         Number of slope-scan steps across ``[-slope_max, +slope_max]``.
+    delta_mag_lim : (float, float) or None
+        Keep a pair only if ``image_mag − refcat_mag`` lies in this window
+        (JHAT's ``delta_mag_lim``; its validated COSMOS value is ``[-3, 4]``).
+        Applied only to pairs where *both* mags are finite — a source or
+        reference without a magnitude is never punished for it. Requires
+        *image_mags* (``tweakwcs`` drops brightness columns when pooling, so
+        image mags ride the surviving ``id`` column via this lookup).
+    image_mags : dict or None
+        ``{id: calibrated AB mag}`` for the pooled image sources, keyed by the
+        ``id`` values the solve assigned to each detector catalog.
+    refcat_mag_col : str
+        Reference-catalog magnitude column (``'mag'`` in campfire-refcat-v1).
     """
 
     def __init__(self, *, searchrad=None, d2d_max=1.5, binsize_px=0.02,
                  gaussian_sigma_px=0.2, rough_cut_px_min=2.5,
                  rough_cut_px_max=2.5, nfwhm=2.5, nsigma=3.0,
                  histocut_order='dxdy', slope_max=10.0 / 2048.0,
-                 slope_nsteps=200):
+                 slope_nsteps=200, delta_mag_lim=None, image_mags=None,
+                 refcat_mag_col='mag'):
         if histocut_order not in ('dxdy', 'dydx'):
             raise ValueError(f"histocut_order must be 'dxdy' or 'dydx', "
                              f"got {histocut_order!r}")
@@ -212,6 +225,9 @@ class OffsetHistogramMatch(MatchCatalogs):
         self.histocut_order = histocut_order
         self.slope_max = float(slope_max)
         self.slope_nsteps = int(slope_nsteps)
+        self.delta_mag_lim = delta_mag_lim
+        self.image_mags = image_mags
+        self.refcat_mag_col = refcat_mag_col
 
     # -- gross translation (2-D offset histogram) ---------------------------
 
@@ -293,6 +309,31 @@ class OffsetHistogramMatch(MatchCatalogs):
             return rough_mask
         return _sigma_clip_median(d_rot, rough_mask, self.nsigma)
 
+    # -- pair-level brightness agreement (JHAT delta_mag_lim) ----------------
+
+    def _delta_mag_ok(self, refcat, imcat, nn):
+        """Boolean mask over image sources: pair passes the ``delta_mag_lim``
+        window, or lacks the information to be judged (missing mags / no
+        lookup / no ``id`` column — never punish a source for missing data).
+        """
+        ok = np.ones(len(imcat), dtype=bool)
+        if (self.delta_mag_lim is None or not self.image_mags
+                or self.refcat_mag_col not in refcat.colnames
+                or 'id' not in imcat.colnames):
+            return ok
+        im_mag = np.array([self.image_mags.get(int(i), np.nan)
+                           for i in np.asarray(imcat['id'])], dtype=float)
+        ref_col = refcat[self.refcat_mag_col]
+        if hasattr(ref_col, 'filled'):                 # MaskedColumn -> NaN
+            ref_mag = np.asarray(ref_col.filled(np.nan), dtype=float)
+        else:
+            ref_mag = np.asarray(ref_col, dtype=float)
+        dmag = im_mag - ref_mag[nn]
+        lo, hi = (float(self.delta_mag_lim[0]), float(self.delta_mag_lim[1]))
+        judged = np.isfinite(dmag)
+        ok[judged] = (dmag[judged] >= lo) & (dmag[judged] <= hi)
+        return ok
+
     # -- MatchCatalogs entry point ------------------------------------------
 
     def __call__(self, refcat, imcat, tp_pscale=1.0, tp_units=None, **kwargs):
@@ -336,6 +377,7 @@ class OffsetHistogramMatch(MatchCatalogs):
         mask = np.isfinite(d2d)
         if self.d2d_max is not None:
             mask &= d2d <= float(self.d2d_max)
+        mask &= self._delta_mag_ok(refcat, imcat, nn)
         if np.count_nonzero(mask) < _MIN_PAIRS:
             return _EMPTY
 

--- a/pipeline/campfire_pipeline/nircam/align/histmatch.py
+++ b/pipeline/campfire_pipeline/nircam/align/histmatch.py
@@ -1,0 +1,361 @@
+"""JHAT-style 1-NN + offset-histogram consensus matcher for the ``align`` phase.
+
+:class:`OffsetHistogramMatch` is the ``tweakwcs`` ``MatchCatalogs`` callable the
+coarse solve uses to pair pooled image sources with the reference catalog. It is
+a faithful port of JHAT's matching algorithm (``jhat.st_wcs_align
+.find_good_refcat_matches`` + ``histogram_cut``), which is structurally
+different from ``tweakwcs.XYXYMatch``:
+
+* ``XYXYMatch`` *enumerates candidate pairs* (``stsci.stimage.xyxymatch``) and
+  sizes its output by the detection count — on real extragalactic catalogs,
+  where detections and refcat rows are the same (clustered) galaxies and the
+  refcat resolves substructure, the number of reference sources finding a
+  partner can exceed the detection count and the matcher dies with
+  ``MatchSourceConfusionError`` (39% of COSMOS LW exposures).
+* JHAT instead pairs **every** image source with its single nearest reference
+  (unbounded 1-NN — most pairs are wrong at this stage *by design*) and then
+  finds the true correspondence by **consensus**: true pairs pile into one
+  narrow peak of the pairwise-offset histogram while false pairs scatter
+  ~uniformly. Nothing is enumerated, nothing can overflow.
+
+The consensus stage mirrors JHAT exactly: per axis (``histocut_order``, dx
+first by default), a rotation-slope scan subtracts a linear ramp of dx vs the
+cross coordinate (small-angle rotation), histograms the de-rotated offsets in
+``binsize_px`` bins, Gaussian-smooths, and keeps the slope whose peak is
+tallest; survivors of a rough cut around the peak (``nfwhm``·FWHM clamped to
+``[rough_cut_px_min, rough_cut_px_max]``) are sigma-clipped
+(median-anchored, ``nsigma``) and the second axis repeats the cut on what is
+left. The returned pairs feed ``tweakwcs``'s robust rigid fit — the matcher
+selects correspondences, the fit still decides the transform.
+
+**Pooling is native.** The matcher sees the tangent-plane catalogs *after*
+``tweakwcs`` concatenates a pool's detectors (shared ``group_id``), so every
+detector's pairs accumulate into ONE shared offset histogram — more detectors
+mean a stronger consensus peak. This is precisely the sparse-field robustness
+argument for pooling, and it is why this port strengthens rather than replaces
+the pooled design.
+
+**Gross-offset stage.** JHAT's 1-NN needs the true counterpart to *be* the
+nearest neighbour, which holds only when the WCS error is below the local
+source spacing (JWST pointing is normally sub-arcsec). To keep the ability to
+recover acquisition failures (tens of arcsec), an optional first stage finds
+the gross translation as the peak of the 2-D pairwise-offset histogram within
+``searchrad`` — the same idea ``XYXYMatch(use2dhist=True)`` uses for its
+initial estimate (bake-off-validated at 97–100%), implemented here by direct
+accumulation so no pair list is ever materialized. ``searchrad=None`` skips
+the stage (the iterate passes, already roughly aligned, don't need it).
+
+Units: the ``*_px`` knobs are **image pixels** — the validated JHAT COSMOS
+configuration carries over verbatim — converted per call via the ``tp_pscale``
+the ``tweakwcs`` machinery passes (the pool's detector pixel size in
+tangent-plane arcsec, so SW/LW each get physically correct values).
+``searchrad`` and ``d2d_max`` are arcsec (matching JHAT's ``d2d_max``).
+"""
+
+import numpy as np
+from tweakwcs.matchutils import MatchCatalogs
+
+from campfire_pipeline.common.io import log
+
+_EMPTY = (np.array([], dtype=int), np.array([], dtype=int))
+
+# Fewest surviving pairs worth returning (JHAT's floor before the fit).
+_MIN_PAIRS = 3
+
+# Gross-stage 2-D histogram bin (arcsec). Precision only needs to bring the
+# residual offset under d2d_max/NN-spacing for the 1-NN stage; the ±2-bin
+# centroid refinement below gives sub-bin accuracy.
+_GROSS_BIN_ARCSEC = 0.5
+
+# Cap on 1-D histogram length; if the (unclamped) offset span demands more
+# bins, the bin size is coarsened. Only reachable with d2d_max=None on a
+# pathologically wide offset distribution.
+_MAX_BINS = 200_000
+
+
+def _smoothed_hist_peak(d, binsize, gaussian_sigma):
+    """Peak of the Gaussian-smoothed histogram of *d*: ``(center, height,
+    fwhm)``.
+
+    Mirrors JHAT's ``find_binmax_for_slope``: plain ``np.histogram`` in
+    *binsize* bins, smoothed by an (unnormalized, like pandas' rolling-gaussian
+    sum) Gaussian kernel of *gaussian_sigma*, peak located on the smoothed
+    curve. ``fwhm`` is measured by walking to half-height on each side
+    (clipped at the histogram edges).
+    """
+    lo = float(np.min(d))
+    hi = float(np.max(d))
+    span = max(hi - lo, binsize)
+    nbins = int(np.ceil(span / binsize))
+    if nbins > _MAX_BINS:
+        binsize = span / _MAX_BINS
+        nbins = _MAX_BINS
+    hist, edges = np.histogram(d, bins=nbins, range=(lo, lo + nbins * binsize))
+
+    sigma_bins = max(gaussian_sigma / binsize, 1e-3)
+    half = max(int(np.ceil(3.0 * sigma_bins)), 1)
+    t = np.arange(-half, half + 1, dtype=float)
+    kernel = np.exp(-0.5 * (t / sigma_bins) ** 2)
+    # centered window of the full (zero-padded) convolution — NOT mode='same',
+    # which returns the KERNEL's length whenever the kernel outgrows a short
+    # histogram, desynchronizing the peak index from `edges`
+    conv = np.convolve(hist.astype(float), kernel, mode='full')
+    smoothed = conv[half:half + hist.size]
+
+    peak_i = int(np.argmax(smoothed))
+    height = float(smoothed[peak_i])
+    center = float(0.5 * (edges[peak_i] + edges[peak_i + 1]))
+
+    # half-height walk for the FWHM
+    half_h = 0.5 * height
+    left = peak_i
+    while left > 0 and smoothed[left - 1] >= half_h:
+        left -= 1
+    right = peak_i
+    while right < smoothed.size - 1 and smoothed[right + 1] >= half_h:
+        right += 1
+    fwhm = max(right - left + 1, 1) * binsize
+    return center, height, fwhm
+
+
+def _sigma_clip_median(values, mask, nsigma, nitmax=10, first_percentile=75.0):
+    """JHAT-style iterated clip of ``values[mask]``; returns the refined mask.
+
+    Mirrors ``calcaverage_sigmacutloop``: the first iteration keeps the
+    *first_percentile* smallest |residuals| about the median (robust against a
+    heavy false-pair floor), then iterates a median-anchored ``nsigma``·std
+    clip to convergence (≤ *nitmax* passes).
+    """
+    idx = np.flatnonzero(mask)
+    d = values[idx]
+    if d.size < _MIN_PAIRS:
+        return mask
+    res = np.abs(d - np.median(d))
+    good = res <= np.percentile(res, first_percentile)
+    if np.count_nonzero(good) < 2:
+        return mask
+    for _ in range(int(nitmax)):
+        center = np.median(d[good])
+        std = np.std(d[good], ddof=1)
+        if not np.isfinite(std) or std <= 0:
+            break
+        new = np.abs(d - center) <= nsigma * std
+        if np.count_nonzero(new) < 2 or np.array_equal(new, good):
+            break
+        good = new
+    out = np.zeros_like(mask)
+    out[idx[good]] = True
+    return out
+
+
+class OffsetHistogramMatch(MatchCatalogs):
+    """Match pooled tangent-plane catalogs by 1-NN + offset-histogram consensus.
+
+    Instances are passed as the ``match=`` callable to ``tweakwcs.align_wcs``.
+    ``__call__`` follows the ``MatchCatalogs`` contract: it receives the
+    reference and (pooled) image catalogs — astropy ``Table``s carrying
+    ``TPx``/``TPy`` tangent-plane columns, arcsec for ``JWSTWCSCorrector`` —
+    and returns ``(ref_idx, im_idx)`` of matched rows, reference indices first.
+
+    Parameters
+    ----------
+    searchrad : float or None
+        Arcsec. When set, a gross-translation stage first locates the peak of
+        the 2-D pairwise-offset histogram within this radius and pre-shifts
+        the image catalog by it, so acquisition-failure offsets far beyond the
+        1-NN capture range are recovered. ``None`` skips the stage (use for
+        iterate passes that start from an already-corrected WCS).
+    d2d_max : float or None
+        Arcsec. Drop 1-NN pairs farther than this (after the gross shift) —
+        JHAT's ``d2d_max`` pre-trim. ``None`` keeps every pair (the histogram
+        consensus still selects; the cut just thins the false-pair floor).
+    binsize_px, gaussian_sigma_px : float
+        Offset-histogram bin size and Gaussian smoothing sigma, in image
+        pixels (JHAT's ``binsize_px``/``gaussian_sigma_px``; converted with
+        ``tp_pscale``).
+    rough_cut_px_min, rough_cut_px_max : float
+        Clamp (image pixels) on the rough cut half-width around the histogram
+        peak, which is ``nfwhm`` × the peak's FWHM before clamping. The
+        validated COSMOS configuration pins both to 2.5 px.
+    nfwhm : float
+        Rough-cut half-width in units of the peak FWHM (JHAT ``Nfwhm``).
+    nsigma : float
+        Sigma-clip threshold for the post-rough-cut iterated clip
+        (JHAT ``d_rotated_Nsigma``).
+    histocut_order : str
+        ``'dxdy'`` (default, the validated order) cuts dx-vs-y first then
+        dy-vs-x; ``'dydx'`` swaps.
+    slope_max : float
+        Half-range of the rotation-slope scan, dimensionless (offset change
+        per unit cross coordinate ≈ rotation in radians). JHAT's default
+        ``10/2048`` px/px ≈ ±0.28°.
+    slope_nsteps : int
+        Number of slope-scan steps across ``[-slope_max, +slope_max]``.
+    """
+
+    def __init__(self, *, searchrad=None, d2d_max=1.5, binsize_px=0.02,
+                 gaussian_sigma_px=0.2, rough_cut_px_min=2.5,
+                 rough_cut_px_max=2.5, nfwhm=2.5, nsigma=3.0,
+                 histocut_order='dxdy', slope_max=10.0 / 2048.0,
+                 slope_nsteps=200):
+        if histocut_order not in ('dxdy', 'dydx'):
+            raise ValueError(f"histocut_order must be 'dxdy' or 'dydx', "
+                             f"got {histocut_order!r}")
+        self.searchrad = searchrad
+        self.d2d_max = d2d_max
+        self.binsize_px = float(binsize_px)
+        self.gaussian_sigma_px = float(gaussian_sigma_px)
+        self.rough_cut_px_min = float(rough_cut_px_min)
+        self.rough_cut_px_max = float(rough_cut_px_max)
+        self.nfwhm = float(nfwhm)
+        self.nsigma = float(nsigma)
+        self.histocut_order = histocut_order
+        self.slope_max = float(slope_max)
+        self.slope_nsteps = int(slope_nsteps)
+
+    # -- gross translation (2-D offset histogram) ---------------------------
+
+    def _gross_shift(self, tree, ref_xy, im_xy):
+        """Peak of the 2-D pairwise-offset histogram within ``searchrad``:
+        ``(dx0, dy0)`` arcsec, or ``None`` when no pair exists.
+
+        Offsets are accumulated straight into the histogram (chunked over
+        image sources), so — unlike a pair-enumerating matcher — memory is
+        bounded by the histogram, not the pair count. The peak is refined by
+        an intensity-weighted centroid over its ±2-bin neighbourhood.
+        """
+        r = float(self.searchrad)
+        nbins = max(int(np.ceil(2.0 * r / _GROSS_BIN_ARCSEC)), 4)
+        edges = np.linspace(-r, r, nbins + 1)
+        acc = np.zeros((nbins, nbins), dtype=float)
+
+        found = False
+        for start in range(0, im_xy.shape[0], 256):
+            chunk = im_xy[start:start + 256]
+            neighbours = tree.query_ball_point(chunk, r=r)
+            offs = [ref_xy[nbrs] - pt
+                    for pt, nbrs in zip(chunk, neighbours) if nbrs]
+            if not offs:
+                continue
+            found = True
+            offs = np.concatenate(offs)
+            acc += np.histogram2d(offs[:, 0], offs[:, 1],
+                                  bins=(edges, edges))[0]
+        if not found:
+            return None
+
+        # light smoothing so a peak split across bin edges still wins
+        k = np.array([0.25, 0.5, 0.25])
+        acc = np.apply_along_axis(np.convolve, 0, acc, k, 'same')
+        acc = np.apply_along_axis(np.convolve, 1, acc, k, 'same')
+
+        i, j = np.unravel_index(int(np.argmax(acc)), acc.shape)
+        centers = 0.5 * (edges[:-1] + edges[1:])
+        i0, i1 = max(i - 2, 0), min(i + 3, nbins)
+        j0, j1 = max(j - 2, 0), min(j + 3, nbins)
+        patch = acc[i0:i1, j0:j1]
+        total = patch.sum()
+        if total <= 0:
+            return None
+        dx0 = float((patch.sum(axis=1) * centers[i0:i1]).sum() / total)
+        dy0 = float((patch.sum(axis=0) * centers[j0:j1]).sum() / total)
+        return dx0, dy0
+
+    # -- per-axis histogram cut (rotation scan + rough cut + sigma clip) ----
+
+    def _histogram_cut(self, d, c, mask, *, binsize, gaussian_sigma,
+                       rough_min, rough_max):
+        """One JHAT ``histogram_cut``: refine *mask* by the consensus peak of
+        offsets *d* against cross coordinate *c* (rotation-slope scan)."""
+        idx = np.flatnonzero(mask)
+        if idx.size < _MIN_PAIRS:
+            return mask
+        d_sel = d[idx]
+        c_sel = c[idx]
+        # rotate about the pool centre (JHAT: the detector centre) so the scan
+        # shifts the histogram as little as possible
+        c0 = 0.5 * (float(np.min(c_sel)) + float(np.max(c_sel)))
+        c_rel = c_sel - c0
+
+        best = None   # (height, slope, center, fwhm)
+        for slope in np.linspace(-self.slope_max, self.slope_max,
+                                 self.slope_nsteps + 1):
+            center, height, fwhm = _smoothed_hist_peak(
+                d_sel - slope * c_rel, binsize, gaussian_sigma)
+            if best is None or height > best[0]:
+                best = (height, slope, center, fwhm)
+
+        _, slope, center, fwhm = best
+        rough = float(np.clip(self.nfwhm * fwhm, rough_min, rough_max))
+        d_rot = d - slope * (c - c0)
+        rough_mask = mask & (np.abs(d_rot - center) <= rough)
+        if np.count_nonzero(rough_mask) < _MIN_PAIRS:
+            return rough_mask
+        return _sigma_clip_median(d_rot, rough_mask, self.nsigma)
+
+    # -- MatchCatalogs entry point ------------------------------------------
+
+    def __call__(self, refcat, imcat, tp_pscale=1.0, tp_units=None, **kwargs):
+        from scipy.spatial import cKDTree
+
+        for cat, side in ((refcat, 'reference'), (imcat, 'image')):
+            for col in ('TPx', 'TPy'):
+                if col not in cat.colnames:
+                    raise KeyError(
+                        f"OffsetHistogramMatch: {side} catalog is missing the "
+                        f"'{col}' column (tangent-plane coordinates).")
+        ref_xy = np.column_stack([np.asarray(refcat['TPx'], dtype=float),
+                                  np.asarray(refcat['TPy'], dtype=float)])
+        im_xy = np.column_stack([np.asarray(imcat['TPx'], dtype=float),
+                                 np.asarray(imcat['TPy'], dtype=float)])
+        # A starved pool must yield zero matches so the solve rejects to
+        # NOT_ALIGNED — never crash the align worker.
+        if len(ref_xy) < _MIN_PAIRS or len(im_xy) < _MIN_PAIRS:
+            return _EMPTY
+
+        pscale = float(tp_pscale) if tp_pscale else 1.0
+        binsize = self.binsize_px * pscale
+        gaussian_sigma = self.gaussian_sigma_px * pscale
+        rough_min = self.rough_cut_px_min * pscale
+        rough_max = self.rough_cut_px_max * pscale
+
+        tree = cKDTree(ref_xy)
+
+        shift = np.zeros(2)
+        if self.searchrad is not None and float(self.searchrad) > 0:
+            gross = self._gross_shift(tree, ref_xy, im_xy)
+            if gross is None:
+                log(f"OffsetHistogramMatch: no reference source within "
+                    f"{self.searchrad:.0f}\" of any image source; no match.")
+                return _EMPTY
+            shift = np.asarray(gross)
+
+        # Unbounded 1-NN: every image source pairs with its closest reference.
+        # Most pairs are wrong at this stage by design — consensus decides.
+        d2d, nn = tree.query(im_xy + shift, k=1)
+        mask = np.isfinite(d2d)
+        if self.d2d_max is not None:
+            mask &= d2d <= float(self.d2d_max)
+        if np.count_nonzero(mask) < _MIN_PAIRS:
+            return _EMPTY
+
+        # Pairwise offsets in the gross-corrected frame + the image-side
+        # coordinates the rotation ramp is scanned against.
+        dx = ref_xy[nn, 0] - (im_xy[:, 0] + shift[0])
+        dy = ref_xy[nn, 1] - (im_xy[:, 1] + shift[1])
+        im_x = im_xy[:, 0]
+        im_y = im_xy[:, 1]
+
+        if self.histocut_order == 'dxdy':
+            axes = ((dx, im_y), (dy, im_x))
+        else:
+            axes = ((dy, im_x), (dx, im_y))
+        for d, c in axes:
+            mask = self._histogram_cut(
+                d, c, mask, binsize=binsize, gaussian_sigma=gaussian_sigma,
+                rough_min=rough_min, rough_max=rough_max)
+
+        im_idx = np.flatnonzero(mask)
+        if im_idx.size < _MIN_PAIRS:
+            return _EMPTY
+        return nn[im_idx].astype(int), im_idx.astype(int)

--- a/pipeline/campfire_pipeline/nircam/align/solve.py
+++ b/pipeline/campfire_pipeline/nircam/align/solve.py
@@ -23,10 +23,12 @@ exposure reader/writer + ``CFP_ALGN`` stamp live in the orchestration layer).
    nothing here is enumerated and nothing can overflow.
 3. *Group gate* — accept the pool only if enough sources match one-to-one and
    span enough sky to condition a rotation; else reject to NOT_ALIGNED.
-4. *Fine* — each detector over tolerance gets an individual fit against a
-   distractor-free local refcat, its geometry chosen down a ladder
-   (``general`` → ``rshift`` → ``shift`` → keep-coarse) by its unique-match count
-   and coverage, accepted only if it measurably reduces the residual.
+4. *Fine* — each detector over tolerance gets an individual fit on its own
+   already-matched (mutual-NN) pairs — handed to ``align_wcs`` row-aligned
+   with ``match=None``, exactly JHAT's ``already_matched`` design — its
+   geometry chosen down a ladder (``general`` → ``rshift`` → ``shift`` →
+   keep-coarse) by its match count and coverage, accepted only if it
+   measurably reduces the residual.
 
 The pooled coarse is the mechanical expression of the pooling constraint: every
 detector of one pool shares one ``group_id`` so a single rigid rshift is fit from
@@ -44,9 +46,9 @@ from typing import List, Optional, Tuple
 
 import numpy as np
 from astropy.coordinates import SkyCoord
+from astropy.table import Table
 from tweakwcs.correctors import JWSTWCSCorrector
 from tweakwcs.imalign import align_wcs
-from tweakwcs.matchutils import XYXYMatch
 
 from campfire_pipeline.common.io import log
 from campfire_pipeline.nircam.align.footprint import clip_refcat_to_exposure
@@ -61,10 +63,6 @@ _REFINE_CONVERGE_ARCSEC = 0.01
 _FINE_LADDER = ('general', 'rshift', 'shift')
 # Geometries that fit a rotation and so need spatial coverage to be conditioned.
 _ROTATING = ('general', 'rshift')
-
-# Min in-catalog source separation (arcsec) for the fine per-detector match.
-# Small (real sources closer than this are blends) but must be > 0 (tweakwcs).
-_FINE_SEPARATION = 0.1
 
 
 @dataclass
@@ -138,16 +136,16 @@ def _coverage_arcsec(ra, dec):
 
 def _match(corrector, catalog, ref_sky, match_radius):
     """One-to-one residual for one detector: ``(residual_arcsec, n_matched,
-    matched_ref_idx)``.
+    src_idx, ref_idx)``.
 
     Transform the detector's own sources through the (corrected) gwcs and match
     them to the reference positions by **mutual nearest neighbour** — a source
     and a reference pair up only if each is the other's closest — keeping pairs
-    within *match_radius* arcsec. ``matched_ref_idx`` is the set of reference
-    rows those sources landed on — reused both to build a distractor-free local
-    reference catalog for the fine fit and to measure coverage.
+    within *match_radius* arcsec. ``src_idx``/``ref_idx`` are the row-aligned
+    pairing (one-to-one by the mutuality); the fine fit consumes it directly as
+    a pre-matched list, and the group gate measures coverage from ``ref_idx``.
     """
-    empty = (float('nan'), 0, np.array([], dtype=int))
+    empty = (float('nan'), 0, np.array([], dtype=int), np.array([], dtype=int))
     x = np.asarray(catalog['x'], dtype=float)
     y = np.asarray(catalog['y'], dtype=float)
     if x.size == 0 or len(ref_sky) == 0:
@@ -164,7 +162,7 @@ def _match(corrector, catalog, ref_sky, match_radius):
     if not np.any(keep):
         return empty
     return (float(np.median(sep[keep])), int(np.count_nonzero(keep)),
-            np.unique(np.asarray(s2r)[keep]))
+            src_ix[keep], np.asarray(s2r)[keep])
 
 
 def _not_aligned(key, detectors, wcs_getter):
@@ -258,21 +256,25 @@ def _choose_fitgeom(n, coverage, ceiling, mins, min_coverage):
     return None
 
 
-def _fine_fit(corr, detector, local_refcat, geom, *, key, match_radius, nclip,
-              sigma):
-    """Individually refit one detector (geometry *geom*) against a
-    distractor-free local refcat; return ``(trial_corrector, fit_info)``.
+def _fine_fit(corr, detector, catalog, refcat, src_idx, ref_idx, geom, *,
+              key, nclip, sigma):
+    """Individually refit one detector (geometry *geom*) on its already-matched
+    pairs; return ``(trial_corrector, fit_info)``.
 
-    Deep-copies the pooled corrector so a rejected fit never touches the shared
-    solution. The detector is already coarse-aligned, so a nearest-neighbour
-    match (``use2dhist=False``) around the small residual re-pairs the sources.
+    Exactly JHAT's design (``already_matched=True``): the mutual-NN pairs from
+    the group gate are handed to ``align_wcs`` as row-aligned catalogs with
+    ``match=None`` — no matcher runs, the sigma-clipped fit alone decides the
+    transform. Deep-copies the pooled corrector so a rejected fit never touches
+    the shared solution.
     """
     trial = copy.deepcopy(corr)
     trial.meta['group_id'] = f'{key}:{detector}'   # distinct -> solo fit
-    match = XYXYMatch(use2dhist=False, searchrad=match_radius,
-                      tolerance=match_radius, separation=_FINE_SEPARATION)
-    align_wcs([trial], refcat=local_refcat, enforce_user_order=True,
-              expand_refcat=False, minobj=None, match=match,
+    trial.meta['catalog'] = Table({
+        'x': np.asarray(catalog['x'], dtype=float)[src_idx],
+        'y': np.asarray(catalog['y'], dtype=float)[src_idx],
+    })
+    align_wcs([trial], refcat=refcat[ref_idx], enforce_user_order=True,
+              expand_refcat=False, minobj=None, match=None,
               fitgeom=geom, nclip=nclip, sigma=(sigma, 'rmse'))
     return trial, trial.meta.get('fit_info', {})
 
@@ -283,6 +285,7 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
                          rough_cut_px_min=2.5, rough_cut_px_max=2.5,
                          nfwhm=2.5, hist_nsigma=3.0, histocut_order='dxdy',
                          slope_max=10.0 / 2048.0, slope_nsteps=200,
+                         delta_mag_lim=None,
                          fine_fitgeom='rshift', fine_min_general=10,
                          fine_min_rshift=4, fine_min_shift=2, tolerance=0.05,
                          match_radius=0.5, min_matched=6, min_coverage_arcsec=5.0,
@@ -295,9 +298,12 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
     offset-histogram consensus, iterated), gated on match count and sky
     coverage, then each over-tolerance detector gets a fine fit whose geometry
     is chosen down the ``fine_fitgeom`` ladder by its match count / coverage and
-    accepted only if it reduces the residual. The ``d2d_max`` … ``slope_nsteps``
-    knobs pass straight to :class:`OffsetHistogramMatch` (the ``*_px`` ones in
-    image pixels, mirroring the validated JHAT configuration).
+    accepted only if it reduces the residual. The ``d2d_max`` …
+    ``slope_nsteps`` / ``delta_mag_lim`` knobs pass straight to
+    :class:`OffsetHistogramMatch` (the ``*_px`` ones in image pixels,
+    mirroring the validated JHAT configuration); ``delta_mag_lim`` reads image
+    mags through the pool-unique ``id`` column assigned below, and judges only
+    pairs where both mags are finite and calibrated.
 
     ``pool_modules`` is accepted for config-passthrough symmetry but unused here
     (the orchestration layer decides pooling before calling this).
@@ -339,6 +345,21 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
 
     wcs_by_det = {d.detector: d.wcs for d in detectors}
 
+    # Pool-unique source ids + an id->mag lookup: tweakwcs' pooled group
+    # catalog keeps 'id' but drops every brightness column, so the matcher's
+    # delta_mag_lim pair cut reads image mags through this map. Only catalogs
+    # carrying CALIBRATED mags contribute (an uncalibrated mag vs a refcat AB
+    # mag would cut on garbage); their sources just pass the cut unjudged.
+    image_mags = {}
+    for i, d in enumerate(detectors):
+        ids = i * 10_000_000 + np.arange(len(d.catalog))
+        d.catalog['id'] = ids
+        if d.catalog.meta.get('mag_calibrated') and 'mag' in d.catalog.colnames:
+            mags = np.asarray(d.catalog['mag'], dtype=float)
+            image_mags.update(
+                (int(s), float(m)) for s, m in zip(ids, mags)
+                if np.isfinite(m))
+
     # 2. Coarse: one pooled rshift, iterated to convergence. Pass 0's matcher
     #    carries the gross-translation stage (acquisition-failure recovery);
     #    the iterate matcher drops it and re-pairs by pure 1-NN + consensus
@@ -348,7 +369,8 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
         gaussian_sigma_px=gaussian_sigma_px,
         rough_cut_px_min=rough_cut_px_min, rough_cut_px_max=rough_cut_px_max,
         nfwhm=nfwhm, nsigma=hist_nsigma, histocut_order=histocut_order,
-        slope_max=slope_max, slope_nsteps=slope_nsteps)
+        slope_max=slope_max, slope_nsteps=slope_nsteps,
+        delta_mag_lim=delta_mag_lim, image_mags=image_mags)
     correctors, last_info, first_info, wcs_by_det = _coarse(
         detectors, wcs_by_det, refcat, key,
         match0=OffsetHistogramMatch(searchrad=coarse_searchrad, **hist_kwargs),
@@ -374,9 +396,9 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
     #    enough sources match AND they span enough sky to condition a rotation.
     prelim = [_match(corr, d.catalog, ref_sky, match_radius)
               for corr, d in zip(correctors, detectors)]
-    group_nmatched = sum(n for _, n, _ in prelim)
+    group_nmatched = sum(n for _, n, _, _ in prelim)
     matched_ref = np.unique(np.concatenate(
-        [idx for _, _, idx in prelim] + [np.array([], dtype=int)]))
+        [idx for _, _, _, idx in prelim] + [np.array([], dtype=int)]))
     coverage = _coverage_arcsec(ref_sky.ra.deg[matched_ref],
                                 ref_sky.dec.deg[matched_ref])
     if group_nmatched < min_matched or coverage < min_coverage_arcsec:
@@ -392,7 +414,8 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
 
     # 4. Fine: per-detector gated fit for any detector over tolerance.
     solutions = []
-    for corr, d, (resid, nmatch, ref_idx) in zip(correctors, detectors, prelim):
+    for corr, d, (resid, nmatch, src_idx, ref_idx) in zip(correctors, detectors,
+                                                          prelim):
         within = bool(np.isfinite(resid) and resid <= tolerance)
         dof, out_wcs = 'coarse', corr.wcs
 
@@ -403,9 +426,8 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
                                    min_coverage_arcsec)
             if geom is not None:
                 try:
-                    trial, tfi = _fine_fit(corr, d.detector, refcat[ref_idx],
-                                           geom, key=key,
-                                           match_radius=match_radius,
+                    trial, tfi = _fine_fit(corr, d.detector, d.catalog, refcat,
+                                           src_idx, ref_idx, geom, key=key,
                                            nclip=nclip, sigma=sigma)
                 except Exception as e:  # noqa: BLE001 — keep the coarse solution
                     log(f"align solve[{key}]: fine {geom} fit for {d.detector} "
@@ -413,8 +435,8 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
                     tfi = {}
                     trial = None
                 if trial is not None and _succeeded(tfi):
-                    new_resid, new_n, _ = _match(trial, d.catalog, ref_sky,
-                                                 match_radius)
+                    new_resid, new_n, _, _ = _match(trial, d.catalog, ref_sky,
+                                                    match_radius)
                     if np.isfinite(new_resid) and new_resid < resid:
                         out_wcs, dof = trial.wcs, geom
                         resid, nmatch = new_resid, new_n

--- a/pipeline/campfire_pipeline/nircam/align/solve.py
+++ b/pipeline/campfire_pipeline/nircam/align/solve.py
@@ -85,6 +85,8 @@ class DetectorSolution:
     residual_arcsec: float   # median matched residual after alignment (nan if none)
     n_matched: int
     within_tolerance: bool
+    aligned: bool = True     # False: rejected by the residual gate — the I/O
+                             # layer stamps NOT_ALIGNED (WCS preserved)
 
 
 @dataclass
@@ -289,7 +291,8 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
                          fine_fitgeom='rshift', fine_min_general=10,
                          fine_min_rshift=4, fine_min_shift=2, tolerance=0.05,
                          match_radius=0.5, min_matched=6, min_coverage_arcsec=5.0,
-                         ref_border_arcmin=1.2, nclip=3, sigma=3.0):
+                         ref_border_arcmin=1.2, nclip=3, sigma=3.0,
+                         max_residual_arcsec=0.1):
     """Solve one pool of detectors; return a :class:`GroupSolution`.
 
     *detectors* is one pool (a module, or a whole channel when the caller pooled
@@ -312,6 +315,13 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
     fit, so acceptance never rests on it alone: the pool rejects to NOT_ALIGNED
     unless at least *min_matched* sources match one-to-one within *match_radius*
     **and** they span at least *min_coverage_arcsec* of sky.
+
+    *max_residual_arcsec* is a final per-detector backstop on top of all of the
+    above: any detector whose post-fit one-to-one residual still exceeds it is
+    individually rejected (``aligned=False`` — the I/O layer stamps NOT_ALIGNED,
+    WCS preserved), so a plausible-looking but wrong solution can never reach a
+    mosaic. Healthy solves sit well under it (~0.02–0.03"); the COSMOS A2/A3
+    misregistrations this guards against sat at 0.20–0.24". ``None`` disables.
     """
     detectors = list(detectors)
     if not detectors:
@@ -442,8 +452,25 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
                         resid, nmatch = new_resid, new_n
                         within = bool(resid <= tolerance)
 
+        # Residual gate (backstop): no solution this bad may reach a mosaic.
+        # Gates only a *measured* bad residual — a nan residual (no one-to-one
+        # matches on this detector) keeps the pooled attitude, which the group
+        # gate above already vetted.
+        if (max_residual_arcsec is not None and np.isfinite(resid)
+                and resid > float(max_residual_arcsec)):
+            log(f"align solve[{key}]: {d.detector} residual {resid:.3f}\" "
+                f"exceeds max_residual_arcsec={float(max_residual_arcsec):g}; "
+                f"rejecting this detector to NOT_ALIGNED (WCS preserved).")
+            solutions.append(DetectorSolution(d.detector, d.wcs, 'identity',
+                                              resid, nmatch, False,
+                                              aligned=False))
+            continue
+
         solutions.append(DetectorSolution(d.detector, out_wcs, dof,
                                           resid, nmatch, within))
 
-    return GroupSolution(key, 'SOLVED', shift, rot_deg, rmse,
+    # If the gate rejected every detector, the pool as a whole failed — report
+    # NOT_ALIGNED so the orchestration surfaces it in the end-of-run warning.
+    status = ('SOLVED' if any(s.aligned for s in solutions) else 'NOT_ALIGNED')
+    return GroupSolution(key, status, shift, rot_deg, rmse,
                          group_nmatched, solutions)

--- a/pipeline/campfire_pipeline/nircam/align/solve.py
+++ b/pipeline/campfire_pipeline/nircam/align/solve.py
@@ -13,11 +13,14 @@ exposure reader/writer + ``CFP_ALGN`` stamp live in the orchestration layer).
 
 1. *Footprint-clip* the field refcat to this pool's detector union + border
    (``footprint.py``), so the coarse matcher works against in-frame sources.
-2. *Coarse* — one pooled ``rshift`` recovered by ``tweakwcs.XYXYMatch`` on its
-   2-D pairwise-offset histogram (``use2dhist``), iterated match→fit→rematch to
-   convergence. The histogram grabs a gross translation (validated to tens of
-   arcsec) and the rigid fit recovers the roll (to ~1 deg) over the iterations —
-   no triangle matcher, no rotation scan (see ``scripts/align_matcher_bakeoff``).
+2. *Coarse* — one pooled ``rshift`` recovered by the JHAT-ported
+   ``OffsetHistogramMatch`` (``histmatch.py``): a 2-D-histogram gross-shift
+   stage over ``coarse_searchrad`` (pass 0 only), then unbounded 1-NN pairing
+   whose true correspondences are selected by the pairwise-offset histogram
+   consensus (rotation-slope scan + sigma clip), iterated match→fit→rematch to
+   convergence. Unlike ``tweakwcs.XYXYMatch`` (pair *enumeration*, which dies
+   with ``MatchSourceConfusionError`` on clustered extragalactic catalogs),
+   nothing here is enumerated and nothing can overflow.
 3. *Group gate* — accept the pool only if enough sources match one-to-one and
    span enough sky to condition a rotation; else reject to NOT_ALIGNED.
 4. *Fine* — each detector over tolerance gets an individual fit against a
@@ -47,6 +50,7 @@ from tweakwcs.matchutils import XYXYMatch
 
 from campfire_pipeline.common.io import log
 from campfire_pipeline.nircam.align.footprint import clip_refcat_to_exposure
+from campfire_pipeline.nircam.align.histmatch import OffsetHistogramMatch
 
 # A coarse iterate pass that moves the shared WCS by less than this (arcsec) has
 # converged — well below a NIRCam pixel (31 mas SW / 63 mas LW).
@@ -195,27 +199,23 @@ def _pool_fit(detectors, wcs_by_det, refcat, match, *, key, fitgeom, nclip, sigm
     return correctors, correctors[0].meta.get('fit_info', {})
 
 
-def _coarse(detectors, wcs_by_det, refcat, key, *, searchrad, tolerance,
-            separation, niter, nclip, sigma):
+def _coarse(detectors, wcs_by_det, refcat, key, *, match0, match_iter, niter,
+            nclip, sigma):
     """Iterate a pooled ``rshift`` to convergence; return
     ``(correctors, last_info, first_info, wcs_by_det)`` or
     ``(None, {}, {}, wcs_by_det)``.
 
-    Pass 0 uses the 2-D-histogram matcher over the full *searchrad* to grab the
-    gross translation; later passes start from the corrected WCS and match by
-    nearest-neighbour (``use2dhist=False``) around the now-small residual, the
-    rigid fit peeling off the roll each pass. *first_info* is pass 0's fit (the
-    gross shift/rot the input WCS was off by, for provenance); *last_info* is the
-    converged fit (its rmse is the final quality).
+    Pass 0 uses *match0* (the histogram matcher with its gross-translation
+    stage over the full search radius); later passes start from the corrected
+    WCS and use *match_iter* (the same consensus matcher without the gross
+    stage) around the now-small residual, the rigid fit peeling off the roll
+    each pass. *first_info* is pass 0's fit (the gross shift/rot the input WCS
+    was off by, for provenance); *last_info* is the converged fit (its rmse is
+    the final quality).
     """
     correctors, last_info, first_info = None, {}, {}
     for i in range(max(1, int(niter))):
-        if i == 0:
-            match = XYXYMatch(use2dhist=True, searchrad=searchrad,
-                              tolerance=tolerance, separation=separation)
-        else:
-            match = XYXYMatch(use2dhist=False, searchrad=tolerance,
-                              tolerance=tolerance, separation=separation)
+        match = match0 if i == 0 else match_iter
         try:
             c, fi = _pool_fit(detectors, wcs_by_det, refcat, match, key=key,
                               fitgeom='rshift', nclip=nclip, sigma=sigma)
@@ -278,8 +278,11 @@ def _fine_fit(corr, detector, local_refcat, geom, *, key, match_radius, nclip,
 
 
 def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
-                         coarse_searchrad=70.0, coarse_tolerance=2.0,
-                         coarse_separation=1.0, refine_niter=3,
+                         coarse_searchrad=70.0, refine_niter=3,
+                         d2d_max=1.5, binsize_px=0.02, gaussian_sigma_px=0.2,
+                         rough_cut_px_min=2.5, rough_cut_px_max=2.5,
+                         nfwhm=2.5, hist_nsigma=3.0, histocut_order='dxdy',
+                         slope_max=10.0 / 2048.0, slope_nsteps=200,
                          fine_fitgeom='rshift', fine_min_general=10,
                          fine_min_rshift=4, fine_min_shift=2, tolerance=0.05,
                          match_radius=0.5, min_matched=6, min_coverage_arcsec=5.0,
@@ -288,10 +291,13 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
 
     *detectors* is one pool (a module, or a whole channel when the caller pooled
     modules). The pool is footprint-clipped, tied to the refcat with a single
-    coarse ``rshift`` (``XYXYMatch`` 2-D-hist + iterate), gated on match count and
-    sky coverage, then each over-tolerance detector gets a fine fit whose geometry
+    coarse ``rshift`` (``OffsetHistogramMatch``: gross 2-D-hist shift + 1-NN /
+    offset-histogram consensus, iterated), gated on match count and sky
+    coverage, then each over-tolerance detector gets a fine fit whose geometry
     is chosen down the ``fine_fitgeom`` ladder by its match count / coverage and
-    accepted only if it reduces the residual.
+    accepted only if it reduces the residual. The ``d2d_max`` … ``slope_nsteps``
+    knobs pass straight to :class:`OffsetHistogramMatch` (the ``*_px`` ones in
+    image pixels, mirroring the validated JHAT configuration).
 
     ``pool_modules`` is accepted for config-passthrough symmetry but unused here
     (the orchestration layer decides pooling before calling this).
@@ -333,12 +339,21 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
 
     wcs_by_det = {d.detector: d.wcs for d in detectors}
 
-    # 2. Coarse: one pooled rshift, iterated to convergence.
+    # 2. Coarse: one pooled rshift, iterated to convergence. Pass 0's matcher
+    #    carries the gross-translation stage (acquisition-failure recovery);
+    #    the iterate matcher drops it and re-pairs by pure 1-NN + consensus
+    #    around the already-corrected WCS.
+    hist_kwargs = dict(
+        d2d_max=d2d_max, binsize_px=binsize_px,
+        gaussian_sigma_px=gaussian_sigma_px,
+        rough_cut_px_min=rough_cut_px_min, rough_cut_px_max=rough_cut_px_max,
+        nfwhm=nfwhm, nsigma=hist_nsigma, histocut_order=histocut_order,
+        slope_max=slope_max, slope_nsteps=slope_nsteps)
     correctors, last_info, first_info, wcs_by_det = _coarse(
         detectors, wcs_by_det, refcat, key,
-        searchrad=coarse_searchrad, tolerance=coarse_tolerance,
-        separation=coarse_separation, niter=refine_niter, nclip=nclip,
-        sigma=sigma)
+        match0=OffsetHistogramMatch(searchrad=coarse_searchrad, **hist_kwargs),
+        match_iter=OffsetHistogramMatch(searchrad=None, **hist_kwargs),
+        niter=refine_niter, nclip=nclip, sigma=sigma)
     if correctors is None or not _succeeded(last_info):
         log(f"align solve[{key}]: coarse fit "
             f"{last_info.get('status', 'FAILED')}; NOT_ALIGNED (WCS preserved).")

--- a/pipeline/campfire_pipeline/nircam/align/solve.py
+++ b/pipeline/campfire_pipeline/nircam/align/solve.py
@@ -23,12 +23,14 @@ exposure reader/writer + ``CFP_ALGN`` stamp live in the orchestration layer).
    nothing here is enumerated and nothing can overflow.
 3. *Group gate* — accept the pool only if enough sources match one-to-one and
    span enough sky to condition a rotation; else reject to NOT_ALIGNED.
-4. *Fine* — each detector over tolerance gets an individual fit on its own
-   already-matched (mutual-NN) pairs — handed to ``align_wcs`` row-aligned
-   with ``match=None``, exactly JHAT's ``already_matched`` design — its
-   geometry chosen down a ladder (``general`` → ``rshift`` → ``shift`` →
-   keep-coarse) by its match count and coverage, accepted only if it
-   measurably reduces the residual.
+4. *Fine* — EVERY detector with enough verified matches gets an individual
+   fit on its own already-matched (mutual-NN) pairs — handed to ``align_wcs``
+   row-aligned with ``match=None``, exactly JHAT's ``already_matched`` design
+   (JHAT fits every detector, always) — its geometry chosen down a ladder
+   (``general`` → ``rshift`` → ``shift`` → keep-coarse) by its match count and
+   coverage, accepted only if it reduces the residual. The ladder floors
+   (``fine_min_shift`` = JHAT's ``minobj=3``) are the guard against
+   noise-chasing; ``tolerance`` is reporting-only.
 
 The pooled coarse is the mechanical expression of the pooling constraint: every
 detector of one pool shares one ``group_id`` so a single rigid rshift is fit from
@@ -289,7 +291,7 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
                          slope_max=10.0 / 2048.0, slope_nsteps=200,
                          delta_mag_lim=None,
                          fine_fitgeom='rshift', fine_min_general=10,
-                         fine_min_rshift=4, fine_min_shift=2, tolerance=0.05,
+                         fine_min_rshift=4, fine_min_shift=3, tolerance=0.05,
                          match_radius=0.5, min_matched=6, min_coverage_arcsec=5.0,
                          ref_border_arcmin=1.2, nclip=3, sigma=3.0,
                          max_residual_arcsec=0.1):
@@ -299,9 +301,11 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
     modules). The pool is footprint-clipped, tied to the refcat with a single
     coarse ``rshift`` (``OffsetHistogramMatch``: gross 2-D-hist shift + 1-NN /
     offset-histogram consensus, iterated), gated on match count and sky
-    coverage, then each over-tolerance detector gets a fine fit whose geometry
-    is chosen down the ``fine_fitgeom`` ladder by its match count / coverage and
-    accepted only if it reduces the residual. The ``d2d_max`` …
+    coverage, then EVERY detector with enough verified matches gets a fine fit
+    whose geometry is chosen down the ``fine_fitgeom`` ladder by its match
+    count / coverage and accepted only if it reduces the residual
+    (*tolerance* only flags ``within_tolerance`` in the result; it gates
+    nothing). The ``d2d_max`` …
     ``slope_nsteps`` / ``delta_mag_lim`` knobs pass straight to
     :class:`OffsetHistogramMatch` (the ``*_px`` ones in image pixels,
     mirroring the validated JHAT configuration); ``delta_mag_lim`` reads image
@@ -422,14 +426,21 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
     mins = {'general': fine_min_general, 'rshift': fine_min_rshift,
             'shift': fine_min_shift}
 
-    # 4. Fine: per-detector gated fit for any detector over tolerance.
+    # 4. Fine: per-detector fit for EVERY detector with matches (JHAT fits
+    #    every detector, always — a sub-tolerance systematic SIAF offset must
+    #    not survive just because it is small). The ladder floors are the real
+    #    guard: the residual-improvement acceptance below is nearly
+    #    tautological (the fit minimizes the same mutual-NN pairs it is judged
+    #    on), so a detector below `fine_min_shift` verified matches keeps the
+    #    pooled attitude — the better estimate at that point. `tolerance` no
+    #    longer gates anything; it is the reporting threshold for `within`.
     solutions = []
     for corr, d, (resid, nmatch, src_idx, ref_idx) in zip(correctors, detectors,
                                                           prelim):
         within = bool(np.isfinite(resid) and resid <= tolerance)
         dof, out_wcs = 'coarse', corr.wcs
 
-        if not within and np.isfinite(resid):
+        if np.isfinite(resid):
             det_cov = _coverage_arcsec(ref_sky.ra.deg[ref_idx],
                                        ref_sky.dec.deg[ref_idx])
             geom = _choose_fitgeom(len(ref_idx), det_cov, fine_fitgeom, mins,

--- a/pipeline/campfire_pipeline/nircam/orchestrate.py
+++ b/pipeline/campfire_pipeline/nircam/orchestrate.py
@@ -788,7 +788,11 @@ def _align_group_worker(key, members, *, refcat, config, overwrite, status):
 
 
 def _warn_not_aligned(field, failed_groups):
-    """Loudly report exposures that failed alignment, and how to resolve them.
+    """Loudly report detectors that failed alignment, and how to resolve them.
+
+    *failed_groups* is a list of ``(pool, rejected_members)`` pairs — a whole
+    pool that rejected, or the subset of a SOLVED pool's members the residual
+    gate rejected individually.
 
     Excluding data from the mosaic is never an automatic decision — a NOT_ALIGNED
     exposure is quarantined from every future combine (its raw WCS would double
@@ -798,14 +802,14 @@ def _warn_not_aligned(field, failed_groups):
     bar = '!' * 72
     log('')
     log(bar)
-    log(f"align: WARNING — {len(failed_groups)} exposure(s) FAILED alignment "
-        f"(CFP_ALGN = {cfp.NOT_ALIGNED}).")
+    log(f"align: WARNING — {len(failed_groups)} pool(s) have detector(s) that "
+        f"FAILED alignment (CFP_ALGN = {cfp.NOT_ALIGNED}).")
     log("These are EXCLUDED from all future mosaics by default (the combine")
     log("quarantine). Omitting data is not automatic — review and resolve first:")
     log('')
-    for g in failed_groups:
-        log(f"  {g.key}  ({g.n_members} detector(s)):")
-        for m in g.members:
+    for g, members in failed_groups:
+        log(f"  {g.key}  ({len(members)} of {g.n_members} detector(s)):")
+        for m in members:
             log(f"      {m.path}")
     log('')
     log("To retry: retune [<field>.align] in fields.toml (e.g. widen "
@@ -832,16 +836,21 @@ def _pending_pools(pools, status, overwrite, refcat_hash):
     generation). *retry_count* is how many pending pools are such re-attempts of
     already-stamped work.
     """
+    def _member_done(path):
+        value = cfp.step_value(path, 'CFP_ALGN')
+        return (value != cfp.NOT_ALIGNED
+                and _algn_refcat_hash(value) == refcat_hash)
+
     if overwrite:
         return list(pools), 0
     pending, retry = [], 0
     for p in pools:
         stamped = all(status.has(m.path, 'CFP_ALGN') for m in p.members)
-        value = (cfp.step_value(p.members[0].path, 'CFP_ALGN')
-                 if stamped else None)
-        done = (stamped and value != cfp.NOT_ALIGNED
-                and _algn_refcat_hash(value) == refcat_hash)
-        if done:
+        # Judge EVERY member, not a representative: the residual gate can
+        # reject a single detector inside an otherwise solved pool, and that
+        # NOT_ALIGNED member must keep the pool pending (re-attempted on a
+        # normal re-run) rather than being silently skipped forever.
+        if stamped and all(_member_done(m.path) for m in p.members):
             continue
         pending.append(p)
         if stamped:
@@ -921,13 +930,24 @@ def _run_align(field, config, filtname, n_processes, overwrite, status,
     for p in pending:
         status.mark_all([m.path for m in p.members], 'CFP_ALGN')
 
-    # A NOT_ALIGNED pool is quarantined from every future mosaic (the combine
-    # quarantine). That must never be silent — surface it loudly with the levers
-    # to resolve it.
+    # A NOT_ALIGNED detector is quarantined from every future mosaic (the
+    # combine quarantine). That must never be silent — surface it loudly with
+    # the levers to resolve it. Covers both whole-pool rejections and single
+    # detectors the residual gate rejected inside an otherwise SOLVED pool.
     by_key = {p.key: p for p in pending}
-    failed = [by_key[r.key] for r in results
-              if r is not None and getattr(r, 'status', None) == 'NOT_ALIGNED'
-              and getattr(r, 'key', None) in by_key]
+    failed = []
+    for r in results:
+        if r is None or getattr(r, 'key', None) not in by_key:
+            continue
+        pool = by_key[r.key]
+        if getattr(r, 'status', None) == 'NOT_ALIGNED':
+            failed.append((pool, list(pool.members)))
+            continue
+        rejected = {d.detector for d in getattr(r, 'detectors', [])
+                    if not getattr(d, 'aligned', True)}
+        if rejected:
+            failed.append((pool, [m for m in pool.members
+                                  if m.detector in rejected]))
     if failed:
         _warn_not_aligned(field, failed)
 

--- a/pipeline/campfire_pipeline/nircam/refcat/extract.py
+++ b/pipeline/campfire_pipeline/nircam/refcat/extract.py
@@ -119,6 +119,98 @@ def _find_sibling_err(mosaic_path):
 # Source extraction
 # ---------------------------------------------------------------------------
 
+def sep_extract_sources(sci, err, *, mask=None, snr_thresh=3.0, minarea=15,
+                        deblend_nthresh=32, deblend_cont=0.001,
+                        filter_fwhm=1.5):
+    """SEP-on-SNR segmentation + Kron photometry, in pixel space.
+
+    The shared detection core of both the refcat build
+    (:func:`extract_from_mosaic`) and the align per-exposure detector
+    (``align/detect.py``). Sharing one recipe is load-bearing: the align coarse
+    matcher histograms image-side detections against refcat entries, and only
+    catalogs built the *same way* correspond 1:1 — point-source detection over
+    bright extended galaxies instead yields swarms of substructure peaks whose
+    clustering can out-vote the true offset (COSMOS A2/A3 misregistration).
+
+    Detection runs on the SNR map (``sci/err``) with a matched-filter Gaussian;
+    photometry (Kron ellipse + small-source circle fallback) runs on *sci*.
+    Zero/non-finite ``sci``/``err`` pixels and any *mask* pixels are excluded.
+
+    Returns an astropy Table with 0-indexed pixel columns ``x, y`` (windowed
+    positions), ``flux, fluxerr`` (in ``sci``'s native per-pixel units) and
+    ``npix``; empty (but typed) when nothing is detected.
+    """
+    import sep
+    from photutils.segmentation import make_2dgaussian_kernel
+
+    # Honor SEP's pixel-stack overflow knobs the way the notebook does;
+    # large images blow past defaults. ``set_extract_pixstack`` is global
+    # state in the C extension, but it's idempotent.
+    sep.set_extract_pixstack(int(1e7))
+    sep.set_sub_object_limit(2048)
+
+    sci = np.ascontiguousarray(sci, dtype=np.float32)
+    err = np.ascontiguousarray(err, dtype=np.float32)
+    bad = (sci == 0) | (err == 0) | ~np.isfinite(err) | ~np.isfinite(sci)
+    if mask is not None:
+        bad |= np.asarray(mask, dtype=bool)
+    sci_clean = np.where(bad, np.nan, sci)
+    err_clean = np.where(bad, np.nan, err)
+    snr = sci_clean / err_clean
+    snr_mask = ~np.isfinite(snr)
+
+    kernel = make_2dgaussian_kernel(fwhm=filter_fwhm, size=5).array
+
+    objs, segmap = sep.extract(
+        snr, thresh=snr_thresh, minarea=minarea,
+        deblend_nthresh=deblend_nthresh, deblend_cont=deblend_cont,
+        mask=snr_mask, filter_type="matched", filter_kernel=kernel,
+        clean=True, clean_param=1.0, segmentation_map=True,
+    )
+    objs = Table(objs)
+    if len(objs) == 0:
+        return Table({"x": np.array([], dtype=float),
+                      "y": np.array([], dtype=float),
+                      "flux": np.array([], dtype=float),
+                      "fluxerr": np.array([], dtype=float),
+                      "npix": np.array([], dtype=int)})
+
+    ids = np.arange(1, len(objs) + 1, dtype=np.int32)
+    objs["theta"][objs["theta"] > np.pi / 2] -= np.pi
+    nan_axes = np.isnan(objs["a"]) | np.isnan(objs["b"])
+    objs["a"][nan_axes] = 5
+    objs["b"][nan_axes] = 5
+
+    kronrad, krflag = sep.kron_radius(
+        snr, objs["x"], objs["y"], objs["a"], objs["b"], objs["theta"],
+        6.0, mask=snr_mask, seg_id=ids, segmap=segmap,
+    )
+    flux_snr, _, _ = sep.sum_ellipse(
+        snr, objs["x"], objs["y"], objs["a"], objs["b"], objs["theta"],
+        2.5 * kronrad, subpix=1, mask=snr_mask,
+        seg_id=ids, segmap=segmap,
+    )
+    rhalf, _ = sep.flux_radius(
+        snr, objs["x"], objs["y"], 6.0 * objs["a"], 0.5,
+        seg_id=ids, segmap=segmap, mask=snr_mask, normflux=flux_snr, subpix=5,
+    )
+    sigma = 2.0 / 2.35 * rhalf
+    xwin, ywin, _ = sep.winpos(snr, objs["x"], objs["y"], sigma, mask=snr_mask)
+
+    # Photometry on the SCI map (Kron + small-source circle fallback)
+    flux, fluxerr, _, _ = _kron_with_circle_fallback(
+        sci_clean, err_clean, objs, kronrad, krflag, segmap, ids, snr_mask,
+    )
+
+    return Table({
+        "x": np.asarray(xwin, dtype=float),
+        "y": np.asarray(ywin, dtype=float),
+        "flux": np.asarray(flux, dtype=float),
+        "fluxerr": np.asarray(fluxerr, dtype=float),
+        "npix": np.asarray(objs["npix"], dtype=int),
+    })
+
+
 def _ab_conversion_factor(header, wcs):
     """Multiplier that takes per-pixel ``BUNIT=MJy/sr`` flux to ``uJy/pixel``.
 
@@ -199,34 +291,16 @@ def extract_from_mosaic(
         Provenance — input paths, SEP params, count of detections at each
         cut. Stash into ``meta['params']`` of the saved refcat.
     """
-    import sep
-    from photutils.segmentation import make_2dgaussian_kernel
-
-    # Honor SEP's pixel-stack overflow knobs the way the notebook does;
-    # large mosaics blow past defaults. ``set_extract_pixstack`` is global
-    # state in the C extension, but it's idempotent.
-    sep.set_extract_pixstack(int(1e7))
-    sep.set_sub_object_limit(2048)
-
     sci, err, header, wcs = _open_sci_err(mosaic_path, err_path=err_path)
-    bad = (sci == 0) | (err == 0) | ~np.isfinite(err) | ~np.isfinite(sci)
-    sci_clean = np.where(bad, np.nan, sci)
-    err_clean = np.where(bad, np.nan, err)
-    snr = sci_clean / err_clean
-    mask = ~np.isfinite(snr)
-
-    kernel = make_2dgaussian_kernel(fwhm=filter_fwhm, size=5).array
 
     log(f"refcat extract: SEP detection on {os.path.basename(mosaic_path)} "
         f"(thresh={snr_thresh}, minarea={minarea})")
-    objs, segmap = sep.extract(
-        snr, thresh=snr_thresh, minarea=minarea,
+    srcs = sep_extract_sources(
+        sci, err, snr_thresh=snr_thresh, minarea=minarea,
         deblend_nthresh=deblend_nthresh, deblend_cont=deblend_cont,
-        mask=mask, filter_type="matched", filter_kernel=kernel,
-        clean=True, clean_param=1.0, segmentation_map=True,
+        filter_fwhm=filter_fwhm,
     )
-    objs = Table(objs)
-    n_detected = len(objs)
+    n_detected = len(srcs)
     log(f"refcat extract: {n_detected} raw detections")
 
     if n_detected == 0:
@@ -235,32 +309,10 @@ def extract_from_mosaic(
             "and the SNR threshold."
         )
 
-    ids = np.arange(1, len(objs) + 1, dtype=np.int32)
-    objs["theta"][objs["theta"] > np.pi / 2] -= np.pi
-    nan_axes = np.isnan(objs["a"]) | np.isnan(objs["b"])
-    objs["a"][nan_axes] = 5
-    objs["b"][nan_axes] = 5
-
-    kronrad, krflag = sep.kron_radius(
-        snr, objs["x"], objs["y"], objs["a"], objs["b"], objs["theta"],
-        6.0, mask=mask, seg_id=ids, segmap=segmap,
-    )
-    flux_snr, _, _ = sep.sum_ellipse(
-        snr, objs["x"], objs["y"], objs["a"], objs["b"], objs["theta"],
-        2.5 * kronrad, subpix=1, mask=mask,
-        seg_id=ids, segmap=segmap,
-    )
-    rhalf, _ = sep.flux_radius(
-        snr, objs["x"], objs["y"], 6.0 * objs["a"], 0.5,
-        seg_id=ids, segmap=segmap, mask=mask, normflux=flux_snr, subpix=5,
-    )
-    sigma = 2.0 / 2.35 * rhalf
-    xwin, ywin, _ = sep.winpos(snr, objs["x"], objs["y"], sigma, mask=mask)
-
-    # Photometry on the SCI map (Kron + small-source circle fallback)
-    flux, fluxerr, kron_a, kron_b = _kron_with_circle_fallback(
-        sci_clean, err_clean, objs, kronrad, krflag, segmap, ids, mask,
-    )
+    xwin = np.asarray(srcs["x"], dtype=float)
+    ywin = np.asarray(srcs["y"], dtype=float)
+    flux = np.asarray(srcs["flux"], dtype=float)
+    fluxerr = np.asarray(srcs["fluxerr"], dtype=float)
 
     conv = _ab_conversion_factor(header, wcs)
     with np.errstate(divide="ignore", invalid="ignore"):

--- a/pipeline/tests/test_align_apply.py
+++ b/pipeline/tests/test_align_apply.py
@@ -210,6 +210,18 @@ def test_overwrite_does_not_double_correct(tmp_path):
         assert _reload_residual(m.path, xy[m.detector], refcat) < 0.05
 
 
+def test_residual_gate_threads_from_config(tmp_path):
+    # [<field>.align].max_residual_arcsec must reach the solve: a 0 gate rejects
+    # every detector (any real residual is > 0), so the pool stamps NOT_ALIGNED
+    # and the WCS stays untouched.
+    members, refcat, _ = _make_exposure(tmp_path, n_det=2)
+    sol = align_exposure_group(members, refcat,
+                               config={'max_residual_arcsec': 0.0})
+    assert sol.status == 'NOT_ALIGNED'
+    for m in members:
+        assert _cfp_algn(m.path) == 'NOT_ALIGNED'
+
+
 # --- fine per-detector fit end-to-end ---------------------------------------
 
 def test_fine_dof_recorded(tmp_path):

--- a/pipeline/tests/test_align_detect.py
+++ b/pipeline/tests/test_align_detect.py
@@ -119,24 +119,70 @@ def test_snr_min_drops_low_peak_sources():
     assert _nearest(cut, 70, 70) > 5.0               # faint dropped
 
 
-def test_objmag_lim_keeps_only_range():
-    # objmag_lim trims a magnitude window (uncalibrated DAO mag). Derive the
-    # limits from the actual catalog so the test doesn't hard-code kernel flux.
+def test_objmag_lim_cuts_calibrated_mags():
+    # With a zeropoint, mags are calibrated (aperture + ZP) and objmag_lim
+    # trims a real AB window. Derive the limits from the actual catalog so the
+    # test doesn't hard-code aperture sums.
     rng = np.random.default_rng(7)
     img = _inject((120, 120),
                   [(30.0, 30.0, 600.0), (60.0, 60.0, 120.0), (90.0, 90.0, 25.0)],
                   rng)
-    full = detect_star_centroids(img, nsigma=4.0)
+    full = detect_star_centroids(img, nsigma=4.0, zeropoint=25.0)
+    assert full.meta['mag_calibrated']
     assert len(full) >= 3
-    # DAOStarFinder can emit a negative-flux detection (mag = nan); rank on the
-    # finite mags. objmag_lim itself drops the nan-mag rows (isfinite gate).
     mags = np.sort(np.asarray(full['mag']))
     mags = mags[np.isfinite(mags)]
     lo, hi = mags[0] + 0.01, mags[-1] - 0.01         # exclude the extremes
-    cut = detect_star_centroids(img, nsigma=4.0, objmag_lim=(lo, hi))
+    cut = detect_star_centroids(img, nsigma=4.0, zeropoint=25.0,
+                                objmag_lim=(lo, hi))
     assert 0 < len(cut) < len(full)
     cm = np.asarray(cut['mag'])
     assert np.all(np.isfinite(cm) & (cm >= lo) & (cm <= hi))
+
+
+def test_objmag_lim_skipped_without_zeropoint():
+    # An AB window applied to instrumental mags would cut everything, so with
+    # no zeropoint the cut must be skipped (loudly), not applied.
+    rng = np.random.default_rng(7)
+    img = _inject((120, 120), [(30.0, 30.0, 600.0), (60.0, 60.0, 120.0)], rng)
+    full = detect_star_centroids(img, nsigma=4.0)
+    assert not full.meta['mag_calibrated']
+    cut = detect_star_centroids(img, nsigma=4.0, objmag_lim=(19.0, 28.0))
+    assert len(cut) == len(full)
+
+
+def test_calibrated_mag_recovers_known_flux():
+    # A bright Gaussian of known total flux F: the aperture (r = 2xFWHM holds
+    # ~99.7% of a 2-D Gaussian) mag must land near ZP - 2.5 log10(F).
+    rng = np.random.default_rng(11)
+    fwhm, amp = 2.5, 2000.0
+    sigma = fwhm / 2.3548
+    total = amp * 2 * np.pi * sigma ** 2
+    img = _inject((100, 100), [(50.0, 50.0, amp)], rng, noise=0.5, fwhm=fwhm)
+    zp = 25.0
+    cat = detect_star_centroids(img, fwhm=fwhm, zeropoint=zp)
+    assert len(cat) >= 1
+    row = np.argmin(np.hypot(np.asarray(cat['x']) - 50,
+                             np.asarray(cat['y']) - 50))
+    expected = zp - 2.5 * np.log10(total)
+    assert abs(float(cat['mag'][row]) - expected) < 0.05
+    assert float(cat['aper_flux'][row]) > 0
+
+
+def test_ab_zeropoint_from_sci_header():
+    from campfire_pipeline.nircam.align.detect import (
+        ab_zeropoint_from_sci_header,
+    )
+    # LW pixel (0.063"): PIXAR_SR ~ 9.31e-14 sr -> ZP ~ 26.5 AB, and exactly
+    # -2.5 log10(PIXAR_SR * 1e6 / 3631)
+    h = fits.Header({'BUNIT': 'MJy/sr', 'PIXAR_SR': 9.31e-14})
+    zp = ab_zeropoint_from_sci_header(h)
+    assert abs(zp - (-2.5 * np.log10(9.31e-14 * 1e6 / 3631.0))) < 1e-10
+    assert 26.0 < zp < 27.0
+    # missing / wrong units -> None
+    assert ab_zeropoint_from_sci_header(fits.Header({'BUNIT': 'MJy/sr'})) is None
+    assert ab_zeropoint_from_sci_header(
+        fits.Header({'BUNIT': 'DN/s', 'PIXAR_SR': 9.31e-14})) is None
 
 
 def test_detect_in_exposure_masks_saturated_dq(tmp_path):

--- a/pipeline/tests/test_align_detect.py
+++ b/pipeline/tests/test_align_detect.py
@@ -1,18 +1,20 @@
-"""Tests for the NIRCam centroid-only source detector (nircam/align/detect.py).
+"""Tests for the NIRCam align source detector (nircam/align/detect.py).
 
-Fixtures inject 2-D Gaussian point sources onto Gaussian noise (mirrors the
-RNG-injection pattern in test_nircam_diag_striping.py) — no real FITS needed for
-the pure core; the wrapper test writes a minimal SCI/ERR/DQ HDUList.
+Detection is SEP segmentation of the SNR map (sci/err), mirroring the refcat
+build (the shared ``refcat/extract.py::sep_extract_sources`` core), with
+calibrated AB Kron magnitudes whenever a zeropoint is available. Fixtures
+inject 2-D Gaussian sources onto Gaussian noise with a unit error map (so the
+SNR map equals the image) — no real FITS needed for the pure core; the wrapper
+tests write a minimal SCI/ERR/DQ HDUList.
 """
 
 import numpy as np
 import pytest
 from astropy.io import fits
-from photutils.utils.exceptions import NoDetectionsWarning
 
 from campfire_pipeline.nircam.align import (
     detect_in_exposure,
-    detect_star_centroids,
+    detect_sources,
 )
 
 
@@ -24,6 +26,10 @@ def _inject(shape, sources, rng, noise=1.0, fwhm=2.5):
     for cx, cy, amp in sources:
         img += amp * np.exp(-((xx - cx) ** 2 + (yy - cy) ** 2) / (2 * sigma ** 2))
     return img
+
+
+def _err(shape, noise=1.0):
+    return np.full(shape, float(noise))
 
 
 def _nearest(cat, cx, cy):
@@ -39,19 +45,21 @@ def test_recovers_injected_sources():
     rng = np.random.default_rng(1)
     truth = [(30.4, 25.2, 300.0), (60.1, 70.8, 150.0), (45.0, 45.0, 500.0)]
     img = _inject((100, 100), truth, rng)
-    cat = detect_star_centroids(img, fwhm=2.5, nsigma=5.0)
+    cat = detect_sources(img, _err(img.shape))
 
     assert len(cat) >= 3
     for cx, cy, _ in truth:
-        assert _nearest(cat, cx, cy) < 0.3
+        assert _nearest(cat, cx, cy) < 0.5
     assert np.all(np.diff(np.asarray(cat['flux'])) <= 0)   # flux descending
 
 
-def test_mag_is_flux_proxy():
+def test_uncalibrated_mag_is_flux_proxy():
+    # Without a zeropoint, mag degrades to -2.5 log10(flux) and is flagged so.
     rng = np.random.default_rng(1)
     img = _inject((100, 100), [(50.0, 50.0, 400.0), (30.0, 70.0, 200.0)], rng)
-    cat = detect_star_centroids(img)
+    cat = detect_sources(img, _err(img.shape))
     assert len(cat) >= 2
+    assert not cat.meta['mag_calibrated']
     assert np.allclose(np.asarray(cat['mag']),
                        -2.5 * np.log10(np.asarray(cat['flux'])), atol=1e-6)
 
@@ -61,80 +69,78 @@ def test_mask_suppresses_source():
     img = _inject((100, 100), [(30.0, 30.0, 400.0), (70.0, 70.0, 400.0)], rng)
     mask = np.zeros((100, 100), dtype=bool)
     mask[24:37, 24:37] = True                    # cover the (30, 30) source
-    cat = detect_star_centroids(img, mask=mask)
-    assert _nearest(cat, 70, 70) < 0.3
+    cat = detect_sources(img, _err(img.shape), mask=mask)
+    assert _nearest(cat, 70, 70) < 0.5
     assert _nearest(cat, 30, 30) > 5.0
 
 
 def test_edge_rejection():
     rng = np.random.default_rng(1)
     img = _inject((100, 100), [(3.0, 50.0, 400.0), (50.0, 50.0, 400.0)], rng)
-    cat = detect_star_centroids(img, edge=8)
-    assert _nearest(cat, 50, 50) < 0.3
+    cat = detect_sources(img, _err(img.shape), edge=8)
+    assert _nearest(cat, 50, 50) < 0.5
     assert not np.any(np.asarray(cat['x']) < 8)  # within-edge source dropped
 
 
-def test_pure_noise_returns_empty_typed(recwarn):
+def test_pure_noise_returns_empty_typed():
     rng = np.random.default_rng(2)
     img = rng.normal(0.0, 1.0, (80, 80)).astype(float)
-    cat = detect_star_centroids(img, nsigma=50.0)
+    cat = detect_sources(img, _err(img.shape))
     assert len(cat) == 0
-    assert {'x', 'y', 'flux', 'mag', 'npix'}.issubset(cat.colnames)
-    # the NoDetectionsWarning is suppressed inside the function
-    assert not any(issubclass(w.category, NoDetectionsWarning) for w in recwarn)
-
-
-def test_brightest_caps_to_n():
-    rng = np.random.default_rng(3)
-    sources = [(15 + 20 * (i % 4), 15 + 20 * (i // 4), 100.0 + 40 * i)
-               for i in range(12)]
-    img = _inject((100, 100), sources, rng)
-    cat_all = detect_star_centroids(img)
-    assert len(cat_all) >= 5
-    cat = detect_star_centroids(img, brightest=5)
-    assert len(cat) == 5
-    assert np.array_equal(np.asarray(cat['flux']),
-                          np.asarray(cat_all['flux'])[:5])   # the 5 brightest
+    assert {'x', 'y', 'flux', 'fluxerr', 'mag', 'snr', 'npix'}.issubset(
+        cat.colnames)
+    assert 'mag_calibrated' in cat.meta
 
 
 def test_nan_pixels_handled():
     rng = np.random.default_rng(4)
     img = _inject((80, 80), [(40.0, 40.0, 400.0)], rng)
     img[0:10, 0:10] = np.nan
-    cat = detect_star_centroids(img)                 # must not crash
-    assert _nearest(cat, 40, 40) < 0.3
+    cat = detect_sources(img, _err(img.shape))        # must not crash
+    assert _nearest(cat, 40, 40) < 0.5
 
 
-# --- quality cuts (S2) ------------------------------------------------------
+def test_missing_err_falls_back_to_global_rms():
+    # No error map: a sigma-clipped constant RMS stands in — degraded but the
+    # bright source must still come out.
+    rng = np.random.default_rng(5)
+    img = _inject((100, 100), [(50.0, 50.0, 400.0)], rng)
+    cat = detect_sources(img, None)
+    assert _nearest(cat, 50, 50) < 0.5
 
-def test_snr_min_drops_low_peak_sources():
-    # peak SNR ≈ amp / background_rms (rms ~ 1 here). snr_min drops the faint
-    # source (~15σ) but keeps the bright one (~400σ), even though nsigma found both.
+
+# --- quality cuts -----------------------------------------------------------
+
+def test_snr_min_drops_low_snr_sources():
+    # snr_min cuts on *integrated* flux SNR (flux/fluxerr), the refcat's own
+    # selection. The faint source detects fine at the per-pixel threshold but
+    # its integrated SNR (~tens) falls below a raised snr_min; the bright one
+    # (~hundreds) survives.
     rng = np.random.default_rng(6)
-    img = _inject((100, 100), [(30.0, 30.0, 400.0), (70.0, 70.0, 15.0)], rng)
-    base = detect_star_centroids(img, nsigma=4.0)
-    assert _nearest(base, 30, 30) < 0.3 and _nearest(base, 70, 70) < 0.6
-    cut = detect_star_centroids(img, nsigma=4.0, snr_min=40.0)
-    assert _nearest(cut, 30, 30) < 0.3               # bright kept
+    img = _inject((100, 100), [(30.0, 30.0, 400.0), (70.0, 70.0, 30.0)], rng)
+    base = detect_sources(img, _err(img.shape), snr_min=None)
+    assert _nearest(base, 30, 30) < 0.5 and _nearest(base, 70, 70) < 1.0
+    cut = detect_sources(img, _err(img.shape), snr_min=150.0)
+    assert _nearest(cut, 30, 30) < 0.5               # bright kept
     assert _nearest(cut, 70, 70) > 5.0               # faint dropped
 
 
 def test_objmag_lim_cuts_calibrated_mags():
-    # With a zeropoint, mags are calibrated (aperture + ZP) and objmag_lim
+    # With a zeropoint, mags are calibrated AB (Kron flux + ZP) and objmag_lim
     # trims a real AB window. Derive the limits from the actual catalog so the
-    # test doesn't hard-code aperture sums.
+    # test doesn't hard-code Kron fluxes.
     rng = np.random.default_rng(7)
     img = _inject((120, 120),
-                  [(30.0, 30.0, 600.0), (60.0, 60.0, 120.0), (90.0, 90.0, 25.0)],
+                  [(30.0, 30.0, 600.0), (60.0, 60.0, 120.0), (90.0, 90.0, 40.0)],
                   rng)
-    full = detect_star_centroids(img, nsigma=4.0, zeropoint=25.0)
+    full = detect_sources(img, _err(img.shape), snr_min=None, zeropoint=25.0)
     assert full.meta['mag_calibrated']
     assert len(full) >= 3
     mags = np.sort(np.asarray(full['mag']))
     mags = mags[np.isfinite(mags)]
     lo, hi = mags[0] + 0.01, mags[-1] - 0.01         # exclude the extremes
-    cut = detect_star_centroids(img, nsigma=4.0, zeropoint=25.0,
-                                objmag_lim=(lo, hi))
+    cut = detect_sources(img, _err(img.shape), snr_min=None, zeropoint=25.0,
+                         objmag_lim=(lo, hi))
     assert 0 < len(cut) < len(full)
     cm = np.asarray(cut['mag'])
     assert np.all(np.isfinite(cm) & (cm >= lo) & (cm <= hi))
@@ -145,28 +151,29 @@ def test_objmag_lim_skipped_without_zeropoint():
     # no zeropoint the cut must be skipped (loudly), not applied.
     rng = np.random.default_rng(7)
     img = _inject((120, 120), [(30.0, 30.0, 600.0), (60.0, 60.0, 120.0)], rng)
-    full = detect_star_centroids(img, nsigma=4.0)
+    full = detect_sources(img, _err(img.shape), snr_min=None)
     assert not full.meta['mag_calibrated']
-    cut = detect_star_centroids(img, nsigma=4.0, objmag_lim=(19.0, 28.0))
+    cut = detect_sources(img, _err(img.shape), snr_min=None,
+                         objmag_lim=(19.0, 28.0))
     assert len(cut) == len(full)
 
 
 def test_calibrated_mag_recovers_known_flux():
-    # A bright Gaussian of known total flux F: the aperture (r = 2xFWHM holds
-    # ~99.7% of a 2-D Gaussian) mag must land near ZP - 2.5 log10(F).
+    # A bright isolated Gaussian of known total flux F: the Kron aperture
+    # (2.5 x Kron radius ~ 3 sigma for a Gaussian, >99% enclosed) mag must
+    # land near ZP - 2.5 log10(F).
     rng = np.random.default_rng(11)
     fwhm, amp = 2.5, 2000.0
     sigma = fwhm / 2.3548
     total = amp * 2 * np.pi * sigma ** 2
     img = _inject((100, 100), [(50.0, 50.0, amp)], rng, noise=0.5, fwhm=fwhm)
     zp = 25.0
-    cat = detect_star_centroids(img, fwhm=fwhm, zeropoint=zp)
+    cat = detect_sources(img, _err(img.shape, 0.5), fwhm=fwhm, zeropoint=zp)
     assert len(cat) >= 1
     row = np.argmin(np.hypot(np.asarray(cat['x']) - 50,
                              np.asarray(cat['y']) - 50))
     expected = zp - 2.5 * np.log10(total)
-    assert abs(float(cat['mag'][row]) - expected) < 0.05
-    assert float(cat['aper_flux'][row]) > 0
+    assert abs(float(cat['mag'][row]) - expected) < 0.1
 
 
 def test_ab_zeropoint_from_sci_header():
@@ -185,30 +192,35 @@ def test_ab_zeropoint_from_sci_header():
         fits.Header({'BUNIT': 'DN/s', 'PIXAR_SR': 9.31e-14})) is None
 
 
+# --- FITS wrapper -----------------------------------------------------------
+
+def _write_exposure(path, sci, err, dq, header_cards=None):
+    sci_hdu = fits.ImageHDU(sci.astype('float32'), name='SCI')
+    for k, v in (header_cards or {}).items():
+        sci_hdu.header[k] = v
+    fits.HDUList([
+        fits.PrimaryHDU(),
+        sci_hdu,
+        fits.ImageHDU(err.astype('float32'), name='ERR'),
+        fits.ImageHDU(dq.astype('uint32'), name='DQ'),
+    ]).writeto(path, overwrite=True)
+
+
 def test_detect_in_exposure_masks_saturated_dq(tmp_path):
     # A SATURATED pixel (DQ bit 1) is masked even without DO_NOT_USE — a
-    # saturated core corrupts the centroid/flux the mag cut can't catch.
+    # saturated core corrupts the position/flux the mag cut can't catch.
     rng = np.random.default_rng(8)
     shape = (100, 100)
-    sci = _inject(shape, [(30.0, 30.0, 400.0), (70.0, 70.0, 400.0)],
-                  rng).astype('float32')
-    err = np.ones(shape, dtype='float32')
+    sci = _inject(shape, [(30.0, 30.0, 400.0), (70.0, 70.0, 400.0)], rng)
     dq = np.zeros(shape, dtype='uint32')
     dq[24:37, 24:37] = 2                             # SATURATED, no DO_NOT_USE
     path = tmp_path / 'jw01727028001_04101_00003_nrca1.fits'
-    fits.HDUList([
-        fits.PrimaryHDU(),
-        fits.ImageHDU(sci, name='SCI'),
-        fits.ImageHDU(err, name='ERR'),
-        fits.ImageHDU(dq, name='DQ'),
-    ]).writeto(path, overwrite=True)
+    _write_exposure(path, sci, np.ones(shape), dq)
 
     cat = detect_in_exposure(str(path))
-    assert _nearest(cat, 70, 70) < 0.3               # clean source detected
+    assert _nearest(cat, 70, 70) < 0.5               # clean source detected
     assert _nearest(cat, 30, 30) > 5.0               # saturated source masked
 
-
-# --- FITS wrapper -----------------------------------------------------------
 
 def test_detect_in_exposure_masks_dq_and_err(tmp_path):
     rng = np.random.default_rng(5)
@@ -216,21 +228,37 @@ def test_detect_in_exposure_masks_dq_and_err(tmp_path):
     # A: DQ-flagged, B: clean, C: under an off-detector (NaN ERR) patch.
     sci = _inject(shape, [(30.0, 30.0, 400.0),
                           (70.0, 70.0, 400.0),
-                          (50.0, 75.0, 400.0)], rng).astype('float32')
-    err = np.ones(shape, dtype='float32')
+                          (50.0, 75.0, 400.0)], rng)
+    err = np.ones(shape)
     err[70:81, 45:56] = np.nan                       # covers C (x=50, y=75)
     dq = np.zeros(shape, dtype='uint32')
     dq[24:37, 24:37] = 1                             # DO_NOT_USE over A (30, 30)
-
     path = tmp_path / 'jw01727028001_04101_00003_nrca1.fits'
-    fits.HDUList([
-        fits.PrimaryHDU(),
-        fits.ImageHDU(sci, name='SCI'),
-        fits.ImageHDU(err, name='ERR'),
-        fits.ImageHDU(dq, name='DQ'),
-    ]).writeto(path, overwrite=True)
+    _write_exposure(path, sci, err, dq)
 
     cat = detect_in_exposure(str(path))
-    assert _nearest(cat, 70, 70) < 0.3               # clean source detected
+    assert _nearest(cat, 70, 70) < 0.5               # clean source detected
     assert _nearest(cat, 30, 30) > 5.0               # DQ-masked
     assert _nearest(cat, 50, 75) > 5.0               # ERR-masked
+
+
+def test_detect_in_exposure_resolves_zeropoint_from_header(tmp_path):
+    # BUNIT=MJy/sr + PIXAR_SR on the SCI header -> calibrated AB mags, exactly
+    # ZP - 2.5 log10(flux) with ZP from ab_zeropoint_from_sci_header.
+    from campfire_pipeline.nircam.align.detect import (
+        ab_zeropoint_from_sci_header,
+    )
+    rng = np.random.default_rng(9)
+    shape = (100, 100)
+    sci = _inject(shape, [(50.0, 50.0, 400.0)], rng)
+    cards = {'BUNIT': 'MJy/sr', 'PIXAR_SR': 9.31e-14}
+    path = tmp_path / 'jw01727028001_04101_00003_nrcalong.fits'
+    _write_exposure(path, sci, np.ones(shape), np.zeros(shape, 'uint32'),
+                    header_cards=cards)
+
+    cat = detect_in_exposure(str(path))
+    assert len(cat) >= 1
+    assert cat.meta['mag_calibrated']
+    zp = ab_zeropoint_from_sci_header(fits.Header(cards))
+    expected = zp - 2.5 * np.log10(np.asarray(cat['flux']))
+    assert np.allclose(np.asarray(cat['mag']), expected, atol=1e-6)

--- a/pipeline/tests/test_align_histmatch.py
+++ b/pipeline/tests/test_align_histmatch.py
@@ -226,3 +226,52 @@ def test_missing_tp_columns_raise():
 def test_bad_histocut_order_raises():
     with pytest.raises(ValueError):
         OffsetHistogramMatch(histocut_order='xy')
+
+
+# --- delta_mag_lim pair cut --------------------------------------------------
+
+def test_delta_mag_lim_cuts_brightness_disagreement():
+    # Two interleaved source populations at the SAME positions offset: the
+    # positional consensus alone cannot separate them, but their mags disagree
+    # with the refcat by 6 mag, so delta_mag_lim=[-3, 4] must cut them.
+    rng = np.random.default_rng(31)
+    true = rng.uniform(0, 130, (100, 2))
+    im = true - [0.5, 0.2] + rng.normal(0, 0.01, true.shape)
+    ref = np.vstack([true, rng.uniform(-10, 140, (400, 2))])
+
+    ref_tab = _tab(ref)
+    ref_mag = np.full(len(ref), 22.0)
+    ref_tab['mag'] = ref_mag
+    im_tab = _tab(im)
+    ids = np.arange(len(im))
+    im_tab['id'] = ids
+    # first 50 image sources agree with the refcat brightness; the rest are
+    # 6 mag brighter than their refcat counterparts (dmag = -6 < -3)
+    image_mags = {int(i): (22.0 if i < 50 else 16.0) for i in ids}
+
+    base = OffsetHistogramMatch(searchrad=70.0)
+    ri0, ii0 = base(ref_tab, im_tab, tp_pscale=LW_PSCALE)
+    assert len(ri0) >= 90                       # without the cut: both halves
+
+    m = OffsetHistogramMatch(searchrad=70.0, delta_mag_lim=(-3.0, 4.0),
+                             image_mags=image_mags)
+    ri, ii = m(ref_tab, im_tab, tp_pscale=LW_PSCALE)
+    assert len(ri) >= 40
+    assert np.all(ii < 50)                      # disagreeing half is gone
+
+
+def test_delta_mag_lim_never_punishes_missing_mags():
+    # Sources absent from the image_mags lookup (uncalibrated detector) and
+    # refcat rows with non-finite mag pass the cut unjudged.
+    rng = np.random.default_rng(37)
+    true = rng.uniform(0, 130, (80, 2))
+    im = true - [0.4, 0.1] + rng.normal(0, 0.01, true.shape)
+    ref_tab = _tab(np.vstack([true, rng.uniform(-10, 140, (300, 2))]))
+    ref_tab['mag'] = np.nan                     # refcat carries no usable mags
+    im_tab = _tab(im)
+    im_tab['id'] = np.arange(len(im))
+
+    m = OffsetHistogramMatch(searchrad=70.0, delta_mag_lim=(-3.0, 4.0),
+                             image_mags={0: 22.0})
+    ri, ii = m(ref_tab, im_tab, tp_pscale=LW_PSCALE)
+    assert len(ri) >= 70                        # nothing was cut on mags

--- a/pipeline/tests/test_align_histmatch.py
+++ b/pipeline/tests/test_align_histmatch.py
@@ -1,0 +1,228 @@
+"""Tests for the JHAT-ported offset-histogram matcher (nircam/align/histmatch).
+
+Catalogs are synthetic tangent-plane tables (TPx/TPy, arcsec) — the frame the
+matcher actually sees after ``tweakwcs`` pools a group's detectors. The key
+regression here is the *overflow regime*: spatially-correlated detection/refcat
+catalogs at the real COSMOS production counts, where ``tweakwcs.XYXYMatch``
+dies with ``MatchSourceConfusionError`` (39% of COSMOS LW exposures) and the
+histogram-consensus matcher must instead recover the offset.
+"""
+
+import numpy as np
+import pytest
+from astropy.table import Table
+
+from campfire_pipeline.nircam.align.histmatch import (
+    OffsetHistogramMatch,
+    _sigma_clip_median,
+    _smoothed_hist_peak,
+)
+
+LW_PSCALE = 0.063   # arcsec / px
+SW_PSCALE = 0.031
+
+
+def _tab(xy):
+    return Table({'TPx': xy[:, 0], 'TPy': xy[:, 1]})
+
+
+def _rot(theta_deg, about):
+    th = np.radians(theta_deg)
+    R = np.array([[np.cos(th), -np.sin(th)], [np.sin(th), np.cos(th)]])
+    return lambda xy: (xy - about) @ R.T + about
+
+
+# --- helpers ----------------------------------------------------------------
+
+def test_smoothed_hist_peak_finds_pileup():
+    rng = np.random.default_rng(0)
+    d = np.concatenate([rng.uniform(-3, 3, 500),        # false-pair floor
+                        rng.normal(1.25, 0.02, 80)])    # consensus pile-up
+    center, height, fwhm = _smoothed_hist_peak(d, 0.00126, 0.0126)
+    assert abs(center - 1.25) < 0.05
+    assert fwhm < 0.5
+
+
+def test_smoothed_hist_peak_short_histogram():
+    # fewer bins than the smoothing kernel: the peak index must still map onto
+    # the bin edges (regression: mode='same' returned the KERNEL's length)
+    d = np.array([1.0, 1.001, 1.002, 1.5])
+    center, _, _ = _smoothed_hist_peak(d, 0.02, 0.2)
+    assert 0.9 < center < 1.6
+
+
+def test_sigma_clip_median_keeps_core():
+    rng = np.random.default_rng(1)
+    vals = np.concatenate([rng.normal(0, 0.02, 90), rng.uniform(1, 3, 10)])
+    mask = np.ones(vals.size, dtype=bool)
+    out = _sigma_clip_median(vals, mask, 3.0)
+    assert np.all(np.abs(vals[out]) < 0.5)
+    assert np.count_nonzero(out) >= 80
+
+
+# --- matcher: recovery ------------------------------------------------------
+
+def test_recovers_translation_under_contamination():
+    # 120 true sources on a ~130" pool, 10x refcat junk; offset (3.2, -1.7)"
+    rng = np.random.default_rng(42)
+    true = rng.uniform(0, 130, (120, 2))
+    offset = np.array([3.2, -1.7])
+    im = true - offset + rng.normal(0, 0.01, true.shape)
+    ref = np.vstack([true, rng.uniform(-20, 150, (1200, 2))])
+
+    m = OffsetHistogramMatch(searchrad=70.0)
+    ri, ii = m(_tab(ref), _tab(im), tp_pscale=LW_PSCALE)
+    assert len(ri) >= 100
+    rec = ref[ri] - im[ii]
+    assert abs(np.median(rec[:, 0]) - offset[0]) < 0.05
+    assert abs(np.median(rec[:, 1]) - offset[1]) < 0.05
+    # true rows come first in ref, aligned with im indices
+    assert np.mean(ri == ii) > 0.9
+
+
+def test_recovers_rotation_via_slope_scan():
+    # 0.15 deg roll about the pool centre + sub-arcsec shift: displacement
+    # varies +-0.17" across the pool, well beyond the true-pair scatter, so
+    # only the rotation-slope scan can stack the peak; pure-histogram matching
+    # with no de-rotation would smear it.
+    rng = np.random.default_rng(7)
+    true = rng.uniform(0, 130, (120, 2))
+    im = _rot(0.15, np.array([65.0, 65.0]))(true) - [0.8, 0.5]
+    im += rng.normal(0, 0.01, im.shape)
+    ref = np.vstack([true, rng.uniform(-20, 150, (1200, 2))])
+
+    m = OffsetHistogramMatch(searchrad=70.0)
+    ri, ii = m(_tab(ref), _tab(im), tp_pscale=LW_PSCALE)
+    assert len(ri) >= 100
+    assert np.mean(ri == ii) > 0.9
+
+
+def test_recovers_large_acquisition_offset():
+    # 60" offset — far beyond 1-NN capture; the gross 2-D-histogram stage must
+    # pre-shift before the consensus stage can work.
+    rng = np.random.default_rng(11)
+    true = rng.uniform(0, 130, (150, 2))
+    offset = np.array([-42.0, 41.0])
+    im = true - offset + rng.normal(0, 0.02, true.shape)
+    ref = np.vstack([true, rng.uniform(-80, 210, (1500, 2))])
+
+    m = OffsetHistogramMatch(searchrad=70.0)
+    ri, ii = m(_tab(ref), _tab(im), tp_pscale=LW_PSCALE)
+    assert len(ri) >= 100
+    rec = ref[ri] - im[ii]
+    assert abs(np.median(rec[:, 0]) - offset[0]) < 0.1
+    assert abs(np.median(rec[:, 1]) - offset[1]) < 0.1
+
+
+def test_iterate_mode_needs_no_gross_stage():
+    # searchrad=None (the iterate passes): a small residual offset is matched
+    # by pure 1-NN + consensus.
+    rng = np.random.default_rng(13)
+    true = rng.uniform(0, 130, (100, 2))
+    im = true - [0.3, 0.2] + rng.normal(0, 0.01, true.shape)
+    ref = np.vstack([true, rng.uniform(-10, 140, (800, 2))])
+
+    m = OffsetHistogramMatch(searchrad=None)
+    ri, ii = m(_tab(ref), _tab(im), tp_pscale=LW_PSCALE)
+    assert len(ri) >= 85
+    assert np.mean(ri == ii) > 0.9
+
+
+def test_pooled_sparse_detectors_share_one_histogram():
+    # Four sparse SW "detectors" (8 sources each — hopeless individually) in
+    # one pooled frame: the shared histogram must still lock onto the offset.
+    # This is the pooling advantage the port must preserve.
+    rng = np.random.default_rng(17)
+    corners = [(0, 0), (68, 0), (0, 68), (68, 68)]     # 2x2 SW module layout
+    true = np.vstack([rng.uniform(0, 64, (8, 2)) + c for c in corners])
+    offset = np.array([1.1, -0.9])
+    im = true - offset + rng.normal(0, 0.01, true.shape)
+    ref = np.vstack([true, rng.uniform(-10, 142, (600, 2))])
+
+    m = OffsetHistogramMatch(searchrad=70.0)
+    ri, ii = m(_tab(ref), _tab(im), tp_pscale=SW_PSCALE)
+    assert len(ri) >= 24
+    rec = ref[ri] - im[ii]
+    assert abs(np.median(rec[:, 0]) - offset[0]) < 0.05
+    assert abs(np.median(rec[:, 1]) - offset[1]) < 0.05
+    # every quadrant (detector) contributes matched sources
+    quadrant = (im[ii][:, 0] > 66).astype(int) * 2 + (im[ii][:, 1] > 66)
+    assert len(np.unique(quadrant)) == 4
+
+
+# --- the production overflow regime -----------------------------------------
+
+def _overflow_regime(rng):
+    """COSMOS-like catalogs at the real failing counts: 427 detections /
+    4128 refs, spatially correlated — every detection IS a refcat galaxy and
+    the refcat resolves substructure (several refs within ~2" of a detection).
+    """
+    n_det = 427
+    centers = rng.uniform(0, 129, (n_det, 2))
+    offset = np.array([0.4, -0.3])
+    im = centers - offset + rng.normal(0, 0.02, centers.shape)
+    parts = [centers]
+    for _ in range(8):
+        sel = rng.random(n_det) < 0.55
+        parts.append(centers[sel] + rng.normal(0, 1.0, (int(sel.sum()), 2)))
+    ref = np.vstack(parts)
+    extra = rng.uniform(-15, 145, (max(0, 4128 - len(ref)), 2))
+    return np.vstack([ref, extra])[:4128], im, offset
+
+
+def test_xyxymatch_overflows_where_histmatch_solves():
+    from tweakwcs.matchutils import MatchSourceConfusionError, XYXYMatch
+
+    rng = np.random.default_rng(101)
+    ref, im, offset = _overflow_regime(rng)
+
+    xyxy = XYXYMatch(use2dhist=True, searchrad=70.0, tolerance=2.0,
+                     separation=1.0)
+    with pytest.raises(MatchSourceConfusionError):
+        xyxy(_tab(ref), _tab(im), tp_pscale=LW_PSCALE)
+
+    m = OffsetHistogramMatch(searchrad=70.0)
+    ri, ii = m(_tab(ref), _tab(im), tp_pscale=LW_PSCALE)
+    assert len(ri) >= 300
+    rec = ref[ri] - im[ii]
+    assert abs(np.median(rec[:, 0]) - offset[0]) < 0.05
+    assert abs(np.median(rec[:, 1]) - offset[1]) < 0.05
+    # first 427 ref rows are the true counterparts, aligned with im indices
+    assert np.mean(ri == ii) > 0.9
+
+
+# --- degeneracy / robustness ------------------------------------------------
+
+def test_starved_catalogs_return_empty():
+    rng = np.random.default_rng(23)
+    im = rng.uniform(0, 100, (50, 2))
+    ref2 = rng.uniform(0, 100, (2, 2))
+    m = OffsetHistogramMatch(searchrad=70.0)
+    for a, b in ((_tab(ref2), _tab(im)), (_tab(im), _tab(ref2[:2]))):
+        ri, ii = m(a, b, tp_pscale=LW_PSCALE)
+        assert len(ri) == 0 and len(ii) == 0
+
+
+def test_disjoint_fields_return_empty():
+    # no reference source within searchrad of any image source
+    rng = np.random.default_rng(29)
+    im = rng.uniform(0, 100, (50, 2))
+    ref = rng.uniform(500, 600, (50, 2))
+    m = OffsetHistogramMatch(searchrad=70.0)
+    ri, ii = m(_tab(ref), _tab(im), tp_pscale=LW_PSCALE)
+    assert len(ri) == 0
+
+
+def test_missing_tp_columns_raise():
+    m = OffsetHistogramMatch()
+    good = _tab(np.zeros((5, 2)))
+    bad = Table({'TPx': np.zeros(5)})
+    with pytest.raises(KeyError):
+        m(bad, good)
+    with pytest.raises(KeyError):
+        m(good, bad)
+
+
+def test_bad_histocut_order_raises():
+    with pytest.raises(ValueError):
+        OffsetHistogramMatch(histocut_order='xy')

--- a/pipeline/tests/test_align_run.py
+++ b/pipeline/tests/test_align_run.py
@@ -36,6 +36,52 @@ def _field(enabled, **kw):
                  step_overrides={'align': {'enabled': enabled, **kw}})
 
 
+def _stamped_pool(tmp_path, values, key='exp'):
+    """A minimal pool of one-detector 'canonicals': tiny FITS files carrying
+    the given CFP_ALGN header values (None = unstamped)."""
+    from types import SimpleNamespace
+    members = []
+    for i, value in enumerate(values):
+        path = str(tmp_path / f'{key}_nrc{i}.fits')
+        hdu = fits.PrimaryHDU()
+        if value is not None:
+            hdu.header['CFP_ALGN'] = value
+        hdu.writeto(path, overwrite=True)
+        members.append(SimpleNamespace(path=path, detector=f'nrc{i}'))
+    return SimpleNamespace(key=key, members=members, n_members=len(members))
+
+
+class _StampStatus:
+    def has(self, path, key):
+        with fits.open(path) as h:
+            return key in h[0].header
+
+
+def test_pending_pools_judges_every_member(tmp_path):
+    # The residual gate can reject a single detector inside an otherwise
+    # solved pool, so 'done' must be judged from EVERY member's stamp — a
+    # NOT_ALIGNED member anywhere in the pool (not just members[0]) keeps the
+    # pool pending on a normal re-run.
+    from campfire_pipeline.nircam.orchestrate import _pending_pools
+    rc = 'abcd1234'
+    solved = f'dof=coarse res=0.01 n=10 rc={rc}'
+    done_pool = _stamped_pool(tmp_path, [solved, solved], key='done')
+    partial = _stamped_pool(tmp_path, [solved, 'NOT_ALIGNED'], key='partial')
+    stale = _stamped_pool(tmp_path, [solved, 'dof=coarse res=0.01 n=10 rc=ffff0000'],
+                          key='stale')
+    unstamped = _stamped_pool(tmp_path, [solved, None], key='unstamped')
+
+    pending, retry = _pending_pools([done_pool, partial, stale, unstamped],
+                                    _StampStatus(), overwrite=False,
+                                    refcat_hash=rc)
+    assert [p.key for p in pending] == ['partial', 'stale', 'unstamped']
+    assert retry == 2                    # partial + stale are stamped re-attempts
+
+    pending, retry = _pending_pools([done_pool, partial], _StampStatus(),
+                                    overwrite=True, refcat_hash=rc)
+    assert [p.key for p in pending] == ['done', 'partial']   # overwrite: all
+
+
 def test_visit_membership_detects_dropped_member():
     # The cheap outlier pre-scan must re-run a visit whose membership changed
     # (e.g. a NOT_ALIGNED quarantine dropped an exposure) — otherwise resample

--- a/pipeline/tests/test_align_solve.py
+++ b/pipeline/tests/test_align_solve.py
@@ -250,10 +250,14 @@ def test_match_measures_small_offset():
                             meta={'catalog': d.catalog, 'group_id': 'g',
                                   'name': d.detector})
     ref_sky = SkyCoord(refcat['RA'], refcat['DEC'], unit='deg')
-    resid, n, ref_idx = _match(corr, d.catalog, ref_sky, match_radius=0.5)
+    resid, n, src_idx, ref_idx = _match(corr, d.catalog, ref_sky,
+                                        match_radius=0.5)
     assert n >= 30
     assert 0.15 < resid < 0.25
-    assert len(ref_idx) >= 30
+    assert len(ref_idx) == len(src_idx) == n
+    # mutual NN => a genuine one-to-one pairing on both sides
+    assert len(np.unique(ref_idx)) == n
+    assert len(np.unique(src_idx)) == n
 
 
 # --- clustered extragalactic refcat (the XYXYMatch overflow regime) ---------
@@ -294,3 +298,26 @@ def test_solves_substructured_refcat_regime():
     assert sol.detectors[0].within_tolerance
     assert sol.detectors[0].n_matched >= 150
     assert abs(np.hypot(*sol.shift) - 0.5) < 0.1     # hypot(0.4, 0.3)
+
+
+# --- calibrated-mag plumbing (delta_mag_lim through the solve) ---------------
+
+def test_delta_mag_lim_plumbs_through_solve():
+    # Catalogs marked calibrated + a refcat 'mag' column: with agreeing mags,
+    # delta_mag_lim must not cost matches (pairs flow id->mag into the
+    # matcher); an absurd window that rejects every judged pair must reject
+    # the pool (proves the cut is actually reaching the matcher).
+    detectors, refcat = _build_group(n_det=2, offset=(1.0, 0.0))
+    refcat['mag'] = 22.0
+    for d in detectors:
+        d.catalog['mag'] = 22.0                     # agrees: dmag = 0
+        d.catalog.meta['mag_calibrated'] = True
+
+    sol = solve_exposure_group(detectors, refcat, key='exp',
+                               delta_mag_lim=(-3.0, 4.0))
+    assert sol.status == 'SOLVED'
+    assert sol.n_matched >= 60
+
+    sol_bad = solve_exposure_group(detectors, refcat, key='exp',
+                                   delta_mag_lim=(5.0, 6.0))
+    assert sol_bad.status == 'NOT_ALIGNED'

--- a/pipeline/tests/test_align_solve.py
+++ b/pipeline/tests/test_align_solve.py
@@ -89,7 +89,9 @@ def test_recovers_shared_translation():
     sol = solve_exposure_group(detectors, refcat, key='exp')
     assert sol.status == 'SOLVED'
     assert len(sol.detectors) == 3
-    assert all(ds.dof == 'coarse' for ds in sol.detectors)
+    # the fine fit now always runs; a healthy detector either keeps the coarse
+    # attitude (no strict improvement) or accepts an rshift refinement
+    assert all(ds.dof in ('coarse', 'rshift') for ds in sol.detectors)
     assert all(ds.within_tolerance for ds in sol.detectors)
     assert all(ds.residual_arcsec < 0.02 for ds in sol.detectors)
     assert abs(np.hypot(*sol.shift) - 2.0) < 0.1
@@ -143,7 +145,7 @@ def test_fine_frees_outlier_detector():
     assert sol.status == 'SOLVED'
     good = sol.detectors[:4]
     outlier = sol.detectors[4]
-    assert all(ds.dof == 'coarse' and ds.within_tolerance for ds in good)
+    assert all(ds.within_tolerance for ds in good)
     assert outlier.dof in ('rshift', 'shift', 'general')
     assert outlier.within_tolerance
     assert outlier.residual_arcsec < 0.15
@@ -359,3 +361,20 @@ def test_delta_mag_lim_plumbs_through_solve():
     sol_bad = solve_exposure_group(detectors, refcat, key='exp',
                                    delta_mag_lim=(5.0, 6.0))
     assert sol_bad.status == 'NOT_ALIGNED'
+
+
+# --- fine fit is no longer gated on tolerance --------------------------------
+
+def test_fine_removes_subtolerance_systematic_offset():
+    # The motivating case for removing the tolerance gate: one detector carries
+    # a small systematic offset (0.03" ~ one SW pixel) that stays UNDER the
+    # 0.05" tolerance. Previously it kept the coarse attitude (gate never
+    # fired) and the offset shipped; now the always-on fine fit removes it.
+    detectors, refcat = _build_group(
+        n_det=3, offset=(2.0, 0.0), per_det_extra={2: (0.0, 0.03)})
+    sol = solve_exposure_group(detectors, refcat, key='exp')
+    assert sol.status == 'SOLVED'
+    biased = sol.detectors[2]
+    assert biased.dof in ('rshift', 'shift', 'general')
+    assert biased.residual_arcsec < 0.01
+    assert biased.within_tolerance

--- a/pipeline/tests/test_align_solve.py
+++ b/pipeline/tests/test_align_solve.py
@@ -217,9 +217,9 @@ def test_footprint_clip_survives_refcat_decoys():
 # --- robustness: exceptions never crash the worker --------------------------
 
 def test_matcher_exception_degrades_to_not_aligned(monkeypatch):
-    # A crowded field can make XYXYMatch raise (source confusion). That must be
-    # swallowed and degrade to NOT_ALIGNED (WCS preserved), never propagate out
-    # of the solve and abort the align worker.
+    # An unforeseen matcher crash must be swallowed and degrade to NOT_ALIGNED
+    # (WCS preserved), never propagate out of the solve and abort the align
+    # worker.
     from tweakwcs.matchutils import MatchCatalogs
     import campfire_pipeline.nircam.align.solve as _s
 
@@ -228,9 +228,9 @@ def test_matcher_exception_degrades_to_not_aligned(monkeypatch):
             pass
 
         def __call__(self, refcat, imcat, **k):
-            raise RuntimeError("simulated source confusion")
+            raise RuntimeError("simulated matcher crash")
 
-    monkeypatch.setattr(_s, 'XYXYMatch', _BoomMatch)
+    monkeypatch.setattr(_s, 'OffsetHistogramMatch', _BoomMatch)
     detectors, refcat = _build_group(n_det=2, offset=(2.0, 0.0))
     originals = [copy.deepcopy(d.wcs) for d in detectors]
     sol = solve_exposure_group(detectors, refcat, key='exp')
@@ -254,3 +254,43 @@ def test_match_measures_small_offset():
     assert n >= 30
     assert 0.15 < resid < 0.25
     assert len(ref_idx) >= 30
+
+
+# --- clustered extragalactic refcat (the XYXYMatch overflow regime) ---------
+
+def test_solves_substructured_refcat_regime():
+    # The COSMOS failure mode: detections and refcat rows are the same
+    # (clustered) galaxies, and the refcat resolves substructure — several
+    # reference rows within ~2" of one detection. XYXYMatch's pair enumeration
+    # died here with MatchSourceConfusionError (39% of COSMOS LW exposures);
+    # the histogram-consensus matcher must solve it.
+    rng = np.random.default_rng(55)
+    crval = [_BASE_RA, _BASE_DEC]
+    x = rng.uniform(50, 950, 300)
+    y = rng.uniform(50, 2000, 300)
+    wt = _mock(crval)
+    ra_t, dec_t = (np.asarray(v, float) for v in wt(x, y))
+
+    # substructure: clone layers offset ~1" around each truth position, plus a
+    # diffuse junk floor — refcat ~6x denser than the detections
+    cosd = _COSD
+    ras, decs = [ra_t], [dec_t]
+    for _ in range(6):
+        sel = rng.random(300) < 0.6
+        n = int(sel.sum())
+        ras.append(ra_t[sel] + rng.normal(0, 1.0, n) / 3600.0 / cosd)
+        decs.append(dec_t[sel] + rng.normal(0, 1.0, n) / 3600.0)
+    ras.append(_BASE_RA + rng.uniform(-0.015, 0.015, 600) / cosd)
+    decs.append(_BASE_DEC + rng.uniform(-0.015, 0.015, 600))
+    refcat = Table({'RA': np.concatenate(ras), 'DEC': np.concatenate(decs)})
+    refcat.meta['name'] = 'clustered'
+
+    crval_off = [crval[0] + 0.4 / 3600.0 / cosd, crval[1] - 0.3 / 3600.0]
+    det = [DetectorInput('nrcblong', _mock(crval_off), _wcsinfo(),
+                         Table({'x': x, 'y': y,
+                                'mag': rng.uniform(18, 24, 300)}))]
+    sol = solve_exposure_group(det, refcat, key='exp')
+    assert sol.status == 'SOLVED'
+    assert sol.detectors[0].within_tolerance
+    assert sol.detectors[0].n_matched >= 150
+    assert abs(np.hypot(*sol.shift) - 0.5) < 0.1     # hypot(0.4, 0.3)

--- a/pipeline/tests/test_align_solve.py
+++ b/pipeline/tests/test_align_solve.py
@@ -162,13 +162,51 @@ def test_fine_ceiling_shift_only():
 def test_few_matches_keeps_coarse():
     # A detector with too few matches for any fine geometry keeps the coarse
     # attitude rather than fitting an under-constrained per-detector correction.
+    # (Gate disabled: this test exercises the ladder degrade, and the outlier's
+    # ~0.24" coarse residual would otherwise trip the residual backstop.)
     detectors, refcat = _build_group(
         n_det=5, offset=(2.0, 0.0), per_det_extra={4: (0.0, 0.3)})
     sol = solve_exposure_group(detectors, refcat, key='exp', tolerance=0.15,
                                fine_min_shift=999, fine_min_rshift=999,
-                               fine_min_general=999)
+                               fine_min_general=999, max_residual_arcsec=None)
     assert sol.detectors[4].dof == 'coarse'
     assert not sol.detectors[4].within_tolerance
+
+
+# --- residual gate (backstop) ------------------------------------------------
+
+def test_residual_gate_rejects_bad_detector():
+    # Random per-source scatter no rigid fit can remove: detector 0's residual
+    # stays ~0.2" while the others solve to ~0. The gate must reject detector 0
+    # individually (aligned=False, input WCS preserved) and keep the pool
+    # SOLVED for the healthy detectors.
+    detectors, refcat = _build_group(n_det=3, offset=(2.0, 0.0), seed=2)
+    rng = np.random.default_rng(11)
+    cat = detectors[0].catalog
+    # mock WCS scale ~2.06"/px -> sigma 0.1 px ~ 0.21"/axis, median 2-D
+    # separation ~0.24" — over the 0.1" gate, inside the 0.5" match radius.
+    cat['x'] = np.asarray(cat['x'], float) + rng.normal(0, 0.1, len(cat))
+    cat['y'] = np.asarray(cat['y'], float) + rng.normal(0, 0.1, len(cat))
+    original = copy.deepcopy(detectors[0].wcs)
+    sol = solve_exposure_group(detectors, refcat, key='exp')
+    assert sol.status == 'SOLVED'
+    bad, good = sol.detectors[0], sol.detectors[1:]
+    assert not bad.aligned
+    assert bad.dof == 'identity'
+    assert bad.residual_arcsec > 0.1
+    assert bad.wcs(500, 500) == original(500, 500)     # input WCS preserved
+    assert all(g.aligned and g.residual_arcsec < 0.1 for g in good)
+
+
+def test_residual_gate_all_rejected_pool_not_aligned():
+    # Gate at 0: every detector's (tiny but nonzero) residual trips it, so the
+    # pool as a whole reads NOT_ALIGNED and the orchestration warning fires.
+    detectors, refcat = _build_group(n_det=2, offset=(2.0, 0.0))
+    sol = solve_exposure_group(detectors, refcat, key='exp',
+                               max_residual_arcsec=0.0)
+    assert sol.status == 'NOT_ALIGNED'
+    assert all(not ds.aligned for ds in sol.detectors)
+    assert all(ds.dof == 'identity' for ds in sol.detectors)
 
 
 # --- NOT_ALIGNED ------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the COSMOS A2/A3 f277w misregistration (13 exposures drizzled in ~25–40″ off, doubling sources over a bright low-z galaxy) and completes the align astrometry work that production has been running from a side branch.

**Supersedes #408** — all three of its commits are cherry-picked here verbatim, so it can be closed without merging.

Commits:

1. **JHAT-ported 1-NN + offset-histogram consensus matcher** (`align/histmatch.py`) — replaces `tweakwcs.XYXYMatch` in the coarse path, whose pair enumeration died with `MatchSourceConfusionError` on clustered extragalactic catalogs (39% of COSMOS LW exposures). *(from #408)*
2. **JHAT-parity fine fit + calibrated detection magnitudes** — per-detector fine fit on pre-matched mutual-NN pairs (`already_matched` design); detection mags calibrated AB via `PIXAR_SR`, enabling `objmag_lim` / `delta_mag_lim` with their validated COSMOS values. *(from #408)*
3. **SEP-segmentation detection + residual backstop** (new, the root-cause fix):
   - Per-exposure detection swapped from `DAOStarFinder` point sources to **SEP segmentation of the SNR map**, sharing the refcat build's exact recipe via a factored-out common core (`refcat/extract.py::sep_extract_sources`). The point-source finder returned thousands of bright substructure peaks over extended galaxies; these trace the same galaxy clustering as the refcat, so the coarse gross-shift 2-D offset histogram grew clustering-scale peaks that out-voted the true (0,0) peak and dragged well-pointed exposures tens of arcsec.
   - **`max_residual_arcsec` backstop** (default 0.1″): any detector whose final one-to-one residual exceeds it is individually rejected to `NOT_ALIGNED` (WCS preserved, quarantined from combine) — no plausible-but-wrong solution can reach a mosaic again. Healthy solves sit at ~0.02–0.03″; the A2/A3 failures sat at 0.20–0.24″.
4. **Per-member pool completion + partial-reject warning** (Codex review): `_pending_pools` judges completion from every member's stamp, and the end-of-run warning covers detectors the residual gate rejected inside an otherwise SOLVED pool.
5. **Fine fit for every detector** — drops the `tolerance` entry gate (JHAT fits every detector, always; a sub-tolerance systematic SIAF offset no longer survives), `fine_min_shift` → jhat's `minobj=3`. *(from #408)*

## Validation (real COSMOS f277w data)

- Batch check on the 13 affected + 10 clean exposures: **13/13 recover (0,0)** (refcat-match fraction 22–31% → 87–91%), **10/10 clean unchanged** (85–98%).
- Full end-to-end solves (detection → gross shift → consensus match → fine fit → gate) on 3 bad + 2 good exposures: corrections of 0.01–0.02″ (vs the buggy ~25–40″), residuals 0.015–0.017″, all accepted (re-verified on the final merged state, always-on fine fit included).
- All pipeline tests pass (70 align-suite tests + full suite), with new coverage for SEP detection, calibrated-mag behavior, the residual gate at solve and apply level, and per-member pool-completion gating.

## Notes

- Detection knobs change: `snr_thresh`/`minarea`/`deblend_*` added; `fwhm` (+ `psf_fwhm_by_filter`) now sets the matched-filter kernel; `snr_min` is now the *integrated* flux SNR (refcat's own cut); DAO-specific `nsigma`/`sharplo`/`roundlo`/`aper_radius_px` are gone. `[cosmos.align]` in the operational `fields.toml` needs no edits.
- Changelog: covered under `## Unreleased` → Algorithm (whole align redesign is unreleased, so this ships in the same MINOR tag).
- After merge: re-run LW `align` (idempotent — solves from `ALGN_BAK`), re-run `align` after the queued SW `process` jobs, then re-run the cancelled LW combine.

Generated with Claude Code