### PR TITLE
NIRCam bkg/wisp: JUMP_DET pathology guard + nmfwisp case shim + detrend fallback

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -155,6 +155,51 @@ Release procedure: edit the `## Unreleased` section below, then run
   omitted grown pixels from the plot entirely.
 
 ### Infrastructure
+- NIRCam `bkg` gains a **DQ pathology guard** so a broken upstream calibration
+  step can no longer hard-fail the whole `process` phase. When an aggressive-DQ
+  class (`JUMP_DET` / `SATURATED` / `PERSISTENCE`) blankets more than
+  `[nircam.bkg.mask].mask_aggressive_dq_max_frac` (default 0.85) of a frame, it is
+  spurious over-flagging, not real transients — folding it into the fit mask left
+  the conditioning-detrend `Background2D` with no box above `exclude_percentile`
+  and raised `All boxes contain <= N unmasked pixels`, killing the step. The
+  offending bit is now dropped from that exposure's fit mask (with a log line);
+  the underlying pixels are kept as good sky. Observed on COSMOS f356w exposures
+  where `jwst` jump detection flagged ~97% of the frame on low-`NGROUPS` ramps
+  (field baseline is ~6%). Independent of `subtract_2d` (the detrend runs
+  regardless). Categorized Infrastructure: normal exposures are unaffected (guard
+  triggers only on pathological frames), and the affected path previously raised
+  rather than producing values. Drizzle already keeps these pixels
+  (`good_bits='~DO_NOT_USE'`; `JUMP_DET` is not promoted), so recovered exposures
+  contribute normally to the coadd.
+- Work around an `nmfwisp` <= 1.1.4 bug that made NMF wisp subtraction fail for
+  **every SW detector/filter on a case-sensitive filesystem**. Upstream's
+  `estimate_wisp_standard` uppercases `filter_name` for its validation list and
+  then passes that same string to `load_wisp_templates`, which builds the
+  template *filename* from it — so it looks for `nrcb4_F200W_wisp.fits.gz` while
+  the shipped file is `nrcb4_f200w_wisp.fits.gz`. The lookup misses,
+  `load_wisp_templates` returns `None` rather than raising, and the `None`
+  surfaces three frames later as an opaque `np.any((mask, None), axis=0)`
+  ValueError. macOS's case-insensitive filesystem hides the bug entirely.
+  `campfire`'s own `_nmf_supports` gate probes the correct (lowercase) name, so
+  the two disagreed: campfire dispatched to NMF for pairs upstream then could
+  not load, crashing the whole `process` phase. The step now builds a cache-
+  resident tree of uppercase-named symlinks (`$CAMPFIRE_ROOT/cache/wisps/
+  _nmfwisp_case_shim`) and passes it as `wisp_path`. Verified by injection:
+  templates recover at ratio 0.995-1.000 with residual/injected <= 0.006. The
+  shim is **self-removing** — it probes the installed `nmfwisp` and returns
+  `None` once the upstream lookup resolves, so a fixed release disables it with
+  no code change. Categorized Infrastructure because no scientific output
+  changes: the affected path previously raised rather than producing values.
+  Delete the block in `steps/wisp.py` when a fixed `nmfwisp` is pinned.
+- The conditioning detrend's in-code `box_size` fallback in the NIRCam `bkg`
+  step was 32 px while `config_default.toml` ships 256 — an 8x finer mesh for
+  any caller that builds `step_config` without the packaged TOML, which would
+  let the detrend absorb the banding/amp-DC detail the per-amp terms are meant
+  to fit. Fallback now mirrors the TOML (256 px SW -> 128 px LW). No change to
+  normal `cfpipe` runs, where the TOML value always wins. The module docstring
+  also had `fine`/`coarse` inverted between the two fits (it described the
+  detrend as the fine box and the applied fit as the coarse one, the opposite
+  of the shipped 256 vs 64); corrected, with the rj0911 A/B rationale noted.
 - Dependency declarations now match actual imports (#330): added `requests`,
   `h5py`, and `Pillow` (previously satisfied only transitively) plus the
   directly-imported JWST-stack packages (`crds`, `asdf`, `stdatamodels`,

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -208,6 +208,13 @@
         # detection): they carry residual signal that would bias the per-amp
         # estimate; the GP tolerates the extra masking.
         mask_aggressive_dq = true
+        # Pathology guard: if any aggressive-DQ class blankets more than this
+        # fraction of a frame it is broken calibration (e.g. JUMP_DET runaway on
+        # low-NGROUPS ramps), not real transients — including it would starve the
+        # Background2D detrend and hard-fail the step. That bit is dropped from
+        # the fit mask for that exposure only (underlying pixels kept as sky).
+        # 0.85 targets only near-total blankets; 1.0 disables the guard.
+        mask_aggressive_dq_max_frac = 0.85
 
         [nircam.bkg.mask.pixel_scale_factor]
             # Mask length params are angular scales in px, tuned at 30 mas.

--- a/pipeline/campfire_pipeline/nircam/steps/bkg.py
+++ b/pipeline/campfire_pipeline/nircam/steps/bkg.py
@@ -24,12 +24,17 @@ R. Endsley's ``subtract_2d_before_1f``):
   gradients and diffuse (scattered-light) structure are per-amp-asymmetric,
   so the per-amp pedestal / GP DC means absorb them differently per amp and
   imprint seams at columns 512/1024/1536. The detrend is fit-only — never
-  subtracted — so it is free to follow structure aggressively (fine box, no
-  mask growth, no rejection; flux conservation cannot be harmed by a fit
-  that removes nothing). Always on by default; with it, the pedestal's
-  per-amp scope is safe even under strong gradients.
+  subtracted — so flux conservation cannot constrain it (a fit that removes
+  nothing cannot harm it). Uses a COARSE box (256 px SW -> 128 px LW), no
+  mask growth, no rejection: the coarse mesh conditions the smooth
+  component — the actual seam driver — while being structurally unable to
+  absorb the banding / amp-DC detail the per-amp terms are meant to fit.
+  Fine boxes measured slightly WORSE on real frames (rj0911 detrend-box A/B
+  2026-07-17). Always on by default; with it, the pedestal's per-amp scope
+  is safe even under strong gradients.
 * The **applied fit** (``subtract_2d``, opt-in per field) is the sky-match /
-  ICL-removal subtraction: a *smooth* model (coarse box, grown source mask,
+  ICL-removal subtraction: a *smooth* model (64 px SW -> 32 px LW — finer
+  than the detrend, but deliberately gentle — plus grown source mask and
   map-outlier reject) whose parameters are set by flux conservation — zero
   median aperture loss in the synthetic sweep — not by flatness, which the
   detrend now owns.
@@ -162,6 +167,16 @@ def bkg_step(exposure_file, field, step_config, overwrite=False, status=None,
 
     pix_factors = mask_cfg.pop('pixel_scale_factor', {'sw': 1.0, 'lw': 0.5})
     aggressive_dq = mask_cfg.pop('mask_aggressive_dq', True)
+    # Pathology guard: an aggressive-DQ class that blankets more than this
+    # fraction of the frame is a broken calibration step (e.g. JUMP_DET runaway
+    # on low-NGROUPS ramps), not real transients — folding it into the fit mask
+    # starves the Background2D detrend of unmasked boxes and hard-fails the step.
+    # Such a bit is dropped from the fit mask per-exposure. 1.0 disables the guard.
+    # Default 0.85 targets only the near-total blankets that actually starve the
+    # fit; borderline low-NGROUPS visits (~50% salt-and-pepper) fit fine either
+    # way and are left untouched (consistent across modules).
+    aggressive_dq_max_frac = float(
+        mask_cfg.pop('mask_aggressive_dq_max_frac', 0.85))
 
     with ImageModel(exposure_file, memmap=False) as model:
         sci0 = model.data.copy()
@@ -193,9 +208,12 @@ def bkg_step(exposure_file, field, step_config, overwrite=False, status=None,
             )
         sb = SubtractBackground.from_config(mcfg)
 
-        # Conditioning detrend fitter: fine box, undilated mask, no reject —
+        # Conditioning detrend fitter: coarse box, undilated mask, no reject —
         # fit-only, so flux conservation cannot constrain it (see docstring).
-        det_box = max(1, int(round(det_cfg.get('box_size', 32) * f2)))
+        # Fallback mirrors config_default.toml (256 px SW -> 128 px LW); a fine
+        # box here would let the detrend absorb the banding/amp-DC detail the
+        # per-amp terms are supposed to fit.
+        det_box = max(1, int(round(det_cfg.get('box_size', 256) * f2)))
         sb_det = SubtractBackground(
             bg_box_size=det_box,
             bg_filter_size=det_cfg.get('filter_size', 3),
@@ -210,7 +228,16 @@ def bkg_step(exposure_file, field, step_config, overwrite=False, status=None,
         # masking via inflated per-row sigma).
         dq_bits = dqflags.pixel['DO_NOT_USE']
         if aggressive_dq:
+            npix = dq.size
             for bit in ('JUMP_DET', 'SATURATED', 'PERSISTENCE'):
+                bit_frac = float((np.bitwise_and(dq, dqflags.pixel[bit]) != 0
+                                  ).sum()) / npix
+                if bit_frac > aggressive_dq_max_frac:
+                    log(f"  {rootname}: {bit} flags {100*bit_frac:.1f}% of the "
+                        f"frame (> {100*aggressive_dq_max_frac:.0f}% guard) — "
+                        f"spurious over-flagging, excluding it from the bkg fit "
+                        f"mask (underlying pixels kept as good sky)")
+                    continue
                 dq_bits |= dqflags.pixel[bit]
         dq_fit = np.bitwise_and(dq, dq_bits) != 0
 

--- a/pipeline/campfire_pipeline/nircam/steps/wisp.py
+++ b/pipeline/campfire_pipeline/nircam/steps/wisp.py
@@ -50,6 +50,103 @@ from campfire_pipeline.nircam.steps._flat import (
 
 WISP_DETECTORS = {'nrca3', 'nrca4', 'nrcb3', 'nrcb4'}
 
+# ---------------------------------------------------------------------------
+# TEMPORARY: nmfwisp filter-name case shim.
+#
+# nmfwisp <= 1.1.4 cannot load ANY bundled template on a case-sensitive
+# filesystem. ``estimate_wisp_standard`` uppercases ``filter_name`` for its
+# validation list and then hands that same uppercased string to
+# ``load_wisp_templates``, which uses it verbatim to build the filename:
+#
+#     nrcb4 + 'F200W'  ->  templates/nrcb4_org/nrcb4_F200W_wisp.fits.gz
+#     shipped file     ->  templates/nrcb4_org/nrcb4_f200w_wisp.fits.gz
+#
+# The lookup misses, ``load_wisp_templates`` returns None for wmask instead of
+# raising, and the None surfaces three frames later as an opaque numpy error
+# from ``np.any((mask, None), axis=0)``. macOS's case-insensitive filesystem
+# hides this entirely, which is likely why it shipped.
+#
+# Workaround: a cache-resident tree of uppercase-named symlinks pointing at the
+# real lowercase templates, passed to ``fit_wisp(wisp_path=...)``.
+#
+# This is SELF-REMOVING: _nmfwisp_case_shim() probes the installed nmfwisp and
+# returns None when the upstream lookup works, so once a fixed nmfwisp is
+# installed the shim stops being built or used with no code change. Delete this
+# block (and the two call sites it feeds) when the fixed release is pinned.
+# ---------------------------------------------------------------------------
+
+# A (detector, filter) pair the package is known to ship, used only to probe
+# whether upstream's lookup resolves.
+_SHIM_PROBE = ('nrcb4', 'F115W')
+
+
+def _upstream_lookup_works():
+    """True when the installed nmfwisp resolves a template from an UPPERCASE
+    filter name (i.e. the case bug is fixed and no shim is needed)."""
+    try:
+        from nmfwisp.nmfwisp import load_wisp_templates
+    except (ModuleNotFoundError, ImportError):
+        return True          # nothing to shim; caller falls back anyway
+    det, filt = _SHIM_PROBE
+    try:
+        _tmpl, _err, wmask, _hsr = load_wisp_templates(None, det, filt)
+    except Exception:
+        # A fixed version may raise FileNotFoundError on a genuine miss; that is
+        # not the case bug, and a shim would not help.
+        return True
+    return wmask is not None and np.size(wmask) > 0
+
+
+@functools.lru_cache(maxsize=1)
+def _nmfwisp_case_shim():
+    """Path to the uppercase-symlink shim tree, or None if not needed.
+
+    Built once per host under the wisps cache. Construction is race-safe: each
+    process builds into a private directory and atomically renames it into
+    place, discarding its copy if another process got there first.
+    """
+    if _upstream_lookup_works():
+        return None
+    try:
+        import importlib.resources as ir
+        import nmfwisp  # noqa: F401
+        src = ir.files('nmfwisp') / 'templates'
+    except (ModuleNotFoundError, ImportError):
+        return None
+
+    from campfire_pipeline.nircam import wisp_cache
+    final = os.path.join(wisp_cache.cache_dir(), '_nmfwisp_case_shim')
+    if os.path.isdir(final):
+        return final
+
+    staging = f'{final}.{os.getpid()}'
+    n = 0
+    for det_dir in sorted(os.listdir(str(src))):
+        sub = os.path.join(str(src), det_dir)
+        if not os.path.isdir(sub):
+            continue
+        os.makedirs(os.path.join(staging, det_dir), exist_ok=True)
+        for fn in sorted(os.listdir(sub)):
+            # <det>_<filt>_wisp.fits[.gz] -> uppercase only the filter token.
+            parts = fn.split('_')
+            if len(parts) < 3:
+                continue
+            parts[1] = parts[1].upper()
+            link = os.path.join(staging, det_dir, '_'.join(parts))
+            try:
+                os.symlink(os.path.join(sub, fn), link)
+                n += 1
+            except FileExistsError:
+                pass
+    try:
+        os.rename(staging, final)
+        log(f'nmfwisp case shim: built {n} uppercase symlinks at {final}')
+    except OSError:
+        # Another process won the race; drop ours and use theirs.
+        import shutil
+        shutil.rmtree(staging, ignore_errors=True)
+    return final if os.path.isdir(final) else None
+
 # Detector-specific bbox where the wisps are most prominent — used as the
 # fitting region for the legacy ``template`` method so faint sources outside
 # the wisp region don't influence the variance minimization.
@@ -217,8 +314,12 @@ def _fit_nmf(exposure_file, step_config, rootname, detector, filtname):
         log(f"Source detection found nothing for {rootname}; "
             "fitting NMF without a source mask")
 
+    # wisp_path is the case shim when the installed nmfwisp needs it, else None
+    # (upstream default). See _nmfwisp_case_shim.
+    shim = _nmfwisp_case_shim()
     wisp, _wisp_e = fit_wisp(
         sci_before, model.err, mask,
+        wisp_path=shim,
         detector_name=detector, filter_name=filtname.upper(),
         correct_1f=correct_1f,
     )


### PR DESCRIPTION
Three pipeline robustness fixes surfaced during the full-field COSMOS reduction. All **Infrastructure (PATCH)** — normal `cfpipe` runs are unchanged; the affected paths previously *raised* rather than producing values.

## Changes

**1. `bkg`: DQ pathology guard** (`steps/bkg.py`, `config_default.toml`)
An aggressive-DQ class (`JUMP_DET`/`SATURATED`/`PERSISTENCE`) that blankets more than `[nircam.bkg.mask].mask_aggressive_dq_max_frac` (**default 0.85**) of a frame is spurious over-flagging, not real transients. Folding it into the fit mask starved the conditioning-detrend `Background2D` (`All boxes contain <= N unmasked pixels`) and hard-failed the whole `process` phase. The offending bit is now dropped from *that exposure's* fit mask (logged); the underlying pixels stay as good sky. Observed on COSMOS f356w exposures where `jwst` jump detection flagged ~97% of the frame on low-`NGROUPS` ramps (field baseline ~6%). Normal exposures never trigger the guard. Drizzle already keeps these pixels (`good_bits='~DO_NOT_USE'`), so recovered exposures contribute normally.

**2. `wisp`: nmfwisp case shim** (`steps/wisp.py`)
Works around an `nmfwisp` <= 1.1.4 bug: it uppercases `filter_name` for validation then builds the template *filename* from the uppercased string, so it looks for `nrcb4_F200W_wisp.fits.gz` while the shipped file is lowercase — the lookup misses, returns `None`, and crashes three frames later. Broke NMF wisp on **every SW detector on a case-sensitive filesystem** (hidden on macOS). The step builds a cache-resident tree of uppercase symlinks and passes it as `wisp_path`. **Self-removing**: auto-disables once a fixed `nmfwisp` resolves the lowercase name.

**3. `bkg`: detrend box_size fallback** (`steps/bkg.py`)
The in-code fallback was 32 px while `config_default.toml` ships 256 — an 8× finer mesh for any caller building `step_config` without the packaged TOML. Fallback now mirrors the TOML (256 SW → 128 LW). Docstring `fine`/`coarse` inversion corrected. No change to normal runs (TOML always wins).

## Testing
- `py_compile` + TOML parse clean.
- Guard verified end-to-end: the 4 COSMOS f356w exposures that previously raised now complete; `Background2D` goes raise→OK when the guard drops `JUMP_DET`; 25 guard firings across the LW field, zero crashes.
- nmfwisp shim verified by injection (template recovery 0.995–1.000) and in production (0 `skipped (no template)` across f200w + LW).

Generated with Claude Code