### PR TITLE
Fix CSV export timeout with keyset pagination (issue #412)

### DIFF
--- a/supabase/migrations/20260720230000_csv_export_keyset_pagination.sql
+++ b/supabase/migrations/20260720230000_csv_export_keyset_pagination.sql
@@ -1,0 +1,384 @@
+-- Issue #412: catalog CSV export timeout.
+--
+-- The two CSV-export RPCs were offset-paged from the web client via PostgREST
+-- .range(), which applies LIMIT/OFFSET OUTSIDE a set-returning function — every
+-- page re-materialized and re-sorted the ENTIRE filtered result set, so a 16k-row
+-- export cost pages x O(N log N) and hit the authenticated role's 8s
+-- statement_timeout (neither function carried the 120s override the other heavy
+-- RPCs use).
+--
+-- Fix: keyset pagination. Both functions take an explicit cursor
+-- (get_csv_export_spectra: p_after_id on the spectra.id PK, since spectrum_id is
+-- not uniquely constrained; get_csv_export_objects: p_after_object_id on the
+-- UNIQUE objects.object_id) plus p_page_size, applied INSIDE the query, so each
+-- page is one index-bounded scan and total export work stays O(N). The
+-- p_sort_column/p_sort_direction params are dropped — rows return in cursor-key
+-- order and the web action re-sorts in JS for cosmetic CSV ordering.
+-- get_csv_export_spectra's RETURNS gains id + observation. Both functions also
+-- get SET statement_timeout = '120s' to match the repo's other heavy RPCs.
+--
+-- Signature + RETURNS changes require DROP first; definitions below are verbatim
+-- from supabase/schemas/functions.sql.
+
+-- =============================================================================
+-- get_csv_export_spectra
+-- =============================================================================
+
+-- Issue #412: keyset pagination. PostgREST applies .range() LIMIT/OFFSET
+-- OUTSIDE a set-returning function, so the old offset-paged export fully
+-- materialized and sorted the WHOLE filtered result set on every page —
+-- pages × O(N log N) — and blew through the authenticated role's 8s
+-- statement_timeout at ~16k rows. The caller now passes p_after_id (spectra.id
+-- PK cursor; spectrum_id is not uniquely constrained) and p_page_size; the
+-- LIMIT lives inside the query, each page is one index-bounded scan in id
+-- order, and total work across an export stays O(N). Rows come back in
+-- spectra.id order — the web action re-sorts in JS for cosmetic CSV ordering,
+-- so p_sort_column/p_sort_direction are gone. RETURNS gains id + observation;
+-- signature/RETURNS changes require DROP first.
+DROP FUNCTION IF EXISTS public.get_csv_export_spectra(
+  TEXT[], TEXT[], TEXT[], TEXT[], TEXT, TEXT[], INTEGER[],
+  DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION,
+  DOUBLE PRECISION, DOUBLE PRECISION,
+  INTEGER, INTEGER, INTEGER,
+  INTEGER[], TEXT, BOOLEAN, BOOLEAN, BOOLEAN, TEXT, TEXT, UUID,
+  DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION, TEXT, TEXT, BOOLEAN
+);
+
+CREATE OR REPLACE FUNCTION public.get_csv_export_spectra(
+  p_program_slugs TEXT[], p_filter_programs TEXT[] DEFAULT NULL,
+  p_fields TEXT[] DEFAULT NULL, p_gratings TEXT[] DEFAULT NULL,
+  p_gratings_mode TEXT DEFAULT 'any', p_observations TEXT[] DEFAULT NULL,
+  p_redshift_quality INTEGER[] DEFAULT NULL,
+  p_redshift_min DOUBLE PRECISION DEFAULT NULL, p_redshift_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_snr_min DOUBLE PRECISION DEFAULT NULL, p_max_snr_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_exposure_time_min DOUBLE PRECISION DEFAULT NULL, p_max_exposure_time_max DOUBLE PRECISION DEFAULT NULL,
+  p_dq_flags_include_any INTEGER DEFAULT NULL, p_dq_flags_include_all INTEGER DEFAULT NULL,
+  p_dq_flags_exclude INTEGER DEFAULT NULL,
+  p_list_ids INTEGER[] DEFAULT NULL,
+  p_search TEXT DEFAULT NULL, p_inspected_only BOOLEAN DEFAULT NULL,
+  p_needs_review BOOLEAN DEFAULT NULL,
+  p_has_photometry BOOLEAN DEFAULT NULL,
+  p_comment_search TEXT DEFAULT NULL, p_comment_search_scope TEXT DEFAULT NULL,
+  p_comment_user_id UUID DEFAULT NULL,
+  p_coord_ra DOUBLE PRECISION DEFAULT NULL, p_coord_dec DOUBLE PRECISION DEFAULT NULL,
+  p_radius_degrees DOUBLE PRECISION DEFAULT NULL,
+  p_include_unpublished BOOLEAN DEFAULT false,
+  p_after_id INTEGER DEFAULT NULL, p_page_size INTEGER DEFAULT 5000
+)
+RETURNS TABLE(
+  id INTEGER, spectrum_id TEXT, target_id TEXT, grating TEXT, field TEXT, observation TEXT,
+  ra DOUBLE PRECISION, "dec" DOUBLE PRECISION,
+  redshift NUMERIC, redshift_quality INTEGER, redshift_auto DOUBLE PRECISION,
+  signal_to_noise DOUBLE PRECISION,
+  exposure_time DOUBLE PRECISION, fits_path TEXT, program_slug TEXT, program_name TEXT,
+  last_inspected_at TIMESTAMPTZ, last_inspected_by TEXT, distance DOUBLE PRECISION,
+  dq_flags INTEGER,
+  lists TEXT
+)
+LANGUAGE plpgsql STABLE
+SET plan_cache_mode = 'force_custom_plan'
+SET statement_timeout = '120s'
+AS $$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_page_size INTEGER;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (p_comment_search IS NOT NULL AND p_comment_search != '' AND p_comment_search_scope IN ('just_me', 'everyone'));
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_page_size := LEAST(GREATEST(COALESCE(p_page_size, 5000), 1), 10000);
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs)) INTO v_filtered_program_slugs;
+  ELSE v_filtered_program_slugs := p_program_slugs; END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN RETURN; END IF;
+
+  RETURN QUERY
+  WITH visible_lists AS (
+    SELECT olm.object_id, string_agg(ol.slug, ';' ORDER BY ol.slug) AS lists
+    FROM object_list_members olm
+    JOIN object_lists ol ON ol.id = olm.list_id
+    WHERE ol.created_by = auth.uid() OR ol.visibility IN ('public_read', 'public_edit')
+    GROUP BY olm.object_id
+  ),
+  filtered_spectra AS (
+    SELECT s.id, s.spectrum_id, t.target_id, s.grating, t.field, t.ra, t.dec,
+      o.redshift, o.redshift_quality,
+      s.redshift_auto,
+      s.signal_to_noise, s.exposure_time, s.fits_path, t.program_slug, t.observation,
+      o.last_inspected_at, o.last_inspected_by,
+      CASE WHEN v_coord_search_active THEN
+        2 * DEGREES(ASIN(SQRT(POWER(SIN(RADIANS(t.dec - p_coord_dec) / 2), 2) + COS(RADIANS(p_coord_dec)) * COS(RADIANS(t.dec)) * POWER(SIN(RADIANS(t.ra - p_coord_ra) / 2), 2))))
+      ELSE NULL END AS distance,
+      COALESCE(s.dq_flags, 0) AS dq_flags,
+      vl.lists
+    FROM targets t
+    JOIN spectra s ON s.target_id = t.target_id
+    LEFT JOIN objects o ON o.id = t.object_id
+    LEFT JOIN visible_lists vl ON vl.object_id = t.object_id
+    WHERE t.program_slug = ANY(v_filtered_program_slugs)
+      AND (p_after_id IS NULL OR s.id > p_after_id)
+      AND (o.id IS NULL OR o.is_active = true)
+      AND (NOT v_grating_filter_active OR s.grating = ANY(p_gratings))
+      -- B1: hide unpublished spectra (fail-closed; admin opt-in only).
+      AND (p_include_unpublished OR s.deploy_status = 'published')
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR t.field = ANY(p_fields))
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR t.observation = ANY(p_observations))
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min) AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR s.signal_to_noise >= p_max_snr_min) AND (p_max_snr_max IS NULL OR s.signal_to_noise <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR s.exposure_time >= p_max_exposure_time_min) AND (p_max_exposure_time_max IS NULL OR s.exposure_time <= p_max_exposure_time_max)
+      AND (p_dq_flags_include_any IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_any) != 0)
+      AND (p_dq_flags_include_all IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_all) = p_dq_flags_include_all)
+      AND (p_dq_flags_exclude IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_exclude) = 0)
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR t.object_id IN (
+          SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_search IS NULL OR s.id IN (SELECT __s.id FROM public.spectra __s WHERE __s.search_text ILIKE '%' || p_search || '%'))
+      AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.redshift_quality > 0) OR (p_inspected_only = FALSE AND COALESCE(o.redshift_quality, 0) = 0))
+      AND (p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at))))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (NOT v_comment_search_active OR t.id IN (
+        SELECT c.target_id FROM comments c WHERE c.target_id IS NOT NULL AND c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (p_comment_search_scope = 'everyone' OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id))))
+      AND (NOT v_coord_search_active OR (
+        t.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND t.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)))
+  ),
+  distance_filtered AS (SELECT fs.* FROM filtered_spectra fs WHERE NOT v_coord_search_active OR fs.distance <= p_radius_degrees)
+  SELECT df.id, df.spectrum_id, df.target_id, df.grating, df.field, df.observation,
+    df.ra, df.dec, df.redshift, df.redshift_quality, df.redshift_auto,
+    df.signal_to_noise, df.exposure_time, df.fits_path, df.program_slug,
+    pr.program_name, df.last_inspected_at, up.full_name AS last_inspected_by,
+    df.distance, df.dq_flags, df.lists
+  FROM distance_filtered df
+  LEFT JOIN programs pr ON pr.slug = df.program_slug
+  LEFT JOIN user_profiles up ON up.user_id = df.last_inspected_by
+  ORDER BY df.id ASC
+  LIMIT v_page_size;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_csv_export_spectra TO authenticated;
+
+
+-- =============================================================================
+-- get_csv_export_objects
+-- (one row per sky-object for CSV download in objects view mode)
+-- =============================================================================
+
+-- Issue #412: keyset pagination — same rationale as get_csv_export_spectra
+-- above. Cursor is objects.object_id (UNIQUE, objects_object_id_key); the
+-- LIMIT lives inside the query so each page is one index-bounded scan and an
+-- export's total work stays O(N). Sort params removed (the web action
+-- re-sorts in JS). Signature change requires DROP first.
+DROP FUNCTION IF EXISTS public.get_csv_export_objects(
+  TEXT[], TEXT[], TEXT[], TEXT[], TEXT, INTEGER[],
+  DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION,
+  DOUBLE PRECISION, DOUBLE PRECISION,
+  TEXT, BOOLEAN, BOOLEAN, INTEGER[],
+  DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION,
+  BOOLEAN, DOUBLE PRECISION, DOUBLE PRECISION, TEXT, TEXT, UUID, TEXT, TEXT, BOOLEAN
+);
+
+CREATE OR REPLACE FUNCTION public.get_csv_export_objects(
+  p_program_slugs TEXT[], p_filter_programs TEXT[] DEFAULT NULL,
+  p_fields TEXT[] DEFAULT NULL, p_gratings TEXT[] DEFAULT NULL,
+  p_gratings_mode TEXT DEFAULT 'any',
+  p_redshift_quality INTEGER[] DEFAULT NULL,
+  p_redshift_min DOUBLE PRECISION DEFAULT NULL, p_redshift_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_snr_min DOUBLE PRECISION DEFAULT NULL, p_max_snr_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_exposure_time_min DOUBLE PRECISION DEFAULT NULL, p_max_exposure_time_max DOUBLE PRECISION DEFAULT NULL,
+  p_search TEXT DEFAULT NULL, p_inspected_only BOOLEAN DEFAULT NULL,
+  p_needs_review BOOLEAN DEFAULT NULL,
+  p_list_ids INTEGER[] DEFAULT NULL,
+  p_coord_ra DOUBLE PRECISION DEFAULT NULL, p_coord_dec DOUBLE PRECISION DEFAULT NULL,
+  p_radius_degrees DOUBLE PRECISION DEFAULT NULL,
+  p_has_photometry BOOLEAN DEFAULT NULL,
+  p_photo_z_min DOUBLE PRECISION DEFAULT NULL, p_photo_z_max DOUBLE PRECISION DEFAULT NULL,
+  p_comment_search TEXT DEFAULT NULL, p_comment_search_scope TEXT DEFAULT NULL,
+  p_comment_user_id UUID DEFAULT NULL,
+  p_include_unpublished BOOLEAN DEFAULT false,
+  p_after_object_id TEXT DEFAULT NULL, p_page_size INTEGER DEFAULT 5000
+)
+RETURNS TABLE(
+  object_id TEXT, field TEXT, ra DOUBLE PRECISION, "dec" DOUBLE PRECISION,
+  redshift NUMERIC, redshift_quality INTEGER,
+  redshift_inspected NUMERIC, redshift_auto DOUBLE PRECISION,
+  last_inspected_at TIMESTAMPTZ, last_inspected_by TEXT,
+  last_data_change_at TIMESTAMPTZ, staleness_reason TEXT, version INTEGER,
+  n_targets INTEGER, n_spectra INTEGER,
+  programs TEXT, gratings TEXT,
+  max_snr DOUBLE PRECISION, max_exposure_time DOUBLE PRECISION,
+  member_target_ids TEXT, distance DOUBLE PRECISION,
+  lists TEXT,
+  has_photometry BOOLEAN, photo_z DOUBLE PRECISION,
+  photo_z_err_lo DOUBLE PRECISION, photo_z_err_hi DOUBLE PRECISION,
+  photometry JSONB
+)
+LANGUAGE plpgsql STABLE
+SET plan_cache_mode = 'force_custom_plan'
+SET statement_timeout = '120s'
+AS $$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_page_size INTEGER;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN v_gratings_mode := 'any'; END IF;
+  v_page_size := LEAST(GREATEST(COALESCE(p_page_size, 5000), 1), 10000);
+
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs)) INTO v_filtered_program_slugs;
+  ELSE v_filtered_program_slugs := p_program_slugs; END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN RETURN; END IF;
+
+  RETURN QUERY
+  WITH member_targets AS (
+    SELECT t.object_id, string_agg(t.target_id, ';' ORDER BY t.target_id) AS member_target_ids
+    FROM targets t
+    WHERE t.program_slug = ANY(v_filtered_program_slugs)
+    GROUP BY t.object_id
+  ),
+  visible_lists AS (
+    SELECT olm.object_id, string_agg(ol.slug, ';' ORDER BY ol.slug) AS lists
+    FROM object_list_members olm
+    JOIN object_lists ol ON ol.id = olm.list_id
+    WHERE ol.created_by = auth.uid() OR ol.visibility IN ('public_read', 'public_edit')
+    GROUP BY olm.object_id
+  ),
+  filtered_objects AS (
+    SELECT o.object_id, o.field, o.ra, o.dec,
+      o.redshift, o.redshift_quality,
+      o.redshift_inspected, o.redshift_auto,
+      o.last_inspected_at, up.full_name AS last_inspected_by,
+      o.last_data_change_at, o.staleness_reason, o.version,
+      -- Aggregates scoped to accessible (+ filtered) programs so mixed-program
+      -- objects don't export proprietary member metadata. See
+      -- object_scoped_aggregates().
+      sa.n_targets, sa.n_spectra,
+      array_to_string(sa.programs, ';') AS programs,
+      array_to_string(sa.gratings, ';') AS gratings,
+      sa.max_snr, sa.max_exposure_time,
+      mt.member_target_ids,
+      CASE WHEN v_coord_search_active THEN
+        2 * DEGREES(ASIN(SQRT(POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) + COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) * POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2))))
+      ELSE NULL END AS distance,
+      vl.lists,
+      o.has_photometry, o.photo_z, o.photo_z_err_lo, o.photo_z_err_hi,
+      phot.photometry
+    FROM objects o
+    LEFT JOIN member_targets mt ON mt.object_id = o.id
+    LEFT JOIN visible_lists vl ON vl.object_id = o.id
+    LEFT JOIN user_profiles up ON up.user_id = o.last_inspected_by
+    LEFT JOIN LATERAL public.object_scoped_aggregates(o.id, v_filtered_program_slugs, p_include_unpublished) sa ON true
+    LEFT JOIN LATERAL (
+      SELECT op.photometry FROM object_photometry op
+      WHERE op.object_id = o.id ORDER BY op.updated_at DESC LIMIT 1
+    ) phot ON true
+    WHERE o.programs && v_filtered_program_slugs
+      AND (p_after_object_id IS NULL OR o.object_id > p_after_object_id)
+      AND o.is_active = true
+      AND (p_include_unpublished OR o.has_published_spectrum)
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+        OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+        OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+      )
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
+      AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.redshift_quality > 0) OR (p_inspected_only = FALSE AND o.redshift_quality = 0))
+      AND (p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at))))
+      AND (NOT v_coord_search_active OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+      ))
+      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+      AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+      AND (
+        NOT v_comment_search_active
+        -- Uncorrelated semijoin; see get_filtered_objects_paginated for rationale.
+        OR o.id IN (
+          SELECT c.object_id FROM comments c
+          WHERE c.object_id IS NOT NULL
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+          UNION
+          SELECT t.object_id FROM comments c
+          JOIN targets t ON t.id = c.target_id
+          WHERE c.target_id IS NOT NULL
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+        )
+      )
+  ),
+  distance_filtered AS (SELECT fo.* FROM filtered_objects fo WHERE NOT v_coord_search_active OR fo.distance <= p_radius_degrees)
+  SELECT df.object_id, df.field, df.ra, df.dec,
+    df.redshift, df.redshift_quality,
+    df.redshift_inspected, df.redshift_auto,
+    df.last_inspected_at, df.last_inspected_by,
+    df.last_data_change_at, df.staleness_reason, df.version,
+    df.n_targets, df.n_spectra,
+    df.programs, df.gratings,
+    df.max_snr, df.max_exposure_time,
+    df.member_target_ids, df.distance, df.lists,
+    df.has_photometry, df.photo_z, df.photo_z_err_lo, df.photo_z_err_hi,
+    df.photometry
+  FROM distance_filtered df
+  ORDER BY df.object_id ASC
+  LIMIT v_page_size;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_csv_export_objects TO authenticated;

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -2120,17 +2120,24 @@ GRANT EXECUTE ON FUNCTION public.get_adjacent_objects TO service_role;
 -- get_csv_export_spectra
 -- =============================================================================
 
--- Phase D: dropped spectral_features filtering (deprecated). redshift_quality
--- and redshift now read from the parent object via the targets→objects FK.
--- redshift_auto + dq_flags are per-spectrum (from spectra). Signature change
--- requires DROP first; CREATE OR REPLACE alone can't widen the RETURNS row.
+-- Issue #412: keyset pagination. PostgREST applies .range() LIMIT/OFFSET
+-- OUTSIDE a set-returning function, so the old offset-paged export fully
+-- materialized and sorted the WHOLE filtered result set on every page —
+-- pages × O(N log N) — and blew through the authenticated role's 8s
+-- statement_timeout at ~16k rows. The caller now passes p_after_id (spectra.id
+-- PK cursor; spectrum_id is not uniquely constrained) and p_page_size; the
+-- LIMIT lives inside the query, each page is one index-bounded scan in id
+-- order, and total work across an export stays O(N). Rows come back in
+-- spectra.id order — the web action re-sorts in JS for cosmetic CSV ordering,
+-- so p_sort_column/p_sort_direction are gone. RETURNS gains id + observation;
+-- signature/RETURNS changes require DROP first.
 DROP FUNCTION IF EXISTS public.get_csv_export_spectra(
   TEXT[], TEXT[], TEXT[], TEXT[], TEXT, TEXT[], INTEGER[],
   DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION,
   DOUBLE PRECISION, DOUBLE PRECISION,
-  INTEGER, INTEGER, INTEGER, INTEGER, INTEGER, INTEGER,
-  INTEGER[], TEXT, BOOLEAN, BOOLEAN, TEXT, TEXT, UUID,
-  DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION, TEXT, TEXT
+  INTEGER, INTEGER, INTEGER,
+  INTEGER[], TEXT, BOOLEAN, BOOLEAN, BOOLEAN, TEXT, TEXT, UUID,
+  DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION, TEXT, TEXT, BOOLEAN
 );
 
 CREATE OR REPLACE FUNCTION public.get_csv_export_spectra(
@@ -2151,11 +2158,12 @@ CREATE OR REPLACE FUNCTION public.get_csv_export_spectra(
   p_comment_user_id UUID DEFAULT NULL,
   p_coord_ra DOUBLE PRECISION DEFAULT NULL, p_coord_dec DOUBLE PRECISION DEFAULT NULL,
   p_radius_degrees DOUBLE PRECISION DEFAULT NULL,
-  p_sort_column TEXT DEFAULT 'target_id', p_sort_direction TEXT DEFAULT 'asc',
-  p_include_unpublished BOOLEAN DEFAULT false
+  p_include_unpublished BOOLEAN DEFAULT false,
+  p_after_id INTEGER DEFAULT NULL, p_page_size INTEGER DEFAULT 5000
 )
 RETURNS TABLE(
-  spectrum_id TEXT, target_id TEXT, grating TEXT, field TEXT, ra DOUBLE PRECISION, "dec" DOUBLE PRECISION,
+  id INTEGER, spectrum_id TEXT, target_id TEXT, grating TEXT, field TEXT, observation TEXT,
+  ra DOUBLE PRECISION, "dec" DOUBLE PRECISION,
   redshift NUMERIC, redshift_quality INTEGER, redshift_auto DOUBLE PRECISION,
   signal_to_noise DOUBLE PRECISION,
   exposure_time DOUBLE PRECISION, fits_path TEXT, program_slug TEXT, program_name TEXT,
@@ -2163,22 +2171,21 @@ RETURNS TABLE(
   dq_flags INTEGER,
   lists TEXT
 )
-LANGUAGE plpgsql STABLE SET plan_cache_mode = 'force_custom_plan'
+LANGUAGE plpgsql STABLE
+SET plan_cache_mode = 'force_custom_plan'
+SET statement_timeout = '120s'
 AS $$
 DECLARE
   v_filtered_program_slugs TEXT[];
   v_coord_search_active BOOLEAN;
   v_comment_search_active BOOLEAN;
   v_grating_filter_active BOOLEAN;
+  v_page_size INTEGER;
 BEGIN
   v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
   v_comment_search_active := (p_comment_search IS NOT NULL AND p_comment_search != '' AND p_comment_search_scope IN ('just_me', 'everyone'));
   v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
-  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
-  IF NOT (p_sort_column IN ('target_id', 'spectrum_id', 'field', 'observation', 'ra', 'dec', 'redshift', 'redshift_quality', 'redshift_auto', 'signal_to_noise', 'exposure_time', 'grating')
-       OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
-    p_sort_column := 'spectrum_id';
-  END IF;
+  v_page_size := LEAST(GREATEST(COALESCE(p_page_size, 5000), 1), 10000);
   IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
     SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs)) INTO v_filtered_program_slugs;
   ELSE v_filtered_program_slugs := p_program_slugs; END IF;
@@ -2193,7 +2200,7 @@ BEGIN
     GROUP BY olm.object_id
   ),
   filtered_spectra AS (
-    SELECT s.spectrum_id, t.target_id, s.grating, t.field, t.ra, t.dec,
+    SELECT s.id, s.spectrum_id, t.target_id, s.grating, t.field, t.ra, t.dec,
       o.redshift, o.redshift_quality,
       s.redshift_auto,
       s.signal_to_noise, s.exposure_time, s.fits_path, t.program_slug, t.observation,
@@ -2208,6 +2215,7 @@ BEGIN
     LEFT JOIN objects o ON o.id = t.object_id
     LEFT JOIN visible_lists vl ON vl.object_id = t.object_id
     WHERE t.program_slug = ANY(v_filtered_program_slugs)
+      AND (p_after_id IS NULL OR s.id > p_after_id)
       AND (o.id IS NULL OR o.is_active = true)
       AND (NOT v_grating_filter_active OR s.grating = ANY(p_gratings))
       -- B1: hide unpublished spectra (fail-closed; admin opt-in only).
@@ -2245,40 +2253,16 @@ BEGIN
         AND t.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)))
   ),
   distance_filtered AS (SELECT fs.* FROM filtered_spectra fs WHERE NOT v_coord_search_active OR fs.distance <= p_radius_degrees)
-  SELECT df.spectrum_id, df.target_id, df.grating, df.field, df.ra, df.dec, df.redshift, df.redshift_quality, df.redshift_auto,
+  SELECT df.id, df.spectrum_id, df.target_id, df.grating, df.field, df.observation,
+    df.ra, df.dec, df.redshift, df.redshift_quality, df.redshift_auto,
     df.signal_to_noise, df.exposure_time, df.fits_path, df.program_slug,
     pr.program_name, df.last_inspected_at, up.full_name AS last_inspected_by,
     df.distance, df.dq_flags, df.lists
   FROM distance_filtered df
   LEFT JOIN programs pr ON pr.slug = df.program_slug
   LEFT JOIN user_profiles up ON up.user_id = df.last_inspected_by
-  ORDER BY
-    CASE WHEN v_coord_search_active THEN df.distance END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'spectrum_id' AND p_sort_direction = 'asc' THEN df.spectrum_id END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'spectrum_id' AND p_sort_direction = 'desc' THEN df.spectrum_id END DESC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'target_id' AND p_sort_direction = 'asc' THEN df.target_id END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'target_id' AND p_sort_direction = 'desc' THEN df.target_id END DESC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'asc' THEN df.field END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'desc' THEN df.field END DESC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'observation' AND p_sort_direction = 'asc' THEN df.observation END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'observation' AND p_sort_direction = 'desc' THEN df.observation END DESC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN df.ra END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN df.ra END DESC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN df.dec END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN df.dec END DESC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN df.redshift END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN df.redshift END DESC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN df.redshift_quality END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN df.redshift_quality END DESC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_auto' AND p_sort_direction = 'asc' THEN df.redshift_auto END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_auto' AND p_sort_direction = 'desc' THEN df.redshift_auto END DESC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'signal_to_noise' AND p_sort_direction = 'asc' THEN df.signal_to_noise END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'signal_to_noise' AND p_sort_direction = 'desc' THEN df.signal_to_noise END DESC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'exposure_time' AND p_sort_direction = 'asc' THEN df.exposure_time END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'exposure_time' AND p_sort_direction = 'desc' THEN df.exposure_time END DESC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'grating' AND p_sort_direction = 'asc' THEN df.grating END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'grating' AND p_sort_direction = 'desc' THEN df.grating END DESC NULLS LAST,
-    df.target_id ASC, df.grating ASC;
+  ORDER BY df.id ASC
+  LIMIT v_page_size;
 END;
 $$;
 
@@ -2290,15 +2274,18 @@ GRANT EXECUTE ON FUNCTION public.get_csv_export_spectra TO authenticated;
 -- (one row per sky-object for CSV download in objects view mode)
 -- =============================================================================
 
--- Phase D: RETURNS columns expanded with per-object inspection fields.
--- CREATE OR REPLACE can't widen the row, so drop first.
+-- Issue #412: keyset pagination — same rationale as get_csv_export_spectra
+-- above. Cursor is objects.object_id (UNIQUE, objects_object_id_key); the
+-- LIMIT lives inside the query so each page is one index-bounded scan and an
+-- export's total work stays O(N). Sort params removed (the web action
+-- re-sorts in JS). Signature change requires DROP first.
 DROP FUNCTION IF EXISTS public.get_csv_export_objects(
   TEXT[], TEXT[], TEXT[], TEXT[], TEXT, INTEGER[],
   DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION,
   DOUBLE PRECISION, DOUBLE PRECISION,
-  TEXT, BOOLEAN, INTEGER[],
+  TEXT, BOOLEAN, BOOLEAN, INTEGER[],
   DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION,
-  BOOLEAN, DOUBLE PRECISION, DOUBLE PRECISION, TEXT, TEXT
+  BOOLEAN, DOUBLE PRECISION, DOUBLE PRECISION, TEXT, TEXT, UUID, TEXT, TEXT, BOOLEAN
 );
 
 CREATE OR REPLACE FUNCTION public.get_csv_export_objects(
@@ -2318,8 +2305,8 @@ CREATE OR REPLACE FUNCTION public.get_csv_export_objects(
   p_photo_z_min DOUBLE PRECISION DEFAULT NULL, p_photo_z_max DOUBLE PRECISION DEFAULT NULL,
   p_comment_search TEXT DEFAULT NULL, p_comment_search_scope TEXT DEFAULT NULL,
   p_comment_user_id UUID DEFAULT NULL,
-  p_sort_column TEXT DEFAULT 'object_id', p_sort_direction TEXT DEFAULT 'asc',
-  p_include_unpublished BOOLEAN DEFAULT false
+  p_include_unpublished BOOLEAN DEFAULT false,
+  p_after_object_id TEXT DEFAULT NULL, p_page_size INTEGER DEFAULT 5000
 )
 RETURNS TABLE(
   object_id TEXT, field TEXT, ra DOUBLE PRECISION, "dec" DOUBLE PRECISION,
@@ -2336,7 +2323,9 @@ RETURNS TABLE(
   photo_z_err_lo DOUBLE PRECISION, photo_z_err_hi DOUBLE PRECISION,
   photometry JSONB
 )
-LANGUAGE plpgsql STABLE SET plan_cache_mode = 'force_custom_plan'
+LANGUAGE plpgsql STABLE
+SET plan_cache_mode = 'force_custom_plan'
+SET statement_timeout = '120s'
 AS $$
 DECLARE
   v_filtered_program_slugs TEXT[];
@@ -2344,6 +2333,7 @@ DECLARE
   v_comment_search_active BOOLEAN;
   v_grating_filter_active BOOLEAN;
   v_gratings_mode TEXT;
+  v_page_size INTEGER;
 BEGIN
   v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
   v_comment_search_active := (
@@ -2354,13 +2344,7 @@ BEGIN
   v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
   v_gratings_mode := COALESCE(p_gratings_mode, 'any');
   IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN v_gratings_mode := 'any'; END IF;
-  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
-  IF NOT (p_sort_column IN (
-    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
-    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time', 'photo_z'
-  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
-    p_sort_column := 'object_id';
-  END IF;
+  v_page_size := LEAST(GREATEST(COALESCE(p_page_size, 5000), 1), 10000);
 
   IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
     SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs)) INTO v_filtered_program_slugs;
@@ -2411,6 +2395,7 @@ BEGIN
       WHERE op.object_id = o.id ORDER BY op.updated_at DESC LIMIT 1
     ) phot ON true
     WHERE o.programs && v_filtered_program_slugs
+      AND (p_after_object_id IS NULL OR o.object_id > p_after_object_id)
       AND o.is_active = true
       AND (p_include_unpublished OR o.has_published_spectrum)
       AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
@@ -2487,31 +2472,8 @@ BEGIN
     df.has_photometry, df.photo_z, df.photo_z_err_lo, df.photo_z_err_hi,
     df.photometry
   FROM distance_filtered df
-  ORDER BY
-    CASE WHEN v_coord_search_active THEN df.distance END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN df.object_id END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'desc' THEN df.object_id END DESC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'asc' THEN df.field END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'field' AND p_sort_direction = 'desc' THEN df.field END DESC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN df.ra END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN df.ra END DESC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN df.dec END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN df.dec END DESC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN df.redshift END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN df.redshift END DESC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN df.redshift_quality END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN df.redshift_quality END DESC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_targets' AND p_sort_direction = 'asc' THEN df.n_targets END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_targets' AND p_sort_direction = 'desc' THEN df.n_targets END DESC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_spectra' AND p_sort_direction = 'asc' THEN df.n_spectra END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'n_spectra' AND p_sort_direction = 'desc' THEN df.n_spectra END DESC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN df.max_snr END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN df.max_snr END DESC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN df.max_exposure_time END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN df.max_exposure_time END DESC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'photo_z' AND p_sort_direction = 'asc' THEN df.photo_z END ASC NULLS LAST,
-    CASE WHEN NOT v_coord_search_active AND p_sort_column = 'photo_z' AND p_sort_direction = 'desc' THEN df.photo_z END DESC NULLS LAST,
-    df.object_id ASC;
+  ORDER BY df.object_id ASC
+  LIMIT v_page_size;
 END;
 $$;
 

--- a/web/components/spectra/DownloadTableButtons.tsx
+++ b/web/components/spectra/DownloadTableButtons.tsx
@@ -4,7 +4,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import { Download, FileText, Package, Loader2, ChevronDown } from 'lucide-react';
 import { generateCSV, generateCsvFilename, generateFitsDownloadUrl } from '@/lib/actions/download';
 import type { SortColumn, SortDirection, ViewMode } from '@/lib/actions/spectra-types';
-import { FITS_DOWNLOAD_FILE_LIMIT } from '@/lib/actions/spectra-types';
+import { FITS_DOWNLOAD_FILE_LIMIT, CSV_EXPORT_ROW_LIMIT } from '@/lib/actions/spectra-types';
 import { downloadFilesAsZip } from '@/lib/utils/zip-download';
 import { AdvancedFilterOptions } from './SpectraFilterBar';
 
@@ -32,7 +32,9 @@ export const DownloadDropdown: React.FC<DownloadDropdownProps> = ({
   const [error, setError] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const CSV_LIMIT = 50000;
+  // Shared with the server action, which enforces the cap (generateCSV stops
+  // its keyset pagination loop at this many rows).
+  const CSV_LIMIT = CSV_EXPORT_ROW_LIMIT;
   // FITS_LIMIT is in spectra/file units. In spectra mode totalCount is already
   // the spectra count, so this gate is exact. In objects mode totalCount is the
   // object count — a loose lower bound on the spectra count (one object fans out

--- a/web/lib/actions/download.ts
+++ b/web/lib/actions/download.ts
@@ -2,11 +2,11 @@
 
 import { getSpectra } from './spectra';
 import type { SortColumn, SortDirection, ViewMode } from './spectra-types';
-import { FITS_DOWNLOAD_FILE_LIMIT } from './spectra-types';
+import { FITS_DOWNLOAD_FILE_LIMIT, CSV_EXPORT_ROW_LIMIT } from './spectra-types';
 import type { FilterOptions } from './filter-params';
 import { trackDownload } from './download-tracking';
 import { createClient } from '@/lib/supabase/server';
-import { paginateRpc } from '@/lib/supabase/paginate';
+import { paginateRpcKeyset } from '@/lib/supabase/paginate';
 import { buildFilterParams } from './filter-params';
 import { DQ_FLAGS } from '@/lib/flags';
 import type { FlagDef } from '@/lib/flags';
@@ -59,12 +59,16 @@ interface ObjectsCsvRow {
 }
 
 interface SpectraCsvRow {
-  spectrum_id?: string;
+  id: number;                  // spectra PK — keyset cursor, not a CSV column
+  spectrum_id: string | null;
   target_id: string;
   grating: string;
   field: string;
+  observation: string;         // sort-only, not a CSV column
   ra: number;
   dec: number;
+  redshift: number | null;          // sort-only; parent-object state lives in the objects CSV
+  redshift_quality: number | null;  // sort-only
   redshift_auto: number | null;
   signal_to_noise: number | null;
   exposure_time: number | null;
@@ -78,9 +82,14 @@ interface SpectraCsvRow {
 
 /**
  * Generate a CSV file from filtered spectra results.
- * Uses a lightweight RPC that returns flat rows — no JSONB object building
- * or nested spectra subqueries, so it handles large result sets (7k+) without
- * hitting statement timeouts.
+ *
+ * Rows are fetched through keyset-paginated RPCs (issue #412): each page is an
+ * index-bounded scan continuing from a unique-key cursor, so total DB work
+ * stays proportional to the result set — offset paging re-executed and
+ * re-sorted the whole query per page and hit the 8s statement timeout at
+ * ~16k rows. The RPCs return rows in cursor-key order; the user's on-screen
+ * sort is applied here in JS (see sortCsvRows). Exports are capped at
+ * CSV_EXPORT_ROW_LIMIT, matching the warning shown in the download dropdown.
  */
 export async function generateCSV(
   filters: FilterOptions,
@@ -110,11 +119,7 @@ export async function generateCSV(
       return { csv: null, error: 'No accessible programs' };
     }
 
-    const rpcParams = {
-      ...buildFilterParams(filters, accessibleProgramSlugs, user.id),
-      p_sort_column: sortColumn,
-      p_sort_direction: sortDirection,
-    };
+    const rpcParams = buildFilterParams(filters, accessibleProgramSlugs, user.id);
 
     const includeDistance = filters.coordinate_search !== null;
 
@@ -126,17 +131,25 @@ export async function generateCSV(
         p_observations: _obs,
         p_dq_flags_include_any: _dq1, p_dq_flags_include_all: _dq2, p_dq_flags_exclude: _dq3,
         ...objectsParams
-      } = { ...rpcParams, p_sort_column: sortColumn, p_sort_direction: sortDirection };
+      } = rpcParams;
       /* eslint-enable @typescript-eslint/no-unused-vars */
 
-      const { data: rows, error: rpcError } = await paginateRpc<ObjectsCsvRow>(
-        supabase, 'get_csv_export_objects', objectsParams,
+      const { data: rows, error: rpcError } = await paginateRpcKeyset<ObjectsCsvRow>(
+        supabase, 'get_csv_export_objects', { ...objectsParams },
+        { cursorParam: 'p_after_object_id', getCursor: r => r.object_id, maxRows: CSV_EXPORT_ROW_LIMIT },
       );
 
       if (rpcError) {
         console.error('Error fetching objects CSV data:', rpcError);
         return { csv: null, error: rpcError.message };
       }
+
+      sortCsvRows(
+        rows,
+        includeDistance ? OBJECTS_CSV_SORT.distance : (OBJECTS_CSV_SORT[sortColumn] ?? OBJECTS_CSV_SORT.object_id),
+        includeDistance ? 'asc' : sortDirection,
+        [r => r.object_id],
+      );
       const csv = objectsRowsToCsv(rows, includeDistance);
 
       const objectIds = rows.map(r => r.object_id);
@@ -153,14 +166,22 @@ export async function generateCSV(
     }
 
     // Spectra mode: one row per (target_id, grating).
-    const { data: rows, error: rpcError } = await paginateRpc<SpectraCsvRow>(
-      supabase, 'get_csv_export_spectra', rpcParams,
+    const { data: rows, error: rpcError } = await paginateRpcKeyset<SpectraCsvRow>(
+      supabase, 'get_csv_export_spectra', { ...rpcParams },
+      { cursorParam: 'p_after_id', getCursor: r => r.id, maxRows: CSV_EXPORT_ROW_LIMIT },
     );
 
     if (rpcError) {
       console.error('Error fetching spectra CSV data:', rpcError);
       return { csv: null, error: rpcError.message };
     }
+
+    sortCsvRows(
+      rows,
+      includeDistance ? SPECTRA_CSV_SORT.distance : (SPECTRA_CSV_SORT[sortColumn] ?? SPECTRA_CSV_SORT.spectrum_id),
+      includeDistance ? 'asc' : sortDirection,
+      [r => r.target_id, r => r.grating],
+    );
     const csv = spectraRowsToCsv(rows, includeDistance);
 
     const targetIds = [...new Set(rows.map(r => r.target_id))];
@@ -185,6 +206,77 @@ export async function generateCSV(
  */
 function expandBitmask(bitmask: number, flags: FlagDef[]): number[] {
   return flags.map(flag => (bitmask & flag.value) !== 0 ? 1 : 0);
+}
+
+type CsvSortValue = string | number | null | undefined;
+
+// Sortable columns per mode, keyed by SortColumn. Doubles as the whitelist the
+// old SQL ORDER BY enforced: an unknown column falls back to the mode default.
+const OBJECTS_CSV_SORT: Partial<Record<SortColumn, (r: ObjectsCsvRow) => CsvSortValue>> = {
+  object_id: r => r.object_id,
+  field: r => r.field,
+  ra: r => r.ra,
+  dec: r => r.dec,
+  redshift: r => r.redshift,
+  redshift_quality: r => r.redshift_quality,
+  n_targets: r => r.n_targets,
+  n_spectra: r => r.n_spectra,
+  max_snr: r => r.max_snr,
+  max_exposure_time: r => r.max_exposure_time,
+  photo_z: r => r.photo_z,
+  distance: r => r.distance,
+};
+
+const SPECTRA_CSV_SORT: Partial<Record<SortColumn, (r: SpectraCsvRow) => CsvSortValue>> = {
+  spectrum_id: r => r.spectrum_id,
+  target_id: r => r.target_id,
+  field: r => r.field,
+  observation: r => r.observation,
+  program_slug: r => r.program_slug,
+  ra: r => r.ra,
+  dec: r => r.dec,
+  redshift: r => r.redshift,
+  redshift_quality: r => r.redshift_quality,
+  redshift_auto: r => r.redshift_auto,
+  signal_to_noise: r => r.signal_to_noise,
+  exposure_time: r => r.exposure_time,
+  grating: r => r.grating,
+  distance: r => r.distance,
+};
+
+/**
+ * Order rows for the CSV in place. The keyset RPCs return rows in cursor-key
+ * order (issue #412); the user's on-screen sort is applied here instead —
+ * sorting the full export in JS costs milliseconds, versus the database
+ * re-sorting the entire result set once per page. Mirrors the old SQL
+ * semantics: distance wins whenever a coordinate search is active (callers
+ * pass the distance accessor and 'asc'), nulls sort last in both directions,
+ * and ties break ascending on the stable unique key(s).
+ */
+function sortCsvRows<T>(
+  rows: T[],
+  primary: ((r: T) => CsvSortValue) | undefined,
+  direction: SortDirection,
+  tiebreaks: ((r: T) => CsvSortValue)[],
+): void {
+  const dir = direction === 'desc' ? -1 : 1;
+  const accessors: [(r: T) => CsvSortValue, number][] = [
+    ...(primary ? [[primary, dir] as [(r: T) => CsvSortValue, number]] : []),
+    ...tiebreaks.map(tb => [tb, 1] as [(r: T) => CsvSortValue, number]),
+  ];
+  rows.sort((x, y) => {
+    for (const [accessor, d] of accessors) {
+      const a = accessor(x);
+      const b = accessor(y);
+      if (a == null || b == null) {
+        if (a != null) return -1; // NULLS LAST regardless of direction
+        if (b != null) return 1;
+        continue;
+      }
+      if (a !== b) return a < b ? -1 * d : d;
+    }
+    return 0;
+  });
 }
 
 /**

--- a/web/lib/actions/spectra-types.ts
+++ b/web/lib/actions/spectra-types.ts
@@ -19,6 +19,15 @@ export type ViewMode = 'spectra' | 'objects';
  */
 export const FITS_DOWNLOAD_FILE_LIMIT = 500;
 
+/**
+ * Maximum number of rows in a catalog CSV export (objects or spectra,
+ * whichever unit the view mode exports in). Enforced server-side by
+ * generateCSV — its keyset pagination loop stops at this cap — and surfaced
+ * as a truncation warning in the download dropdown. Shared constant so the
+ * warning and the actual behavior can't disagree.
+ */
+export const CSV_EXPORT_ROW_LIMIT = 50000;
+
 // Spectra-mode sort columns (must match get_filtered_spectra_paginated whitelist)
 export const SPECTRA_SORT_COLUMNS = ['spectrum_id', 'target_id', 'field', 'observation', 'program_slug', 'ra', 'dec', 'redshift', 'redshift_quality', 'redshift_auto', 'signal_to_noise', 'exposure_time', 'grating', 'distance'] as const;
 

--- a/web/lib/supabase/paginate.ts
+++ b/web/lib/supabase/paginate.ts
@@ -37,6 +37,62 @@ export async function paginateRpc<T = Record<string, unknown>>(
 }
 
 /**
+ * Keyset-paginate through all results of a Supabase RPC.
+ *
+ * Unlike paginateRpc above, which pages with PostgREST .range() — LIMIT/OFFSET
+ * applied OUTSIDE a set-returning function, so every page re-executes and
+ * re-sorts the entire result set — this drives RPCs that accept an explicit
+ * cursor + page-size argument and apply the LIMIT inside the query. Each page
+ * is then one index-bounded scan from the cursor, and total work across the
+ * whole export stays proportional to the result set (issue #412).
+ *
+ * The RPC must return rows in ascending cursor-key order and cap its output at
+ * the page size it was passed (a shorter page signals the last one).
+ */
+export async function paginateRpcKeyset<T = Record<string, unknown>>(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: SupabaseClient<any, any>,
+  fnName: string,
+  args: Record<string, unknown>,
+  opts: {
+    /** RPC argument name that carries the cursor (null on the first page). */
+    cursorParam: string;
+    /** Extracts the cursor value from the last row of a page. */
+    getCursor: (row: T) => string | number;
+    /** Stop after this many rows (result is truncated to exactly this count). */
+    maxRows?: number;
+    pageSize?: number;
+  },
+): Promise<{ data: T[]; error: Error | null }> {
+  const pageSize = opts.pageSize ?? DEFAULT_PAGE_SIZE;
+  const allRows: T[] = [];
+  let cursor: string | number | null = null;
+
+  while (true) {
+    const { data, error } = await supabase.rpc(fnName, {
+      ...args,
+      [opts.cursorParam]: cursor,
+      p_page_size: pageSize,
+    });
+
+    if (error) {
+      return { data: allRows, error: new Error(error.message) };
+    }
+
+    const rows = (data ?? []) as T[];
+    allRows.push(...rows);
+    if (opts.maxRows != null && allRows.length >= opts.maxRows) {
+      allRows.length = opts.maxRows;
+      break;
+    }
+    if (rows.length < pageSize) break;
+    cursor = opts.getCursor(rows[rows.length - 1]);
+  }
+
+  return { data: allRows, error: null };
+}
+
+/**
  * Paginate through all results of a Supabase table/view query.
  *
  * Accepts a factory callback that returns a fresh query builder on each call.


### PR DESCRIPTION
## Summary

Fixes catalog CSV export timeouts by replacing offset-based pagination with keyset pagination. The previous implementation used PostgREST's `.range()` to paginate results, which applied LIMIT/OFFSET outside the RPC — causing the entire filtered result set to be materialized and re-sorted on every page. This resulted in O(N log N) work per page, hitting the 8-second statement timeout at ~16k rows.

The new implementation passes explicit cursor and page-size parameters to the RPCs, applying the LIMIT inside the query. Each page is now a single index-bounded scan, keeping total work proportional to the result set size.

## Key Changes

**Database (Supabase migrations & schemas)**
- Modified `get_csv_export_spectra()` RPC:
  - Replaced `p_sort_column` and `p_sort_direction` parameters with `p_after_id` (spectra.id cursor) and `p_page_size`
  - Added `id` and `observation` to RETURNS (id is the keyset cursor; observation enables client-side sorting)
  - Applied LIMIT inside the query with cursor-based filtering (`s.id > p_after_id`)
  - Added `SET statement_timeout = '120s'` to match other heavy RPCs
  - Removed complex multi-column ORDER BY; rows now return in `id` order

- Modified `get_csv_export_objects()` RPC:
  - Replaced sort parameters with `p_after_object_id` (objects.object_id cursor) and `p_page_size`
  - Applied LIMIT inside the query with cursor-based filtering
  - Added `SET statement_timeout = '120s'`
  - Removed sort parameters; rows return in `object_id` order

**Web client (TypeScript/React)**
- Added `paginateRpcKeyset()` function in `paginate.ts`:
  - New pagination strategy that drives RPCs with explicit cursor + page-size arguments
  - Each page is one index-bounded scan; total work stays O(N)
  - Supports optional `maxRows` cap for export limits

- Updated `generateCSV()` in `download.ts`:
  - Switched from `paginateRpc()` to `paginateRpcKeyset()` for both objects and spectra modes
  - Removed sort parameters from RPC calls
  - Added client-side sorting via new `sortCsvRows()` function (mirrors old SQL ORDER BY semantics)
  - Integrated `CSV_EXPORT_ROW_LIMIT` cap (50,000 rows) to prevent unbounded exports

- Added `CSV_EXPORT_ROW_LIMIT` constant in `spectra-types.ts` (50,000 rows)
  - Enforced server-side by pagination loop and surfaced as UI warning

- Updated `DownloadTableButtons.tsx`:
  - Integrated export row limit warning in download dropdown UI

## Implementation Details

- **Cursor selection**: Uses `spectra.id` (PK) for spectra mode since `spectrum_id` is not uniquely constrained; uses `objects.object_id` (UNIQUE) for objects mode
- **Sorting**: RPCs return rows in cursor-key order; client-side `sortCsvRows()` applies the user's selected sort in JavaScript (milliseconds vs. database re-sorting entire result set per page)
- **Null handling**: Maintains SQL semantics (NULLS LAST in both directions)
- **Tiebreaking**: Spectra mode breaks ties on `(target_id, grating)` for stable ordering
- **Export cap**: Both modes truncate results at `CSV_EXPORT_ROW_LIMIT` to prevent runaway exports

https://claude.ai/code/session_01FC1hKJkBA8XBnMcpiE3EVv