### PR TITLE
NIRCam align/refcat: raise SEP sub_object_limit 2048→8192 for crowded fields

### DIFF
--- a/pipeline/campfire_pipeline/nircam/refcat/extract.py
+++ b/pipeline/campfire_pipeline/nircam/refcat/extract.py
@@ -147,7 +147,12 @@ def sep_extract_sources(sci, err, *, mask=None, snr_thresh=3.0, minarea=15,
     # large images blow past defaults. ``set_extract_pixstack`` is global
     # state in the C extension, but it's idempotent.
     sep.set_extract_pixstack(int(1e7))
-    sep.set_sub_object_limit(2048)
+    # Crowded/bright fields (e.g. COSMOS jw05427002001_03201 module B: a saturated
+    # star with diffraction spikes + a bright extended galaxy) blow past 2048
+    # sub-objects and raise a deblend overflow, dropping the exposure to
+    # NOT_ALIGNED. 8192 clears the observed cases; still bounded so a runaway
+    # can't consume unlimited memory.
+    sep.set_sub_object_limit(8192)
 
     sci = np.ascontiguousarray(sci, dtype=np.float32)
     err = np.ascontiguousarray(err, dtype=np.float32)


### PR DESCRIPTION
## Problem

Bright/crowded fields overflow SEP's deblender at the current `sub_object_limit=2048` and raise a *deblend overflow* exception. Because `align/detect.py` and the refcat build share `refcat/extract.py::sep_extract_sources`, this drops the whole exposure to **NOT_ALIGNED** (excluded from combine).

Observed case: **COSMOS `jw05427002001_03201` module B** — a saturated star with diffraction spikes plus a bright extended galaxy. All four module-B detectors threw the exception during align.

## Fix

Raise the cap to **8192** (one line in `sep_extract_sources`, the shared core). Bounded, so a pathological field still can't consume unlimited memory.

## Verification

With the bump, the previously-failing exposure detects cleanly (649/264/373/364 sources across nrcb1–4, no overflow) and **solves**: `n_matched=939`, **rmse 0.024″**, per-detector residuals 0.015–0.021″ — all well inside the 0.1″ residual gate.

Fixes the deblend-overflow class of NOT_ALIGNED failures (align + refcat).

Generated with Claude Code