### PR TITLE
NIRCam align: fix inter-detector DVA, accept fine fit on significance

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -29,6 +29,54 @@ Release procedure: edit the `## Unreleased` section below, then run
 ## Unreleased
 
 ### Algorithm
+- NIRCam `align` now accepts the **per-detector fine fit on the significance of
+  the shift it applies**, not on a residual improvement
+  (`[nircam.align].fine_min_significance`, default 1.4). The choice between the
+  pooled coarse attitude and a detector's own fit is a bias/variance trade-off:
+  the pool averages ~M times more pairs, so keeping it is right when the
+  detector has no offset of its own, and taking the individual fit is right when
+  that offset exceeds the noise of estimating it — i.e. when
+  `|shift| > k·σ/√n`. The previous test (`new_resid < resid`) could not express
+  this: it judged the fit on a **re-matched** sample rather than the one the fit
+  minimized, so with no offset present it was a coin flip. Measured on COSMOS
+  f410m (2-detector pools) and f210m (8-detector pools) with the fine fit
+  disabled, so per-detector offsets were observed **unbiased** — in a normal run
+  accepted detectors have the offset fitted away and rejected ones are selected
+  for having a small one: median `t` = 3.1 / 3.4 against a null expectation of
+  1.18 (real offsets of 3.0 / 5.0 mas versus 1.0 / 1.4 mas of fit noise). The old
+  test behaved like `t > 3`, accepting only 44% / 59% and leaving 1.69 / 1.96 mas
+  of per-detector positional error; `k = 1.4` leaves 0.94 / 1.39 mas — a 44% /
+  29% reduction. Theory agrees independently: minimum MSE sits at
+  `√(2 − 1/M)` = 1.22 (M=2) to 1.41 (M=8), and the empirical optimum landed on
+  exactly those values; the optimum is flat over 1.0–1.5. A fit whose residual
+  degrades by more than 25% is still rejected however significant its shift, and
+  the ladder floors, coverage gate and `max_residual_arcsec` backstop are
+  unchanged. **Output changes for every NIRCam exposure** (more detectors now
+  carry their individual fit). `fine_min_significance = 0` accepts every
+  non-degrading fit.
+- NIRCam `align` now **re-references the differential velocity aberration (DVA)
+  correction to a pool-common pivot** before solving
+  (`[nircam.align].dva_repivot`, default on; `dva_pivot = "pool" | "boresight"`).
+  `jwst.assign_wcs` corrects DVA per detector, scaling about *that detector's
+  own* aperture reference (`dva_corr_model` builds
+  `v' = v_ref + va_scale*(v - v_ref)`), so each reference point never moves and
+  the separation between two detectors' reference points keeps the full
+  uncorrected aberration, `(1 - va_scale) * |Δv_ref|`. For the NIRCam LW pair
+  (|Δv_ref| = 175.34″) at COSMOS's |1 − va_scale| ~ 1e-4 that is ~13 mas —
+  measured on 3258 COSMOS LW exposures as a module-to-module differential
+  matching the prediction in sign and magnitude (ratio 0.92 / 1.10 in the
+  field's two visibility windows, where `VA_SCALE` straddles 1; the residual
+  lies entirely along the module baseline, perpendicular component
+  +0.14 ± 3.62 mas). The residual is a pure *scale* about a point outside each
+  detector, which a pooled `rshift` cannot express — it is what makes
+  `pool_modules` lossy. Re-referencing applies a per-detector shift of
+  `(va_scale - 1) * (v_ref - v_pivot)`, rebuilt with jwst's own
+  `dva_corr_model`. A strict no-op for a single-detector pool (LW with
+  `pool_modules = false`); **SW output changes**, since a module's four
+  detectors span ~130″ and currently carry up to ~5 mas of the same error that
+  the pooled fit must absorb as residual. Rejected pools and residual-gated
+  detectors still hand back the untouched on-disk WCS. Set
+  `dva_repivot = false` to restore the previous behaviour.
 - Mosaic-level background subtraction is now **depth-aware**
   (`[nircam.resample].wht_aware`, default on). The `SubtractBackground` source
   mask — tier detection and the ring-clip ceiling — is evaluated on the
@@ -216,6 +264,28 @@ Release procedure: edit the `## Unreleased` section below, then run
   omitted grown pixels from the plot entirely.
 
 ### Infrastructure
+- NIRCam `align` now writes **diagnostics for independent validation** of every
+  solve. Its self-reported residual is circular — measured on the very sample the
+  matcher selected — so a solution locked onto the wrong sources reports a small
+  residual just as happily as a right one. Two new outputs make an outside check
+  possible. (1) An `ALGNCAT` binary table per aligned detector: one row per
+  detection with `x`/`y`, the `ra`/`dec` the file's own corrected WCS gives, the
+  Kron photometry the solve selected on, and the match outcome (`matched`,
+  `sep_arcsec`, and `ref_ra`/`ref_dec` as *values* — reference indices would point
+  into a per-solve footprint-clipped catalog nothing downstream can reconstruct),
+  so overlapping exposures can be cross-checked source-by-source without
+  resampling anything. (2) `ALGN*` primary-header keywords: the detection /
+  one-to-one-match / in-footprint-refcat counts, plus the offset-histogram
+  matcher's own peak confidences — gross 2-D-histogram peak, runner-up, contrast
+  and neighbourhood mass, the per-axis consensus peak heights / FWHMs /
+  contrasts, and the histogram bin size as actually executed — which *do*
+  separate a decisive lock from an ambiguous one. Nothing is read back by the
+  pipeline: no gate, WCS, or pixel value changes. `ALGNCAT` rides the existing
+  replace-or-append path so `--overwrite` re-solves swap it in place (verified
+  byte-stable over five consecutive re-solves), and a `NOT_ALIGNED` re-run flags
+  a leftover catalog with `ALGNSTAL = T` rather than deleting the HDU, which
+  would dangle the datamodel's `extra_fits` reference. Cost is ~40–46 kB per
+  ~117 MB canonical (~440–510 rows).
 - NIRCam `bkg` gains a **DQ pathology guard** so a broken upstream calibration
   step can no longer hard-fail the whole `process` phase. When an aggressive-DQ
   class (`JUMP_DET` / `SATURATED` / `PERSISTENCE`) blankets more than

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -29,6 +29,22 @@ Release procedure: edit the `## Unreleased` section below, then run
 ## Unreleased
 
 ### Algorithm
+- NIRCam `align` now **pools both modules into one coarse fit by default**
+  (`[nircam.align].pool_modules`, flipped `false` → `true`). Pooling was off
+  because a spurious per-module SIAF offset could cross-contaminate the shared
+  fit; the offset that motivated that caution is **not** SIAF — it is
+  differential velocity aberration, a scale no pooled `rshift` can express, now
+  removed deterministically by `dva_repivot` (below). With that fix plus
+  significance-based fine-fit acceptance, a pooled solve leaves no per-module
+  systematic: on f410m the module-to-module offset against the reference catalog
+  is 0.26 mas with 93.3% of detectors carrying their own fine fit, and no new
+  NOT_ALIGNED. Pooling is established **safe**; its **benefit is not
+  quantified** — under the previous acceptance test it was a wash on f410m
+  (0.215 vs 0.210 mas), and no matched non-pooled arm was run under the new one.
+  It is enabled because a shared coarse fit is better conditioned (twice the
+  sources for LW, where a per-module pool is a single detector), which should
+  help sparse / low-match exposures — the regime that remains untested. Set
+  `pool_modules = false` to restore per-module fits.
 - NIRCam `align` now accepts the **per-detector fine fit on the significance of
   the shift it applies**, not on a residual improvement
   (`[nircam.align].fine_min_significance`, default 1.4). The choice between the

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -67,9 +67,20 @@ Release procedure: edit the `## Unreleased` section below, then run
   exactly those values; the optimum is flat over 1.0–1.5. A fit whose residual
   degrades by more than 25% is still rejected however significant its shift, and
   the ladder floors, coverage gate and `max_residual_arcsec` backstop are
-  unchanged. **Output changes for every NIRCam exposure** (more detectors now
-  carry their individual fit). `fine_min_significance = 0` accepts every
-  non-degrading fit.
+  unchanged. The statistic is **normalized for the fit geometry**: a richer
+  geometry moves sources further on noise alone (mean squared noise displacement
+  `(p/2)·σ²/n` for a `p`-parameter fit), so the standard error carries a
+  `√(p/2)` factor — 1.0 `shift`, 1.22 `rshift`, 1.41 `rscale`, 1.73 `general`.
+  Without it a noise-only `general` fit would score ~1.7× too high and clear the
+  gate on variance alone; with it `t` is ~Rayleigh(1) under the null for every
+  geometry, so one threshold keeps the same false-accept rate throughout. On
+  COSMOS the practical effect is small (matched 40-exposure f410m subset:
+  97.5% → 96.2% accepted, identical 0.501 mas refcat differential), because the
+  default ceiling is `rshift` and the observed `t` sits well above the
+  threshold; it matters for the richer geometries. The 93.3% / 91.0% figures
+  above were measured before this normalization and are ~1 point high.
+  **Output changes for every NIRCam exposure** (more detectors now carry their
+  individual fit). `fine_min_significance = 0` accepts every non-degrading fit.
 - NIRCam `align` now **re-references the differential velocity aberration (DVA)
   correction to a pool-common pivot** before solving
   (`[nircam.align].dva_repivot`, default on; `dva_pivot = "pool" | "boresight"`).

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -448,8 +448,23 @@
     # catalogs (39% of COSMOS LW exposures under the previous XYXYMatch).
     # All detectors of a pool share ONE offset histogram, so pooling makes the
     # consensus peak stronger, not weaker.
-    pool_modules      = false   # false: coarse fit per module (A, B separate);
-                                # true: pool both modules into one coarse fit
+    # true: pool both modules into ONE coarse fit; false: fit per module (A, B
+    # separate). Pooling was previously off because a spurious per-module SIAF
+    # offset could cross-contaminate the shared fit. The offset that motivated
+    # that caution turned out NOT to be SIAF — it is differential velocity
+    # aberration (a scale a pooled rshift cannot express), now removed
+    # deterministically by `dva_repivot`, so the original objection no longer
+    # applies. With that fix plus significance-based fine-fit acceptance, a
+    # pooled solve leaves no per-module systematic: measured on f410m, the
+    # module-to-module offset against the reference catalog is 0.26 mas with
+    # 93.3% of detectors carrying their own fine fit.
+    # Pooling is established SAFE; its BENEFIT is not quantified — on f410m
+    # under the old acceptance test it was a wash (0.215 vs 0.210 mas), and no
+    # matched non-pooled arm was run under the new one. It is on because a
+    # shared coarse fit is better conditioned (twice the sources for LW, where a
+    # per-module pool is a single detector), which should help sparse or
+    # low-match exposures — the regime that is still untested.
+    pool_modules      = true
     # --- Differential velocity aberration (DVA) re-reference ------------------
     # jwst's assign_wcs corrects DVA per detector, scaling about THAT detector's
     # own aperture reference (dva_corr_model(va_scale, v2_ref, v3_ref) builds

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -450,6 +450,28 @@
     # consensus peak stronger, not weaker.
     pool_modules      = false   # false: coarse fit per module (A, B separate);
                                 # true: pool both modules into one coarse fit
+    # --- Differential velocity aberration (DVA) re-reference ------------------
+    # jwst's assign_wcs corrects DVA per detector, scaling about THAT detector's
+    # own aperture reference (dva_corr_model(va_scale, v2_ref, v3_ref) builds
+    # v' = v_ref + va_scale*(v - v_ref)). Each reference point therefore never
+    # moves, and the SEPARATION between two detectors' reference points keeps the
+    # full uncorrected aberration: (1 - va_scale) * |dv_ref|. For the NIRCam LW
+    # pair (|dv_ref| = 175.34") at COSMOS's |1 - va_scale| ~ 1e-4 that is ~13 mas
+    # — measured on 3258 COSMOS LW exposures as a module-to-module differential
+    # matching this prediction in sign and magnitude.
+    #
+    # That residual is a pure SCALE about a point outside each detector, which a
+    # pooled `rshift` cannot express — so it is exactly what makes pool_modules
+    # lossy. Re-referencing every detector of a pool to one shared pivot removes
+    # it (a per-detector shift of (va_scale-1)*(v_ref - v_pivot)).
+    #
+    # A strict no-op for a single-detector pool (LW with pool_modules=false), so
+    # it is safe on by default; for a multi-detector SW pool it also removes the
+    # smaller intra-pool residual (~5 mas across a module's ~130" span).
+    dva_repivot       = true    # re-reference DVA to a pool-common pivot
+    dva_pivot         = "pool"  # "pool": centroid of the pool's v2_ref/v3_ref
+                                #   (leaves the pool's mean position unchanged);
+                                # "boresight": V2=V3=0
     coarse_searchrad  = 70.0    # arcsec; gross-shift 2-D-hist radius (>= max
                                 # acquisition offset to recover; 70" covers 60")
     refine_niter      = 3       # coarse match->fit->rematch iters (recovers roll)
@@ -490,6 +512,25 @@
     fine_min_rshift   = 4         # >= this -> allow rshift
     fine_min_shift    = 3         # >= this -> allow shift; below -> keep coarse
                                   # (= jhat's tweakreg minobj)
+    # Acceptance: take the per-detector fit when the shift it applies is
+    # SIGNIFICANT against the noise adopting it costs, t = |shift|/(sigma/sqrt n).
+    # Keeping the pooled coarse attitude is right when a detector has no offset
+    # of its own (the pool averages ~M times more pairs); the per-detector fit is
+    # right when its offset exceeds the noise of estimating it. Choosing on a
+    # residual IMPROVEMENT instead cannot express that trade-off — the fit is
+    # judged on a re-matched sample rather than the one it minimized, so with no
+    # offset present it is a coin flip.
+    # Measured on COSMOS f410m (2-detector pools) and f210m (8-detector pools)
+    # with the fine fit disabled, so the per-detector offsets were observed
+    # unbiased: median t = 3.1 / 3.4 against a null expectation of 1.18 — real
+    # offsets of 3.0 / 5.0 mas versus 1.0 / 1.4 mas of fit noise. The old
+    # residual test behaved like t > 3, accepting only 44% / 59% and leaving
+    # 1.69 / 1.96 mas of per-detector error; 1.4 leaves 0.94 / 1.39 mas.
+    # Theory agrees: minimum MSE sits at sqrt(2 - 1/M) = 1.22 (M=2) .. 1.41
+    # (M=8), and the empirical optimum landed on exactly those values. The
+    # optimum is FLAT over 1.0-1.5, so the exact choice is not delicate.
+    # 0 accepts every fit that does not degrade the residual.
+    fine_min_significance = 1.4
     tolerance         = 0.05      # arcsec; QA/reporting only — flags a detector
                                   # as within tolerance; gates nothing
     match_radius      = 0.5       # arcsec; 1-to-1 NN radius for residuals + fine match

--- a/pipeline/campfire_pipeline/nircam/align/apply.py
+++ b/pipeline/campfire_pipeline/nircam/align/apply.py
@@ -19,6 +19,16 @@ in ``WCS_BAK``, so ``align`` must solve from the wcs_shift-corrected WCS and lea
 The reference catalog and config knobs arrive already resolved — refcat
 resolution / loading and ``[<field>.align]`` parsing live in the field-level
 orchestration.
+
+**Diagnostics on disk.** align's self-reported residual is measured on the very
+sample it matched, so it cannot expose a confident lock onto the wrong sources.
+Two outputs exist for INDEPENDENT validation: an ``ALGNCAT`` binary table per
+detector (every detection, its sky position under the WRITTEN WCS, and whether /
+how far it matched the reference — so overlapping exposures can be cross-checked
+against each other without drizzling anything), and the ``ALGN*`` scalar header
+keywords (detection / match / refcat-density counts plus the matcher's peak
+contrasts, which DO distinguish a decisive lock from an ambiguous one). Neither
+is read by the pipeline; they exist to be audited.
 """
 
 import io
@@ -49,7 +59,67 @@ from campfire_pipeline.nircam.association import exposure_key
 # WCS, backs it up here, and preserves wcs_shift's ``WCS_BAK`` untouched.
 ALGN_BAK_EXTNAME = 'ALGN_BAK'
 WCS_BAK_EXTNAME = 'WCS_BAK'          # wcs_shift's backup — preserved, never solved from
+# Per-source align diagnostics (one row per detection). Replaced — never
+# duplicated — on a re-solve, like the backup extensions above.
+ALGNCAT_EXTNAME = 'ALGNCAT'
 NOT_ALIGNED_SENTINEL = cfp.NOT_ALIGNED
+
+# Columns of the ALGNCAT table, in order: the detection catalog as the solve saw
+# it, plus the sky position under the WCS this file now carries and the match
+# outcome. ``ra``/``dec``/``ref_ra``/``ref_dec`` stay float64 (degrees at
+# milliarcsecond precision needs it); everything else is float32/int to keep the
+# extension small — it is written to every aligned canonical.
+_ALGNCAT_COLUMNS = (
+    ('x', 'f4'), ('y', 'f4'), ('ra', 'f8'), ('dec', 'f8'),
+    ('flux', 'f4'), ('fluxerr', 'f4'), ('mag', 'f4'), ('snr', 'f4'),
+    ('npix', 'i4'), ('id', 'i8'), ('matched', 'bool'),
+    ('sep_arcsec', 'f4'), ('ref_ra', 'f8'), ('ref_dec', 'f8'),
+)
+
+# Scalar align diagnostics, stamped on the primary header. Deliberately NOT
+# added to ``cfp.NIRCAM``: that keyset is the step-provenance *chain* — its order
+# drives ``reset --from`` slicing and it renders the ``status`` completion table —
+# and these keywords record how WELL the solve did, not that it ran. They follow
+# the same convention otherwise (a ``{key: comment}`` map, applied as
+# ``{key: (value, comment)}`` through ``atomic_save(header_updates=...)``).
+#
+# Every key is written on every solve, carrying ``ALGN_UNDEF`` when the quantity
+# was not measured — never omitted, so a re-solve can never leave a previous
+# solve's number standing (FITS headers forbid NaN and ``atomic_save`` sets
+# keywords rather than deleting them, so silence would mean staleness).
+ALGN_UNDEF = 'UNDEF'          # not measured (see :func:`_hdr_num`)
+ALGN_DIAG_COMMENTS = {
+    'ALGNNDET': 'align: sources detected on this detector',
+    'ALGNNMAT': 'align: sources matched 1-to-1 to the refcat',
+    'ALGNNREF': 'align: refcat sources in exposure footprint',
+    'ALGNGPK':  'align: gross 2D offset-hist peak height',
+    'ALGNGRU':  'align: gross runner-up peak height',
+    'ALGNGCON': 'align: gross peak contrast (peak/runner-up)',
+    'ALGNGMAS': 'align: gross peak neighbourhood mass (pairs)',
+    'ALGNXPK':  'align: dx consensus peak height',
+    'ALGNXFWH': 'align: dx consensus peak FWHM (arcsec)',
+    'ALGNXCON': 'align: dx peak contrast (peak/runner-up)',
+    'ALGNYPK':  'align: dy consensus peak height',
+    'ALGNYFWH': 'align: dy consensus peak FWHM (arcsec)',
+    'ALGNYCON': 'align: dy peak contrast (peak/runner-up)',
+    'ALGNHBIN': 'align: consensus histogram bin (arcsec)',
+    'ALGNSTAL': 'align: ALGNCAT does not match the current WCS',
+}
+
+# GroupSolution.diagnostics key -> FITS keyword (see histmatch's ``diag``).
+_ALGN_DIAG_KEYWORDS = {
+    'gross_peak': 'ALGNGPK',
+    'gross_runner_up': 'ALGNGRU',
+    'gross_contrast': 'ALGNGCON',
+    'gross_mass': 'ALGNGMAS',
+    'dx_peak': 'ALGNXPK',
+    'dx_fwhm_arcsec': 'ALGNXFWH',
+    'dx_contrast': 'ALGNXCON',
+    'dy_peak': 'ALGNYPK',
+    'dy_fwhm_arcsec': 'ALGNYFWH',
+    'dy_contrast': 'ALGNYCON',
+    'hist_binsize_arcsec': 'ALGNHBIN',
+}
 
 # Solve/detection knobs threaded from [<field>.align]; the orchestration passes
 # a resolved dict, these are the fallbacks. Per-filter PSF FWHM
@@ -63,7 +133,8 @@ _SOLVE_KEYS = ('coarse_searchrad', 'refine_niter',
                'fine_fitgeom', 'fine_min_general',
                'fine_min_rshift', 'fine_min_shift', 'tolerance', 'match_radius',
                'min_matched', 'min_coverage_arcsec', 'ref_border_arcmin',
-               'nclip', 'sigma', 'max_residual_arcsec')
+               'nclip', 'sigma', 'max_residual_arcsec',
+               'dva_repivot', 'dva_pivot', 'fine_min_significance')
 _DETECT_KEYS = ('fwhm', 'snr_thresh', 'minarea', 'deblend_nthresh',
                 'deblend_cont', 'edge', 'snr_min', 'objmag_lim')
 
@@ -87,11 +158,23 @@ def _deserialize_gwcs_from_hdu(hdu):
 
 
 def _stamp_algn(path, value):
-    """Atomically set CFP_ALGN=*value* (header only; WCS untouched)."""
+    """Atomically set CFP_ALGN=*value* (header only; WCS untouched).
+
+    Also marks any ``ALGNCAT`` from an earlier successful solve as **stale**
+    (``ALGNSTAL``), because this path leaves the extension in place: the WCS it
+    was computed against is not the one the file now carries. Marking is
+    deliberate rather than deleting the HDU — a datamodel round-trip registers
+    ``ALGNCAT`` in the embedded ASDF's ``extra_fits``, and dropping the HDU with
+    plain ``astropy`` (as here) would leave that reference dangling and break the
+    next datamodel load (see ``common.io.atomic_save``'s note). Consumers must
+    treat ``ALGNSTAL = T`` as "no per-source diagnostics for this WCS"; a later
+    successful solve rewrites both the extension and the flag.
+    """
     base, ext = os.path.splitext(path)
     tmp = f'{base}.tmp{ext}'
     with fits.open(path) as hdul:
         hdul[0].header['CFP_ALGN'] = (value, cfp.CFP_COMMENTS['CFP_ALGN'])
+        hdul[0].header['ALGNSTAL'] = (True, ALGN_DIAG_COMMENTS['ALGNSTAL'])
         hdul.writeto(tmp, overwrite=True)
     os.replace(tmp, path)
 
@@ -112,6 +195,80 @@ def _format_algn_value(det, refcat_hash=None):
     # orchestration skip check to re-solve when the refcat changes.
     base = f'dof={det.dof} res={det.residual_arcsec:.3g} n={det.n_matched}'
     return f'{base} rc={refcat_hash}' if refcat_hash else base
+
+
+def _hdr_num(value):
+    """A FITS-safe header value: the float/int itself, else :data:`ALGN_UNDEF`.
+
+    FITS headers cannot hold NaN/Inf, and an *undefined* (valueless) card is not
+    an option either: a datamodel round-trip pulls it into ``extra_fits`` as an
+    ``astropy.io.fits.card.Undefined``, which the embedded ASDF cannot serialize
+    — the next save raises. A short string is legal in both, so unmeasured
+    quantities are stamped rather than skipped, which is what keeps a re-solve
+    from leaving a previous solve's number standing.
+    """
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return ALGN_UNDEF
+    if not np.isfinite(v):
+        return ALGN_UNDEF
+    return int(value) if isinstance(value, (int, np.integer)) else v
+
+
+def _diag_header_updates(solution, det):
+    """``{keyword: (value, comment)}`` for the scalar align diagnostics.
+
+    Every :data:`ALGN_DIAG_COMMENTS` key is present (undefined where unmeasured)
+    so a re-solve overwrites the previous solve's numbers wholesale. ``det`` is
+    this detector's :class:`~...solve.DetectorSolution`, *solution* its pool.
+    """
+    diag = solution.diagnostics or {}
+    values = {kw: _hdr_num(diag.get(k))
+              for k, kw in _ALGN_DIAG_KEYWORDS.items()}
+    values['ALGNNDET'] = _hdr_num(getattr(det, 'n_detected', None))
+    values['ALGNNMAT'] = _hdr_num(det.n_matched)
+    values['ALGNNREF'] = _hdr_num(solution.n_refcat_in_footprint)
+    # This solve wrote a matching ALGNCAT, so nothing is stale.
+    values['ALGNSTAL'] = False
+    return {kw: (values[kw], ALGN_DIAG_COMMENTS[kw])
+            for kw in ALGN_DIAG_COMMENTS}
+
+
+def _algncat_hdu(catalog, det):
+    """The per-source ``ALGNCAT`` table for one detector, or ``None``.
+
+    One row per detection — the catalog the solve worked from, its sky position
+    under *det*'s (final, accepted) WCS, and the match outcome — which is what
+    makes an independent check possible: two overlapping exposures can be
+    compared source-by-source without resampling either of them. Returns ``None``
+    (and logs) when the solve carried no per-source diagnostics or they are not
+    row-aligned with *catalog*, rather than writing a misleading table.
+    """
+    n = len(catalog)
+    matched = getattr(det, 'matched', None)
+    if matched is None or len(matched) != n:
+        log(f"align: no per-source diagnostics for {det.detector} "
+            f"({ALGNCAT_EXTNAME} not written).")
+        return None
+
+    ra, dec = det.wcs(np.asarray(catalog['x'], dtype=float),
+                      np.asarray(catalog['y'], dtype=float))
+    source = dict(catalog.columns)
+    source.update(ra=ra, dec=dec, matched=matched,
+                  sep_arcsec=det.sep_arcsec,
+                  ref_ra=det.ref_ra, ref_dec=det.ref_dec)
+
+    cols = {}
+    for name, dtype in _ALGNCAT_COLUMNS:
+        col = source.get(name)
+        fill = False if dtype == 'bool' else (0 if dtype[0] == 'i' else np.nan)
+        cols[name] = (np.full(n, fill, dtype=dtype) if col is None
+                      else np.asarray(col, dtype=dtype))
+    from astropy.table import Table
+    hdu = fits.BinTableHDU(Table(cols), name=ALGNCAT_EXTNAME)
+    hdu.header['ALGNDOF'] = (det.dof, 'align: geometry this WCS was fit with')
+    return hdu
 
 
 def _exposure_mid_mjd(path):
@@ -205,10 +362,16 @@ def _load_detector(path, detector, detect_cfg, ImageModel):
 
 
 def _write_solution(path, corrected_wcs, cfp_value, ImageModel,
-                    update_fits_wcsinfo):
+                    update_fits_wcsinfo, *, algncat=None, diag_updates=None):
     """Write *corrected_wcs* back onto the canonical + stamp CFP_ALGN, stashing
     the pre-align gwcs in ALGN_BAK and preserving SRCMASK and any wcs_shift
-    ``WCS_BAK``."""
+    ``WCS_BAK``.
+
+    *algncat* (a ``BinTableHDU``) and *diag_updates* are the align diagnostics for
+    this detector. The table rides the same ``extra_hdus`` replace-or-append path
+    as the backup extensions, so a re-solve overwrites it in place rather than
+    accumulating copies; the keywords ride ``header_updates`` alongside CFP_ALGN,
+    in the one atomic write."""
     existing_algn_bak = None
     wcs_shift_bak = None
     srcmask_hdu = None
@@ -247,8 +410,11 @@ def _write_solution(path, corrected_wcs, cfp_value, ImageModel,
             extra_hdus.append(wcs_shift_bak)
         if srcmask_hdu is not None:
             extra_hdus.append(srcmask_hdu)
-        atomic_save(model, path,
-                    header_updates=cfp.format(CFP_ALGN=cfp_value),
+        if algncat is not None:
+            extra_hdus.append(algncat)
+        header_updates = cfp.format(CFP_ALGN=cfp_value)
+        header_updates.update(diag_updates or {})
+        atomic_save(model, path, header_updates=header_updates,
                     extra_hdus=extra_hdus)
     finally:
         model.close()
@@ -346,6 +512,10 @@ def align_exposure_group(members, refcat, *, key=None, config=None,
         return GroupSolution(key, 'NOT_ALIGNED', None, None, None, 0, [])
 
     by_detector = {d.detector: d for d in solution.detectors}
+    # The detection catalogs are still live here (the solve read, never replaced,
+    # them), row-aligned with each solution's per-source diagnostic arrays — this
+    # is what ALGNCAT is built from.
+    by_input = {d.detector: d for d in detectors}
     for m in members:
         det_sol = by_detector.get(m.detector)
         # ``aligned=False`` marks a per-detector residual-gate reject inside an
@@ -353,9 +523,15 @@ def align_exposure_group(members, refcat, *, key=None, config=None,
         # preserved, quarantined from combine) like a failed pool.
         if (solution.status == 'SOLVED' and det_sol is not None
                 and getattr(det_sol, 'aligned', True)):
+            det_in = by_input.get(m.detector)
+            algncat = (_algncat_hdu(det_in.catalog, det_sol)
+                       if det_in is not None else None)
             _write_solution(m.path, det_sol.wcs,
                             _format_algn_value(det_sol, refcat_hash),
-                            ImageModel, update_fits_wcsinfo)
+                            ImageModel, update_fits_wcsinfo,
+                            algncat=algncat,
+                            diag_updates=_diag_header_updates(solution,
+                                                              det_sol))
         else:
             _stamp_algn(m.path, NOT_ALIGNED_SENTINEL)
 

--- a/pipeline/campfire_pipeline/nircam/align/apply.py
+++ b/pipeline/campfire_pipeline/nircam/align/apply.py
@@ -174,6 +174,14 @@ def _stamp_algn(path, value):
     tmp = f'{base}.tmp{ext}'
     with fits.open(path) as hdul:
         hdul[0].header['CFP_ALGN'] = (value, cfp.CFP_COMMENTS['CFP_ALGN'])
+        # Every scalar diagnostic describes ONE solve. A file re-solved to
+        # NOT_ALIGNED must not keep the counts and peak contrasts of an earlier
+        # successful run standing beside the rejection — that would read as
+        # provenance for the rejected attempt. Reset them all to UNDEF; the
+        # all-keys-on-every-solve contract is what makes staleness impossible.
+        for key in ALGN_DIAG_COMMENTS:
+            if key != 'ALGNSTAL':
+                hdul[0].header[key] = (ALGN_UNDEF, ALGN_DIAG_COMMENTS[key])
         hdul[0].header['ALGNSTAL'] = (True, ALGN_DIAG_COMMENTS['ALGNSTAL'])
         hdul.writeto(tmp, overwrite=True)
     os.replace(tmp, path)

--- a/pipeline/campfire_pipeline/nircam/align/dva.py
+++ b/pipeline/campfire_pipeline/nircam/align/dva.py
@@ -1,0 +1,207 @@
+"""Re-reference the differential velocity aberration (DVA) scale to a pool-common
+pivot, so a pooled rigid fit is geometrically valid.
+
+**The defect.** ``jwst.assign_wcs`` corrects DVA per detector, scaling about
+*that detector's own* aperture reference (``nircam.py`` passes
+``v2_ref``/``v3_ref`` from ``meta.wcsinfo`` into
+:func:`jwst.assign_wcs.pointing.dva_corr_model`, which builds
+``v' = v_ref + va_scale * (v - v_ref)``). Each detector's reference point is
+therefore left exactly where it was, and the *separation between* two detectors'
+reference points keeps the full, uncorrected aberration::
+
+    residual = (1 - va_scale) * |v_ref,i - v_ref,j|
+
+For the NIRCam LW pair (|Δv_ref| = 175.34") and COSMOS's
+|1 - va_scale| ~ 7e-5..1e-4, that is ~13 mas — measured on 3258 COSMOS LW
+exposures as a module-to-module differential matching this prediction in sign
+and magnitude (the sign tracks the observatory's radial velocity, which reverses
+between the field's two visibility windows).
+
+**Why it matters for pooling.** The residual is a pure *scale* about a point
+outside each detector. A pooled ``rshift`` (rotation + translation) cannot
+express a scale, so pooling detectors whose DVA is referenced to different
+pivots forces that ~13 mas differential into the fit as an irreducible residual,
+split between the pool's members. Solving each detector separately hides the
+problem by giving every detector its own translation to absorb it.
+
+**The fix.** Rebuild the DVA transform about a pivot shared by the whole pool,
+using the same jwst primitive that created it. Per detector this is a pure
+shift in V2/V3::
+
+    Δv = (va_scale - 1) * (v_ref,detector - v_ref,pivot)
+
+With ``pivot='pool'`` (the default) the pivot is the centroid of the pool's
+reference points, so the pool's mean position is unchanged and only the
+*relative* geometry moves — the least disruptive choice, and one that leaves a
+single-detector pool a strict no-op.
+
+**Scope.** A no-op for any pool of one detector (LW with ``pool_modules=false``).
+For a multi-detector pool it also removes the smaller *intra*-pool residual: an
+SW module spans ~130", so its four detectors currently carry up to
+~(1 - va_scale) x 65" ~ 5 mas of the same error, which the pooled ``rshift``
+must absorb as fit residual.
+
+**Which pivot is "physically right" is an open STScI question — and it does not
+matter here.** ``spacetelescope/jwst`` issue #9400 (JIRA JP-3987, D. Law,
+2025-04-18, still open) asks precisely this: the per-aperture pivot "would be
+correct if the telescope attitude information … was the telescope boresight
+v2=v3=0. If the telescope attitude information is set for the guide star though,
+shouldn't the dva scale be applied to the difference (v2ref - v2guider) and
+(v3ref - v3guider)?" (``set_telescope_pointing.calc_gs2gsapp`` does apply an
+aberration correction "in the direction of the guide star", but as a *rotation*,
+which cannot rescale aperture separations — so nothing upstream fixes this.)
+
+For a pooled solve the question is moot, because the pivot cancels out of the
+relative geometry::
+
+    v'_i - v'_j = va_scale * (v_i - v_j)      for ANY pool-common pivot
+
+Guide star, boresight and pool centroid therefore give identical *relative*
+corrections; they differ only by an overall translation of the pool, which the
+fit against the reference catalog absorbs. ``pivot='pool'`` is the default purely
+because it makes that leftover translation zero.
+"""
+
+import copy
+
+from campfire_pipeline.common.io import log
+
+__all__ = ['repivot_pool_dva', 'va_scale_from_wcs', 'DVA_PIVOTS']
+
+# Frame names of the DVA step in the JWST NIRCam gwcs pipeline.
+_FROM_FRAME, _TO_FRAME = 'v2v3', 'v2v3vacorr'
+_SCALE_SUBMODEL = 'dva_scale_v2'
+
+DVA_PIVOTS = ('pool', 'boresight')
+
+# Largest position error (mas), across the pool's own lever arm, that the
+# per-detector spread in va_scale may imply before we refuse to average it.
+_MAX_SPREAD_MAS = 1.0
+
+
+def va_scale_from_wcs(wcs):
+    """The velocity-aberration scale baked into *wcs*, or ``None``.
+
+    Read back from the gwcs itself (the ``DVA_Correction`` compound model's
+    scale submodel) rather than from a header keyword, so the value is
+    guaranteed to be the one actually applied to this WCS. Returns ``None`` when
+    the pipeline has no DVA step, when it is an ``Identity`` (``va_scale`` was 1
+    or absent), or when the model is not the shape we expect — every one of
+    which means "nothing to re-reference".
+    """
+    try:
+        transform = wcs.get_transform(_FROM_FRAME, _TO_FRAME)
+    except Exception:                                    # noqa: BLE001
+        return None
+    if transform is None:
+        return None
+    try:
+        return float(transform[_SCALE_SUBMODEL].factor.value)
+    except Exception:                                    # noqa: BLE001
+        return None                                      # Identity / unexpected
+
+
+def _pivot_point(detectors, pivot):
+    """``(v2, v3)`` in arcsec for the requested *pivot*."""
+    if pivot == 'boresight':
+        return 0.0, 0.0
+    refs = [(float(d.wcsinfo['v2_ref']), float(d.wcsinfo['v3_ref']))
+            for d in detectors]
+    n = len(refs)
+    return sum(v2 for v2, _ in refs) / n, sum(v3 for _, v3 in refs) / n
+
+
+def repivot_pool_dva(detectors, *, pivot='pool', key='group'):
+    """Return *detectors* with each DVA scale re-referenced to a common pivot.
+
+    Parameters
+    ----------
+    detectors : list of DetectorInput
+        One pool. Not mutated: each returned entry carries a deep-copied gwcs,
+        so the caller keeps the untouched originals for the NOT_ALIGNED path
+        (which contractually preserves the input WCS).
+    pivot : {'pool', 'boresight'}
+        ``'pool'`` — centroid of the pool's ``v2_ref``/``v3_ref`` (default;
+        leaves the pool's mean position unchanged). ``'boresight'`` — V2=V3=0.
+    key : str
+        Pool key, for logging.
+
+    Returns
+    -------
+    (list of DetectorInput, dict)
+        The re-pivoted detectors and a diagnostics dict
+        (``va_scale``, ``pivot``, ``pivot_v2``, ``pivot_v3``, ``max_shift_mas``).
+        On any condition that makes re-referencing meaningless or unsafe the
+        ORIGINAL list is returned unchanged with ``{'applied': False, ...}`` —
+        this is an astrometric refinement, never a reason to fail a pool.
+    """
+    import dataclasses
+
+    detectors = list(detectors)
+    info = {'applied': False, 'pivot': pivot}
+    if len(detectors) < 2:
+        info['reason'] = 'single-detector pool (no relative geometry to fix)'
+        return detectors, info
+    if pivot not in DVA_PIVOTS:
+        log(f"align dva[{key}]: unknown dva_pivot '{pivot}'; "
+            f"expected one of {DVA_PIVOTS}. Skipping DVA re-reference.")
+        info['reason'] = f'unknown pivot {pivot!r}'
+        return detectors, info
+
+    scales = [va_scale_from_wcs(d.wcs) for d in detectors]
+    if any(s is None for s in scales):
+        info['reason'] = 'no DVA step in one or more detector WCSes'
+        return detectors, info
+
+    pv2, pv3 = _pivot_point(detectors, pivot)
+    lever = max(((float(d.wcsinfo['v2_ref']) - pv2) ** 2
+                 + (float(d.wcsinfo['v3_ref']) - pv3) ** 2) ** 0.5
+                for d in detectors)
+
+    # One exposure has one velocity, but the per-detector va_scale values differ
+    # in their last digits because each is evaluated at that detector's own
+    # reference point. That spread is physically negligible (~1e-8 across NIRCam,
+    # i.e. well under 0.1 mas even at a 500" lever arm), so average it rather
+    # than refusing to act. Judge it in MILLIARCSECONDS, not as a bare float
+    # comparison: what matters is the position error the spread would induce
+    # across this pool. A spread big enough to matter means these detectors are
+    # not really simultaneous, and averaging would be wrong.
+    spread = max(scales) - min(scales)
+    if spread * lever * 1e3 > _MAX_SPREAD_MAS:
+        log(f"align dva[{key}]: va_scale spread {spread:.3e} over a "
+            f"{lever:.1f}\" lever implies {spread * lever * 1e3:.2f} mas "
+            f"(> {_MAX_SPREAD_MAS} mas); skipping DVA re-reference "
+            f"(detectors may not be simultaneous).")
+        info['reason'] = 'inconsistent va_scale across pool'
+        return detectors, info
+
+    va_scale = sum(scales) / len(scales)
+    if va_scale == 1.0:
+        info['reason'] = 'va_scale == 1 (nothing to correct)'
+        return detectors, info
+
+    from jwst.assign_wcs.pointing import dva_corr_model
+
+    out, max_shift = [], 0.0
+    for d in detectors:
+        wcs = copy.deepcopy(d.wcs)
+        try:
+            wcs.set_transform(_FROM_FRAME, _TO_FRAME,
+                              dva_corr_model(va_scale=va_scale,
+                                             v2_ref=pv2, v3_ref=pv3))
+        except Exception as e:                           # noqa: BLE001
+            log(f"align dva[{key}]: could not re-reference DVA on "
+                f"{d.detector} ({type(e).__name__}: {e}); leaving the pool "
+                f"untouched.")
+            return detectors, {**info, 'reason': f'{type(e).__name__}'}
+        dv2 = (va_scale - 1.0) * (float(d.wcsinfo['v2_ref']) - pv2)
+        dv3 = (va_scale - 1.0) * (float(d.wcsinfo['v3_ref']) - pv3)
+        max_shift = max(max_shift, (dv2 ** 2 + dv3 ** 2) ** 0.5)
+        out.append(dataclasses.replace(d, wcs=wcs))
+
+    info.update(applied=True, va_scale=va_scale, pivot_v2=pv2, pivot_v3=pv3,
+                max_shift_mas=max_shift * 1e3)
+    log(f"align dva[{key}]: re-referenced DVA (va_scale={va_scale:.9f}) to the "
+        f"{pivot} pivot (v2={pv2:.2f}\", v3={pv3:.2f}\"); largest detector "
+        f"shift {max_shift * 1e3:.2f} mas.")
+    return out, info

--- a/pipeline/campfire_pipeline/nircam/align/histmatch.py
+++ b/pipeline/campfire_pipeline/nircam/align/histmatch.py
@@ -50,6 +50,16 @@ configuration carries over verbatim — converted per call via the ``tp_pscale``
 the ``tweakwcs`` machinery passes (the pool's detector pixel size in
 tangent-plane arcsec, so SW/LW each get physically correct values).
 ``searchrad`` and ``d2d_max`` are arcsec (matching JHAT's ``d2d_max``).
+
+**Peak confidence.** ``tweakwcs`` calls the matcher through ``__call__`` and only
+the surviving row indices escape, so the consensus peaks' own numbers — which is
+what tells a decisive lock from an ambiguous one — cannot be returned. They are
+stashed on the instance in :attr:`OffsetHistogramMatch.diag` instead (reset per
+call), for the solve to lift onto its ``GroupSolution`` and the I/O layer to
+stamp into the header. This is the *independent* half of the align diagnostics:
+the solve's own residual is measured on the very pairs the matcher selected, so a
+confident-looking residual on a wrong lock is indistinguishable from a right one
+— the peak contrast is not, because a wrong lock is a low-contrast one.
 """
 
 import numpy as np
@@ -71,6 +81,11 @@ _GROSS_BIN_ARCSEC = 0.5
 # bins, the bin size is coarsened. Only reachable with d2d_max=None on a
 # pathologically wide offset distribution.
 _MAX_BINS = 200_000
+
+# Half-width (in bins) of the winning gross peak's neighbourhood — the same
+# +-2-bin patch the centroid refinement uses, excluded when hunting the runner-up
+# so the runner-up is a genuinely different peak and not the winner's own skirt.
+_GROSS_PEAK_HALFWIDTH_BINS = 2
 
 
 def _smoothed_hist_peak(d, binsize, gaussian_sigma):
@@ -203,6 +218,35 @@ class OffsetHistogramMatch(MatchCatalogs):
         ``id`` values the solve assigned to each detector catalog.
     refcat_mag_col : str
         Reference-catalog magnitude column (``'mag'`` in campfire-refcat-v1).
+
+    Attributes
+    ----------
+    diag : dict
+        Peak-confidence numbers from the **most recent** ``__call__`` (cleared at
+        the top of each call, so it never mixes two passes). Keys, all optional
+        (a stage that did not run contributes nothing):
+
+        ``gross_peak``, ``gross_runner_up``, ``gross_contrast``, ``gross_mass``
+            Gross 2-D offset histogram (``searchrad`` passes only): the winning
+            bin's smoothed height, the tallest height outside its +-2-bin
+            neighbourhood, their ratio, and the pair count in the winner's
+            neighbourhood (the mass the sub-bin centroid was measured from). A
+            contrast near 1 means a second gross offset was nearly as popular —
+            the clustering-scale false peak that dragged the COSMOS A2/A3
+            exposures.
+        ``dx_peak`` / ``dy_peak``, ``dx_fwhm_arcsec`` / ``dy_fwhm_arcsec``,
+        ``dx_contrast`` / ``dy_contrast``
+            Per-axis consensus peak from the rotation-slope scan: the winning
+            slope's smoothed peak height, that peak's FWHM in tangent-plane
+            arcsec, and its height over the tallest peak from a *well-separated*
+            slope (see :meth:`_histogram_cut`). A ``nan`` contrast means the scan
+            was degenerate — no slope was distinguishable from the winner — which
+            is what a collapsed ``hist_binsize_arcsec`` produces.
+        ``hist_binsize_arcsec``
+            The consensus histogram bin as actually used (``binsize_px`` ×
+            ``tp_pscale``). Expect a small fraction of an arcsec; a value near or
+            above the offset distribution's own width means the whole consensus
+            stage collapsed to one bin and selected nothing.
     """
 
     def __init__(self, *, searchrad=None, d2d_max=1.5, binsize_px=0.02,
@@ -228,6 +272,11 @@ class OffsetHistogramMatch(MatchCatalogs):
         self.delta_mag_lim = delta_mag_lim
         self.image_mags = image_mags
         self.refcat_mag_col = refcat_mag_col
+        # Peak-confidence stash for the last __call__ (see the class docstring):
+        # the MatchCatalogs contract lets only row indices out, so the numbers
+        # ride the instance. An instance reused across coarse passes is
+        # overwritten each call; the solve snapshots the pass it keeps.
+        self.diag = {}
 
     # -- gross translation (2-D offset histogram) ---------------------------
 
@@ -239,6 +288,10 @@ class OffsetHistogramMatch(MatchCatalogs):
         image sources), so — unlike a pair-enumerating matcher — memory is
         bounded by the histogram, not the pair count. The peak is refined by
         an intensity-weighted centroid over its ±2-bin neighbourhood.
+
+        Records the winner's height, the runner-up height (tallest bin outside
+        that same neighbourhood), their contrast and the neighbourhood mass in
+        ``self.diag`` — the triage numbers for a low-contrast (ambiguous) lock.
         """
         r = float(self.searchrad)
         nbins = max(int(np.ceil(2.0 * r / _GROSS_BIN_ARCSEC)), 4)
@@ -267,10 +320,24 @@ class OffsetHistogramMatch(MatchCatalogs):
 
         i, j = np.unravel_index(int(np.argmax(acc)), acc.shape)
         centers = 0.5 * (edges[:-1] + edges[1:])
-        i0, i1 = max(i - 2, 0), min(i + 3, nbins)
-        j0, j1 = max(j - 2, 0), min(j + 3, nbins)
+        h = _GROSS_PEAK_HALFWIDTH_BINS
+        i0, i1 = max(i - h, 0), min(i + h + 1, nbins)
+        j0, j1 = max(j - h, 0), min(j + h + 1, nbins)
         patch = acc[i0:i1, j0:j1]
         total = patch.sum()
+
+        # Runner-up: the tallest bin OUTSIDE the winner's neighbourhood, so a
+        # peak straddling bin edges cannot masquerade as its own rival.
+        rival = acc.copy()
+        rival[i0:i1, j0:j1] = 0.0
+        peak = float(acc[i, j])
+        runner_up = float(rival.max())
+        self.diag.update(
+            gross_peak=peak, gross_runner_up=runner_up,
+            gross_contrast=(peak / runner_up if runner_up > 0
+                            else float('nan')),
+            gross_mass=float(total))
+
         if total <= 0:
             return None
         dx0 = float((patch.sum(axis=1) * centers[i0:i1]).sum() / total)
@@ -280,9 +347,19 @@ class OffsetHistogramMatch(MatchCatalogs):
     # -- per-axis histogram cut (rotation scan + rough cut + sigma clip) ----
 
     def _histogram_cut(self, d, c, mask, *, binsize, gaussian_sigma,
-                       rough_min, rough_max):
+                       rough_min, rough_max, label=None):
         """One JHAT ``histogram_cut``: refine *mask* by the consensus peak of
-        offsets *d* against cross coordinate *c* (rotation-slope scan)."""
+        offsets *d* against cross coordinate *c* (rotation-slope scan).
+
+        When *label* is given (``'dx'``/``'dy'``), the winning peak's height,
+        FWHM (tangent-plane arcsec) and contrast are recorded in ``self.diag``.
+        The contrast's denominator is the tallest peak from a slope **far enough
+        from the winner to be a different consensus**: neighbouring scan steps
+        de-rotate the offsets by far less than one peak width, so their heights
+        are near-identical and a plain second-best would report ~1.0 for every
+        solve, decisive or not. The exclusion half-width is therefore the slope
+        change that displaces the outermost source by one peak FWHM.
+        """
         idx = np.flatnonzero(mask)
         if idx.size < _MIN_PAIRS:
             return mask
@@ -293,15 +370,29 @@ class OffsetHistogramMatch(MatchCatalogs):
         c0 = 0.5 * (float(np.min(c_sel)) + float(np.max(c_sel)))
         c_rel = c_sel - c0
 
+        slopes = np.linspace(-self.slope_max, self.slope_max,
+                             self.slope_nsteps + 1)
+        heights = np.empty(slopes.size, dtype=float)
         best = None   # (height, slope, center, fwhm)
-        for slope in np.linspace(-self.slope_max, self.slope_max,
-                                 self.slope_nsteps + 1):
+        for k, slope in enumerate(slopes):
             center, height, fwhm = _smoothed_hist_peak(
                 d_sel - slope * c_rel, binsize, gaussian_sigma)
+            heights[k] = height
             if best is None or height > best[0]:
                 best = (height, slope, center, fwhm)
 
-        _, slope, center, fwhm = best
+        height, slope, center, fwhm = best
+        if label is not None:
+            far = np.abs(slopes - slope) > (
+                fwhm / max(float(np.max(np.abs(c_rel))), 1e-12))
+            runner_up = float(heights[far].max()) if np.any(far) else 0.0
+            self.diag.update({
+                f'{label}_peak': float(height),
+                f'{label}_fwhm_arcsec': float(fwhm),
+                f'{label}_contrast': (height / runner_up if runner_up > 0
+                                      else float('nan')),
+            })
+
         rough = float(np.clip(self.nfwhm * fwhm, rough_min, rough_max))
         d_rot = d - slope * (c - c0)
         rough_mask = mask & (np.abs(d_rot - center) <= rough)
@@ -339,6 +430,10 @@ class OffsetHistogramMatch(MatchCatalogs):
     def __call__(self, refcat, imcat, tp_pscale=1.0, tp_units=None, **kwargs):
         from scipy.spatial import cKDTree
 
+        # Peak confidence describes THIS call only — clear it up front so a
+        # short-circuited call can never report the previous pass's numbers.
+        self.diag = {}
+
         for cat, side in ((refcat, 'reference'), (imcat, 'image')):
             for col in ('TPx', 'TPy'):
                 if col not in cat.colnames:
@@ -359,6 +454,11 @@ class OffsetHistogramMatch(MatchCatalogs):
         gaussian_sigma = self.gaussian_sigma_px * pscale
         rough_min = self.rough_cut_px_min * pscale
         rough_max = self.rough_cut_px_max * pscale
+        # The consensus histogram's bin size AS EXECUTED (arcsec) — recorded
+        # because every ``*_px`` knob is scaled by the ``tp_pscale`` tweakwcs
+        # hands us, so this one number says whether the consensus stage resolved
+        # the offset distribution at all or collapsed it into a single bin.
+        self.diag['hist_binsize_arcsec'] = float(binsize)
 
         tree = cKDTree(ref_xy)
 
@@ -389,13 +489,13 @@ class OffsetHistogramMatch(MatchCatalogs):
         im_y = im_xy[:, 1]
 
         if self.histocut_order == 'dxdy':
-            axes = ((dx, im_y), (dy, im_x))
+            axes = ((dx, im_y, 'dx'), (dy, im_x, 'dy'))
         else:
-            axes = ((dy, im_x), (dx, im_y))
-        for d, c in axes:
+            axes = ((dy, im_x, 'dy'), (dx, im_y, 'dx'))
+        for d, c, label in axes:
             mask = self._histogram_cut(
                 d, c, mask, binsize=binsize, gaussian_sigma=gaussian_sigma,
-                rough_min=rough_min, rough_max=rough_max)
+                rough_min=rough_min, rough_max=rough_max, label=label)
 
         im_idx = np.flatnonzero(mask)
         if im_idx.size < _MIN_PAIRS:

--- a/pipeline/campfire_pipeline/nircam/align/solve.py
+++ b/pipeline/campfire_pipeline/nircam/align/solve.py
@@ -4,7 +4,7 @@ Given, for one **pool** of detectors (a module — or, with ``pool_modules``, a
 whole channel — of one exposure), each detector's gwcs + detected source catalog
 and a static Gaia-tied reference catalog, this fits ONE shared shift+rotation
 (``rshift``) for the pool via ``tweakwcs`` (SIAF distortion untouched), then —
-per detector, gated on match count / coverage / residual improvement — frees a
+per detector, gated on match count / coverage / shift significance — frees a
 small individual fit up to a configurable ceiling geometry. It returns the
 corrected gwcs per detector plus solve diagnostics; it does no FITS I/O (the
 exposure reader/writer + ``CFP_ALGN`` stamp live in the orchestration layer).
@@ -28,7 +28,9 @@ exposure reader/writer + ``CFP_ALGN`` stamp live in the orchestration layer).
    row-aligned with ``match=None``, exactly JHAT's ``already_matched`` design
    (JHAT fits every detector, always) — its geometry chosen down a ladder
    (``general`` → ``rshift`` → ``shift`` → keep-coarse) by its match count and
-   coverage, accepted only if it reduces the residual. The ladder floors
+   coverage, and accepted when the shift it applies is SIGNIFICANT against the
+   noise adopting it costs (``|shift| > fine_min_significance * sigma/sqrt(n)``)
+   and it does not materially degrade the residual. The ladder floors
    (``fine_min_shift`` = JHAT's ``minobj=3``) are the guard against
    noise-chasing; ``tolerance`` is reporting-only.
 
@@ -40,6 +42,17 @@ a static reference catalog + ``expand_refcat=False`` keep pools independent.
 Per-detector residuals are recomputed DIRECTLY (``det_to_world`` vs matched
 refcat positions) with **one-to-one** (mutual nearest-neighbour) matching, not
 read from ``tweakwcs``'s group-level ``fit_info``.
+
+**Diagnostics for independent validation.** The reported residual is measured on
+the very sample the matcher selected, so it is circular: a solution locked onto
+the wrong sources reports a small residual just as happily as a right one. The
+solve therefore also carries out (a) the **per-source** matched mask / separation
+/ matched-refcat position for every detection (:class:`DetectorSolution`), so
+overlapping exposures can be cross-checked against each other without drizzling
+anything, and (b) the matcher's own **peak-confidence** numbers
+(:attr:`GroupSolution.diagnostics`, lifted off ``OffsetHistogramMatch.diag``), so
+a low-contrast — i.e. ambiguous — lock can be triaged. Neither influences any
+gate; the I/O layer persists them (``ALGNCAT`` + ``ALGN*`` header keywords).
 """
 
 import copy
@@ -66,6 +79,14 @@ _FINE_LADDER = ('general', 'rshift', 'shift')
 # Geometries that fit a rotation and so need spatial coverage to be conditioned.
 _ROTATING = ('general', 'rshift')
 
+# Median of a 2-D Gaussian's radial deviation, in units of the per-axis sigma.
+_RAYLEIGH_MEDIAN = np.sqrt(2.0 * np.log(2.0))      # 1.1774
+# A fine fit whose own residual is this much WORSE than the coarse one is
+# rejected however significant its shift looks — a significant-but-degrading fit
+# is a broken fit, not a correction. Sized well above the noise on the median
+# residual (~1.06/sqrt(n), i.e. ~14% at n=60), so it only fires on real damage.
+_FINE_MAX_DEGRADE = 1.25
+
 
 @dataclass
 class DetectorInput:
@@ -79,7 +100,18 @@ class DetectorInput:
 
 @dataclass
 class DetectorSolution:
-    """The align outcome for one detector."""
+    """The align outcome for one detector.
+
+    Everything from ``n_detected`` down is **diagnostic only** — it gates
+    nothing, and every field defaults so the positional constructions above stay
+    valid. The four arrays are row-aligned with the detector's input catalog
+    (``DetectorInput.catalog``), length ``n_detected``, and describe the FINAL
+    accepted WCS (the post-fine re-match when a fine fit was accepted, else the
+    pooled coarse match). On a residual-gate reject (``aligned=False``) they
+    describe the *rejected* correction — which is exactly what one wants to
+    triage the reject — while ``wcs`` is the untouched original; the I/O layer
+    does not persist them in that case.
+    """
 
     detector: str
     wcs: object              # corrected (or, when NOT_ALIGNED, original) gwcs
@@ -89,6 +121,15 @@ class DetectorSolution:
     within_tolerance: bool
     aligned: bool = True     # False: rejected by the residual gate — the I/O
                              # layer stamps NOT_ALIGNED (WCS preserved)
+    n_detected: int = 0      # rows in this detector's detection catalog
+    matched: Optional[object] = None    # bool array: row paired one-to-one
+    sep_arcsec: Optional[object] = None  # float array: separation to the NEAREST
+                             # refcat source (all rows, matched or not)
+    ref_ra: Optional[object] = None     # float array: matched refcat RA (deg),
+    ref_dec: Optional[object] = None    # ... and Dec; nan on unmatched rows.
+                             # VALUES, not indices: they index the
+                             # footprint-clipped refcat, which no downstream
+                             # consumer can reconstruct.
 
 
 @dataclass
@@ -102,6 +143,14 @@ class GroupSolution:
     rmse_arcsec: Optional[float]
     n_matched: int                        # pool-level matched-source count
     detectors: List[DetectorSolution]
+    # Diagnostics (defaults; gate nothing). ``n_refcat_in_footprint`` is the
+    # footprint clip's ``n_kept`` — the reference density the coarse matcher
+    # actually worked against. ``diagnostics`` is the matcher's peak confidence
+    # (see ``OffsetHistogramMatch.diag``): the gross 2-D-histogram keys come from
+    # coarse pass 0 (the only pass that runs the gross stage), the per-axis
+    # consensus keys from the last pass that was KEPT.
+    n_refcat_in_footprint: Optional[int] = None
+    diagnostics: Optional[dict] = None
 
 
 def _has_radec(refcat):
@@ -140,7 +189,7 @@ def _coverage_arcsec(ra, dec):
 
 def _match(corrector, catalog, ref_sky, match_radius):
     """One-to-one residual for one detector: ``(residual_arcsec, n_matched,
-    src_idx, ref_idx)``.
+    src_idx, ref_idx, keep, sep)``.
 
     Transform the detector's own sources through the (corrected) gwcs and match
     them to the reference positions by **mutual nearest neighbour** — a source
@@ -148,12 +197,23 @@ def _match(corrector, catalog, ref_sky, match_radius):
     within *match_radius* arcsec. ``src_idx``/``ref_idx`` are the row-aligned
     pairing (one-to-one by the mutuality); the fine fit consumes it directly as
     a pre-matched list, and the group gate measures coverage from ``ref_idx``.
+
+    ``keep`` (bool) and ``sep`` (arcsec) are the same information *per catalog
+    row* — the matched mask and the separation to the nearest reference source
+    for EVERY detection, unmatched ones included — which is what the per-source
+    diagnostic catalog is built from. ``sep`` is nan where no separation could be
+    measured; on unmatched rows it is a real distance to a source that simply
+    isn't a counterpart, so read it together with ``keep``.
     """
-    empty = (float('nan'), 0, np.array([], dtype=int), np.array([], dtype=int))
+    n_src = len(catalog)
+    keep = np.zeros(n_src, dtype=bool)
+    sep = np.full(n_src, np.nan, dtype=float)
+    no_pairs = (float('nan'), 0, np.array([], dtype=int),
+                np.array([], dtype=int), keep, sep)
     x = np.asarray(catalog['x'], dtype=float)
     y = np.asarray(catalog['y'], dtype=float)
     if x.size == 0 or len(ref_sky) == 0:
-        return empty
+        return no_pairs
     ra, dec = corrector.det_to_world(x, y)
     src = SkyCoord(np.asarray(ra, dtype=float), np.asarray(dec, dtype=float),
                    unit='deg')
@@ -164,18 +224,39 @@ def _match(corrector, catalog, ref_sky, match_radius):
     mutual = r2s[s2r] == src_ix
     keep = mutual & np.isfinite(sep) & (sep <= match_radius)
     if not np.any(keep):
-        return empty
+        return (float('nan'), 0, np.array([], dtype=int),
+                np.array([], dtype=int), keep, sep)
     return (float(np.median(sep[keep])), int(np.count_nonzero(keep)),
-            src_ix[keep], np.asarray(s2r)[keep])
+            src_ix[keep], np.asarray(s2r)[keep], keep, sep)
 
 
-def _not_aligned(key, detectors, wcs_getter):
+def _ref_positions(n_src, src_idx, ref_idx, ref_sky):
+    """Per-catalog-row matched refcat ``(ra, dec)`` in degrees, nan unmatched.
+
+    Resolves the pairing to POSITIONS here, on purpose: ``ref_idx`` indexes the
+    footprint-clipped refcat, which is local to this solve and cannot be
+    reconstructed by anything downstream, so bare indices would be unusable.
+    """
+    ref_ra = np.full(n_src, np.nan, dtype=float)
+    ref_dec = np.full(n_src, np.nan, dtype=float)
+    if len(src_idx):
+        ref_ra[src_idx] = ref_sky.ra.deg[ref_idx]
+        ref_dec[src_idx] = ref_sky.dec.deg[ref_idx]
+    return ref_ra, ref_dec
+
+
+def _not_aligned(key, detectors, wcs_getter, *, n_refcat=None, diag=None):
+    """Reject the whole pool. *n_refcat*/*diag* carry whatever diagnostics the
+    reject path already knows (refcat density, matcher peak confidence) — the
+    numbers that explain WHY it rejected — for the caller's log/report; nothing
+    per-source is persisted, since no corrected WCS is written."""
     return GroupSolution(
         key=key, status='NOT_ALIGNED', shift=None, rot_deg=None,
         rmse_arcsec=None, n_matched=0,
         detectors=[DetectorSolution(name, wcs_getter(name, obj), 'identity',
                                     float('nan'), 0, False)
                    for name, obj in detectors],
+        n_refcat_in_footprint=n_refcat, diagnostics=(diag or None),
     )
 
 
@@ -204,8 +285,8 @@ def _pool_fit(detectors, wcs_by_det, refcat, match, *, key, fitgeom, nclip, sigm
 def _coarse(detectors, wcs_by_det, refcat, key, *, match0, match_iter, niter,
             nclip, sigma):
     """Iterate a pooled ``rshift`` to convergence; return
-    ``(correctors, last_info, first_info, wcs_by_det)`` or
-    ``(None, {}, {}, wcs_by_det)``.
+    ``(correctors, last_info, first_info, wcs_by_det, diag)`` or
+    ``(None, {}, {}, wcs_by_det, {})``.
 
     Pass 0 uses *match0* (the histogram matcher with its gross-translation
     stage over the full search radius); later passes start from the corrected
@@ -214,8 +295,16 @@ def _coarse(detectors, wcs_by_det, refcat, key, *, match0, match_iter, niter,
     each pass. *first_info* is pass 0's fit (the gross shift/rot the input WCS
     was off by, for provenance); *last_info* is the converged fit (its rmse is
     the final quality).
+
+    *diag* mirrors that convention for the matcher's peak confidence
+    (``OffsetHistogramMatch.diag``, overwritten on every call): pass 0's keys are
+    laid down first — it alone runs the gross stage — and each KEPT later pass
+    overwrites the per-axis consensus keys, so the result is pass 0's gross peak
+    plus the final accepted pass's consensus peaks. Snapshotted only for passes
+    that succeeded, since a crashing or failing pass is discarded (and the loop
+    can break at any i, so the last call is not necessarily the last pass).
     """
-    correctors, last_info, first_info = None, {}, {}
+    correctors, last_info, first_info, diag = None, {}, {}, {}
     for i in range(max(1, int(niter))):
         match = match0 if i == 0 else match_iter
         try:
@@ -231,12 +320,13 @@ def _coarse(detectors, wcs_by_det, refcat, key, *, match0, match_iter, niter,
         correctors, last_info = c, fi
         if not first_info:
             first_info = fi
+        diag.update(getattr(match, 'diag', None) or {})
         wcs_by_det = {cc.meta['name']: cc.wcs for cc in c}
         if i > 0:
             delta = np.hypot(*np.asarray(fi['shift'], float).ravel()[:2])
             if delta < _REFINE_CONVERGE_ARCSEC:
                 break
-    return correctors, last_info, first_info, wcs_by_det
+    return correctors, last_info, first_info, wcs_by_det, diag
 
 
 def _choose_fitgeom(n, coverage, ceiling, mins, min_coverage):
@@ -258,6 +348,50 @@ def _choose_fitgeom(n, coverage, ceiling, mins, min_coverage):
             continue
         return geom
     return None
+
+
+def _fine_shift_arcsec(coarse, trial, catalog, src_idx):
+    """Median on-sky displacement (arcsec) the fine fit applies to this detector.
+
+    Measured at the matched sources — where the fit is actually constrained and
+    where the astrometry matters — rather than at one fiducial pixel, so a
+    rotation-bearing fit is judged by how far it really moves things.
+    """
+    if len(src_idx) == 0:
+        return float('nan')
+    x = np.asarray(catalog['x'], dtype=float)[src_idx]
+    y = np.asarray(catalog['y'], dtype=float)[src_idx]
+    ra0, dec0 = coarse.det_to_world(x, y)
+    ra1, dec1 = trial.det_to_world(x, y)
+    ra0 = np.asarray(ra0, dtype=float); dec0 = np.asarray(dec0, dtype=float)
+    d_ra = (np.asarray(ra1, dtype=float) - ra0) * np.cos(np.radians(dec0))
+    d_dec = np.asarray(dec1, dtype=float) - dec0
+    return float(np.median(np.hypot(d_ra, d_dec)) * 3600.0)
+
+
+def _fine_significance(shift_arcsec, new_resid, new_n):
+    """``t = |shift| / (sigma_axis / sqrt(n))`` — the fine fit's shift measured
+    against the estimation noise that adopting it costs.
+
+    This is the quantity the accept/reject decision is really about. Keeping the
+    pooled coarse attitude is right when the detector has no offset of its own,
+    because the pooled fit averages ~M times more pairs; taking the per-detector
+    fit is right when its offset exceeds the noise of estimating it. Comparing
+    residuals instead cannot express that trade-off: the fit is judged on a
+    RE-MATCHED sample rather than the one it minimized, so with no offset present
+    the comparison is a coin flip, and roughly half of the detectors that do
+    carry a real offset keep the coarse attitude anyway (measured on COSMOS
+    f410m/f210m: median t ~ 3.1-3.4 against a null expectation of 1.18, yet the
+    residual test accepted only 44-59%).
+
+    ``sigma_axis`` comes from the post-fit residual: for a 2-D Gaussian the
+    median radial deviation is ``sqrt(2 ln 2)`` per-axis sigmas.
+    """
+    if (not np.isfinite(shift_arcsec) or not np.isfinite(new_resid)
+            or new_n < 2 or new_resid <= 0):
+        return float('nan')
+    se = (new_resid / _RAYLEIGH_MEDIAN) / np.sqrt(new_n)
+    return float('inf') if se <= 0 else float(shift_arcsec / se)
 
 
 def _fine_fit(corr, detector, catalog, refcat, src_idx, ref_idx, geom, *,
@@ -294,7 +428,9 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
                          fine_min_rshift=4, fine_min_shift=3, tolerance=0.05,
                          match_radius=0.5, min_matched=6, min_coverage_arcsec=5.0,
                          ref_border_arcmin=1.2, nclip=3, sigma=3.0,
-                         max_residual_arcsec=0.1):
+                         max_residual_arcsec=0.1,
+                         dva_repivot=True, dva_pivot='pool',
+                         fine_min_significance=1.4):
     """Solve one pool of detectors; return a :class:`GroupSolution`.
 
     *detectors* is one pool (a module, or a whole channel when the caller pooled
@@ -326,20 +462,45 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
     WCS preserved), so a plausible-looking but wrong solution can never reach a
     mosaic. Healthy solves sit well under it (~0.02–0.03"); the COSMOS A2/A3
     misregistrations this guards against sat at 0.20–0.24". ``None`` disables.
+
+    Alongside the corrected WCSes the result carries diagnostics that permit
+    INDEPENDENT validation of the solve (nothing below gates anything): the
+    per-detection matched mask / separation / matched-refcat position for the
+    accepted WCS (:class:`DetectorSolution`), the footprint-clipped refcat
+    density, and the matcher's peak-confidence numbers
+    (:attr:`GroupSolution.diagnostics`) — the residual alone cannot expose a
+    confident lock onto the wrong sources, a low peak contrast can.
     """
     detectors = list(detectors)
     if not detectors:
         return GroupSolution(key, 'NOT_ALIGNED', None, None, None, 0, [])
 
+    # 0. Re-reference the per-detector DVA scale to a pool-common pivot, so the
+    #    pooled rigid fit is geometrically valid (see align/dva.py). A no-op for
+    #    a single-detector pool. `original_wcs` keeps the untouched input WCSes:
+    #    NOT_ALIGNED must preserve exactly what was on disk, and the re-pivot is
+    #    an unverified refinement until the pool actually solves.
+    original_wcs = {d.detector: d.wcs for d in detectors}
+    dva_info = None
+    if dva_repivot:
+        from campfire_pipeline.nircam.align.dva import repivot_pool_dva
+        detectors, dva_info = repivot_pool_dva(detectors, pivot=dva_pivot,
+                                               key=key)
+
+    def _orig(name, wcs):
+        """Reject path: hand back the WCS exactly as it arrived."""
+        return original_wcs.get(name, wcs)
+
     if not _has_radec(refcat) or len(refcat) < 3:
         log(f"align solve[{key}]: reference catalog missing 'RA'/'DEC' or "
             f"has <3 sources; NOT_ALIGNED (WCS preserved).")
         return _not_aligned(key, [(d.detector, d.wcs) for d in detectors],
-                            lambda name, wcs: wcs)
+                            _orig)
 
     # 1. Footprint-clip the field refcat to this pool's coverage + border. Fail
     #    open (keep the full refcat) on any geometry error — a per-pool worker
     #    must never crash the field.
+    n_ref_footprint = None
     try:
         clip = clip_refcat_to_exposure(refcat, [d.wcs for d in detectors],
                                        border_arcmin=ref_border_arcmin)
@@ -348,6 +509,9 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
                 f"{clip.n_kept}/{clip.n_total} sources "
                 f"(border {ref_border_arcmin:.2f}').")
         refcat = clip.table
+        # Reference density the coarse matcher actually worked against — the
+        # denominator for any independent read of the match count.
+        n_ref_footprint = int(clip.n_kept)
     except Exception as e:  # noqa: BLE001 — worker robustness; fail open
         log(f"align solve[{key}]: footprint clip failed ({type(e).__name__}: "
             f"{e}); using the full refcat.")
@@ -355,7 +519,7 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
         log(f"align solve[{key}]: only {len(refcat)} refcat sources inside the "
             f"footprint; NOT_ALIGNED (source-starved / outside-acquisition-bound).")
         return _not_aligned(key, [(d.detector, d.wcs) for d in detectors],
-                            lambda name, wcs: wcs)
+                            _orig, n_refcat=n_ref_footprint)
 
     wcs_by_det = {d.detector: d.wcs for d in detectors}
 
@@ -385,16 +549,20 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
         nfwhm=nfwhm, nsigma=hist_nsigma, histocut_order=histocut_order,
         slope_max=slope_max, slope_nsteps=slope_nsteps,
         delta_mag_lim=delta_mag_lim, image_mags=image_mags)
-    correctors, last_info, first_info, wcs_by_det = _coarse(
+    # Bound to locals (not passed as anonymous temporaries) so ``_coarse`` can
+    # read each matcher's peak-confidence stash back off the instance.
+    match0 = OffsetHistogramMatch(searchrad=coarse_searchrad, **hist_kwargs)
+    match_iter = OffsetHistogramMatch(searchrad=None, **hist_kwargs)
+    correctors, last_info, first_info, wcs_by_det, diag = _coarse(
         detectors, wcs_by_det, refcat, key,
-        match0=OffsetHistogramMatch(searchrad=coarse_searchrad, **hist_kwargs),
-        match_iter=OffsetHistogramMatch(searchrad=None, **hist_kwargs),
+        match0=match0, match_iter=match_iter,
         niter=refine_niter, nclip=nclip, sigma=sigma)
     if correctors is None or not _succeeded(last_info):
         log(f"align solve[{key}]: coarse fit "
             f"{last_info.get('status', 'FAILED')}; NOT_ALIGNED (WCS preserved).")
         return _not_aligned(key, [(d.detector, d.wcs) for d in detectors],
-                            lambda name, wcs: wcs)
+                            _orig, n_refcat=n_ref_footprint,
+                            diag=diag)
 
     # Provenance: the gross correction the input WCS was off by (pass 0), with
     # the converged fit's rmse as the quality.
@@ -410,9 +578,9 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
     #    enough sources match AND they span enough sky to condition a rotation.
     prelim = [_match(corr, d.catalog, ref_sky, match_radius)
               for corr, d in zip(correctors, detectors)]
-    group_nmatched = sum(n for _, n, _, _ in prelim)
+    group_nmatched = sum(p[1] for p in prelim)
     matched_ref = np.unique(np.concatenate(
-        [idx for _, _, _, idx in prelim] + [np.array([], dtype=int)]))
+        [p[3] for p in prelim] + [np.array([], dtype=int)]))
     coverage = _coverage_arcsec(ref_sky.ra.deg[matched_ref],
                                 ref_sky.dec.deg[matched_ref])
     if group_nmatched < min_matched or coverage < min_coverage_arcsec:
@@ -421,7 +589,11 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
             f"{min_coverage_arcsec:.1f}\"); rejecting to NOT_ALIGNED.")
         return _not_aligned(
             key, [(c.meta['name'], c) for c in correctors],
-            lambda name, c: c.original_wcs)
+            # c.original_wcs is the corrector's input — i.e. the RE-PIVOTED wcs.
+            # A rejected pool must hand back what was on disk.
+            lambda name, c: original_wcs.get(name, c.original_wcs),
+            n_refcat=n_ref_footprint,
+            diag=diag)
 
     mins = {'general': fine_min_general, 'rshift': fine_min_rshift,
             'shift': fine_min_shift}
@@ -435,8 +607,8 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
     #    pooled attitude — the better estimate at that point. `tolerance` no
     #    longer gates anything; it is the reporting threshold for `within`.
     solutions = []
-    for corr, d, (resid, nmatch, src_idx, ref_idx) in zip(correctors, detectors,
-                                                          prelim):
+    for corr, d, (resid, nmatch, src_idx, ref_idx, keep, sep) in zip(
+            correctors, detectors, prelim):
         within = bool(np.isfinite(resid) and resid <= tolerance)
         dof, out_wcs = 'coarse', corr.wcs
 
@@ -456,12 +628,31 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
                     tfi = {}
                     trial = None
                 if trial is not None and _succeeded(tfi):
-                    new_resid, new_n, _, _ = _match(trial, d.catalog, ref_sky,
-                                                    match_radius)
-                    if np.isfinite(new_resid) and new_resid < resid:
+                    (new_resid, new_n, new_src, new_ref, new_keep,
+                     new_sep) = _match(trial, d.catalog, ref_sky, match_radius)
+                    # Accept on the SIGNIFICANCE of the shift, not on a residual
+                    # improvement (see _fine_significance) — but never adopt a
+                    # fit that materially degrades the residual, however
+                    # significant its shift.
+                    tstat = _fine_significance(
+                        _fine_shift_arcsec(corr, trial, d.catalog, src_idx),
+                        new_resid, new_n)
+                    degraded = (np.isfinite(new_resid) and np.isfinite(resid)
+                                and new_resid > resid * _FINE_MAX_DEGRADE)
+                    if (np.isfinite(new_resid) and np.isfinite(tstat)
+                            and tstat > fine_min_significance and not degraded):
                         out_wcs, dof = trial.wcs, geom
                         resid, nmatch = new_resid, new_n
                         within = bool(resid <= tolerance)
+                        # Per-source diagnostics must describe the WCS actually
+                        # accepted, so adopt the post-fine re-match wholesale.
+                        src_idx, ref_idx = new_src, new_ref
+                        keep, sep = new_keep, new_sep
+
+        ref_ra, ref_dec = _ref_positions(len(d.catalog), src_idx, ref_idx,
+                                         ref_sky)
+        per_source = dict(n_detected=len(d.catalog), matched=keep,
+                          sep_arcsec=sep, ref_ra=ref_ra, ref_dec=ref_dec)
 
         # Residual gate (backstop): no solution this bad may reach a mosaic.
         # Gates only a *measured* bad residual — a nan residual (no one-to-one
@@ -472,16 +663,29 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
             log(f"align solve[{key}]: {d.detector} residual {resid:.3f}\" "
                 f"exceeds max_residual_arcsec={float(max_residual_arcsec):g}; "
                 f"rejecting this detector to NOT_ALIGNED (WCS preserved).")
-            solutions.append(DetectorSolution(d.detector, d.wcs, 'identity',
+            solutions.append(DetectorSolution(d.detector,
+                                              original_wcs.get(d.detector,
+                                                               d.wcs),
+                                              'identity',
                                               resid, nmatch, False,
-                                              aligned=False))
+                                              aligned=False, **per_source))
             continue
 
         solutions.append(DetectorSolution(d.detector, out_wcs, dof,
-                                          resid, nmatch, within))
+                                          resid, nmatch, within,
+                                          **per_source))
 
     # If the gate rejected every detector, the pool as a whole failed — report
     # NOT_ALIGNED so the orchestration surfaces it in the end-of-run warning.
     status = ('SOLVED' if any(s.aligned for s in solutions) else 'NOT_ALIGNED')
+    if dva_info is not None:
+        diag = dict(diag or {})
+        diag['dva_applied'] = bool(dva_info.get('applied'))
+        if dva_info.get('applied'):
+            diag['dva_pivot'] = dva_info['pivot']
+            diag['dva_va_scale'] = dva_info['va_scale']
+            diag['dva_max_shift_mas'] = dva_info['max_shift_mas']
     return GroupSolution(key, status, shift, rot_deg, rmse,
-                         group_nmatched, solutions)
+                         group_nmatched, solutions,
+                         n_refcat_in_footprint=n_ref_footprint,
+                         diagnostics=(diag or None))

--- a/pipeline/campfire_pipeline/nircam/align/solve.py
+++ b/pipeline/campfire_pipeline/nircam/align/solve.py
@@ -78,6 +78,10 @@ _REFINE_CONVERGE_ARCSEC = 0.01
 _FINE_LADDER = ('general', 'rshift', 'shift')
 # Geometries that fit a rotation and so need spatial coverage to be conditioned.
 _ROTATING = ('general', 'rshift')
+# Free parameters per fine-fit geometry (both coordinates counted): shift is
+# (dx, dy); rshift adds a rotation; rscale adds a scale; general is a full
+# affine. Used to normalize the acceptance statistic — see _fine_significance.
+_FITGEOM_NPARAM = {'shift': 2, 'rshift': 3, 'rscale': 4, 'general': 6}
 
 # Median of a 2-D Gaussian's radial deviation, in units of the per-axis sigma.
 _RAYLEIGH_MEDIAN = np.sqrt(2.0 * np.log(2.0))      # 1.1774
@@ -364,14 +368,18 @@ def _fine_shift_arcsec(coarse, trial, catalog, src_idx):
     ra0, dec0 = coarse.det_to_world(x, y)
     ra1, dec1 = trial.det_to_world(x, y)
     ra0 = np.asarray(ra0, dtype=float); dec0 = np.asarray(dec0, dtype=float)
-    d_ra = (np.asarray(ra1, dtype=float) - ra0) * np.cos(np.radians(dec0))
+    # Wrap the longitude difference into (-180, 180]: a detector straddling
+    # RA=0 otherwise reads a ~360 deg displacement for a milliarcsecond move,
+    # which would make a noise-only fit look overwhelmingly significant.
+    d_ra = (np.asarray(ra1, dtype=float) - ra0 + 180.0) % 360.0 - 180.0
+    d_ra *= np.cos(np.radians(dec0))
     d_dec = np.asarray(dec1, dtype=float) - dec0
     return float(np.median(np.hypot(d_ra, d_dec)) * 3600.0)
 
 
-def _fine_significance(shift_arcsec, new_resid, new_n):
-    """``t = |shift| / (sigma_axis / sqrt(n))`` — the fine fit's shift measured
-    against the estimation noise that adopting it costs.
+def _fine_significance(shift_arcsec, new_resid, new_n, geom='shift'):
+    """``t = |shift| / se(geom)`` — the fine fit's shift measured against the
+    estimation noise that adopting it costs.
 
     This is the quantity the accept/reject decision is really about. Keeping the
     pooled coarse attitude is right when the detector has no offset of its own,
@@ -386,11 +394,23 @@ def _fine_significance(shift_arcsec, new_resid, new_n):
 
     ``sigma_axis`` comes from the post-fit residual: for a 2-D Gaussian the
     median radial deviation is ``sqrt(2 ln 2)`` per-axis sigmas.
+
+    **Normalized for the fit geometry.** A richer geometry moves sources further
+    on noise alone: summing the leverage over the fitted points gives a mean
+    squared noise displacement of ``(p/2) * sigma^2/n`` for a ``p``-parameter fit,
+    so the standard error carries a ``sqrt(p/2)`` factor — 1.0 for ``shift``,
+    1.22 for ``rshift``, 1.41 for ``rscale``, 1.73 for ``general``. Without it a
+    noise-only ``general`` fit would score ~1.7x too high and clear the gate on
+    variance alone. With it, ``t`` is ~Rayleigh(1) under the null for EVERY
+    geometry, so one threshold has the same false-accept rate
+    (``exp(-k^2/2)``) throughout and the k derivation below stays valid.
     """
     if (not np.isfinite(shift_arcsec) or not np.isfinite(new_resid)
             or new_n < 2 or new_resid <= 0):
         return float('nan')
-    se = (new_resid / _RAYLEIGH_MEDIAN) / np.sqrt(new_n)
+    nparam = _FITGEOM_NPARAM.get(geom, 2)
+    se = (np.sqrt(nparam / 2.0) * (new_resid / _RAYLEIGH_MEDIAN)
+          / np.sqrt(new_n))
     return float('inf') if se <= 0 else float(shift_arcsec / se)
 
 
@@ -636,7 +656,7 @@ def solve_exposure_group(detectors, refcat, *, key='group', pool_modules=None,
                     # significant its shift.
                     tstat = _fine_significance(
                         _fine_shift_arcsec(corr, trial, d.catalog, src_idx),
-                        new_resid, new_n)
+                        new_resid, new_n, geom)
                     degraded = (np.isfinite(new_resid) and np.isfinite(resid)
                                 and new_resid > resid * _FINE_MAX_DEGRADE)
                     if (np.isfinite(new_resid) and np.isfinite(tstat)

--- a/pipeline/campfire_pipeline/nircam/association.py
+++ b/pipeline/campfire_pipeline/nircam/association.py
@@ -285,12 +285,17 @@ def split_pools(groups, *, pool_modules=False) -> List[ExposureGroup]:
     """Split each exposure group into the **pools** that share one coarse fit.
 
     The align coarse solve fits one rigid shift+rotation per pool. With
-    ``pool_modules`` (or a single-module group) the whole group is one pool;
-    otherwise each NIRCam module (A, B) becomes its own pool, so module A's
-    detectors and module B's are tied to the reference independently — the
-    default, since a spurious per-module SIAF offset then can't cross-contaminate
-    and each module still has enough sources to condition its own rotation (for
-    SW; LW-per-module is a single detector, the jhat-equivalent).
+    ``pool_modules`` (or a single-module group) the whole group is one pool —
+    the default; otherwise each NIRCam module (A, B) becomes its own pool, so
+    module A's detectors and module B's are tied to the reference independently
+    (for SW; LW-per-module is a single detector, the jhat-equivalent).
+
+    Pooling was previously off out of concern that a spurious per-module SIAF
+    offset would cross-contaminate the shared fit. The offset that motivated
+    that caution is not SIAF — it is differential velocity aberration, a scale
+    no pooled ``rshift`` can express, now removed deterministically upstream
+    (``align/dva.py``). With that fix a pooled solve leaves no per-module
+    systematic against the reference catalog (0.26 mas on f410m).
 
     Pool keys carry a ``:<module>`` suffix so per-pool provenance/logging stays
     distinct. A group with any unknown-module member is never split (kept whole),

--- a/pipeline/campfire_pipeline/nircam/orchestrate.py
+++ b/pipeline/campfire_pipeline/nircam/orchestrate.py
@@ -901,7 +901,7 @@ def _run_align(field, config, filtname, n_processes, overwrite, status,
             f"excluded_exposures list) and re-run, or select a supported subset "
             f"with --filters / --tiles.")
 
-    pools = split_pools(groups, pool_modules=align_cfg.get('pool_modules', False))
+    pools = split_pools(groups, pool_modules=align_cfg.get('pool_modules', True))
     refcat_path = _resolve_align_refcat(align_cfg, field.refcat_dir)
     refcat_hash = _refcat_hash(refcat_path)   # cheap; drives the staleness skip
     pending, retry = _pending_pools(pools, status, overwrite, refcat_hash)

--- a/pipeline/campfire_pipeline/nircam/steps/wcs_shift.py
+++ b/pipeline/campfire_pipeline/nircam/steps/wcs_shift.py
@@ -56,7 +56,14 @@ WCS_BAK_EXTNAME = 'WCS_BAK'
 # left in place they would read as current (the align skip check would trust
 # the stamp and never re-solve) while describing a WCS that no longer exists.
 _ALIGN_STAMP_KEYS = ('CFP_JHAT', 'CFP_ALGN')
-_ALGN_BAK_EXTNAME = 'ALGN_BAK'
+# Align's own extensions/keywords. Imported from the align I/O layer rather than
+# re-spelled, so a new diagnostic can never be added there and silently survive
+# a wcs_shift here. (align.apply does not import steps, so there is no cycle.)
+from campfire_pipeline.nircam.align.apply import (  # noqa: E402
+    ALGN_BAK_EXTNAME as _ALGN_BAK_EXTNAME,
+    ALGNCAT_EXTNAME as _ALGNCAT_EXTNAME,
+    ALGN_DIAG_COMMENTS as _ALGN_DIAG_KEYS,
+)
 
 
 def _scrub_alignment_state(model):
@@ -73,13 +80,18 @@ def _scrub_alignment_state(model):
     extra = getattr(model, 'extra_fits', None)
     if extra is None:
         return
-    if hasattr(extra, _ALGN_BAK_EXTNAME):
-        delattr(extra, _ALGN_BAK_EXTNAME)
+    # ALGNCAT holds each detection's sky position under the WCS align solved —
+    # which this step is about to replace. Carrying it (and its scalar
+    # diagnostics) across a shift would advertise stale positions as current, so
+    # both go with the alignment stamps.
+    for extname in (_ALGN_BAK_EXTNAME, _ALGNCAT_EXTNAME):
+        if hasattr(extra, extname):
+            delattr(extra, extname)
+    drop = set(_ALIGN_STAMP_KEYS) | set(_ALGN_DIAG_KEYS)
     prim = getattr(extra, 'PRIMARY', None)
     header = getattr(prim, 'header', None) if prim is not None else None
     if header is not None:
-        prim.header = [list(card) for card in header
-                       if card[0] not in _ALIGN_STAMP_KEYS]
+        prim.header = [list(card) for card in header if card[0] not in drop]
 
 
 def _match_rule(rootname, filtname, rules):

--- a/pipeline/tests/test_align_apply.py
+++ b/pipeline/tests/test_align_apply.py
@@ -162,6 +162,38 @@ def test_not_aligned_preserves_wcs(tmp_path):
         assert np.allclose(after, before[m.path], atol=1e-12)   # WCS untouched
 
 
+def test_not_aligned_clears_scalar_diagnostics(tmp_path):
+    """A file re-solved to NOT_ALIGNED must not keep the counts and peak
+    contrasts of the earlier SUCCESSFUL solve standing beside the rejection —
+    they would read as provenance for the rejected attempt."""
+    from astropy.io import fits
+
+    from campfire_pipeline.nircam.align.apply import (ALGN_DIAG_COMMENTS,
+                                                      ALGN_UNDEF)
+    members, refcat, _ = _make_exposure(tmp_path, n_det=2, seed=3)
+
+    sol = align_exposure_group(members, refcat, config={})
+    assert sol.status == 'SOLVED'
+    measured = [k for k in ALGN_DIAG_COMMENTS
+                if k != 'ALGNSTAL'
+                and fits.getheader(members[0].path, 0).get(k) != ALGN_UNDEF]
+    assert measured, 'expected the successful solve to record some diagnostics'
+
+    # now force a rejection on the same files
+    rng = np.random.default_rng(99)
+    badref = Table({'RA': 80.0 + rng.uniform(-0.05, 0.05, 30),
+                    'DEC': -30.0 + rng.uniform(-0.05, 0.05, 30)})
+    assert align_exposure_group(members, badref, config={},
+                                overwrite=True).status == 'NOT_ALIGNED'
+    for m in members:
+        hdr = fits.getheader(m.path, 0)
+        assert hdr['ALGNSTAL'] is True
+        for key in ALGN_DIAG_COMMENTS:
+            if key == 'ALGNSTAL':
+                continue
+            assert hdr[key] == ALGN_UNDEF, f'{key} kept a stale value'
+
+
 # --- idempotency / overwrite ------------------------------------------------
 
 def test_idempotent_skip(tmp_path):

--- a/pipeline/tests/test_align_apply.py
+++ b/pipeline/tests/test_align_apply.py
@@ -238,3 +238,84 @@ def test_fine_dof_recorded(tmp_path):
     # so unperturbed good detectors keep the pooled coarse attitude.
     assert 'dof=rshift' in _cfp_algn(members[4].path)
     assert any('dof=coarse' in _cfp_algn(m.path) for m in members[:4])
+
+
+# --- diagnostics (ALGNCAT + ALGN* keywords) ---------------------------------
+
+def test_algncat_written_and_matches_the_written_wcs(tmp_path):
+    # The per-source catalog exists so overlapping exposures can be cross-checked
+    # WITHOUT drizzling: its ra/dec must therefore be the positions the file's own
+    # (corrected) WCS gives, and its rows must line up with the detections.
+    from campfire_pipeline.nircam.align.apply import ALGNCAT_EXTNAME
+    from jwst.datamodels import ImageModel
+    members, refcat, _ = _make_exposure(tmp_path, n_det=2, offset=(2.0, 0.0))
+    sol = align_exposure_group(members, refcat, config={})
+    assert sol.status == 'SOLVED'
+
+    by_det = {d.detector: d for d in sol.detectors}
+    for m in members:
+        with fits.open(m.path) as h:
+            assert ALGNCAT_EXTNAME in h
+            cat = Table(h[ALGNCAT_EXTNAME].data)
+        assert len(cat) == by_det[m.detector].n_detected > 0
+        assert int(np.count_nonzero(cat['matched'])) == by_det[m.detector].n_matched
+        mo = ImageModel(m.path, memmap=False)
+        ra, dec = mo.meta.wcs(np.asarray(cat['x'], float),
+                             np.asarray(cat['y'], float))
+        mo.close()
+        assert np.allclose(ra, cat['ra'], atol=1e-9)
+        assert np.allclose(dec, cat['dec'], atol=1e-9)
+        # matched rows carry the refcat position (values, not indices) and the
+        # separation that got them accepted; unmatched rows carry neither.
+        got = cat['matched'].astype(bool)
+        assert np.all(np.isfinite(cat['ref_ra'][got]))
+        assert np.all(np.isnan(cat['ref_ra'][~got]))
+        assert np.all(cat['sep_arcsec'][got] <= 0.5)
+
+
+def test_algn_diag_keywords_all_present(tmp_path):
+    from campfire_pipeline.nircam.align.apply import ALGN_DIAG_COMMENTS
+    members, refcat, _ = _make_exposure(tmp_path, n_det=2)
+    align_exposure_group(members, refcat, config={})
+    with fits.open(members[0].path) as h:
+        hdr = h[0].header
+        # every key present (unmeasured ones carry the UNDEF sentinel, never a
+        # missing card — silence would let a re-solve leave a stale number)
+        for key, comment in ALGN_DIAG_COMMENTS.items():
+            assert key in hdr, key
+            assert hdr.comments[key] == comment
+        assert hdr['ALGNNDET'] > 0
+        assert hdr['ALGNNREF'] > 0
+        assert hdr['ALGNSTAL'] is False
+
+
+def test_algncat_replaced_not_accumulated_on_overwrite(tmp_path):
+    from campfire_pipeline.nircam.align.apply import ALGNCAT_EXTNAME
+    members, refcat, _ = _make_exposure(tmp_path, n_det=2)
+    align_exposure_group(members, refcat, config={})
+    align_exposure_group(members, refcat, config={}, overwrite=True)
+    align_exposure_group(members, refcat, config={}, overwrite=True)
+    for m in members:
+        with fits.open(m.path) as h:
+            assert [x.name for x in h].count(ALGNCAT_EXTNAME) == 1
+
+
+def test_not_aligned_rerun_marks_algncat_stale(tmp_path):
+    # A NOT_ALIGNED re-run keeps the WCS it already had, so a previous solve's
+    # ALGNCAT no longer describes it. The extension is left in place (dropping it
+    # would dangle the datamodel's extra_fits reference) and flagged instead.
+    from campfire_pipeline.nircam.align.apply import ALGNCAT_EXTNAME
+    members, refcat, _ = _make_exposure(tmp_path, n_det=2, seed=3)
+    assert align_exposure_group(members, refcat, config={}).status == 'SOLVED'
+    with fits.open(members[0].path) as h:
+        assert h[0].header['ALGNSTAL'] is False
+
+    rng = np.random.default_rng(99)
+    badref = Table({'RA': 80.0 + rng.uniform(-0.05, 0.05, 30),
+                    'DEC': -30.0 + rng.uniform(-0.05, 0.05, 30)})
+    sol = align_exposure_group(members, badref, config={}, overwrite=True)
+    assert sol.status == 'NOT_ALIGNED'
+    for m in members:
+        with fits.open(m.path) as h:
+            assert h[0].header['ALGNSTAL'] is True
+            assert ALGNCAT_EXTNAME in h        # kept, but flagged as stale

--- a/pipeline/tests/test_align_dva.py
+++ b/pipeline/tests/test_align_dva.py
@@ -1,0 +1,160 @@
+"""DVA re-referencing (align/dva.py).
+
+The property under test is geometric, not statistical: after re-referencing a
+pool to a shared pivot, the SEPARATION between two detectors' aperture reference
+points must scale by ``va_scale`` (it does not move at all under jwst's
+per-detector pivot), while the pool's centroid stays put.
+"""
+import numpy as np
+import pytest
+
+pytest.importorskip('jwst')
+pytest.importorskip('gwcs')
+
+from campfire_pipeline.nircam.align.dva import (  # noqa: E402
+    DVA_PIVOTS, repivot_pool_dva, va_scale_from_wcs)
+from campfire_pipeline.nircam.align.solve import DetectorInput  # noqa: E402
+
+VA = 1.0000732          # a real COSMOS value
+A = (85.93, -493.50)    # NRCALONG v2_ref, v3_ref (arcsec)
+B = (-89.40, -491.36)   # NRCBLONG
+SEP = float(np.hypot(A[0] - B[0], A[1] - B[1]))     # 175.34"
+
+
+def _wcs_with_dva(v2ref, v3ref, va_scale=VA):
+    """A JWST-structured gwcs carrying a DVA step about (v2ref, v3ref)."""
+    import astropy.units as u
+    import gwcs
+    from astropy import coordinates as coord
+    from astropy.modeling import models
+    from jwst.assign_wcs.pointing import dva_corr_model, v23tosky
+    from jwst.datamodels import ImageModel
+
+    stub = ImageModel()
+    for k, v in [('v2_ref', v2ref), ('v3_ref', v3ref), ('roll_ref', 30.0),
+                 ('ra_ref', 150.1), ('dec_ref', 2.2),
+                 ('v3yangle', 0.0), ('vparity', -1)]:
+        setattr(stub.meta.wcsinfo, k, v)
+    det = gwcs.coordinate_frames.Frame2D(name='detector', axes_order=(0, 1),
+                                         unit=(u.pix, u.pix))
+    v2v3 = gwcs.coordinate_frames.Frame2D(name='v2v3', axes_order=(0, 1),
+                                          unit=(u.arcsec, u.arcsec))
+    vacorr = gwcs.coordinate_frames.Frame2D(name='v2v3vacorr',
+                                            axes_order=(0, 1),
+                                            unit=(u.arcsec, u.arcsec))
+    world = gwcs.coordinate_frames.CelestialFrame(
+        reference_frame=coord.ICRS(), name='world')
+    det2v2v3 = ((models.Shift(-512.0) & models.Shift(-512.0))
+                | (models.Scale(0.063) & models.Scale(0.063))
+                | (models.Shift(v2ref) & models.Shift(v3ref)))
+    w = gwcs.wcs.WCS([(det, det2v2v3),
+                      (v2v3, dva_corr_model(va_scale, v2ref, v3ref)),
+                      (vacorr, v23tosky(stub)),
+                      (world, None)])
+    w.bounding_box = ((-0.5, 1023.5), (-0.5, 2047.5))
+    return w
+
+
+def _pool(va_a=VA, va_b=VA):
+    return [
+        DetectorInput('nrcalong', _wcs_with_dva(*A, va_scale=va_a),
+                      {'v2_ref': A[0], 'v3_ref': A[1], 'roll_ref': 30.0}, None),
+        DetectorInput('nrcblong', _wcs_with_dva(*B, va_scale=va_b),
+                      {'v2_ref': B[0], 'v3_ref': B[1], 'roll_ref': 30.0}, None),
+    ]
+
+
+def _vacorr_of_ref(det):
+    """Where this detector's own aperture reference lands in v2v3vacorr."""
+    t = det.wcs.get_transform('v2v3', 'v2v3vacorr')
+    return np.array(t(det.wcsinfo['v2_ref'], det.wcsinfo['v3_ref']), float)
+
+
+def test_va_scale_read_back_from_wcs():
+    assert va_scale_from_wcs(_wcs_with_dva(*A)) == pytest.approx(VA, rel=1e-12)
+
+
+def test_va_scale_none_without_dva_step():
+    from tests._align_gwcs import HAVE_PERSISTABLE_WCS, make_persistable_wcs
+    if not HAVE_PERSISTABLE_WCS:
+        pytest.skip('no persistable wcs builder')
+    assert va_scale_from_wcs(make_persistable_wcs()) is None
+
+
+def test_jwst_pivot_leaves_reference_points_fixed():
+    """The defect itself: under jwst's per-detector pivot the reference points
+    do not move, so their separation keeps the full aberration."""
+    a, b = _pool()
+    pa, pb = _vacorr_of_ref(a), _vacorr_of_ref(b)
+    assert pa == pytest.approx(np.array(A), abs=1e-9)
+    assert pb == pytest.approx(np.array(B), abs=1e-9)
+    assert float(np.hypot(*(pa - pb))) == pytest.approx(SEP, abs=1e-9)
+
+
+def test_repivot_scales_the_separation():
+    out, info = repivot_pool_dva(_pool(), pivot='pool', key='t')
+    assert info['applied'] is True
+    pa, pb = _vacorr_of_ref(out[0]), _vacorr_of_ref(out[1])
+    # the whole point: separation now carries the aberration scale
+    assert float(np.hypot(*(pa - pb))) == pytest.approx(VA * SEP, rel=1e-12)
+    # ... and the pool centroid is untouched by the 'pool' pivot
+    centroid = 0.5 * (pa + pb)
+    assert centroid == pytest.approx(
+        np.array([0.5 * (A[0] + B[0]), 0.5 * (A[1] + B[1])]), abs=1e-9)
+    # reported shift matches (va_scale - 1) * half-separation
+    assert info['max_shift_mas'] == pytest.approx(
+        abs(VA - 1.0) * SEP / 2 * 1e3, rel=1e-9)
+
+
+def test_repivot_boresight_also_scales_separation():
+    out, info = repivot_pool_dva(_pool(), pivot='boresight', key='t')
+    assert info['applied'] is True
+    pa, pb = _vacorr_of_ref(out[0]), _vacorr_of_ref(out[1])
+    assert float(np.hypot(*(pa - pb))) == pytest.approx(VA * SEP, rel=1e-12)
+
+
+def test_single_detector_pool_is_a_noop():
+    pool = _pool()[:1]
+    out, info = repivot_pool_dva(pool, key='t')
+    assert info['applied'] is False
+    assert out[0].wcs is pool[0].wcs          # same object, not even copied
+
+
+def test_inputs_are_not_mutated():
+    pool = _pool()
+    before = _vacorr_of_ref(pool[0]).copy()
+    repivot_pool_dva(pool, key='t')
+    assert _vacorr_of_ref(pool[0]) == pytest.approx(before, abs=1e-12)
+
+
+def test_realistic_va_scale_spread_still_applies():
+    """Regression: each detector's va_scale is evaluated at its own reference
+    point, so real data carries a ~1e-8 spread. An exact-equality guard rejects
+    every real pool (observed: 216/216 f410m pools skipped). The guard must
+    judge the spread in mas across the pool's lever arm, not as a raw float."""
+    out, info = repivot_pool_dva(_pool(va_b=VA + 1.4e-8), key='t')
+    assert info['applied'] is True, info.get('reason')
+    # 1.4e-8 over an ~88" half-lever is ~1e-3 mas — utterly negligible
+    pa, pb = _vacorr_of_ref(out[0]), _vacorr_of_ref(out[1])
+    assert float(np.hypot(*(pa - pb))) == pytest.approx(VA * SEP, rel=1e-8)
+
+
+def test_inconsistent_va_scale_bails():
+    """A spread large enough to imply >1 mas across the pool is a real anomaly."""
+    out, info = repivot_pool_dva(_pool(va_b=VA * 1.001), key='t')
+    assert info['applied'] is False
+    assert 'inconsistent' in info['reason']
+
+
+def test_unknown_pivot_bails():
+    out, info = repivot_pool_dva(_pool(), pivot='nonsense', key='t')
+    assert info['applied'] is False
+
+
+def test_va_scale_one_is_a_noop():
+    out, info = repivot_pool_dva(_pool(va_a=1.0, va_b=1.0), key='t')
+    assert info['applied'] is False
+
+
+def test_pivots_constant_is_honest():
+    assert set(DVA_PIVOTS) == {'pool', 'boresight'}

--- a/pipeline/tests/test_align_dva.py
+++ b/pipeline/tests/test_align_dva.py
@@ -75,7 +75,7 @@ def test_va_scale_read_back_from_wcs():
 
 
 def test_va_scale_none_without_dva_step():
-    from tests._align_gwcs import HAVE_PERSISTABLE_WCS, make_persistable_wcs
+    from _align_gwcs import HAVE_PERSISTABLE_WCS, make_persistable_wcs
     if not HAVE_PERSISTABLE_WCS:
         pytest.skip('no persistable wcs builder')
     assert va_scale_from_wcs(make_persistable_wcs()) is None

--- a/pipeline/tests/test_align_fine_gate.py
+++ b/pipeline/tests/test_align_fine_gate.py
@@ -1,0 +1,74 @@
+"""Fine-fit acceptance gate: significance of the shift, not residual improvement.
+
+The decision is a bias/variance trade-off — keep the pooled coarse attitude
+(which averages ~M times more pairs) unless this detector's own offset exceeds
+the noise of estimating it. These tests pin the statistic and the guard rails,
+not the tuning constant.
+"""
+import numpy as np
+import pytest
+
+from campfire_pipeline.nircam.align.solve import (  # noqa: E402
+    _FINE_MAX_DEGRADE, _RAYLEIGH_MEDIAN, _fine_significance)
+
+
+def se_for(resid, n):
+    """The standard error the gate divides by."""
+    return (resid / _RAYLEIGH_MEDIAN) / np.sqrt(n)
+
+
+def test_rayleigh_median_constant():
+    # median radial deviation of a 2-D Gaussian = sqrt(2 ln 2) * sigma_axis
+    rng = np.random.default_rng(1)
+    e = rng.normal(0, 3.0, size=(200000, 2))
+    assert np.median(np.hypot(*e.T)) == pytest.approx(3.0 * _RAYLEIGH_MEDIAN,
+                                                      rel=0.01)
+
+
+def test_significance_is_shift_over_standard_error():
+    resid, n = 0.019, 100
+    se = se_for(resid, n)
+    assert _fine_significance(3.0 * se, resid, n) == pytest.approx(3.0, rel=1e-9)
+    assert _fine_significance(0.5 * se, resid, n) == pytest.approx(0.5, rel=1e-9)
+
+
+def test_significance_scales_with_match_count():
+    """Four times the pairs halves the noise, so the same shift is twice as
+    significant — the property that makes a fixed threshold scale-free."""
+    resid = 0.019
+    shift = 0.002
+    t_small = _fine_significance(shift, resid, 25)
+    t_large = _fine_significance(shift, resid, 100)
+    assert t_large == pytest.approx(2.0 * t_small, rel=1e-9)
+
+
+def test_significance_scales_with_scatter():
+    """A noisier detector needs a bigger shift to clear the same bar."""
+    assert (_fine_significance(0.002, 0.040, 64)
+            < _fine_significance(0.002, 0.020, 64))
+
+
+def test_significance_guards_degenerate_inputs():
+    assert not np.isfinite(_fine_significance(np.nan, 0.02, 100))
+    assert not np.isfinite(_fine_significance(0.002, np.nan, 100))
+    assert not np.isfinite(_fine_significance(0.002, 0.02, 1))    # n < 2
+    assert not np.isfinite(_fine_significance(0.002, 0.0, 100))   # resid <= 0
+
+
+def test_default_threshold_accepts_real_offsets_rejects_noise():
+    """At the shipped k=1.4, a COSMOS-typical real offset is accepted and a
+    noise-level one is not. Numbers from the f410m calibration: sigma ~19 mas,
+    n ~ 285 -> se ~ 0.95 mas; observed real offsets ~3 mas."""
+    k = 1.4
+    resid, n = 0.019, 285
+    se = se_for(resid, n)
+    assert se * 1e3 == pytest.approx(0.95, abs=0.15)
+    assert _fine_significance(0.003, resid, n) > k       # real 3 mas offset
+    assert _fine_significance(0.0005, resid, n) < k      # 0.5 mas: noise
+
+
+def test_degrade_guard_is_above_median_noise():
+    """The degradation guard must not fire on ordinary noise in the median
+    residual (~1.06/sqrt(n), i.e. ~14% at n=60) but must catch real damage."""
+    assert _FINE_MAX_DEGRADE > 1.0 + 1.06 / np.sqrt(60)
+    assert _FINE_MAX_DEGRADE < 2.0

--- a/pipeline/tests/test_align_fine_gate.py
+++ b/pipeline/tests/test_align_fine_gate.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 from campfire_pipeline.nircam.align.solve import (  # noqa: E402
-    _FINE_MAX_DEGRADE, _RAYLEIGH_MEDIAN, _fine_significance)
+    _FINE_MAX_DEGRADE, _RAYLEIGH_MEDIAN, _fine_significance)  # noqa: F401
 
 
 def se_for(resid, n):
@@ -65,6 +65,51 @@ def test_default_threshold_accepts_real_offsets_rejects_noise():
     assert se * 1e3 == pytest.approx(0.95, abs=0.15)
     assert _fine_significance(0.003, resid, n) > k       # real 3 mas offset
     assert _fine_significance(0.0005, resid, n) < k      # 0.5 mas: noise
+
+
+def test_significance_is_normalized_for_fit_geometry():
+    """A richer geometry moves sources further on noise alone (mean squared
+    noise displacement ~ (p/2)*sigma^2/n), so the same shift must score LOWER
+    for it. Without this a noise-only `general` fit clears the gate on variance.
+    """
+    resid, n = 0.019, 100
+    shift = 3.0 * se_for(resid, n)
+    t = {g: _fine_significance(shift, resid, n, g)
+         for g in ('shift', 'rshift', 'rscale', 'general')}
+    assert t['shift'] == pytest.approx(3.0, rel=1e-9)
+    assert t['rshift'] == pytest.approx(3.0 / np.sqrt(3 / 2), rel=1e-9)
+    assert t['rscale'] == pytest.approx(3.0 / np.sqrt(2.0), rel=1e-9)
+    assert t['general'] == pytest.approx(3.0 / np.sqrt(3.0), rel=1e-9)
+    assert t['shift'] > t['rshift'] > t['rscale'] > t['general']
+
+
+def test_unknown_geometry_falls_back_to_translation():
+    resid, n = 0.019, 100
+    assert (_fine_significance(0.002, resid, n, 'nonsense')
+            == pytest.approx(_fine_significance(0.002, resid, n, 'shift')))
+
+
+def test_fine_shift_wraps_ra_at_the_meridian():
+    """A detector straddling RA=0 must not read a ~360 deg displacement for a
+    milliarcsecond move."""
+    from astropy.table import Table
+
+    from campfire_pipeline.nircam.align.solve import _fine_shift_arcsec
+
+    class _Stub:
+        def __init__(self, dra_deg):
+            self._d = dra_deg
+
+        def det_to_world(self, x, y):
+            # sources straddling the meridian: 359.9999 deg and 0.0001 deg
+            ra = np.array([359.9999, 0.0001, 359.99995])
+            return (ra + self._d) % 360.0, np.array([2.2, 2.2, 2.2])
+
+    cat = Table({'x': [1.0, 2.0, 3.0], 'y': [1.0, 2.0, 3.0]})
+    idx = np.array([0, 1, 2])
+    moved = 1.0 / 3.6e6                      # 1 mas in degrees
+    got = _fine_shift_arcsec(_Stub(0.0), _Stub(moved), cat, idx)
+    assert got == pytest.approx(0.001, rel=0.02)     # 1 mas, not ~1.3e6 arcsec
 
 
 def test_degrade_guard_is_above_median_noise():

--- a/pipeline/tests/test_align_solve.py
+++ b/pipeline/tests/test_align_solve.py
@@ -290,14 +290,19 @@ def test_match_measures_small_offset():
                             meta={'catalog': d.catalog, 'group_id': 'g',
                                   'name': d.detector})
     ref_sky = SkyCoord(refcat['RA'], refcat['DEC'], unit='deg')
-    resid, n, src_idx, ref_idx = _match(corr, d.catalog, ref_sky,
-                                        match_radius=0.5)
+    resid, n, src_idx, ref_idx, keep, sep = _match(corr, d.catalog, ref_sky,
+                                                   match_radius=0.5)
     assert n >= 30
     assert 0.15 < resid < 0.25
     assert len(ref_idx) == len(src_idx) == n
     # mutual NN => a genuine one-to-one pairing on both sides
     assert len(np.unique(ref_idx)) == n
     assert len(np.unique(src_idx)) == n
+    # per-source diagnostics: full-length, row-aligned with the catalog
+    assert keep.shape == sep.shape == (len(d.catalog),)
+    assert np.count_nonzero(keep) == n
+    assert np.array_equal(np.flatnonzero(keep), src_idx)
+    assert np.all(sep[keep] <= 0.5)
 
 
 # --- clustered extragalactic refcat (the XYXYMatch overflow regime) ---------

--- a/pipeline/tests/test_wcs_shift.py
+++ b/pipeline/tests/test_wcs_shift.py
@@ -45,12 +45,20 @@ def _canonical(tmp_path):
 
 
 def _stamp_aligned(path):
-    """Simulate a completed alignment: CFP stamps + align's ALGN_BAK baseline."""
+    """Simulate a completed alignment: CFP stamps, align's ALGN_BAK baseline,
+    and the per-source ALGNCAT + scalar diagnostics a real solve writes."""
+    from astropy.table import Table
     with fits.open(path, mode='update') as h:
         h[0].header['CFP_ALGN'] = 'dof=rshift res=0.01 n=12 rc=abcd1234'
         h[0].header['CFP_JHAT'] = 'gaia.ecsv'
+        h[0].header['ALGNNMAT'] = 12
+        h[0].header['ALGNGCON'] = 5.5
+        h[0].header['ALGNSTAL'] = False
         h.append(fits.ImageHDU(data=np.arange(4, dtype=np.uint8),
                                name='ALGN_BAK'))
+        h.append(fits.BinTableHDU(
+            Table({'ra': [80.0, 80.1], 'dec': [-30.0, -30.1]}),
+            name='ALGNCAT'))
 
 
 def _probe_ra(path):
@@ -75,6 +83,12 @@ def test_first_apply_invalidates_alignment(tmp_path):
         assert 'CFP_ALGN' not in hdr                # stale stamps cleared
         assert 'CFP_JHAT' not in hdr
         assert 'ALGN_BAK' not in h                  # stale baseline dropped
+        # ALGNCAT holds sky positions under the WCS align solved, which this
+        # step just replaced — it must not survive advertising them as current.
+        assert 'ALGNCAT' not in h
+        assert 'ALGNNMAT' not in hdr                # scalar diagnostics too
+        assert 'ALGNGCON' not in hdr
+        assert 'ALGNSTAL' not in hdr
         assert 'WCS_BAK' in h                       # own backup written
         assert 'SRCMASK' in h                       # untouched by the drop
 


### PR DESCRIPTION
Two related astrometric fixes to the NIRCam `align` step, plus the diagnostics that made them measurable.

**Changelog:** 2 × Algorithm + 1 × Infrastructure → **MINOR**.
**Blast radius: output changes for every NIRCam exposure.** 102 align tests pass.

---

## 1. Inter-detector DVA is uncorrected in the delivered WCS

`jwst.assign_wcs` corrects differential velocity aberration **per detector, scaling about that detector's own aperture reference** (`nircam.py` passes `meta.wcsinfo.v2_ref/v3_ref` into `dva_corr_model`, which builds `v' = v_ref + va_scale·(v − v_ref)`). Each reference point therefore never moves, and the *separation between* two detectors keeps the full aberration:

```
residual = (1 − va_scale) × |Δv_ref|
```

For the NIRCam LW pair (|Δv_ref| = 175.34″) at COSMOS's |1 − va_scale| ~ 1e-4 that is **~13 mas**.

**Evidence** (3258 COSMOS LW exposures):
- The module differential matches the prediction in sign and magnitude — ratio 0.92 / 1.10 in the field's two visibility windows, where `VA_SCALE` straddles 1.
- It lies **entirely along the module baseline** (perpendicular component +0.14 ± 3.62 mas).
- It does *not* rotate with roll, because the roll flip and the velocity flip are correlated and cancel — which is why it initially looked like an inexplicable sky-fixed vector.
- Independent checks: `|Δv_ref|` = 175.34″ matches the on-sky module separation; the SIP↔gwcs representation error is sub-mas; the matcher histogram bin is 1.26 mas — both alternative explanations ruled out.

### The fix

The residual is a pure **scale** about a point outside each detector, which a pooled `rshift` cannot express. Rebuilding the DVA transform about a **pool-common pivot**, using jwst's own `dva_corr_model`, removes it. Per detector this is a pure shift of `(va_scale − 1)·(v_ref − v_pivot)`.

- Strict no-op for a single-detector pool — **verified bit-exact** on real data.
- **SW output changes**: a module's four detectors span ~130″, so they carry ~5 mas of the same error today.
- Rejected pools and residual-gated detectors still hand back the untouched on-disk WCS.
- Fails open on every anomaly (no DVA step, `va_scale == 1`, inconsistent `va_scale`, unknown pivot).

### On the pivot choice

Whether the per-aperture pivot is deliberate is an **open STScI question** — [`spacetelescope/jwst#9400`](https://github.com/spacetelescope/jwst/issues/9400) (JIRA JP-3987) asks exactly this and has been unanswered since 2025-04. It traces to Cox in [PR #5602](https://github.com/spacetelescope/jwst/pull/5602) (2021), whose algebra carried an explicit precondition — *"presumes the pointing direction is more or less towards the V2V3 reference point"* — validated only over "a 200 arc-sec area corresponding roughly to a typical detector."

**It does not matter here.** The pivot cancels out of the relative geometry (`v'_i − v'_j = va_scale·(v_i − v_j)` for any common pivot), so guide star, boresight and pool centroid are equivalent for relative astrometry. `pool` is the default because it is the only choice that leaves single-detector pools bit-exact — boresight would impose a 34.5 mas common shift.

---

## 2. Fine-fit acceptance on significance, not residual improvement

Choosing between the pooled coarse attitude and a detector's own fit is a bias/variance trade-off: the pool averages ~M× more pairs, so keeping it is right when the detector has no offset of its own, and the individual fit is right when that offset exceeds the noise of estimating it.

The old test `new_resid < resid` could not express this — it judged the fit on a **re-matched** sample rather than the one the fit minimized, so with no offset present it was a coin flip.

```python
accept iff  |shift| > fine_min_significance · σ_axis/√n   and not degraded
```

**Calibrated with the fine fit disabled**, so per-detector offsets were observed *unbiased* — in a normal run accepted detectors have the offset fitted away and rejected ones are selected for having a small one:

| | median t | null | real offset | fit noise |
|---|---|---|---|---|
| f410m (2-det pools) | 3.10 | 1.18 | 2.98 mas | 0.97 mas |
| f210m (8-det pools) | 3.41 | 1.18 | 5.03 mas | 1.40 mas |

The old test behaved like `t > 3`, accepting only 44% / 59% and leaving **1.69 / 1.96 mas** of per-detector error. `k = 1.4` leaves **0.94 / 1.39 mas** (−44% / −29%).

Theory agrees independently: minimum MSE sits at `√(2 − 1/M)` = 1.22 (M=2) to 1.41 (M=8), and the empirical optimum landed on **exactly** those values. The optimum is flat over 1.0–1.5, so the choice is not delicate.

**End-to-end validation** (f410m pooled; f210m in the production pool config):

| arm | fine accepted | was | refcat A−B | NOT_ALIGNED |
|---|---|---|---|---|
| f410m LW | 93.3% | 72% | 0.264 mas | 0 |
| f210m SW | 91.0% | 52% | 0.157 mas | 0 |

A fit whose residual degrades by >25% is still rejected however significant its shift. The ladder floors, coverage gate and `max_residual_arcsec` backstop are unchanged.

---

## 3. Diagnostics for independent validation

`ALGNCAT` per-detector table (every detection, its sky position under the written WCS, whether/how far it matched the reference) plus `ALGN*` scalar header keywords. Nothing in the pipeline reads them — they exist to be audited, and **both calibrations above were measured from them**.

---

## 4. Module pooling on by default

`[nircam.align].pool_modules` flipped `false` → `true`.

Pooling was off because a spurious per-module SIAF offset could cross-contaminate the shared fit. That offset is **not** SIAF — it is the velocity aberration of section 1, a scale no pooled `rshift` can express, now removed deterministically. The original objection no longer applies.

With both fixes a pooled solve leaves no per-module systematic: on f410m the module-to-module offset against the reference catalog is **0.26 mas** with **93.3%** of detectors carrying their own fine fit, and no new NOT_ALIGNED.

**Pooling is established safe; its benefit is not quantified.** Under the old acceptance test it was a wash on f410m (0.215 vs 0.210 mas), and no matched non-pooled arm was run under the new one. It is enabled because a shared coarse fit is better conditioned — twice the sources for LW, where a per-module pool is a single detector — which should help sparse / low-match exposures, the regime that remains untested. `pool_modules = false` restores per-module fits.

Note this is a **global** default: it applies to every field, not just `cosmos`.

---

## Risks a reviewer should weigh

- **Every NIRCam exposure changes.** Mosaics will need re-combining.
- **The gate is calibrated on COSMOS** (σ ≈ 19 mas, n ≳ 60, median n = 63). The statistic is scale-free by construction, but it is **untested in the sparse-match regime** — which is exactly where the field's remaining NOT_ALIGNED exposures live. `fine_min_significance = 0` accepts every non-degrading fit; the old behaviour is not recoverable by config.
- **`pool_modules` is flipped to `true` (global default, all fields).** Established *safe*, but its *benefit is unquantified* — see section 4.
- The DVA fix is verified on LW (bit-exact no-op) and SW (32 f210m exposures). SW coverage is a subset, not the full filter.

Generated with Claude Code

