### PR TITLE
NIRCam mosaics: tier-0 pre-tier for large extended sources

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -29,6 +29,27 @@ Release procedure: edit the `## Unreleased` section below, then run
 ## Unreleased
 
 ### Algorithm
+- Mosaic background subtraction gains a **large-extended-source pre-tier**
+  (tier 0) in `[nircam.resample]`, fixing a galaxy-shaped over-subtraction bowl.
+  A galaxy far larger than `bg_box_size` is over-subtracted *even when fully
+  masked at the pixel level*: `Background2D` keeps mesh cells masked out to
+  `bg_exclude_percentile` at the galaxy edge, samples its outskirts there, and
+  `BkgZoomInterpolator` extrapolates that gradient inward — a galaxy-shaped
+  `+30..90e-3 MJy/sr` bowl, 4–11σ of sky. The mechanism is the **mesh boundary**,
+  not the pixel mask, so making the source mask deeper does not help; tier 0
+  instead masks the bright core plus a heavy dilation (600 px) so the mesh
+  boundary lands on true sky. Selectivity is what keeps it safe: `nsigma = 100`
+  with `npixels = 30000` admits only objects with a ≥30k-pixel core above 100σ —
+  ~4 per COSMOS 30 mas tile, versus ~120 at 5σ — so the normal aggressive
+  flattening of ordinary galaxy wings is unchanged everywhere else, and it is a
+  strict no-op on tiles with no such object. Verified over a full 152-mosaic
+  COSMOS LW campaign (11 filters, restored from `_i2d_before_bkgsub`): 152/152
+  succeeded, tier 0 fired on 50 tiles and no-opped on the other 102, and in the
+  four LW bands covering the extreme galaxy the 10–21″ annulus went from a
+  `+0.25` bowl to `+2.98e-3` against `σ_sky ~ 7e-3`. Deliberately **not** applied
+  to the per-exposure `[nircam.bkg.mask]` tiers: 30k px / 600 px are sized for a
+  30 mas mosaic tile, not a 2048² frame. Affected mosaics need `--overwrite` to
+  pick up the fix.
 - NIRCam `align` now **pools both modules into one coarse fit by default**
   (`[nircam.align].pool_modules`, flipped `false` → `true`). Pooling was off
   because a spurious per-module SIAF offset could cross-contaminate the shared

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -723,10 +723,20 @@
     ring_clip_max_sigma = 5.0
     ring_clip_box_size = 100
     ring_clip_filter_size = 3
-    tier_kernel_size = [25, 15, 5, 2]
-    tier_npixels = [15, 10, 3, 1]
-    tier_nsigma = [1.5, 1.5, 1.5, 1.5]
-    tier_dilate_size = [33, 25, 21, 19]
+    # Tier 0 is a large-extended-source PRE-tier (see nircam/bkgsub.py). It fires
+    # only on objects with a >=30k-pixel core above 100*sigma — ~4 per COSMOS
+    # 30mas tile — and exists because a galaxy far larger than bg_box_size is
+    # over-subtracted even when fully masked at pixel level: Background2D keeps
+    # mesh cells masked at the galaxy edge, samples its outskirts there, and the
+    # zoom interpolator extrapolates that gradient inward as a galaxy-shaped
+    # bowl. The heavy dilation (600 px) pushes the mesh boundary out to true sky.
+    # A no-op on tiles with no such object. Deliberately NOT applied to the
+    # per-exposure [nircam.bkg.mask] tiers above: 30k px / 600 px dilation are
+    # sized for a 30mas mosaic tile, not a 2048^2 frame.
+    tier_kernel_size = [25, 25, 15, 5, 2]
+    tier_npixels = [30000, 15, 10, 3, 1]
+    tier_nsigma = [100.0, 1.5, 1.5, 1.5, 1.5]
+    tier_dilate_size = [600, 33, 25, 21, 19]
     bg_box_size = 10
     bg_filter_size = 5
     bg_exclude_percentile = 90

--- a/pipeline/campfire_pipeline/nircam/bkgsub.py
+++ b/pipeline/campfire_pipeline/nircam/bkgsub.py
@@ -82,10 +82,25 @@ class SubtractBackground:
     ring_downsample: int = 1
 
     # -- Tiered source masking -------------------------------------------------
-    tier_kernel_size: list = field(default_factory=lambda: [25, 15, 5, 2])
-    tier_npixels: list = field(default_factory=lambda: [15, 10, 3, 1])
-    tier_nsigma: list = field(default_factory=lambda: [1.5, 1.5, 1.5, 1.5])
-    tier_dilate_size: list = field(default_factory=lambda: [33, 25, 21, 19])
+    # Tier 0 is a large-extended-source pre-tier that fires ONLY on the handful
+    # of extremely bright, large galaxies (and comparably bright stars) per tile.
+    # A galaxy far larger than ``bg_box_size`` is fully masked at the pixel level
+    # yet still over-subtracted: ``Background2D`` keeps mesh cells up to
+    # ``bg_exclude_percentile`` masked at the galaxy edge, samples its outskirts
+    # there, and the zoom interpolator extrapolates that gradient inward (a
+    # galaxy-shaped +30..90e-3 MJy/sr bowl, 4-11 sigma of sky). Tier 0 masks the
+    # bright core + a heavy dilation so the mesh boundary lands on true sky.
+    # Selectivity: a HIGH ``tier_nsigma`` (100) plus a large ``tier_npixels``
+    # (30k min connected area) means only objects with a >=30k-px core above
+    # 100*sigma survive -- ~4 per COSMOS 30mas tile (vs ~120 at 5*sigma), so the
+    # normal aggressive flattening of ordinary galaxy wings is UNCHANGED
+    # everywhere else. The heavy ``tier_dilate_size`` (600) compensates for the
+    # small high-sigma footprint and reaches the galaxy's sky radius. It is a
+    # no-op on tiles with no such object. Tiers 1-4 are the compact-source cascade.
+    tier_kernel_size: list = field(default_factory=lambda: [25, 25, 15, 5, 2])
+    tier_npixels: list = field(default_factory=lambda: [30000, 15, 10, 3, 1])
+    tier_nsigma: list = field(default_factory=lambda: [100.0, 1.5, 1.5, 1.5, 1.5])
+    tier_dilate_size: list = field(default_factory=lambda: [600, 33, 25, 21, 19])
 
     # -- Background estimation -------------------------------------------------
     bg_box_size: int = 10

--- a/pipeline/tests/test_nircam_bkg.py
+++ b/pipeline/tests/test_nircam_bkg.py
@@ -374,14 +374,14 @@ def _extended_galaxy_scene(rng, n=1600, re=150.0, amp=200.0):
     return sci, np.ones((n, n), np.float32), r
 
 
-def _tier_cfg(tier0=False, nsigma0=100.0):
-    """Mosaic tiers, using the SHIPPED tier-0 values. *nsigma0* is exposed only
-    so a test can show that threshold is load-bearing."""
+def _tier_cfg(tier0=False, nsigma0=100.0, npixels0=30000):
+    """Mosaic tiers, using the SHIPPED tier-0 values. *nsigma0* / *npixels0* are
+    exposed only so a test can toggle ONE gate and show it is load-bearing."""
     base = dict(ring_radius_in=80, ring_width=4, ring_downsample=4,
                 bg_box_size=10, bg_filter_size=5)
     if tier0:
         return dict(base, tier_kernel_size=[25, 25, 15, 5, 2],
-                    tier_npixels=[30000, 15, 10, 3, 1],
+                    tier_npixels=[npixels0, 15, 10, 3, 1],
                     tier_nsigma=[nsigma0, 1.5, 1.5, 1.5, 1.5],
                     tier_dilate_size=[600, 33, 25, 21, 19])
     return dict(base, tier_kernel_size=[25, 15, 5, 2],
@@ -413,10 +413,17 @@ def test_tier0_removes_extended_source_oversubtraction_bowl():
     assert abs(fixed) < 0.35 * bowl          # observed ~0.18x
 
 
-def test_tier0_is_a_noop_without_a_large_bright_source():
-    """Ordinary compact sources must not trip tier 0, so their wings keep the
-    normal aggressive flattening. Here `npixels` is what rejects them — see
-    test_tier0_nsigma_is_load_bearing for the other half of the selectivity."""
+def test_tier0_is_a_noop_on_an_ordinary_field():
+    """End-to-end safety property: on a field of ordinary compact sources tier 0
+    must not fire at all, so their wings keep the normal aggressive flattening.
+
+    A realistic-scene check, NOT a test of either gate individually. `nsigma` is
+    what rejects here — after the tier-0 kernel (gaussian_filter, sigma=25) these
+    blobs peak at a*s^2/(s^2+25^2) = 2.18 and 2.87 against a 100-sigma threshold,
+    so detect_sources returns None before npixels is ever consulted (setting
+    npixels to 1 gives a byte-identical mask). The two gates are covered
+    individually by the two tests below.
+    """
     rng = np.random.default_rng(5)
     n = 400
     y, x = np.mgrid[:n, :n]
@@ -428,6 +435,31 @@ def test_tier0_is_a_noop_without_a_large_bright_source():
     m0, _ = SubtractBackground(**_tier_cfg(tier0=False)).mask_from_arrays(sci, err)
     m1, _ = SubtractBackground(**_tier_cfg(tier0=True)).mask_from_arrays(sci, err)
     assert np.array_equal(m0, m1)
+
+
+def test_tier0_npixels_is_load_bearing():
+    """`npixels = 30000` must do real selectivity work. This source is BRIGHT
+    enough to clear the 100-sigma threshold after smoothing (peak
+    a*s^2/(s^2+25^2) = 400*900/1525 = 236) but COMPACT, so its footprint stays
+    under the 30k floor and only npixels can reject it."""
+    rng = np.random.default_rng(11)
+    n, amp, sb = 600, 400.0, 30.0
+    y, x = np.mgrid[:n, :n]
+    sci = (rng.normal(0.0, 1.0, (n, n))
+           + amp * np.exp(-(((x - n / 2) ** 2 + (y - n / 2) ** 2)
+                            / (2 * sb ** 2)))).astype(np.float32)
+    err = np.ones((n, n), np.float32)
+
+    def mask(cfg):
+        return SubtractBackground(**cfg).mask_from_arrays(sci, err)[0]
+
+    baseline = mask(_tier_cfg(tier0=False))
+    shipped = mask(_tier_cfg(tier0=True))                    # npixels = 30000
+    lowered = mask(_tier_cfg(tier0=True, npixels0=500))      # only npixels changed
+
+    assert np.array_equal(shipped, baseline)   # the 30k floor rejects it: no-op
+    assert not np.array_equal(lowered, baseline)
+    assert lowered.mean() > 0.9
 
 
 def test_tier0_nsigma_is_load_bearing():

--- a/pipeline/tests/test_nircam_bkg.py
+++ b/pipeline/tests/test_nircam_bkg.py
@@ -374,14 +374,15 @@ def _extended_galaxy_scene(rng, n=1600, re=150.0, amp=200.0):
     return sci, np.ones((n, n), np.float32), r
 
 
-def _tier_cfg(tier0=False):
-    """Mosaic tiers, using the SHIPPED tier-0 values."""
+def _tier_cfg(tier0=False, nsigma0=100.0):
+    """Mosaic tiers, using the SHIPPED tier-0 values. *nsigma0* is exposed only
+    so a test can show that threshold is load-bearing."""
     base = dict(ring_radius_in=80, ring_width=4, ring_downsample=4,
                 bg_box_size=10, bg_filter_size=5)
     if tier0:
         return dict(base, tier_kernel_size=[25, 25, 15, 5, 2],
                     tier_npixels=[30000, 15, 10, 3, 1],
-                    tier_nsigma=[100.0, 1.5, 1.5, 1.5, 1.5],
+                    tier_nsigma=[nsigma0, 1.5, 1.5, 1.5, 1.5],
                     tier_dilate_size=[600, 33, 25, 21, 19])
     return dict(base, tier_kernel_size=[25, 15, 5, 2],
                 tier_npixels=[15, 10, 3, 1], tier_nsigma=[1.5, 1.5, 1.5, 1.5],
@@ -413,8 +414,9 @@ def test_tier0_removes_extended_source_oversubtraction_bowl():
 
 
 def test_tier0_is_a_noop_without_a_large_bright_source():
-    """Selectivity: nsigma=100 with npixels=30000 admits only a >=30k-pixel core
-    above 100 sigma, so ordinary galaxy wings keep their normal flattening."""
+    """Ordinary compact sources must not trip tier 0, so their wings keep the
+    normal aggressive flattening. Here `npixels` is what rejects them — see
+    test_tier0_nsigma_is_load_bearing for the other half of the selectivity."""
     rng = np.random.default_rng(5)
     n = 400
     y, x = np.mgrid[:n, :n]
@@ -428,22 +430,63 @@ def test_tier0_is_a_noop_without_a_large_bright_source():
     assert np.array_equal(m0, m1)
 
 
-def test_shipped_mosaic_tier_config_is_coherent():
-    """The mosaic tiers actually shipped carry tier 0 and stay the same length
-    (the four lists are consumed in lockstep); the per-exposure tiers
-    deliberately do NOT — 30k px / 600 px are sized for a mosaic tile."""
+def test_tier0_nsigma_is_load_bearing():
+    """`nsigma = 100` must do real selectivity work, not ride along behind
+    `npixels`. This scene is deliberately BROAD but FAINT — its smoothed
+    footprint is far past the 30k-pixel floor, so `npixels` cannot reject it and
+    only the 100-sigma threshold can. Dropping nsigma to 1.5 fires tier 0 and
+    swallows the frame; at the shipped 100 the mask is untouched."""
+    rng = np.random.default_rng(7)
+    n, amp, s = 1000, 25.0, 150.0
+    y, x = np.mgrid[:n, :n]
+    sci = (rng.normal(0.0, 1.0, (n, n))
+           + amp * np.exp(-(((x - n / 2) ** 2 + (y - n / 2) ** 2)
+                            / (2 * s ** 2)))).astype(np.float32)
+    err = np.ones((n, n), np.float32)
+
+    def mask(cfg):
+        return SubtractBackground(**cfg).mask_from_arrays(sci, err)[0]
+
+    baseline = mask(_tier_cfg(tier0=False))
+    shipped = mask(_tier_cfg(tier0=True))                 # nsigma = 100
+    lowered = mask(_tier_cfg(tier0=True, nsigma0=1.5))    # only nsigma changed
+
+    assert np.array_equal(shipped, baseline)   # 100 sigma rejects it: no-op
+    assert not np.array_equal(lowered, baseline)
+    assert lowered.mean() > 0.9                # 1.5 sigma would swallow the frame
+
+
+def test_shipped_mosaic_tier_config_is_coherent(tmp_path):
+    """Pin the tiers as SHIPPED. Both the config and the field file are given
+    explicitly: `load_config()` would deep-merge $CAMPFIRE_ROOT/config/config.toml
+    and `Field.load()` without `fields_file=` raises on a clean checkout, so the
+    unqualified calls would test the developer's machine rather than the package
+    (and would not run in CI at all)."""
+    from pathlib import Path
+
+    import campfire_pipeline
     from campfire_pipeline.config import get_nircam_step_config, load_config
     from campfire_pipeline.nircam.field import Field
 
-    cfg = load_config()
+    packaged = Path(campfire_pipeline.__file__).parent / 'data' / 'config_default.toml'
+    cfg = load_config(config_path=str(packaged))
+    ff = tmp_path / 'fields.toml'
+    ff.write_text('[cosmos]\n'
+                  'filters = ["f444w"]\n'
+                  'files = ["jw01727*"]\n'
+                  'tangent_point = [150.1, 2.1]\n')
+    field = Field.load('cosmos', fields_file=str(ff))     # no step overrides
+    assert not field.step_overrides
+
     keys = ('tier_kernel_size', 'tier_npixels', 'tier_nsigma',
             'tier_dilate_size')
-    mosaic = get_nircam_step_config('resample', cfg, Field.load('cosmos'))
-    assert {len(mosaic[k]) for k in keys} == {5}
+    mosaic = get_nircam_step_config('resample', cfg, field)
+    assert {len(mosaic[k]) for k in keys} == {5}          # consumed in lockstep
     assert mosaic['tier_nsigma'][0] == 100.0
     assert mosaic['tier_npixels'][0] == 30000
     assert mosaic['tier_dilate_size'][0] == 600
 
-    per_exp = (get_nircam_step_config('bkg', cfg, Field.load('cosmos'))
-               .get('mask') or {})
+    # per-exposure deliberately keeps 4 tiers: 30k px / 600 px are sized for a
+    # 30mas mosaic tile, not a 2048^2 frame
+    per_exp = get_nircam_step_config('bkg', cfg, field).get('mask') or {}
     assert {len(per_exp[k]) for k in keys} == {4}

--- a/pipeline/tests/test_nircam_bkg.py
+++ b/pipeline/tests/test_nircam_bkg.py
@@ -355,3 +355,95 @@ def test_skymatch_invariant_and_banding_removal():
     before, after = band_std(sci), band_std(out)
     for amp in 'ABCD':
         assert after[amp] < 0.3 * before[amp]
+
+
+def _extended_galaxy_scene(rng, n=1600, re=150.0, amp=200.0):
+    """Mostly-sky frame with one very bright, very extended galaxy at centre.
+
+    Three properties are load-bearing and each was found the hard way:
+    a de Vaucouleurs (r^1/4) profile, because a Gaussian's wing is too steep to
+    bias the mesh at all; NO truncation, because a hard cut puts clean sky just
+    outside the mask and removes the bias entirely; and a frame the galaxy
+    occupies only a small part of, because otherwise the galaxy inflates the RMS
+    the 100-sigma tier-0 threshold is measured against and tier 0 never fires.
+    """
+    y, x = np.mgrid[:n, :n]
+    r = np.hypot(x - n / 2, y - n / 2)
+    prof = amp * np.exp(-7.669 * ((np.maximum(r, 1e-3) / re) ** 0.25 - 1.0))
+    sci = (rng.normal(0.0, 1.0, (n, n)) + prof).astype(np.float32)
+    return sci, np.ones((n, n), np.float32), r
+
+
+def _tier_cfg(tier0=False):
+    """Mosaic tiers, using the SHIPPED tier-0 values."""
+    base = dict(ring_radius_in=80, ring_width=4, ring_downsample=4,
+                bg_box_size=10, bg_filter_size=5)
+    if tier0:
+        return dict(base, tier_kernel_size=[25, 25, 15, 5, 2],
+                    tier_npixels=[30000, 15, 10, 3, 1],
+                    tier_nsigma=[100.0, 1.5, 1.5, 1.5, 1.5],
+                    tier_dilate_size=[600, 33, 25, 21, 19])
+    return dict(base, tier_kernel_size=[25, 15, 5, 2],
+                tier_npixels=[15, 10, 3, 1], tier_nsigma=[1.5, 1.5, 1.5, 1.5],
+                tier_dilate_size=[33, 25, 21, 19])
+
+
+def test_tier0_removes_extended_source_oversubtraction_bowl():
+    """A galaxy far larger than bg_box_size is over-subtracted even when fully
+    masked at pixel level: Background2D keeps mesh cells up to
+    bg_exclude_percentile masked at the galaxy edge, samples its outskirts
+    there, and the zoom interpolator extrapolates that gradient inward. Tier 0
+    pushes the mesh boundary out to true sky."""
+    rng = np.random.default_rng(4)
+    sci, err, radius = _extended_galaxy_scene(rng)
+    assert int((sci > 100.0).sum()) > 30000, 'scene must trip the tier-0 floor'
+
+    without = SubtractBackground(**_tier_cfg(tier0=False))
+    m0, _ = without.mask_from_arrays(sci, err)
+    bowl = float(without.estimate_background(sci, m0).background[radius < 50].mean())
+
+    with_t0 = SubtractBackground(**_tier_cfg(tier0=True))
+    m1, _ = with_t0.mask_from_arrays(sci, err)
+    fixed = float(with_t0.estimate_background(sci, m1).background[radius < 50].mean())
+
+    # Guard: without a real bowl the comparison below passes vacuously.
+    assert bowl > 3.0, f'scene did not reproduce the bowl (got {bowl:.2f} sigma)'
+    assert m1.mean() > m0.mean()             # tier 0 actually fired
+    assert abs(fixed) < 0.35 * bowl          # observed ~0.18x
+
+
+def test_tier0_is_a_noop_without_a_large_bright_source():
+    """Selectivity: nsigma=100 with npixels=30000 admits only a >=30k-pixel core
+    above 100 sigma, so ordinary galaxy wings keep their normal flattening."""
+    rng = np.random.default_rng(5)
+    n = 400
+    y, x = np.mgrid[:n, :n]
+    sci = rng.normal(0.0, 1.0, (n, n)).astype(np.float32)
+    for cx, cy, a, s in ((100, 120, 40.0, 6.0), (280, 300, 25.0, 9.0)):
+        sci += a * np.exp(-(((x - cx) ** 2 + (y - cy) ** 2) / (2 * s ** 2)))
+    err = np.ones((n, n), np.float32)
+
+    m0, _ = SubtractBackground(**_tier_cfg(tier0=False)).mask_from_arrays(sci, err)
+    m1, _ = SubtractBackground(**_tier_cfg(tier0=True)).mask_from_arrays(sci, err)
+    assert np.array_equal(m0, m1)
+
+
+def test_shipped_mosaic_tier_config_is_coherent():
+    """The mosaic tiers actually shipped carry tier 0 and stay the same length
+    (the four lists are consumed in lockstep); the per-exposure tiers
+    deliberately do NOT — 30k px / 600 px are sized for a mosaic tile."""
+    from campfire_pipeline.config import get_nircam_step_config, load_config
+    from campfire_pipeline.nircam.field import Field
+
+    cfg = load_config()
+    keys = ('tier_kernel_size', 'tier_npixels', 'tier_nsigma',
+            'tier_dilate_size')
+    mosaic = get_nircam_step_config('resample', cfg, Field.load('cosmos'))
+    assert {len(mosaic[k]) for k in keys} == {5}
+    assert mosaic['tier_nsigma'][0] == 100.0
+    assert mosaic['tier_npixels'][0] == 30000
+    assert mosaic['tier_dilate_size'][0] == 600
+
+    per_exp = (get_nircam_step_config('bkg', cfg, Field.load('cosmos'))
+               .get('mask') or {})
+    assert {len(per_exp[k]) for k in keys} == {4}


### PR DESCRIPTION
Fixes a galaxy-shaped over-subtraction bowl in mosaic background subtraction.

**Changelog:** Algorithm → **MINOR** (changes pixel values wherever tier 0 fires).

## The bug

A galaxy far larger than `bg_box_size` is over-subtracted **even when it is already fully masked at the pixel level**. The mechanism is the **mesh**, not the pixel mask:

1. `Background2D` keeps mesh cells that are up to `bg_exclude_percentile` (90%) masked,
2. so at the galaxy edge it samples the galaxy's *outskirts* rather than sky,
3. and `BkgZoomInterpolator` extrapolates that gradient inward.

Result: a galaxy-shaped `+30..90e-3 MJy/sr` bowl — **4–11σ of sky**.

Because the mask is not the problem, deepening it does not help. The mesh boundary has to be pushed out to true sky, which is what tier 0's heavy dilation (600 px) does.

## Why it is safe

Selectivity. `nsigma = 100` with `npixels = 30000` admits only objects with a **≥30k-pixel core above 100σ** — roughly **4 per COSMOS 30 mas tile, versus ~120 at 5σ**. Ordinary galaxy wings keep their normal aggressive flattening, and the pre-tier is a strict no-op on tiles containing no such object.

Applied to `[nircam.resample]` (mosaics) only — **not** to the per-exposure `[nircam.bkg.mask]` tiers, where 30k px / 600 px would be nonsense on a 2048² frame.

> ⚠️ Worth a reviewer's attention: the config supplies these lists **explicitly**, so changing only the dataclass default would have been **inert in a real run**. Both are updated, and a test pins the effective config.

## Validation on real data

Full 152-mosaic COSMOS LW campaign (11 filters, each restored from its `_i2d_before_bkgsub`):

- **152/152** succeeded, zero errors
- tier 0 fired on **50** tiles, no-opped on **102**
- in the four LW bands covering the extreme galaxy, the 10–21″ annulus went from a **+0.25 bowl to +2.98e-3**, against `σ_sky ~ 7e-3`

## Tests

Three, all passing (16 in the file, 23 s).

The mechanism test reproduces the bowl synthetically, and getting it to do so required three properties I only found by failing:

| property | why |
|---|---|
| de Vaucouleurs `r^1/4` profile | a Gaussian wing is too steep to bias the mesh at all (0.15σ) |
| **no** truncation | a hard cut puts clean sky just outside the mask and removes the bias entirely |
| mostly-sky frame | otherwise the galaxy inflates the RMS the 100σ threshold is measured against, and **tier 0 never fires** |

It asserts the bowl **exists** before asserting it is removed, so it cannot pass vacuously: **+22.4σ → +4.1σ**. A second test pins the no-op on ordinary fields (masks bit-identical); a third pins the shipped config — 5 tiers, all four lists equal length, per-exposure still 4.

## Note for deployment

Affected mosaics need `--overwrite` to pick up the fix.

Generated with Claude Code
