### PR TITLE
Fix import-skip upsert omitting the NOT NULL detector column

### DIFF
--- a/python/campfire/deploy/nircam_exclusions.py
+++ b/python/campfire/deploy/nircam_exclusions.py
@@ -102,7 +102,7 @@ def import_skip(field, config, dry_run=False):
 
     client = get_supabase_client(config)
     resp = (client.table('nircam_exposures')
-            .select('filter,filename,review_status')
+            .select('filter,detector,filename,review_status')
             .eq('field', field)
             .execute())
     rows = resp.data or []
@@ -127,9 +127,16 @@ def import_skip(field, config, dry_run=False):
         return
 
     now = _utcnow_iso()
+    # `detector` must be carried through even though this only ever UPDATEs an
+    # existing row: Postgres validates NOT NULL on the proposed INSERT tuple
+    # BEFORE resolving ON CONFLICT, so omitting a NOT NULL column with no
+    # default (nircam_exposures.detector) fails the whole upsert with 23502.
+    # Every other NOT NULL column is either supplied here or has a default
+    # (id -> nextval, stage -> 'uncal', correction -> 'none').
     updates = [{
         'field': field,
         'filter': row['filter'],
+        'detector': row['detector'],
         'filename': row['filename'],
         'review_status': 'excluded',
         'updated_at': now,

--- a/python/tests/test_nircam_exclusions.py
+++ b/python/tests/test_nircam_exclusions.py
@@ -19,9 +19,16 @@ class _FakeQuery:
         self._rows = rows
         self._eq = []
         self._in = None
+        self._cols = None
         self._sink = sink
 
     def select(self, *a, **k):
+        # Honour PostgREST column projection: a column the caller did not ask
+        # for is NOT present on the returned rows. Without this the fake hands
+        # back every fixture key and a missing column in the real `.select()`
+        # goes undetected (that is how the `detector` NOT-NULL bug shipped).
+        cols = ','.join(str(x) for x in a if x)
+        self._cols = [c.strip() for c in cols.split(',') if c.strip()] or None
         return self
 
     def eq(self, col, val):
@@ -47,6 +54,9 @@ class _FakeQuery:
             rows = [r for r in rows if r.get(col) in vals]
         for col, val in self._eq:
             rows = [r for r in rows if r.get(col) == val]
+        if self._cols and '*' not in self._cols:
+            rows = [{k: v for k, v in r.items() if k in self._cols}
+                    for r in rows]
         return types.SimpleNamespace(data=rows)
 
 
@@ -144,9 +154,9 @@ def _patch_field_skip(monkeypatch, skip):
 def test_import_skip_matches_globs_additive(monkeypatch):
     _patch_field_skip(monkeypatch, ['jw1_04101_'])  # prefix glob, like fields.toml
     rows = [
-        {'field': 'cosmos', 'filter': 'f444w', 'filename': 'jw1_04101_00003_nrcalong', 'review_status': 'pending'},
-        {'field': 'cosmos', 'filter': 'f444w', 'filename': 'jw1_04101_00001_nrcalong', 'review_status': 'excluded'},  # already
-        {'field': 'cosmos', 'filter': 'f200w', 'filename': 'jw1_02101_00002_nrca1', 'review_status': 'approved'},  # no match
+        {'field': 'cosmos', 'filter': 'f444w', 'detector': 'nrcalong', 'filename': 'jw1_04101_00003_nrcalong', 'review_status': 'pending'},
+        {'field': 'cosmos', 'filter': 'f444w', 'detector': 'nrcalong', 'filename': 'jw1_04101_00001_nrcalong', 'review_status': 'excluded'},  # already
+        {'field': 'cosmos', 'filter': 'f200w', 'detector': 'nrca1', 'filename': 'jw1_02101_00002_nrca1', 'review_status': 'approved'},  # no match
     ]
     client = _patch_client(monkeypatch, rows)
     nx.import_skip('cosmos', config={})
@@ -158,9 +168,36 @@ def test_import_skip_matches_globs_additive(monkeypatch):
     assert batch[0]['review_status'] == 'excluded'
 
 
+# Columns on `nircam_exposures` that are NOT NULL with no DB default. Postgres
+# validates NOT NULL on the PROPOSED INSERT tuple BEFORE resolving ON CONFLICT,
+# so an upsert omitting any of these fails with 23502 even though import_skip
+# only ever updates a row that already exists. (`id` -> nextval, `stage` ->
+# 'uncal', `correction` -> 'none' all carry defaults and may be omitted.)
+_NOT_NULL_NO_DEFAULT = ('field', 'filter', 'detector', 'filename')
+
+
+def test_import_skip_upsert_payload_carries_not_null_columns(monkeypatch):
+    """Regression: the upsert payload omitted `detector` and every real
+    import-skip run died with 23502 (null value in column "detector").
+    The fake client cannot enforce NOT NULL, so assert the contract directly.
+    """
+    _patch_field_skip(monkeypatch, ['jw1_04101_'])
+    rows = [{'field': 'cosmos', 'filter': 'f444w', 'detector': 'nrcblong',
+             'filename': 'jw1_04101_00003_nrcblong', 'review_status': 'pending'}]
+    client = _patch_client(monkeypatch, rows)
+    nx.import_skip('cosmos', config={})
+
+    assert len(client.upserts) == 1
+    payload = client.upserts[0][0]
+    missing = [c for c in _NOT_NULL_NO_DEFAULT if payload.get(c) is None]
+    assert not missing, f"upsert payload omits NOT NULL column(s): {missing}"
+    # carried through from the row, not invented
+    assert payload['detector'] == 'nrcblong'
+
+
 def test_import_skip_dry_run_no_write(monkeypatch):
     _patch_field_skip(monkeypatch, ['jw1_04101_'])
-    rows = [{'field': 'cosmos', 'filter': 'f444w',
+    rows = [{'field': 'cosmos', 'filter': 'f444w', 'detector': 'nrcalong',
              'filename': 'jw1_04101_00003_nrcalong', 'review_status': 'pending'}]
     client = _patch_client(monkeypatch, rows)
     nx.import_skip('cosmos', config={}, dry_run=True)


### PR DESCRIPTION
Found while deploying the new `a2744` field: `campfire deploy nircam import-skip` is broken for **every** field with a non-empty `[<field>].skip`.

```
APIError 23502: null value in column "detector" of relation
"nircam_exposures" violates not-null constraint
```

## Cause

`import_skip()` upserted a payload of only `{field, filter, filename, review_status, updated_at}`, but `nircam_exposures.detector` is `NOT NULL` with no default (`supabase/schemas/tables.sql:809`).

Postgres validates NOT NULL on the **proposed INSERT tuple before resolving `ON CONFLICT`**, so `INSERT ... ON CONFLICT DO UPDATE` fails even though `import_skip` only ever updates a row that already exists.

Ruled out: the conflict target was correct. `nircam_exposures_unique` is `UNIQUE (field, filter, filename)` (`tables.sql:1662`) — a mismatched `on_conflict` raises 42P10, not 23502.

## Fix

Select `detector` and carry it into the payload. An audit of the table confirms this is the complete fix, not a partial one that would fail on the next column:

| column | NOT NULL | default | supplied? |
|---|---|---|---|
| `id` | yes | `nextval` | n/a |
| `field` / `filter` / `filename` | yes | none | already |
| `detector` | yes | **none** | **was missing** |
| `stage` | yes | `uncal` | n/a |
| `correction` | yes | `none` | n/a |
| `review_status` | yes | `pending` | already |

## Why the tests missed it

The fake Supabase client ignored `.select()` arguments — rows carried every fixture key regardless of what was requested — and its `.upsert()` recorded the payload without enforcing NOT NULL. So a missing column was invisible on both sides.

This PR makes the fake honour PostgREST column projection, and adds a regression test asserting the payload carries every NOT NULL column lacking a default. **Verified non-vacuous:** it fails without the source fix and passes with it. Existing fixtures gained the `detector` key they should always have had (it is NOT NULL in the real table).

`501 passed, 9 skipped` across `python/tests/`.

## Verified end-to-end against production (field `a2744`)

- `import-skip` excluded both detectors of a guide-star-failed exposure — `Excluded 2 exposure(s)`
- post-write dry-run matched 0, confirming the write landed
- re-running was a clean no-op, so additive-only/idempotent semantics hold
- `deploy nircam pull` materialized them into `reference/nircam/a2744/exposures.json`
- the pipeline honoured that file independently of the `fields.toml` skip glob, resolving 538 of 540 exposures

Generated with Claude Code