### PR TITLE
Fix race condition in triage state during navigation

### DIFF
--- a/web/app/admin/nircam/[id]/page.tsx
+++ b/web/app/admin/nircam/[id]/page.tsx
@@ -63,10 +63,36 @@ function ExposureDetailPageInner() {
   const [correction, setCorrection] = useState<string>('none');
   const [notes, setNotes] = useState<string>('');
 
+  // Whether the operator has touched / persisted the triage panel for the
+  // exposure currently on screen. The background revalidation below fires on
+  // arrival and lands 100-300 ms later — long after a fast operator has already
+  // pressed 2 — so it must not write over what they set. Without these guards
+  // the status visibly flips back to the DB value, `hasChanges` goes false, and
+  // the auto-save on → silently skips: the exposure flashes Approved for a frame
+  // and stays Pending. Reset on every route-id change (below), so arriving at a
+  // fresh exposure still takes the server's values.
+  const localEditsRef = useRef({ dirty: false, saved: false });
+  const editStatus = useCallback((v: string) => {
+    localEditsRef.current.dirty = true;
+    setReviewStatus(v);
+  }, []);
+  const editCorrection = useCallback((v: string) => {
+    localEditsRef.current.dirty = true;
+    setCorrection(v);
+  }, []);
+  const editNotes = useCallback((v: string) => {
+    localEditsRef.current.dirty = true;
+    setNotes(v);
+  }, []);
+
   // Sibling-exposure nav: the ±window neighbors + absolute position within
   // the filtered, ordered set, from get_admin_exposure_neighbors. Survives
   // refresh and direct entry because the filter context lives in the URL.
-  const [nav, setNav] = useState<ExposureNeighbors | null>(null);
+  // Tagged with the id it was fetched for: `id` changes the instant we push, but
+  // the neighbors RPC for the new exposure takes another round trip to land.
+  const [navState, setNavState] = useState<
+    { forId: number; data: ExposureNeighbors } | null
+  >(null);
   const [showHelp, setShowHelp] = useState(false);
   // N4 (epic #261): live FITS render vs the legacy pre-generated PNG. Defaults
   // to PNG; the toggle doubles as the pixel-parity check during the rollout.
@@ -82,10 +108,33 @@ function ExposureDetailPageInner() {
     let cancelled = false;
     getExposureNeighbors(id, { ...navFilters, window: PREFETCH_AHEAD }).then((res) => {
       if (cancelled) return;
-      setNav(res.error || res.total === 0 ? null : res);
+      setNavState(res.error || res.total === 0 ? null : { forId: id, data: res });
     });
     return () => { cancelled = true; };
   }, [id, navFilters]);
+
+  // While that RPC is in flight, `navState` still describes the exposure we just
+  // left, and using it verbatim mis-targets both arrows: → points at the current
+  // exposure (a no-op push, so hammering → appears to stick) and ← skips one.
+  // The stale window almost always already contains the new id, so re-derive
+  // prev/next/position from it — instant and correct for the single-step case.
+  // Only when the new id falls outside that window do we report "no nav" and let
+  // the arrows sit disabled for the ~100 ms until the fresh result lands.
+  const nav = useMemo<ExposureNeighbors | null>(() => {
+    if (!navState) return null;
+    if (navState.forId === id) return navState.data;
+    const stale = navState.data;
+    const idx = stale.windowIds.indexOf(id);
+    const fromIdx = stale.windowIds.indexOf(navState.forId);
+    if (idx < 0 || fromIdx < 0) return null;
+    return {
+      prevId: idx > 0 ? stale.windowIds[idx - 1] : null,
+      nextId: idx < stale.windowIds.length - 1 ? stale.windowIds[idx + 1] : null,
+      position: stale.position != null ? stale.position + (idx - fromIdx) : null,
+      total: stale.total,
+      windowIds: stale.windowIds,
+    };
+  }, [navState, id]);
 
   // When the route id changes, reset state synchronously from the in-memory
   // cache so the new exposure paints in the same frame as the URL change —
@@ -102,11 +151,14 @@ function ExposureDetailPageInner() {
     setLoading(!cached);
     setError(null);
     setSaved(false);
+    localEditsRef.current = { dirty: false, saved: false };
   }
 
   // Background revalidation against the DB on every id change. Auto-save on
-  // navigation has already flushed any dirty triage state, so it's safe to
-  // overwrite the editable fields with the freshly-fetched values.
+  // navigation has already flushed the *previous* exposure's triage state, so
+  // arriving clean means the server's values win. But this read races the
+  // operator: anything they've typed or keyed since arriving, and any save that
+  // has already landed, is newer than this response and must survive it.
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -118,11 +170,18 @@ function ExposureDetailPageInner() {
         return;
       }
       if (result.exposure) {
-        setCachedExposure(result.exposure);
-        setExposure(result.exposure);
-        setReviewStatus(result.exposure.review_status);
-        setCorrection(result.exposure.correction);
-        setNotes(result.exposure.notes || '');
+        const edits = localEditsRef.current;
+        // A save for this exposure already landed — our write is strictly newer
+        // than this read, so don't let it back into state *or* the cache.
+        if (!edits.saved) {
+          setCachedExposure(result.exposure);
+          setExposure(result.exposure);
+        }
+        if (!edits.dirty) {
+          setReviewStatus(result.exposure.review_status);
+          setCorrection(result.exposure.correction);
+          setNotes(result.exposure.notes || '');
+        }
       }
       setLoading(false);
     })();
@@ -214,6 +273,7 @@ function ExposureDetailPageInner() {
       return { ok: false };
     }
     if (result.exposure) {
+      localEditsRef.current.saved = true;
       setCachedExposure(result.exposure);
       setExposure(result.exposure);
     }
@@ -225,14 +285,16 @@ function ExposureDetailPageInner() {
   // Auto-save on nav: mirror inspection mode — flush dirty triage so the
   // operator can blast through a queue with arrow keys without losing state.
   const goTo = useCallback(async (targetId: number | null) => {
-    if (targetId == null) return;
+    // targetId === id means the neighbor window is stale in a way the derivation
+    // above couldn't repair; pushing would be a no-op that looks like a step.
+    if (targetId == null || targetId === id) return;
     if (stateRef.current.hasChanges) {
       const result = await handleSave();
       if (!result.ok) return; // don't navigate on a save failure
     }
     // Carry the filter context so the next exposure's nav walks the same set.
     router.push(`/admin/nircam/${targetId}${navQuery ? `?${navQuery}` : ''}`);
-  }, [handleSave, router, navQuery]);
+  }, [handleSave, router, navQuery, id]);
 
   const handleNext = useCallback(() => goTo(nav?.nextId ?? null), [goTo, nav]);
   const handlePrev = useCallback(() => goTo(nav?.prevId ?? null), [goTo, nav]);
@@ -248,9 +310,9 @@ function ExposureDetailPageInner() {
       if (e.metaKey || e.ctrlKey || e.altKey) return;
 
       switch (e.key) {
-        case '1': e.preventDefault(); setReviewStatus('pending');  break;
-        case '2': e.preventDefault(); setReviewStatus('approved'); break;
-        case '3': e.preventDefault(); setReviewStatus('excluded'); break;
+        case '1': e.preventDefault(); editStatus('pending');  break;
+        case '2': e.preventDefault(); editStatus('approved'); break;
+        case '3': e.preventDefault(); editStatus('excluded'); break;
         case 'ArrowRight':
         case 'n':
         case 'N': e.preventDefault(); handleNext(); break;
@@ -265,7 +327,7 @@ function ExposureDetailPageInner() {
     };
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
-  }, [handleNext, handlePrev, handleSave, showHelp]);
+  }, [handleNext, handlePrev, handleSave, showHelp, editStatus]);
 
   if (loading) {
     return (
@@ -320,6 +382,9 @@ function ExposureDetailPageInner() {
   const handleSaveMasks = async (regions: MaskRegionsPayload) => {
     const res = await saveExposureMaskRegions(exposure.id, regions);
     if (res.exposure) {
+      // Same newer-than-the-read rule as the triage save: a mask write must not
+      // be undone by an in-flight revalidation landing after it.
+      localEditsRef.current.saved = true;
       setCachedExposure(res.exposure);
       setExposure(res.exposure);
     }
@@ -524,7 +589,7 @@ function ExposureDetailPageInner() {
                 </label>
                 <select
                   value={reviewStatus}
-                  onChange={(e) => setReviewStatus(e.target.value)}
+                  onChange={(e) => editStatus(e.target.value)}
                   className="w-full text-sm border border-border rounded-lg px-3 py-2 bg-card text-text-primary"
                 >
                   <option value="pending">Pending</option>
@@ -539,7 +604,7 @@ function ExposureDetailPageInner() {
                 </label>
                 <select
                   value={correction}
-                  onChange={(e) => setCorrection(e.target.value)}
+                  onChange={(e) => editCorrection(e.target.value)}
                   className="w-full text-sm border border-border rounded-lg px-3 py-2 bg-card text-text-primary"
                 >
                   <option value="none">None</option>
@@ -554,7 +619,7 @@ function ExposureDetailPageInner() {
                 </label>
                 <textarea
                   value={notes}
-                  onChange={(e) => setNotes(e.target.value)}
+                  onChange={(e) => editNotes(e.target.value)}
                   placeholder="Describe artifacts, masking needs, etc."
                   rows={4}
                   className="w-full text-sm border border-border rounded-lg px-3 py-2 bg-card text-text-primary placeholder:text-text-tertiary resize-none"

--- a/web/app/admin/nircam/[id]/page.tsx
+++ b/web/app/admin/nircam/[id]/page.tsx
@@ -63,25 +63,43 @@ function ExposureDetailPageInner() {
   const [correction, setCorrection] = useState<string>('none');
   const [notes, setNotes] = useState<string>('');
 
-  // Whether the operator has touched / persisted the triage panel for the
-  // exposure currently on screen. The background revalidation below fires on
-  // arrival and lands 100-300 ms later — long after a fast operator has already
-  // pressed 2 — so it must not write over what they set. Without these guards
-  // the status visibly flips back to the DB value, `hasChanges` goes false, and
-  // the auto-save on → silently skips: the exposure flashes Approved for a frame
-  // and stays Pending. Reset on every route-id change (below), so arriving at a
-  // fresh exposure still takes the server's values.
-  const localEditsRef = useRef({ dirty: false, saved: false });
+  // Which triage fields the operator has touched, and whether a save has landed,
+  // for the exposure currently on screen. The background revalidation below fires
+  // on arrival and lands 100-300 ms later — long after a fast operator has
+  // already pressed 2 — so it must not write over what they set. Without these
+  // guards the status visibly flips back to the DB value, `hasChanges` goes
+  // false, and the auto-save on → silently skips: the exposure flashes Approved
+  // for a frame and stays Pending.
+  //
+  // `dirty` is per-field rather than one flag: with a stale cached row, editing
+  // a single field would otherwise pin *every* control to its cached value while
+  // `exposure` is replaced with the fresh row — so `hasChanges` reads the
+  // untouched-but-stale fields as edits and the next save writes them back over
+  // a newer server decision.
+  //
+  // `forId` tags the whole record with the exposure it describes (same pattern
+  // as `navState` below), so a save resolving after we've navigated away can
+  // tell that it no longer owns this state. Reset on every route-id change
+  // (below), so arriving at a fresh exposure still takes the server's values.
+  const localEditsRef = useRef<{
+    forId: number | null;
+    dirty: { reviewStatus: boolean; correction: boolean; notes: boolean };
+    saved: boolean;
+  }>({
+    forId: null,
+    dirty: { reviewStatus: false, correction: false, notes: false },
+    saved: false,
+  });
   const editStatus = useCallback((v: string) => {
-    localEditsRef.current.dirty = true;
+    localEditsRef.current.dirty.reviewStatus = true;
     setReviewStatus(v);
   }, []);
   const editCorrection = useCallback((v: string) => {
-    localEditsRef.current.dirty = true;
+    localEditsRef.current.dirty.correction = true;
     setCorrection(v);
   }, []);
   const editNotes = useCallback((v: string) => {
-    localEditsRef.current.dirty = true;
+    localEditsRef.current.dirty.notes = true;
     setNotes(v);
   }, []);
 
@@ -151,7 +169,11 @@ function ExposureDetailPageInner() {
     setLoading(!cached);
     setError(null);
     setSaved(false);
-    localEditsRef.current = { dirty: false, saved: false };
+    localEditsRef.current = {
+      forId: id,
+      dirty: { reviewStatus: false, correction: false, notes: false },
+      saved: false,
+    };
   }
 
   // Background revalidation against the DB on every id change. Auto-save on
@@ -177,11 +199,10 @@ function ExposureDetailPageInner() {
           setCachedExposure(result.exposure);
           setExposure(result.exposure);
         }
-        if (!edits.dirty) {
-          setReviewStatus(result.exposure.review_status);
-          setCorrection(result.exposure.correction);
-          setNotes(result.exposure.notes || '');
-        }
+        // Per field: an untouched control still takes the fresh server value.
+        if (!edits.dirty.reviewStatus) setReviewStatus(result.exposure.review_status);
+        if (!edits.dirty.correction) setCorrection(result.exposure.correction);
+        if (!edits.dirty.notes) setNotes(result.exposure.notes || '');
       }
       setLoading(false);
     })();
@@ -259,22 +280,34 @@ function ExposureDetailPageInner() {
 
   const handleSave = useCallback(async (): Promise<{ ok: boolean }> => {
     const s = stateRef.current;
+    // The exposure this save is for. `goTo` awaits its own save before pushing,
+    // but the `S` shortcut fires handleSave un-awaited and mask saves aren't
+    // gated by `goTo` at all — so a response can land after the route moved on.
+    const savedForId = id;
     setSaving(true);
     setSaved(false);
     setError(null);
-    const result = await updateExposureReview(id, {
+    const result = await updateExposureReview(savedForId, {
       review_status: s.reviewStatus as NircamExposure['review_status'],
       correction: s.correction as NircamExposure['correction'],
       notes: s.notes || undefined,
     });
     setSaving(false);
     if (result.error) {
+      // Surfaced even if we've navigated on: a failed save means the operator's
+      // decision didn't stick, which they need to know about either way.
       setError(result.error);
       return { ok: false };
     }
+    // Keyed by the exposure's own id, so this is correct regardless of route.
+    if (result.exposure) setCachedExposure(result.exposure);
+    // Everything below writes state belonging to whatever is on screen *now* —
+    // only safe while that's still the exposure we saved. Otherwise this would
+    // render the old exposure under the new one's URL and set the new one's
+    // `saved` guard, permanently suppressing its revalidation.
+    if (localEditsRef.current.forId !== savedForId) return { ok: true };
     if (result.exposure) {
       localEditsRef.current.saved = true;
-      setCachedExposure(result.exposure);
       setExposure(result.exposure);
     }
     setSaved(true);
@@ -380,13 +413,19 @@ function ExposureDetailPageInner() {
   );
 
   const handleSaveMasks = async (regions: MaskRegionsPayload) => {
-    const res = await saveExposureMaskRegions(exposure.id, regions);
+    // Mask saves run from the editor's own toolbar, outside `goTo`'s dirty
+    // check — so the operator can navigate away while one is still in flight.
+    const savedForId = exposure.id;
+    const res = await saveExposureMaskRegions(savedForId, regions);
     if (res.exposure) {
-      // Same newer-than-the-read rule as the triage save: a mask write must not
-      // be undone by an in-flight revalidation landing after it.
-      localEditsRef.current.saved = true;
       setCachedExposure(res.exposure);
-      setExposure(res.exposure);
+      // Same newer-than-the-read rule as the triage save: a mask write must not
+      // be undone by an in-flight revalidation landing after it — but only for
+      // the exposure it was issued for (see handleSave).
+      if (localEditsRef.current.forId === savedForId) {
+        localEditsRef.current.saved = true;
+        setExposure(res.exposure);
+      }
     }
     return { error: res.error };
   };

--- a/web/app/admin/nirspec/rate/[id]/page.tsx
+++ b/web/app/admin/nirspec/rate/[id]/page.tsx
@@ -46,17 +46,62 @@ function RateDetailPageInner() {
   const [reviewStatus, setReviewStatus] = useState<string>('pending');
   const [notes, setNotes] = useState<string>('');
 
-  const [nav, setNav] = useState<RateNeighbors | null>(null);
+  // Whether the operator has touched / persisted the triage panel for the row
+  // currently on screen. The background revalidation below fires on arrival and
+  // lands a round trip later — long after a fast operator has already pressed 2 —
+  // so it must not write over what they set. Without these guards the status
+  // visibly flips back to the DB value, `hasChanges` goes false, and the
+  // auto-save on → silently skips: the row flashes Approved and stays Pending.
+  // Reset on every route-id change (below), so arriving at a fresh row still
+  // takes the server's values.
+  const localEditsRef = useRef({ dirty: false, saved: false });
+  const editStatus = useCallback((v: string) => {
+    localEditsRef.current.dirty = true;
+    setReviewStatus(v);
+  }, []);
+  const editNotes = useCallback((v: string) => {
+    localEditsRef.current.dirty = true;
+    setNotes(v);
+  }, []);
+
+  // Tagged with the id it was fetched for: `id` changes the instant we push, but
+  // the neighbors RPC for the new row takes another round trip to land.
+  const [navState, setNavState] = useState<
+    { forId: number; data: RateNeighbors } | null
+  >(null);
   const [showHelp, setShowHelp] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
     getNirspecRateNeighbors(id, { ...navFilters, window: 3 }).then((res) => {
       if (cancelled) return;
-      setNav(res.error || res.total === 0 ? null : res);
+      setNavState(res.error || res.total === 0 ? null : { forId: id, data: res });
     });
     return () => { cancelled = true; };
   }, [id, navFilters]);
+
+  // While that RPC is in flight, `navState` still describes the row we just
+  // left, and using it verbatim mis-targets both arrows: → points at the current
+  // row (a no-op push, so hammering → appears to stick) and ← skips one. The
+  // stale window almost always already contains the new id, so re-derive
+  // prev/next/position from it — instant and correct for the single-step case.
+  // Only when the new id falls outside that window do we report "no nav" and let
+  // the arrows sit disabled until the fresh result lands.
+  const nav = useMemo<RateNeighbors | null>(() => {
+    if (!navState) return null;
+    if (navState.forId === id) return navState.data;
+    const stale = navState.data;
+    const idx = stale.windowIds.indexOf(id);
+    const fromIdx = stale.windowIds.indexOf(navState.forId);
+    if (idx < 0 || fromIdx < 0) return null;
+    return {
+      prevId: idx > 0 ? stale.windowIds[idx - 1] : null,
+      nextId: idx < stale.windowIds.length - 1 ? stale.windowIds[idx + 1] : null,
+      position: stale.position != null ? stale.position + (idx - fromIdx) : null,
+      total: stale.total,
+      windowIds: stale.windowIds,
+    };
+  }, [navState, id]);
 
   // Reset state synchronously from the in-memory cache on route-id change so the
   // new row paints in the same frame (React's "set state during render" pattern,
@@ -70,9 +115,12 @@ function RateDetailPageInner() {
     setLoading(!cached);
     setError(null);
     setSaved(false);
+    localEditsRef.current = { dirty: false, saved: false };
   }
 
-  // Background revalidation against the DB on every id change.
+  // Background revalidation against the DB on every id change. This read races
+  // the operator: anything they've typed or keyed since arriving, and any save
+  // that has already landed, is newer than this response and must survive it.
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -84,10 +132,17 @@ function RateDetailPageInner() {
         return;
       }
       if (result.exposure) {
-        setCachedRate(result.exposure);
-        setExposure(result.exposure);
-        setReviewStatus(result.exposure.review_status);
-        setNotes(result.exposure.notes || '');
+        const edits = localEditsRef.current;
+        // A save for this row already landed — our write is strictly newer than
+        // this read, so don't let it back into state *or* the cache.
+        if (!edits.saved) {
+          setCachedRate(result.exposure);
+          setExposure(result.exposure);
+        }
+        if (!edits.dirty) {
+          setReviewStatus(result.exposure.review_status);
+          setNotes(result.exposure.notes || '');
+        }
       }
       setLoading(false);
     })();
@@ -128,6 +183,7 @@ function RateDetailPageInner() {
       return { ok: false };
     }
     if (result.exposure) {
+      localEditsRef.current.saved = true;
       setCachedRate(result.exposure);
       setExposure(result.exposure);
     }
@@ -139,13 +195,15 @@ function RateDetailPageInner() {
   // Auto-save on nav: flush dirty triage so the operator can blast through a
   // queue with arrow keys without losing state.
   const goTo = useCallback(async (targetId: number | null) => {
-    if (targetId == null) return;
+    // targetId === id means the neighbor window is stale in a way the derivation
+    // above couldn't repair; pushing would be a no-op that looks like a step.
+    if (targetId == null || targetId === id) return;
     if (stateRef.current.hasChanges) {
       const result = await handleSave();
       if (!result.ok) return; // don't navigate on a save failure
     }
     router.push(`/admin/nirspec/rate/${targetId}${navQuery ? `?${navQuery}` : ''}`);
-  }, [handleSave, router, navQuery]);
+  }, [handleSave, router, navQuery, id]);
 
   const handleNext = useCallback(() => goTo(nav?.nextId ?? null), [goTo, nav]);
   const handlePrev = useCallback(() => goTo(nav?.prevId ?? null), [goTo, nav]);
@@ -159,9 +217,9 @@ function RateDetailPageInner() {
       if (e.metaKey || e.ctrlKey || e.altKey) return;
 
       switch (e.key) {
-        case '1': e.preventDefault(); setReviewStatus('pending');  break;
-        case '2': e.preventDefault(); setReviewStatus('approved'); break;
-        case '3': e.preventDefault(); setReviewStatus('excluded'); break;
+        case '1': e.preventDefault(); editStatus('pending');  break;
+        case '2': e.preventDefault(); editStatus('approved'); break;
+        case '3': e.preventDefault(); editStatus('excluded'); break;
         case 'ArrowRight':
         case 'n':
         case 'N': e.preventDefault(); handleNext(); break;
@@ -176,7 +234,7 @@ function RateDetailPageInner() {
     };
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
-  }, [handleNext, handlePrev, handleSave, showHelp]);
+  }, [handleNext, handlePrev, handleSave, showHelp, editStatus]);
 
   if (loading) {
     return (
@@ -207,6 +265,9 @@ function RateDetailPageInner() {
   const handleSaveMasks = async (regions: MaskRegionsPayload) => {
     const res = await saveRateMaskRegions(exposure.id, regions);
     if (res.exposure) {
+      // Same newer-than-the-read rule as the triage save: a mask write must not
+      // be undone by an in-flight revalidation landing after it.
+      localEditsRef.current.saved = true;
       setCachedRate(res.exposure);
       setExposure(res.exposure);
     }
@@ -362,7 +423,7 @@ function RateDetailPageInner() {
                 </label>
                 <select
                   value={reviewStatus}
-                  onChange={(e) => setReviewStatus(e.target.value)}
+                  onChange={(e) => editStatus(e.target.value)}
                   className="w-full text-sm border border-border rounded-lg px-3 py-2 bg-card text-text-primary"
                 >
                   <option value="pending">Pending</option>
@@ -377,7 +438,7 @@ function RateDetailPageInner() {
                 </label>
                 <textarea
                   value={notes}
-                  onChange={(e) => setNotes(e.target.value)}
+                  onChange={(e) => editNotes(e.target.value)}
                   placeholder="Describe persistence trails, MSA shorts, etc."
                   rows={4}
                   className="w-full text-sm border border-border rounded-lg px-3 py-2 bg-card text-text-primary placeholder:text-text-tertiary resize-none"

--- a/web/app/admin/nirspec/rate/[id]/page.tsx
+++ b/web/app/admin/nirspec/rate/[id]/page.tsx
@@ -46,21 +46,38 @@ function RateDetailPageInner() {
   const [reviewStatus, setReviewStatus] = useState<string>('pending');
   const [notes, setNotes] = useState<string>('');
 
-  // Whether the operator has touched / persisted the triage panel for the row
-  // currently on screen. The background revalidation below fires on arrival and
-  // lands a round trip later — long after a fast operator has already pressed 2 —
-  // so it must not write over what they set. Without these guards the status
-  // visibly flips back to the DB value, `hasChanges` goes false, and the
+  // Which triage fields the operator has touched, and whether a save has landed,
+  // for the row currently on screen. The background revalidation below fires on
+  // arrival and lands a round trip later — long after a fast operator has already
+  // pressed 2 — so it must not write over what they set. Without these guards the
+  // status visibly flips back to the DB value, `hasChanges` goes false, and the
   // auto-save on → silently skips: the row flashes Approved and stays Pending.
-  // Reset on every route-id change (below), so arriving at a fresh row still
-  // takes the server's values.
-  const localEditsRef = useRef({ dirty: false, saved: false });
+  //
+  // `dirty` is per-field rather than one flag: with a stale cached row, editing
+  // a single field would otherwise pin *every* control to its cached value while
+  // `exposure` is replaced with the fresh row — so `hasChanges` reads the
+  // untouched-but-stale fields as edits and the next save writes them back over
+  // a newer server decision.
+  //
+  // `forId` tags the whole record with the row it describes (same pattern as
+  // `navState` below), so a save resolving after we've navigated away can tell
+  // that it no longer owns this state. Reset on every route-id change (below),
+  // so arriving at a fresh row still takes the server's values.
+  const localEditsRef = useRef<{
+    forId: number | null;
+    dirty: { reviewStatus: boolean; notes: boolean };
+    saved: boolean;
+  }>({
+    forId: null,
+    dirty: { reviewStatus: false, notes: false },
+    saved: false,
+  });
   const editStatus = useCallback((v: string) => {
-    localEditsRef.current.dirty = true;
+    localEditsRef.current.dirty.reviewStatus = true;
     setReviewStatus(v);
   }, []);
   const editNotes = useCallback((v: string) => {
-    localEditsRef.current.dirty = true;
+    localEditsRef.current.dirty.notes = true;
     setNotes(v);
   }, []);
 
@@ -115,7 +132,11 @@ function RateDetailPageInner() {
     setLoading(!cached);
     setError(null);
     setSaved(false);
-    localEditsRef.current = { dirty: false, saved: false };
+    localEditsRef.current = {
+      forId: id,
+      dirty: { reviewStatus: false, notes: false },
+      saved: false,
+    };
   }
 
   // Background revalidation against the DB on every id change. This read races
@@ -139,10 +160,9 @@ function RateDetailPageInner() {
           setCachedRate(result.exposure);
           setExposure(result.exposure);
         }
-        if (!edits.dirty) {
-          setReviewStatus(result.exposure.review_status);
-          setNotes(result.exposure.notes || '');
-        }
+        // Per field: an untouched control still takes the fresh server value.
+        if (!edits.dirty.reviewStatus) setReviewStatus(result.exposure.review_status);
+        if (!edits.dirty.notes) setNotes(result.exposure.notes || '');
       }
       setLoading(false);
     })();
@@ -170,21 +190,33 @@ function RateDetailPageInner() {
 
   const handleSave = useCallback(async (): Promise<{ ok: boolean }> => {
     const s = stateRef.current;
+    // The row this save is for. `goTo` awaits its own save before pushing, but
+    // the `S` shortcut fires handleSave un-awaited and mask saves aren't gated
+    // by `goTo` at all — so a response can land after the route moved on.
+    const savedForId = id;
     setSaving(true);
     setSaved(false);
     setError(null);
-    const result = await updateNirspecRateReview(id, {
+    const result = await updateNirspecRateReview(savedForId, {
       review_status: s.reviewStatus as NirspecRateExposure['review_status'],
       notes: s.notes || undefined,
     });
     setSaving(false);
     if (result.error) {
+      // Surfaced even if we've navigated on: a failed save means the operator's
+      // decision didn't stick, which they need to know about either way.
       setError(result.error);
       return { ok: false };
     }
+    // Keyed by the row's own id, so this is correct regardless of route.
+    if (result.exposure) setCachedRate(result.exposure);
+    // Everything below writes state belonging to whatever is on screen *now* —
+    // only safe while that's still the row we saved. Otherwise this would render
+    // the old row under the new one's URL and set the new one's `saved` guard,
+    // permanently suppressing its revalidation.
+    if (localEditsRef.current.forId !== savedForId) return { ok: true };
     if (result.exposure) {
       localEditsRef.current.saved = true;
-      setCachedRate(result.exposure);
       setExposure(result.exposure);
     }
     setSaved(true);
@@ -263,13 +295,19 @@ function RateDetailPageInner() {
   );
 
   const handleSaveMasks = async (regions: MaskRegionsPayload) => {
-    const res = await saveRateMaskRegions(exposure.id, regions);
+    // Mask saves run from the editor's own toolbar, outside `goTo`'s dirty
+    // check — so the operator can navigate away while one is still in flight.
+    const savedForId = exposure.id;
+    const res = await saveRateMaskRegions(savedForId, regions);
     if (res.exposure) {
-      // Same newer-than-the-read rule as the triage save: a mask write must not
-      // be undone by an in-flight revalidation landing after it.
-      localEditsRef.current.saved = true;
       setCachedRate(res.exposure);
-      setExposure(res.exposure);
+      // Same newer-than-the-read rule as the triage save: a mask write must not
+      // be undone by an in-flight revalidation landing after it — but only for
+      // the row it was issued for (see handleSave).
+      if (localEditsRef.current.forId === savedForId) {
+        localEditsRef.current.saved = true;
+        setExposure(res.exposure);
+      }
     }
     return { error: res.error };
   };


### PR DESCRIPTION
## Summary
Fixes a race condition where background revalidation could overwrite operator edits during rapid navigation through exposure/rate queues. When an operator quickly navigates (e.g., pressing arrow keys), the new page's server revalidation could land after they've already made changes, causing their edits to be silently lost.

## Key Changes

**State tracking for local edits:**
- Added `localEditsRef` to track whether the operator has made unsaved changes (`dirty`) or if a save has already landed (`saved`)
- Created `editStatus()`, `editCorrection()`, and `editNotes()` callbacks that set the dirty flag before updating state
- Reset the ref on every route ID change so fresh pages still accept server values

**Guarded revalidation logic:**
- Modified background revalidation to check `localEditsRef.current` before overwriting state
- If `saved` is true, skip updating the cache and exposure object (the save is newer)
- If `dirty` is true, skip updating triage fields (operator changes are in-flight)
- Set `saved = true` after successful save operations to prevent subsequent reads from overwriting them

**Fixed navigation targeting during stale state:**
- Changed `nav` state to `navState` that tracks which ID it was fetched for
- Added `useMemo` derivation that re-calculates nav targets from stale data when the ID has changed but the RPC hasn't landed yet
- Prevents arrow key mashing from appearing to stick or skip items during the ~100ms RPC round trip
- Added guard in `goTo()` to prevent no-op navigation when `targetId === id`

**Applied consistently across both pages:**
- Implemented identical fixes in both `/admin/nircam/[id]/page.tsx` and `/admin/nirspec/rate/[id]/page.tsx`
- Also protected mask region saves with the same `saved` flag logic

## Implementation Details
The fix uses a ref-based approach rather than state to avoid triggering re-renders while still providing a reliable guard against the revalidation race. The stale nav window derivation allows single-step navigation to work instantly even while the fresh RPC is in flight, improving perceived responsiveness.

https://claude.ai/code/session_01UdeiQ44kvKFLwdtnngrazC