### PR TITLE
Add astrometric digest to exposure identity for re-alignment detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,10 +176,15 @@ The local products tree and cloud storage are two ends of one sync relationship,
 mediated by the `storage_objects` registry (server) and its local mirror
 (`$CAMPFIRE_ROOT/meta/campfire.db`). One engine (`python/campfire/storage/` +
 `campfire/deploy/push.py`) serves both directions with content-identity dedup
-(sci_dq for NIRCam exposures, whole-file otherwise), a stat fast-path (unchanged
-files are never re-read), and per-batch registration (interrupted transfers
-resume at file granularity). **All data products live on OSN; map tiles are the
-sole R2 exception.**
+(whole-file everywhere except NIRCam exposures, which use the two-component
+**exposure identity**: `sci_dq_hash` over the SCI/DQ/CFMASK arrays *and*
+`wcs_hash` over the WCS header cards — both must match to skip an upload,
+because `align`/`wcs_shift` move an exposure's astrometry without touching a
+science pixel), a stat fast-path (unchanged files are never re-read), and
+per-batch registration (interrupted transfers resume at file granularity).
+Registry rows predating `wcs_hash` are reconciled against `content_hash` and
+backfilled in place, so upgrading never stampedes a full re-upload. **All data
+products live on OSN; map tiles are the sole R2 exception.**
 
 ```bash
 campfire sync                          # refresh the local index (never touches the tree)

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -29,6 +29,25 @@ Release procedure: edit the `## Unreleased` section below, then run
 ## Unreleased
 
 ### Algorithm
+- **NIRCam manifest change detection now sees a re-alignment.** `manifest`
+  entries gain a `wcs_hash` — a SHA-256 over the WCS-defining header cards —
+  alongside the existing SCI+DQ `file_hash`, and `file_unchanged` compares
+  both. `align` and `wcs_shift` rewrite an exposure's WCS *without touching a
+  science pixel*, so a re-solved input hashed identically to its pre-alignment
+  self: a CRF regenerated with corrected astrometry read as unchanged, and the
+  outlier visit / mosaic tile that consumed it stayed on its stale product.
+  The outlier up-to-date check (`orchestrate.py`) now routes through
+  `file_unchanged` rather than comparing `file_hash` inline, so it picks the
+  same comparison up. The new digest is compared **only when the stored entry
+  carries one**, so pre-existing manifests keep their current verdicts instead
+  of invalidating en masse and re-drizzling every tile of every field on the
+  next run; they gain the digest the next time they are rewritten (or force it
+  with `--overwrite`). Categorized Algorithm rather than Infrastructure because
+  it changes which products are considered stale — mosaics that should have
+  rebuilt after a re-alignment now do. Mirrors the client-side fix to the
+  deploy dedup identity (`campfire.storage.hashing.wcs_hash`), which had the
+  same blind spot; the two recipes are written out separately (the client must
+  not import the pipeline) and pinned equal by a test.
 - Mosaic background subtraction gains a **large-extended-source pre-tier**
   (tier 0) in `[nircam.resample]`, fixing a galaxy-shaped over-subtraction bowl.
   A galaxy far larger than `bg_box_size` is over-subtracted *even when fully

--- a/pipeline/campfire_pipeline/nircam/manifest.py
+++ b/pipeline/campfire_pipeline/nircam/manifest.py
@@ -8,6 +8,8 @@ stale tiles need to be re-mosaicked when new data arrives.
 import hashlib
 import json
 import os
+import re
+import warnings
 from datetime import datetime, timezone
 
 from astropy.io import fits
@@ -25,6 +27,10 @@ def compute_file_hash(filepath):
 
     Only hashing the science data (not padding or auxiliary HDUs) keeps this
     fast and deterministic across different astropy write orderings.
+
+    This is the *pixel* half of an input's identity. It says nothing about
+    where those pixels sit on the sky — see :func:`compute_wcs_hash`, which
+    :func:`file_unchanged` compares alongside it.
 
     Parameters
     ----------
@@ -51,6 +57,71 @@ def compute_file_hash(filepath):
     return f'sha256:{h.hexdigest()}'
 
 
+# The header cards that define an input's sky mapping. A whitelist rather than
+# a denylist: the digest must move when the astrometry moves and never on a
+# plain re-save (a re-save that looks "modified" costs a needless re-drizzle of
+# every tile the file touches). Mirrored client-side in
+# ``campfire.storage.hashing`` — the client cannot import the pipeline, so the
+# recipe is written out in both places and the two must stay in step.
+_WCS_KEY_RE = re.compile(
+    r'^(?:'
+    r'WCSAXES|RADESYS|EQUINOX|LONPOLE|LATPOLE'
+    r'|C(?:TYPE|UNIT|RPIX|RVAL|DELT|ROTA)\d+'
+    r'|CD\d+_\d+|PC\d+_\d+'
+    r'|[AB]P?_ORDER|[AB]P?_DMAX|[AB]P?_\d+_\d+'
+    r'|V[23]_REF|VPARITY|VA_SCALE|ROLL_REF|RA_REF|DEC_REF'
+    r'|S_REGION'
+    r')$'
+)
+
+_WCS_DIGEST_VERSION = b'campfire-wcs-1\n'
+_WCS_HEADER_EXTS = (0, 'SCI')
+
+
+def compute_wcs_hash(filepath):
+    """SHA-256 over a FITS file's WCS-defining header cards, or ``None``.
+
+    The astrometric half of an input's identity. ``align`` and ``wcs_shift``
+    rewrite an exposure's WCS *without touching a science pixel*, so
+    :func:`compute_file_hash` cannot see a re-alignment — a CRF regenerated with
+    corrected astrometry but identical SCI/DQ hashes the same as before, and the
+    tile that consumed it is judged up to date while its inputs have moved on
+    the sky.
+
+    ``None`` means the file carries no WCS cards at all (or could not be read);
+    :func:`file_unchanged` treats that as "no astrometric component", never as
+    a match.
+
+    Digests the FITS (SIP-approximated) WCS that ``update_fits_wcsinfo`` writes
+    from the authoritative gwcs on every solve, not the gwcs in the embedded
+    ASDF extension — those bytes carry a save timestamp and would churn on every
+    re-save, defeating the point of a partial digest. The two disagree only when
+    ``update_fits_wcsinfo`` fails, which ``align`` logs.
+    """
+    h = hashlib.sha256()
+    h.update(_WCS_DIGEST_VERSION)
+    found = False
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            with fits.open(filepath, memmap=False, lazy_load_hdus=True) as hdul:
+                for ext in _WCS_HEADER_EXTS:
+                    try:
+                        header = hdul[ext].header
+                    except (KeyError, IndexError):
+                        continue
+                    # Sorted, so card order in the file cannot move the digest;
+                    # repr() round-trips a float's full precision exactly, so a
+                    # re-save writing the same numbers hashes the same.
+                    for key in sorted(k for k in header if _WCS_KEY_RE.match(k)):
+                        h.update(
+                            f'{ext}|{key}={header[key]!r}\n'.encode('utf-8', 'replace'))
+                        found = True
+    except Exception:
+        return None
+    return f'sha256:{h.hexdigest()}' if found else None
+
+
 def file_stat(filepath):
     """Return ``(size, mtime_ns)`` for fast change detection."""
     st = os.stat(filepath)
@@ -64,6 +135,13 @@ def file_unchanged(filepath, old_entry):
     match the current stat, the file hasn't been rewritten — skip the
     SHA-256 read entirely. Otherwise fall back to recomputing the content
     hash and comparing.
+
+    The astrometric digest is compared **only when the old entry carries one**.
+    Manifests written before ``wcs_hash`` existed therefore keep their current
+    verdicts instead of declaring every input modified — a recipe change that
+    invalidated every manifest at once would re-drizzle every field's every tile
+    on the next run. Those entries pick up the digest the next time the manifest
+    is rewritten, and ``--overwrite`` forces the rebuild in the meantime.
     """
     size = old_entry.get('size')
     mtime_ns = old_entry.get('mtime_ns')
@@ -71,7 +149,12 @@ def file_unchanged(filepath, old_entry):
         cur_size, cur_mtime = file_stat(filepath)
         if cur_size == size and cur_mtime == mtime_ns:
             return True
-    return compute_file_hash(filepath) == old_entry.get('file_hash')
+    if compute_file_hash(filepath) != old_entry.get('file_hash'):
+        return False
+    old_wcs = old_entry.get('wcs_hash')
+    if old_wcs and compute_wcs_hash(filepath) != old_wcs:
+        return False
+    return True
 
 
 def input_entry(filepath, extra=None):
@@ -80,6 +163,9 @@ def input_entry(filepath, extra=None):
     entry = {
         'filename': os.path.basename(filepath),
         'file_hash': compute_file_hash(filepath),
+        # Astrometric digest: without it a re-aligned input (same pixels, new
+        # WCS) reads as unchanged and its tiles are never rebuilt.
+        'wcs_hash': compute_wcs_hash(filepath),
         'size': size,
         'mtime_ns': mtime_ns,
     }

--- a/pipeline/campfire_pipeline/nircam/orchestrate.py
+++ b/pipeline/campfire_pipeline/nircam/orchestrate.py
@@ -493,7 +493,7 @@ def _run_outlier_per_visit(field, cfg, filtname, n_processes, overwrite, status,
     # The CFP_OUT-only short-circuit avoids the polygon-overlap setup work
     # done at the top of outlier_step on no-op runs.
     from campfire_pipeline.nircam.manifest import (
-        compute_file_hash, load_manifest,
+        file_unchanged, load_manifest,
     )
 
     def _visit_up_to_date(visit, visit_files):
@@ -510,16 +510,17 @@ def _run_outlier_per_visit(field, cfg, filtname, n_processes, overwrite, status,
         # the now-absent exposure still pooled (see _visit_membership_matches).
         if not _visit_membership_matches(manifest, visit, visit_files):
             return False
-        # Check that visit_files (a subset of all_inputs) hashes still match.
-        old_hashes = {
-            inp['filename']: inp['file_hash']
-            for inp in manifest['inputs']
-        }
+        # Check that visit_files (a subset of all_inputs) still match their
+        # recorded entries. file_unchanged compares the science AND astrometric
+        # digests: a re-aligned working copy has identical SCI/DQ and a new WCS,
+        # so a pixels-only comparison would reuse CR masks derived under the old
+        # astrometry.
+        old_by_name = {inp['filename']: inp for inp in manifest['inputs']}
         for f in visit_files:
             bn = os.path.basename(f)
-            if bn not in old_hashes:
+            if bn not in old_by_name:
                 return False
-            if compute_file_hash(f) != old_hashes[bn]:
+            if not file_unchanged(f, old_by_name[bn]):
                 return False
         return True
 

--- a/pipeline/tests/test_manifest_wcs_identity.py
+++ b/pipeline/tests/test_manifest_wcs_identity.py
@@ -1,0 +1,89 @@
+"""Manifest change detection must see a re-ALIGNMENT, not just new pixels.
+
+`compute_file_hash` digests SCI+DQ only, so an exposure that `align` (or
+`wcs_shift`) re-solved — identical science, corrected WCS — hashed the same as
+before and every tile that consumed it was judged up to date. `compute_wcs_hash`
+is the missing half; these tests pin both halves and the legacy tolerance that
+keeps existing manifests from all invalidating at once.
+"""
+import numpy as np
+import pytest
+from astropy.io import fits
+
+from campfire_pipeline.nircam.manifest import (
+    compute_file_hash, compute_wcs_hash, file_unchanged, input_entry,
+)
+
+WCS_CARDS = {
+    'CTYPE1': 'RA---TAN', 'CTYPE2': 'DEC--TAN',
+    'CRPIX1': 1024.0, 'CRPIX2': 1024.0,
+    'CRVAL1': 150.0, 'CRVAL2': 2.0,
+    'CD1_1': -8.6e-6, 'CD1_2': 0.0, 'CD2_1': 0.0, 'CD2_2': 8.6e-6,
+}
+
+
+@pytest.fixture
+def exposure(tmp_path):
+    sci = fits.ImageHDU(np.arange(16, dtype='f4').reshape(4, 4), name='SCI')
+    for key, value in WCS_CARDS.items():
+        sci.header[key] = value
+    dq = fits.ImageHDU(np.zeros((4, 4), dtype='i4'), name='DQ')
+    path = str(tmp_path / 'jw001_nrca1.fits')
+    fits.HDUList([fits.PrimaryHDU(), sci, dq]).writeto(path)
+    return path
+
+
+def _realign(path, crval1):
+    """Move the WCS and nothing else — what an align re-solve writes."""
+    with fits.open(path, mode='update') as hdul:
+        hdul['SCI'].header['CRVAL1'] = crval1
+
+
+def test_wcs_hash_moves_on_realignment_science_hash_does_not(exposure):
+    before_sci = compute_file_hash(exposure)
+    before_wcs = compute_wcs_hash(exposure)
+    _realign(exposure, 150.0001)
+    assert compute_file_hash(exposure) == before_sci   # not one pixel moved
+    assert compute_wcs_hash(exposure) != before_wcs
+
+
+def test_wcs_hash_survives_a_plain_resave(exposure):
+    before = compute_wcs_hash(exposure)
+    with fits.open(exposure, mode='update') as hdul:
+        hdul[0].header['DATE'] = '2026-07-27T12:00:00'
+        hdul[0].header['HISTORY'] = 'resaved'
+    assert compute_wcs_hash(exposure) == before
+
+
+def test_wcs_hash_is_none_without_wcs_cards(tmp_path):
+    path = str(tmp_path / 'bare.fits')
+    fits.HDUList([fits.PrimaryHDU()]).writeto(path)
+    assert compute_wcs_hash(path) is None
+
+
+def test_file_unchanged_detects_realignment(exposure):
+    entry = input_entry(exposure)
+    assert entry['wcs_hash'] is not None
+    _realign(exposure, 150.0001)
+    # The stat fast path must not mask this: the re-solve rewrote the file, so
+    # size/mtime_ns no longer match and the digests are consulted.
+    assert file_unchanged(exposure, entry) is False
+
+
+def test_legacy_entry_without_wcs_hash_stays_tolerant(exposure):
+    # Manifests written before this digest existed keep their verdicts — a
+    # recipe change that invalidated all of them at once would re-drizzle every
+    # tile of every field on the next run.
+    entry = input_entry(exposure)
+    legacy = {k: v for k, v in entry.items() if k != 'wcs_hash'}
+    _realign(exposure, 150.0001)
+    assert file_unchanged(exposure, legacy) is True
+    # ...but a science change is still caught, exactly as before.
+    with fits.open(exposure, mode='update') as hdul:
+        hdul['SCI'].data = np.ones((4, 4), dtype='f4')
+    assert file_unchanged(exposure, legacy) is False
+
+
+def test_stat_fast_path_still_short_circuits(exposure):
+    entry = input_entry(exposure)
+    assert file_unchanged(exposure, entry) is True

--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -629,8 +629,11 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
     png_upload_list = [t[0] for t in png_tasks]
     osn_tasks = fits_tasks + expmap_tasks + png_upload_list + layout_tasks
     store = open_reducer_store()
+    # apply_backfill: this path is past every dry-run return, so it is a real
+    # deploy — legacy exposure rows proven unchanged can learn their wcs_hash.
     plan, _server_rows = plan_remote_push(
-        client, store, osn_tasks, backend=_CANONICAL_BACKEND)
+        client, store, osn_tasks, backend=_CANONICAL_BACKEND,
+        apply_backfill=True)
     print(f"\nPlan: {plan.summary()}")
 
     # --- Upload new/changed products to OSN, registering per batch -----------

--- a/python/campfire/deploy/push.py
+++ b/python/campfire/deploy/push.py
@@ -41,18 +41,23 @@ from typing import Optional
 from campfire_layout import KeyScheme, Scope, storage_key
 
 from campfire.config import ensure_data_dir, meta_dir, products_dir
-from campfire.storage.hashing import sci_dq_hashes_parallel
-from campfire.storage.plan import PushPlan, identity_kind_for_key, plan_push
+from campfire.storage.hashing import exposure_identities_parallel
+from campfire.storage.plan import (
+    PushPlan, compose_identity, identity_kind_for_key, plan_push,
+)
 from campfire.storage.transfer import BatchFlusher
 from campfire.deploy.r2 import UploadTask, upload_files_parallel
 
 # Registry columns fetched for push planning — the mirror-row shape (everything
-# the local storage_objects cache carries), so fetched rows double as a cache
-# refresh for the keys being pushed.
+# the local storage_objects cache carries) plus wcs_hash, so fetched rows double
+# as a cache refresh for the keys being pushed. wcs_hash is deliberately NOT
+# mirrored locally: the planner always reads it from the live server fetch
+# below, so mirroring it would cost every reducer a forced re-sync (a client
+# schema bump) to store a column no decision reads.
 _PLAN_COLUMNS = (
-    'id, backend, bucket, storage_key, content_hash, sci_dq_hash, size_bytes, '
-    'content_type, product_type, instrument, status, observation, field, '
-    'filter, spectrum_id, exposure_ref, deployment_id, cfpipe_version, '
+    'id, backend, bucket, storage_key, content_hash, sci_dq_hash, wcs_hash, '
+    'size_bytes, content_type, product_type, instrument, status, observation, '
+    'field, filter, spectrum_id, exposure_ref, deployment_id, cfpipe_version, '
     'created_at, updated_at'
 )
 
@@ -138,12 +143,26 @@ def plan_remote_push(
     NIRCam mosaic path) need the server rows for the sizes/hashes of
     dedup-skipped objects.
     """
+    from campfire.deploy.registry import backfill_wcs_hashes
+
     keys = [t.r2_key for t in tasks]
     server_rows = fetch_registry_rows(client, keys, backend=backend)
     local_rows = store.get_storage_rows_by_keys(keys) if store else {}
 
     plan = plan_push(tasks, server_rows, local_rows=local_rows,
                      max_workers=max_workers, progress=progress)
+
+    # Legacy exposure rows the planner proved unchanged learn their astrometric
+    # digest here — no bytes move, and the next push compares on the full
+    # exposure identity. Best-effort: a failed backfill only means the same
+    # reconciliation runs again next time.
+    if plan.backfill:
+        try:
+            n = backfill_wcs_hashes(client, plan.backfill)
+            if n:
+                print(f"  Backfilled wcs_hash on {n} unchanged exposure row(s)")
+        except Exception as e:  # noqa: BLE001 - bookkeeping must not sink a push
+            print(f"  Note: wcs_hash backfill skipped ({e})")
 
     if store:
         # Cache the fresh server rows (preserves local_*/pushed_* on conflict)
@@ -186,9 +205,10 @@ def registration_flusher(
     prod_dir = products_dir().resolve()
 
     def _flush(batch: list[UploadTask]) -> None:
-        # Science-only digests for exposure-identity products: reuse the plan's
-        # value when it hashed the file, compute for plan-unhashed (new) files.
+        # Exposure identities (science + astrometric digests): reuse the plan's
+        # values when it hashed the file, compute for plan-unhashed (new) files.
         sci_dq: dict[str, str] = {}
+        wcs: dict[str, str] = {}
         need = []
         for t in batch:
             if identity_kind_for_key(t.r2_key) != 'sci_dq':
@@ -196,20 +216,25 @@ def registration_flusher(
             h = plan.identities.get(t.r2_key)
             if h:
                 sci_dq[t.r2_key] = h
+                w = plan.wcs_hashes.get(t.r2_key)
+                if w:
+                    wcs[t.r2_key] = w
             else:
                 need.append(t)
         if need:
-            by_path = sci_dq_hashes_parallel(
+            by_path = exposure_identities_parallel(
                 [t.local_path for t in need], max_workers=max_workers)
             for t in need:
-                h = by_path.get(Path(t.local_path))
+                h, w = by_path.get(Path(t.local_path), (None, None))
                 if h:
                     sci_dq[t.r2_key] = h
+                if w:
+                    wcs[t.r2_key] = w
 
         rows = build_registry_rows(
             batch, backend=backend, deployment_id=deployment_id,
             uploaded_by=uploaded_by, cfpipe_version=cfpipe_version,
-            sci_dq_hashes=sci_dq, precomputed=plan.whole_file,
+            sci_dq_hashes=sci_dq, wcs_hashes=wcs, precomputed=plan.whole_file,
             max_workers=max_workers, stored_sizes=stored_sizes,
         )
         upsert_storage_objects(client, rows)
@@ -226,7 +251,10 @@ def registration_flusher(
                 except OSError:
                     continue
                 kind = identity_kind_for_key(t.r2_key)
-                identity = row.get('sci_dq_hash') if kind == 'sci_dq' else row.get('content_hash')
+                identity = (
+                    compose_identity(row.get('sci_dq_hash'), row.get('wcs_hash'))
+                    if kind == 'sci_dq' else row.get('content_hash')
+                )
                 store.mark_object_pushed(
                     t.r2_key, identity, st.st_mtime, st.st_size, commit=False)
                 # Pull-side write-through: a pushed tree file IS materialized

--- a/python/campfire/deploy/push.py
+++ b/python/campfire/deploy/push.py
@@ -136,12 +136,21 @@ def plan_remote_push(
     backend: str,
     max_workers: Optional[int] = None,
     progress: bool = True,
+    apply_backfill: bool = False,
 ) -> tuple[PushPlan, dict[str, dict]]:
     """Plan a push: live server-row fetch + local fast-path + classification.
 
     Returns ``(plan, server_rows)`` — callers that index derived tables (the
     NIRCam mosaic path) need the server rows for the sizes/hashes of
     dedup-skipped objects.
+
+    ``apply_backfill`` writes ``plan.backfill`` (legacy exposure rows the
+    planner *proved* unchanged) to the server registry. It defaults to **False**
+    because planning is also what a dry run does: ``campfire push --dry-run``
+    and scoped ``campfire status`` both call this and then return, and a command
+    advertised as a read-only diff must not mutate ``storage_objects``. Only the
+    paths that actually go on to transfer bytes opt in. Skipping the write is
+    free: the reconciliation is re-derived on the next run.
     """
     from campfire.deploy.registry import backfill_wcs_hashes
 
@@ -152,11 +161,10 @@ def plan_remote_push(
     plan = plan_push(tasks, server_rows, local_rows=local_rows,
                      max_workers=max_workers, progress=progress)
 
-    # Legacy exposure rows the planner proved unchanged learn their astrometric
-    # digest here — no bytes move, and the next push compares on the full
-    # exposure identity. Best-effort: a failed backfill only means the same
-    # reconciliation runs again next time.
-    if plan.backfill:
+    # Legacy exposure rows learn their astrometric digest — no bytes move, and
+    # the next push compares on the full exposure identity. Best-effort: a
+    # failed backfill only means the same reconciliation runs again next time.
+    if plan.backfill and apply_backfill:
         try:
             n = backfill_wcs_hashes(client, plan.backfill)
             if n:
@@ -342,7 +350,8 @@ def push_observation(
 
     client = get_supabase_client(config)
     store = open_reducer_store()
-    plan, _server_rows = plan_remote_push(client, store, tasks, backend='osn')
+    plan, _server_rows = plan_remote_push(client, store, tasks, backend='osn',
+                                          apply_backfill=not dry_run)
     print(f"  Plan: {plan.summary()}")
     for t in plan.missing:
         print(f"    missing locally: {t.local_path}")
@@ -461,7 +470,8 @@ def push_field(
 
     client = get_supabase_client(config)
     store = open_reducer_store()
-    plan, _server_rows = plan_remote_push(client, store, tasks, backend='osn')
+    plan, _server_rows = plan_remote_push(client, store, tasks, backend='osn',
+                                          apply_backfill=not dry_run)
     print(f"  Plan: {plan.summary()}")
 
     if dry_run or not plan.to_upload:

--- a/python/campfire/deploy/registry.py
+++ b/python/campfire/deploy/registry.py
@@ -152,6 +152,7 @@ def row_for_key(
     status: str = 'active',
     bucket: Optional[str] = None,
     sci_dq_hash: Optional[str] = None,
+    wcs_hash: Optional[str] = None,
     stored_size_bytes: Optional[int] = None,
 ) -> dict | None:
     """Build one ``storage_objects`` row dict from a storage key + integrity info.
@@ -191,6 +192,11 @@ def row_for_key(
         # Science-only change-detection digest (epic #261, N1). Only NIRCam
         # canonical exposures carry one today; None leaves the column NULL.
         'sci_dq_hash': sci_dq_hash,
+        # Astrometric half of the same change-detection identity: a re-aligned
+        # exposure has identical SCI/DQ pixels and a different WCS, so without
+        # this the re-alignment never reaches the cloud. NULL for everything
+        # that compares on the whole-file hash.
+        'wcs_hash': wcs_hash,
         'size_bytes': int(size_bytes),
         # Bytes as stored in the bucket for transport-compressed products
         # (gzipped mosaic FITS); NULL = stored verbatim (== size_bytes, which
@@ -228,6 +234,7 @@ def build_registry_rows(
     cfpipe_version: Optional[str] = None,
     succeeded_keys: Optional[set[str]] = None,
     sci_dq_hashes: Optional[dict[str, str]] = None,
+    wcs_hashes: Optional[dict[str, str]] = None,
     max_workers: Optional[int] = None,
     precomputed: Optional[dict[str, tuple[str, int]]] = None,
     stored_sizes: Optional[dict[str, int]] = None,
@@ -245,13 +252,16 @@ def build_registry_rows(
     ``sci_dq_hashes`` optionally supplies a precomputed ``sha256:<hex>`` science-only
     digest per storage key (NIRCam exposures, epic #261) — the ``content_hash`` is
     still the whole-file sha256, but ``sci_dq_hash`` carries the science-only digest
-    that change-detection compares against.
+    that change-detection compares against. ``wcs_hashes`` supplies the astrometric
+    digest that goes with it; the pair is the exposure identity, and an exposure
+    registered without the WCS half would dedup as unchanged after a re-alignment.
 
     ``precomputed`` optionally supplies ``{r2_key: ('sha256:<hex>', size)}``
     whole-file digests already computed upstream (the push planner hashes
     changed files to decide the upload) — those files are not re-read here.
     """
     sci_dq_hashes = sci_dq_hashes or {}
+    wcs_hashes = wcs_hashes or {}
     precomputed = precomputed or {}
     stored_sizes = stored_sizes or {}
     selected: list[tuple[UploadTask, Path]] = []
@@ -281,6 +291,7 @@ def build_registry_rows(
             uploaded_by=uploaded_by,
             cfpipe_version=cfpipe_version,
             sci_dq_hash=sci_dq_hashes.get(task.r2_key),
+            wcs_hash=wcs_hashes.get(task.r2_key),
             stored_size_bytes=stored_sizes.get(task.r2_key),
         )
         if row is not None:
@@ -305,6 +316,43 @@ def set_active_deployment(client, keys: list[str], deployment_id: int) -> int:
          .update({'deployment_id': deployment_id})
          .in_('storage_key', chunk).eq('status', 'active').execute())
     return len(keys)
+
+
+def backfill_wcs_hashes(client, pairs: list[tuple[str, str]]) -> int:
+    """Record ``wcs_hash`` on legacy rows the push planner proved unchanged.
+
+    ``pairs`` is ``PushPlan.backfill``: keys whose cloud object is byte-identical
+    to the local file (whole-file sha256 == the row's ``content_hash``), so the
+    local astrometric digest describes the cloud copy too. Writing it costs no
+    transfer and completes the row's exposure identity, so the *next* push
+    compares on both components — and a subsequent re-alignment is finally seen.
+
+    Guarded with ``is_('wcs_hash', 'null')`` so this can only ever fill a hole:
+    a row another reducer has since re-uploaded (with its own, possibly
+    different, WCS) is left alone rather than being stamped with ours. Returns
+    the number of rows written.
+    """
+    if not pairs:
+        return 0
+    # Group by digest so identical values go out as one filtered UPDATE rather
+    # than one request per exposure (a field's exposures rarely share a WCS, but
+    # the grouping costs nothing and bounds the request count when they do).
+    by_hash: dict[str, list[str]] = {}
+    for key, wcs in pairs:
+        if wcs:
+            by_hash.setdefault(wcs, []).append(key)
+    written = 0
+    for wcs, keys in by_hash.items():
+        for i in range(0, len(keys), 200):
+            chunk = keys[i:i + 200]
+            resp = (client.table('storage_objects')
+                    .update({'wcs_hash': wcs})
+                    .in_('storage_key', chunk)
+                    .eq('status', 'active')
+                    .is_('wcs_hash', 'null')
+                    .execute())
+            written += len(resp.data or [])
+    return written
 
 
 def fetch_active_content_hashes(client, keys: list[str]) -> dict[str, str]:

--- a/python/campfire/storage/__init__.py
+++ b/python/campfire/storage/__init__.py
@@ -20,9 +20,12 @@ out loud (see ``presign.request_put_urls``).
 from .hashing import (
     compute_file_hash,
     default_hash_workers,
+    exposure_identities_parallel,
+    exposure_identity,
     hash_file,
     hash_files_parallel,
     sci_dq_hash,
+    wcs_hash,
 )
 from .session import create_transfer_session
 from .transfer import BatchFlusher, TransferResult, run_transfers
@@ -33,8 +36,11 @@ __all__ = [
     "compute_file_hash",
     "create_transfer_session",
     "default_hash_workers",
+    "exposure_identities_parallel",
+    "exposure_identity",
     "hash_file",
     "hash_files_parallel",
     "run_transfers",
     "sci_dq_hash",
+    "wcs_hash",
 ]

--- a/python/campfire/storage/hashing.py
+++ b/python/campfire/storage/hashing.py
@@ -1,15 +1,22 @@
 """Content hashing — the single implementation for both transfer directions.
 
-Two kinds of content identity live here:
+Three kinds of content identity live here:
 
 * **Whole-file** (``hash_file`` / ``compute_file_hash``): the authoritative
   ``content_hash`` stored in the ``storage_objects`` registry and verified on
   download. Byte-exact, so it churns whenever a FITS is re-saved with fresh
   header timestamps.
 * **Science-only** (``sci_dq_hash``): SHA-256 over the SCI+DQ+CFMASK arrays of
-  a FITS file — the *change-detection* identity for push dedup (epic #261, D1).
-  Stable across a science-identical re-save, which is exactly why whole-file
-  hashes can't drive "should I re-upload this exposure".
+  a FITS file — the pixel half of the *change-detection* identity for push
+  dedup (epic #261, D1). Stable across a science-identical re-save, which is
+  exactly why whole-file hashes can't drive "should I re-upload this exposure".
+* **Astrometric** (``wcs_hash``): SHA-256 over the WCS-defining header cards.
+  The array digests alone are blind to a re-*alignment*: ``align`` (and
+  ``wcs_shift``) rewrite an exposure's WCS without touching a single SCI or DQ
+  pixel, so a re-aligned exposure used to dedup as "unchanged" and the cloud
+  copy kept its pre-alignment astrometry forever. The two digests together are
+  the exposure identity — see :func:`exposure_identity` and
+  ``campfire.storage.plan``.
 
 Historically ``campfire/sync.py`` and ``campfire/deploy/registry.py`` each had
 their own streamer (64 KB vs 1 MB chunks, hash-only vs hash+size); both now
@@ -20,9 +27,11 @@ from __future__ import annotations
 
 import hashlib
 import os
+import re
+import warnings
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Iterable, Optional, Tuple
 
 _HASH_CHUNK = 1 << 20  # 1 MB: one sequential read beats many small reads on NFS
 
@@ -92,6 +101,93 @@ def hash_files_parallel(
     return out
 
 
+# --------------------------------------------------------------------------
+# Astrometric identity
+# --------------------------------------------------------------------------
+
+# The header cards that define an exposure's sky mapping. Deliberately a
+# whitelist, not "every card except a denylist": the digest must change when the
+# astrometry changes and NEVER on a plain re-save, and only an explicit set can
+# promise the second half (a denylist silently admits every new volatile keyword
+# the calibration software starts writing, and each one costs a spurious
+# re-upload of a ~40 MB exposure over a slow link).
+#
+# Covered: the core FITS WCS (CTYPE/CRPIX/CRVAL/CDELT/CD/PC/CROTA + celestial
+# frame), the SIP distortion coefficients ``update_fits_wcsinfo`` refreshes from
+# the gwcs after a solve, the JWST aperture-reference values, and S_REGION (the
+# recorded sky footprint). None of these are touched by a re-save that does not
+# move the WCS.
+_WCS_KEY_RE = re.compile(
+    r'^(?:'
+    r'WCSAXES|RADESYS|EQUINOX|LONPOLE|LATPOLE'
+    r'|C(?:TYPE|UNIT|RPIX|RVAL|DELT|ROTA)\d+'
+    r'|CD\d+_\d+|PC\d+_\d+'
+    r'|[AB]P?_ORDER|[AB]P?_DMAX|[AB]P?_\d+_\d+'
+    r'|V[23]_REF|VPARITY|VA_SCALE|ROLL_REF|RA_REF|DEC_REF'
+    r'|S_REGION'
+    r')$'
+)
+
+# Bumped if the recipe below ever changes, so a digest computed under an old
+# rule can never compare equal to one computed under a new rule.
+_WCS_DIGEST_VERSION = b'campfire-wcs-1\n'
+
+# Headers scanned for WCS cards: the primary (S_REGION and friends live there)
+# and SCI (where the datamodel writes the FITS WCS + SIP).
+_WCS_HEADER_EXTS = (0, 'SCI')
+
+
+def _wcs_digest_from_hdul(hdul) -> Optional[str]:
+    """``'sha256:<hex>'`` over the WCS cards of an open HDUList, or None.
+
+    None means *no WCS cards at all* (a product with no sky mapping, or a
+    header we could not read) — callers must treat that as "this file has no
+    astrometric component", never as a match.
+    """
+    h = hashlib.sha256()
+    h.update(_WCS_DIGEST_VERSION)
+    found = False
+    for ext in _WCS_HEADER_EXTS:
+        try:
+            header = hdul[ext].header
+        except (KeyError, IndexError):
+            continue
+        # Sorted, so card ORDER in the file can never move the digest; the
+        # value's repr() carries a float's full precision and round-trips
+        # exactly, so a re-save that rewrites the same numbers hashes the same.
+        for key in sorted(k for k in header if _WCS_KEY_RE.match(k)):
+            h.update(f'{ext}|{key}={header[key]!r}\n'.encode('utf-8', 'replace'))
+            found = True
+    return f'sha256:{h.hexdigest()}' if found else None
+
+
+def wcs_hash(path) -> Optional[str]:
+    """Return ``'sha256:<hex>'`` over a FITS file's WCS header cards, or None.
+
+    The astrometric half of the exposure identity (see
+    :func:`exposure_identity`). Header-only, so it costs a header parse rather
+    than a data read.
+
+    **Known limit.** This digests the *FITS* WCS — the SIP approximation
+    ``jwst.assign_wcs.util.update_fits_wcsinfo`` writes from the authoritative
+    gwcs on every solve — not the gwcs in the embedded ASDF extension. The ASDF
+    bytes cannot be hashed directly (a datamodel save stamps a fresh
+    ``meta.date`` into them, so they churn on every re-save and would defeat
+    the whole point of a partial digest). The two disagree only when
+    ``update_fits_wcsinfo`` fails, which the align step logs loudly as
+    "FITS SIP keywords not refreshed".
+    """
+    from astropy.io import fits
+
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            with fits.open(path, memmap=False, lazy_load_hdus=True) as hdul:
+                return _wcs_digest_from_hdul(hdul)
+    except Exception:
+        return None
+
+
 def sci_dq_hash(path) -> Optional[str]:
     """Return ``'sha256:<hex>'`` over the SCI+DQ+CFMASK arrays, or None.
 
@@ -109,7 +205,9 @@ def sci_dq_hash(path) -> Optional[str]:
     post-N7 deploy).
 
     Returns None if none of the arrays are present or the file is unreadable
-    (never dedup on an empty hash).
+    (never dedup on an empty hash). This is the *pixel* half of an exposure's
+    identity only — pair it with :func:`wcs_hash`, or call
+    :func:`exposure_identity` to get both from one open.
     """
     from astropy.io import fits
 
@@ -127,6 +225,41 @@ def sci_dq_hash(path) -> Optional[str]:
     except Exception:
         return None
     return f'sha256:{h.hexdigest()}' if hashed_any else None
+
+
+def exposure_identity(path) -> Tuple[Optional[str], Optional[str]]:
+    """Return ``(sci_dq_hash, wcs_hash)`` for one exposure, from a single open.
+
+    The full change-detection identity of a NIRCam canonical exposure: what the
+    pixels are *and* where they are on the sky. Computed together because the
+    pixel digest already reads the whole file — pulling the WCS cards out of the
+    same HDUList costs nothing, whereas a second :func:`wcs_hash` call would
+    re-open (and on NFS, re-read) it.
+
+    Either element is None when that component is absent or unreadable; see
+    ``campfire.storage.plan`` for how each None is interpreted (never as a
+    match).
+    """
+    from astropy.io import fits
+
+    h = hashlib.sha256()
+    hashed_any = False
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            with fits.open(path, memmap=False,
+                           do_not_scale_image_data=True) as hdul:
+                for extname in ('SCI', 'DQ', 'CFMASK'):
+                    if extname not in hdul:
+                        continue
+                    data = hdul[extname].data
+                    if data is not None:
+                        h.update(data.tobytes())
+                        hashed_any = True
+                wcs = _wcs_digest_from_hdul(hdul)
+    except Exception:
+        return None, None
+    return (f'sha256:{h.hexdigest()}' if hashed_any else None), wcs
 
 
 def sci_dq_hashes_parallel(
@@ -158,6 +291,44 @@ def sci_dq_hashes_parallel(
                     out[path] = fut.result()
                 except Exception:
                     out[path] = None
+                if pbar:
+                    pbar.update(1)
+    finally:
+        if pbar:
+            pbar.close()
+    return out
+
+
+def exposure_identities_parallel(
+    paths: Iterable[Path], *, max_workers: Optional[int] = None,
+    progress_desc: Optional[str] = None,
+) -> dict[Path, Tuple[Optional[str], Optional[str]]]:
+    """:func:`exposure_identity` for many files concurrently.
+
+    Returns ``{path: (sci_dq_hash, wcs_hash)}``. Same shape and failure
+    semantics as :func:`sci_dq_hashes_parallel` — a per-file failure records
+    ``(None, None)`` so it can never be mistaken for a match — and the same
+    tqdm bar, since this pass is the dominant local cost before a NIRCam
+    upload starts.
+    """
+    unique = list({Path(p) for p in paths})
+    if not unique:
+        return {}
+    workers = max(1, min(max_workers or default_hash_workers(), len(unique)))
+    out: dict[Path, Tuple[Optional[str], Optional[str]]] = {}
+    pbar = None
+    if progress_desc:
+        from tqdm import tqdm
+        pbar = tqdm(total=len(unique), desc=progress_desc, unit='file')
+    try:
+        with ThreadPoolExecutor(max_workers=workers) as ex:
+            futures = {ex.submit(exposure_identity, p): p for p in unique}
+            for fut in as_completed(futures):
+                path = futures[fut]
+                try:
+                    out[path] = fut.result()
+                except Exception:
+                    out[path] = (None, None)
                 if pbar:
                     pbar.update(1)
     finally:

--- a/python/campfire/storage/plan.py
+++ b/python/campfire/storage/plan.py
@@ -8,9 +8,13 @@ rows for those keys, classify each file as **new** (no active cloud object),
 
 Content identity is per-product-type, not per-direction:
 
-* NIRCam canonical exposures compare on the science-only ``sci_dq_hash`` —
-  whole-file hashes churn on every pipeline re-save (header timestamps), so
-  they cannot drive dedup (epic #261, D1).
+* NIRCam canonical exposures compare on the **exposure identity**: the
+  science-only ``sci_dq_hash`` *and* the astrometric ``wcs_hash``, both of which
+  must match to skip an upload. Whole-file hashes churn on every pipeline
+  re-save (header timestamps), so they cannot drive dedup (epic #261, D1) — but
+  the science digest alone is blind to a re-alignment, which rewrites an
+  exposure's WCS without touching one SCI or DQ pixel. Pixels *and* sky
+  position together are what makes an exposure the exposure it is.
 * Everything else compares on the whole-file ``content_hash``. Only an
   authoritative ``sha256:`` value is comparable; a provisional ``etag:`` row
   (bucket-metadata backfill) always re-uploads.
@@ -20,13 +24,24 @@ that this same file (mtime+size unchanged) was already confirmed against the
 same server identity, the file is skipped **without reading it** — the
 rsync-style short-circuit that keeps a no-op re-push at directory-walk cost
 instead of a full re-hash of hundreds of GB. Files are only hashed when their
-stat changed, and then only to answer "did the science change or was this a
-re-save". The pipeline's own manifest logic (``file_unchanged``) uses the same
-idiom at reduction time.
+stat changed, and then only to answer "did the science or the astrometry change,
+or was this a re-save". The pipeline's own manifest logic (``file_unchanged``)
+uses the same idiom at reduction time.
+
+**Legacy exposure rows.** Registry rows written before ``wcs_hash`` existed
+carry a science digest and a NULL astrometric one, so their exposure identity
+is not directly comparable. Rather than re-upload an entire NIRCam corpus over
+a slow link, those rows are *reconciled*: when the science digest still matches,
+the local whole-file sha256 is compared against the row's authoritative
+``content_hash``, and a byte-for-byte match proves the cloud copy carries this
+file's WCS — so the upload is skipped and the row's ``wcs_hash`` is backfilled
+(``PushPlan.backfill``). Anything that fails that proof uploads, which is the
+correct outcome: it is exactly the re-aligned exposure the old identity missed.
 
 This module is pure bookkeeping — no Supabase, no network. The deploy-side
 wrapper (``campfire.deploy.push``) fetches the server rows for the candidate
-keys and applies the plan's bookkeeping to the local mirror.
+keys, applies the plan's bookkeeping to the local mirror, and flushes the
+``wcs_hash`` backfill to the registry.
 """
 
 from __future__ import annotations
@@ -36,7 +51,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-from .hashing import hash_files_parallel, sci_dq_hashes_parallel
+from .hashing import exposure_identities_parallel, hash_files_parallel
 
 # Product types whose push identity is the science-only SCI+DQ+CFMASK digest.
 IDENTITY_SCI_DQ_TYPES = frozenset({'nircam_exposure'})
@@ -60,19 +75,44 @@ def identity_kind_for_key(storage_key: str) -> str:
     return 'sci_dq' if product_type in IDENTITY_SCI_DQ_TYPES else 'whole_file'
 
 
+def compose_identity(sci_dq: Optional[str],
+                     wcs: Optional[str]) -> Optional[str]:
+    """The exposure identity token: science digest + astrometric digest.
+
+    A single opaque string, because that is what both sides of the comparison
+    store in one column (``storage_objects.pushed_identity`` on the local
+    mirror). ``wcs=None`` composes to the bare science digest, so a file with no
+    WCS component — and every ``pushed_identity`` recorded before this existed —
+    keeps its old token and its stat fast path. None in, None out: an exposure
+    with no readable science digest has no identity at all.
+    """
+    if not sci_dq:
+        return None
+    return f'{sci_dq}+wcs={wcs}' if wcs else sci_dq
+
+
 def server_identity_for(row: Optional[dict], kind: str) -> Optional[str]:
     """The comparable cloud-side identity for a registry row, or None.
 
     None means "no comparable identity" — the caller must treat the file as
     changed (always upload): a missing/inactive row, a provisional ``etag:``
     whole-file hash, or a legacy exposure row without a science digest.
+
+    For ``sci_dq`` rows this is the composed exposure identity. A row with a
+    science digest but a NULL ``wcs_hash`` (written before the astrometric
+    component existed) therefore composes to the bare science digest, which will
+    not equal a local identity that *does* carry a WCS — see the reconciliation
+    pass in :func:`plan_push`, which resolves those without re-uploading files
+    that are provably unchanged.
     """
     if not row or row.get('status') != 'active':
         return None
     if kind == 'sci_dq':
         h = row.get('sci_dq_hash')
-    else:
-        h = row.get('content_hash')
+        if h and h.startswith('sha256:'):
+            return compose_identity(h, row.get('wcs_hash'))
+        return None
+    h = row.get('content_hash')
     if h and h.startswith('sha256:'):
         return h
     return None
@@ -83,13 +123,18 @@ class PushPlan:
     """Classification of upload tasks against the cloud registry.
 
     ``to_upload`` preserves the input task order (new + changed interleaved).
-    ``identities`` maps ``r2_key`` → the local content identity for every task
-    that was hashed at plan time (uploads whose identity was needed for the
-    decision); ``whole_file`` carries ``(sha256, size)`` for plan-hashed
-    whole-file tasks so registration never re-reads them. ``confirmed``
-    lists ``(r2_key, identity, mtime, size)`` for identity-verified unchanged
-    files — the caller records these in the mirror so the next run takes the
-    stat fast path.
+    ``identities`` maps ``r2_key`` → the local **registerable** digest for every
+    task hashed at plan time (the science-only digest for exposures, the
+    whole-file sha256 otherwise), and ``wcs_hashes`` the matching astrometric
+    digest for exposures — the two go into their own registry columns, so they
+    are kept apart here rather than composed. ``whole_file`` carries
+    ``(sha256, size)`` for plan-hashed whole-file tasks so registration never
+    re-reads them. ``confirmed`` lists ``(r2_key, identity, mtime, size)`` for
+    identity-verified unchanged files — the caller records these in the mirror
+    so the next run takes the stat fast path — where ``identity`` is the
+    *composed* token. ``backfill`` lists ``(r2_key, wcs_hash)`` for legacy rows
+    proven unchanged by the reconciliation pass, for the caller to write back to
+    the registry.
     """
 
     to_upload: List = field(default_factory=list)
@@ -99,9 +144,11 @@ class PushPlan:
     missing: List = field(default_factory=list)
     fast_skipped: int = 0
     identities: Dict[str, Optional[str]] = field(default_factory=dict)
+    wcs_hashes: Dict[str, Optional[str]] = field(default_factory=dict)
     whole_file: Dict[str, Tuple[str, int]] = field(default_factory=dict)
     stats: Dict[str, Tuple[float, int]] = field(default_factory=dict)
     confirmed: List[Tuple[str, str, float, int]] = field(default_factory=list)
+    backfill: List[Tuple[str, str]] = field(default_factory=list)
 
     def summary(self) -> str:
         parts = [
@@ -111,6 +158,8 @@ class PushPlan:
         ]
         if self.fast_skipped:
             parts.append(f"{self.fast_skipped} via stat fast-path")
+        if self.backfill:
+            parts.append(f"{len(self.backfill)} wcs_hash backfilled")
         if self.missing:
             parts.append(f"{len(self.missing)} missing locally")
         return ", ".join(parts)
@@ -134,7 +183,9 @@ def plan_push(
     server_rows
         ``{storage_key: row}`` fetched from the **server** registry for these
         keys (authoritative — never a possibly-stale full mirror). Rows carry
-        ``status`` / ``content_hash`` / ``sci_dq_hash``.
+        ``status`` / ``content_hash`` / ``sci_dq_hash`` / ``wcs_hash``. The last
+        is read only from here, never from the local mirror, so a reducer whose
+        mirror predates it still plans correctly.
     local_rows
         ``{storage_key: row}`` from the local mirror, supplying the
         ``pushed_*`` stat fast-path bookkeeping. Optional: without it every
@@ -144,10 +195,15 @@ def plan_push(
     plan = PushPlan()
     local_rows = local_rows or {}
 
-    # (task, kind, server_identity, stat) needing a local hash to decide.
+    # Verdicts are recorded per task index and emitted in input order at the
+    # end, so the multi-pass classification below (hash, then reconcile legacy
+    # rows) cannot disturb ``to_upload``'s documented ordering.
+    verdict: Dict[int, str] = {}
+    # (index, task, kind, server_identity, row, stat) needing a local hash.
     undecided: List[Tuple] = []
+    ordered: List[Tuple[int, object]] = []
 
-    for task in tasks:
+    for idx, task in enumerate(tasks):
         key = task.r2_key
         path = Path(task.local_path)
         try:
@@ -155,6 +211,7 @@ def plan_push(
         except OSError:
             plan.missing.append(task)
             continue
+        ordered.append((idx, task))
         plan.stats[key] = (st.st_mtime, st.st_size)
 
         kind = identity_kind_for_key(key)
@@ -164,11 +221,7 @@ def plan_push(
         if identity is None:
             # No comparable cloud identity: brand-new object, inactive row, or
             # provisional/absent digest → always upload.
-            if row and row.get('status') == 'active':
-                plan.changed.append(task)
-            else:
-                plan.new.append(task)
-            plan.to_upload.append(task)
+            verdict[idx] = 'changed' if (row and row.get('status') == 'active') else 'new'
             continue
 
         # Stat fast path: this machine already confirmed this exact file
@@ -183,43 +236,99 @@ def plan_push(
             and abs(st.st_mtime - lrow['pushed_mtime']) < _MTIME_TOL
             and st.st_size == lrow['pushed_size']
         ):
-            plan.unchanged.append(task)
+            verdict[idx] = 'unchanged'
             plan.fast_skipped += 1
             continue
 
-        undecided.append((task, kind, identity, st))
+        undecided.append((idx, task, kind, identity, row, st))
 
     # Hash the undecided files (stat changed, or no fast-path record), grouped
     # by identity kind so each file is read once with the right reader.
-    sci_dq_paths = [Path(t.local_path) for t, k, _i, _s in undecided if k == 'sci_dq']
-    whole_paths = [Path(t.local_path) for t, k, _i, _s in undecided if k == 'whole_file']
+    exp_paths = [Path(t.local_path) for _i, t, k, _id, _r, _s in undecided
+                 if k == 'sci_dq']
+    whole_paths = [Path(t.local_path) for _i, t, k, _id, _r, _s in undecided
+                   if k == 'whole_file']
 
-    sci_dq_local = sci_dq_hashes_parallel(
-        sci_dq_paths, max_workers=max_workers,
-        progress_desc='Hashing exposures (SCI+DQ)' if progress else None,
-    ) if sci_dq_paths else {}
+    exp_local = exposure_identities_parallel(
+        exp_paths, max_workers=max_workers,
+        progress_desc='Hashing exposures (SCI+DQ+WCS)' if progress else None,
+    ) if exp_paths else {}
     whole_local = hash_files_parallel(
         whole_paths, max_workers=max_workers,
         progress_desc='Hashing changed candidates' if progress else None,
     ) if whole_paths else {}
 
-    for task, kind, identity, st in undecided:
+    # Legacy exposure rows that survive the identity comparison and need the
+    # whole-file proof: (index, task, path, sci_dq, wcs, row, stat).
+    reconcile: List[Tuple] = []
+
+    for idx, task, kind, identity, row, st in undecided:
         key = task.r2_key
         path = Path(task.local_path)
+        sci = wcs = None
         if kind == 'sci_dq':
-            local_identity = sci_dq_local.get(path)
+            sci, wcs = exp_local.get(path, (None, None))
+            plan.identities[key] = sci
+            plan.wcs_hashes[key] = wcs
+            local_identity = compose_identity(sci, wcs)
         else:
             local_identity, size = whole_local[path]
             plan.whole_file[key] = (local_identity, size)
-        plan.identities[key] = local_identity
+            plan.identities[key] = local_identity
 
         if local_identity is not None and local_identity == identity:
-            # Science-identical (or byte-identical) — skip the upload and
+            # Identical on every comparable component — skip the upload and
             # record the fresh stat so the next run takes the fast path.
-            plan.unchanged.append(task)
+            verdict[idx] = 'unchanged'
             plan.confirmed.append((key, local_identity, st.st_mtime, st.st_size))
-        else:
-            plan.changed.append(task)
-            plan.to_upload.append(task)
+            continue
+
+        # A legacy row (science digest matches, no astrometric digest recorded)
+        # is not evidence of a change — only of a row written before the WCS
+        # was part of the identity. Defer it to the reconciliation pass rather
+        # than re-uploading a whole corpus on the first post-upgrade push.
+        if (
+            kind == 'sci_dq'
+            and wcs is not None
+            and row is not None
+            and not row.get('wcs_hash')
+            and row.get('sci_dq_hash') == sci
+        ):
+            reconcile.append((idx, task, path, sci, wcs, row, st))
+            continue
+
+        verdict[idx] = 'changed'
+
+    # Reconciliation: the cloud object's bytes ARE this local file's bytes iff
+    # the whole-file sha256 matches the row's authoritative content_hash — which
+    # proves the cloud copy carries this WCS, so the row can simply learn its
+    # wcs_hash. Anything else uploads: a byte difference with no recorded
+    # astrometry is unprovable, and is precisely the re-aligned exposure the
+    # science-only identity used to skip.
+    if reconcile:
+        legacy_hashes = hash_files_parallel(
+            [p for _i, _t, p, _sci, _w, _r, _s in reconcile],
+            max_workers=max_workers,
+            progress_desc='Reconciling legacy exposure rows' if progress else None,
+        )
+        for idx, task, path, sci, wcs, row, st in reconcile:
+            key = task.r2_key
+            whole, size = legacy_hashes[path]
+            plan.whole_file[key] = (whole, size)
+            if whole == row.get('content_hash'):
+                verdict[idx] = 'unchanged'
+                identity = compose_identity(sci, wcs)
+                plan.confirmed.append((key, identity, st.st_mtime, st.st_size))
+                plan.backfill.append((key, wcs))
+            else:
+                verdict[idx] = 'changed'
+
+    for idx, task in ordered:
+        v = verdict[idx]
+        if v == 'unchanged':
+            plan.unchanged.append(task)
+            continue
+        (plan.new if v == 'new' else plan.changed).append(task)
+        plan.to_upload.append(task)
 
     return plan

--- a/python/campfire/storage/plan.py
+++ b/python/campfire/storage/plan.py
@@ -159,7 +159,10 @@ class PushPlan:
         if self.fast_skipped:
             parts.append(f"{self.fast_skipped} via stat fast-path")
         if self.backfill:
-            parts.append(f"{len(self.backfill)} wcs_hash backfilled")
+            # "reconciled", not "backfilled": the plan only determines these —
+            # whether the registry write happens is the caller's call (a dry run
+            # never writes). The actual write count is printed by the backfill.
+            parts.append(f"{len(self.backfill)} legacy wcs_hash reconciled")
         if self.missing:
             parts.append(f"{len(self.missing)} missing locally")
         return ", ".join(parts)

--- a/python/tests/test_nircam_deploy.py
+++ b/python/tests/test_nircam_deploy.py
@@ -1,10 +1,11 @@
 """Unit tests for the NIRCam canonical-exposure deploy (epic #261, N1).
 
 Pure/local: the science-only content hash (SCI+DQ, stable across a header-only
-re-save), canonical FITS/expmap upload-task keys, the registry row identity for a
-NIRCam exposure (field-scoped, admin-only, carrying a sci_dq_hash + exposure_ref),
-and sci_dq_hash threading through build_registry_rows. The full upload + registry
-round-trip is exercised live against local Supabase in CI.
+re-save), the astrometric wcs_hash that goes with it (so a re-alignment is not
+mistaken for a re-save), canonical FITS/expmap upload-task keys, the registry row
+identity for a NIRCam exposure (field-scoped, admin-only, carrying both digests +
+an exposure_ref), and digest threading through build_registry_rows. The full
+upload + registry round-trip is exercised live against local Supabase in CI.
 """
 import numpy as np
 import pytest
@@ -76,6 +77,105 @@ def test_sci_dq_hash_includes_cfmask(tmp_path):
         hdul.append(fits.ImageHDU(data=cf, name="CFMASK"))
         hdul.flush()
     assert nc._sci_dq_hash(masked) != nc._sci_dq_hash(plain)
+
+
+# --- wcs_hash (the astrometric half of the exposure identity) ----------------
+
+def _wcs_cards(crval1=150.0, crval2=2.0):
+    return {
+        "CTYPE1": "RA---TAN", "CTYPE2": "DEC--TAN",
+        "CRPIX1": 1024.0, "CRPIX2": 1024.0,
+        "CRVAL1": crval1, "CRVAL2": crval2,
+        "CD1_1": -8.6e-6, "CD1_2": 0.0, "CD2_1": 0.0, "CD2_2": 8.6e-6,
+    }
+
+
+def _make_wcs_exposure(path, sci, dq, wcs_cards, *, extra_header=None):
+    p = _make_exposure(path, sci, dq, extra_header=extra_header)
+    with fits.open(p, mode="update") as hdul:
+        for k, v in wcs_cards.items():
+            hdul["SCI"].header[k] = v
+        hdul.flush()
+    return p
+
+
+def test_wcs_hash_moves_when_the_solution_moves(tmp_path):
+    from campfire.storage.hashing import wcs_hash
+    sci = np.arange(16, dtype="float32").reshape(4, 4)
+    dq = np.zeros((4, 4), dtype="int32")
+    a = _make_wcs_exposure(tmp_path / "a.fits", sci, dq, _wcs_cards())
+    # A re-alignment: same pixels, corrected reference position.
+    b = _make_wcs_exposure(tmp_path / "b.fits", sci, dq,
+                           _wcs_cards(crval1=150.0001))
+    assert nc._sci_dq_hash(a) == nc._sci_dq_hash(b)   # science is identical...
+    assert wcs_hash(a) != wcs_hash(b)                 # ...astrometry is not.
+    assert wcs_hash(a).startswith("sha256:")
+
+
+def test_wcs_hash_stable_across_a_plain_resave(tmp_path):
+    # The property that makes a partial digest usable at all: nothing a re-save
+    # touches (timestamps, HISTORY, card order) may move it.
+    from campfire.storage.hashing import wcs_hash
+    sci = np.arange(16, dtype="float32").reshape(4, 4)
+    dq = np.zeros((4, 4), dtype="int32")
+    p = _make_wcs_exposure(tmp_path / "a.fits", sci, dq, _wcs_cards())
+    before = wcs_hash(p)
+    with fits.open(p, mode="update") as hdul:
+        hdul[0].header["DATE"] = "2026-07-27T12:00:00"
+        hdul[0].header["HISTORY"] = "resaved"
+        hdul["SCI"].header["BUNIT"] = "MJy/sr"
+        hdul.flush()
+    assert wcs_hash(p) == before
+
+
+def test_wcs_hash_covers_sip_distortion(tmp_path):
+    # update_fits_wcsinfo re-fits the SIP approximation from the corrected gwcs
+    # on every solve, so a distortion-only change is a real astrometric change
+    # that must not slip past the digest.
+    from campfire.storage.hashing import wcs_hash
+    sci = np.arange(16, dtype="float32").reshape(4, 4)
+    dq = np.zeros((4, 4), dtype="int32")
+    cards = dict(_wcs_cards(), A_ORDER=2, A_0_2=1e-7, B_ORDER=2, B_2_0=1e-7)
+    a = _make_wcs_exposure(tmp_path / "a.fits", sci, dq, cards)
+    b = _make_wcs_exposure(tmp_path / "b.fits", sci, dq,
+                           dict(cards, A_0_2=2e-7))
+    assert wcs_hash(a) != wcs_hash(b)
+
+
+def test_wcs_hash_none_without_wcs_cards(tmp_path):
+    # No WCS → no astrometric component. Must be None, never a digest over an
+    # empty card set, so it can't compare equal to some other WCS-less file.
+    from campfire.storage.hashing import wcs_hash
+    p = _make_exposure(tmp_path / "e.fits", np.zeros((4, 4), "float32"),
+                       np.zeros((4, 4), "int32"))
+    assert wcs_hash(p) is None
+
+
+def test_exposure_identity_matches_the_separate_digests(tmp_path):
+    # exposure_identity() reads both from one open; it must agree exactly with
+    # the two standalone readers.
+    from campfire.storage.hashing import exposure_identity, wcs_hash
+    sci = np.arange(16, dtype="float32").reshape(4, 4)
+    dq = np.zeros((4, 4), dtype="int32")
+    p = _make_wcs_exposure(tmp_path / "a.fits", sci, dq, _wcs_cards())
+    assert exposure_identity(p) == (nc._sci_dq_hash(p), wcs_hash(p))
+
+
+def test_exposure_identity_matches_pipeline_recipe(tmp_path):
+    # The client re-implements the pipeline's digests (it must not import the
+    # pipeline). The two copies drifting apart would silently churn uploads, so
+    # pin them together here.
+    pipeline_manifest = pytest.importorskip(
+        "campfire_pipeline.nircam.manifest",
+        reason="campfire-pipeline not installed")
+    from campfire.storage.hashing import exposure_identity
+    sci = np.arange(16, dtype="float32").reshape(4, 4)
+    dq = np.zeros((4, 4), dtype="int32")
+    p = _make_wcs_exposure(tmp_path / "a.fits", sci, dq, _wcs_cards())
+    assert exposure_identity(str(p)) == (
+        pipeline_manifest.compute_file_hash(str(p)),
+        pipeline_manifest.compute_wcs_hash(str(p)),
+    )
 
 
 # --- upload-task builders ---------------------------------------------------
@@ -163,7 +263,8 @@ def test_row_for_nircam_exposure_identity_and_sci_dq():
     row = reg.row_for_key(
         EXP_KEY, backend="osn", content_hash="sha256:" + "a" * 64,
         size_bytes=100, content_type="application/fits",
-        deployment_id=42, sci_dq_hash="sha256:" + "b" * 64)
+        deployment_id=42, sci_dq_hash="sha256:" + "b" * 64,
+        wcs_hash="sha256:" + "d" * 64)
     assert row["product_type"] == "nircam_exposure"
     assert row["instrument"] == "nircam"
     assert row["field"] == "cosmos"
@@ -173,6 +274,7 @@ def test_row_for_nircam_exposure_identity_and_sci_dq():
     assert row["deployment_id"] == 42        # tagged with the field deployment
     assert row["exposure_ref"] == ROOT       # one active row per exposure
     assert row["sci_dq_hash"] == "sha256:" + "b" * 64
+    assert row["wcs_hash"] == "sha256:" + "d" * 64
 
 
 def test_row_sci_dq_hash_none_by_default():
@@ -186,6 +288,7 @@ def test_row_sci_dq_hash_none_by_default():
     assert row["field"] == "cosmos"
     assert row["filter"] == "f444w"
     assert row["sci_dq_hash"] is None
+    assert row["wcs_hash"] is None
 
 
 def test_build_registry_rows_threads_sci_dq_hashes(tmp_path):
@@ -194,11 +297,15 @@ def test_build_registry_rows_threads_sci_dq_hashes(tmp_path):
     tasks = [UploadTask(p, EXP_KEY, "application/fits")]
     rows = reg.build_registry_rows(
         tasks, backend="osn", succeeded_keys={EXP_KEY},
-        sci_dq_hashes={EXP_KEY: "sha256:" + "c" * 64})
+        sci_dq_hashes={EXP_KEY: "sha256:" + "c" * 64},
+        wcs_hashes={EXP_KEY: "sha256:" + "d" * 64})
     assert len(rows) == 1
     assert rows[0]["content_hash"].startswith("sha256:")   # whole-file digest
     assert rows[0]["content_hash"] != "sha256:" + "c" * 64  # not the sci_dq one
     assert rows[0]["sci_dq_hash"] == "sha256:" + "c" * 64
+    # Both identity components ride the same row; a row registered without the
+    # astrometric one would dedup as unchanged after a re-alignment.
+    assert rows[0]["wcs_hash"] == "sha256:" + "d" * 64
 
 
 # --- mosaic deploy (N2) -----------------------------------------------------

--- a/python/tests/test_push_backfill_gating.py
+++ b/python/tests/test_push_backfill_gating.py
@@ -1,0 +1,115 @@
+"""`plan_remote_push` must not write to the registry unless it is really pushing.
+
+Planning is also what a dry run does: `campfire push --dry-run` and scoped
+`campfire status` both call `plan_remote_push` and then return. The legacy
+`wcs_hash` reconciliation produces registry UPDATEs, so it is gated behind an
+explicit `apply_backfill` — otherwise a command advertised as a read-only diff
+mutates `storage_objects`.
+"""
+import types
+
+import numpy as np
+import pytest
+from astropy.io import fits
+from campfire_layout import KeyScheme, Scope, storage_key
+
+from campfire.deploy import push as push_mod
+from campfire.deploy.r2 import UploadTask
+from campfire.storage.hashing import compute_file_hash, exposure_identity
+
+
+class _FakeQuery:
+    """Records the writes it is asked to perform; reads return seeded rows."""
+
+    def __init__(self, rows, updates):
+        self._rows = rows
+        self._updates = updates
+        self._payload = None
+
+    def select(self, *_a, **_k):
+        return self
+
+    def update(self, payload):
+        self._payload = payload
+        return self
+
+    def eq(self, *_a):
+        return self
+
+    def in_(self, *_a):
+        return self
+
+    def is_(self, *_a):
+        return self
+
+    def execute(self):
+        if self._payload is not None:
+            self._updates.append(self._payload)
+            return types.SimpleNamespace(data=[])
+        return types.SimpleNamespace(data=list(self._rows))
+
+
+class _FakeClient:
+    def __init__(self, rows):
+        self._rows = rows
+        self.updates = []
+
+    def table(self, name):
+        return _FakeQuery(self._rows if name == 'storage_objects' else [],
+                          self.updates)
+
+
+@pytest.fixture
+def legacy_exposure(tmp_path):
+    """An exposure + the pre-`wcs_hash` registry row that reconciles to it."""
+    sci = fits.ImageHDU(np.arange(16, dtype='f4').reshape(4, 4), name='SCI')
+    for key, value in {
+        'CTYPE1': 'RA---TAN', 'CTYPE2': 'DEC--TAN',
+        'CRPIX1': 2.0, 'CRPIX2': 2.0, 'CRVAL1': 150.0, 'CRVAL2': 2.0,
+        'CD1_1': -8.6e-6, 'CD2_2': 8.6e-6,
+    }.items():
+        sci.header[key] = value
+    dq = fits.ImageHDU(np.zeros((4, 4), dtype='i4'), name='DQ')
+    path = tmp_path / 'jw001_nrca1.fits'
+    fits.HDUList([fits.PrimaryHDU(), sci, dq]).writeto(path)
+
+    key = storage_key('nircam_exposure', Scope(field='cosmos', filt='f444w'),
+                      path.name, scheme=KeyScheme.CANONICAL)
+    task = UploadTask(path, key, 'application/fits')
+    sci_dq, wcs = exposure_identity(path)
+    row = {
+        'storage_key': key, 'status': 'active', 'backend': 'osn',
+        'content_hash': compute_file_hash(path),   # cloud bytes ARE these bytes
+        'sci_dq_hash': sci_dq, 'wcs_hash': None,   # ...but no recorded WCS
+    }
+    return task, row, wcs
+
+
+def test_planning_alone_does_not_write_to_the_registry(legacy_exposure):
+    task, row, wcs = legacy_exposure
+    client = _FakeClient([row])
+
+    plan, _rows = plan_remote_push_default(client, [task])
+
+    # The reconciliation is still *derived* — a dry run reports it accurately.
+    assert plan.unchanged == [task]
+    assert plan.backfill == [(task.r2_key, wcs)]
+    assert 'reconciled' in plan.summary()
+    # ...but nothing was written.
+    assert client.updates == []
+
+
+def test_backfill_written_only_when_opted_in(legacy_exposure):
+    task, row, wcs = legacy_exposure
+    client = _FakeClient([row])
+
+    push_mod.plan_remote_push(client, None, [task], backend='osn',
+                              progress=False, apply_backfill=True)
+
+    assert client.updates == [{'wcs_hash': wcs}]
+
+
+def plan_remote_push_default(client, tasks):
+    """Call with the default gating — what a dry run gets."""
+    return push_mod.plan_remote_push(client, None, tasks, backend='osn',
+                                     progress=False)

--- a/python/tests/test_storage_plan.py
+++ b/python/tests/test_storage_plan.py
@@ -3,7 +3,9 @@
 Pure classification: no Supabase, no network. Covers the new/changed/unchanged
 split, the pushed_* stat fast path (skip without reading), identity-kind
 selection (sci_dq for NIRCam exposures vs whole-file), provisional-etag
-handling, and the confirmed-unchanged bookkeeping that arms the fast path.
+handling, the confirmed-unchanged bookkeeping that arms the fast path, and the
+two-component exposure identity (science + astrometry) with its legacy-row
+reconciliation.
 """
 
 import os
@@ -12,8 +14,11 @@ from pathlib import Path
 from campfire_layout import KeyScheme, Scope, storage_key
 
 from campfire.deploy.r2 import UploadTask
-from campfire.storage.hashing import compute_file_hash, sci_dq_hash
+from campfire.storage.hashing import (
+    compute_file_hash, exposure_identity, sci_dq_hash, wcs_hash,
+)
 from campfire.storage.plan import (
+    compose_identity,
     identity_kind_for_key,
     plan_push,
     server_identity_for,
@@ -143,7 +148,7 @@ def test_stat_fast_path_skips_without_reading(tmp_path, monkeypatch):
     def _boom(*a, **k):
         raise AssertionError("fast path must not hash")
     monkeypatch.setattr(plan_mod, 'hash_files_parallel', _boom)
-    monkeypatch.setattr(plan_mod, 'sci_dq_hashes_parallel', _boom)
+    monkeypatch.setattr(plan_mod, 'exposure_identities_parallel', _boom)
 
     plan = plan_push([task], rows, local_rows=local, progress=False)
     assert plan.unchanged == [task]
@@ -181,10 +186,21 @@ def test_fast_path_ignored_when_server_identity_moved(tmp_path):
 
 # --- sci_dq identity end-to-end ------------------------------------------------
 
-def _exposure_task(tmp_path, name='jw001_nrca1.fits', seed=1.0):
+def _exposure_task(tmp_path, name='jw001_nrca1.fits', seed=1.0, crval=None):
     import numpy as np
     from astropy.io import fits as afits
     sci = afits.ImageHDU(np.full((4, 4), seed, dtype='f4'), name='SCI')
+    if crval is not None:
+        # A minimal but real celestial WCS on the SCI header, as the datamodel
+        # writes it — this is what a re-alignment moves.
+        sci.header['CTYPE1'] = 'RA---TAN'
+        sci.header['CTYPE2'] = 'DEC--TAN'
+        sci.header['CRPIX1'] = 2.0
+        sci.header['CRPIX2'] = 2.0
+        sci.header['CRVAL1'] = crval[0]
+        sci.header['CRVAL2'] = crval[1]
+        sci.header['CD1_1'] = -8.6e-6
+        sci.header['CD2_2'] = 8.6e-6
     dq = afits.ImageHDU(np.zeros((4, 4), dtype='i4'), name='DQ')
     hdul = afits.HDUList([afits.PrimaryHDU(), sci, dq])
     p = tmp_path / name
@@ -192,6 +208,14 @@ def _exposure_task(tmp_path, name='jw001_nrca1.fits', seed=1.0):
     key = storage_key('nircam_exposure', Scope(field='cosmos', filt='f444w'),
                       name, scheme=KeyScheme.CANONICAL)
     return UploadTask(p, key, 'application/fits')
+
+
+def _realign(path, crval):
+    """Rewrite only the WCS — exactly what `cfpipe nircam align` does."""
+    from astropy.io import fits as afits
+    with afits.open(path, mode='update') as hdul:
+        hdul['SCI'].header['CRVAL1'] = crval[0]
+        hdul['SCI'].header['CRVAL2'] = crval[1]
 
 
 def test_sci_dq_resave_with_header_change_skips(tmp_path):
@@ -228,3 +252,144 @@ def test_legacy_exposure_row_without_sci_dq_uploads(tmp_path):
     rows = {task.r2_key: _row(task.r2_key, 'sha256:' + '9' * 64, sci_dq=None)}
     plan = plan_push([task], rows, progress=False)
     assert plan.changed == [task]
+
+
+# --- astrometric identity: the re-alignment case ------------------------------
+
+def test_realignment_uploads_despite_identical_science(tmp_path):
+    # The regression this component exists for: align rewrites the WCS and does
+    # not touch one SCI or DQ pixel, so a science-only identity said "unchanged"
+    # and the cloud copy kept its pre-alignment astrometry forever.
+    task = _exposure_task(tmp_path, crval=(150.0, 2.0))
+    sci, wcs_before = exposure_identity(task.local_path)
+    rows = {task.r2_key: _row(task.r2_key, 'sha256:' + '9' * 64,
+                              sci_dq=sci, wcs_hash=wcs_before)}
+
+    _realign(task.local_path, (150.0001, 2.0001))
+    plan = plan_push([task], rows, progress=False)
+
+    assert plan.changed == [task]
+    assert plan.to_upload == [task]
+    # Science digest is genuinely unchanged — only the WCS moved.
+    assert plan.identities[task.r2_key] == sci
+    assert plan.wcs_hashes[task.r2_key] != wcs_before
+
+
+def test_resave_without_wcs_change_still_skips(tmp_path):
+    # The property that made the partial digest worth having must survive: a
+    # re-save that shifts the whole-file hash but moves neither pixels nor WCS
+    # is still an upload we skip.
+    from astropy.io import fits as afits
+    task = _exposure_task(tmp_path, crval=(150.0, 2.0))
+    sci, wcs = exposure_identity(task.local_path)
+    rows = {task.r2_key: _row(task.r2_key, 'sha256:' + '9' * 64,
+                              sci_dq=sci, wcs_hash=wcs)}
+    with afits.open(task.local_path, mode='update') as hdul:
+        hdul[0].header['DATE'] = '2026-07-27T00:00:00'
+    plan = plan_push([task], rows, progress=False)
+    assert plan.unchanged == [task]
+    assert plan.to_upload == []
+
+
+def test_both_components_must_match_to_skip(tmp_path):
+    task = _exposure_task(tmp_path, crval=(150.0, 2.0))
+    sci, wcs = exposure_identity(task.local_path)
+    # Right WCS, wrong science → upload.
+    rows = {task.r2_key: _row(task.r2_key, 'sha256:' + '9' * 64,
+                              sci_dq='sha256:' + '0' * 64, wcs_hash=wcs)}
+    assert plan_push([task], rows, progress=False).changed == [task]
+    # Right science, wrong WCS → upload.
+    rows = {task.r2_key: _row(task.r2_key, 'sha256:' + '9' * 64,
+                              sci_dq=sci, wcs_hash='sha256:' + '0' * 64)}
+    assert plan_push([task], rows, progress=False).changed == [task]
+
+
+def test_composed_identity_arms_the_stat_fast_path(tmp_path, monkeypatch):
+    task = _exposure_task(tmp_path, crval=(150.0, 2.0))
+    sci, wcs = exposure_identity(task.local_path)
+    st = os.stat(task.local_path)
+    rows = {task.r2_key: _row(task.r2_key, 'sha256:' + '9' * 64,
+                              sci_dq=sci, wcs_hash=wcs)}
+    local = {task.r2_key: {'pushed_identity': compose_identity(sci, wcs),
+                           'pushed_mtime': st.st_mtime,
+                           'pushed_size': st.st_size}}
+
+    import campfire.storage.plan as plan_mod
+
+    def _boom(*a, **k):
+        raise AssertionError("fast path must not hash")
+    monkeypatch.setattr(plan_mod, 'hash_files_parallel', _boom)
+    monkeypatch.setattr(plan_mod, 'exposure_identities_parallel', _boom)
+
+    plan = plan_push([task], rows, local_rows=local, progress=False)
+    assert plan.unchanged == [task]
+    assert plan.fast_skipped == 1
+
+
+def test_wcsless_exposure_identity_is_bare_science_digest(tmp_path):
+    # A file with no WCS cards has no astrometric component; its identity is
+    # the science digest alone, so pre-existing pushed_identity records and
+    # registry rows keep working untouched.
+    task = _exposure_task(tmp_path)
+    assert wcs_hash(task.local_path) is None
+    assert compose_identity(sci_dq_hash(task.local_path), None) == \
+        sci_dq_hash(task.local_path)
+
+
+# --- legacy-row reconciliation (no stampede on the first upgraded push) --------
+
+def test_legacy_row_reconciles_without_uploading(tmp_path):
+    # Row predates wcs_hash. The science digest matches and the cloud object is
+    # byte-identical to this file, which proves the cloud copy carries this WCS
+    # — so: no upload, and the row learns its digest.
+    task = _exposure_task(tmp_path, crval=(150.0, 2.0))
+    sci, wcs = exposure_identity(task.local_path)
+    whole = compute_file_hash(task.local_path)
+    rows = {task.r2_key: _row(task.r2_key, whole, sci_dq=sci, wcs_hash=None)}
+
+    plan = plan_push([task], rows, progress=False)
+
+    assert plan.unchanged == [task]
+    assert plan.to_upload == []
+    assert plan.backfill == [(task.r2_key, wcs)]
+    # The confirmed identity is the COMPOSED token, so the next run fast-paths
+    # against a row that now carries both components.
+    assert plan.confirmed[0][1] == compose_identity(sci, wcs)
+
+
+def test_legacy_row_with_differing_bytes_uploads(tmp_path):
+    # Same science, no recorded astrometry, and the cloud bytes are NOT ours —
+    # unprovable, so it uploads. This is the re-aligned exposure the old
+    # identity silently skipped.
+    task = _exposure_task(tmp_path, crval=(150.0, 2.0))
+    sci, wcs = exposure_identity(task.local_path)
+    rows = {task.r2_key: _row(task.r2_key, 'sha256:' + '9' * 64,
+                              sci_dq=sci, wcs_hash=None)}
+
+    plan = plan_push([task], rows, progress=False)
+
+    assert plan.changed == [task]
+    assert plan.backfill == []
+    # The whole-file hash the reconciliation computed is handed to registration
+    # rather than thrown away.
+    assert plan.whole_file[task.r2_key][0] == compute_file_hash(task.local_path)
+
+
+def test_upload_order_preserved_across_reconciliation(tmp_path):
+    # Reconciliation runs as a second pass; to_upload must still follow the
+    # input task order.
+    a = _exposure_task(tmp_path, name='jw_a_nrca1.fits', crval=(150.0, 2.0))
+    b = _exposure_task(tmp_path, name='jw_b_nrca1.fits', seed=2.0)
+    c = _exposure_task(tmp_path, name='jw_c_nrca1.fits', seed=3.0,
+                       crval=(151.0, 3.0))
+    rows = {
+        # a: legacy row, bytes differ → reconciliation says upload.
+        a.r2_key: _row(a.r2_key, 'sha256:' + '9' * 64,
+                       sci_dq=sci_dq_hash(a.local_path), wcs_hash=None),
+        # b: no row at all → new.
+        # c: identity mismatch → changed in the first pass.
+        c.r2_key: _row(c.r2_key, 'sha256:' + '9' * 64,
+                       sci_dq='sha256:' + '0' * 64, wcs_hash='sha256:' + '1' * 64),
+    }
+    plan = plan_push([a, b, c], rows, progress=False)
+    assert plan.to_upload == [a, b, c]

--- a/supabase/migrations/20260727120000_storage_objects_wcs_hash.sql
+++ b/supabase/migrations/20260727120000_storage_objects_wcs_hash.sql
@@ -1,0 +1,27 @@
+-- storage_objects.wcs_hash — the astrometric half of the NIRCam exposure
+-- identity.
+--
+-- sci_dq_hash (epic #261, N1) digests only the SCI/DQ/CFMASK arrays, so it is
+-- blind to a re-ALIGNMENT: `cfpipe nircam align` (and wcs_shift) rewrite an
+-- exposure's WCS without touching a single science pixel. The push planner
+-- compared that digest alone, classified re-aligned exposures as "unchanged",
+-- and left the cloud copy carrying its pre-alignment astrometry indefinitely.
+-- Deploy now requires BOTH digests to match before skipping an upload.
+--
+-- Existing exposure rows keep wcs_hash NULL. The planner does not stampede on
+-- those: when the science digest still matches it compares the local whole-file
+-- sha256 against content_hash, and a byte-for-byte match proves the cloud object
+-- already carries this WCS, so the row is backfilled in place with no transfer.
+--
+-- Additive only — no backfill statement here, since the digest can only be
+-- computed from the local FITS headers on a reducer machine.
+
+alter table "public"."storage_objects" add column "wcs_hash" text;
+
+alter table "public"."storage_objects"
+  add constraint "storage_objects_wcs_hash_check"
+  CHECK (((wcs_hash IS NULL) OR (wcs_hash ~ '^sha256:'::text)));
+
+COMMENT ON COLUMN "public"."storage_objects"."wcs_hash" IS 'Astrometric change-detection digest: sha256 over the WCS-defining header cards of a NIRCam canonical exposure. The companion to sci_dq_hash — the align and wcs_shift steps rewrite an exposure''s WCS without touching a SCI or DQ pixel, so a science-only identity skipped re-aligned exposures and left the cloud copy on its pre-alignment astrometry. Never used for download/copy verification. NULL for whole-file-identity products, and on exposure rows written before this column existed (the push planner reconciles those against content_hash and backfills the digest without re-uploading).';
+
+COMMENT ON COLUMN "public"."storage_objects"."sci_dq_hash" IS 'Science-only sha256(SCI+DQ) change-detection digest (epic #261, N1). Lets deploy skip re-uploading a NIRCam canonical exposure whose science is unchanged even though its whole-file content_hash shifted (pipeline re-save bumps header timestamps). Paired with wcs_hash: BOTH must match for deploy to skip an upload, since the array digest alone cannot see a re-alignment. content_hash remains the authoritative whole-file integrity token; this is never used for download/copy verification. NULL for products without a partial digest.';

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -1009,6 +1009,16 @@ CREATE TABLE IF NOT EXISTS "public"."storage_objects" (
     -- checks; sci_dq_hash is only a change-detection key. NULL for products with
     -- no partial digest (everything except nircam_exposure today).
     "sci_dq_hash" "text",
+    -- Astrometric half of the same change-detection identity. sci_dq_hash alone
+    -- is blind to a re-ALIGNMENT: the align (and wcs_shift) steps rewrite an
+    -- exposure's WCS without touching a single SCI or DQ pixel, so a re-aligned
+    -- exposure deduped as "unchanged" and the cloud copy kept its pre-alignment
+    -- astrometry indefinitely. Deploy now requires BOTH digests to match before
+    -- skipping an upload. sha256 over the WCS-defining header cards (see
+    -- campfire.storage.hashing.wcs_hash). NULL for products that compare on the
+    -- whole-file hash, and on exposure rows written before this column existed —
+    -- the push planner reconciles those against content_hash and backfills.
+    "wcs_hash" "text",
     "size_bytes" bigint NOT NULL,
     -- Bytes as stored in the bucket for transport-compressed products (gzipped
     -- mosaic FITS, epic #261 / PR #383); NULL = stored verbatim. size_bytes
@@ -1041,6 +1051,9 @@ CREATE TABLE IF NOT EXISTS "public"."storage_objects" (
     -- sci_dq_hash, when present, is always an authoritative sha256 (no provisional
     -- etag form — it is computed from the local FITS arrays, never a HEAD).
     CONSTRAINT "storage_objects_sci_dq_hash_check" CHECK (("sci_dq_hash" IS NULL OR "sci_dq_hash" ~ '^sha256:'::"text")),
+    -- wcs_hash, like sci_dq_hash, is always an authoritative sha256 when present
+    -- (computed from the local FITS header cards, never from a HEAD).
+    CONSTRAINT "storage_objects_wcs_hash_check" CHECK (("wcs_hash" IS NULL OR "wcs_hash" ~ '^sha256:'::"text")),
     -- product_type tracks the campfire_layout PRODUCTS registry (every entry with a
     -- non-null bucket). A new cloud-backed product type requires a migration here.
     CONSTRAINT "storage_objects_product_type_check" CHECK (("product_type" = ANY (ARRAY[
@@ -1085,7 +1098,9 @@ COMMENT ON COLUMN "public"."storage_objects"."filter" IS 'Typed, indexed scope c
 
 COMMENT ON COLUMN "public"."storage_objects"."exposure_ref" IS 'Stable per-exposure reference for intermediate products (nircam rootname; nirspec (root,nod,detector,source) tuple). Backs the partial unique (product_type, exposure_ref) WHERE status=''active'' — one current object per product/exposure.';
 
-COMMENT ON COLUMN "public"."storage_objects"."sci_dq_hash" IS 'Science-only sha256(SCI+DQ) change-detection digest (epic #261, N1). Lets deploy skip re-uploading a NIRCam canonical exposure whose science is unchanged even though its whole-file content_hash shifted (pipeline re-save bumps header timestamps). content_hash remains the authoritative whole-file integrity token; this is never used for download/copy verification. NULL for products without a partial digest.';
+COMMENT ON COLUMN "public"."storage_objects"."sci_dq_hash" IS 'Science-only sha256(SCI+DQ) change-detection digest (epic #261, N1). Lets deploy skip re-uploading a NIRCam canonical exposure whose science is unchanged even though its whole-file content_hash shifted (pipeline re-save bumps header timestamps). Paired with wcs_hash: BOTH must match for deploy to skip an upload, since the array digest alone cannot see a re-alignment. content_hash remains the authoritative whole-file integrity token; this is never used for download/copy verification. NULL for products without a partial digest.';
+
+COMMENT ON COLUMN "public"."storage_objects"."wcs_hash" IS 'Astrometric change-detection digest: sha256 over the WCS-defining header cards of a NIRCam canonical exposure. The companion to sci_dq_hash — the align and wcs_shift steps rewrite an exposure''s WCS without touching a SCI or DQ pixel, so a science-only identity skipped re-aligned exposures and left the cloud copy on its pre-alignment astrometry. Never used for download/copy verification. NULL for whole-file-identity products, and on exposure rows written before this column existed (the push planner reconciles those against content_hash and backfills the digest without re-uploading).';
 
 COMMENT ON COLUMN "public"."storage_objects"."status" IS 'active = current object; superseded = replaced by a newer hash (tombstone, GC-eligible later); revoked = un-published. Only active rows count toward the budget and the partial-unique constraint.';
 

--- a/web/components/admin/StorageObjectDrawer.tsx
+++ b/web/components/admin/StorageObjectDrawer.tsx
@@ -201,6 +201,7 @@ export function StorageObjectDrawer({ id, onClose }: { id: number; onClose: () =
                 <Row label="Status">{obj.status}</Row>
                 <Row label="Content hash">{obj.content_hash}</Row>
                 <Row label="SCI+DQ hash">{obj.sci_dq_hash ?? '—'}</Row>
+                <Row label="WCS hash">{obj.wcs_hash ?? '—'}</Row>
                 <Row label="cfpipe version">{obj.cfpipe_version ?? '—'}</Row>
                 <Row label="Created">{fmtDate(obj.created_at)}</Row>
                 <Row label="Updated">{fmtDate(obj.updated_at)}</Row>

--- a/web/lib/actions/storage-registry.ts
+++ b/web/lib/actions/storage-registry.ts
@@ -178,6 +178,7 @@ export interface StorageObjectDetail {
   size_bytes: number;
   content_hash: string;
   sci_dq_hash: string | null;
+  wcs_hash: string | null;
   content_type: string;
   backend: string;
   bucket: string;
@@ -232,7 +233,7 @@ export async function getStorageObjectDetail(
       .from('storage_objects')
       .select(
         'id, storage_key, product_type, instrument, observation, field, exposure_ref, ' +
-        'size_bytes, content_hash, sci_dq_hash, content_type, backend, bucket, status, ' +
+        'size_bytes, content_hash, sci_dq_hash, wcs_hash, content_type, backend, bucket, status, ' +
         'cfpipe_version, deployment_id, uploaded_by, created_at, updated_at',
       )
       .eq('id', id)


### PR DESCRIPTION
## Summary

Extends the NIRCam exposure change-detection identity from science-only (`sci_dq_hash`) to include an astrometric component (`wcs_hash`). This prevents re-aligned exposures from being incorrectly deduplicated as unchanged when their WCS has moved but pixels remain identical.

## Problem

The `align` and `wcs_shift` pipeline steps rewrite an exposure's WCS without touching a single SCI or DQ pixel. The existing science-only digest (`sci_dq_hash`) cannot detect this change, causing re-aligned exposures to be classified as unchanged and uploaded with stale astrometry to the cloud.

## Solution

Introduces a two-component exposure identity:
- **Science digest** (`sci_dq_hash`): SHA-256 over SCI+DQ+CFMASK arrays
- **Astrometric digest** (`wcs_hash`): SHA-256 over WCS-defining header cards (CTYPE, CRPIX, CRVAL, CD, PC, SIP coefficients, JWST aperture refs, S_REGION)

Both must match for an upload to be skipped. The digests are kept separate in the registry and composed only when needed for comparison.

## Key Changes

**Storage & Registry:**
- Add `wcs_hash` column to `storage_objects` table (nullable, for backward compatibility)
- Update registry schema and migration

**Hashing (`campfire/storage/hashing.py`):**
- New `wcs_hash(path)` function: computes astrometric digest from FITS WCS header cards
- New `exposure_identity(path)` function: returns both digests from a single file open (efficient)
- New `exposure_identities_parallel()` function: parallel version for batch processing
- WCS card whitelist (`_WCS_KEY_RE`) ensures digest stability across re-saves

**Planning (`campfire/storage/plan.py`):**
- New `compose_identity(sci_dq, wcs)` function: combines digests into opaque token for fast-path bookkeeping
- Updated `server_identity_for()` to compose exposure identities from server rows
- Extended `PushPlan` dataclass with `wcs_hashes` dict and `backfill` list
- **Legacy row reconciliation**: When a pre-`wcs_hash` row's science digest matches, compare local whole-file sha256 against `content_hash`. A byte-for-byte match proves the cloud copy carries this WCS, so skip upload and backfill the row's `wcs_hash` without re-uploading

**Deployment (`campfire/deploy/push.py` & `registry.py`):**
- Thread `wcs_hash` through registry row building
- Implement `backfill_wcs_hashes()` to write reconciled digests back to registry
- Update column fetch list to include `wcs_hash` from server

**Pipeline (`campfire_pipeline/nircam/manifest.py` & `orchestrate.py`):**
- Mirror `compute_wcs_hash()` implementation (client cannot import pipeline)
- Update `file_unchanged()` to compare both digests
- Update outlier up-to-date check to use `file_unchanged()` instead of inline hash comparison

## Notable Details

- **Backward compatibility**: Existing rows with NULL `wcs_hash` are handled gracefully via reconciliation—no stampede of re-uploads on first upgraded push
- **Efficiency**: `exposure_identity()` reads both digests from one file open; composed identity arms the stat fast-path so unchanged files are never re-read
- **Mirroring strategy**: `wcs_hash` is deliberately NOT mirrored locally; always read from live server fetch to avoid forcing a schema bump on all reducers
- **WCS card selection**: Whitelist (not denylist) ensures digest never churns on re-saves that don't move astrometry
- **Pipeline sync**: Both client and pipeline implement identical WCS digest recipe; tests pin them together to prevent silent drift

## Testing

- Unit tests for both digest functions and their stability across re-saves
- Integration tests for re-alignment detection and legacy row reconciliation
- Tests verifying composed identity arms the stat fast-path

https://claude.ai/code/session_017c6A8ePrWuwe7Hmn2roLMa