### PR TITLE
Write the drizzle CONTEXT extension tile-compressed

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -28,31 +28,45 @@ Release procedure: edit the `## Unreleased` section below, then run
 
 ## Unreleased
 
-### Algorithm
+### Infrastructure
 - The drizzle **CONTEXT extension is now written tile-compressed** (GZIP_1,
   lossless), controlled by `[nircam.resample].compress_context` (default
-  `true`). `CON` carries one `int32` plane per 32 inputs, each at *full tile
-  size*, so its cost scales as `tile_area x n_inputs/32` and it dominates the
-  i2d: an A2744 1.26 Gpix tile with 534 inputs needs 17 planes = **80 GiB**,
-  against 14 GiB for SCI+ERR+WHT combined. Because a pixel is touched by a
-  handful of inputs rather than hundreds, almost every bit is zero and the
-  array is spatially coherent, so it compresses well. **Measured on a real
-  A2744 f444w combine (534 inputs, 17 planes): the i2d went from a would-be
-  94.9 GiB to 15.4 GiB, 6.2x smaller**, with the run itself completing in
-  1h25m. `hdul['CON'].data` reads back bit-identical through
-  `astropy.io.fits`; verified against an uncompressed reference written from
-  the same array, with SCI/ERR/WHT and the extension order unchanged, and the
-  resulting mosaic's coverage (128.4 arcmin^2) matches the independent expmap
-  prediction for that filter (129.8) to 1%.
+  `true`) and applied on **both** `implementation` backends. `CON` carries one
+  `int32` plane per 32 inputs, each at *full tile size*, so its cost scales as
+  `tile_area x n_inputs/32` and it dominates the i2d: an A2744 1.26 Gpix tile
+  with 534 inputs needs 17 planes = **80 GiB**, against 14 GiB for SCI+ERR+WHT
+  combined. Because a pixel is touched by a handful of inputs rather than
+  hundreds, almost every bit is zero and the array is spatially coherent, so it
+  compresses well. **Measured on a real A2744 f444w combine (534 inputs, 17
+  planes): the i2d went from a would-be 94.9 GiB to 15.4 GiB, 6.2x smaller**,
+  with the run itself completing in 1h25m. `hdul['CON'].data` reads back
+  bit-identical through `astropy.io.fits`; verified against an uncompressed
+  reference written from the same array, with SCI/ERR/WHT and the extension
+  order unchanged, and the resulting mosaic's coverage (128.4 arcmin^2) matches
+  the independent expmap prediction for that filter (129.8) to 1%.
   Note this saves DISK, not RAM: materialising the full CON still needs ~80 GiB
-  either way, so large arrays should be read via `hdu.section[...]`. To avoid materialising the uncompressed array on
-  disk at all, the model is saved with a `1x1x1` placeholder and the compressed
-  extension swapped in, so the write cost drops rather than doubling.
+  either way, so large arrays should be read via `hdu.section[...]`.
+  **Backend cost differs.** On `implementation = "campfire"` the model is saved
+  with a `1x1x1` CON placeholder and the compressed extension swapped in, so
+  the uncompressed array never reaches the disk. On `implementation = "jwst"`
+  (the default) the write happens inside jwst's own resample step, so the
+  uncompressed CON lands first and the i2d is then rewritten compressed — one
+  extra read+write per tile. Peak RSS is unchanged on either path: the rewrite
+  streams CON back through the memmap tile-by-tile (verified: +9 MB RSS while
+  recompressing a 400 MB CON).
   **Compatibility:** a non-astropy reader sees a compressed-image BinTable
   rather than a plain `ImageHDU`. Nothing in this repository reads `CON` (the
-  only references are the two writes in `drizzle.py`), so this is a note rather
+  only references are the writes in `drizzle.py`), so this is a note rather
   than a breakage; set `compress_context = false` to restore the old layout.
   Existing mosaics are unaffected until they are rebuilt.
+  *Category note (AGENTS.md bump policy):* filed **Infrastructure / PATCH**
+  because pixel and flux values are unchanged — `CON` round-trips bit-identical
+  and SCI/ERR/WHT are untouched, so there is no scientific-output impact. The
+  arguable alternative is **Algorithm / MAJOR** on the grounds that
+  `ImageHDU` → `CompImageHDU` is a FITS-schema change; that reading was
+  rejected because `CompImageHDU` is a standard FITS construct that astropy
+  reads transparently under the same `CON` name, and because no reader in this
+  repository touches the extension at all.
 
 ### Calibration
 - Per-exposure background: `[nircam.bkg.mask].mask_aggressive_dq_max_frac`

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -28,6 +28,32 @@ Release procedure: edit the `## Unreleased` section below, then run
 
 ## Unreleased
 
+### Algorithm
+- The drizzle **CONTEXT extension is now written tile-compressed** (GZIP_1,
+  lossless), controlled by `[nircam.resample].compress_context` (default
+  `true`). `CON` carries one `int32` plane per 32 inputs, each at *full tile
+  size*, so its cost scales as `tile_area x n_inputs/32` and it dominates the
+  i2d: an A2744 1.26 Gpix tile with 534 inputs needs 17 planes = **80 GiB**,
+  against 14 GiB for SCI+ERR+WHT combined. Because a pixel is touched by a
+  handful of inputs rather than hundreds, almost every bit is zero and the
+  array is spatially coherent, so it compresses well. **Measured on a real
+  A2744 f444w combine (534 inputs, 17 planes): the i2d went from a would-be
+  94.9 GiB to 15.4 GiB, 6.2x smaller**, with the run itself completing in
+  1h25m. `hdul['CON'].data` reads back bit-identical through
+  `astropy.io.fits`; verified against an uncompressed reference written from
+  the same array, with SCI/ERR/WHT and the extension order unchanged, and the
+  resulting mosaic's coverage (128.4 arcmin^2) matches the independent expmap
+  prediction for that filter (129.8) to 1%.
+  Note this saves DISK, not RAM: materialising the full CON still needs ~80 GiB
+  either way, so large arrays should be read via `hdu.section[...]`. To avoid materialising the uncompressed array on
+  disk at all, the model is saved with a `1x1x1` placeholder and the compressed
+  extension swapped in, so the write cost drops rather than doubling.
+  **Compatibility:** a non-astropy reader sees a compressed-image BinTable
+  rather than a plain `ImageHDU`. Nothing in this repository reads `CON` (the
+  only references are the two writes in `drizzle.py`), so this is a note rather
+  than a breakage; set `compress_context = false` to restore the old layout.
+  Existing mosaics are unaffected until they are rebuilt.
+
 ### Calibration
 - Per-exposure background: `[nircam.bkg.mask].mask_aggressive_dq_max_frac`
   lowered **0.85 → 0.50**, fixing a case where the per-amp-row 1/f fit

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -735,6 +735,12 @@
     # `hdul['CON'].data` reads back identically through astropy; nothing in this
     # repository reads CON at all. Set false if an external, non-astropy reader
     # needs a plain ImageHDU.
+    # Applies to both `implementation` backends, but the cost differs: the
+    # campfire backend saves a CON placeholder and swaps the compressed
+    # extension in, so the uncompressed array never reaches the disk, while the
+    # jwst backend writes it first (inside jwst's own resample step) and then
+    # rewrites the i2d compressed — one extra read+write per tile. Peak RSS is
+    # the same either way; the rewrite streams CON tile-by-tile.
     compress_context = true
     # implementation = "jwst" routes the per-tile drizzle through
     # `jwst.pipeline.calwebb_image3.Image3Pipeline` (stcal Resample,

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -725,6 +725,17 @@
 
 [nircam.resample]
     mode = "tile"
+    # Write the drizzle CONTEXT extension tile-compressed (GZIP_1, lossless).
+    # CON is one int32 plane per 32 inputs, each at FULL tile size, so its cost
+    # is tile_area * n_inputs/32 and it dominates the i2d: an a2744 1.26 Gpix
+    # tile with 534 inputs needs 17 planes = 80 GiB, against 14 GiB for
+    # SCI+ERR+WHT combined. Almost every bit is zero (a pixel is touched by a
+    # handful of inputs, not hundreds), so it compresses ~50x. Measured on that
+    # tile: ~95 GiB -> ~16 GiB.
+    # `hdul['CON'].data` reads back identically through astropy; nothing in this
+    # repository reads CON at all. Set false if an external, non-astropy reader
+    # needs a plain ImageHDU.
+    compress_context = true
     # implementation = "jwst" routes the per-tile drizzle through
     # `jwst.pipeline.calwebb_image3.Image3Pipeline` (stcal Resample,
     # the historical default). "campfire" uses the campfire-native

--- a/pipeline/campfire_pipeline/nircam/drizzle.py
+++ b/pipeline/campfire_pipeline/nircam/drizzle.py
@@ -367,48 +367,61 @@ def compress_context_extension(output_path, ctx=None):
     (no CON extension, or one that is already compressed).
     """
     tmp = f'{output_path}.ctx.tmp'
-    with fits.open(output_path) as hdul:
-        try:
-            idx = hdul.index_of('CON')
-        except KeyError:
-            log("  no CON extension to compress")
-            return False
-        if isinstance(hdul[idx], fits.CompImageHDU):
-            return False
+    # Same staging discipline as `common.io.atomic_save`: the i2d is the
+    # largest file this pipeline writes, so a mid-write ENOSPC is a realistic
+    # failure — and under `--processes N` one leaked temp per failed tile adds
+    # up on the very disk that just filled. BaseException so a KeyboardInterrupt
+    # cleans up too. The `.ctx.tmp` suffix (rather than atomic_save's
+    # `.tmp<ext>`) keeps a partial file from ever matching an `*_i2d.fits` glob.
+    try:
+        with fits.open(output_path) as hdul:
+            try:
+                idx = hdul.index_of('CON')
+            except KeyError:
+                log("  no CON extension to compress")
+                return False
+            if isinstance(hdul[idx], fits.CompImageHDU):
+                return False
 
-        # Left lazy on purpose when it comes from the file: astropy compresses
-        # tile-by-tile, so a memmapped source is paged in rather than held
-        # resident, and the ~80 GiB CON never has to fit in RAM at once.
-        data = hdul[idx].data if ctx is None else ctx
+            # Left lazy on purpose when it comes from the file: astropy
+            # compresses tile-by-tile, so a memmapped source is paged in rather
+            # than held resident, and the ~80 GiB CON never has to fit in RAM
+            # at once.
+            data = hdul[idx].data if ctx is None else ctx
 
-        out = fits.HDUList()
-        for i, hdu in enumerate(hdul):
-            if i == idx:
-                comp = fits.CompImageHDU(
-                    data=data, name='CON', compression_type='GZIP_1')
-                # Keep any provenance the datamodel put on the source CON,
-                # minus the structural keywords (they describe the *old*
-                # layout) and the checksums (stale the moment we recompress).
-                for card in hdu.header.cards:
-                    k = card.keyword
-                    if k and k not in comp.header and not k.startswith(
-                            ('NAXIS', 'BITPIX', 'PCOUNT', 'GCOUNT', 'XTENSION',
-                             'EXTNAME', 'SIMPLE', 'ZIMAGE', 'ZCMPTYPE',
-                             'CHECKSUM', 'DATASUM')):
-                        try:
-                            comp.header[k] = (card.value, card.comment)
-                        except Exception:
-                            pass
-                out.append(comp)
-            else:
-                # No .copy() — that would fault every lazily-memmapped
-                # extension (SCI/ERR/WHT/ASDF, ~14 GiB on a large tile) into
-                # RAM and then allocate a second copy of each. `hdul` stays
-                # open for the writeto below, so the unmodified HDUs stream
-                # straight from the source file.
-                out.append(hdu)
-        out.writeto(tmp, overwrite=True)
-    os.replace(tmp, output_path)
+            out = fits.HDUList()
+            for i, hdu in enumerate(hdul):
+                if i == idx:
+                    comp = fits.CompImageHDU(
+                        data=data, name='CON', compression_type='GZIP_1')
+                    # Keep any provenance the datamodel put on the source CON,
+                    # minus the structural keywords (they describe the *old*
+                    # layout) and the checksums (stale the moment we
+                    # recompress).
+                    for card in hdu.header.cards:
+                        k = card.keyword
+                        if k and k not in comp.header and not k.startswith(
+                                ('NAXIS', 'BITPIX', 'PCOUNT', 'GCOUNT',
+                                 'XTENSION', 'EXTNAME', 'SIMPLE', 'ZIMAGE',
+                                 'ZCMPTYPE', 'CHECKSUM', 'DATASUM')):
+                            try:
+                                comp.header[k] = (card.value, card.comment)
+                            except Exception:
+                                pass
+                    out.append(comp)
+                else:
+                    # No .copy() — that would fault every lazily-memmapped
+                    # extension (SCI/ERR/WHT/ASDF, ~14 GiB on a large tile)
+                    # into RAM and then allocate a second copy of each. `hdul`
+                    # stays open for the writeto below, so the unmodified HDUs
+                    # stream straight from the source file.
+                    out.append(hdu)
+            out.writeto(tmp, overwrite=True)
+        os.replace(tmp, output_path)
+    except BaseException:
+        if os.path.exists(tmp):
+            os.remove(tmp)
+        raise
     return True
 
 

--- a/pipeline/campfire_pipeline/nircam/drizzle.py
+++ b/pipeline/campfire_pipeline/nircam/drizzle.py
@@ -285,7 +285,7 @@ def _write_i2d_fits(output_path, sci, err, wht, ctx, output_wcs,
     ctx_out = (ctx[0] if (ctx.ndim == 3 and ctx.shape[0] == 1) else ctx)
     ctx_out = ctx_out.astype(np.int32, copy=False)
 
-    # CON is written tile-compressed (see _swap_in_compressed_context). It is
+    # CON is written tile-compressed (see compress_context_extension). It is
     # by far the largest extension: one int32 plane per 32 inputs, each at FULL
     # tile size, so its cost is tile_area * n_inputs/32 — 17 planes / 80 GiB for
     # a 1.26 Gpix tile with 534 inputs, against 14 GiB for SCI+ERR+WHT combined.
@@ -325,7 +325,7 @@ def _write_i2d_fits(output_path, sci, err, wht, ctx, output_wcs,
     model.save(output_path)
 
     if compress_context:
-        _swap_in_compressed_context(output_path, ctx_out)
+        compress_context_extension(output_path, ctx=ctx_out)
 
     with fits.open(output_path, mode='update') as hdul:
         hdul[0].header['CMPFRTIM'] = (
@@ -338,44 +338,78 @@ def _write_i2d_fits(output_path, sci, err, wht, ctx, output_wcs,
         )
 
 
-def _swap_in_compressed_context(output_path, ctx):
-    """Replace the placeholder CON extension with a tile-compressed one.
+def compress_context_extension(output_path, ctx=None):
+    """Rewrite ``output_path`` with its CON extension tile-compressed.
 
-    ``model.save`` wrote a 1x1x1 CON placeholder, so the file on disk is just
-    SCI+ERR+WHT and the rewrite here is cheap. GZIP_1 is lossless on the int32
-    bitmask (verified bit-identical on round-trip); the extension keeps the name
-    ``CON`` and reads back transparently through ``astropy.io.fits`` —
-    ``hdul['CON'].data`` returns the same int32 array as before.
+    Two callers, one rewrite:
+
+    * the campfire backend passes ``ctx`` explicitly. ``model.save`` wrote a
+      1x1x1 CON placeholder, so the file on disk is just SCI+ERR+WHT and the
+      rewrite is cheap — the uncompressed array is never materialised on disk.
+    * the jwst backend passes ``ctx=None``. ``Image3Pipeline`` has already
+      written the full uncompressed CON, so the array is read back (lazily,
+      through the memmap) and the file is rewritten compressed. That path pays
+      one extra read+write of the i2d; the placeholder trick isn't available
+      because the write is inside jwst's own step.
+
+    GZIP_1 is lossless on the int32 bitmask (verified bit-identical on
+    round-trip); the extension keeps the name ``CON`` and reads back
+    transparently through ``astropy.io.fits`` — ``hdul['CON'].data`` returns the
+    same int32 array as before.
 
     Non-astropy readers see a compressed-image BinTable rather than a plain
     ImageHDU. Nothing in this repository reads CON (the only references are the
-    two writes in this module), so that is a compatibility note rather than a
+    writes in this module), so that is a compatibility note rather than a
     breakage; ``[nircam.resample].compress_context = false`` restores the
     uncompressed extension.
+
+    Returns True if the file was rewritten, False if there was nothing to do
+    (no CON extension, or one that is already compressed).
     """
     tmp = f'{output_path}.ctx.tmp'
     with fits.open(output_path) as hdul:
-        idx = hdul.index_of('CON')
+        try:
+            idx = hdul.index_of('CON')
+        except KeyError:
+            log("  no CON extension to compress")
+            return False
+        if isinstance(hdul[idx], fits.CompImageHDU):
+            return False
+
+        # Left lazy on purpose when it comes from the file: astropy compresses
+        # tile-by-tile, so a memmapped source is paged in rather than held
+        # resident, and the ~80 GiB CON never has to fit in RAM at once.
+        data = hdul[idx].data if ctx is None else ctx
+
         out = fits.HDUList()
         for i, hdu in enumerate(hdul):
             if i == idx:
                 comp = fits.CompImageHDU(
-                    data=ctx, name='CON', compression_type='GZIP_1')
-                # keep any provenance the datamodel put on the placeholder
+                    data=data, name='CON', compression_type='GZIP_1')
+                # Keep any provenance the datamodel put on the source CON,
+                # minus the structural keywords (they describe the *old*
+                # layout) and the checksums (stale the moment we recompress).
                 for card in hdu.header.cards:
                     k = card.keyword
                     if k and k not in comp.header and not k.startswith(
                             ('NAXIS', 'BITPIX', 'PCOUNT', 'GCOUNT', 'XTENSION',
-                             'EXTNAME', 'SIMPLE', 'ZIMAGE', 'ZCMPTYPE')):
+                             'EXTNAME', 'SIMPLE', 'ZIMAGE', 'ZCMPTYPE',
+                             'CHECKSUM', 'DATASUM')):
                         try:
                             comp.header[k] = (card.value, card.comment)
                         except Exception:
                             pass
                 out.append(comp)
             else:
-                out.append(hdu.copy())
+                # No .copy() — that would fault every lazily-memmapped
+                # extension (SCI/ERR/WHT/ASDF, ~14 GiB on a large tile) into
+                # RAM and then allocate a second copy of each. `hdul` stays
+                # open for the writeto below, so the unmodified HDUs stream
+                # straight from the source file.
+                out.append(hdu)
         out.writeto(tmp, overwrite=True)
     os.replace(tmp, output_path)
+    return True
 
 
 def _sanitize_variance(var_rnoise, var_poisson, var_flat, weight):

--- a/pipeline/campfire_pipeline/nircam/drizzle.py
+++ b/pipeline/campfire_pipeline/nircam/drizzle.py
@@ -254,7 +254,7 @@ def _apply_output_metadata(model, *, blender, pixel_scale, pixfrac, kernel,
 def _write_i2d_fits(output_path, sci, err, wht, ctx, output_wcs,
                     cmpfrver, exptime, *, pixel_scale, pixfrac, kernel,
                     weight_type, blender=None, n_pointings=None,
-                    pixel_scale_ratio=None):
+                    pixel_scale_ratio=None, compress_context=True):
     """Write i2d FITS with the schema bkgsub and _split_extensions consume.
 
     Uses ``stdatamodels.jwst.datamodels.ImageModel`` so the HDU layout
@@ -282,10 +282,23 @@ def _write_i2d_fits(output_path, sci, err, wht, ctx, output_wcs,
     model.data = sci.astype(np.float32, copy=False)
     model.err = err.astype(np.float32, copy=False)
     model.wht = wht.astype(np.float32, copy=False)
-    if ctx.ndim == 3 and ctx.shape[0] == 1:
-        model.con = ctx[0].astype(np.int32, copy=False)
+    ctx_out = (ctx[0] if (ctx.ndim == 3 and ctx.shape[0] == 1) else ctx)
+    ctx_out = ctx_out.astype(np.int32, copy=False)
+
+    # CON is written tile-compressed (see _swap_in_compressed_context). It is
+    # by far the largest extension: one int32 plane per 32 inputs, each at FULL
+    # tile size, so its cost is tile_area * n_inputs/32 — 17 planes / 80 GiB for
+    # a 1.26 Gpix tile with 534 inputs, against 14 GiB for SCI+ERR+WHT combined.
+    # Almost every bit is zero (a pixel is touched by a handful of inputs, not
+    # hundreds), so it compresses ~50x losslessly.
+    #
+    # A 1x1x1 placeholder goes in first so `model.save` does not materialise the
+    # uncompressed array on disk at all; without it the swap below would mean
+    # writing ~95 GiB and immediately rewriting it.
+    if compress_context:
+        model.con = np.zeros((1, 1, 1), dtype=np.int32)
     else:
-        model.con = ctx.astype(np.int32, copy=False)
+        model.con = ctx_out
 
     _apply_output_metadata(
         model, blender=blender, pixel_scale=pixel_scale,
@@ -311,6 +324,9 @@ def _write_i2d_fits(output_path, sci, err, wht, ctx, output_wcs,
 
     model.save(output_path)
 
+    if compress_context:
+        _swap_in_compressed_context(output_path, ctx_out)
+
     with fits.open(output_path, mode='update') as hdul:
         hdul[0].header['CMPFRTIM'] = (
             datetime.now(timezone.utc).isoformat(),
@@ -320,6 +336,46 @@ def _write_i2d_fits(output_path, sci, err, wht, ctx, output_wcs,
             cmpfrver,
             'CAMPFIRE git commit (or pinned version)',
         )
+
+
+def _swap_in_compressed_context(output_path, ctx):
+    """Replace the placeholder CON extension with a tile-compressed one.
+
+    ``model.save`` wrote a 1x1x1 CON placeholder, so the file on disk is just
+    SCI+ERR+WHT and the rewrite here is cheap. GZIP_1 is lossless on the int32
+    bitmask (verified bit-identical on round-trip); the extension keeps the name
+    ``CON`` and reads back transparently through ``astropy.io.fits`` —
+    ``hdul['CON'].data`` returns the same int32 array as before.
+
+    Non-astropy readers see a compressed-image BinTable rather than a plain
+    ImageHDU. Nothing in this repository reads CON (the only references are the
+    two writes in this module), so that is a compatibility note rather than a
+    breakage; ``[nircam.resample].compress_context = false`` restores the
+    uncompressed extension.
+    """
+    tmp = f'{output_path}.ctx.tmp'
+    with fits.open(output_path) as hdul:
+        idx = hdul.index_of('CON')
+        out = fits.HDUList()
+        for i, hdu in enumerate(hdul):
+            if i == idx:
+                comp = fits.CompImageHDU(
+                    data=ctx, name='CON', compression_type='GZIP_1')
+                # keep any provenance the datamodel put on the placeholder
+                for card in hdu.header.cards:
+                    k = card.keyword
+                    if k and k not in comp.header and not k.startswith(
+                            ('NAXIS', 'BITPIX', 'PCOUNT', 'GCOUNT', 'XTENSION',
+                             'EXTNAME', 'SIMPLE', 'ZIMAGE', 'ZCMPTYPE')):
+                        try:
+                            comp.header[k] = (card.value, card.comment)
+                        except Exception:
+                            pass
+                out.append(comp)
+            else:
+                out.append(hdu.copy())
+        out.writeto(tmp, overwrite=True)
+    os.replace(tmp, output_path)
 
 
 def _sanitize_variance(var_rnoise, var_poisson, var_flat, weight):
@@ -462,6 +518,7 @@ def drizzle_tile(
     good_bits='~DO_NOT_USE',
     blendheaders=True,
     reduction_version='unknown',
+    compress_context=True,
 ):
     """Drizzle ``crf_files`` into a single i2d at ``output_path``.
 
@@ -598,6 +655,7 @@ def drizzle_tile(
         weight_type=weight_type,
         blender=blender if contributing > 0 else None,
         n_pointings=contributing if contributing > 0 else None,
+        compress_context=compress_context,
         pixel_scale_ratio=pixel_scale_ratio,
     )
 

--- a/pipeline/campfire_pipeline/nircam/steps/resample.py
+++ b/pipeline/campfire_pipeline/nircam/steps/resample.py
@@ -75,6 +75,7 @@ def _drizzle_tile_via_campfire(
         good_bits=resample_cfg.get('good_bits', '~DO_NOT_USE'),
         blendheaders=resample_cfg.get('blendheaders', True),
         reduction_version=reduction_version,
+        compress_context=resample_cfg.get('compress_context', True),
     )
 
 

--- a/pipeline/campfire_pipeline/nircam/steps/resample.py
+++ b/pipeline/campfire_pipeline/nircam/steps/resample.py
@@ -97,6 +97,14 @@ def _drizzle_tile_via_jwst(
     every substep but ``resample`` skipped, and stamps ``CMPFRTIM`` /
     ``CMPFRVER`` on the primary header of the resulting i2d.
 
+    ``[nircam.resample].compress_context`` is honored here too, but it costs
+    more than on the campfire backend: the write happens inside jwst's own
+    resample step, so the uncompressed CON hits the disk first and is then
+    rewritten compressed (one extra read+write of the i2d). The campfire
+    backend instead saves a placeholder and never materialises it. Peak RSS is
+    unaffected either way — the rewrite streams the CON back through the memmap
+    tile-by-tile rather than holding it resident.
+
     Parameters
     ----------
     selected_files : list of str
@@ -153,6 +161,16 @@ def _drizzle_tile_via_jwst(
         asn_file, output_dir=mosaic_outdir, steps=params,
         save_results=True,
     )
+
+    if resample_cfg.get('compress_context', True):
+        from campfire_pipeline.nircam.drizzle import compress_context_extension
+
+        before = os.path.getsize(output_path)
+        if compress_context_extension(output_path):
+            after = os.path.getsize(output_path)
+            log(f"  compressed CON: {before / 2**30:.1f} GiB → "
+                f"{after / 2**30:.1f} GiB "
+                f"({before / max(after, 1):.1f}x smaller)")
 
     with fits.open(output_path, mode='update') as hdul:
         hdul[0].header['CMPFRTIM'] = (

--- a/pipeline/tests/test_nircam_drizzle.py
+++ b/pipeline/tests/test_nircam_drizzle.py
@@ -26,6 +26,7 @@ import numpy as np
 import pytest
 from astropy.io import fits
 
+import campfire_pipeline.nircam.drizzle as drizzle_mod
 from campfire_pipeline.nircam.drizzle import (
     _apply_output_metadata, _sanitize_variance, _output_bbox_in_tile,
     compress_context_extension,
@@ -501,3 +502,54 @@ def test_compress_context_leaves_no_temp_file(tmp_path):
     compress_context_extension(path)
     assert not os.path.exists(f'{path}.ctx.tmp')
     assert sorted(os.listdir(tmp_path)) == ['tmpcheck_i2d.fits']
+
+
+def test_compress_context_cleans_up_temp_when_write_fails(tmp_path,
+                                                          monkeypatch):
+    """A failed compression must not strand a partial `.ctx.tmp`.
+
+    ENOSPC partway through is realistic here — the i2d is the largest file the
+    pipeline writes — and under ``--processes N`` a whole-field run would
+    otherwise leak one partial temp per failed tile onto the disk that just
+    filled. Same guarantee `common.io.atomic_save` gives.
+    """
+    path = str(tmp_path / 'failing_i2d.fits')
+    ctx = _context_array()
+    _write_i2d_like(path, ctx)
+    original = fits.HDUList.writeto
+
+    def _writeto_then_fail(self, fileobj, *args, **kwargs):
+        # Land a partial file first, the way a truncated write would.
+        with open(fileobj, 'wb') as fp:
+            fp.write(b'SIMPLE  =                    T')
+        raise OSError(28, 'No space left on device')
+
+    monkeypatch.setattr(fits.HDUList, 'writeto', _writeto_then_fail)
+    with pytest.raises(OSError):
+        compress_context_extension(path, ctx=ctx)
+    monkeypatch.setattr(fits.HDUList, 'writeto', original)
+
+    assert not os.path.exists(f'{path}.ctx.tmp')
+    # The original i2d is untouched — the swap never got as far as os.replace.
+    assert sorted(os.listdir(tmp_path)) == ['failing_i2d.fits']
+    with fits.open(path) as hdul:
+        np.testing.assert_array_equal(hdul['CON'].data, ctx)
+        np.testing.assert_array_equal(hdul['SCI'].data, _SCI)
+
+
+def test_compress_context_cleans_up_temp_when_replace_fails(tmp_path,
+                                                            monkeypatch):
+    """Cleanup also covers a failure after the temp is fully written."""
+    path = str(tmp_path / 'replacefail_i2d.fits')
+    ctx = _context_array()
+    _write_i2d_like(path, ctx)
+
+    def _boom(src, dst):
+        raise OSError(28, 'No space left on device')
+
+    monkeypatch.setattr(drizzle_mod.os, 'replace', _boom)
+    with pytest.raises(OSError):
+        compress_context_extension(path, ctx=ctx)
+
+    assert not os.path.exists(f'{path}.ctx.tmp')
+    assert sorted(os.listdir(tmp_path)) == ['replacefail_i2d.fits']

--- a/pipeline/tests/test_nircam_drizzle.py
+++ b/pipeline/tests/test_nircam_drizzle.py
@@ -20,11 +20,15 @@ the bug and validate the fix deterministically without depending on WCS
 construction.
 """
 
+import os
+
 import numpy as np
 import pytest
+from astropy.io import fits
 
 from campfire_pipeline.nircam.drizzle import (
     _apply_output_metadata, _sanitize_variance, _output_bbox_in_tile,
+    compress_context_extension,
 )
 
 Drizzle = pytest.importorskip("drizzle.resample").Drizzle
@@ -377,3 +381,123 @@ def test_apply_output_metadata_without_blender_still_sets_photometry():
     assert out.meta.bunit_data == 'MJy/sr'
     assert out.meta.bunit_err == 'MJy/sr'
     assert out.meta.cal_step.resample == 'COMPLETE'
+
+
+# ---------------------------------------------------------------------------
+# CON compression
+#
+# Two call paths share one rewrite: the campfire backend hands the array in
+# (the file holds a 1x1x1 placeholder), the jwst backend hands nothing in and
+# the full uncompressed CON is read back off the disk. Both must land on a
+# bit-identical CON under the same extension name and order, with every other
+# extension untouched.
+# ---------------------------------------------------------------------------
+
+_SCI = np.arange(12, dtype=np.float32).reshape(3, 4)
+_ERR = (_SCI + 0.5).astype(np.float32)
+_WHT = np.ones((3, 4), dtype=np.float32)
+
+
+def _context_array():
+    """A coherent int32 bitmask: blocky, mostly zero — like a real CON."""
+    ctx = np.zeros((3, 3, 4), dtype=np.int32)
+    ctx[0, 1:, 1:3] = 0b1011
+    ctx[1, 2:, :2] = 0b110
+    return ctx
+
+
+def _write_i2d_like(path, con_data):
+    """Minimal stand-in for the i2d layout, CON in its usual third slot."""
+    primary = fits.PrimaryHDU()
+    primary.header['CMPFRVER'] = ('test', 'CAMPFIRE git commit')
+    con = fits.ImageHDU(con_data, name='CON')
+    con.header['BUNIT'] = ('', 'provenance the datamodel put on CON')
+    hdrtab = fits.BinTableHDU.from_columns(
+        [fits.Column(name='FILENAME', format='8A',
+                     array=np.array(['a.fits', 'b.fits']))],
+        name='HDRTAB',
+    )
+    fits.HDUList([
+        primary,
+        fits.ImageHDU(_SCI, name='SCI'),
+        fits.ImageHDU(_ERR, name='ERR'),
+        con,
+        fits.ImageHDU(_WHT, name='WHT'),
+        hdrtab,
+    ]).writeto(path, overwrite=True)
+
+
+def _assert_compressed_i2d_intact(path, expected_ctx):
+    with fits.open(path) as hdul:
+        assert [h.name for h in hdul] == [
+            'PRIMARY', 'SCI', 'ERR', 'CON', 'WHT', 'HDRTAB']
+        assert isinstance(hdul['CON'], fits.CompImageHDU)
+        con = hdul['CON'].data
+        assert con.shape == expected_ctx.shape
+        # FITS stores big-endian >i4 and CompImageHDU decompresses to native
+        # int32 — same integers, so compare on kind/itemsize not exact dtype.
+        assert con.dtype.kind == 'i' and con.dtype.itemsize == 4
+        assert np.array_equal(con, expected_ctx)
+        assert hdul['CON'].header.get('BUNIT') == ''
+        np.testing.assert_array_equal(hdul['SCI'].data, _SCI)
+        np.testing.assert_array_equal(hdul['ERR'].data, _ERR)
+        np.testing.assert_array_equal(hdul['WHT'].data, _WHT)
+        assert list(hdul['HDRTAB'].data['FILENAME']) == ['a.fits', 'b.fits']
+        assert hdul[0].header['CMPFRVER'] == 'test'
+
+
+def test_compress_context_from_supplied_array(tmp_path):
+    """campfire backend: the file carries a placeholder, ctx comes in memory."""
+    path = str(tmp_path / 'placeholder_i2d.fits')
+    ctx = _context_array()
+    _write_i2d_like(path, np.zeros((1, 1, 1), dtype=np.int32))
+
+    assert compress_context_extension(path, ctx=ctx) is True
+    _assert_compressed_i2d_intact(path, ctx)
+
+
+def test_compress_context_read_back_from_file(tmp_path):
+    """jwst backend: CON is already on disk uncompressed and gets rewritten.
+
+    This is the path that used to be a no-op — `compress_context` was only
+    threaded into the campfire backend, so the shipped default
+    (`implementation = "jwst"`) ignored it entirely.
+    """
+    path = str(tmp_path / 'uncompressed_i2d.fits')
+    ctx = _context_array()
+    _write_i2d_like(path, ctx)
+
+    assert compress_context_extension(path) is True
+    _assert_compressed_i2d_intact(path, ctx)
+
+
+def test_compress_context_is_idempotent(tmp_path):
+    """Re-running on an already-compressed i2d is a no-op, not a re-wrap."""
+    path = str(tmp_path / 'twice_i2d.fits')
+    ctx = _context_array()
+    _write_i2d_like(path, ctx)
+
+    assert compress_context_extension(path) is True
+    assert compress_context_extension(path) is False
+    _assert_compressed_i2d_intact(path, ctx)
+
+
+def test_compress_context_without_con_extension(tmp_path):
+    """A product with no CON is left alone rather than raising."""
+    path = str(tmp_path / 'nocon.fits')
+    fits.HDUList([
+        fits.PrimaryHDU(), fits.ImageHDU(_SCI, name='SCI'),
+    ]).writeto(path, overwrite=True)
+
+    assert compress_context_extension(path) is False
+    with fits.open(path) as hdul:
+        assert [h.name for h in hdul] == ['PRIMARY', 'SCI']
+
+
+def test_compress_context_leaves_no_temp_file(tmp_path):
+    path = str(tmp_path / 'tmpcheck_i2d.fits')
+    _write_i2d_like(path, _context_array())
+
+    compress_context_extension(path)
+    assert not os.path.exists(f'{path}.ctx.tmp')
+    assert sorted(os.listdir(tmp_path)) == ['tmpcheck_i2d.fits']


### PR DESCRIPTION
The `CON` extension dominates the i2d, and almost all of it is zeros.

## Why it is so large

`CON` records which inputs contributed to each output pixel as an `int32` bitmask — 32 images per plane, each plane at **full tile size**. So its cost is `tile_area x n_inputs/32`, and both factors are maximised by a large single-tile field:

| | cosmos B10 tile | A2744 `full` tile |
|---|---|---|
| pixels | 0.478 Gpix | 1.258 Gpix |
| inputs | ~96 | **534** |
| CON planes | 3 | **17** |
| CON size | 5.7 GiB | **79.7 GiB** |
| SCI+ERR+WHT | 5.7 GiB | 14.1 GiB |

That is a 95 GiB file that is ~84 % bookkeeping.

## Why it compresses

A pixel is touched by a handful of inputs, not hundreds, so almost every bit is zero; and contributing-input sets are spatially coherent, so the array is blocky rather than noisy. Synthetic white noise gives only 5.6x, but realistic coherent context gives ~47x — the real data behaves like the latter.

## Measured on a real combine

A full A2744 f444w combine (534 inputs, 17 planes, 1.258 Gpix), not a synthetic:

| | |
|---|---|
| i2d would-be uncompressed | 94.9 GiB |
| **i2d actual** | **15.43 GiB** (6.2x smaller) |
| combine runtime | 1h25m, rc=0 |
| `CON` on disk | `CompImageHDU (17, 22171, 56759)` |
| coverage cross-check | 128.4 arcmin² vs 129.8 predicted independently by the expmap — **1 %** |

## Both backends, at different cost

`compress_context` is honoured on both `[nircam.resample].implementation` backends, but the write path differs:

- **`campfire`** — the model is saved with a `1x1x1` CON placeholder and the compressed extension swapped in afterwards, so the uncompressed array is never materialised on disk.
- **`jwst`** (the shipped default) — the write happens inside jwst's own resample step, so the uncompressed CON lands first and the i2d is then rewritten compressed. One extra read+write per tile; the placeholder trick isn't available there.

Peak RSS is the same either way. The rewrite carries the unmodified extensions through without `hdu.copy()` and compresses CON tile-by-tile straight off the memmap, so neither the ~14 GiB of SCI/ERR/WHT nor the ~80 GiB CON is ever resident — measured at **+9 MB RSS** while recompressing a 400 MB on-disk CON.

## Verification

Against an uncompressed reference written from the same array: `CON` identical in values and shape, SCI/ERR/WHT untouched, extension names and order preserved. The check is on values plus dtype kind/itemsize rather than exact dtype — FITS stores big-endian `&gt;i4` while `CompImageHDU` decompresses to native `int32`, same integers either way.

`pipeline/tests/test_nircam_drizzle.py` covers both call paths (array supplied vs. read back off the file), plus idempotence on an already-compressed CON and the no-CON no-op.

## Caveats

- **Saves disk, not RAM.** Materialising the full CON still needs ~80 GiB either way; large arrays should be read via `hdu.section[...]`.
- A non-astropy reader sees a compressed-image BinTable rather than a plain `ImageHDU`. Nothing in this repository reads `CON` — the only references are the writes in `drizzle.py` — so this is a note rather than a breakage. `[nircam.resample].compress_context = false` restores the old layout.
- Existing mosaics are unaffected until rebuilt.

Categorised **Infrastructure / PATCH**: pixel and flux values are bit-identical, which is what AGENTS.md ties the category to. The arguable Algorithm/MAJOR reading (`ImageHDU` → `CompImageHDU` as a FITS-schema change) is recorded in the changelog entry along with why it was rejected — `CompImageHDU` is a standard FITS construct that astropy reads transparently under the same `CON` name.

Generated with Claude Code