### PR TITLE
fix(nirspec): mask edit no longer corrupts the rate file (dangling asdf ref)

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -312,6 +312,27 @@ Release procedure: edit the `## Unreleased` section below, then run
   omitted grown pixels from the plot entirely.
 
 ### Infrastructure
+- **NIRSpec manual masks: editing or clearing a mask no longer corrupts the rate
+  file.** `masks.py` dropped the `CFDQMASK` / `CFBKG` / `CFBKGMASK` extensions
+  with `fits.open(mode="update")` immediately before reopening the file as an
+  `ImageModel`. Those HDUs carry no asdf ref when first appended with astropy,
+  but any subsequent `ImageModel.save()` — in the real flow, stage 1's
+  background subtraction — promotes them into `extra_fits` and *does* record
+  one. Deleting the HDU then left a dangling `extra_fits.<NAME>` entry in the
+  embedded ASDF tree, so the next open died with
+  `KeyError: Extension ('CFDQMASK', 1) not found`. The failure mode was nasty:
+  `cfpipe nirspec mask apply` aborted partway, leaving the rate file with
+  `DO_NOT_USE` still set, the `CFMASKSH`/`CFMASKN` sentinels still stamped, and
+  the `CFDQMASK` record of *which* pixels to revert destroyed — i.e. the mask
+  became unrevertable and the file unopenable by any datamodel, recoverable
+  only by re-running stage 1 from `uncal`. Triggered by the ordinary workflow
+  of removing a `.reg` and re-applying. Fixed by dropping extensions *through
+  the datamodel* (`_drop_extra_fits`, replacing `_drop_extensions_if_present`)
+  so the FITS and the ASDF tree stay consistent across the save; applied to all
+  three call sites, including the latent instance in `restore_pre_bkgsub`.
+  Regression test reproduces the exact sequence (apply → intervening
+  `model.save()` → clear); the pre-existing round-trip test missed it because
+  nothing saved the model in between. No change to pixel or flux values.
 - NIRCam `align` now writes **diagnostics for independent validation** of every
   solve. Its self-reported residual is circular — measured on the very sample the
   matcher selected — so a solution locked onto the wrong sources reports a small

--- a/pipeline/campfire_pipeline/nirspec/masks.py
+++ b/pipeline/campfire_pipeline/nirspec/masks.py
@@ -182,18 +182,27 @@ def is_stale(rate_file: str, reg_string: str | None) -> bool:
 # the extension.
 
 
-def _drop_extensions_if_present(rate_file: str, names: tuple[str, ...]) -> None:
-    """Delete the named extensions from ``rate_file`` if present. No-op for
-    names that don't exist. Used to remove extensions *before* an upcoming
-    ``ImageModel.save()`` — that save snapshots asdf refs to whatever
-    extensions are present at save time, so deleting after would leave
-    dangling refs and break the next ImageModel open."""
-    with fits.open(rate_file, mode="update") as hdul:
-        for name in names:
-            try:
-                del hdul[name]
-            except KeyError:
-                pass
+def _drop_extra_fits(model, names: tuple[str, ...]) -> None:
+    """Remove the named extra-FITS extensions from an open ``model`` so the
+    next ``model.save()`` writes neither the HDU nor an asdf ref to it.
+
+    Extensions we append with ``astropy`` (``CFDQMASK``, ``CFBKG``,
+    ``CFBKGMASK``) carry no asdf ref when first written, but any later
+    ``ImageModel.save()`` picks them up into ``extra_fits`` and *does* record
+    one. Deleting such an HDU with ``fits.open(mode="update")`` therefore
+    leaves a dangling ``extra_fits.<NAME>`` entry in the embedded ASDF tree,
+    and the next ``ImageModel`` open fails with::
+
+        KeyError: ERROR loading embedded ASDF: Extension ('<NAME>', 1) not found
+
+    Dropping through the datamodel keeps the FITS and the ASDF tree
+    consistent. Always prefer this over deleting the HDU directly.
+    """
+    extra = getattr(model, "extra_fits", None)
+    if extra is None:
+        return
+    for name in names:
+        extra.instance.pop(name, None)
 
 
 def apply_mask_dq(rate_file: str, reg_string: str | None) -> int:
@@ -207,10 +216,6 @@ def apply_mask_dq(rate_file: str, reg_string: str | None) -> int:
     if not canonicalize(reg_string):
         return 0
 
-    # Drop any pre-existing CFDQMASK *before* the ImageModel save below so
-    # the save doesn't snapshot an asdf ref to a soon-to-be-replaced HDU.
-    _drop_extensions_if_present(rate_file, ("CFDQMASK",))
-
     from jwst.datamodels import ImageModel
 
     with ImageModel(rate_file) as model:
@@ -222,6 +227,9 @@ def apply_mask_dq(rate_file: str, reg_string: str | None) -> int:
         prior_dnu = (model.dq & DO_NOT_USE).astype(bool)
         flipped = mask & ~prior_dnu
         model.dq[mask] |= DO_NOT_USE
+        # Drop any pre-existing CFDQMASK through the datamodel so this save
+        # doesn't carry an asdf ref to the HDU we replace just below.
+        _drop_extra_fits(model, ("CFDQMASK",))
         model.save(rate_file)
 
     with fits.open(rate_file, mode="update") as hdul:
@@ -239,9 +247,6 @@ def clear_manual_mask_dq(rate_file: str) -> None:
             return
         flipped = hdul["CFDQMASK"].data.astype(bool).copy()
 
-    # Drop CFDQMASK *before* the ImageModel save below — see _drop_extensions_if_present.
-    _drop_extensions_if_present(rate_file, ("CFDQMASK",))
-
     from jwst.datamodels import ImageModel
 
     with ImageModel(rate_file) as model:
@@ -253,6 +258,8 @@ def clear_manual_mask_dq(rate_file: str) -> None:
             return
         # AND-NOT DO_NOT_USE on the recorded pixels.
         model.dq[flipped] &= ~np.uint32(DO_NOT_USE)
+        # Drop through the datamodel, not the FITS: see _drop_extra_fits.
+        _drop_extra_fits(model, ("CFDQMASK",))
         model.save(rate_file)
 
 
@@ -310,15 +317,14 @@ def restore_pre_bkgsub(rate_file: str) -> None:
             )
         bkg = np.asarray(hdul["CFBKG"].data).copy()
 
-    # Tear down the bkgsub state *before* reopening as ImageModel — see
-    # _drop_extensions_if_present for the asdf-ref reasoning. Header keys
-    # are cleared in the same pass for atomicity.
+    # Clear the bkgsub header sentinels. Header keys carry no asdf refs, so
+    # they are safe to strip with astropy; the CFBKG/CFBKGMASK *extensions*
+    # are dropped through the datamodel below (see _drop_extra_fits).
     with fits.open(rate_file, mode="update") as hdul:
         hdr = hdul[0].header
         for k in ("CFBKGSUB", "CFBKGRMS", "CFBKGDT", "CFMASKSH", "CFMASKDT", "CFMASKN"):
             if k in hdr:
                 del hdr[k]
-    _drop_extensions_if_present(rate_file, ("CFBKG", "CFBKGMASK"))
 
     with ImageModel(rate_file) as model:
         if bkg.shape != model.data.shape:
@@ -332,6 +338,7 @@ def restore_pre_bkgsub(rate_file: str) -> None:
         #   reverse:  data += bkg;        var_rnoise /= var_rescale
         model.data = model.data + bkg
         model.var_rnoise = model.var_rnoise / float(var_rescale)
+        _drop_extra_fits(model, ("CFBKG", "CFBKGMASK", "CFDQMASK"))
         model.save(rate_file)
 
 

--- a/pipeline/tests/test_masks.py
+++ b/pipeline/tests/test_masks.py
@@ -158,6 +158,48 @@ class TestApplyAndClearDQ:
             # Pixel inside polygon (that we flipped) should be cleared.
             assert not (model.dq[10, 8] & masks.DO_NOT_USE)
 
+    def test_clear_after_intervening_save_leaves_file_readable(self, tmp_path):
+        """Regression: clearing a mask must not corrupt the rate file.
+
+        ``apply_mask_dq`` appends CFDQMASK with astropy, which records no asdf
+        ref. But any later ``ImageModel.save()`` — in the real flow, stage 1's
+        background subtraction — picks the HDU up into ``extra_fits`` and
+        *does* write one. Deleting the HDU with astropy then left a dangling
+        ``extra_fits.CFDQMASK`` entry, so the next ``ImageModel`` open died
+        with ``Extension ('CFDQMASK', 1) not found`` and the rate file was
+        unrecoverable through the supported path.
+
+        The original round-trip test misses this because nothing saves the
+        model between apply and clear.
+        """
+        pytest.importorskip("jwst")
+        from jwst.datamodels import ImageModel
+
+        rate = str(tmp_path / "jw00000000001_nrs1_rate.fits")
+        n = 32
+        dq = np.zeros((n, n), dtype=np.uint32)
+        dq[10, 10] = masks.DO_NOT_USE
+        self._make_rate_with_dq(rate, dq)
+
+        masks.apply_mask_dq(rate, "image\npolygon(5,5,15,5,15,15,5,15)")
+
+        # Stand in for the bkgsub re-save that promotes CFDQMASK into the
+        # asdf tree. Without this the bug does not reproduce.
+        with ImageModel(rate) as model:
+            model.save(rate)
+        with fits.open(rate) as hdul:
+            assert "CFDQMASK" in hdul, "setup: CFDQMASK should survive the re-save"
+
+        masks.clear_manual_mask_dq(rate)
+
+        # The file must still be openable as a datamodel...
+        with ImageModel(rate) as model:
+            assert model.dq[10, 10] & masks.DO_NOT_USE
+            assert not (model.dq[10, 8] & masks.DO_NOT_USE)
+        # ...and the extension must actually be gone.
+        with fits.open(rate) as hdul:
+            assert "CFDQMASK" not in hdul
+
 
 class TestBkgsubExtensionsAndRestore:
     """Round-trip CFBKG/CFBKGMASK/CFBKGSUB/CFBKGRMS: simulate a bkgsub by


### PR DESCRIPTION
## The bug

Editing or clearing a NIRSpec manual mask **corrupts the rate file**, leaving it unopenable by any JWST datamodel.

`masks.py` dropped the `CFDQMASK` / `CFBKG` / `CFBKGMASK` extensions with `fits.open(mode="update")` immediately before reopening the file as an `ImageModel`. Those HDUs carry no asdf ref when first appended with astropy — but any later `ImageModel.save()` (in the real flow, stage 1's background subtraction) promotes them into `extra_fits` and *does* record one. Deleting the HDU then leaves a dangling `extra_fits.<NAME>` entry in the embedded ASDF tree:

```
KeyError: ERROR loading embedded ASDF: "Extension ('CFDQMASK', 1) not found."
  File campfire_pipeline/nirspec/masks.py:247, in clear_manual_mask_dq
```

The `_drop_extensions_if_present` docstring anticipated dangling refs on *save*; the failure is actually on *open*.

## Why it matters

`cfpipe nirspec mask apply` aborts partway, leaving the rate file with:

- `DO_NOT_USE` still set in DQ,
- the `CFMASKSH` / `CFMASKN` sentinels still stamped (so it *looks* masked),
- the `CFDQMASK` record of **which** pixels to revert destroyed.

The mask is now unrevertable through the supported path and the file is unopenable by `ImageModel` — recoverable only by re-running stage 1 from `uncal`. It is triggered by the ordinary workflow of removing a `.reg` and re-applying, and it cost two rate files in the session that found it.

## The fix

Drop extensions **through the datamodel** (`_drop_extra_fits`, replacing `_drop_extensions_if_present`) so the FITS and the ASDF tree stay consistent across the save.

Applied at all three call sites, including the **latent** instance in `restore_pre_bkgsub` — that one has not fired yet only because a fresh stage-1 rate file has `CFBKG` appended without a ref; it would fail the same way once a mask cycle promotes it.

## Testing

- New regression test reproduces the exact sequence — apply → intervening `model.save()` → clear — and **fails on `main`** with the `KeyError` above, passes here.
- The pre-existing round-trip test missed this because nothing saves the model between apply and clear, so `CFDQMASK` never acquires the ref.
- `pytest tests/test_masks.py tests/test_mask_regions.py` → 24 passed.

## Impact

**Infrastructure (PATCH)** — no change to pixel or flux values.

Generated with Claude Code