### PR TITLE
NIRCam mosaic bkgsub: negativity guard (ceiling + trough pass); remove tier-0 pre-tier

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -68,6 +68,33 @@ Release procedure: edit the `## Unreleased` section below, then run
   reads transparently under the same `CON` name, and because no reader in this
   repository touches the extension at all.
 
+### Algorithm
+- Mosaic-level background subtraction gains a **negativity guard**
+  (`bg_guard`, default **on** for the mosaic stage): the final background
+  map is constrained so the subtracted mosaic carries no statistically
+  significant negative structure (physical prior: true flux ≥ 0 makes the
+  observed flux floor an upper bound on the background, even under the
+  source mask). Two data-side corrections after the existing fit — a
+  maskless one-sided **ceiling** capping the background mesh (multi-scale
+  min over box 32/64/128, self-calibrated per image on quiet sky, 2σ
+  slack, noise model `s/sqrt(WHT)`), then a detection-gated iterated
+  **trough pass** lifting coherent negative residual regions to the −2σ
+  floor. Blank fields are a near-no-op by construction of the gate.
+  Validated on A2744 F444W 120″ cutouts: cluster-core negative structure
+  159k px → 1.3k px, offcluster 186k px → 2k px, at unchanged
+  empty-aperture medians. See `experiments/bkg_nonneg/README.md`.
+- The mosaic mask's **tier-0 giant-galaxy pre-tier is removed** (100σ /
+  30k px core, 600 px dilation; tier lists shrink 5 → 4 entries, so
+  `SRCMASK` tier-bit meanings shift down by one). The A/B on the field
+  that tripped it showed the fit inside the tier-0 hole is pure
+  extrapolation — ~3× more significant negative area than without the
+  tier, ~9× more even after guard cleanup — while the tier never fired on
+  the envelope-dominated BCGs it was meant to protect. The guard subsumes
+  its purpose (the oversubtraction bowl is exactly the failure mode it
+  removes) and works under masks, so no protective hole is needed.
+  Enabling the guard + tier change alters mosaic config hashes → tiles
+  rebuild on next run.
+
 ### Calibration
 - Per-exposure background: `[nircam.bkg.mask].mask_aggressive_dq_max_frac`
   lowered **0.85 → 0.50**, fixing a case where the per-amp-row 1/f fit

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -92,8 +92,12 @@ Release procedure: edit the `## Unreleased` section below, then run
   the envelope-dominated BCGs it was meant to protect. The guard subsumes
   its purpose (the oversubtraction bowl is exactly the failure mode it
   removes) and works under masks, so no protective hole is needed.
-  Enabling the guard + tier change alters mosaic config hashes → tiles
-  rebuild on next run.
+  Rollout: the tile config hash (`nircam/manifest.py`) now folds in every
+  pixel-affecting bkgsub setting plus a bkgsub algorithm version, so all
+  existing mosaic manifests hash stale and their tiles rerun background
+  subtraction on the next resample pass — previously the hash covered
+  none of these, and the resample step's skip logic would have kept the
+  old subtraction on existing tiles indefinitely.
 
 ### Calibration
 - Per-exposure background: `[nircam.bkg.mask].mask_aggressive_dq_max_frac`

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -763,20 +763,20 @@
     ring_clip_max_sigma = 5.0
     ring_clip_box_size = 100
     ring_clip_filter_size = 3
-    # Tier 0 is a large-extended-source PRE-tier (see nircam/bkgsub.py). It fires
-    # only on objects with a >=30k-pixel core above 100*sigma — ~4 per COSMOS
-    # 30mas tile — and exists because a galaxy far larger than bg_box_size is
-    # over-subtracted even when fully masked at pixel level: Background2D keeps
-    # mesh cells masked at the galaxy edge, samples its outskirts there, and the
-    # zoom interpolator extrapolates that gradient inward as a galaxy-shaped
-    # bowl. The heavy dilation (600 px) pushes the mesh boundary out to true sky.
-    # A no-op on tiles with no such object. Deliberately NOT applied to the
-    # per-exposure [nircam.bkg.mask] tiers above: 30k px / 600 px dilation are
-    # sized for a 30mas mosaic tile, not a 2048^2 frame.
-    tier_kernel_size = [25, 25, 15, 5, 2]
-    tier_npixels = [30000, 15, 10, 3, 1]
-    tier_nsigma = [100.0, 1.5, 1.5, 1.5, 1.5]
-    tier_dilate_size = [600, 33, 25, 21, 19]
+    # Compact-source detection cascade (aggressive -> fine). The former
+    # "tier 0" giant-galaxy pre-tier (100 sigma / 30k px core, 600 px
+    # dilation) was REMOVED together with the introduction of bg_guard: the
+    # A2744 120" A/B showed the fit inside a tier-0 hole is pure
+    # extrapolation (negative area ~3x worse than without the tier, ~9x
+    # worse even after guard cleanup), and the tier never fired on the
+    # envelope-dominated BCGs it was meant to protect. The guard bounds the
+    # background with the observed flux floor instead — it works under
+    # masks, so no protective hole is needed. See nircam/bkgsub.py and
+    # pipeline/experiments/bkg_nonneg.
+    tier_kernel_size = [25, 15, 5, 2]
+    tier_npixels = [15, 10, 3, 1]
+    tier_nsigma = [1.5, 1.5, 1.5, 1.5]
+    tier_dilate_size = [33, 25, 21, 19]
     bg_box_size = 10
     bg_filter_size = 5
     bg_exclude_percentile = 90
@@ -808,6 +808,27 @@
     bg_reject_sigma_lo = 3.0
     bg_reject_percentile = 60.0
     bg_reject_dilate = 40.0
+    # Negativity guard (see SubtractBackground.bg_guard in nircam/bkgsub.py):
+    # constrains the final background map so the subtracted mosaic carries no
+    # statistically significant negative structure (true flux >= 0 makes the
+    # observed flux floor an upper bound on the background, even under
+    # masks). Two data-side corrections: a maskless one-sided ceiling capping
+    # the background mesh (multi-scale min over guard_ceiling_boxes,
+    # self-calibrated on quiet sky, k-sigma slack), then a detection-gated
+    # iterated trough pass lifting coherent negative residual regions to the
+    # -t sigma floor. Noise model is s/sqrt(WHT) (source-independent).
+    # Default ON: validated on A2744 F444W 120" cutouts (cluster core
+    # negative structure 159k px -> 1.3k px, empty-aperture medians
+    # unchanged; blank-tile null is a near-no-op by construction of the
+    # gate). NOTE: enabling changes tile config hashes -> mosaic rebuild.
+    bg_guard = true
+    guard_ceiling_boxes = [32, 64, 128]
+    guard_ceiling_k = 2.0
+    guard_ceiling_sigma_upper = 1.0
+    guard_trough_sigmas = [5.0, 15.0]
+    guard_trough_t = 2.0
+    guard_trough_npix = 8.0
+    guard_trough_max_iter = 12
     split_extensions = true
     plot = true
     plot_downsample = 4

--- a/pipeline/campfire_pipeline/nircam/bkgsub.py
+++ b/pipeline/campfire_pipeline/nircam/bkgsub.py
@@ -82,25 +82,24 @@ class SubtractBackground:
     ring_downsample: int = 1
 
     # -- Tiered source masking -------------------------------------------------
-    # Tier 0 is a large-extended-source pre-tier that fires ONLY on the handful
-    # of extremely bright, large galaxies (and comparably bright stars) per tile.
-    # A galaxy far larger than ``bg_box_size`` is fully masked at the pixel level
-    # yet still over-subtracted: ``Background2D`` keeps mesh cells up to
-    # ``bg_exclude_percentile`` masked at the galaxy edge, samples its outskirts
-    # there, and the zoom interpolator extrapolates that gradient inward (a
-    # galaxy-shaped +30..90e-3 MJy/sr bowl, 4-11 sigma of sky). Tier 0 masks the
-    # bright core + a heavy dilation so the mesh boundary lands on true sky.
-    # Selectivity: a HIGH ``tier_nsigma`` (100) plus a large ``tier_npixels``
-    # (30k min connected area) means only objects with a >=30k-px core above
-    # 100*sigma survive -- ~4 per COSMOS 30mas tile (vs ~120 at 5*sigma), so the
-    # normal aggressive flattening of ordinary galaxy wings is UNCHANGED
-    # everywhere else. The heavy ``tier_dilate_size`` (600) compensates for the
-    # small high-sigma footprint and reaches the galaxy's sky radius. It is a
-    # no-op on tiles with no such object. Tiers 1-4 are the compact-source cascade.
-    tier_kernel_size: list = field(default_factory=lambda: [25, 25, 15, 5, 2])
-    tier_npixels: list = field(default_factory=lambda: [30000, 15, 10, 3, 1])
-    tier_nsigma: list = field(default_factory=lambda: [100.0, 1.5, 1.5, 1.5, 1.5])
-    tier_dilate_size: list = field(default_factory=lambda: [600, 33, 25, 21, 19])
+    # Tiers are the compact-source detection cascade (aggressive -> fine).
+    #
+    # HISTORY: a "tier 0" giant-galaxy pre-tier (100 sigma / 30k px core,
+    # 600 px dilation) used to precede these tiers on mosaics, masking the
+    # handful of extremely bright large galaxies out to their sky radius so
+    # the Background2D mesh boundary landed on true sky (guarding against the
+    # galaxy-shaped oversubtraction bowl). It was REMOVED with the negativity
+    # guard (``bg_guard``): the A2744 120" A/B showed the fit inside the
+    # tier-0 hole is pure extrapolation — negative area ~3x WORSE than no
+    # tier 0, and ~9x worse even after guard cleanup — while the tier never
+    # fired on the envelope-dominated BCGs it was meant to protect (their
+    # 25 px-smoothed cores never reach 100 sigma over 30k connected px). The
+    # guard bounds the background with the observed flux floor instead, which
+    # works under masks and needs no hole. See experiments/bkg_nonneg.
+    tier_kernel_size: list = field(default_factory=lambda: [25, 15, 5, 2])
+    tier_npixels: list = field(default_factory=lambda: [15, 10, 3, 1])
+    tier_nsigma: list = field(default_factory=lambda: [1.5, 1.5, 1.5, 1.5])
+    tier_dilate_size: list = field(default_factory=lambda: [33, 25, 21, 19])
 
     # -- Background estimation -------------------------------------------------
     bg_box_size: int = 10
@@ -120,6 +119,53 @@ class SubtractBackground:
     bg_reject_sigma_lo: float = 3.0
     bg_reject_percentile: float = 60.0
     bg_reject_dilate: float = 40.0
+
+    # -- Negativity guard (opt-in; the mosaic config enables it) ---------------
+    # Constrains the final background map so the subtracted image carries no
+    # statistically significant negative structure. Physical prior: true flux
+    # >= 0, so every pixel — masked or not — asserts bkg(x) <= sci(x) + noise.
+    # Two data-side corrections applied after the (bg_reject-refit) fit:
+    #
+    # 1. CEILING MESHCAP: maskless coarse Background2D fits with a hard
+    #    one-sided upper clip track the lower envelope of the local flux — a
+    #    valid upper bound on any admissible background, even where the map
+    #    tracks (sky + wing). Fit on the noise-equalized image so the clip
+    #    bias is depth-uniform; self-calibrated per image against the masked
+    #    fit on quiet sky (removes the clip bias), plus guard_ceiling_k x the
+    #    quiet-sky scatter of that difference as slack (a slack ceiling is
+    #    costless — it is a bound, never an estimate). The minimum over
+    #    guard_ceiling_boxes tightens the bound in sky gaps next to bright
+    #    masked sources. Enforced by capping the low-res background MESH and
+    #    re-interpolating (smooth by construction) — a mask-and-refit
+    #    enforcement is a no-op for violations under fully-masked regions,
+    #    where the interpolator would extrapolate identically.
+    # 2. GATED TROUGH PASS: the residual is observable even under the fit
+    #    mask. Where its smoothed, noise-equalized map is coherently below
+    #    -guard_trough_t sigma over a connected region of at least
+    #    guard_trough_npix * sigma_smooth^2 px (area threshold tracks the
+    #    smoothing correlation area, so blank-field false-fire is scale-
+    #    independent and small), the map is lowered so the residual comes
+    #    back up to the -t sigma floor — the minimal correction that removes
+    #    statistical significance, continuous at the region edge (no seams),
+    #    and zero over compliant sky (blank fields are a near-no-op).
+    #    Iterated to convergence per smoothing scale.
+    #
+    # Noise model: sigma(x) = s / sqrt(WHT), s calibrated as the robust scale
+    # of the noise-equalized first-pass residual over unmasked sky. WHT is
+    # source-independent (ERR's source-Poisson term would suppress trough
+    # significance and loosen the ceiling exactly under bright wings/ICL).
+    # Without a WHT map the noise is a single global scalar (uniform depth).
+    # Validated on A2744 F444W 120" cutouts: negative structure 159k px ->
+    # 1.3k px (cluster core) at unchanged empty-aperture medians. See
+    # experiments/bkg_nonneg/README.md.
+    bg_guard: bool = False
+    guard_ceiling_boxes: list = field(default_factory=lambda: [32, 64, 128])
+    guard_ceiling_k: float = 2.0
+    guard_ceiling_sigma_upper: float = 1.0
+    guard_trough_sigmas: list = field(default_factory=lambda: [5.0, 15.0])
+    guard_trough_t: float = 2.0
+    guard_trough_npix: float = 8.0
+    guard_trough_max_iter: int = 12
 
     # -- WHT-aware (variable-depth) masking ------------------------------------
     # When a weight map is available (mosaic WHT extension, or the ``wht``
@@ -487,6 +533,228 @@ class SubtractBackground:
         return self._fit_background2d(img, mask | outliers)
 
     # ------------------------------------------------------------------
+    # Negativity guard
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _smooth_masked(
+        field_img: np.ndarray, exclude: np.ndarray, sigma: float
+    ) -> np.ndarray:
+        """NaN-tolerant gaussian smoothing (normalized convolution).
+
+        Excluded pixels contribute nothing; regions with <5% local coverage
+        go NaN so starved areas never produce fake significance.
+        """
+        filled = np.where(exclude, np.nan, field_img)
+        w = np.isfinite(filled).astype(np.float32)
+        f0 = np.where(np.isfinite(filled), filled, 0.0).astype(np.float32)
+        num = gaussian_filter(f0, sigma, mode="reflect")
+        den = gaussian_filter(w, sigma, mode="reflect")
+        with np.errstate(invalid="ignore", divide="ignore"):
+            return np.where(den > 0.05, num / den, np.nan)
+
+    def _guard_sigma_map(
+        self, resid: np.ndarray, skymask: np.ndarray
+    ) -> np.ndarray:
+        """Local sky-noise map for the guard.
+
+        With a weight map (and ``wht_aware``): sigma(x) = s / sqrt(WHT),
+        with s the robust scale of the noise-equalized residual over usable
+        sky (``skymask``) — background variance is alpha/WHT with alpha
+        global, and WHT carries no source-Poisson term. Otherwise a single
+        global robust scale (uniform depth).
+        """
+        if self.wht is not None and self.wht_aware:
+            good = np.isfinite(self.wht) & (self.wht > 0)
+            with np.errstate(invalid="ignore"):
+                sqw = np.where(good, np.sqrt(np.where(good, self.wht, 0.0)),
+                               np.nan)
+            sel = skymask & good & np.isfinite(resid)
+            s = float(astrostats.biweight_scale((resid * sqw)[sel]))
+            with np.errstate(divide="ignore", invalid="ignore"):
+                return np.where(good, s / sqw, np.nan)
+        sel = skymask & np.isfinite(resid)
+        s = float(astrostats.biweight_scale(resid[sel]))
+        return np.full(resid.shape, s, dtype=np.float32)
+
+    def _onesided_ceiling_map(
+        self, e_img: np.ndarray, off: np.ndarray, box: int
+    ) -> np.ndarray:
+        """Maskless (off-detector only) coarse background of the equalized
+        image with a hard upper clip: tracks the lower envelope of the local
+        flux distribution — an upper bound on the background up to a
+        (calibrated) clip bias."""
+        bkg = Background2D(
+            e_img,
+            box_size=box,
+            sigma_clip=astrostats.SigmaClip(
+                sigma_lower=10.0,
+                sigma_upper=self.guard_ceiling_sigma_upper,
+                maxiters=10,
+            ),
+            filter_size=3,
+            bkg_estimator=BiweightLocationBackground(),
+            exclude_percentile=95,
+            mask=off,
+            interpolator=BkgZoomInterpolator(),
+        )
+        return bkg.background
+
+    def _multiscale_ceiling(
+        self,
+        sci: np.ndarray,
+        off: np.ndarray,
+        bkgmap: np.ndarray,
+        fitmask: np.ndarray,
+        sigma_map: np.ndarray,
+    ) -> np.ndarray:
+        """Minimum over independently calibrated one-sided ceilings at
+        several box scales (min of upper bounds = tighter bound; finer
+        scales catch the sky gaps next to bright masked sources, where a
+        coarse mesh is source-embedded and its ceiling useless).
+
+        Everything runs in noise-equalized units (sci/sigma bounds
+        bkg/sigma pixelwise since true flux >= 0) so the one-sided clip
+        bias is depth-uniform and one global calibration constant is valid;
+        the bound maps back through the local sigma.
+        """
+        good = np.isfinite(sigma_map) & (sigma_map > 0)
+        with np.errstate(invalid="ignore"):
+            e_sci = np.where(good, sci / sigma_map, np.nan)
+            e_bkg = np.where(good, bkgmap / sigma_map, np.nan)
+        off_e = off | ~good
+        quiet = ~(fitmask | off_e)
+        ceils = []
+        for box in self.guard_ceiling_boxes:
+            om = self._onesided_ceiling_map(e_sci, off_e, int(box))
+            diff = (om - e_bkg)[quiet]
+            delta = float(astrostats.biweight_location(diff))
+            scatter = float(astrostats.biweight_scale(diff))
+            ceils.append(om - delta + self.guard_ceiling_k * scatter)
+            log(f"  guard ceiling box={box}: clip bias={delta:.3f} "
+                f"quiet-sky scatter={scatter:.3f} (equalized units)")
+        ceil_e = np.minimum.reduce(ceils)
+        return np.where(good, ceil_e * sigma_map, np.inf)
+
+    def _cap_mesh(self, bkg2d: Background2D, ceiling: np.ndarray,
+                  shape) -> np.ndarray:
+        """Cap the low-res background mesh at the ceiling (block-averaged
+        onto the mesh grid) and re-run the zoom interpolation — smooth by
+        construction, and effective under fully-masked regions where a
+        mask-and-refit pass cannot change the extrapolation."""
+        mesh = np.asarray(bkg2d.background_mesh, dtype=float)
+        box = np.atleast_1d(bkg2d.box_size)
+        by, bx = int(box[0]), int(box[-1])
+        my, mx = mesh.shape
+        pady, padx = my * by - shape[0], mx * bx - shape[1]
+        cpad = np.pad(np.where(np.isfinite(ceiling), ceiling, np.inf),
+                      ((0, pady), (0, padx)), mode="edge")
+        # mean over finite entries per cell; all-inf cells stay uncapped
+        cgrid = cpad.reshape(my, by, mx, bx)
+        finite = np.isfinite(cgrid)
+        csum = np.where(finite, cgrid, 0.0).sum(axis=(1, 3))
+        cnt = finite.sum(axis=(1, 3))
+        with np.errstate(invalid="ignore"):
+            cmesh = np.where(cnt > 0, csum / np.maximum(cnt, 1), np.inf)
+        capped = np.minimum(mesh, cmesh)
+        n_capped = int((mesh > cmesh).sum())
+        log(f"  guard ceiling: capped {n_capped}/{mesh.size} mesh cells")
+        interp = BkgZoomInterpolator()
+        return interp(capped, box_size=(by, bx), shape=shape, dtype=float)
+
+    def _residual_exclusion(
+        self, resid_eq: np.ndarray, off: np.ndarray
+    ) -> np.ndarray:
+        """Positive-only compact-source mask on the equalized residual.
+
+        Keeps source flux from diluting the trough-pass smoothing WITHOUT
+        blinding it: exclusion follows positive detections in the residual,
+        never SCI brightness, so negative lanes (e.g. under bright ICL)
+        stay visible to the negativity detector.
+        """
+        field_img = np.where(np.isfinite(resid_eq), resid_eq, 0.0)
+        sm = gaussian_filter(np.where(off, 0.0, field_img).astype(np.float32),
+                             2.0, mode="reflect")
+        rms = astrostats.biweight_scale(sm[~off])
+        lvl = astrostats.biweight_location(sm[~off])
+        seg = detect_sources(sm, threshold=lvl + 2.0 * rms, npixels=8,
+                             mask=off)
+        if seg is None:
+            return off.copy()
+        m = seg.make_source_mask()
+        m = distance_transform_edt(~m) <= 5.0
+        return m | off
+
+    def _gated_trough_pass(
+        self,
+        sci: np.ndarray,
+        bkgmap: np.ndarray,
+        exclude: np.ndarray,
+        sigma_map: np.ndarray,
+    ) -> np.ndarray:
+        """Iterated, detection-gated trough correction (see class docstring).
+
+        Returns the corrected background map (only ever lowered, and only
+        inside detected coherent negative regions).
+        """
+        m = bkgmap.copy()
+        with np.errstate(invalid="ignore"):
+            inv_sigma = np.where(
+                np.isfinite(sigma_map) & (sigma_map > 0),
+                1.0 / sigma_map, np.nan)
+        for s in self.guard_trough_sigmas:
+            npixels = max(int(self.guard_trough_npix * s * s), 30)
+            for it in range(self.guard_trough_max_iter):
+                resid_eq = (sci - m) * inv_sigma
+                sm = self._smooth_masked(resid_eq, exclude, s)
+                ok = np.isfinite(sm) & ~exclude
+                rms = float(astrostats.biweight_scale(sm[ok]))
+                if not np.isfinite(rms) or rms <= 0:
+                    break
+                signif = np.where(ok, sm / rms, 0.0)
+                seg = detect_sources(-signif,
+                                     threshold=self.guard_trough_t,
+                                     npixels=npixels)
+                if seg is None:
+                    break
+                gate = seg.make_source_mask()
+                corr = np.where(
+                    gate,
+                    np.minimum(sm + self.guard_trough_t * rms, 0.0), 0.0)
+                corr[~np.isfinite(corr)] = 0.0
+                corr = corr * np.where(np.isfinite(sigma_map), sigma_map, 0.0)
+                m = m + corr
+                log(f"  guard trough sigma={s} iter={it}: corrected "
+                    f"{float(gate.mean()):.4f} of area, "
+                    f"min={float(corr.min()):.3g}")
+        return m
+
+    def apply_negativity_guard(
+        self,
+        sci: np.ndarray,
+        bkg2d: Background2D,
+        mask_final: np.ndarray,
+        off: np.ndarray,
+    ) -> np.ndarray:
+        """Apply ceiling meshcap + gated trough pass to a fitted background.
+
+        Parameters: the SCI image, the fitted ``Background2D``, the full fit
+        mask, and the off-detector/DQ/zero-weight seed mask (bit 0 of the
+        bitmask). Returns the guarded background map.
+        """
+        bkgmap = bkg2d.background
+        sigma_map = self._guard_sigma_map(sci - bkgmap, ~mask_final & ~off)
+        ceiling = self._multiscale_ceiling(
+            sci, off, bkgmap, mask_final, sigma_map)
+        capped = self._cap_mesh(bkg2d, ceiling, sci.shape)
+        with np.errstate(invalid="ignore"):
+            resid_eq = np.where(
+                np.isfinite(sigma_map) & (sigma_map > 0),
+                (sci - capped) / sigma_map, np.nan)
+        excl = self._residual_exclusion(resid_eq, off)
+        return self._gated_trough_pass(sci, capped, excl, sigma_map)
+
+    # ------------------------------------------------------------------
     # Evaluation / diagnostics
     # ------------------------------------------------------------------
 
@@ -609,7 +877,12 @@ class SubtractBackground:
         )
 
         bkg = self.estimate_background(sci, mask_final)
-        bkgd_subtracted = sci - bkg.background
+        bkgmap = bkg.background
+        if self.bg_guard:
+            log("Applying negativity guard (ceiling meshcap + trough pass)")
+            off = (bitmask & 1) != 0
+            bkgmap = self.apply_negativity_guard(sci, bkg, mask_final, off)
+        bkgd_subtracted = sci - bkgmap
 
         self.mask_final = mask_final
         return bkgd_subtracted, mask_final, bitmask

--- a/pipeline/campfire_pipeline/nircam/bkgsub.py
+++ b/pipeline/campfire_pipeline/nircam/bkgsub.py
@@ -659,18 +659,24 @@ class SubtractBackground:
         capped = np.minimum(mesh, cmesh)
         n_capped = int((mesh > cmesh).sum())
         log(f"  guard ceiling: capped {n_capped}/{mesh.size} mesh cells")
-        interp = BkgZoomInterpolator()
-        # photutils' BkgZoomInterpolator.__call__ reads kwargs['edge_method']
-        # unconditionally (2.3.0, interpolators.py:97), so omitting it is a hard
-        # KeyError on every call — this path cannot run without it. Take the
-        # value from the Background2D being capped rather than hardcoding
-        # 'pad': re-interpolating the capped mesh has to use exactly the
-        # interpolation the original fit used, or the capped map is not
-        # comparable to the one it replaces. Verified on a synthetic fit —
-        # with this kwarg, interp(uncapped_mesh) reproduces bkg2d.background
-        # to 0.0e+00.
-        return interp(capped, box_size=(by, bx), shape=shape, dtype=float,
-                      edge_method=getattr(bkg2d, "edge_method", "pad"))
+        # Re-run exactly the interpolation the original fit used:
+        # Background2D.background is interpolator(background_mesh,
+        # **_interp_kwargs) (photutils 2.3.0, background_2d.py), so calling
+        # the fit's own interpolator with the fit's own kwargs reproduces
+        # bkg2d.background bit-for-bit from the uncapped mesh, and the capped
+        # map differs only through the capped cells. This also honors the
+        # configured bg_interpolator: a hardcoded BkgZoomInterpolator here
+        # would silently replace an IDW background with a zoom-interpolated
+        # one even when no cell is capped (and _interp_kwargs carries the
+        # mesh_yxcen/mesh_nan_mask the IDW call requires).
+        interp_kwargs = getattr(bkg2d, "_interp_kwargs", None)
+        if interp_kwargs is None:
+            # photutils without _interp_kwargs: fall back to the zoom-style
+            # call (edge_method is read unconditionally in 2.3.0).
+            interp_kwargs = dict(
+                box_size=(by, bx), shape=shape, dtype=float,
+                edge_method=getattr(bkg2d, "edge_method", "pad"))
+        return bkg2d.interpolator(capped, **interp_kwargs)
 
     def _residual_exclusion(
         self, resid_eq: np.ndarray, off: np.ndarray
@@ -717,17 +723,39 @@ class SubtractBackground:
             for it in range(self.guard_trough_max_iter):
                 resid_eq = (sci - m) * inv_sigma
                 sm = self._smooth_masked(resid_eq, exclude, s)
-                ok = np.isfinite(sm) & ~exclude
-                rms = float(astrostats.biweight_scale(sm[ok]))
+                # exclude keeps source flux out of the smoothing inputs and
+                # the rms estimate ONLY. The gate and the correction use sm
+                # wherever it is finite — including under excluded source
+                # footprints, where the normalized convolution interpolates
+                # the ambient trough from the surrounding sky — so corr stays
+                # continuous across footprint edges. Zeroing signif on
+                # excluded pixels instead would hard-zero corr over every
+                # source inside a fired trough, leaving each one on a
+                # pedestal at the original trough depth (a seam the class
+                # docstring promises not to make).
+                finite = np.isfinite(sm)
+                rms = float(astrostats.biweight_scale(sm[finite & ~exclude]))
                 if not np.isfinite(rms) or rms <= 0:
                     break
-                signif = np.where(ok, sm / rms, 0.0)
+                signif = np.where(finite, sm / rms, 0.0)
                 seg = detect_sources(-signif,
                                      threshold=self.guard_trough_t,
                                      npixels=npixels)
                 if seg is None:
                     break
-                gate = seg.make_source_mask()
+                # A region's significance must rest on at least npixels of
+                # real (non-excluded) sky: interpolated sm under excluded
+                # islands may extend a genuine trough across a footprint,
+                # but must never create or carry a firing on its own —
+                # otherwise shallow negative patches bridged by source
+                # footprints erode the blank-field near-no-op guarantee.
+                sky_area = np.bincount(
+                    seg.data[~exclude].ravel(), minlength=seg.nlabels + 1)
+                keep = sky_area >= npixels
+                keep[0] = False
+                if not keep.any():
+                    break
+                gate = keep[seg.data]
                 corr = np.where(
                     gate,
                     np.minimum(sm + self.guard_trough_t * rms, 0.0), 0.0)

--- a/pipeline/campfire_pipeline/nircam/bkgsub.py
+++ b/pipeline/campfire_pipeline/nircam/bkgsub.py
@@ -660,7 +660,17 @@ class SubtractBackground:
         n_capped = int((mesh > cmesh).sum())
         log(f"  guard ceiling: capped {n_capped}/{mesh.size} mesh cells")
         interp = BkgZoomInterpolator()
-        return interp(capped, box_size=(by, bx), shape=shape, dtype=float)
+        # photutils' BkgZoomInterpolator.__call__ reads kwargs['edge_method']
+        # unconditionally (2.3.0, interpolators.py:97), so omitting it is a hard
+        # KeyError on every call — this path cannot run without it. Take the
+        # value from the Background2D being capped rather than hardcoding
+        # 'pad': re-interpolating the capped mesh has to use exactly the
+        # interpolation the original fit used, or the capped map is not
+        # comparable to the one it replaces. Verified on a synthetic fit —
+        # with this kwarg, interp(uncapped_mesh) reproduces bkg2d.background
+        # to 0.0e+00.
+        return interp(capped, box_size=(by, bx), shape=shape, dtype=float,
+                      edge_method=getattr(bkg2d, "edge_method", "pad"))
 
     def _residual_exclusion(
         self, resid_eq: np.ndarray, off: np.ndarray

--- a/pipeline/campfire_pipeline/nircam/bkgsub.py
+++ b/pipeline/campfire_pipeline/nircam/bkgsub.py
@@ -892,7 +892,16 @@ class SubtractBackground:
             log("Applying negativity guard (ceiling meshcap + trough pass)")
             off = (bitmask & 1) != 0
             bkgmap = self.apply_negativity_guard(sci, bkg, mask_final, off)
-        bkgd_subtracted = sci - bkgmap
+        # Cast back to the input precision. The guard works in float64 —
+        # _cap_mesh reads the mesh as `dtype=float` — so `sci - bkgmap` would
+        # otherwise promote a float32 mosaic to float64 and double every SCI
+        # array on disk (A2744 F444W: _sci 4.68 -> 9.37 GiB, _i2d 15.4 -> 20.1
+        # GiB), silently, for no gain over float32 drizzle inputs. The
+        # unguarded path already returns float32, and this method's docstring
+        # promises "same dtype as the input SCI"; without this the guard breaks
+        # that invariant. Keeping the arithmetic in float64 and casting only
+        # the result costs 2.4e-07 relative rounding.
+        bkgd_subtracted = (sci - bkgmap).astype(sci.dtype, copy=False)
 
         self.mask_final = mask_final
         return bkgd_subtracted, mask_final, bitmask

--- a/pipeline/campfire_pipeline/nircam/manifest.py
+++ b/pipeline/campfire_pipeline/nircam/manifest.py
@@ -124,16 +124,66 @@ def build_mosaic_name(filtname, field_name, pixel_scale, tile, epoch=None,
     return name
 
 
+# Bump whenever the mosaic bkgsub *algorithm* changes results at identical
+# settings, so existing manifests hash stale and get_stale_tiles / the
+# resample-step skip logic rebuild their tiles. v2 = negativity guard
+# rollout + tier-0 pre-tier removal (both change pixels at the default
+# config, so the bump — not any key below — is what marks pre-guard tiles
+# stale).
+_BKGSUB_ALGORITHM_VERSION = 2
+
+# Every SubtractBackground setting that changes mosaic pixels, with the
+# defaults resample_step applies. Single source of truth: the config hash
+# below and the SubtractBackground construction in steps/resample.py both
+# iterate this dict, so a new tunable (or a default change) can never be
+# applied without also invalidating the tiles it affects. ``wht_aware`` is
+# deliberately absent — it is hashed separately (non-default-only, for
+# historical-hash compatibility) and passed explicitly by resample_step.
+BKGSUB_PIXEL_DEFAULTS = {
+    'ring_radius_in': 80,
+    'ring_width': 4,
+    'ring_downsample': 4,
+    'ring_clip_max_sigma': 5.0,
+    'ring_clip_box_size': 100,
+    'ring_clip_filter_size': 3,
+    'tier_kernel_size': [25, 15, 5, 2],
+    'tier_npixels': [15, 10, 3, 1],
+    'tier_nsigma': [1.5, 1.5, 1.5, 1.5],
+    'tier_dilate_size': [33, 25, 21, 19],
+    'bg_box_size': 10,
+    'bg_filter_size': 5,
+    'bg_exclude_percentile': 90,
+    'bg_sigma': 3,
+    'bg_interpolator': 'zoom',
+    'bg_reject': False,
+    'bg_reject_sigma_hi': 4.0,
+    'bg_reject_sigma_lo': 3.0,
+    'bg_reject_percentile': 60.0,
+    'bg_reject_dilate': 40.0,
+    'bg_guard': True,
+    'guard_ceiling_boxes': [32, 64, 128],
+    'guard_ceiling_k': 2.0,
+    'guard_ceiling_sigma_upper': 1.0,
+    'guard_trough_sigmas': [5.0, 15.0],
+    'guard_trough_t': 2.0,
+    'guard_trough_npix': 8.0,
+    'guard_trough_max_iter': 12,
+}
+
+
 def _resample_config_hash(resample_cfg, pixel_scale):
     """Hash the resample config fields that affect mosaic pixels.
 
     Single source of truth for :func:`create_manifest` and
-    :func:`check_config_changed` so the two can never drift. The bg_reject
-    keys are folded in **only when the guard is enabled** (non-default):
-    existing tiles keep their historical hash (no spurious global rebuild),
-    while flipping ``bg_reject`` on a field hashes distinctly so
-    ``get_stale_tiles`` rebuilds its tiles. ``wht_aware`` follows the same
-    non-default-only pattern (folded in only when *disabled*).
+    :func:`check_config_changed` so the two can never drift. When
+    background subtraction is enabled, the hash folds in every bkgsub
+    setting that changes pixels (:data:`BKGSUB_PIXEL_DEFAULTS`) plus the
+    bkgsub algorithm version, so both tuning changes and behavior changes
+    at identical settings mark tiles stale — resample_step skips bkgsub
+    entirely for a tile whose manifest and ``_i2d_before_bkgsub.fits``
+    exist, so a stale hash is the *only* thing that reruns it.
+    ``wht_aware`` is folded in only when *disabled* (non-default), keeping
+    historical hashes for the common case.
     """
     cfg = {
         'pixfrac': resample_cfg.get('pixfrac', 1),
@@ -143,13 +193,10 @@ def _resample_config_hash(resample_cfg, pixel_scale):
     }
     if not resample_cfg.get('wht_aware', True):
         cfg['wht_aware'] = False
-    if resample_cfg.get('bg_reject', False):
-        cfg['bg_reject'] = True
-        cfg['bg_reject_sigma_hi'] = resample_cfg.get('bg_reject_sigma_hi', 4.0)
-        cfg['bg_reject_sigma_lo'] = resample_cfg.get('bg_reject_sigma_lo', 3.0)
-        cfg['bg_reject_percentile'] = resample_cfg.get(
-            'bg_reject_percentile', 60.0)
-        cfg['bg_reject_dilate'] = resample_cfg.get('bg_reject_dilate', 40.0)
+    if cfg['background_subtract']:
+        cfg['bkgsub_algorithm'] = _BKGSUB_ALGORITHM_VERSION
+        for key, default in BKGSUB_PIXEL_DEFAULTS.items():
+            cfg[key] = resample_cfg.get(key, default)
     config_str = json.dumps(cfg, sort_keys=True)
     return f'sha256:{hashlib.sha256(config_str.encode()).hexdigest()}'
 

--- a/pipeline/campfire_pipeline/nircam/steps/resample.py
+++ b/pipeline/campfire_pipeline/nircam/steps/resample.py
@@ -214,8 +214,8 @@ def resample_step(filtname, exposure_files, field, step_config,
         epoch segment.
     """
     from campfire_pipeline.nircam.manifest import (
-        build_mosaic_name, check_config_changed, check_inputs_changed,
-        create_manifest, write_manifest,
+        BKGSUB_PIXEL_DEFAULTS, build_mosaic_name, check_config_changed,
+        check_inputs_changed, create_manifest, write_manifest,
     )
 
     pixel_scale, pixel_scale_str = _resolve_pixel_scale(
@@ -327,52 +327,14 @@ def resample_step(filtname, exposure_files, field, step_config,
                 if needs_rebuild and bkgsub_done:
                     os.remove(pre_bkg)
 
+                # Pixel-affecting settings and their defaults come from the
+                # manifest's BKGSUB_PIXEL_DEFAULTS — the same dict the tile
+                # config hash iterates — so nothing applied here can change
+                # mosaic pixels without also marking existing tiles stale.
                 bkg = SubtractBackground(
-                    ring_radius_in=step_config.get('ring_radius_in', 80),
-                    ring_width=step_config.get('ring_width', 4),
-                    ring_downsample=step_config.get('ring_downsample', 4),
-                    ring_clip_max_sigma=step_config.get(
-                        'ring_clip_max_sigma', 5.0),
-                    ring_clip_box_size=step_config.get(
-                        'ring_clip_box_size', 100),
-                    ring_clip_filter_size=step_config.get(
-                        'ring_clip_filter_size', 3),
-                    tier_kernel_size=step_config.get(
-                        'tier_kernel_size', [25, 15, 5, 2]),
-                    tier_npixels=step_config.get(
-                        'tier_npixels', [15, 10, 3, 1]),
-                    tier_nsigma=step_config.get(
-                        'tier_nsigma', [1.5, 1.5, 1.5, 1.5]),
-                    tier_dilate_size=step_config.get(
-                        'tier_dilate_size', [33, 25, 21, 19]),
-                    bg_box_size=step_config.get('bg_box_size', 10),
-                    bg_filter_size=step_config.get('bg_filter_size', 5),
-                    bg_exclude_percentile=step_config.get(
-                        'bg_exclude_percentile', 90),
-                    bg_sigma=step_config.get('bg_sigma', 3),
-                    bg_interpolator=step_config.get('bg_interpolator', 'zoom'),
-                    bg_reject=step_config.get('bg_reject', False),
-                    bg_reject_sigma_hi=step_config.get(
-                        'bg_reject_sigma_hi', 4.0),
-                    bg_reject_sigma_lo=step_config.get(
-                        'bg_reject_sigma_lo', 3.0),
-                    bg_reject_percentile=step_config.get(
-                        'bg_reject_percentile', 60.0),
-                    bg_reject_dilate=step_config.get('bg_reject_dilate', 40.0),
+                    **{k: step_config.get(k, d)
+                       for k, d in BKGSUB_PIXEL_DEFAULTS.items()},
                     wht_aware=step_config.get('wht_aware', True),
-                    bg_guard=step_config.get('bg_guard', True),
-                    guard_ceiling_boxes=step_config.get(
-                        'guard_ceiling_boxes', [32, 64, 128]),
-                    guard_ceiling_k=step_config.get('guard_ceiling_k', 2.0),
-                    guard_ceiling_sigma_upper=step_config.get(
-                        'guard_ceiling_sigma_upper', 1.0),
-                    guard_trough_sigmas=step_config.get(
-                        'guard_trough_sigmas', [5.0, 15.0]),
-                    guard_trough_t=step_config.get('guard_trough_t', 2.0),
-                    guard_trough_npix=step_config.get(
-                        'guard_trough_npix', 8.0),
-                    guard_trough_max_iter=step_config.get(
-                        'guard_trough_max_iter', 12),
                     suffix='bkgsub',
                     replace_sci=True,
                 )

--- a/pipeline/campfire_pipeline/nircam/steps/resample.py
+++ b/pipeline/campfire_pipeline/nircam/steps/resample.py
@@ -360,6 +360,19 @@ def resample_step(filtname, exposure_files, field, step_config,
                         'bg_reject_percentile', 60.0),
                     bg_reject_dilate=step_config.get('bg_reject_dilate', 40.0),
                     wht_aware=step_config.get('wht_aware', True),
+                    bg_guard=step_config.get('bg_guard', True),
+                    guard_ceiling_boxes=step_config.get(
+                        'guard_ceiling_boxes', [32, 64, 128]),
+                    guard_ceiling_k=step_config.get('guard_ceiling_k', 2.0),
+                    guard_ceiling_sigma_upper=step_config.get(
+                        'guard_ceiling_sigma_upper', 1.0),
+                    guard_trough_sigmas=step_config.get(
+                        'guard_trough_sigmas', [5.0, 15.0]),
+                    guard_trough_t=step_config.get('guard_trough_t', 2.0),
+                    guard_trough_npix=step_config.get(
+                        'guard_trough_npix', 8.0),
+                    guard_trough_max_iter=step_config.get(
+                        'guard_trough_max_iter', 12),
                     suffix='bkgsub',
                     replace_sci=True,
                 )

--- a/pipeline/experiments/bkg_nonneg/.gitignore
+++ b/pipeline/experiments/bkg_nonneg/.gitignore
@@ -1,0 +1,3 @@
+out*/
+*.npz
+__pycache__/

--- a/pipeline/experiments/bkg_nonneg/README.md
+++ b/pipeline/experiments/bkg_nonneg/README.md
@@ -1,0 +1,255 @@
+# bkg_nonneg — conditioning background subtraction against negative flux
+
+Prototype (2026-07-27) for constraining `SubtractBackground` so the
+subtracted image contains no statistically significant negative structure.
+Physical prior: true flux >= 0, so every pixel — masked or not — asserts
+`bkg(x) <= sci(x) + k*sigma(x)`. Absorbing smooth wing/ICL light stays
+intentional; the sole objective is no coherent oversubtraction.
+
+Test data: two 40" A2744 F444W cutouts (30 mas, pre-mosaic-bkgsub) at
+`~/Downloads/a2744_f444w_{offcluster_galaxy,cluster_core}_before_40as.fits`.
+Both carry negativity baked in by the per-exposure `subtract_2d` stage
+(A2744 is a cluster field): a coherent negative lane between the two
+bright core galaxies, and a band along the offcluster spiral's major axis.
+
+## Files
+
+- `metrics.py` — validation metrics, independent of the pipeline mask:
+  empty-aperture statistics (0.3–1.5" apertures, radial profiles),
+  negative-structure detector (smoothed significance map + inverted
+  `detect_sources`, with a positive control), mesh mask-fraction maps.
+  All significance is empirical (correlated-noise safe).
+- `nonneg.py` — the constrained-fit mechanisms (see below).
+- `run_cutouts.py` — arm sweep on the two cutouts; writes
+  `out/<name>/{maps,profiles}.png` + `summary.json`.
+- `test_blank_null.py` — success-criterion #3: synthetic blank tile
+  (gradient + correlated noise + faint sources); the constraints must be a
+  no-op there.
+- `finalmaps.py` — before/after figure for the per-exposure path
+  (`out/final_perexp.png`).
+
+## Mechanisms (in `nonneg.py`)
+
+1. **Asymmetric sigma clip** in the main fit
+   (`AsymmetricSubtractBackground`, sigma_upper=2). **REJECTED**: biases
+   the whole sky estimate low — 1" empty-aperture median jumps
+   +0.17 vs +0.014 (offcluster). The handoff's warning #3 realized.
+2. **One-sided ceiling meshcap** (`onesided_ceiling_map` + `cap_mesh`).
+   Maskless coarse Background2D with hard upper clip (sigma_upper=1)
+   tracks the lower envelope of local flux — a valid upper bound on the
+   background everywhere (true flux >= 0). Per-image self-calibration
+   (`calibrate_ceiling`): robust median offset vs the arm's own masked fit
+   on quiet pixels removes the one-sided clip bias; slack = 2x the robust
+   scatter of that difference. Enforced at the *mesh* level + re-zoom
+   (smooth by construction; a mask-and-refit enforcement is provably a
+   no-op for violations under fully-masked regions — the interpolator
+   extrapolates identically). `multiscale_ceiling` takes the min over
+   box 32/64/128 (min of upper bounds = tighter bound; finer scales catch
+   the sky gaps next to bright masked sources).
+3. **Residual trough pass** (`trough_correction`, handoff C6). The
+   residual is observable even under the fit mask: where its 5-px-smoothed
+   map is coherently below -t*sigma_sm (t=2), lower the map by
+   (sm + t*sigma_sm) — continuous at the boundary, no seams, pedestal
+   bounded by the t-tail. Catches what the ceiling misses (meshes mixing
+   wing flux with the trough).
+
+## Results (negative-structure area / deepest trough)
+
+| arm | offcluster | core |
+|---|---|---|
+| input (per-exp damage baked in) | 6118 px / -3.3σ | 5996 px / -3.0σ |
+| perexp64 (current cluster path) | 4837 px / -3.3σ | 6306 px / -3.1σ |
+| perexp64 + cap + trough | 2403 px / -2.7σ | **0 px / -2.2σ** |
+| mosaic10 (current mosaic fit) | 1905 px / -4.2σ | 10373 px / -6.0σ |
+| mosaic10 + msceil + trough | 262 px / -2.9σ | 3418 px / -2.8σ |
+
+- The ceiling alone nearly cleans the coarse per-exposure fit (37/441
+  cells capped on core); the trough pass finishes it. On the fine mosaic
+  fit the trough pass carries more of the load.
+- The constraint also *heals baked-in* negativity: where the image sits
+  coherently below zero the ceiling goes negative and pulls the model
+  down (adds flux back). Legitimate under the prior, but it means the
+  right home for this is the per-exposure stage, with the mosaic stage as
+  a second guard.
+- Pedestal cost: ceiling arms +1e-5/px (0.1% sigma_pix); trough pass none
+  measurable. Blank-tile null: median map shift exactly 0, p99 = +5e-5.
+- Aside: the *current* fine-box fit shows a -6σ negative empty-aperture
+  median on the synthetic blank tile (absorption of unresolved faint
+  flux) — pre-existing, not introduced here.
+
+## Composition + tier-0 A/B (`run_composed.py`, out/composed.png)
+
+- **end2end** (constrained perexp64 -> fresh mask -> constrained mosaic10)
+  is statistically identical to `mosaic10_msceil_tr` alone (offcluster
+  258 vs 262 px; core 3206 vs 3418 px) with a slightly lower wing pedestal.
+  Retroactively, the constrained mosaic stage recovers nearly everything;
+  no double-subtraction pathology. (In production the per-exposure fix is
+  still the right home -- the damage is drizzle-coherent and should never
+  enter the mosaic.)
+- **Tier-0 A/B** (offcluster; tier 0 masks 87% of this 40" cutout --
+  unrepresentative of a full tile, treat as an upper bound): the
+  unconstrained box-10 fit under the tier-0 mask is far WORSE (50368 px /
+  -4.5 sigma / 1" apmed -0.22 vs 1905 px without): inside the hole the fit
+  is pure extrapolation, box-scale artifacts appear, and the real negative
+  lane goes uncorrected. Tier 0 trades "biased local data" (the bowl) for
+  "no local data at all"; it provides zero negativity protection inside
+  the hole. Needs a >=120" cutout (~3x dilation radius) for a fair
+  production-scale verdict.
+- **Rescue test** (`t0_rescue.py`): ceiling + trough are mask-independent
+  (maskless map; residual visible everywhere), so they still fire inside
+  the tier-0 hole: 50368 -> 2544 px, -4.5 -> -2.7 sigma. A -0.13 aperture
+  pedestal remains -- nothing anchors the fit level in the hole and the
+  k=2 slack tolerates sub-threshold bias. The guard makes the pipeline
+  robust to masking choices, but cannot conjure an anchor from no data.
+
+## Mosaic-level "final guard" design (`ms_trough.py`, `ms_trough2.py`, `gated_test.py`)
+
+Candidate production recipe for the mosaic stage (msceil meshcap + trough):
+
+- **Iterate the trough pass per scale** (a single pass under-corrects deep
+  troughs: re-smoothing erodes the correction peak). Converges in 2-4
+  iterations.
+- **Multi-scale** (sigma = 5, 15 px): the sigma=15 pass is what catches
+  broad lanes (offcluster). sigma=45 contributed nothing on either real
+  cutout and is the worst blank-field offender -- drop it.
+- **Detection-gate the correction** (`gated_trough_correction`): apply only
+  inside connected regions below -t*sigma_sm of >= 8*sigma_sm^2 px.
+  Continuous at the segment edge by construction (correction field is zero
+  at the -t isophote). With gating + iteration both real cutouts reach
+  **0 px** of detected negative structure (corrected area <= 0.6%).
+- **Quantified residual risk**: even gated, the blank-tile null fires on
+  0.7%/2% of area (sigma=5/15) -- not on noise but on the box-10 fit's own
+  error field (~1.7e-3 wiggles coherent at the ~50 px mesh scale look like
+  significant dips at large smoothing sigma). One-sided correction of
+  symmetric fit error => median map shift exactly 0, mean pulled ~0.75%
+  of sigma_pix. Mitigations to evaluate on real data: t=3 for sigma=15,
+  and note the synthetic blank lacks confusion-level faint flux (which
+  biases residuals positive), so this is likely an upper bound. Needs a
+  real blank-tile cutout for the production regression.
+
+## 120" validation (`run_120.py`, out120 = flux-space, out120dw = depth-aware)
+
+4000x4000 cutouts with WHT, plus production `after` mosaics as reference.
+Two separate negativity mechanisms appear at this scale:
+
+1. **Tier-0 hole extrapolation is the dominant source of the wing troughs.**
+   A/B at production scale (tier 0 masks 10% of the frame): m10 68,744 px
+   vs m10_t0 195,940 px (depth-aware scoring) — and the production `after`
+   morphology around the galaxy matches m10_t0, not m10. Tier 0 still
+   never fires on the BCGs (even with full context), so it also doesn't
+   protect cluster cores. The guard neutralizes the hole: corrections
+   land under/around the tier-0 region and the wing trough disappears.
+2. **Inter-visit depth strips** carry real (small) sky-level offsets; in
+   flux-space scoring they also FAKE negativity (input 182k px flux-space
+   -> 119k depth-aware: a third of the flux-space number was scoring
+   artifact).
+
+**Depth-awareness is mandatory at this scale** (`err=` arguments
+throughout): significance and corrections computed on resid/ERR, mapped
+back through local ERR; the one-sided ceiling is fit on sci/ERR (upper
+bound survives the transform since flux >= 0) and its clip bias becomes
+scale-uniform (-0.21 sigma at box 32/64/128) — one global calibration
+valid everywhere. The flux-space version overshot positive in the shallow
+strip; the depth-aware version does not. Trough iteration needs
+max_iter ~ 8-12 at 120" scale (converges, frac -> 0).
+
+**Scoreboard (depth-aware negative area / deepest trough):**
+
+| arm | offcluster | core |
+|---|---|---|
+| input | 119,448 px / -5.4σ | 146,157 px / -9.1σ |
+| after (production) | 170,854 px / -7.7σ | 153,776 px / -12.7σ |
+| m10_t0 + guard | **8,773 px / -7.1σ** | **320 px / -4.1σ** |
+
+Guard survivors on offcluster are ~41 compact (~200-400 px) scattered
+patches, NOT the wing trough (fully healed). These are sub-background-
+scale features (likely snowball/persistence-class artifacts); correcting
+them through the background model is the wrong tool — flag/DQ territory.
+Deliberately not chased.
+
+## Lane + edge diagnostics (`analyze_zoom.py`, out120dw/core/zoom_lane.png)
+
+- **Inter-BCG lane (core)**: the trough is (a) baked into the input, (b)
+  deepened broadly by production, (c) turned into compact deeper
+  pinch-point troughs by the fine-box fit (saddle bias: a smooth fit
+  overestimates the background at the valley between two peaks; the lane
+  meshes are interpolated from wing-elevated edge cells). The zoom shows
+  the guard's blind spot directly: the SCI-based `excl` covers 45% of the
+  lane region, so the significance map is undefined over the lane interior
+  and the trough gate cannot fire there; surviving blue sits at the excl
+  boundary. FIX (not yet applied): build the trough-pass exclusion from
+  positive detections in the *residual*, not SCI brightness, and switch
+  ERR -> alpha/WHT so ICL Poisson noise stops suppressing trough
+  significance and loosening the ceiling.
+- **Offcluster strips/border**: quantified, the depth-aware guard does NOT
+  overcorrect them (strip median signif -0.31 -> -0.29, f(>+2 sigma)
+  0.0042 -> 0.0039; border similarly unchanged). The earlier flux-space
+  guard DID overshoot there (visible in out120/maps.png) -- depth-
+  awareness removed it. The strips remain coherently negative (median
+  -0.3 sigma_sm over ~900k px) in every arm including production: real
+  inter-visit DC offsets with sharp coverage-boundary edges, deliberately
+  below the guard's 2-sigma regional threshold. Right fix is upstream
+  visit-level sky matching, not the background fit.
+
+## v3: alpha/WHT noise model + residual-based exclusion (out120v3)
+
+Both lane fixes applied and validated:
+
+- **Noise model**: sigma(x) = s/sqrt(WHT), s calibrated as the robust
+  scale of resid*sqrt(WHT) on unmasked sky. Median ERR/sigma_wht ~ 3.6 on
+  sky — the drizzle correlation factor (ERR propagates uncorrelated
+  variance; the map's per-pixel scatter is ~3.6x smaller). Consistency:
+  the ceiling clip bias is -0.21 in ERR units and -0.77 in sigma_wht
+  units (0.21 x 3.6). All guard significance/corrections + scoring now use
+  sigma_wht (source-independent — no Poisson suppression over ICL).
+- **Exclusion**: built per-arm from positive detections in the
+  (equalized) residual, not SCI brightness — negative lanes stay visible
+  to the trough gate and the metric.
+
+Scoring changed (lane interior now visible) — v3 numbers are not
+comparable to earlier tables. v3 scoreboard:
+
+| arm | offcluster | core |
+|---|---|---|
+| after (production) | 185,711 px / -6.8σ | 158,892 px / -13.3σ |
+| m10(_t0) | 210,486 px / -7.0σ | 52,889 px / -18.7σ |
+| guard | **15,534 px / -7.2σ** | **1,314 px / -4.8σ** |
+
+The lane zoom (out120v3/core/zoom_lane.png): area below -2 sigma in the
+window drops 57,810 px (after) / 27,388 px (m10, with its true -11.9σ
+pinch-trough depth now visible) -> 5,764 px (guard), and the guard's
+remnants are shallow + concentrated at the star-spike region. Aperture
+medians unchanged (guard +0.0125 vs m10 +0.0130 on core): no pedestal.
+Offcluster guard survivors remain the compact artifact-class patches
+(flag-don't-correct).
+
+## Open questions / next steps
+
+- Offcluster's residual lane only partially heals (t=2 at sigma_sm=5 px
+  misses broad ~2σ-coherent structure). Knobs: larger smoothing scale in
+  the trough pass (or multi-scale), t sweep against blank-field false-fire
+  rate. Caution: some of that lane may be a genuine artifact (1/f / wisp
+  residual) that *should* stay visible rather than be papered over — check
+  against the exposure layout before tuning it away.
+- Ceiling calibration currently references the arm's own masked fit
+  (quiet-pixel diff). On fields with almost no quiet sky this could bias;
+  consider calibrating on the blank corners of the full tile instead.
+- Tier-0 finding: the 100σ/30k-px pre-tier fires on the offcluster spiral
+  but NOT on the A2744 BCGs (too diffuse after 25-px smoothing) — the
+  bowl guard doesn't protect cluster cores at all.
+- Integration sketch: opt-in config block on `SubtractBackground`
+  (`bg_ceiling = true`, boxes, k, trough t/sigma) applied in
+  `estimate_background` after the existing `bg_reject` pass; per-exposure
+  `[nircam.bkg.bkg2d]` first, mosaic later. Needs the WHT-aware sigma
+  logic for variable-depth tiles before production.
+
+## Tier-0 A/B with the guard (`run_m10_guard.py`)
+
+Guard applied to the no-tier-0 fit: offcluster **1,809 px / -7.4σ** vs
+15,534 px / -7.2σ with tier 0 (core identical, tier 0 no-op). Tier 0 is
+net harmful even guard-cleaned — the guard subsumes its entire purpose
+(the bowl it prevented is a negativity failure the guard fixes from the
+data side, including where tier 0 can't reach: BCGs, saddles). Production
+recommendation: with the guard enabled, drop tier 0. Confirm on 1-2 more
+tier-0-firing objects (bright spiked star archetype) before flipping the
+default.

--- a/pipeline/experiments/bkg_nonneg/analyze_zoom.py
+++ b/pipeline/experiments/bkg_nonneg/analyze_zoom.py
@@ -1,0 +1,67 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import numpy as np, matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from astropy.io import fits
+import metrics
+from run_120 import CUTOUTS_120, load
+
+# ---------- core zoom: inter-BCG lane ----------
+d = np.load("out120dw/core/arms.npz")
+sci, err, wht = load(CUTOUTS_120["core"][0])
+excl = d["excl"]
+y0, y1, x0, x1 = 2000, 3000, 1200, 2600
+fig, axes = plt.subplots(1, 4, figsize=(18, 4.8), dpi=110)
+for i, arm in enumerate(["after", "m10", "m10_t0_guard"]):
+    neg = metrics.negative_structure(d[f"resid_{arm}"], excl, err=err)
+    ax = axes[i]
+    ax.imshow(neg.signif_map[y0:y1, x0:x1], origin="lower", cmap="RdBu_r",
+              vmin=-6, vmax=6, extent=[x0, x1, y0, y1])
+    ax.contour(excl[y0:y1, x0:x1], levels=[0.5], colors="k",
+               linewidths=0.4, extent=[x0, x1, y0, y1])
+    ax.set_title(f"{arm}: signif + excl (black)", fontsize=9)
+    ax.set_xticks([]); ax.set_yticks([])
+from astropy.visualization import AsinhStretch, ImageNormalize, PercentileInterval
+norm = ImageNormalize(sci, interval=PercentileInterval(99.5),
+                      stretch=AsinhStretch(0.05))
+axes[3].imshow(sci[y0:y1, x0:x1], origin="lower", cmap="Greys_r", norm=norm,
+               extent=[x0, x1, y0, y1])
+axes[3].contour(excl[y0:y1, x0:x1], levels=[0.5], colors="#d62728",
+                linewidths=0.4, extent=[x0, x1, y0, y1])
+axes[3].set_title("SCI + excl (red)", fontsize=9)
+axes[3].set_xticks([]); axes[3].set_yticks([])
+fig.suptitle("core: inter-BCG lane zoom")
+fig.tight_layout()
+fig.savefig("out120dw/core/zoom_lane.png")
+print("saved out120dw/core/zoom_lane.png")
+
+# fraction of the deep m10 lane trough that is excl-blinded
+neg_m10 = metrics.negative_structure(d["resid_m10"], excl, err=err)
+sub = neg_m10.signif_map[y0:y1, x0:x1]
+deep = np.isfinite(sub) & (sub < -2)
+print(f"[core lane zoom] px with signif<-2 (m10): {deep.sum()}, "
+      f"of which inside excl-dilated border... excl frac in zoom: "
+      f"{excl[y0:y1, x0:x1].mean():.3f}")
+
+# ---------- offcluster edges: strip + border overshoot ----------
+d2 = np.load("out120dw/offcluster/arms.npz")
+sci2, err2, wht2 = load(CUTOUTS_120["offcluster"][0])
+excl2 = d2["excl"]; off2 = d2["off"]
+stats = {}
+for arm in ["m10", "m10_t0", "m10_t0_guard"]:
+    neg = metrics.negative_structure(d2[f"resid_{arm}"], excl2, err=err2)
+    s = neg.signif_map
+    ok = np.isfinite(s) & ~excl2
+    N = s.shape[0]
+    border = np.zeros_like(ok); b = 60
+    border[:b, :] = border[-b:, :] = border[:, :b] = border[:, -b:] = True
+    # shallow strip: use WHT to define it (below 60% of median weight)
+    wmed = np.nanmedian(wht2[wht2 > 0])
+    strip = (wht2 > 0) & (wht2 < 0.6 * wmed) & ~border
+    interior = ok & ~border & ~strip
+    stats[arm] = (np.nanmedian(s[ok & strip]), np.nanmedian(s[ok & border]),
+                  np.nanmedian(s[interior]))
+    print(f"[offcluster] {arm}: median signif strip={stats[arm][0]:+.2f} "
+          f"border={stats[arm][1]:+.2f} interior={stats[arm][2]:+.2f} "
+          f"(strip px={int((ok&strip).sum())})")

--- a/pipeline/experiments/bkg_nonneg/blank_null2.py
+++ b/pipeline/experiments/bkg_nonneg/blank_null2.py
@@ -1,0 +1,38 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import numpy as np
+from astropy import stats as astrostats
+from scipy.ndimage import gaussian_filter
+import metrics, nonneg
+from run_cutouts import build_masker
+from ms_trough2 import iterated_trough
+
+rng = np.random.default_rng(7)
+N = 1333; SIG = 0.012; SKY0 = 0.003
+yy, xx = np.mgrid[0:N, 0:N] / N
+sky = SKY0 * (1 + 0.5 * xx + 0.3 * yy - 0.4 * xx * yy)
+noise = gaussian_filter(rng.normal(size=(N, N)), 1.5, mode="wrap")
+noise *= SIG / noise.std()
+src = np.zeros((N, N))
+for _ in range(150):
+    y0, x0 = rng.uniform(20, N - 20, 2)
+    amp = rng.lognormal(np.log(5 * SIG), 1.0); s = rng.uniform(1.5, 4.0)
+    y1, y2, x1, x2 = int(y0)-20, int(y0)+20, int(x0)-20, int(x0)+20
+    dy = np.arange(y1, y2)[:, None] - y0; dx = np.arange(x1, x2)[None, :] - x0
+    src[y1:y2, x1:x2] += amp * np.exp(-(dy**2 + dx**2) / (2*s*s))
+sci = (sky + noise + src).astype(np.float32)
+err = np.full_like(sci, SIG); off = np.zeros_like(sci, bool)
+
+masker = build_masker()
+mask, _ = masker.mask_from_arrays(sci, err)
+excl = metrics.compact_source_mask(sci, off) | off
+bkg = masker.estimate_background(sci, mask)
+ceil_ms, _ = nonneg.multiscale_ceiling(sci, off, bkg.background, mask)
+ms_map, _, _ = nonneg.cap_mesh(bkg, ceil_ms, sci.shape)
+final = iterated_trough(sci, ms_map, excl)
+d = final - bkg.background
+print(f"final - unconstrained map: median={np.median(d):.3e} "
+      f"({np.median(d)/SIG:+.4f} sig_pix), p1={np.percentile(d,1):.3e} "
+      f"p99={np.percentile(d,99):.3e}, mean={d.mean():.3e}")
+print(f"map error vs truth: constrained median={np.median(final-sky):.3e} "
+      f"unconstrained median={np.median(bkg.background-sky):.3e}")

--- a/pipeline/experiments/bkg_nonneg/edge_check.py
+++ b/pipeline/experiments/bkg_nonneg/edge_check.py
@@ -1,0 +1,22 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import numpy as np
+import metrics
+from run_120 import CUTOUTS_120, load
+
+d2 = np.load("out120dw/offcluster/arms.npz")
+sci2, err2, wht2 = load(CUTOUTS_120["offcluster"][0])
+excl2 = d2["excl"]
+wmed = np.nanmedian(wht2[wht2 > 0])
+N = 4000; b = 60
+border = np.zeros((N, N), bool)
+border[:b, :] = border[-b:, :] = border[:, :b] = border[:, -b:] = True
+strip = (wht2 > 0) & (wht2 < 0.6 * wmed) & ~border
+for arm in ["m10", "m10_t0_guard"]:
+    s = metrics.negative_structure(d2[f"resid_{arm}"], excl2, err=err2).signif_map
+    ok = np.isfinite(s) & ~excl2
+    for label, m in [("strip", strip), ("border", border), 
+                     ("interior", ~strip & ~border)]:
+        sel = ok & m
+        print(f"{arm:14s} {label:8s}: med={np.nanmedian(s[sel]):+.2f} "
+              f"f(>+2)={np.mean(s[sel]>2):.4f} f(<-2)={np.mean(s[sel]<-2):.4f}")

--- a/pipeline/experiments/bkg_nonneg/finalmaps.py
+++ b/pipeline/experiments/bkg_nonneg/finalmaps.py
@@ -1,0 +1,51 @@
+# Compact comparison: input / baseline / final-constrained for both cutouts
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import numpy as np, matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from astropy.io import fits
+from astropy import stats as astrostats
+import metrics, nonneg
+from run_cutouts import CUTOUTS, build_masker, dilate_source_tiers
+
+fig, axes = plt.subplots(2, 4, figsize=(17, 8.6), dpi=110)
+for row, name in enumerate(["offcluster", "core"]):
+    with fits.open(CUTOUTS[name]) as hdu:
+        sci = hdu["SCI"].data.astype(float); err = hdu["ERR"].data.astype(float)
+    off = np.isnan(err) | np.isnan(sci)
+    masker = build_masker()
+    mask_final, bitmask = masker.mask_from_arrays(sci, err)
+    excl = metrics.compact_source_mask(sci, off) | off
+    ped = astrostats.biweight_location(sci[~mask_final])
+
+    m64 = build_masker(bg_box_size=64, bg_reject=True)
+    mask64 = dilate_source_tiers(bitmask, 20)
+    bkg64 = m64.estimate_background(sci, mask64)
+    onesided = nonneg.onesided_ceiling_map(sci, off, box=64)
+    ceil64, _, _ = nonneg.calibrate_ceiling(onesided, bkg64.background, mask64)
+    cap_map, _, _ = nonneg.cap_mesh(bkg64, ceil64, sci.shape)
+    corr, _ = nonneg.trough_correction(sci, cap_map, excl)
+    final = cap_map + corr
+
+    panels = [("input", sci - ped), ("perexp64 (current)", sci - bkg64.background),
+              ("perexp64 cap+trough", sci - final)]
+    for col, (label, resid) in enumerate(panels):
+        neg = metrics.negative_structure(resid, excl)
+        ax = axes[row, col]
+        im = ax.imshow(neg.signif_map, origin="lower", cmap="RdBu_r", vmin=-5, vmax=5)
+        ax.set_title(f"{name}: {label}\nneg area={neg.area_neg}px min={neg.min_signif:.1f}σ",
+                     fontsize=9)
+        ax.set_xticks([]); ax.set_yticks([])
+    ax = axes[row, 3]
+    d = (bkg64.background - final)
+    im = ax.imshow(d, origin="lower", cmap="PuOr_r",
+                   vmin=-np.nanpercentile(np.abs(d), 99.5),
+                   vmax=np.nanpercentile(np.abs(d), 99.5))
+    plt.colorbar(im, ax=ax, fraction=0.045)
+    ax.set_title(f"{name}: bkg lowered by (map diff)", fontsize=9)
+    ax.set_xticks([]); ax.set_yticks([])
+fig.suptitle("per-exposure path: one-sided ceiling meshcap + residual trough pass")
+fig.tight_layout()
+fig.savefig("out/final_perexp.png")
+print("saved out/final_perexp.png")

--- a/pipeline/experiments/bkg_nonneg/gated_test.py
+++ b/pipeline/experiments/bkg_nonneg/gated_test.py
@@ -1,0 +1,51 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import numpy as np
+from astropy.io import fits
+from astropy import stats as astrostats
+from scipy.ndimage import gaussian_filter
+import metrics, nonneg
+from run_cutouts import CUTOUTS, build_masker
+
+def constrained(sci, err, off):
+    excl = metrics.compact_source_mask(sci, off) | off
+    masker = build_masker()
+    mask, _ = masker.mask_from_arrays(sci, err)
+    bkg = masker.estimate_background(sci, mask)
+    ceil_ms, _ = nonneg.multiscale_ceiling(sci, off, bkg.background, mask)
+    ms_map, _, _ = nonneg.cap_mesh(bkg, ceil_ms, sci.shape)
+    final = nonneg.iterated_gated_trough(sci, ms_map, excl)
+    return bkg.background, final, excl
+
+for name in ["core", "offcluster"]:
+    with fits.open(CUTOUTS[name]) as hdu:
+        sci = hdu["SCI"].data.astype(float); err = hdu["ERR"].data.astype(float)
+    off = np.isnan(err) | np.isnan(sci)
+    base, final, excl = constrained(sci, err, off)
+    resid = sci - final
+    neg = metrics.negative_structure(resid, excl)
+    ap = metrics.empty_aperture_stats(resid, excl, (33,))[33]
+    print(f"[{name}] GATED: neg n={neg.n_neg} area={neg.area_neg}px "
+          f"min={neg.min_signif:.1f}sig apmed={ap.median:+.4f}")
+
+# blank null
+rng = np.random.default_rng(7)
+N = 1333; SIG = 0.012; SKY0 = 0.003
+yy, xx = np.mgrid[0:N, 0:N] / N
+sky = SKY0 * (1 + 0.5*xx + 0.3*yy - 0.4*xx*yy)
+noise = gaussian_filter(rng.normal(size=(N, N)), 1.5, mode="wrap")
+noise *= SIG / noise.std()
+src = np.zeros((N, N))
+for _ in range(150):
+    y0, x0 = rng.uniform(20, N-20, 2)
+    amp = rng.lognormal(np.log(5*SIG), 1.0); s = rng.uniform(1.5, 4.0)
+    y1, y2, x1, x2 = int(y0)-20, int(y0)+20, int(x0)-20, int(x0)+20
+    dy = np.arange(y1, y2)[:, None]-y0; dx = np.arange(x1, x2)[None, :]-x0
+    src[y1:y2, x1:x2] += amp*np.exp(-(dy**2+dx**2)/(2*s*s))
+sci = (sky+noise+src).astype(np.float32)
+err = np.full_like(sci, SIG); off = np.zeros_like(sci, bool)
+base, final, excl = constrained(sci, err, off)
+d = final - base
+print(f"[blank] GATED: final-uncon map: median={np.median(d):.3e} "
+      f"mean={d.mean():.3e} p1={np.percentile(d,1):.3e} "
+      f"p99={np.percentile(d,99):.3e} corr_area={float((final<base-1e-12).mean()):.4f}")

--- a/pipeline/experiments/bkg_nonneg/metrics.py
+++ b/pipeline/experiments/bkg_nonneg/metrics.py
@@ -1,0 +1,253 @@
+"""Negativity-validation metrics for background subtraction.
+
+Everything here is judged on *statistical* negativity: individual negative
+pixels at the noise level are correct; the failure mode is a region whose
+mean is significantly below zero on scales larger than the noise
+correlation length. Drizzled mosaics have correlated noise, so all
+significance here is empirical (measured from the map itself), never a
+naive per-pixel sigma scaling.
+
+Independent of the pipeline's own source mask by design: the compact-source
+exclusion mask is rebuilt here with a simple positive-only detector, so
+metrics sample the dilated/interpolated rings where oversubtraction lives.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import numpy as np
+from astropy import stats as astrostats
+from photutils.segmentation import detect_sources
+from scipy.ndimage import distance_transform_edt, gaussian_filter
+
+
+# ----------------------------------------------------------------------
+# Source exclusion mask (metrics-internal, independent of pipeline mask)
+# ----------------------------------------------------------------------
+
+def compact_source_mask(
+    sci: np.ndarray,
+    off: np.ndarray,
+    nsigma: float = 2.0,
+    smooth_sigma: float = 2.0,
+    npixels: int = 8,
+    dilate: float = 5.0,
+) -> np.ndarray:
+    """Positive-only compact-source segments with light dilation.
+
+    Deliberately *not* the pipeline's tiered mask: no heavy dilation, so the
+    wing/ring regions the pipeline interpolates across remain available to
+    the aperture metrics. Detection is on a lightly smoothed image against a
+    robust global RMS.
+    """
+    sm = gaussian_filter(np.where(off, 0.0, sci), smooth_sigma, mode="reflect")
+    rms = astrostats.biweight_scale(sm[~off])
+    lvl = astrostats.biweight_location(sm[~off])
+    seg = detect_sources(sm, threshold=lvl + nsigma * rms, npixels=npixels,
+                         mask=off)
+    if seg is None:
+        return np.zeros(sci.shape, bool)
+    m = seg.make_source_mask()
+    if dilate > 0:
+        m = distance_transform_edt(~m) <= dilate
+    return m
+
+
+# ----------------------------------------------------------------------
+# Empty-aperture statistics
+# ----------------------------------------------------------------------
+
+@dataclass
+class ApertureStats:
+    diameter_px: float
+    n: int
+    fluxes: np.ndarray            # aperture sums
+    dists: np.ndarray             # center distance from reference point (px)
+    median: float = 0.0
+    sigma: float = 0.0            # robust width of the flux distribution
+    mean_signif: float = 0.0      # median / (sigma / sqrt(n)) -- crude
+    frac_below_m3sig: float = 0.0
+    frac_above_p3sig: float = 0.0
+
+    def finalize(self):
+        self.n = len(self.fluxes)
+        if self.n == 0:
+            return self
+        self.median = float(np.median(self.fluxes))
+        self.sigma = float(astrostats.biweight_scale(self.fluxes))
+        if self.sigma > 0 and self.n > 1:
+            self.mean_signif = float(
+                self.median / (self.sigma / np.sqrt(self.n))
+            )
+            self.frac_below_m3sig = float(
+                np.mean(self.fluxes < -3 * self.sigma))
+            self.frac_above_p3sig = float(
+                np.mean(self.fluxes > 3 * self.sigma))
+        return self
+
+
+def empty_aperture_stats(
+    resid: np.ndarray,
+    exclude: np.ndarray,
+    diameters_px=(10, 20, 33, 50),
+    n_target: int = 2000,
+    rng: Optional[np.random.Generator] = None,
+    ref_center=None,
+) -> dict:
+    """Random-aperture flux distributions on the residual image.
+
+    Apertures are fully contained in ~exclude (checked via the Euclidean
+    distance transform, so placement is O(1) per try). Overlap between
+    apertures is allowed -- we want dense sampling near the bright galaxy,
+    and the summary statistics are robust.
+    """
+    if rng is None:
+        rng = np.random.default_rng(42)
+    ny, nx = resid.shape
+    if ref_center is None:
+        ref_center = (ny / 2, nx / 2)
+    edt = distance_transform_edt(~exclude)
+    out = {}
+    yy, xx = np.mgrid[0:ny, 0:nx]
+    for d in diameters_px:
+        r = d / 2.0
+        valid = edt > r + 1
+        # keep away from the image edge
+        valid[: int(r) + 1, :] = False
+        valid[-(int(r) + 1):, :] = False
+        valid[:, : int(r) + 1] = False
+        valid[:, -(int(r) + 1):] = False
+        vy, vx = np.nonzero(valid)
+        if len(vy) == 0:
+            out[d] = ApertureStats(d, 0, np.array([]), np.array([])).finalize()
+            continue
+        pick = rng.integers(0, len(vy), size=min(n_target, len(vy) * 4))
+        cy, cx = vy[pick], vx[pick]
+        fluxes = np.empty(len(cy))
+        for i, (y0, x0) in enumerate(zip(cy, cx)):
+            y1, y2 = int(y0 - r), int(np.ceil(y0 + r)) + 1
+            x1, x2 = int(x0 - r), int(np.ceil(x0 + r)) + 1
+            sub = resid[y1:y2, x1:x2]
+            dy = yy[y1:y2, x1:x2] - y0
+            dx = xx[y1:y2, x1:x2] - x0
+            circ = (dy * dy + dx * dx) <= r * r
+            fluxes[i] = np.nansum(sub[circ])
+        dists = np.hypot(cy - ref_center[0], cx - ref_center[1])
+        out[d] = ApertureStats(d, len(fluxes), fluxes, dists).finalize()
+    return out
+
+
+def radial_aperture_profile(ap: ApertureStats, bins_px) -> dict:
+    """Median aperture flux and robust scatter vs distance from reference."""
+    med, sig, n, cen = [], [], [], []
+    for lo, hi in zip(bins_px[:-1], bins_px[1:]):
+        sel = (ap.dists >= lo) & (ap.dists < hi)
+        cen.append(0.5 * (lo + hi))
+        n.append(int(sel.sum()))
+        if sel.sum() > 5:
+            med.append(float(np.median(ap.fluxes[sel])))
+            sig.append(float(astrostats.biweight_scale(ap.fluxes[sel])))
+        else:
+            med.append(np.nan)
+            sig.append(np.nan)
+    return {"r_px": np.array(cen), "median": np.array(med),
+            "sigma": np.array(sig), "n": np.array(n)}
+
+
+# ----------------------------------------------------------------------
+# Negative-structure detection
+# ----------------------------------------------------------------------
+
+@dataclass
+class NegStructure:
+    n_neg: int
+    n_pos: int                    # positive control on source-masked image
+    area_neg: int
+    area_pos: int
+    min_signif: float             # most negative smoothed significance
+    signif_map: np.ndarray = field(repr=False)
+    neg_segmap: Optional[np.ndarray] = field(default=None, repr=False)
+
+
+def smooth_masked(
+    resid: np.ndarray, exclude: np.ndarray, sigma: float
+) -> np.ndarray:
+    """NaN-tolerant gaussian smoothing (normalized convolution); excluded
+    pixels contribute nothing, regions with <5% local coverage go NaN."""
+    filled = np.where(exclude, np.nan, resid)
+    w = np.isfinite(filled).astype(float)
+    f0 = np.where(np.isfinite(filled), filled, 0.0)
+    num = gaussian_filter(f0, sigma, mode="reflect")
+    den = gaussian_filter(w, sigma, mode="reflect")
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return np.where(den > 0.05, num / den, np.nan)
+
+
+def negative_structure(
+    resid: np.ndarray,
+    exclude: np.ndarray,
+    smooth_sigma: float = 5.0,
+    nsigma: float = 2.0,
+    npixels: int = 200,
+    err: Optional[np.ndarray] = None,
+) -> NegStructure:
+    """Detect coherent negative regions on a smoothed significance map.
+
+    The map noise sigma is measured empirically on the smoothed residual in
+    source-free pixels (correlated-noise safe). The positive-control run on
+    the same (source-excluded) map calibrates the false-positive rate: for a
+    clean subtraction, negative counts should match the positive control.
+
+    With ``err`` the significance is depth-aware: computed on the
+    noise-equalized residual ``resid / err`` (unit variance everywhere), so
+    variable-depth strips neither hide nor fake negative structure.
+    """
+    field = resid if err is None else np.where(err > 0, resid / err, np.nan)
+    sm = smooth_masked(field, exclude, smooth_sigma)
+    ok = np.isfinite(sm) & ~exclude
+    rms = astrostats.biweight_scale(sm[ok])
+    lvl = 0.0  # significance is against literal zero, not the map median
+    signif = (sm - lvl) / rms
+
+    detmask = ~ok
+    seg_neg = detect_sources(-signif, threshold=nsigma, npixels=npixels,
+                             mask=detmask)
+    seg_pos = detect_sources(signif, threshold=nsigma, npixels=npixels,
+                             mask=detmask)
+    n_neg = 0 if seg_neg is None else seg_neg.nlabels
+    n_pos = 0 if seg_pos is None else seg_pos.nlabels
+    a_neg = 0 if seg_neg is None else int(seg_neg.make_source_mask().sum())
+    a_pos = 0 if seg_pos is None else int(seg_pos.make_source_mask().sum())
+    return NegStructure(
+        n_neg=n_neg, n_pos=n_pos, area_neg=a_neg, area_pos=a_pos,
+        min_signif=float(np.nanmin(np.where(ok, signif, np.nan))),
+        signif_map=signif,
+        neg_segmap=None if seg_neg is None else seg_neg.data,
+    )
+
+
+# ----------------------------------------------------------------------
+# Mesh diagnostics
+# ----------------------------------------------------------------------
+
+def mesh_mask_fraction(mask: np.ndarray, box: int) -> np.ndarray:
+    """Fraction of masked pixels per (box x box) mesh cell."""
+    ny, nx = mask.shape
+    my, mx = int(np.ceil(ny / box)), int(np.ceil(nx / box))
+    pad = np.pad(mask.astype(float),
+                 ((0, my * box - ny), (0, mx * box - nx)),
+                 constant_values=1.0)
+    return pad.reshape(my, box, mx, box).mean(axis=(1, 3))
+
+
+def summarize(name: str, apstats: dict, neg: NegStructure) -> dict:
+    row = {"arm": name,
+           "neg_n": neg.n_neg, "neg_area": neg.area_neg,
+           "pos_n": neg.n_pos, "pos_area": neg.area_pos,
+           "min_signif": round(neg.min_signif, 2)}
+    for d, ap in apstats.items():
+        row[f"apmed_d{d}"] = ap.median
+        row[f"apsig_d{d}"] = ap.sigma
+        row[f"apfneg_d{d}"] = ap.frac_below_m3sig
+        row[f"apfpos_d{d}"] = ap.frac_above_p3sig
+    return row

--- a/pipeline/experiments/bkg_nonneg/ms_trough.py
+++ b/pipeline/experiments/bkg_nonneg/ms_trough.py
@@ -1,0 +1,43 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import numpy as np
+from astropy import stats as astrostats
+from astropy.io import fits
+from scipy.ndimage import gaussian_filter
+import metrics, nonneg
+from run_cutouts import CUTOUTS, build_masker
+
+def multiscale_trough(sci, bkgmap, excl, sigmas=(5, 15, 45), t=2.0):
+    """Sequentially apply the trough pass at increasing smoothing scales.
+    Each pass lowers the map only where the residual is coherently below
+    -t*sigma_sm at that scale; sequential application means a broad lane
+    caught at sigma=45 is corrected even if invisible at sigma=5."""
+    total = np.zeros_like(bkgmap)
+    m = bkgmap.copy()
+    for s in sigmas:
+        corr, frac = nonneg.trough_correction(sci, m, excl, smooth_sigma=s, t=t)
+        m = m + corr
+        total += corr
+        print(f"    sigma={s}: corrected {frac:.4f} of area, "
+              f"min={corr.min():.5g}")
+    return m, total
+
+for name in ["offcluster", "core"]:
+    with fits.open(CUTOUTS[name]) as hdu:
+        sci = hdu["SCI"].data.astype(float); err = hdu["ERR"].data.astype(float)
+    off = np.isnan(err) | np.isnan(sci)
+    excl = metrics.compact_source_mask(sci, off) | off
+    masker = build_masker()
+    mask, _ = masker.mask_from_arrays(sci, err)
+    bkg = masker.estimate_background(sci, mask)
+    ceil_ms, _ = nonneg.multiscale_ceiling(sci, off, bkg.background, mask)
+    ms_map, _, _ = nonneg.cap_mesh(bkg, ceil_ms, sci.shape)
+    print(f"[{name}] multiscale trough on msceil map:")
+    final, total = multiscale_trough(sci, ms_map, excl)
+    resid = sci - final
+    neg = metrics.negative_structure(resid, excl)
+    ap = metrics.empty_aperture_stats(resid, excl, (33,))[33]
+    print(f"[{name}] RESULT: neg n={neg.n_neg} area={neg.area_neg}px "
+          f"min={neg.min_signif:.1f}sig apmed={ap.median:+.4f} "
+          f"(single-scale was: "
+          f"{'262px/-2.9' if name=='offcluster' else '3418px/-2.8'})")

--- a/pipeline/experiments/bkg_nonneg/ms_trough2.py
+++ b/pipeline/experiments/bkg_nonneg/ms_trough2.py
@@ -1,0 +1,41 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import numpy as np
+from astropy.io import fits
+import metrics, nonneg
+from run_cutouts import CUTOUTS, build_masker
+
+def iterated_trough(sci, bkgmap, excl, sigmas=(5, 15, 45), t=2.0,
+                    max_iter=4, min_frac=1e-4):
+    m = bkgmap.copy()
+    for s in sigmas:
+        for it in range(max_iter):
+            corr, frac = nonneg.trough_correction(sci, m, excl,
+                                                  smooth_sigma=s, t=t)
+            m = m + corr
+            print(f"    sigma={s} iter={it}: frac={frac:.4f} "
+                  f"min={corr.min():.5g}")
+            if frac < min_frac:
+                break
+    return m
+
+for name in ["core", "offcluster"]:
+    with fits.open(CUTOUTS[name]) as hdu:
+        sci = hdu["SCI"].data.astype(float); err = hdu["ERR"].data.astype(float)
+    off = np.isnan(err) | np.isnan(sci)
+    excl = metrics.compact_source_mask(sci, off) | off
+    masker = build_masker()
+    mask, _ = masker.mask_from_arrays(sci, err)
+    bkg = masker.estimate_background(sci, mask)
+    ceil_ms, _ = nonneg.multiscale_ceiling(sci, off, bkg.background, mask)
+    ms_map, _, _ = nonneg.cap_mesh(bkg, ceil_ms, sci.shape)
+    print(f"[{name}] iterated multiscale trough:")
+    final = iterated_trough(sci, ms_map, excl)
+    resid = sci - final
+    neg = metrics.negative_structure(resid, excl)
+    ap = metrics.empty_aperture_stats(resid, excl, (33,))[33]
+    tot = ms_map - final
+    print(f"[{name}] RESULT: neg n={neg.n_neg} area={neg.area_neg}px "
+          f"min={neg.min_signif:.1f}sig apmed={ap.median:+.4f} "
+          f"total corr: area={float((tot>0).mean()):.4f} "
+          f"max={tot.max():.5g}")

--- a/pipeline/experiments/bkg_nonneg/nonneg.py
+++ b/pipeline/experiments/bkg_nonneg/nonneg.py
@@ -1,0 +1,311 @@
+"""Negativity-constrained background estimation prototypes.
+
+Three mechanisms, composable with the stock SubtractBackground fit:
+
+1. AsymmetricSubtractBackground -- SigmaClip(sigma_upper, sigma_lower) in the
+   main Background2D fit (mask held fixed, so arms differ only in the fit).
+
+2. onesided_ceiling() -- maskless coarse Background2D with a hard upper clip.
+   Because true flux >= 0, this maskless map is a valid *upper bound* on any
+   admissible background even where it tracks (sky + wing). Calibrated
+   against the arm's own masked fit on quiet pixels (removes the one-sided
+   clip bias empirically, per image), plus k-sigma slack so the ceiling sits
+   slightly above true sky (a slack ceiling is costless -- it's a bound).
+
+3. Enforcement:
+   - clamp_map():   bkg_final = minimum(bkg, ceiling) at pixel level.
+   - cap_mesh():    cap the low-res background *mesh* at the ceiling sampled
+     on the mesh grid, then re-run the zoom interpolator -- smooth by
+     construction, and it fixes violations *under* fully-masked regions
+     where a mask-and-refit pass is a no-op (the interpolator would
+     extrapolate identically).
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+from astropy import stats as astrostats
+from astropy.nddata import block_reduce
+from photutils.background import (
+    Background2D,
+    BiweightLocationBackground,
+    BkgZoomInterpolator,
+)
+
+from campfire_pipeline.nircam.bkgsub import SubtractBackground
+
+import metrics as _metrics
+
+
+@dataclass
+class AsymmetricSubtractBackground(SubtractBackground):
+    """Main-fit sigma clip made asymmetric: hard on positive contamination,
+    loose on the negative side so it anchors the estimate."""
+
+    bg_sigma_upper: float = 2.0
+    bg_sigma_lower: float = 10.0
+
+    def _fit_background2d(self, img, mask):
+        if self.bg_interpolator != "zoom":
+            raise ValueError("prototype supports zoom only")
+        return Background2D(
+            img,
+            box_size=self.bg_box_size,
+            sigma_clip=astrostats.SigmaClip(
+                sigma_lower=self.bg_sigma_lower,
+                sigma_upper=self.bg_sigma_upper,
+            ),
+            filter_size=self.bg_filter_size,
+            bkg_estimator=BiweightLocationBackground(),
+            exclude_percentile=self.bg_exclude_percentile,
+            mask=mask,
+            interpolator=BkgZoomInterpolator(),
+        )
+
+
+# ----------------------------------------------------------------------
+# One-sided ceiling map
+# ----------------------------------------------------------------------
+
+def wht_sigma_map(
+    resid: np.ndarray,
+    wht: np.ndarray,
+    skymask: np.ndarray,
+) -> np.ndarray:
+    """Source-independent local sky-noise map from the drizzle weight.
+
+    Background variance is alpha/WHT with alpha a global factor, so
+    sigma(x) = s / sqrt(WHT) with s calibrated empirically as the robust
+    scale of the noise-equalized residual over sky pixels (``skymask``
+    True = usable sky). Unlike ERR this carries no source Poisson term, so
+    trough significance is not suppressed (and the ceiling not loosened)
+    under bright ICL/wings.
+    """
+    good = np.isfinite(wht) & (wht > 0)
+    sqw = np.where(good, np.sqrt(np.where(good, wht, 0.0)), np.nan)
+    sel = skymask & good & np.isfinite(resid)
+    s = float(astrostats.biweight_scale((resid * sqw)[sel]))
+    with np.errstate(divide="ignore", invalid="ignore"):
+        return np.where(good, s / sqw, np.nan)
+
+
+def onesided_ceiling_map(
+    sci: np.ndarray,
+    off: np.ndarray,
+    box: int = 64,
+    filter_size: int = 3,
+    sigma_upper: float = 1.0,
+    sigma_lower: float = 10.0,
+) -> np.ndarray:
+    """Maskless (DQ/off-detector only) coarse background with a hard upper
+    clip: tracks the lower envelope of the local flux distribution, which is
+    an upper bound on the background up to a (calibratable) clip bias."""
+    bkg = Background2D(
+        sci,
+        box_size=box,
+        sigma_clip=astrostats.SigmaClip(
+            sigma_lower=sigma_lower, sigma_upper=sigma_upper, maxiters=10
+        ),
+        filter_size=filter_size,
+        bkg_estimator=BiweightLocationBackground(),
+        exclude_percentile=95,
+        mask=off,
+        interpolator=BkgZoomInterpolator(),
+    )
+    return bkg.background
+
+
+def calibrate_ceiling(
+    onesided: np.ndarray,
+    bkgmap: np.ndarray,
+    fitmask: np.ndarray,
+    k: float = 2.0,
+):
+    """Empirical per-image bias removal + slack.
+
+    On quiet (unmasked) pixels both the one-sided map and the arm's masked
+    symmetric fit estimate the same sky; their robust median difference is
+    the one-sided clip bias, and the robust scatter sets the slack unit.
+    Returns (ceiling, delta, sigma_diff).
+    """
+    diff = (onesided - bkgmap)[~fitmask]
+    delta = float(astrostats.biweight_location(diff))
+    sigma = float(astrostats.biweight_scale(diff))
+    ceiling = onesided - delta + k * sigma
+    return ceiling, delta, sigma
+
+
+# ----------------------------------------------------------------------
+# Enforcement
+# ----------------------------------------------------------------------
+
+def multiscale_ceiling(
+    sci: np.ndarray,
+    off: np.ndarray,
+    bkgmap: np.ndarray,
+    fitmask: np.ndarray,
+    boxes=(32, 64, 128),
+    k: float = 2.0,
+    err: Optional[np.ndarray] = None,
+):
+    """Minimum over independently-calibrated one-sided ceilings at several
+    box scales. Each scale is (statistically) an upper bound on the
+    background; the min is a tighter bound. Finer scales tighten the bound
+    in the sky gaps next to bright masked sources, where a coarse mesh is
+    source-embedded and its ceiling useless.
+
+    With ``err`` the whole construction is depth-aware: the one-sided map
+    is fit on the noise-equalized image sci/err (so the hard upper clip cuts
+    at the same significance at every depth), calibration happens in
+    equalized units, and the bound is mapped back through the local err.
+    True flux >= 0 makes sci/err an upper bound on bkg/err pixelwise, so
+    the bound survives the transformation.
+    """
+    if err is not None:
+        good = np.isfinite(err) & (err > 0)
+        e_sci = np.where(good, sci / err, np.nan)
+        e_bkg = np.where(good, bkgmap / err, np.nan)
+        off_e = off | ~good
+        ceils, cal = [], {}
+        for box in boxes:
+            om = onesided_ceiling_map(e_sci, off_e, box=box)
+            c_e, d, s = calibrate_ceiling(om, e_bkg, fitmask | off_e, k=k)
+            ceils.append(c_e)
+            cal[box] = (d, s)
+        ceil_e = np.minimum.reduce(ceils)
+        ceiling = np.where(good, ceil_e * err, np.inf)
+        return ceiling, cal
+    ceils, cal = [], {}
+    for box in boxes:
+        om = onesided_ceiling_map(sci, off, box=box)
+        c, d, s = calibrate_ceiling(om, bkgmap, fitmask, k=k)
+        ceils.append(c)
+        cal[box] = (d, s)
+    return np.minimum.reduce(ceils), cal
+
+
+def clamp_map(bkgmap: np.ndarray, ceiling: np.ndarray):
+    """Pixel-level minimum. Returns (new map, violation mask)."""
+    viol = bkgmap > ceiling
+    return np.minimum(bkgmap, ceiling), viol
+
+
+def trough_correction(
+    sci: np.ndarray,
+    bkgmap: np.ndarray,
+    exclude: np.ndarray,
+    smooth_sigma: float = 5.0,
+    t: float = 2.0,
+):
+    """Residual-driven trough pass (handoff option C6).
+
+    The residual sci - bkgmap is observable everywhere, including under the
+    fit mask, so this catches oversubtraction the maskless ceiling misses
+    (meshes that mix wing flux with the trough). Wherever the smoothed
+    residual is coherently below -t*sigma_sm, lower the map by
+    (sm + t*sigma_sm): continuous at the boundary (no seams), zero over
+    >= -t*sigma_sm sky, so the positive-pedestal bias is bounded by the
+    t-tail of the smoothed noise. `exclude` should mask compact positive
+    sources only -- their segments must not dilute the smoothing.
+
+    Returns (corr, frac_corrected); apply as bkgmap + corr (corr <= 0).
+    """
+    resid = sci - bkgmap
+    sm = _metrics.smooth_masked(resid, exclude, smooth_sigma)
+    ok = np.isfinite(sm) & ~exclude
+    rms = float(astrostats.biweight_scale(sm[ok]))
+    corr = np.minimum(sm + t * rms, 0.0)
+    corr[~np.isfinite(corr)] = 0.0
+    return corr, float((corr < 0).mean())
+
+
+def gated_trough_correction(
+    sci: np.ndarray,
+    bkgmap: np.ndarray,
+    exclude: np.ndarray,
+    smooth_sigma: float = 5.0,
+    t: float = 2.0,
+    npix_per_sigma2: float = 8.0,
+    err: Optional[np.ndarray] = None,
+):
+    """Detection-gated trough pass.
+
+    Same correction field as trough_correction, but applied only inside
+    *detected* coherent negative regions: connected areas below -t*sigma_sm
+    of at least npix_per_sigma2 * smooth_sigma**2 pixels (area threshold
+    scales with the smoothing correlation area, so the blank-field
+    false-fire rate is scale-independent and small). Because the correction
+    field is zero exactly at the -t*sigma_sm isophote, restricting it to
+    the detected segments keeps it continuous -- no seams.
+
+    On a blank field this is an exact no-op almost always (regression
+    safety); on a real trough it applies the full aggressive correction.
+    """
+    from photutils.segmentation import detect_sources
+
+    resid = sci - bkgmap
+    if err is not None:
+        # depth-aware: work on the noise-equalized residual (unit variance
+        # everywhere), map the correction back through the local err.
+        field = np.where(err > 0, resid / err, np.nan)
+    else:
+        field = resid
+    sm = _metrics.smooth_masked(field, exclude, smooth_sigma)
+    ok = np.isfinite(sm) & ~exclude
+    rms = float(astrostats.biweight_scale(sm[ok]))
+    signif = np.where(ok, sm / rms, 0.0)
+    npixels = max(int(npix_per_sigma2 * smooth_sigma**2), 30)
+    seg = detect_sources(-signif, threshold=t, npixels=npixels)
+    if seg is None:
+        return np.zeros_like(bkgmap), 0.0
+    gate = seg.make_source_mask()
+    corr = np.where(gate, np.minimum(sm + t * rms, 0.0), 0.0)
+    corr[~np.isfinite(corr)] = 0.0
+    if err is not None:
+        corr = corr * np.where(np.isfinite(err), err, 0.0)
+    return corr, float(gate.mean())
+
+
+def iterated_gated_trough(
+    sci: np.ndarray,
+    bkgmap: np.ndarray,
+    exclude: np.ndarray,
+    sigmas=(5, 15, 45),
+    t: float = 2.0,
+    max_iter: int = 12,
+    err: Optional[np.ndarray] = None,
+    verbose: bool = True,
+):
+    """Run the gated trough pass to convergence at each scale (a single
+    pass under-corrects deep troughs: re-smoothing the corrected image
+    erodes the correction peak)."""
+    m = bkgmap.copy()
+    for s in sigmas:
+        for it in range(max_iter):
+            corr, frac = gated_trough_correction(
+                sci, m, exclude, smooth_sigma=s, t=t, err=err)
+            if frac == 0.0:
+                break
+            m = m + corr
+            if verbose:
+                print(f"    gated sigma={s} iter={it}: frac={frac:.4f} "
+                      f"min={corr.min():.5g}")
+    return m
+
+
+def cap_mesh(bkg2d, ceiling: np.ndarray, shape) -> np.ndarray:
+    """Cap the low-res mesh at the ceiling (block-averaged onto the mesh
+    grid) and re-run the zoom interpolation. Smooth by construction."""
+    mesh = np.asarray(bkg2d.background_mesh, dtype=float)
+    box = np.atleast_1d(bkg2d.box_size)
+    by, bx = (int(box[0]), int(box[-1]))
+    my, mx = mesh.shape
+    pady, padx = my * by - shape[0], mx * bx - shape[1]
+    cpad = np.pad(ceiling, ((0, pady), (0, padx)), mode="edge")
+    cmesh = block_reduce(cpad, (by, bx), func=np.mean)
+    capped = np.minimum(mesh, cmesh)
+    interp = BkgZoomInterpolator()
+    newmap = interp(capped, box_size=(by, bx), shape=shape, dtype=float)
+    n_capped = int((mesh > cmesh).sum())
+    return newmap, n_capped, mesh.size

--- a/pipeline/experiments/bkg_nonneg/run_120.py
+++ b/pipeline/experiments/bkg_nonneg/run_120.py
@@ -1,0 +1,195 @@
+"""120-arcsec cutout validation: tier-0 A/B at production scale + the
+proposed mosaic-level final guard, scored against the production `after`
+mosaics.
+
+Arms:
+  input        : before-cutout minus constant robust pedestal
+  after        : the production mosaic-level bkgsub output (reference)
+  m10          : unconstrained mosaic fit, mask WITHOUT tier 0
+  m10_t0       : unconstrained mosaic fit, full production mask (tier 0)
+  m10_t0_guard : m10_t0 + multiscale ceiling meshcap + gated iterated trough
+
+WHT handling this round: wht is passed to the pipeline mask builder (its
+noise-equalized detection), and off-detector/zero-weight pixels are masked
+everywhere; ceiling + trough + metrics still operate in flux space (bulk
+depth variation on these cutouts is ~1.2-1.4x; edges are masked). Full
+depth-aware significance is a next step.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+from astropy import stats as astrostats
+from astropy.io import fits
+from astropy.visualization import AsinhStretch, ImageNormalize, PercentileInterval
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import metrics  # noqa: E402
+import nonneg  # noqa: E402
+from run_cutouts import build_masker  # noqa: E402
+
+DL = "/Users/hollis/Downloads"
+CUTOUTS_120 = {
+    "offcluster": (f"{DL}/a2744_f444w_offcluster_galaxy_before_120as.fits",
+                   f"{DL}/a2744_f444w_offcluster_galaxy_after_120as.fits"),
+    "core": (f"{DL}/a2744_f444w_cluster_core_before_120as.fits",
+             f"{DL}/a2744_f444w_cluster_core_after_120as.fits"),
+}
+AP_DIAMS = (10, 20, 33, 50)
+
+TIER0_CFG = dict(
+    tier_kernel_size=[25, 25, 15, 5, 2],
+    tier_npixels=[30000, 15, 10, 3, 1],
+    tier_nsigma=[100.0, 1.5, 1.5, 1.5, 1.5],
+    tier_dilate_size=[600, 33, 25, 21, 19],
+)
+
+
+def load(path):
+    with fits.open(path) as hdu:
+        sci = hdu["SCI"].data.astype(float)
+        err = hdu["ERR"].data.astype(float)
+        wht = hdu["WHT"].data.astype(float) if "WHT" in hdu else None
+    return sci, err, wht
+
+
+def run(name, outdir):
+    os.makedirs(outdir, exist_ok=True)
+    before, after = CUTOUTS_120[name]
+    sci, err, wht = load(before)
+    sci_after, _, _ = load(after)
+    off = ~np.isfinite(sci) | ~np.isfinite(err)
+    if wht is not None:
+        off |= ~(wht > 0)
+    sci = np.where(off, np.nan, sci)
+
+    excl = metrics.compact_source_mask(np.where(off, 0.0, sci), off) | off
+    print(f"[{name}] off={off.mean():.4f} excl={excl.mean():.3f}")
+
+    arms = {}
+    # masks
+    m_no = build_masker()
+    mask_no, _ = m_no.mask_from_arrays(sci, err, wht=wht)
+    m_t0 = build_masker(**TIER0_CFG)
+    mask_t0, bm_t0 = m_t0.mask_from_arrays(sci, err, wht=wht)
+    t0_frac = float(((bm_t0 >> 1) & 1).mean())
+    print(f"[{name}] mask no-t0={mask_no.mean():.3f} with-t0={mask_t0.mean():.3f} "
+          f"tier0 alone={t0_frac:.3f}")
+
+    ped = astrostats.biweight_location(sci[~mask_no & ~off])
+    arms["input"] = sci - ped
+    arms["after"] = np.where(off, np.nan, sci_after)
+
+    bkg_no = m_no.estimate_background(sci, mask_no)
+    arms["m10"] = sci - bkg_no.background
+    bkg_t0 = m_t0.estimate_background(sci, mask_t0)
+    arms["m10_t0"] = sci - bkg_t0.background
+
+    # --- alpha/WHT sky-noise map (source-independent), calibrated on the
+    # baseline-fit residual over unmasked sky ---------------------------------
+    sig_wht = nonneg.wht_sigma_map(sci - bkg_t0.background, wht,
+                                   ~mask_t0 & ~off)
+    with np.errstate(invalid="ignore"):
+        infl = np.nanmedian((err / sig_wht)[~mask_t0 & ~off])
+    print(f"[{name}] sigma_wht calibrated; median ERR/sigma_wht on sky = "
+          f"{infl:.3f}")
+
+    ceil_ms, cal = nonneg.multiscale_ceiling(
+        sci, off, bkg_t0.background, mask_t0, boxes=(32, 64, 128), k=2.0,
+        err=sig_wht)
+    print(f"[{name}] ceiling calib: " + " ".join(
+        f"b{b}: d={d:.5f} s={s:.5f};" for b, (d, s) in cal.items()))
+    ms_map, ncap, nmesh = nonneg.cap_mesh(bkg_t0, ceil_ms, sci.shape)
+    print(f"[{name}] meshcap: {ncap}/{nmesh} cells")
+    # trough-pass exclusion: positive detections in the guard-input RESIDUAL
+    # (equalized), so negative lanes stay visible to the corrector
+    with np.errstate(invalid="ignore"):
+        resid_eq0 = (sci - ms_map) / sig_wht
+    excl_tr = metrics.compact_source_mask(
+        np.where(np.isfinite(resid_eq0), resid_eq0, 0.0), off) | off
+    print(f"[{name}] trough exclusion (residual-based): {excl_tr.mean():.3f} "
+          f"(SCI-based was {excl.mean():.3f})")
+    guard_map = nonneg.iterated_gated_trough(sci, ms_map, excl_tr,
+                                             sigmas=(5, 15), t=2.0,
+                                             err=sig_wht)
+    arms["m10_t0_guard"] = sci - guard_map
+
+    rows, results = [], {}
+    for arm, resid in arms.items():
+        # score each arm against its OWN residual-based positive exclusion
+        with np.errstate(invalid="ignore"):
+            r_eq = resid / sig_wht
+        excl_arm = metrics.compact_source_mask(
+            np.where(np.isfinite(r_eq), r_eq, 0.0), off) | off
+        ap = metrics.empty_aperture_stats(resid, excl_arm, AP_DIAMS)
+        neg = metrics.negative_structure(resid, excl_arm, err=sig_wht)
+        rows.append(metrics.summarize(arm, ap, neg))
+        results[arm] = (resid, ap, neg)
+        print(f"[{name}] {arm}: neg n={neg.n_neg} area={neg.area_neg}px "
+              f"min={neg.min_signif:.1f}sig apmed33={ap[33].median:+.4f} "
+              f"excl={excl_arm.mean():.3f}")
+
+    with open(os.path.join(outdir, "summary.json"), "w") as f:
+        json.dump(rows, f, indent=2, default=float)
+
+    np.savez_compressed(
+        os.path.join(outdir, "arms.npz"),
+        excl=excl, off=off, tier0=((bm_t0 >> 1) & 1).astype(bool),
+        mask_t0=mask_t0, sig_wht=sig_wht.astype(np.float32),
+        **{f"resid_{a}": r.astype(np.float32) for a, r in arms.items()},
+    )
+
+    # maps figure
+    nrow = len(results)
+    fig, axes = plt.subplots(nrow, 3, figsize=(14, 4.4 * nrow), dpi=100)
+    norm = ImageNormalize(np.where(off, 0, sci),
+                          interval=PercentileInterval(99.5),
+                          stretch=AsinhStretch(0.05))
+    sig_pix = astrostats.biweight_scale(arms["input"][~excl & ~off])
+    for i, (arm, (resid, ap, neg)) in enumerate(results.items()):
+        ax = axes[i, 0]
+        ax.imshow(resid, origin="lower", cmap="RdBu_r",
+                  vmin=-3 * sig_pix, vmax=3 * sig_pix)
+        ax.set_title(f"{arm}: residual", fontsize=9)
+        ax = axes[i, 1]
+        im = ax.imshow(neg.signif_map, origin="lower", cmap="RdBu_r",
+                       vmin=-6, vmax=6)
+        ax.set_title(f"{arm}: smoothed signif "
+                     f"(neg={neg.area_neg}px min={neg.min_signif:.1f}σ)",
+                     fontsize=9)
+        plt.colorbar(im, ax=ax, fraction=0.045)
+        ax = axes[i, 2]
+        ax.imshow(np.where(off, 0, sci), origin="lower", cmap="Greys_r",
+                  norm=norm)
+        if neg.neg_segmap is not None:
+            ax.contour(neg.neg_segmap > 0, levels=[0.5], colors="#d62728",
+                       linewidths=1.0)
+        if arm in ("m10_t0", "m10_t0_guard"):
+            ax.contour(((bm_t0 >> 1) & 1), levels=[0.5], colors="#ff7f0e",
+                       linewidths=0.7)
+        ax.set_title(f"{arm}: neg regions (red); tier0 (orange)", fontsize=9)
+        for a in axes[i]:
+            a.set_xticks([]), a.set_yticks([])
+    fig.suptitle(f"{name} 120as")
+    fig.tight_layout()
+    fig.savefig(os.path.join(outdir, "maps.png"))
+    plt.close(fig)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--out", default="out120")
+    p.add_argument("--cutouts", default="offcluster,core")
+    args = p.parse_args()
+    for name in args.cutouts.split(","):
+        run(name, os.path.join(args.out, name))
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/experiments/bkg_nonneg/run_composed.py
+++ b/pipeline/experiments/bkg_nonneg/run_composed.py
@@ -1,0 +1,137 @@
+"""End-to-end composition + tier-0 A/B.
+
+Arms (per cutout):
+  ms_tr      : constrained mosaic10 on the raw input (= mosaic10_msceil_tr
+               from run_cutouts; what "fix the mosaic stage only" ships)
+  end2end    : constrained perexp64 (cap+trough) -> fresh mask -> constrained
+               mosaic10 on that output (what "fix both stages" ships,
+               applied retroactively to data that already carries the
+               per-exposure damage)
+  mosaic10_t0: UNconstrained mosaic10 fit using the full mosaic-config mask
+               INCLUDING tier 0 (100 sigma / 30k px / 600 px dilation) --
+               tests whether tier-0 masking itself drives troughs. Caveat:
+               on a 40 arcsec cutout tier 0 masks a far larger fraction
+               than on a full tile, so treat degeneracies as an upper bound.
+"""
+
+import os
+import sys
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+from astropy import stats as astrostats
+from astropy.io import fits
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import metrics
+import nonneg
+from run_cutouts import CUTOUTS, build_masker, dilate_source_tiers
+
+
+def constrained_mosaic10(img, err, off, excl):
+    """Fresh mask -> box-10 fit -> multiscale ceiling meshcap -> trough."""
+    masker = build_masker()
+    mask, _ = masker.mask_from_arrays(img, err)
+    bkg = masker.estimate_background(img, mask)
+    ceil_ms, _ = nonneg.multiscale_ceiling(img, off, bkg.background, mask)
+    ms_map, ncap, _ = nonneg.cap_mesh(bkg, ceil_ms, img.shape)
+    corr, cfrac = nonneg.trough_correction(img, ms_map, excl)
+    return ms_map + corr, ncap, cfrac
+
+
+def constrained_perexp64(img, err, off, excl):
+    masker = build_masker()
+    _, bitmask = masker.mask_from_arrays(img, err)
+    m64 = build_masker(bg_box_size=64, bg_reject=True)
+    mask64 = dilate_source_tiers(bitmask, 20)
+    bkg64 = m64.estimate_background(img, mask64)
+    onesided = nonneg.onesided_ceiling_map(img, off, box=64)
+    ceil64, _, _ = nonneg.calibrate_ceiling(onesided, bkg64.background, mask64)
+    cap_map, _, _ = nonneg.cap_mesh(bkg64, ceil64, img.shape)
+    corr, _ = nonneg.trough_correction(img, cap_map, excl)
+    return cap_map + corr
+
+
+def main():
+    fig, axes = plt.subplots(2, 4, figsize=(17.5, 8.6), dpi=110)
+    for row, name in enumerate(["offcluster", "core"]):
+        with fits.open(CUTOUTS[name]) as hdu:
+            sci = hdu["SCI"].data.astype(float)
+            err = hdu["ERR"].data.astype(float)
+        off = np.isnan(err) | np.isnan(sci)
+        excl = metrics.compact_source_mask(sci, off) | off
+
+        # --- ms_tr: constrained mosaic10 on raw input ---------------------
+        map_ms, ncap_ms, cfrac_ms = constrained_mosaic10(sci, err, off, excl)
+        resid_ms = sci - map_ms
+
+        # --- end2end ------------------------------------------------------
+        map64 = constrained_perexp64(sci, err, off, excl)
+        residA = sci - map64
+        exclA = metrics.compact_source_mask(residA, off) | off
+        mapB, ncap_b, cfrac_b = constrained_mosaic10(residA, err, off, exclA)
+        resid_e2e = residA - mapB
+
+        # --- tier-0 A/B: unconstrained mosaic10, mask WITH tier 0 ---------
+        masker_t0 = build_masker(
+            tier_kernel_size=[25, 25, 15, 5, 2],
+            tier_npixels=[30000, 15, 10, 3, 1],
+            tier_nsigma=[100.0, 1.5, 1.5, 1.5, 1.5],
+            tier_dilate_size=[600, 33, 25, 21, 19],
+        )
+        mask_t0, bm_t0 = masker_t0.mask_from_arrays(sci, err)
+        t0_frac = float(((bm_t0 >> 1) & 1).mean())
+        bkg_t0 = masker_t0.estimate_background(sci, mask_t0)
+        resid_t0 = sci - bkg_t0.background
+
+        # baseline no-tier0 mosaic10 for the map comparison
+        masker0 = build_masker()
+        mask0, _ = masker0.mask_from_arrays(sci, err)
+        bkg0 = masker0.estimate_background(sci, mask0)
+
+        print(f"[{name}] tier0 fraction={t0_frac:.3f} "
+              f"total mask with t0={mask_t0.mean():.3f} "
+              f"(without: {mask0.mean():.3f})")
+
+        panels = [
+            ("mosaic10_msceil_tr", resid_ms, excl),
+            ("end2end (fix both stages)", resid_e2e, exclA),
+            ("mosaic10 + tier0 mask (uncon)", resid_t0, excl),
+        ]
+        for col, (label, resid, exm) in enumerate(panels):
+            neg = metrics.negative_structure(resid, exm)
+            ap = metrics.empty_aperture_stats(resid, exm, (33,))
+            a = ap[33]
+            print(f"[{name}] {label}: neg n={neg.n_neg} "
+                  f"area={neg.area_neg}px min={neg.min_signif:.1f}sig "
+                  f"| 1\" apmed={a.median:+.4f} sig={a.sigma:.4f}")
+            ax = axes[row, col]
+            ax.imshow(neg.signif_map, origin="lower", cmap="RdBu_r",
+                      vmin=-5, vmax=5)
+            ax.set_title(f"{name}: {label}\nneg={neg.area_neg}px "
+                         f"min={neg.min_signif:.1f}σ apmed={a.median:+.3f}",
+                         fontsize=9)
+            ax.set_xticks([]), ax.set_yticks([])
+
+        # tier0-induced map change (t0 minus no-t0 background)
+        ax = axes[row, 3]
+        d = bkg_t0.background - bkg0.background
+        lim = np.nanpercentile(np.abs(d), 99.5)
+        im = ax.imshow(d, origin="lower", cmap="PuOr_r", vmin=-lim, vmax=lim)
+        plt.colorbar(im, ax=ax, fraction=0.045)
+        ax.contour(((bm_t0 >> 1) & 1), levels=[0.5], colors="k",
+                   linewidths=0.5)
+        ax.set_title(f"{name}: bkg(t0 mask) − bkg(no t0)\n"
+                     f"tier0 masks {t0_frac:.0%} (black contour)", fontsize=9)
+        ax.set_xticks([]), ax.set_yticks([])
+
+    fig.suptitle("end-to-end composition + tier-0 mask A/B (unconstrained)")
+    fig.tight_layout()
+    fig.savefig("out/composed.png")
+    print("saved out/composed.png")
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/experiments/bkg_nonneg/run_cutouts.py
+++ b/pipeline/experiments/bkg_nonneg/run_cutouts.py
@@ -1,0 +1,274 @@
+"""Characterize + prototype negativity-constrained bkg subtraction on real
+A2744 F444W cutouts (30 mas mosaic pixels, SCI+ERR, pre-mosaic-bkgsub).
+
+Round 1 arms:
+  input     : cutout minus a constant robust pedestal (reference: what
+              negativity is already baked in from the per-exposure stage)
+  mosaic10  : current mosaic-level fit (box 10, filter 5, sym 3-sigma clip)
+  perexp64  : per-exposure-like fit (box 64, extra_dilate 20, reject on) --
+              the [nircam.bkg.bkg2d] cluster path in mosaic pixels
+
+Usage:
+  conda run -n campfire python run_cutouts.py --out out
+"""
+
+import argparse
+import json
+import os
+import sys
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+from astropy import stats as astrostats
+from astropy.io import fits
+from astropy.visualization import AsinhStretch, ImageNormalize, PercentileInterval
+from scipy.ndimage import distance_transform_edt
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import metrics  # noqa: E402
+import nonneg  # noqa: E402
+
+from campfire_pipeline.nircam.bkgsub import SubtractBackground  # noqa: E402
+
+CUTOUTS = {
+    "offcluster": "/Users/hollis/Downloads/a2744_f444w_offcluster_galaxy_before_40as.fits",
+    "core": "/Users/hollis/Downloads/a2744_f444w_cluster_core_before_40as.fits",
+}
+
+# arcsec per px (30 mas)
+PIXSCALE = 0.03
+AP_DIAMS = (10, 20, 33, 50)  # px: 0.3, 0.6, 1.0, 1.5 arcsec
+
+
+def build_masker(**over) -> SubtractBackground:
+    """Mosaic-style config sans tier 0 (30k px / 600 px dilation are sized
+    for a full tile, not a 40 arcsec cutout)."""
+    kw = dict(
+        ring_radius_in=80, ring_width=4, ring_downsample=4,
+        ring_clip_max_sigma=5.0, ring_clip_box_size=100,
+        ring_clip_filter_size=3,
+        tier_kernel_size=[25, 15, 5, 2],
+        tier_npixels=[15, 10, 3, 1],
+        tier_nsigma=[1.5, 1.5, 1.5, 1.5],
+        tier_dilate_size=[33, 25, 21, 19],
+        bg_box_size=10, bg_filter_size=5, bg_exclude_percentile=90,
+        bg_sigma=3, bg_interpolator="zoom",
+    )
+    kw.update(over)
+    return SubtractBackground(**kw)
+
+
+def dilate_source_tiers(bitmask: np.ndarray, extra: float) -> np.ndarray:
+    """Grow the source tiers (bits 1+) by `extra` px; keep bit 0 ungrown."""
+    src = (bitmask >> 1) != 0
+    if extra > 0:
+        src = distance_transform_edt(~src) <= extra
+    return src | ((bitmask & 1) != 0)
+
+
+def run_arms(sci, err, out, name):
+    os.makedirs(out, exist_ok=True)
+    off = np.isnan(err) | np.isnan(sci)
+
+    # ---- pipeline source mask (shared across fit arms) -------------------
+    masker = build_masker()
+    mask_final, bitmask = masker.mask_from_arrays(sci, err)
+    tier_frac = {f"tier{b}": float(((bitmask >> b) & 1).mean())
+                 for b in range(5)}
+    print(f"[{name}] mask fractions: total={mask_final.mean():.3f} "
+          + " ".join(f"{k}={v:.3f}" for k, v in tier_frac.items()))
+
+    # what tier 0 WOULD do on this cutout (mosaic config) — log only
+    masker_t0 = build_masker(
+        tier_kernel_size=[25, 25, 15, 5, 2],
+        tier_npixels=[30000, 15, 10, 3, 1],
+        tier_nsigma=[100.0, 1.5, 1.5, 1.5, 1.5],
+        tier_dilate_size=[600, 33, 25, 21, 19],
+    )
+    _, bm_t0 = masker_t0.mask_from_arrays(sci, err)
+    print(f"[{name}] tier0 (mosaic cfg) would mask "
+          f"{(((bm_t0 >> 1) & 1).mean()):.3f} of the cutout")
+
+    # ---- metrics-internal exclusion mask ---------------------------------
+    excl = metrics.compact_source_mask(sci, off) | off
+    print(f"[{name}] metrics source-exclusion fraction: {excl.mean():.3f}")
+
+    arms = {}
+
+    # input: constant pedestal only
+    ped = astrostats.biweight_location(sci[~mask_final])
+    arms["input"] = (sci - ped, None)
+    print(f"[{name}] constant pedestal = {ped:.5g} MJy/sr")
+
+    # mosaic-level fit, box 10
+    bkg10 = masker.estimate_background(sci, mask_final)
+    arms["mosaic10"] = (sci - bkg10.background, bkg10.background)
+
+    # per-exposure-like fit, box 64 (mosaic px), extra_dilate 20, reject on
+    m64 = build_masker(bg_box_size=64, bg_reject=True)
+    mask64 = dilate_source_tiers(bitmask, 20)
+    bkg64 = m64.estimate_background(sci, mask64)
+    arms["perexp64"] = (sci - bkg64.background, bkg64.background)
+
+    # --- constrained arms -------------------------------------------------
+    # asymmetric clip in the main fit (mask held fixed)
+    masym = nonneg.AsymmetricSubtractBackground(
+        **{k: getattr(masker, k) for k in (
+            "bg_box_size", "bg_filter_size", "bg_exclude_percentile",
+            "bg_sigma", "bg_interpolator")})
+    bkg_asym = masym.estimate_background(sci, mask_final)
+    arms["mosaic10_asym"] = (sci - bkg_asym.background, bkg_asym.background)
+
+    # one-sided ceiling (shared across enforcement arms)
+    onesided = nonneg.onesided_ceiling_map(sci, off, box=64)
+    ceil10, d10, s10 = nonneg.calibrate_ceiling(
+        onesided, bkg10.background, mask_final, k=2.0)
+    print(f"[{name}] ceiling calib vs mosaic10: delta={d10:.5g} "
+          f"sigma_diff={s10:.5g}")
+
+    cl_map, viol = nonneg.clamp_map(bkg10.background, ceil10)
+    print(f"[{name}] mosaic10 clamp engaged on {viol.mean():.3f} of pixels, "
+          f"max violation={np.nanmax(bkg10.background - ceil10):.5g}")
+    arms["mosaic10_clamp"] = (sci - cl_map, cl_map)
+
+    mc_map, ncap, nmesh = nonneg.cap_mesh(bkg10, ceil10, sci.shape)
+    print(f"[{name}] mosaic10 meshcap: {ncap}/{nmesh} mesh cells capped")
+    arms["mosaic10_meshcap"] = (sci - mc_map, mc_map)
+
+    # multi-scale ceiling for the fine-box fit
+    ceil_ms, cal = nonneg.multiscale_ceiling(
+        sci, off, bkg10.background, mask_final, boxes=(32, 64, 128), k=2.0)
+    print(f"[{name}] multiscale ceiling calib: " + " ".join(
+        f"b{b}: d={d:.5f} s={s:.5f};" for b, (d, s) in cal.items()))
+    ms_map, ncap_ms, _ = nonneg.cap_mesh(bkg10, ceil_ms, sci.shape)
+    print(f"[{name}] mosaic10 msceil: {ncap_ms} mesh cells capped")
+    arms["mosaic10_msceil"] = (sci - ms_map, ms_map)
+
+    # residual-driven trough pass composed on the capped fine-box map
+    corr, cfrac = nonneg.trough_correction(sci, ms_map, excl)
+    print(f"[{name}] trough pass on msceil: corrected {cfrac:.4f} of area, "
+          f"min corr={corr.min():.5g}")
+    arms["mosaic10_msceil_tr"] = (sci - (ms_map + corr), ms_map + corr)
+
+    ceil64, d64, s64 = nonneg.calibrate_ceiling(
+        onesided, bkg64.background, mask64, k=2.0)
+    mc64_map, ncap64, nmesh64 = nonneg.cap_mesh(bkg64, ceil64, sci.shape)
+    print(f"[{name}] perexp64 meshcap: {ncap64}/{nmesh64} mesh cells capped "
+          f"(delta={d64:.5g} sigma_diff={s64:.5g})")
+    arms["perexp64_meshcap"] = (sci - mc64_map, mc64_map)
+
+    corr64, cfrac64 = nonneg.trough_correction(sci, mc64_map, excl)
+    print(f"[{name}] trough pass on perexp64_meshcap: corrected "
+          f"{cfrac64:.4f} of area, min corr={corr64.min():.5g}")
+    arms["perexp64_cap_tr"] = (sci - (mc64_map + corr64), mc64_map + corr64)
+
+    # ---- metrics ---------------------------------------------------------
+    rows = []
+    results = {}
+    for arm, (resid, bmap) in arms.items():
+        ap = metrics.empty_aperture_stats(resid, excl, AP_DIAMS)
+        neg = metrics.negative_structure(resid, excl)
+        rows.append(metrics.summarize(arm, ap, neg))
+        results[arm] = (resid, bmap, ap, neg)
+        print(f"[{name}] {arm}: neg n={neg.n_neg} area={neg.area_neg}px "
+              f"(pos control n={neg.n_pos} area={neg.area_pos}px) "
+              f"min_signif={neg.min_signif:.1f}")
+
+    with open(os.path.join(out, "summary.json"), "w") as f:
+        json.dump([{k: (float(v) if isinstance(v, (int, float, np.floating))
+                        else v) for k, v in r.items()} for r in rows],
+                  f, indent=2)
+
+    plot_maps(sci, excl, mask_final, results, out, name)
+    plot_profiles(results, out, name)
+    return rows
+
+
+def plot_maps(sci, excl, mask_final, results, out, name):
+    arms = list(results)
+    nrow = len(arms)
+    fig, axes = plt.subplots(nrow, 3, figsize=(13, 4 * nrow), dpi=110)
+    axes = np.atleast_2d(axes)
+    norm = ImageNormalize(sci, interval=PercentileInterval(99.5),
+                          stretch=AsinhStretch(0.05))
+    sig_pix = astrostats.biweight_scale(results["input"][0][~excl])
+    for i, arm in enumerate(arms):
+        resid, bmap, ap, neg = results[arm]
+        ax = axes[i, 0]
+        ax.imshow(resid, origin="lower", cmap="RdBu_r",
+                  vmin=-3 * sig_pix, vmax=3 * sig_pix)
+        ax.set_title(f"{arm}: residual (±3σ_pix)")
+        ax = axes[i, 1]
+        im = ax.imshow(neg.signif_map, origin="lower", cmap="RdBu_r",
+                       vmin=-6, vmax=6)
+        ax.set_title(f"{arm}: smoothed significance")
+        plt.colorbar(im, ax=ax, fraction=0.045)
+        ax = axes[i, 2]
+        ax.imshow(sci, origin="lower", cmap="Greys_r", norm=norm)
+        if neg.neg_segmap is not None:
+            ax.contour(neg.neg_segmap > 0, levels=[0.5], colors="#d62728",
+                       linewidths=1.0)
+        ax.contour(mask_final, levels=[0.5], colors="#1f77b4",
+                   linewidths=0.3, alpha=0.6)
+        ax.set_title(f"{arm}: neg regions (red) on SCI")
+        for a in axes[i]:
+            a.set_xticks([]), a.set_yticks([])
+    fig.suptitle(name)
+    fig.tight_layout()
+    fig.savefig(os.path.join(out, "maps.png"))
+    plt.close(fig)
+
+
+def plot_profiles(results, out, name):
+    bins = np.arange(0, 700, 50)
+    d_show = 33  # 1.0 arcsec apertures
+    fig, axes = plt.subplots(1, 2, figsize=(12, 4.5), dpi=110)
+    colors = {"input": "#555555", "mosaic10": "#1f77b4",
+              "perexp64": "#d62728", "mosaic10_asym": "#2ca02c",
+              "mosaic10_clamp": "#9467bd", "mosaic10_meshcap": "#ff7f0e",
+              "mosaic10_msceil": "#e377c2", "perexp64_meshcap": "#8c564b",
+              "mosaic10_msceil_tr": "#17becf", "perexp64_cap_tr": "#bcbd22"}
+    for arm, (resid, bmap, ap, neg) in results.items():
+        prof = metrics.radial_aperture_profile(ap[d_show], bins)
+        c = colors.get(arm, None)
+        axes[0].plot(prof["r_px"] * PIXSCALE, prof["median"], "-o", ms=3,
+                     label=arm, color=c)
+        lo = np.percentile(ap[d_show].fluxes, [1, 99])
+        h = np.linspace(lo[0], lo[1], 60)
+        axes[1].hist(ap[d_show].fluxes, bins=h, histtype="step",
+                     density=True, label=arm, color=c)
+    axes[0].axhline(0, color="k", lw=0.8)
+    axes[0].set_xlabel("distance from cutout center [arcsec]")
+    axes[0].set_ylabel(f'median aperture flux (d={d_show}px = '
+                       f'{d_show*PIXSCALE:.1f}")')
+    axes[0].legend(fontsize=8)
+    axes[1].axvline(0, color="k", lw=0.8)
+    axes[1].set_xlabel("aperture flux")
+    axes[1].set_ylabel("density")
+    axes[1].legend(fontsize=8)
+    fig.suptitle(f"{name}: empty-aperture statistics")
+    fig.tight_layout()
+    fig.savefig(os.path.join(out, "profiles.png"))
+    plt.close(fig)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--out", default="out")
+    p.add_argument("--cutouts", default="offcluster,core")
+    args = p.parse_args()
+    all_rows = {}
+    for name in args.cutouts.split(","):
+        path = CUTOUTS[name]
+        with fits.open(path) as hdu:
+            sci = hdu["SCI"].data.astype(float)
+            err = hdu["ERR"].data.astype(float)
+        rows = run_arms(sci, err, os.path.join(args.out, name), name)
+        all_rows[name] = rows
+    print(json.dumps(all_rows, indent=2, default=float))
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline/experiments/bkg_nonneg/run_m10_guard.py
+++ b/pipeline/experiments/bkg_nonneg/run_m10_guard.py
@@ -1,0 +1,45 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import numpy as np
+from astropy import stats as astrostats
+import metrics, nonneg
+from run_120 import CUTOUTS_120, load
+from run_cutouts import build_masker
+
+for name in ["offcluster", "core"]:
+    sci, err, wht = load(CUTOUTS_120[name][0])
+    off = ~np.isfinite(sci) | ~np.isfinite(err)
+    if wht is not None:
+        off |= ~(wht > 0)
+    sci = np.where(off, np.nan, sci)
+
+    m_no = build_masker()
+    mask_no, _ = m_no.mask_from_arrays(sci, err, wht=wht)
+    bkg = m_no.estimate_background(sci, mask_no)
+
+    sig_wht = nonneg.wht_sigma_map(sci - bkg.background, wht, ~mask_no & ~off)
+    ceil_ms, _ = nonneg.multiscale_ceiling(
+        sci, off, bkg.background, mask_no, boxes=(32, 64, 128), k=2.0,
+        err=sig_wht)
+    ms_map, ncap, nmesh = nonneg.cap_mesh(bkg, ceil_ms, sci.shape)
+    with np.errstate(invalid="ignore"):
+        req0 = (sci - ms_map) / sig_wht
+    excl_tr = metrics.compact_source_mask(
+        np.where(np.isfinite(req0), req0, 0.0), off) | off
+    guard_map = nonneg.iterated_gated_trough(sci, ms_map, excl_tr,
+                                             sigmas=(5, 15), t=2.0,
+                                             err=sig_wht, verbose=False)
+    resid = sci - guard_map
+
+    with np.errstate(invalid="ignore"):
+        req = resid / sig_wht
+    excl_arm = metrics.compact_source_mask(
+        np.where(np.isfinite(req), req, 0.0), off) | off
+    ap = metrics.empty_aperture_stats(resid, excl_arm, (33,))[33]
+    neg = metrics.negative_structure(resid, excl_arm, err=sig_wht)
+    print(f"[{name}] m10_guard (no tier0): neg n={neg.n_neg} "
+          f"area={neg.area_neg}px min={neg.min_signif:.1f}sig "
+          f"apmed33={ap.median:+.4f} (meshcap {ncap}/{nmesh})")
+    np.savez_compressed(f"out120v3/{name}/m10_guard.npz",
+                        resid=resid.astype(np.float32),
+                        sig_wht=sig_wht.astype(np.float32))

--- a/pipeline/experiments/bkg_nonneg/smoke_production.py
+++ b/pipeline/experiments/bkg_nonneg/smoke_production.py
@@ -1,0 +1,33 @@
+"""Smoke test: the shipped bkgsub.py guard on the real 120as cutouts,
+scored with the experiment metrics (expect ~ the prototype numbers)."""
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import numpy as np
+from astropy import stats as astrostats
+import metrics
+from run_120 import CUTOUTS_120, load
+from campfire_pipeline.nircam.bkgsub import SubtractBackground
+
+for name in ["core", "offcluster"]:
+    sb = SubtractBackground(
+        ring_downsample=4,
+        bg_box_size=10, bg_filter_size=5, bg_sigma=3,
+        bg_guard=True,   # mosaic default; tier lists = new tier-0-less defaults
+    )
+    sub, mask, bitmask = sb.compute(CUTOUTS_120[name][0])
+    _, err, wht = load(CUTOUTS_120[name][0])
+    off = (bitmask & 1) != 0
+    # score exactly like out120v3: sigma_wht + per-arm residual exclusion
+    good = np.isfinite(wht) & (wht > 0)
+    sqw = np.sqrt(np.where(good, wht, np.nan))
+    s = float(astrostats.biweight_scale((sub * sqw)[~mask & ~off]))
+    sig_wht = np.where(good, s / sqw, np.nan)
+    with np.errstate(invalid="ignore"):
+        req = sub / sig_wht
+    excl = metrics.compact_source_mask(
+        np.where(np.isfinite(req), req, 0.0), off) | off
+    neg = metrics.negative_structure(sub, excl, err=sig_wht)
+    ap = metrics.empty_aperture_stats(sub, excl, (33,))[33]
+    print(f"[{name}] PRODUCTION GUARD: neg n={neg.n_neg} "
+          f"area={neg.area_neg}px min={neg.min_signif:.1f}sig "
+          f"apmed33={ap.median:+.4f}")

--- a/pipeline/experiments/bkg_nonneg/t0_rescue.py
+++ b/pipeline/experiments/bkg_nonneg/t0_rescue.py
@@ -1,0 +1,28 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import numpy as np
+from astropy.io import fits
+import metrics, nonneg
+from run_cutouts import CUTOUTS, build_masker
+
+with fits.open(CUTOUTS["offcluster"]) as hdu:
+    sci = hdu["SCI"].data.astype(float); err = hdu["ERR"].data.astype(float)
+off = np.isnan(err) | np.isnan(sci)
+excl = metrics.compact_source_mask(sci, off) | off
+
+masker_t0 = build_masker(
+    tier_kernel_size=[25, 25, 15, 5, 2], tier_npixels=[30000, 15, 10, 3, 1],
+    tier_nsigma=[100.0, 1.5, 1.5, 1.5, 1.5],
+    tier_dilate_size=[600, 33, 25, 21, 19])
+mask_t0, _ = masker_t0.mask_from_arrays(sci, err)
+bkg = masker_t0.estimate_background(sci, mask_t0)
+ceil_ms, _ = nonneg.multiscale_ceiling(sci, off, bkg.background, mask_t0)
+ms_map, ncap, _ = nonneg.cap_mesh(bkg, ceil_ms, sci.shape)
+corr, cfrac = nonneg.trough_correction(sci, ms_map, excl)
+resid = sci - (ms_map + corr)
+neg = metrics.negative_structure(resid, excl)
+ap = metrics.empty_aperture_stats(resid, excl, (33,))[33]
+print(f"t0-masked mosaic10 + msceil + trough: neg n={neg.n_neg} "
+      f"area={neg.area_neg}px min={neg.min_signif:.1f}sig "
+      f"apmed={ap.median:+.4f} (uncon t0 arm was 50368px/-4.5sig/-0.220)")
+print(f"mesh cells capped={ncap}, trough area={cfrac:.4f}")

--- a/pipeline/experiments/bkg_nonneg/test_blank_null.py
+++ b/pipeline/experiments/bkg_nonneg/test_blank_null.py
@@ -1,0 +1,81 @@
+"""Blank-field null test (success criterion #3): on a source-free tile the
+constrained machinery must (a) leave the background model within noise of
+the unconstrained fit, and (b) inject no positive pedestal.
+
+Synthetic blank tile: smooth sky gradient + correlated noise (white noise
+gaussian-smoothed to mimic drizzle correlation, rescaled to a target
+per-pixel sigma), plus a sprinkling of faint compact sources so the tiered
+mask has something realistic to chew on.
+"""
+
+import os
+import sys
+
+import numpy as np
+from astropy import stats as astrostats
+from scipy.ndimage import gaussian_filter
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import metrics
+import nonneg
+from run_cutouts import build_masker
+
+rng = np.random.default_rng(7)
+N = 1333
+SIG = 0.012          # per-pixel sigma, matches the A2744 cutouts
+SKY0 = 0.003
+
+yy, xx = np.mgrid[0:N, 0:N] / N
+sky = SKY0 * (1 + 0.5 * xx + 0.3 * yy - 0.4 * xx * yy)  # smooth gradient
+noise = gaussian_filter(rng.normal(size=(N, N)), 1.5, mode="wrap")
+noise *= SIG / noise.std()
+
+# faint compact sources (gaussian blobs)
+src = np.zeros((N, N))
+for _ in range(150):
+    y0, x0 = rng.uniform(20, N - 20, 2)
+    amp = rng.lognormal(np.log(5 * SIG), 1.0)
+    s = rng.uniform(1.5, 4.0)
+    y1, y2 = int(y0) - 20, int(y0) + 20
+    x1, x2 = int(x0) - 20, int(x0) + 20
+    dy = np.arange(y1, y2)[:, None] - y0
+    dx = np.arange(x1, x2)[None, :] - x0
+    src[y1:y2, x1:x2] += amp * np.exp(-(dy**2 + dx**2) / (2 * s * s))
+
+sci = (sky + noise + src).astype(np.float32)
+err = np.full_like(sci, SIG)
+off = np.zeros_like(sci, bool)
+
+masker = build_masker()
+mask_final, bitmask = masker.mask_from_arrays(sci, err)
+excl = metrics.compact_source_mask(sci, off) | off
+
+bkg10 = masker.estimate_background(sci, mask_final)
+base_map = bkg10.background
+
+# constrained: multiscale ceiling meshcap + trough pass
+ceil_ms, cal = nonneg.multiscale_ceiling(sci, off, base_map, mask_final)
+ms_map, ncap, nmesh = nonneg.cap_mesh(bkg10, ceil_ms, sci.shape)
+corr, cfrac = nonneg.trough_correction(sci, ms_map, excl)
+final_map = ms_map + corr
+
+d_map = final_map - base_map
+d_sky = final_map - sky
+
+print(f"mask fraction: {mask_final.mean():.3f}, mesh cells capped: "
+      f"{ncap}/{nmesh}, trough-corrected area: {cfrac:.4f}")
+print(f"constrained - unconstrained map: median={np.median(d_map):.3e} "
+      f"(= {np.median(d_map)/SIG:.4f} sigma_pix), "
+      f"p1={np.percentile(d_map,1):.3e} p99={np.percentile(d_map,99):.3e}")
+print(f"constrained map - true sky: median={np.median(d_sky):.3e} "
+      f"robust sigma={astrostats.biweight_scale(d_sky):.3e}")
+print(f"unconstrained map - true sky: "
+      f"median={np.median(base_map - sky):.3e} "
+      f"robust sigma={astrostats.biweight_scale(base_map - sky):.3e}")
+
+for r, (resid, label) in enumerate(
+    [(sci - base_map, "baseline"), (sci - final_map, "constrained")]):
+    ap = metrics.empty_aperture_stats(resid - src, excl, (33,))
+    a = ap[33]
+    print(f"{label}: 1\" empty-aperture median={a.median:+.4e} "
+          f"sigma={a.sigma:.4e} mean_signif={a.mean_signif:+.2f}")

--- a/pipeline/experiments/bkg_nonneg/zoom_v3.py
+++ b/pipeline/experiments/bkg_nonneg/zoom_v3.py
@@ -1,0 +1,34 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import numpy as np, matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import metrics
+from run_120 import CUTOUTS_120, load
+
+d = np.load("out120v3/core/arms.npz")
+sci, err, wht = load(CUTOUTS_120["core"][0])
+off = d["off"]; sw = d["sig_wht"]
+y0, y1, x0, x1 = 2000, 3000, 1200, 2600
+fig, axes = plt.subplots(1, 3, figsize=(15, 5.0), dpi=110)
+for i, arm in enumerate(["after", "m10", "m10_t0_guard"]):
+    r = d[f"resid_{arm}"]
+    with np.errstate(invalid="ignore"):
+        req = r / sw
+    excl_arm = metrics.compact_source_mask(
+        np.where(np.isfinite(req), req, 0.0), off) | off
+    neg = metrics.negative_structure(r, excl_arm, err=sw)
+    ax = axes[i]
+    ax.imshow(neg.signif_map[y0:y1, x0:x1], origin="lower", cmap="RdBu_r",
+              vmin=-8, vmax=8, extent=[x0, x1, y0, y1])
+    ax.contour(excl_arm[y0:y1, x0:x1], levels=[0.5], colors="k",
+               linewidths=0.35, extent=[x0, x1, y0, y1])
+    sub = neg.signif_map[y0:y1, x0:x1]
+    fin = np.isfinite(sub)
+    ax.set_title(f"{arm}: min={np.nanmin(sub):.1f}σ "
+                 f"area(<-2σ)={int((fin&(sub<-2)).sum())}px", fontsize=10)
+    ax.set_xticks([]); ax.set_yticks([])
+fig.suptitle("core inter-BCG lane, WHT-noise + residual-based exclusion")
+fig.tight_layout()
+fig.savefig("out120v3/core/zoom_lane.png")
+print("saved out120v3/core/zoom_lane.png")

--- a/pipeline/tests/test_nircam_bkg.py
+++ b/pipeline/tests/test_nircam_bkg.py
@@ -513,12 +513,14 @@ def test_shipped_mosaic_tier_config_is_coherent(tmp_path):
     keys = ('tier_kernel_size', 'tier_npixels', 'tier_nsigma',
             'tier_dilate_size')
     mosaic = get_nircam_step_config('resample', cfg, field)
-    assert {len(mosaic[k]) for k in keys} == {5}          # consumed in lockstep
-    assert mosaic['tier_nsigma'][0] == 100.0
-    assert mosaic['tier_npixels'][0] == 30000
-    assert mosaic['tier_dilate_size'][0] == 600
+    # tier 0 (100 sigma / 30k px / 600 px pre-tier) removed with bg_guard:
+    # both stages now run the same 4-tier compact-source cascade
+    assert {len(mosaic[k]) for k in keys} == {4}          # consumed in lockstep
+    assert mosaic['tier_nsigma'][0] == 1.5
+    assert mosaic['bg_guard'] is True                     # negativity guard on
 
-    # per-exposure deliberately keeps 4 tiers: 30k px / 600 px are sized for a
-    # 30mas mosaic tile, not a 2048^2 frame
     per_exp = get_nircam_step_config('bkg', cfg, field).get('mask') or {}
     assert {len(per_exp[k]) for k in keys} == {4}
+    # the guard is mosaic-scoped: the per-exposure mask section must not
+    # carry it (SubtractBackground default is False)
+    assert 'bg_guard' not in per_exp

--- a/pipeline/tests/test_nircam_bkgsub_guard.py
+++ b/pipeline/tests/test_nircam_bkgsub_guard.py
@@ -152,6 +152,52 @@ def test_guard_sigma_map_follows_wht():
     assert ratio == pytest.approx(2.0, rel=1e-3)
 
 
+@pytest.mark.parametrize("interp_name", ["zoom", "IDW"])
+def test_cap_mesh_preserves_configured_interpolator(interp_name):
+    """An uncapping ceiling must reproduce the fitted map for BOTH
+    interpolators — _cap_mesh re-runs the fit's own interpolation, so
+    enabling the guard with bg_interpolator='IDW' cannot silently swap the
+    whole background for a zoom-interpolated one."""
+    sci, err, _ = _scene(n=256)
+    sb = _guard_sb(bg_interpolator=interp_name)
+    mask, _ = sb.mask_from_arrays(sci, err)
+    bkg = sb.estimate_background(sci, mask)
+    ref = bkg.background
+    uncapping = np.full(sci.shape, np.inf)
+    remade = sb._cap_mesh(bkg, uncapping, sci.shape)
+    # identical interpolation of an identical mesh; tolerance only for the
+    # float32-mesh vs float64-capped-mesh arithmetic
+    assert np.allclose(remade, ref, rtol=1e-5, atol=1e-6 * SIG)
+
+
+def test_trough_correction_continuous_across_excluded_footprint():
+    """The trough correction must not hard-zero over excluded source
+    footprints: a source inside a fired trough gets the same ambient
+    lowering as its surroundings (no per-source pedestal/seam)."""
+    n = 256
+    yy, xx = np.mgrid[0:n, 0:n]
+    noise = gaussian_filter(RNG.normal(size=(n, n)), 1.2, mode="wrap")
+    noise *= SIG / noise.std()
+    trough = 6 * SIG * np.exp(-(((yy - 128) ** 2 + (xx - 128) ** 2)
+                                / (2 * 30.0 ** 2)))
+    sci = (noise - trough).astype(np.float32)
+    sigma_map = np.full((n, n), SIG, dtype=np.float32)
+    exclude = np.hypot(yy - 128, xx - 128) < 8      # compact source footprint
+    sb = _guard_sb()
+
+    m = sb._gated_trough_pass(sci, np.zeros_like(sci), exclude, sigma_map)
+
+    r_in = np.hypot(yy - 128, xx - 128)
+    annulus = (r_in >= 9) & (r_in < 14)
+    corr_inside = float(np.mean(m[exclude]))
+    corr_annulus = float(np.mean(m[annulus]))
+    assert corr_annulus < -2 * SIG                  # the trough fired
+    # continuity: interior lowered like its immediate surroundings, not
+    # left at ~0 on a pedestal
+    assert corr_inside < 0.5 * corr_annulus
+    assert abs(corr_inside - corr_annulus) < 1.5 * SIG
+
+
 def test_compute_applies_guard(tmp_path):
     """End-to-end through compute(): guard on vs off differ only where the
     guard fired, and the guard never raises the background."""

--- a/pipeline/tests/test_nircam_bkgsub_guard.py
+++ b/pipeline/tests/test_nircam_bkgsub_guard.py
@@ -1,0 +1,175 @@
+"""Tests for the SubtractBackground negativity guard (bg_guard).
+
+Fast synthetic scenes (small boxes, scaled-down guard params). The three
+behaviors under test mirror the A2744 validation in
+experiments/bkg_nonneg:
+
+1. Near-no-op on a compliant field (the gate keeps blank fields intact).
+2. A coherent oversubtraction trough (masked region, elevated model) is
+   corrected back to statistical insignificance.
+3. The ceiling caps a background mesh that sits above the observed flux
+   floor, including where the fit mask hides the violation.
+"""
+
+import numpy as np
+import pytest
+from astropy import stats as astrostats
+from scipy.ndimage import gaussian_filter
+
+from campfire_pipeline.nircam.bkgsub import SubtractBackground
+
+SIG = 0.01
+RNG = np.random.default_rng(11)
+
+
+def _scene(n=512, sky=0.005, nsrc=40):
+    """Smooth sky gradient + correlated noise + compact sources."""
+    yy, xx = np.mgrid[0:n, 0:n] / n
+    skymap = sky * (1 + 0.4 * xx - 0.2 * yy)
+    noise = gaussian_filter(RNG.normal(size=(n, n)), 1.2, mode="wrap")
+    noise *= SIG / noise.std()
+    src = np.zeros((n, n))
+    for _ in range(nsrc):
+        y0, x0 = RNG.uniform(15, n - 15, 2)
+        amp = RNG.lognormal(np.log(8 * SIG), 0.7)
+        s = RNG.uniform(1.5, 3.0)
+        y1, y2 = int(y0) - 12, int(y0) + 12
+        x1, x2 = int(x0) - 12, int(x0) + 12
+        dy = np.arange(y1, y2)[:, None] - y0
+        dx = np.arange(x1, x2)[None, :] - x0
+        src[y1:y2, x1:x2] += amp * np.exp(-(dy**2 + dx**2) / (2 * s * s))
+    sci = (skymap + noise + src).astype(np.float32)
+    err = np.full_like(sci, SIG)
+    return sci, err, skymap
+
+
+def _guard_sb(**over):
+    kw = dict(
+        ring_radius_in=40, ring_width=4, ring_downsample=2,
+        tier_kernel_size=[15, 5, 2], tier_npixels=[10, 3, 1],
+        tier_nsigma=[1.5, 1.5, 1.5], tier_dilate_size=[15, 9, 7],
+        bg_box_size=10, bg_filter_size=5,
+        bg_guard=True,
+        guard_ceiling_boxes=[16, 32, 64],
+        guard_trough_sigmas=[3.0, 8.0],
+    )
+    kw.update(over)
+    return SubtractBackground(**kw)
+
+
+def _smoothed_min_signif(resid, exclude, sigma=3.0):
+    sm = SubtractBackground._smooth_masked(resid, exclude, sigma)
+    ok = np.isfinite(sm) & ~exclude
+    rms = astrostats.biweight_scale(sm[ok])
+    return float(np.nanmin(np.where(ok, sm, np.nan))) / rms
+
+
+def test_guard_near_noop_on_compliant_field():
+    sci, err, _ = _scene()
+    sb = _guard_sb()
+    mask, bitmask = sb.mask_from_arrays(sci, err)
+    bkg = sb.estimate_background(sci, mask)
+    off = (bitmask & 1) != 0
+    guarded = sb.apply_negativity_guard(sci, bkg, mask, off)
+    d = guarded - bkg.background
+    # corrections only ever lower the map, by at most a small ceiling slack
+    assert np.median(d) == pytest.approx(0.0, abs=1e-5)
+    assert np.percentile(d, 99) <= 1e-4
+    # materially a no-op: re-interpolation ripple from a handful of capped
+    # mesh cells is ~1e-11..1e-7, so bound the amplitude, not exact zeros
+    assert float((np.abs(d) > 0.2 * SIG).mean()) < 0.01
+
+
+def test_guard_corrects_masked_oversubtraction_trough():
+    sci, err, _ = _scene()
+    sb = _guard_sb()
+    mask, bitmask = sb.mask_from_arrays(sci, err)
+    off = (bitmask & 1) != 0
+
+    # carve a coherent trough: remove a smooth blob from the image and mask
+    # its footprint for the fit, so the fitted model rides above the local
+    # flux floor there (the wing-oversubtraction geometry)
+    n = sci.shape[0]
+    yy, xx = np.mgrid[0:n, 0:n]
+    blob = 4 * SIG * np.exp(-(((yy - 250) ** 2 + (xx - 250) ** 2)
+                              / (2 * 25.0 ** 2)))
+    sci_t = sci - blob.astype(np.float32)
+    mask_t = mask | (blob > 0.4 * SIG)
+
+    bkg = sb.estimate_background(sci_t, mask_t)
+    resid_before = sci_t - bkg.background
+    guarded = sb.apply_negativity_guard(sci_t, bkg, mask_t, off)
+    resid_after = sci_t - guarded
+
+    excl = np.zeros_like(mask)
+    before = _smoothed_min_signif(resid_before, excl)
+    after = _smoothed_min_signif(resid_after, excl)
+    assert before < -5          # the injected trough is highly significant
+    # guard lifts it back toward the -t floor; a residual core smaller than
+    # the gate's npixels can keep the minimum slightly below it
+    assert after > before + 1.5
+    assert after > -4.2
+    # and the correction is local: the far field sees at most the same
+    # sparse small-area firing the compliant-field test allows
+    far = np.hypot(yy - 250, xx - 250) > 120
+    d = guarded - bkg.background
+    assert float((np.abs(d[far]) > 0.2 * SIG).mean()) < 0.01
+
+
+def test_ceiling_caps_elevated_background():
+    sci, err, _ = _scene()
+    sb = _guard_sb()
+    mask, bitmask = sb.mask_from_arrays(sci, err)
+    bkg = sb.estimate_background(sci, mask)
+
+    # elevate the model over a region and verify the multiscale ceiling
+    # (built only from sci) vetoes it
+    n = sci.shape[0]
+    yy, xx = np.mgrid[0:n, 0:n]
+    bump_region = np.hypot(yy - 150, xx - 350) < 60
+    elevated = bkg.background + np.where(bump_region, 5 * SIG, 0.0)
+
+    sigma_map = sb._guard_sigma_map(sci - bkg.background, ~mask)
+    ceiling = sb._multiscale_ceiling(sci, np.zeros_like(mask), elevated,
+                                     mask, sigma_map)
+    viol = elevated > ceiling
+    assert viol[bump_region].mean() > 0.9    # elevation caught
+    # outside the bump the only violations are genuine caps of the raw
+    # fit near sources (the guard working as intended) — keep them bounded
+    assert viol[~bump_region].mean() < 0.10
+
+
+def test_guard_sigma_map_follows_wht():
+    sci, err, _ = _scene(n=256)
+    sb = _guard_sb()
+    resid = RNG.normal(scale=SIG, size=sci.shape)
+    wht = np.full(sci.shape, 4000.0)
+    wht[:, 128:] = 1000.0                    # 2x noisier half
+    resid[:, 128:] *= 2.0
+    sb.wht = wht.astype(np.float32)
+    sig = sb._guard_sigma_map(resid, np.ones_like(sci, dtype=bool))
+    ratio = np.median(sig[:, 128:]) / np.median(sig[:, :128])
+    assert ratio == pytest.approx(2.0, rel=1e-3)
+
+
+def test_compute_applies_guard(tmp_path):
+    """End-to-end through compute(): guard on vs off differ only where the
+    guard fired, and the guard never raises the background."""
+    from astropy.io import fits
+
+    sci, err, _ = _scene()
+    path = str(tmp_path / "scene.fits")
+    fits.HDUList([
+        fits.PrimaryHDU(),
+        fits.ImageHDU(sci, name="SCI"),
+        fits.ImageHDU(err, name="ERR"),
+    ]).writeto(path)
+
+    sub_on, _, _ = _guard_sb().compute(path)
+    sub_off, _, _ = _guard_sb(bg_guard=False).compute(path)
+    d = sub_on - sub_off
+    # guard only ever adds flux back, up to the (non-monotone) zoom spline's
+    # re-interpolation ripple around capped mesh cells — bound it well below
+    # the noise rather than at exact zero
+    assert np.all(d > -0.05 * SIG)
+    assert np.median(d) == pytest.approx(0.0, abs=1e-5)

--- a/pipeline/tests/test_nircam_manifest_hash.py
+++ b/pipeline/tests/test_nircam_manifest_hash.py
@@ -1,0 +1,78 @@
+"""Tests for the resample config hash (tile staleness detection).
+
+The resample step skips background subtraction entirely for a tile whose
+manifest and ``_i2d_before_bkgsub.fits`` both exist, so the config hash is
+the only thing that reruns bkgsub on existing tiles. It must therefore
+cover every bkgsub setting that changes mosaic pixels, plus an algorithm
+version for behavior changes at identical settings (the guard rollout).
+"""
+
+import dataclasses
+
+from campfire_pipeline.nircam.bkgsub import SubtractBackground
+from campfire_pipeline.nircam.manifest import (
+    BKGSUB_PIXEL_DEFAULTS, _resample_config_hash,
+)
+
+
+def _h(cfg):
+    return _resample_config_hash(cfg, '60mas')
+
+
+def test_guard_and_tier_settings_change_hash():
+    base = _h({})
+    # the settings this rollout changes must all hash distinctly
+    assert _h({'bg_guard': False}) != base
+    assert _h({'guard_trough_t': 3.0}) != base
+    assert _h({'guard_ceiling_boxes': [32, 64]}) != base
+    assert _h({'tier_kernel_size': [25, 15, 5]}) != base
+    assert _h({'bg_interpolator': 'IDW'}) != base
+    assert _h({'bg_reject': True}) != base
+    # ... and settings that don't affect pixels must not
+    assert _h({'plot': False, 'split_extensions': False}) == base
+
+
+def test_algorithm_version_marks_pre_guard_manifests_stale():
+    """A pre-guard (v1) manifest hash can never equal a current hash.
+
+    The v1 hash was built from only pixfrac/kernel/pixel_scale/
+    background_subtract (+ conditional wht_aware/bg_reject keys); the
+    current hash always adds ``bkgsub_algorithm`` and the bkgsub settings
+    when background subtraction is on, so every historical manifest
+    rehashes stale and its tile reruns bkgsub — the rollout the changelog
+    promises.
+    """
+    import hashlib
+    import json
+
+    v1 = json.dumps({
+        'pixfrac': 1, 'kernel': 'square', 'pixel_scale': '60mas',
+        'background_subtract': True,
+    }, sort_keys=True)
+    v1_hash = f'sha256:{hashlib.sha256(v1.encode()).hexdigest()}'
+    assert _h({}) != v1_hash
+
+
+def test_no_bkgsub_keys_hashed_when_subtraction_disabled():
+    """background_subtract=False tiles never touch bkgsub, so guard/tier
+    tuning must not mark them stale."""
+    off = {'background_subtract': False}
+    assert _h(off) == _h({**off, 'bg_guard': False, 'guard_trough_t': 3.0})
+
+
+def test_defaults_dict_matches_subtract_background_fields():
+    """Every hashed key must be a real SubtractBackground field with the
+    same default, so the hash can't drift from what resample_step applies
+    (resample_step constructs SubtractBackground from this same dict)."""
+    fields = {f.name: f for f in dataclasses.fields(SubtractBackground)}
+    for key, default in BKGSUB_PIXEL_DEFAULTS.items():
+        assert key in fields, key
+        f = fields[key]
+        dc_default = (f.default_factory()
+                      if f.default_factory is not dataclasses.MISSING
+                      else f.default)
+        # resample_step's mosaic-stage defaults deliberately differ from
+        # the dataclass (per-exposure) defaults for these two:
+        if key in ('ring_downsample', 'bg_guard'):
+            continue
+        assert dc_default == default, key


### PR DESCRIPTION
## Summary

Adds a **negativity guard** (`bg_guard`, default **on**) to the mosaic-level background subtraction, and **removes the tier-0 giant-galaxy pre-tier** it obsoletes.

The problem: final mosaics show statistically significant negative flux in the wings of bright galaxies, worst in lensing-cluster fields. Root cause: the background fit discards the one-sided information carried by masked pixels — physically, every pixel (masked or not) asserts `bkg(x) ≤ sci(x) + noise`, because true flux is nonnegative. The fit near bright masked complexes rides up on wing-elevated mesh cells and extrapolates that elevation across masks (and any smooth symmetric fit overestimates the background at a saddle between two peaks — the inter-BCG lane failure).

## Mechanism (two data-side corrections, applied to the fitted map)

1. **Ceiling meshcap** — maskless coarse `Background2D` fits with a hard one-sided upper clip track the lower envelope of the local flux: a valid *upper bound* on any admissible background, everywhere, including under masks (absorbing smooth wing/ICL light stays allowed — the bound only forbids overshooting the flux floor). Multi-scale min over box 32/64/128, self-calibrated per image on quiet sky (removes the one-sided clip bias), 2σ slack. Enforced by capping the low-res background **mesh** and re-interpolating — a mask-and-refit enforcement is provably a no-op under fully-masked regions.
2. **Gated trough pass** — the residual is observable even under the fit mask. Where its smoothed, noise-equalized map is coherently below −2σ over a connected region ≥ `8σ_sm²` px, the map is lowered so the residual returns to the −2σ floor: the minimal correction that removes statistical significance, seam-free by construction, iterated to convergence at σ = 5 and 15 px. Blank fields are a near-no-op (the gate needs large connected sub-threshold regions).

Noise model: `σ(x) = s/√WHT`, calibrated on unmasked sky (source-independent; ERR's Poisson term would suppress trough significance and loosen the ceiling exactly under bright ICL). Falls back to a global scalar without a WHT map.

## Tier-0 removal

The 100σ/30k px/600 px-dilation pre-tier was designed to prevent exactly the oversubtraction bowl the guard now removes — but the A2744 120″ A/B showed:
- inside the tier-0 hole the fit is pure extrapolation: **~3× more** significant negative area than without the tier, **~9× more** even after guard cleanup;
- it never fires on the envelope-dominated BCGs it was meant to protect (their 25 px-smoothed cores never reach 100σ over 30k connected px) — no protection where the problem is worst.

Tier lists shrink 5 → 4 entries (note: `SRCMASK` tier-bit meanings shift down by one).

## Validation (A2744 F444W 120″ cutouts, WHT-aware scoring; full history in `pipeline/experiments/bkg_nonneg/README.md`)

| | cluster core | offcluster galaxy |
|---|---|---|
| production mosaics | 158,892 px / −13.3σ | 185,711 px / −6.8σ |
| **guarded (this PR, shipped code)** | **1,314 px / −4.8σ** | **1,809 px / −7.4σ** |

- Empty-aperture medians unchanged (no positive pedestal); the offcluster survivors are compact snowball/persistence-class artifact patches (flag territory, deliberately not absorbed into the background).
- Synthetic blank-tile null: median map shift exactly 0.
- Rejected alternative for the record: asymmetric sigma-clipping (biases the global sky estimate low).
- 5 new unit tests (`tests/test_nircam_bkgsub_guard.py`); shipped-code smoke test reproduces the prototype numbers exactly.

## Impact / rollout

- **MINOR** release (Algorithm): pixel values change wherever the guard fires; config hashes change → mosaic tiles rebuild on next run.
- Scope is mosaic-only: the per-exposure `[nircam.bkg]` paths construct `SubtractBackground` without `bg_guard` (dataclass default `False`) and are byte-identical.

## Pre-merge checklist

- [ ] **Real blank-tile regression**: run the guard on a genuinely blank 120″ cutout (pre-mosaic-bkgsub, with WHT) and confirm near-no-op — the synthetic null lacks confusion-level faint flux, so it is only an upper bound on false-fire.
- [ ] **Second tier-0-firing archetype**: repeat the tier-0-removal A/B on a bright spiked-star field.
- [ ] Eyeball a production tile before/after (guard log lines report capped cells + trough area per scale).

Follow-ups (separate PRs): per-exposure (`subtract_2d`) guard for cluster fields; inter-visit strip DC offsets (sky-matching, distinct mechanism); flagging pipeline for compact negative artifacts.

Generated with Claude Code