### PR TITLE
Show a Scale for NIRCam exposure-map rows

### DIFF
--- a/python/campfire/deploy/fields.py
+++ b/python/campfire/deploy/fields.py
@@ -5,10 +5,10 @@ loop (programs / observations / fields). The full fields.toml section is mirrore
 losslessly into the `config` jsonb column; the commonly-queried bits are lifted
 into typed columns.
 
-`coverage_area_*` and `latest_deployment_id` are **deploy-owned** — written by
-`deploy_nircam` from `<field>_layout.json` — so `sync_fields` never sends them and
-the upsert leaves them untouched on existing rows (PostgREST merge-duplicates only
-updates the columns present in the payload).
+`coverage_area_*`, `expmap_pixel_scale_arcsec` and `latest_deployment_id` are
+**deploy-owned** — written by `deploy_nircam` from `<field>_layout.json` — so
+`sync_fields` never sends them and the upsert leaves them untouched on existing rows
+(PostgREST merge-duplicates only updates the columns present in the payload).
 
 Scoped to fields that already have deployed NIRCam data, so the cloud table
 reflects what is actually reduced, not every field defined locally.
@@ -152,6 +152,12 @@ def upsert_field_on_deploy(client, products_dir, field: str,
         row["coverage_area_arcmin2"] = coverage["coverage_area_arcmin2"]
         row["coverage_area_deg2"] = coverage.get("coverage_area_deg2")
         area_msg = f", area {coverage['coverage_area_arcmin2']:.1f} arcmin2"
+    # The expmap grid's pixel scale, so the web product table can show a Scale
+    # for expmap rows (an expmap FITS carries it only in CDELT1/2, and the
+    # registry row has no scale axis). Lifted separately from the area: it is
+    # present whenever the layout JSON is, independent of coverage.
+    if coverage and coverage.get("pixel_scale_arcsec") is not None:
+        row["expmap_pixel_scale_arcsec"] = coverage["pixel_scale_arcsec"]
     upsert_field(client, row)
     print(f"  fields: upserted '{field}' "
           f"({len(row['filters'])} filters, {len(row['tiles'])} tiles{area_msg})")

--- a/python/tests/test_deploy_fields.py
+++ b/python/tests/test_deploy_fields.py
@@ -187,7 +187,8 @@ def test_upsert_field_on_deploy_writes_config_area_and_deployment(tmp_path, monk
     products = tmp_path / "products"
     products.mkdir()
     (products / "cosmos_layout.json").write_text(
-        json.dumps({"coverage_area_arcmin2": 1944.0, "coverage_area_deg2": 0.54}))
+        json.dumps({"coverage_area_arcmin2": 1944.0, "coverage_area_deg2": 0.54,
+                    "pixel_scale_arcsec": 0.5}))
     client = _FakeClient()
     assert F.upsert_field_on_deploy(client, products, "cosmos", 42) is True
     (name, on_conflict, row), = client.store["upserts"]
@@ -195,7 +196,37 @@ def test_upsert_field_on_deploy_writes_config_area_and_deployment(tmp_path, monk
     assert row["latest_deployment_id"] == 42
     assert row["coverage_area_arcmin2"] == 1944.0
     assert row["coverage_area_deg2"] == 0.54
+    assert row["expmap_pixel_scale_arcsec"] == 0.5
     assert row["filters"] == ["f115w", "f444w"]
+
+
+def test_upsert_field_on_deploy_lifts_pixel_scale_without_coverage(tmp_path, monkeypatch):
+    """The expmap grid scale rides its own guard: a layout JSON that records the
+    scale but no coverage area still populates the column the web Scale column
+    reads. (Pre-AREA layout JSONs exist in the wild.)"""
+    _write_root(tmp_path, monkeypatch)
+    products = tmp_path / "products"
+    products.mkdir()
+    (products / "cosmos_layout.json").write_text(
+        json.dumps({"pixel_scale_arcsec": 0.5}))
+    client = _FakeClient()
+    assert F.upsert_field_on_deploy(client, products, "cosmos", 42) is True
+    (_t, _c, row), = client.store["upserts"]
+    assert row["expmap_pixel_scale_arcsec"] == 0.5
+    assert "coverage_area_arcmin2" not in row
+
+
+def test_upsert_field_on_deploy_without_layout_omits_deploy_owned_columns(tmp_path, monkeypatch):
+    """No layout JSON at all: the upsert must not send the deploy-owned columns,
+    so a prior deploy's scale/area survive on the existing row."""
+    _write_root(tmp_path, monkeypatch)
+    products = tmp_path / "products"
+    products.mkdir()
+    client = _FakeClient()
+    assert F.upsert_field_on_deploy(client, products, "cosmos", 42) is True
+    (_t, _c, row), = client.store["upserts"]
+    assert "expmap_pixel_scale_arcsec" not in row
+    assert "coverage_area_arcmin2" not in row
 
 
 def test_upsert_field_on_deploy_skips_unknown_field(tmp_path, monkeypatch):

--- a/supabase/migrations/20260728120000_fields_expmap_pixel_scale.sql
+++ b/supabase/migrations/20260728120000_fields_expmap_pixel_scale.sql
@@ -1,0 +1,27 @@
+-- fields.expmap_pixel_scale_arcsec — the pixel scale of a field's exposure-map
+-- grid, so the NIRCam product table can render a Scale for expmap rows instead
+-- of an em-dash. Deploy-owned: written from <field>_layout.json alongside
+-- coverage_area_* (see python/campfire/deploy/fields.py).
+--
+-- One value per field rather than per object: expmap builds a single shared
+-- auto-WCS across every filter in an invocation, so a field's expmap FITS are
+-- all on the same grid.
+
+ALTER TABLE "public"."fields"
+  ADD COLUMN IF NOT EXISTS "expmap_pixel_scale_arcsec" double precision;
+
+-- Backfill already-deployed fields. Every expmap in the registry predates this
+-- column and was built with the cfpipe default (`cfpipe nircam expmap
+-- --pixel-scale`, default 0.5 since the command was introduced — no release
+-- ever shipped another value and nothing in the repo passes the flag). Scoped
+-- to fields that actually have an active expmap so a field with none stays
+-- NULL and picks up its real value on its next deploy.
+UPDATE "public"."fields" f
+   SET "expmap_pixel_scale_arcsec" = 0.5
+ WHERE f."expmap_pixel_scale_arcsec" IS NULL
+   AND EXISTS (
+     SELECT 1 FROM "public"."storage_objects" so
+      WHERE so."product_type" = 'nircam_expmap'
+        AND so."status" = 'active'
+        AND so."field" = f."name"
+   );

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -730,8 +730,9 @@ ALTER TABLE "public"."programs" OWNER TO "postgres";
 -- the commonly-queried bits are also lifted into typed columns. `latest_deployment_id`
 -- mirrors observations. `coverage_area_*` are deploy-computed from <field>_layout.json
 -- (exact survey area = non-zero pixels of the stacked exposure map x pixel area);
--- sync-fields upserts only config columns so it never clobbers them. Read by
--- get_nircam_fields / get_nircam_field_summary.
+-- `expmap_pixel_scale_arcsec` comes from the same file. sync-fields upserts only
+-- config columns so it never clobbers them. Read by get_nircam_fields /
+-- get_nircam_field_summary / getNircamExpmaps.
 CREATE TABLE IF NOT EXISTS "public"."fields" (
     "name" "text" NOT NULL,
     "display_name" "text",
@@ -747,6 +748,13 @@ CREATE TABLE IF NOT EXISTS "public"."fields" (
     "config" "jsonb",
     "coverage_area_arcmin2" double precision,
     "coverage_area_deg2" double precision,
+    -- Pixel scale (arcsec/pix) of the field's exposure-map grid. Deploy-owned,
+    -- from <field>_layout.json. One value per field: expmap builds a single
+    -- shared auto-WCS across every filter in the invocation, so all of a
+    -- field's expmap FITS are pixel-registered on the same grid. Unlike the
+    -- mosaics (whose scale is a key axis in nircam_images) an expmap carries
+    -- its scale only in CDELT1/2, so the web table has nothing else to read.
+    "expmap_pixel_scale_arcsec" double precision,
     "latest_deployment_id" integer,
     "created_at" timestamp with time zone DEFAULT "now"(),
     CONSTRAINT "fields_pkey" PRIMARY KEY ("name")

--- a/web/app/nircam/[field]/NircamFieldPageContent.tsx
+++ b/web/app/nircam/[field]/NircamFieldPageContent.tsx
@@ -86,6 +86,15 @@ const extSort = (a: string, b: string): number => {
   return ai - bi;
 };
 
+// Scale facet order: finest grid first, numerically — a plain string sort would
+// put the expmaps' '500mas' before a mosaic's '30mas'.
+const scaleSort = (a: string, b: string): number => {
+  const mas = (s: string) => parseFloat(s);
+  const [am, bm] = [mas(a), mas(b)];
+  if (Number.isNaN(am) || Number.isNaN(bm)) return a.localeCompare(b);
+  return am - bm;
+};
+
 interface NircamFieldPageContentProps {
   field: string;
 }
@@ -142,7 +151,9 @@ export function NircamFieldPageContent({ field }: NircamFieldPageContentProps) {
       setFieldImages(imagesUrlsRes);
 
       // Merge mosaics + expmaps into the single products list. Expmaps ride as
-      // a synthetic 'exp' extension with no tile/scale axes.
+      // a synthetic 'exp' extension with no tile axis; their scale is the
+      // field's expmap grid (one shared WCS across every filter), not a
+      // per-product axis like a mosaic's.
       const mosaicRows: NircamProductRow[] = (imagesRes.error ? [] : imagesRes.images).map(
         (img) => ({
           kind: 'mosaic',
@@ -163,7 +174,7 @@ export function NircamFieldPageContent({ field }: NircamFieldPageContentProps) {
           field: e.field,
           filter: e.filter,
           tile: null,
-          pixel_scale: null,
+          pixel_scale: e.pixel_scale,
           extension: 'exp',
           file_path: e.storage_key,
           file_size: e.file_size,
@@ -205,7 +216,12 @@ export function NircamFieldPageContent({ field }: NircamFieldPageContentProps) {
     return {
       tiles: [...new Set(mosaics.map((p) => p.tile as string))].sort(tileSort),
       filters: [...new Set(products.map((p) => p.filter))].sort(),
-      pixel_scales: [...new Set(mosaics.map((p) => p.pixel_scale as string))].sort(),
+      // Every product with a scale, not just mosaics — expmaps now carry the
+      // field's grid scale, so the facet has to offer it or the Scale filter
+      // could never match a row the Scale column visibly labels.
+      pixel_scales: [...new Set(
+        products.map((p) => p.pixel_scale).filter((s): s is string => s !== null),
+      )].sort(scaleSort),
       extensions: [...new Set(products.map((p) => p.extension))].sort(extSort),
       epochs: [...new Set(mosaics.map((p) => p.epoch ?? ''))].sort(),
     };

--- a/web/lib/actions/nircam.ts
+++ b/web/lib/actions/nircam.ts
@@ -152,6 +152,16 @@ async function attachStoredSizes(
 }
 
 /**
+ * Render an arcsec/pix scale in the same vocabulary the mosaic Scale column uses
+ * ('30mas'), so expmap and mosaic rows read as one column: 0.5 -> '500mas'.
+ * Returns null for a null/non-finite input so the cell falls back to an em-dash.
+ */
+function formatPixelScale(arcsec: unknown): string | null {
+  if (typeof arcsec !== 'number' || !Number.isFinite(arcsec) || arcsec <= 0) return null;
+  return `${Math.round(arcsec * 1000)}mas`;
+}
+
+/**
  * Fetch the per-(field, filter) exposure-coverage maps a user may see.
  *
  * Expmaps are registered in `storage_objects` (product_type `nircam_expmap`) and
@@ -191,6 +201,18 @@ export async function getNircamExpmaps(field?: string): Promise<NircamExpmapsRes
       return { expmaps: [], error: error.message, isAuthenticated: true };
     }
 
+    // Grid scale per field. An expmap FITS records its scale only in CDELT1/2 and
+    // the registry row has no scale axis, so it comes from the `fields` registry,
+    // where deploy lifts it out of <field>_layout.json. One value per field —
+    // expmap builds a single shared WCS across all of a field's filters. A failure
+    // here is non-fatal: the rows still render, just without a Scale.
+    let scaleQuery = supabase.from('fields').select('name, expmap_pixel_scale_arcsec');
+    if (field) scaleQuery = scaleQuery.eq('name', field);
+    const { data: fieldRows } = await scaleQuery;
+    const scaleByField = new Map(
+      (fieldRows || []).map((f) => [f.name as string, formatPixelScale(f.expmap_pixel_scale_arcsec)])
+    );
+
     const expmaps: NircamExpmap[] = data
       .filter((r) => r.filter)  // per-filter product; skip any unscoped row
       .map((r) => ({
@@ -198,6 +220,7 @@ export async function getNircamExpmaps(field?: string): Promise<NircamExpmapsRes
         filter: r.filter as string,
         storage_key: r.storage_key,
         file_size: r.size_bytes ?? undefined,
+        pixel_scale: scaleByField.get(r.field) ?? null,
       }));
 
     return { expmaps, isAuthenticated: true };

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -296,12 +296,16 @@ export interface NircamImage {
 
 // A per-(field, filter) exposure-coverage map (product_type 'nircam_expmap',
 // sourced from the storage_objects registry). Unlike mosaics there is one
-// fiducial map per field/filter — no tile/scale/extension axes.
+// fiducial map per field/filter — no tile/extension axes.
 export interface NircamExpmap {
   field: string;
   filter: string;
   storage_key: string;
   file_size?: number; // size_bytes from the registry, if available
+  /** Expmap grid scale, formatted like the mosaic column ('500mas'). Comes from
+   *  fields.expmap_pixel_scale_arcsec (one grid per field, not per object);
+   *  null for a field deployed before that column was populated. */
+  pixel_scale: string | null;
 }
 
 // One row of the /nircam landing grid (get_nircam_fields RPC + a presigned


### PR DESCRIPTION
The NIRCam product table renders `—` in the **Scale** column for every expmap row. Mosaics carry `pixel_scale` as a key axis in `nircam_images`, but an expmap FITS records its grid only in `CDELT1/2` and its `storage_objects` row has no scale axis to read.

(The real value is **0.5″/pix** — `cfpipe nircam expmap --pixel-scale`, `pipeline/campfire_pipeline/nircam/cli.py:380`. Rendered as `500mas` to match the mosaic column's vocabulary.)

## Approach

Stored on `fields`, not per object: `expmap` builds a single shared auto-WCS across every filter in an invocation (`expmap.py:146`), so a field's expmap FITS are all pixel-registered on one grid. The value already exists in `<field>_layout.json` as `pixel_scale_arcsec`, and deploy already reads that file for `coverage_area_*` — so this rides an existing path rather than adding a product-specific column to the generic registry table.

| file | change |
|---|---|
| `supabase/schemas/tables.sql` | `fields.expmap_pixel_scale_arcsec double precision` |
| `supabase/migrations/20260728120000_…` | ADD COLUMN + backfill |
| `python/campfire/deploy/fields.py` | lift `pixel_scale_arcsec` from the layout JSON |
| `web/lib/actions/nircam.ts` | `getNircamExpmaps` joins the field scale, formats `500mas` |
| `web/lib/types.ts`, `NircamFieldPageContent.tsx` | thread onto `NircamProductRow` |

## Two things to look at

**The migration backfills `0.5`.** Every deployed expmap predates the column and used the cfpipe default — that default has been 0.5 since the command was introduced, no release shipped another value, and nothing in the repo passes the flag. Scoped to fields that actually have an active `nircam_expmap`, so a field with none stays NULL and picks up its real value on its next deploy. This is what makes EGS render on merge instead of waiting for a redeploy.

**The Scale facet is widened** (`NircamFieldPageContent.tsx`) to include expmap scales — it was mosaics-only. Without it the dropdown offers `30mas` but not `500mas`, so the column would show a value you can't filter by. Added a numeric `scaleSort` too, since a plain string sort puts `500mas` before `30mas`.

The deploy-side lift sits under its own guard rather than inside the coverage-area branch, so a layout JSON that records the scale but no area still populates the column.

## Verification

- `pytest python/tests/test_deploy_fields.py` — 20 passed (3 new: scale lifted alongside area; lifted without area; omitted entirely when there's no layout JSON, so a prior deploy's values survive the upsert)
- `tsc --noEmit` clean, `npm run build` green

## Caveat

**The migration is hand-authored** — Docker wasn't available in this environment, so I couldn't run `supabase db diff`. It's one `ADD COLUMN IF NOT EXISTS` plus an idempotent `UPDATE`, but it deserves a `supabase db reset` to confirm it replays cleanly.

## Not included

The duplicate-row issue in the same table (stale `_uncal` / `_canonical` registry rows from pre-`4c8025c` deploys) is being cleaned up separately by hand — it's data, not code, and deploy already blocks new ones via `_EXPMAP_NONFIDUCIAL_STEMS`.

Generated with Claude Code