### PR TITLE
Check for and override usetex

### DIFF
--- a/pipeline/campfire_pipeline/nirspec/plots.py
+++ b/pipeline/campfire_pipeline/nirspec/plots.py
@@ -17,6 +17,10 @@ from astropy.visualization import ImageNormalize, ZScaleInterval
 
 from campfire_pipeline.common.io import log, files_to_glob
 
+if plt.rcParams['text.usetex']: # if usetex is enabled in a users matplotlibrc, plotting is very slow. Disable this when running the pipeline. 
+    plt.rcParams['text.usetex']=False
+    plt.rcParams['font.serif']='DejaVu Serif'
+
 
 # ---------------------------------------------------------------------------
 # Shared style helpers


### PR DESCRIPTION
Matplotlib's usetex (if enabled in a user's matplotlibrc) significantly slows down the plotting speed. This PR checks if usetex is enabled, and disables it on the fly. 