### PR TITLE
Redesign NIRCam admin dashboard around inspection triage

### DIFF
--- a/supabase/migrations/20260729120000_nircam_progress_inspection_summary.sql
+++ b/supabase/migrations/20260729120000_nircam_progress_inspection_summary.sql
@@ -1,0 +1,20 @@
+-- Admin dashboard redesign: rework nircam_reduction_progress around
+-- inspection triage. Grouping gains detector (for per-detector pending
+-- quick-filter links), the per-stage at_<step> distribution columns are
+-- dropped (no signal — whole filters sit at the same stage), and a masked
+-- count (mask_regions IS NOT NULL) is added.
+-- Hand-authored to match `supabase db diff` output for a view swap.
+
+drop view if exists "public"."nircam_reduction_progress";
+
+create or replace view "public"."nircam_reduction_progress" with (security_invoker = true) as  SELECT field,
+    filter,
+    detector,
+    count(*) AS total,
+    count(*) FILTER (WHERE (review_status = 'pending'::text)) AS pending_review,
+    count(*) FILTER (WHERE (review_status = 'approved'::text)) AS approved,
+    count(*) FILTER (WHERE (review_status = 'excluded'::text)) AS excluded,
+    count(*) FILTER (WHERE (mask_regions IS NOT NULL)) AS masked,
+    count(*) FILTER (WHERE (correction = 'needed'::text)) AS needs_correction
+   FROM public.nircam_exposures
+  GROUP BY field, filter, detector;

--- a/supabase/schemas/views.sql
+++ b/supabase/schemas/views.sql
@@ -131,11 +131,15 @@ DROP VIEW IF EXISTS public.targets_with_flags;
 
 
 -- 5. nircam_reduction_progress
---    Aggregated reduction progress per field/filter for the admin dashboard.
---    Bucketed by the canonical NIRCam pipeline step names (matching
---    `cfpipe nircam <step>` and the campfire_pipeline.common.cfp.CFP_KEYS
---    chain). `uncal` means the raw exposure exists but no canonical file
---    has been produced yet by `detector1`.
+--    Inspection-triage progress per field/filter/detector for the admin
+--    dashboard. The per-stage at_<step> distribution columns were dropped
+--    (2026-07 dashboard redesign): whole filters sit at the same pipeline
+--    stage in practice, so the distribution carried no signal. The view now
+--    answers the questions reviewers actually have — how far along is
+--    inspection (approved+excluded vs total), how many masks exist, and
+--    which detectors still have pending exposures (feeding the dashboard's
+--    quick-filter links). Detector granularity is aggregated back up to
+--    filter/field client-side.
 DROP VIEW IF EXISTS public.nircam_reduction_progress;
 -- security_invoker (B1): this was a plain (definer) view that bypassed the
 -- admin-only RLS on nircam_exposures, leaking QA aggregates to all authenticated
@@ -146,31 +150,16 @@ WITH (security_invoker = true) AS
 SELECT
     field,
     filter,
+    detector,
     count(*) AS total,
-    -- Per-step distribution: count of exposures whose highest-completed
-    -- CFP key is exactly this step. (Diag_striping and wcs_shift are
-    -- opt-in; expect zeros for fields that don't enable them.)
-    count(*) FILTER (WHERE stage = 'uncal')         AS at_uncal,
-    count(*) FILTER (WHERE stage = 'detector1')     AS at_detector1,
-    count(*) FILTER (WHERE stage = 'persistence')   AS at_persistence,
-    count(*) FILTER (WHERE stage = 'wisp')          AS at_wisp,
-    count(*) FILTER (WHERE stage = 'image2')        AS at_image2,
-    count(*) FILTER (WHERE stage = 'edge')          AS at_edge,
-    -- bkg unifies the former striping/sky/variance stages
-    count(*) FILTER (WHERE stage = 'bkg')           AS at_bkg,
-    count(*) FILTER (WHERE stage = 'diag_striping') AS at_diag_striping,
-    count(*) FILTER (WHERE stage = 'wcs_shift')     AS at_wcs_shift,
-    count(*) FILTER (WHERE stage = 'preview')       AS at_preview,
-    count(*) FILTER (WHERE stage = 'jhat')          AS at_jhat,
-    count(*) FILTER (WHERE stage = 'apply_mask')    AS at_apply_mask,
-    count(*) FILTER (WHERE stage = 'bad_pixel')     AS at_bad_pixel,
-    count(*) FILTER (WHERE stage = 'outlier')       AS at_outlier,
-    -- Triage summary
+    -- Triage summary. "Masked" is derived state: a non-null mask_regions is
+    -- the sole signal (matches the admin exposure table's Masked column).
     count(*) FILTER (WHERE review_status = 'pending')  AS pending_review,
     count(*) FILTER (WHERE review_status = 'approved') AS approved,
     count(*) FILTER (WHERE review_status = 'excluded') AS excluded,
+    count(*) FILTER (WHERE mask_regions IS NOT NULL)   AS masked,
     count(*) FILTER (WHERE correction = 'needed')      AS needs_correction
 FROM public.nircam_exposures
-GROUP BY field, filter;
+GROUP BY field, filter, detector;
 
 GRANT SELECT ON public.nircam_reduction_progress TO authenticated;

--- a/web/app/admin/nircam/page.tsx
+++ b/web/app/admin/nircam/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import React, { Suspense, useMemo, useState } from 'react';
+import { Suspense, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useQuery } from '@tanstack/react-query';
 import type { ColumnDef } from '@tanstack/react-table';
 import { Card } from '@/components/ui/Card';
-import { Loader2, ChevronRight, Copy, Check } from 'lucide-react';
+import { Loader2, ChevronRight, Check } from 'lucide-react';
 import { AdminTable } from '@/components/admin/AdminTable';
 import { AdminFilterBar } from '@/components/admin/AdminFilterBar';
 import { flatFilterCodec, useTableUrlState, type SortState } from '@/lib/hooks/useTableUrlState';
@@ -14,18 +14,11 @@ import {
   getNircamExposures,
   getReductionProgress,
   getExposureFilterOptions,
-  getExcludedExposures,
   type ReductionProgress,
-  type ExcludedExposure,
 } from '@/lib/actions/nircam-exposures';
 import { EXPOSURE_SORT_KEYS } from '@/lib/admin/sort-keys';
 import type { NircamExposure } from '@/lib/types';
-import {
-  stageBadgeClasses,
-  stageBarClasses,
-  NIRCAM_STAGES,
-  STAGE_COLUMN_KEYS,
-} from '@/lib/nircam-stages';
+import { stageBadgeClasses, NIRCAM_STAGES } from '@/lib/nircam-stages';
 import { buildExposureNavQuery } from '@/lib/nircam-exposure-nav';
 
 // ---------------------------------------------------------------------------
@@ -80,171 +73,264 @@ function StageBadge({ stage }: { stage: string }) {
   );
 }
 
-// Horizontal stacked-bar showing distribution of exposures across pipeline
-// stages within a (field, filter) group. Segments are colored by phase
-// bucket; native title-tooltips show the exact step name and count.
-function StageDistributionBar({ progress }: { progress: ReductionProgress }) {
-  const total = progress.total || 1;
-  const segments = STAGE_COLUMN_KEYS
-    .map(({ stage, key }) => ({
-      stage,
-      count: (progress[key] as number) || 0,
-    }))
-    .filter(s => s.count > 0);
+// ---------------------------------------------------------------------------
+// Reduction progress — inspection-centric summary, grouped field → filter →
+// detector. Fields collapse (default closed) so the exposure table stays one
+// scroll away regardless of how many field/filter combinations exist. Each
+// filter row shows inspection progress (approved+excluded of total), the mask
+// count, and per-detector quick-filter links into the pending queue below.
+// (The old per-stage distribution bar is gone: whole filters sit at the same
+// pipeline stage in practice, so it carried no signal. The excluded-exposures
+// copy-paste panel is gone too — `campfire pull` materializes exclusions into
+// reference/nircam/<field>/exposures.json, no fields.toml edit needed.)
+// ---------------------------------------------------------------------------
 
-  if (segments.length === 0) {
-    return <div className="h-3 bg-surface-2 rounded" />;
-  }
+interface DetectorProgress { detector: string; total: number; pending: number }
 
-  return (
-    <div className="flex h-3 rounded overflow-hidden bg-surface-2">
-      {segments.map(({ stage, count }) => (
-        <div
-          key={stage}
-          className={stageBarClasses(stage)}
-          style={{ width: `${(count / total) * 100}%` }}
-          title={`${stage}: ${count}`}
-        />
-      ))}
-    </div>
-  );
+interface TriageCounts {
+  total: number;
+  pending: number;
+  approved: number;
+  excluded: number;
+  masked: number;
+  needsCorrection: number;
 }
 
-// ---------------------------------------------------------------------------
-// Progress table
-// ---------------------------------------------------------------------------
-
-function ProgressTable({ progress }: { progress: ReductionProgress[] }) {
-  if (progress.length === 0) {
-    return (
-      <p className="text-sm text-text-secondary py-4">
-        No reduction data available. Deploy exposures with <code className="text-xs bg-card dark:bg-card-hover px-1 py-0.5 rounded">campfire deploy nircam</code>.
-      </p>
-    );
-  }
-
-  return (
-    <div className="overflow-x-auto">
-      <table className="w-full text-sm">
-        <thead className="border-b border-border">
-          <tr>
-            <th className="px-3 py-2 text-left text-xs font-medium text-text-secondary uppercase">Field</th>
-            <th className="px-3 py-2 text-left text-xs font-medium text-text-secondary uppercase">Filter</th>
-            <th className="px-3 py-2 text-right text-xs font-medium text-text-secondary uppercase">Total</th>
-            <th className="px-3 py-2 text-left text-xs font-medium text-text-secondary uppercase w-1/3">Stage distribution</th>
-            <th className="px-3 py-2 text-right text-xs font-medium text-text-secondary uppercase">Pending</th>
-            <th className="px-3 py-2 text-right text-xs font-medium text-text-secondary uppercase">Correction</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-border">
-          {progress.map((row) => (
-            <tr key={`${row.field}-${row.filter}`} className="hover:bg-card-hover">
-              <td className="px-3 py-2 font-medium text-text-primary">{row.field}</td>
-              <td className="px-3 py-2 text-text-primary">{row.filter}</td>
-              <td className="px-3 py-2 text-right text-text-primary">{row.total}</td>
-              <td className="px-3 py-2">
-                <StageDistributionBar progress={row} />
-              </td>
-              <td className="px-3 py-2 text-right">
-                {row.pending_review > 0 ? (
-                  <Link
-                    href={`/admin/nircam?field=${encodeURIComponent(row.field)}&filter=${encodeURIComponent(row.filter)}&review=pending`}
-                    className="text-yellow-600 dark:text-yellow-400 font-medium hover:underline"
-                  >
-                    {row.pending_review}
-                  </Link>
-                ) : (
-                  <span className="text-text-secondary">0</span>
-                )}
-              </td>
-              <td className="px-3 py-2 text-right">
-                {row.needs_correction > 0 ? (
-                  <Link
-                    href={`/admin/nircam?field=${encodeURIComponent(row.field)}&filter=${encodeURIComponent(row.filter)}&correction=needed`}
-                    className="text-orange-600 dark:text-orange-400 font-medium hover:underline"
-                  >
-                    {row.needs_correction}
-                  </Link>
-                ) : (
-                  <span className="text-text-secondary">0</span>
-                )}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  );
+interface FilterProgress extends TriageCounts {
+  filter: string;
+  detectors: DetectorProgress[];
 }
 
-// ---------------------------------------------------------------------------
-// Excluded exposures panel — copy-paste source for fields.toml skip=[]
-// ---------------------------------------------------------------------------
+interface FieldProgress extends TriageCounts {
+  field: string;
+  filters: FilterProgress[];
+}
 
-function ExcludedPanel({ excluded }: { excluded: ExcludedExposure[] }) {
-  const [copied, setCopied] = useState<string | null>(null);
+const emptyCounts = (): TriageCounts => ({
+  total: 0, pending: 0, approved: 0, excluded: 0, masked: 0, needsCorrection: 0,
+});
 
-  // Group by (field, filter); within each group emit the TOML-fragment line list.
-  const groups = React.useMemo(() => {
-    const m = new Map<string, ExcludedExposure[]>();
-    for (const e of excluded) {
-      const k = `${e.field} / ${e.filter}`;
-      if (!m.has(k)) m.set(k, []);
-      m.get(k)!.push(e);
+// Rows arrive ordered by (field, filter, detector) — see getReductionProgress
+// — so grouping is a single linear pass appending to the tail.
+function groupProgress(rows: ReductionProgress[]): FieldProgress[] {
+  const out: FieldProgress[] = [];
+  for (const r of rows) {
+    let fld = out[out.length - 1];
+    if (!fld || fld.field !== r.field) {
+      fld = { field: r.field, filters: [], ...emptyCounts() };
+      out.push(fld);
     }
-    return Array.from(m.entries());
-  }, [excluded]);
+    let flt = fld.filters[fld.filters.length - 1];
+    if (!flt || flt.filter !== r.filter) {
+      flt = { filter: r.filter, detectors: [], ...emptyCounts() };
+      fld.filters.push(flt);
+    }
+    flt.detectors.push({ detector: r.detector, total: r.total, pending: r.pending_review });
+    for (const acc of [fld, flt]) {
+      acc.total += r.total;
+      acc.pending += r.pending_review;
+      acc.approved += r.approved;
+      acc.excluded += r.excluded;
+      acc.masked += r.masked;
+      acc.needsCorrection += r.needs_correction;
+    }
+  }
+  return out;
+}
 
-  if (excluded.length === 0) return null;
+function pendingHref(field: string, filter?: string, detector?: string) {
+  const p = new URLSearchParams({ field, review: 'pending' });
+  if (filter) p.set('filter', filter);
+  if (detector) p.set('detector', detector);
+  return `/admin/nircam?${p.toString()}`;
+}
 
-  const copy = (key: string, text: string) => {
-    navigator.clipboard.writeText(text);
-    setCopied(key);
-    setTimeout(() => setCopied(null), 1500);
-  };
+// Single-hue completion meter: fill = inspected (approved + excluded) share.
+// The approved/excluded split lives in the title tooltip and the text counts,
+// not in bar segments, so the meter stays readable for all color vision.
+function InspectionMeter({ counts }: { counts: TriageCounts }) {
+  const inspected = counts.approved + counts.excluded;
+  const pct = counts.total > 0 ? (inspected / counts.total) * 100 : 0;
+  return (
+    <div
+      className="flex items-center gap-2"
+      title={`${counts.approved} approved · ${counts.excluded} excluded · ${counts.pending} pending`}
+    >
+      <div className="h-2 flex-1 min-w-16 rounded-full bg-surface-2 overflow-hidden">
+        <div
+          className="h-full rounded-full bg-green-500 dark:bg-green-600"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="text-xs tabular-nums text-text-secondary whitespace-nowrap">
+        {inspected}/{counts.total}
+      </span>
+    </div>
+  );
+}
+
+// Quick-filter chip: jumps to the exposure table pre-filtered to this
+// field/filter/detector's pending queue.
+function PendingChip({ label, count, href }: { label: string; count: number; href: string }) {
+  return (
+    <Link
+      href={href}
+      className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-mono
+        bg-yellow-100 dark:bg-yellow-900/50 text-yellow-800 dark:text-yellow-300
+        hover:bg-yellow-200 dark:hover:bg-yellow-900"
+    >
+      {label}
+      <span className="font-semibold tabular-nums">{count}</span>
+    </Link>
+  );
+}
+
+function FieldSection({ fp }: { fp: FieldProgress }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div>
+      <div className="flex items-center gap-3 px-4 py-2.5 hover:bg-card-hover">
+        <button
+          onClick={() => setOpen(o => !o)}
+          className="flex items-center gap-2 flex-1 min-w-0 text-left"
+          aria-expanded={open}
+        >
+          <ChevronRight
+            className={`w-4 h-4 shrink-0 text-text-secondary transition-transform ${open ? 'rotate-90' : ''}`}
+          />
+          <span className="font-medium text-text-primary">{fp.field}</span>
+          <span className="text-xs text-text-secondary whitespace-nowrap">
+            {fp.filters.length} filter{fp.filters.length !== 1 ? 's' : ''} · {fp.total} exp
+            {fp.masked > 0 && <> · {fp.masked} masked</>}
+          </span>
+        </button>
+        <div className="w-40 shrink-0 hidden sm:block">
+          <InspectionMeter counts={fp} />
+        </div>
+        <div className="w-20 shrink-0 text-right">
+          {fp.pending > 0 ? (
+            <PendingChip label="pending" count={fp.pending} href={pendingHref(fp.field)} />
+          ) : (
+            <span className="inline-flex items-center gap-1 text-xs text-green-600 dark:text-green-400">
+              <Check className="w-3.5 h-3.5" /> done
+            </span>
+          )}
+        </div>
+      </div>
+
+      {open && (
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-t border-border">
+              <th className="pl-11 pr-3 py-1.5 text-left text-xs font-medium text-text-secondary uppercase">Filter</th>
+              <th className="px-3 py-1.5 text-left text-xs font-medium text-text-secondary uppercase w-52">Inspected</th>
+              <th className="px-3 py-1.5 text-right text-xs font-medium text-text-secondary uppercase w-20">Masks</th>
+              <th className="px-3 py-1.5 text-left text-xs font-medium text-text-secondary uppercase">Pending by detector</th>
+              <th className="px-3 py-1.5 text-right text-xs font-medium text-text-secondary uppercase w-16">Corr</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {fp.filters.map((flt) => (
+              <tr key={flt.filter} className="border-t border-border hover:bg-card-hover/50">
+                <td className="pl-11 pr-3 py-1.5">
+                  <Link
+                    href={`/admin/nircam?${new URLSearchParams({ field: fp.field, filter: flt.filter })}`}
+                    className="font-mono text-text-primary hover:text-primary hover:underline"
+                  >
+                    {flt.filter}
+                  </Link>
+                </td>
+                <td className="px-3 py-1.5">
+                  <InspectionMeter counts={flt} />
+                </td>
+                <td className="px-3 py-1.5 text-right tabular-nums">
+                  {flt.masked > 0
+                    ? <span className="text-blue-600 dark:text-blue-400">{flt.masked}</span>
+                    : <span className="text-text-secondary">&mdash;</span>}
+                </td>
+                <td className="px-3 py-1.5">
+                  {flt.pending === 0 ? (
+                    <span className="inline-flex items-center gap-1 text-xs text-green-600 dark:text-green-400">
+                      <Check className="w-3.5 h-3.5" /> inspected
+                    </span>
+                  ) : (
+                    <div className="flex flex-wrap gap-1">
+                      {flt.detectors
+                        .filter((d) => d.pending > 0)
+                        .map((d) => (
+                          <PendingChip
+                            key={d.detector}
+                            label={d.detector}
+                            count={d.pending}
+                            href={pendingHref(fp.field, flt.filter, d.detector)}
+                          />
+                        ))}
+                    </div>
+                  )}
+                </td>
+                <td className="px-3 py-1.5 text-right">
+                  {flt.needsCorrection > 0 ? (
+                    <Link
+                      href={`/admin/nircam?${new URLSearchParams({ field: fp.field, filter: flt.filter, correction: 'needed' })}`}
+                      className="text-orange-600 dark:text-orange-400 font-medium hover:underline tabular-nums"
+                    >
+                      {flt.needsCorrection}
+                    </Link>
+                  ) : (
+                    <span className="text-text-secondary">&mdash;</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+function ProgressSummary({ progress }: { progress: ReductionProgress[] }) {
+  const fields = useMemo(() => groupProgress(progress), [progress]);
+
+  const grand = useMemo(() => {
+    const g = emptyCounts();
+    for (const f of fields) {
+      g.total += f.total;
+      g.pending += f.pending;
+      g.approved += f.approved;
+      g.excluded += f.excluded;
+      g.masked += f.masked;
+      g.needsCorrection += f.needsCorrection;
+    }
+    return g;
+  }, [fields]);
+  const inspected = grand.approved + grand.excluded;
 
   return (
     <Card className="mb-6 overflow-hidden">
-      <div className="px-4 py-3 border-b border-border flex items-baseline justify-between bg-surface-2">
+      <div className="px-4 py-3 border-b border-border bg-surface-2 flex items-baseline justify-between gap-3">
         <h2 className="text-sm font-medium text-text-primary uppercase tracking-wider">
-          Excluded — copy into <code className="font-mono text-xs">fields.toml</code> <code className="font-mono text-xs">skip = […]</code>
+          Reduction Progress
         </h2>
-        <span className="text-xs text-text-secondary">{excluded.length} total</span>
+        {grand.total > 0 && (
+          <span className="text-xs text-text-secondary whitespace-nowrap">
+            {inspected}/{grand.total} inspected ({Math.round((inspected / grand.total) * 100)}%)
+            · {grand.masked} masked · {grand.pending} pending
+          </span>
+        )}
       </div>
-      <div className="divide-y divide-border">
-        {groups.map(([heading, rows]) => {
-          const tomlBlock = rows.map(r => `    "${r.filename}",`).join('\n');
-          return (
-            <div key={heading} className="p-4">
-              <div className="flex items-baseline justify-between mb-2">
-                <h3 className="text-xs font-medium text-text-secondary">
-                  {heading} <span className="text-text-secondary">({rows.length})</span>
-                </h3>
-                <button
-                  onClick={() => copy(heading, tomlBlock)}
-                  className="text-xs text-primary hover:underline inline-flex items-center gap-1"
-                >
-                  {copied === heading ? (
-                    <><Check className="w-3 h-3" /> Copied</>
-                  ) : (
-                    <><Copy className="w-3 h-3" /> Copy</>
-                  )}
-                </button>
-              </div>
-              <pre className="text-xs font-mono bg-surface-2 p-2 rounded overflow-x-auto text-text-primary">{tomlBlock}</pre>
-              {rows.some(r => r.notes) && (
-                <ul className="mt-2 text-xs text-text-secondary space-y-0.5">
-                  {rows.filter(r => r.notes).map(r => (
-                    <li key={r.filename}>
-                      <span className="font-mono">{r.filename}</span> — {r.notes}
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
-          );
-        })}
-      </div>
+      {fields.length === 0 ? (
+        <p className="text-sm text-text-secondary p-4">
+          No reduction data available. Deploy exposures with <code className="text-xs bg-card dark:bg-card-hover px-1 py-0.5 rounded">campfire deploy nircam</code>.
+        </p>
+      ) : (
+        <div className="divide-y divide-border">
+          {fields.map((fp) => (
+            <FieldSection key={fp.field} fp={fp} />
+          ))}
+        </div>
+      )}
     </Card>
   );
 }
@@ -308,11 +394,6 @@ function AdminNircamPageInner() {
   const { data: progressResult } = useQuery({
     queryKey: ['admin-nircam-progress'],
     queryFn: getReductionProgress,
-    staleTime: 30_000,
-  });
-  const { data: excludedResult } = useQuery({
-    queryKey: ['admin-nircam-excluded'],
-    queryFn: getExcludedExposures,
     staleTime: 30_000,
   });
   const { data: facets } = useQuery({
@@ -409,17 +490,7 @@ function AdminNircamPageInner() {
       )}
 
       {/* Progress summary */}
-      <Card className="mb-6 overflow-hidden">
-        <div className="px-4 py-3 border-b border-border bg-surface-2">
-          <h2 className="text-sm font-medium text-text-primary uppercase tracking-wider">
-            Reduction Progress
-          </h2>
-        </div>
-        <ProgressTable progress={progressResult?.progress ?? []} />
-      </Card>
-
-      {/* Excluded exposures (copy-paste source for fields.toml skip=[]) */}
-      <ExcludedPanel excluded={excludedResult?.excluded ?? []} />
+      <ProgressSummary progress={progressResult?.progress ?? []} />
 
       <AdminFilterBar
         facets={[

--- a/web/app/admin/page.tsx
+++ b/web/app/admin/page.tsx
@@ -100,16 +100,17 @@ export default function AdminDashboardPage() {
   const pendingReview = progress.reduce((s, r) => s + (r.pending_review ?? 0), 0);
   const needsCorrection = progress.reduce((s, r) => s + (r.needs_correction ?? 0), 0);
   // The view is detector-grain; roll up to field/filter for the queue table.
+  // Accumulate every row (so Total covers fully-reviewed detectors too), then
+  // keep only groups that still have pending work.
   const attentionMap = new Map<string, { field: string; filter: string; pending: number; total: number }>();
   for (const r of progress) {
-    if (!r.pending_review) continue;
     const key = `${r.field}|${r.filter}`;
     const acc = attentionMap.get(key) ?? { field: r.field, filter: r.filter, pending: 0, total: 0 };
-    acc.pending += r.pending_review;
-    acc.total += r.total;
+    acc.pending += r.pending_review ?? 0;
+    acc.total += r.total ?? 0;
     attentionMap.set(key, acc);
   }
-  const attention = Array.from(attentionMap.values());
+  const attention = Array.from(attentionMap.values()).filter((r) => r.pending > 0);
 
   const budgetOk = budget && 'total_bytes' in budget;
   const b = budgetOk ? (budget as StorageBudget) : null;

--- a/web/app/admin/page.tsx
+++ b/web/app/admin/page.tsx
@@ -99,7 +99,17 @@ export default function AdminDashboardPage() {
   const progress = progressResult?.progress ?? [];
   const pendingReview = progress.reduce((s, r) => s + (r.pending_review ?? 0), 0);
   const needsCorrection = progress.reduce((s, r) => s + (r.needs_correction ?? 0), 0);
-  const attention = progress.filter((r) => r.pending_review > 0);
+  // The view is detector-grain; roll up to field/filter for the queue table.
+  const attentionMap = new Map<string, { field: string; filter: string; pending: number; total: number }>();
+  for (const r of progress) {
+    if (!r.pending_review) continue;
+    const key = `${r.field}|${r.filter}`;
+    const acc = attentionMap.get(key) ?? { field: r.field, filter: r.filter, pending: 0, total: 0 };
+    acc.pending += r.pending_review;
+    acc.total += r.total;
+    attentionMap.set(key, acc);
+  }
+  const attention = Array.from(attentionMap.values());
 
   const budgetOk = budget && 'total_bytes' in budget;
   const b = budgetOk ? (budget as StorageBudget) : null;
@@ -180,7 +190,7 @@ export default function AdminDashboardPage() {
                       href={`/admin/nircam?field=${encodeURIComponent(r.field)}&filter=${encodeURIComponent(r.filter)}&review=pending`}
                       className="text-yellow-600 dark:text-yellow-400 font-medium hover:underline"
                     >
-                      {r.pending_review}
+                      {r.pending}
                     </Link>
                   </td>
                   <td className="px-4 py-2 text-right text-text-secondary tabular-nums">{r.total}</td>

--- a/web/lib/actions/nircam-exposures.ts
+++ b/web/lib/actions/nircam-exposures.ts
@@ -367,28 +367,18 @@ export async function saveExposureMaskRegions(
 // Reduction progress (aggregated view)
 // ---------------------------------------------------------------------------
 
+// One row per (field, filter, detector) — matches the columns of the
+// nircam_reduction_progress view. Callers aggregate back up to filter/field
+// grain; detector grain exists to power per-detector pending quick-filters.
 export interface ReductionProgress {
   field: string;
   filter: string;
+  detector: string;
   total: number;
-  // Per-step counts (matches the columns in the nircam_reduction_progress view)
-  at_uncal: number;
-  at_detector1: number;
-  at_persistence: number;
-  at_wisp: number;
-  at_image2: number;
-  at_edge: number;
-  at_bkg: number;
-  at_diag_striping: number;
-  at_wcs_shift: number;
-  at_preview: number;
-  at_jhat: number;
-  at_apply_mask: number;
-  at_bad_pixel: number;
-  at_outlier: number;
   pending_review: number;
   approved: number;
   excluded: number;
+  masked: number;
   needs_correction: number;
 }
 
@@ -403,7 +393,8 @@ export async function getReductionProgress(): Promise<{
       .from('nircam_reduction_progress')
       .select('*')
       .order('field')
-      .order('filter');
+      .order('filter')
+      .order('detector');
 
     if (error) {
       return { progress: [], error: error.message };
@@ -418,44 +409,11 @@ export async function getReductionProgress(): Promise<{
   }
 }
 
-// ---------------------------------------------------------------------------
-// Excluded exposures (copy-paste source for fields.toml skip=[])
-// ---------------------------------------------------------------------------
-
-export interface ExcludedExposure {
-  field: string;
-  filter: string;
-  filename: string;
-  notes: string | null;
-}
-
-export async function getExcludedExposures(): Promise<{
-  excluded: ExcludedExposure[];
-  error?: string;
-}> {
-  try {
-    const supabase = await requireSession();
-
-    const { data, error } = await supabase
-      .from('nircam_exposures')
-      .select('field, filter, filename, notes')
-      .eq('review_status', 'excluded')
-      .order('field')
-      .order('filter')
-      .order('filename');
-
-    if (error) {
-      return { excluded: [], error: error.message };
-    }
-
-    return { excluded: data || [] };
-  } catch (err) {
-    return {
-      excluded: [],
-      error: err instanceof Error ? err.message : 'Failed to fetch excluded exposures',
-    };
-  }
-}
+// The former getExcludedExposures action (copy-paste source for fields.toml
+// skip=[]) is gone: exclusions reach the pipeline automatically via
+// `campfire pull` → reference/nircam/<field>/exposures.json
+// (campfire.deploy.nircam_exclusions.pull_exclusions), which
+// Field._load_excluded_exposures merges into the effective skip list.
 
 // ---------------------------------------------------------------------------
 // Filter options (for dropdowns)

--- a/web/lib/nircam-stages.ts
+++ b/web/lib/nircam-stages.ts
@@ -24,15 +24,6 @@ const STAGE_PHASE: Record<NircamStage, Phase> = {
   outlier:       'done',
 };
 
-const PHASE_BG: Record<Phase, string> = {
-  pre:     'bg-gray-200 dark:bg-slate-700',
-  early:   'bg-blue-200 dark:bg-blue-900',
-  mid:     'bg-indigo-200 dark:bg-indigo-900',
-  late:    'bg-purple-200 dark:bg-purple-900',
-  combine: 'bg-amber-200 dark:bg-amber-900',
-  done:    'bg-green-300 dark:bg-green-800',
-};
-
 const PHASE_BADGE: Record<Phase, string> = {
   pre:     'bg-gray-100 dark:bg-slate-700 text-gray-600 dark:text-slate-400',
   early:   'bg-blue-100 dark:bg-blue-950 text-blue-700 dark:text-blue-300',
@@ -46,17 +37,6 @@ export function stageBadgeClasses(stage: NircamStage | string): string {
   const phase = STAGE_PHASE[stage as NircamStage] ?? 'pre';
   return PHASE_BADGE[phase];
 }
-
-export function stageBarClasses(stage: NircamStage | string): string {
-  const phase = STAGE_PHASE[stage as NircamStage] ?? 'pre';
-  return PHASE_BG[phase];
-}
-
-// Map the at_<step> column names returned by nircam_reduction_progress
-// back to the canonical stage names for rendering.
-export const STAGE_COLUMN_KEYS = NIRCAM_STAGES.map(s =>
-  ({ stage: s, key: `at_${s}` as const })
-);
 
 export type { NircamStage };
 export { NIRCAM_STAGES };


### PR DESCRIPTION
Rework the reduction progress view and dashboard UI to focus on inspection-triage metrics rather than pipeline stage distribution. The old per-stage distribution bar carried no signal (whole filters sit at the same pipeline stage), and the excluded-exposures copy-paste panel is obsolete (exclusions now materialize automatically via `campfire pull`).

## Key Changes

**Backend (Supabase)**
- Modified `nircam_reduction_progress` view to group by `(field, filter, detector)` instead of just `(field, filter)`, enabling per-detector pending quick-filter links
- Dropped all `at_<step>` distribution columns (uncal, detector1, persistence, wisp, image2, edge, bkg, diag_striping, wcs_shift, preview, jhat, apply_mask, bad_pixel, outlier)
- Added `masked` count (derived from `mask_regions IS NOT NULL`)
- Kept triage summary columns: `pending_review`, `approved`, `excluded`, `needs_correction`
- Added migration `20260729120000_nircam_progress_inspection_summary.sql`

**Frontend (React/TypeScript)**
- Removed `getExcludedExposures` action and `ExcludedPanel` component (exclusions handled server-side)
- Removed `StageDistributionBar` component (no longer needed)
- Removed unused imports: `React` (converted to named import), `Copy` icon, `stageBarClasses`, `STAGE_COLUMN_KEYS`
- Introduced new data structures: `TriageCounts`, `DetectorProgress`, `FilterProgress`, `FieldProgress`
- Added `groupProgress()` function to aggregate detector-grain rows back to field/filter hierarchy client-side
- Replaced `ProgressTable` with `ProgressSummary` component featuring:
  - Collapsible field sections (default closed) to keep exposure table one scroll away
  - `InspectionMeter` showing inspected (approved + excluded) fill percentage with tooltip breakdown
  - `PendingChip` quick-filter links to jump to pending queue by field/filter/detector
  - Per-filter row showing inspection progress, mask count, and per-detector pending chips
  - Grand totals in header (inspected %, masked count, pending count)
- Updated admin dashboard home page to roll up detector-grain progress back to field/filter for the attention queue table

## Implementation Details

- Detector granularity exists solely to power per-detector pending quick-filters; all other UI aggregates back to filter/field level
- `pendingHref()` helper constructs filtered URLs with field, optional filter, and optional detector parameters
- `InspectionMeter` uses a single-hue green bar (readable for all color vision) with detailed breakdown in title tooltip
- Field sections collapse by default to prevent the exposure table from being buried under many field/filter combinations
- The view now directly answers reviewer questions: inspection progress, mask inventory, and which detectors need attention

https://claude.ai/code/session_01P85m4hKoo69xPGXrEctemh