### PR TITLE
Guard exposure-cache writes at response time so slow reads can't stomp decisions

### DIFF
--- a/web/app/admin/nircam/[id]/page.tsx
+++ b/web/app/admin/nircam/[id]/page.tsx
@@ -758,13 +758,36 @@ function ExposureDetailPageInner() {
   const handleSaveMasks = async (regions: MaskRegionsPayload) => {
     // Mask saves run from the editor's own toolbar, outside `goTo`'s dirty
     // check — so the operator can navigate away while one is still in flight.
+    //
+    // Serialized through the SAME per-exposure queue as the triage saves.
+    // Unqueued, a mask save and a nav triage save for this row could commit
+    // at the database in either order, and each confirmation only reflects
+    // the fields the database held at ITS commit — so whichever response was
+    // snapshotted first is missing the other's write, and no response-time
+    // guard can reassemble the truth from two partial rows. Queued, dispatch
+    // order is commit order and each later confirmation contains every
+    // earlier write. Marked pending for the same reason as triage saves:
+    // revalidation and the sibling prefetch must not resurrect the pre-save
+    // row while this write is in flight.
     const savedForId = exposure.id;
-    const res = await saveExposureMaskRegions(savedForId, regions);
+    beginPendingSave(savedForId);
+    let res: Awaited<ReturnType<typeof saveExposureMaskRegions>>;
+    try {
+      res = await enqueueSave(savedForId, () =>
+        saveExposureMaskRegions(savedForId, regions));
+    } catch (err) {
+      res = {
+        exposure: null,
+        error: err instanceof Error ? err.message : 'Save failed',
+      };
+    } finally {
+      endPendingSave(savedForId);
+    }
     if (res.exposure) {
-      // Same response-time rule as the triage paths: a triage save in flight
-      // for this row has already written its optimistic decision — this
-      // (possibly older) row must not go over it. Its own confirmation will
-      // refresh the cache when it lands.
+      // A save queued behind this one (triage flush during the mask round
+      // trip) has already written its optimistic row, and — because the queue
+      // serializes commits — its confirmation will carry this mask write too.
+      // Only the newest pending state may own the cache.
       if (!hasPendingSave(savedForId)) setCachedExposure(res.exposure);
       // Same newer-than-the-read rule as the triage save: a mask write must not
       // be undone by an in-flight revalidation landing after it — but only for

--- a/web/app/admin/nircam/[id]/page.tsx
+++ b/web/app/admin/nircam/[id]/page.tsx
@@ -342,7 +342,17 @@ function ExposureDetailPageInner() {
     for (const sibId of [nav.nextId, nav.prevId]) {
       if (sibId == null || getCachedExposure(sibId)) continue;
       getNircamExposureById(sibId).then((res) => {
-        if (res.exposure) setCachedExposure(res.exposure);
+        // Re-checked at RESPONSE time, not just dispatch: the operator can
+        // arrive at this sibling and key a decision while this read is in
+        // flight (one slow round trip is all it takes). Any cache entry that
+        // appeared since dispatch — the optimistic row or a save confirmation
+        // — is strictly newer than what this read saw, and a pending save with
+        // no cache entry (row never loaded) outranks it too. Overwriting here
+        // painted the pre-decision row on the next revisit as if the decision
+        // had reverted.
+        if (!res.exposure) return;
+        if (getCachedExposure(sibId) || hasPendingSave(sibId)) return;
+        setCachedExposure(res.exposure);
       });
     }
   }, [nav]);
@@ -751,7 +761,11 @@ function ExposureDetailPageInner() {
     const savedForId = exposure.id;
     const res = await saveExposureMaskRegions(savedForId, regions);
     if (res.exposure) {
-      setCachedExposure(res.exposure);
+      // Same response-time rule as the triage paths: a triage save in flight
+      // for this row has already written its optimistic decision — this
+      // (possibly older) row must not go over it. Its own confirmation will
+      // refresh the cache when it lands.
+      if (!hasPendingSave(savedForId)) setCachedExposure(res.exposure);
       // Same newer-than-the-read rule as the triage save: a mask write must not
       // be undone by an in-flight revalidation landing after it — but only for
       // the exposure it was issued for (see handleSave).


### PR DESCRIPTION
## Summary

Follow-up to #434. The flash-then-revert symptom survived on production despite the non-blocking triage flow: decisions persisted to the database correctly, but a revisited exposure could still paint the pre-decision status. Root cause is a latency-dependent race that preview branches (round trips of tens of ms) can never hit but production hits routinely during rapid Space/A triage.

## Root cause

The sibling-row prefetch that makes prev/next paint instantly checked "is this row already cached?" only at **dispatch** time. On a slow link the operator can arrive at that sibling and key a decision while the prefetch is still in flight; the late response then unconditionally overwrote the optimistic row in the cache with the pre-decision DB row it had read.

The next revisit paints synchronously from the cache, so it shows the stale status — and both safety nets correctly stand down: the arrival revalidation defers while the save is in flight, and the save's own confirmation writes only the cache, not the on-screen state. The reverted display sticks, with no error banner, because nothing actually failed.

## Fix

- Re-check at **response** time in the sibling prefetch: if a cache entry appeared for the row since dispatch (the optimistic decision or a save confirmation), or a save is pending for it, the response is stale by construction and is dropped.
- Apply the same rule to the mask-save confirmation — the one remaining unguarded cache write.

## Testing

- `npm run build` compiles, lints, and type-checks cleanly (prerender step needs deployment env vars, as on unmodified `main`).
- Race is timing-dependent; verify on production by rapid Space/A triage through a queue, then stepping back — statuses should now hold.

Generated with Claude Code

https://claude.ai/code/session_01NX2jxPp944jBZxdDFS9sU1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NX2jxPp944jBZxdDFS9sU1)_