### PR TITLE
M1: extract generic ref_cache engine from wisp_cache

### DIFF
--- a/layout/campfire_layout/paths.py
+++ b/layout/campfire_layout/paths.py
@@ -170,6 +170,7 @@ _CACHE_KINDS = {
     "crds": "crds",
     "templates": "templates",
     "wisps": "wisps",
+    "spike_models": "spike_models",
 }
 
 

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -29,6 +29,16 @@ Release procedure: edit the `## Unreleased` section below, then run
 ## Unreleased
 
 ### Infrastructure
+- **Generic reference-data cache engine (`common/ref_cache.py`)** — M1 of the
+  spike-masking build plan (`docs/design-nircam-spike-masking.md` §6.1). The
+  manifest-driven fetch+cache core (load, `ensure()`, atomic verified
+  download, per-file locking, fail-loud semantics) is extracted from
+  `nircam/wisp_cache.py` into a shared `RefCache` engine parameterized by
+  (cache kind, manifest, error class); `wisp_cache` is now a thin wrapper with
+  an unchanged public surface (`test_wisp_cache.py` passes unmodified).
+  `campfire-layout` gains one cache kind (`spike_models` →
+  `cache/spike_models/`) for the M3 consumer. Pure refactor; no behavior or
+  output changes.
 - The drizzle **CONTEXT extension is now written tile-compressed** (GZIP_1,
   lossless), controlled by `[nircam.resample].compress_context` (default
   `true`) and applied on **both** `implementation` backends. `CON` carries one

--- a/pipeline/campfire_pipeline/common/ref_cache.py
+++ b/pipeline/campfire_pipeline/common/ref_cache.py
@@ -1,0 +1,224 @@
+"""Generic manifest-driven fetch + cache engine for large reference data.
+
+Extracted from ``nircam/wisp_cache.py`` (M1 of the spike-masking build plan,
+``docs/design-nircam-spike-masking.md`` §3.4) so the wisp templates and the
+spike footprint models share one engine instead of forked copies.
+``wisp_cache`` is now a thin wrapper over this module.
+
+A dataset plugs in three things: a packaged TOML manifest (``base_url`` +
+per-file ``sha256``/``bytes``), a registered ``campfire_layout`` cache kind,
+and an error class. The engine provides the shared semantics the wisp layer
+established:
+
+* fetch by plain anonymous-HTTPS ``urllib`` GET of ``{base_url}/{name}`` —
+  no login, no cloud credentials, no storage keys;
+* stream to a sibling ``.part`` temp file, verify size + sha256 against the
+  manifest, then ``os.replace`` into place — a file present in the cache is
+  always a complete, verified download, so present files are trusted and
+  never re-hashed;
+* per-file advisory lock so concurrent runs don't double-fetch or read a
+  half-written file;
+* **fail loud**: listed-but-unfetchable raises; a name missing from the
+  manifest is the *caller's* decision to surface (the engine skips it with a
+  visible log line — what "required" means is dataset policy, not engine
+  policy).
+"""
+
+import hashlib
+import os
+import tempfile
+import time
+import urllib.error
+import urllib.request
+
+from campfire_layout import cache_path
+
+from campfire_pipeline.common.io import log
+
+_DOWNLOAD_RETRIES = 3
+_HTTP_TIMEOUT = 120  # seconds per read
+
+
+class RefCacheError(RuntimeError):
+    """A manifest-listed reference file is missing and could not be fetched."""
+
+
+def load_manifest(path, entry_table):
+    """Load a manifest TOML: ``(base_url, {name: (sha256, bytes)})``.
+
+    ``entry_table`` is the array-of-tables key (``"template"`` for wisps,
+    ``"model"`` for spike models). A malformed or unconfigured manifest (empty
+    ``base_url`` / no entries) loads fine — the emptiness is surfaced later,
+    loudly, only if a fetch is actually needed.
+    """
+    import toml
+    data = toml.load(path)
+    base_url = (data.get('base_url') or '').rstrip('/')
+    entries = {}
+    for entry in data.get(entry_table, []):
+        entries[entry['name']] = (entry.get('sha256'), entry.get('bytes'))
+    return base_url, entries
+
+
+class RefCache:
+    """One dataset's fetch+cache policy bound to the shared engine.
+
+    ``manifest_fn`` is a zero-arg callable returning
+    ``(base_url, {name: (sha256, bytes)})`` — a callable rather than a value
+    so wrappers can keep a monkeypatchable module-level loader and the
+    manifest is only read when actually consulted.
+    """
+
+    def __init__(self, cache_kind, manifest_fn, *, error_cls=RefCacheError,
+                 log_prefix='ref', log_noun='reference file',
+                 no_base_url_hint=''):
+        self._cache_kind = cache_kind
+        self._manifest_fn = manifest_fn
+        self._error_cls = error_cls
+        self._log_prefix = log_prefix
+        self._log_noun = log_noun
+        self._no_base_url_hint = no_base_url_hint
+
+    def cache_dir(self):
+        """``$CAMPFIRE_ROOT/cache/<kind>/``, created on demand."""
+        d = str(cache_path(self._cache_kind))
+        os.makedirs(d, exist_ok=True)
+        return d
+
+    def resolve(self, name, legacy_dir=None):
+        """Absolute path to ``name`` if already present, else ``None``.
+
+        Resolution order: the fetch cache first, then a legacy user-supplied
+        directory if given — machines with files already copied there keep
+        working with zero disruption and no fetch.
+        """
+        cached = os.path.join(self.cache_dir(), name)
+        if os.path.exists(cached):
+            return cached
+        if legacy_dir:
+            legacy = os.path.join(legacy_dir, name)
+            if os.path.exists(legacy):
+                return legacy
+        return None
+
+    def ensure(self, names, legacy_dir=None):
+        """Ensure every file in ``names`` is present locally, fetching if needed.
+
+        Present files (cache or legacy) are trusted and skipped — the atomic,
+        verified write in ``_download_one`` means a cached file was already
+        checked. Names not in the manifest are skipped with a warning rather
+        than erroring here — the caller's "required" gate decides what is
+        genuinely required; this only fulfills a given list.
+
+        Returns the number of files actually downloaded. Raises the dataset's
+        error class if a manifest-listed file can't be fetched.
+        """
+        base_url, entries = self._manifest_fn()
+        cdir = self.cache_dir()
+        fetched = 0
+        for name in names:
+            if self.resolve(name, legacy_dir) is not None:
+                continue
+            if name not in entries:
+                log(f"  {self._log_prefix}: {name} is not in the manifest; "
+                    f"cannot fetch, skipping")
+                continue
+            sha, nbytes = entries[name]
+            dest = os.path.join(cdir, name)
+            with _file_lock(dest + '.lock'):
+                # Double-check under the lock: another process may have just
+                # fetched it.
+                if os.path.exists(dest):
+                    continue
+                log(f"  fetching {self._log_noun} {name} …")
+                self._download_one(name, dest, base_url, sha, nbytes)
+                fetched += 1
+        return fetched
+
+    def _download_one(self, name, dest, base_url, expected_sha, expected_bytes):
+        """Stream one file to ``dest`` atomically, verifying size + sha256.
+
+        Retries transient HTTP/URL errors; raises on exhaustion or a checksum
+        mismatch (the latter is not retried by url — a mismatch is
+        deterministic).
+        """
+        if not base_url:
+            hint = f" {self._no_base_url_hint}" if self._no_base_url_hint else ""
+            raise self._error_cls(
+                f"cannot fetch {name}: {self._log_prefix} manifest has no "
+                f"base_url set.{hint}")
+
+        url = f'{base_url}/{name}'
+        last_err = None
+        for attempt in range(1, _DOWNLOAD_RETRIES + 1):
+            fd, tmp = tempfile.mkstemp(dir=os.path.dirname(dest), suffix='.part')
+            h = hashlib.sha256()
+            total = 0
+            try:
+                with os.fdopen(fd, 'wb') as out:
+                    req = urllib.request.Request(
+                        url, headers={'User-Agent': 'campfire-pipeline'})
+                    with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as resp:
+                        while True:
+                            chunk = resp.read(1 << 20)
+                            if not chunk:
+                                break
+                            out.write(chunk)
+                            h.update(chunk)
+                            total += len(chunk)
+                    out.flush()
+                    os.fsync(out.fileno())
+
+                if expected_bytes is not None and total != expected_bytes:
+                    raise self._error_cls(
+                        f"size mismatch for {name}: got {total} bytes, "
+                        f"manifest says {expected_bytes}")
+                digest = h.hexdigest()
+                if expected_sha and digest != expected_sha:
+                    raise self._error_cls(
+                        f"checksum mismatch for {name}: got {digest}, "
+                        f"manifest says {expected_sha}")
+                os.replace(tmp, dest)
+                return
+            except (urllib.error.URLError, TimeoutError, ConnectionError) as e:
+                last_err = e
+                _unlink_quiet(tmp)
+                if attempt < _DOWNLOAD_RETRIES:
+                    log(f"  {self._log_prefix} fetch {name}: {e} (attempt "
+                        f"{attempt}/{_DOWNLOAD_RETRIES}); retrying")
+                    time.sleep(2 * attempt)
+            except BaseException:
+                _unlink_quiet(tmp)
+                raise
+        raise self._error_cls(
+            f"failed to fetch {name} from {url} after {_DOWNLOAD_RETRIES} "
+            f"attempts: {last_err}")
+
+
+def _unlink_quiet(path):
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+class _file_lock:
+    """Minimal advisory lock via ``fcntl.flock`` on a lock file (POSIX)."""
+
+    def __init__(self, path):
+        self._path = path
+        self._fd = None
+
+    def __enter__(self):
+        import fcntl
+        self._fd = os.open(self._path, os.O_CREAT | os.O_RDWR, 0o644)
+        fcntl.flock(self._fd, fcntl.LOCK_EX)
+        return self
+
+    def __exit__(self, *exc):
+        import fcntl
+        try:
+            fcntl.flock(self._fd, fcntl.LOCK_UN)
+        finally:
+            os.close(self._fd)
+            self._fd = None

--- a/pipeline/campfire_pipeline/nircam/wisp_cache.py
+++ b/pipeline/campfire_pipeline/nircam/wisp_cache.py
@@ -9,10 +9,10 @@ fetches each needed template once from a public, anonymous-HTTPS endpoint into
 ``$CAMPFIRE_ROOT/cache/wisps/``, verifies its sha256, and hard-fails if a
 listed template is missing or unfetchable.
 
-Deliberately independent of the campfire CLI / auth / storage-key machinery:
-downloads are plain ``urllib`` GETs against ``base_url`` from the manifest — no
-login, no cloud credentials, no ``campfire_layout`` storage key. The only new
-runtime requirement is outbound HTTPS.
+The generic fetch/verify/cache machinery lives in ``common/ref_cache.py``
+(extracted from here — M1 of the spike-masking build plan); this module is the
+wisp-specific policy: template naming, the wisp detector set, and what
+"required" means.
 
 Manifest semantics (mirrored in ``data/wisp_manifest.toml``):
   * A ``(detector, filter)`` whose 4 templates ARE listed but are missing on
@@ -23,17 +23,9 @@ Manifest semantics (mirrored in ``data/wisp_manifest.toml``):
 """
 
 import functools
-import hashlib
-import os
-import tempfile
-import time
-import urllib.error
-import urllib.request
 from pathlib import Path
 
-from campfire_layout import cache_path
-
-from campfire_pipeline.common.io import log
+from campfire_pipeline.common import ref_cache
 
 
 # Detectors that carry wisps and the four smoothing variants each must have.
@@ -48,30 +40,28 @@ _VARIANT_SUFFIXES = (
 
 _MANIFEST_PATH = Path(__file__).resolve().parent.parent / 'data' / 'wisp_manifest.toml'
 
-_DOWNLOAD_RETRIES = 3
-_HTTP_TIMEOUT = 120  # seconds per read; templates are ~16 MB each
 
-
-class WispTemplateError(RuntimeError):
+class WispTemplateError(ref_cache.RefCacheError):
     """A required wisp template is missing and could not be fetched."""
 
 
 @functools.lru_cache(maxsize=1)
 def _manifest():
-    """Load and index the shipped manifest once.
+    """Load and index the shipped manifest once: ``(base_url, {name: (sha, bytes)})``."""
+    return ref_cache.load_manifest(_MANIFEST_PATH, 'template')
 
-    Returns ``(base_url, {name: (sha256, bytes)})``. A malformed or unconfigured
-    manifest (empty ``base_url`` / no templates) loads fine — the emptiness is
-    surfaced later, loudly, only if a fetch is actually needed.
-    """
-    import toml
-    data = toml.load(_MANIFEST_PATH)
-    base_url = (data.get('base_url') or '').rstrip('/')
-    templates = {}
-    for entry in data.get('template', []):
-        name = entry['name']
-        templates[name] = (entry.get('sha256'), entry.get('bytes'))
-    return base_url, templates
+
+# The lambda resolves ``_manifest`` from module globals at call time, so tests
+# that monkeypatch ``wisp_cache._manifest`` keep working.
+_ENGINE = ref_cache.RefCache(
+    'wisps', lambda: _manifest(),
+    error_cls=WispTemplateError,
+    log_prefix='wisp',
+    log_noun='wisp template',
+    no_base_url_hint=(
+        f"The manifest ({_MANIFEST_PATH.name}) is unconfigured — publish "
+        "templates and regenerate it with scripts/build_wisp_manifest.py."),
+)
 
 
 def build_names(detector, filtname):
@@ -100,9 +90,7 @@ def required_templates(detector, filtname):
 
 def cache_dir():
     """``$CAMPFIRE_ROOT/cache/wisps/``, created on demand."""
-    d = str(cache_path('wisps'))
-    os.makedirs(d, exist_ok=True)
-    return d
+    return _ENGINE.cache_dir()
 
 
 def resolve(name, legacy_dir=None):
@@ -112,119 +100,17 @@ def resolve(name, legacy_dir=None):
     reference directory (``field.wisp_dir``) if given — so machines that already
     have templates copied there keep working with zero disruption and no fetch.
     """
-    cached = os.path.join(cache_dir(), name)
-    if os.path.exists(cached):
-        return cached
-    if legacy_dir:
-        legacy = os.path.join(legacy_dir, name)
-        if os.path.exists(legacy):
-            return legacy
-    return None
-
-
-def _download_one(name, dest, base_url, expected_sha, expected_bytes):
-    """Stream one template to ``dest`` atomically, verifying size + sha256.
-
-    Downloads to a sibling ``.part`` temp file, checks byte count and sha256
-    against the manifest, then ``os.replace`` into place — so a file that exists
-    in the cache is always a complete, verified download. Retries transient
-    HTTP/URL errors; raises ``WispTemplateError`` on exhaustion or a checksum
-    mismatch (the latter is not retried by url — a mismatch is deterministic).
-    """
-    if not base_url:
-        raise WispTemplateError(
-            f"cannot fetch {name}: wisp manifest has no base_url set. The "
-            f"manifest ({_MANIFEST_PATH.name}) is unconfigured — publish "
-            "templates and regenerate it with scripts/build_wisp_manifest.py.")
-
-    url = f'{base_url}/{name}'
-    last_err = None
-    for attempt in range(1, _DOWNLOAD_RETRIES + 1):
-        fd, tmp = tempfile.mkstemp(dir=os.path.dirname(dest), suffix='.part')
-        h = hashlib.sha256()
-        total = 0
-        try:
-            with os.fdopen(fd, 'wb') as out:
-                req = urllib.request.Request(
-                    url, headers={'User-Agent': 'campfire-pipeline'})
-                with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as resp:
-                    while True:
-                        chunk = resp.read(1 << 20)
-                        if not chunk:
-                            break
-                        out.write(chunk)
-                        h.update(chunk)
-                        total += len(chunk)
-                out.flush()
-                os.fsync(out.fileno())
-
-            if expected_bytes is not None and total != expected_bytes:
-                raise WispTemplateError(
-                    f"size mismatch for {name}: got {total} bytes, "
-                    f"manifest says {expected_bytes}")
-            digest = h.hexdigest()
-            if expected_sha and digest != expected_sha:
-                raise WispTemplateError(
-                    f"checksum mismatch for {name}: got {digest}, "
-                    f"manifest says {expected_sha}")
-            os.replace(tmp, dest)
-            return
-        except (urllib.error.URLError, TimeoutError, ConnectionError) as e:
-            last_err = e
-            _unlink_quiet(tmp)
-            if attempt < _DOWNLOAD_RETRIES:
-                log(f"  wisp fetch {name}: {e} (attempt {attempt}/"
-                    f"{_DOWNLOAD_RETRIES}); retrying")
-                time.sleep(2 * attempt)
-        except BaseException:
-            _unlink_quiet(tmp)
-            raise
-    raise WispTemplateError(
-        f"failed to fetch {name} from {url} after {_DOWNLOAD_RETRIES} "
-        f"attempts: {last_err}")
-
-
-def _unlink_quiet(path):
-    try:
-        os.unlink(path)
-    except OSError:
-        pass
+    return _ENGINE.resolve(name, legacy_dir)
 
 
 def ensure(names, legacy_dir=None):
     """Ensure every template in ``names`` is present locally, fetching if needed.
 
-    Present files (cache or legacy) are trusted and skipped — the atomic,
-    verified write in ``_download_one`` means a cached file was already checked,
-    so re-hashing 2.5 GB every run is avoided. Missing ones are downloaded under
-    a per-file lock so two concurrent ``cfpipe`` runs don't fetch the same file
-    twice or read a half-written one.
-
-    Names not present in the manifest are skipped with a warning rather than
-    erroring here — ``required_templates`` is the gate that decides what is
-    genuinely required; this function only fulfills a given list.
-
-    Raises ``WispTemplateError`` if a manifest-listed template can't be fetched.
+    See ``ref_cache.RefCache.ensure`` for the shared semantics (trust present
+    files, per-file locking, loud failure on listed-but-unfetchable). Raises
+    ``WispTemplateError``; returns the number of files actually downloaded.
     """
-    base_url, templates = _manifest()
-    cdir = cache_dir()
-    fetched = 0
-    for name in names:
-        if resolve(name, legacy_dir) is not None:
-            continue
-        if name not in templates:
-            log(f"  wisp: {name} is not in the manifest; cannot fetch, skipping")
-            continue
-        sha, nbytes = templates[name]
-        dest = os.path.join(cdir, name)
-        with _file_lock(dest + '.lock'):
-            # Double-check under the lock: another process may have just fetched it.
-            if os.path.exists(dest):
-                continue
-            log(f"  fetching wisp template {name} …")
-            _download_one(name, dest, base_url, sha, nbytes)
-            fetched += 1
-    return fetched
+    return _ENGINE.ensure(names, legacy_dir=legacy_dir)
 
 
 def ensure_for_pairs(pairs, legacy_dir=None):
@@ -246,25 +132,3 @@ def ensure_for_pairs(pairs, legacy_dir=None):
     if not names:
         return 0
     return ensure(names, legacy_dir=legacy_dir)
-
-
-class _file_lock:
-    """Minimal advisory lock via ``fcntl.flock`` on a lock file (POSIX)."""
-
-    def __init__(self, path):
-        self._path = path
-        self._fd = None
-
-    def __enter__(self):
-        import fcntl
-        self._fd = os.open(self._path, os.O_CREAT | os.O_RDWR, 0o644)
-        fcntl.flock(self._fd, fcntl.LOCK_EX)
-        return self
-
-    def __exit__(self, *exc):
-        import fcntl
-        try:
-            fcntl.flock(self._fd, fcntl.LOCK_UN)
-        finally:
-            os.close(self._fd)
-            self._fd = None

--- a/pipeline/tests/test_ref_cache.py
+++ b/pipeline/tests/test_ref_cache.py
@@ -1,0 +1,146 @@
+"""Tests for the generic manifest fetch/cache engine (``common/ref_cache.py``).
+
+Engine-level: a throwaway dataset bound to the ``spike_models`` cache kind
+(which doubles as coverage for the new layout entry). Dataset-policy behavior
+(wisp naming, required-set gating) stays in ``test_wisp_cache.py``, which also
+pins the wrapper's back-compat surface. No network: ``file://`` URLs.
+"""
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from campfire_pipeline.common import ref_cache
+
+
+@pytest.fixture
+def campfire_root(tmp_path, monkeypatch):
+    monkeypatch.setenv('CAMPFIRE_ROOT', str(tmp_path))
+    return tmp_path
+
+
+def _publish(srcdir, files):
+    """Write ``{name: bytes}`` into srcdir; return (base_url, entries)."""
+    srcdir.mkdir(parents=True, exist_ok=True)
+    entries = {}
+    for name, content in files.items():
+        (srcdir / name).write_bytes(content)
+        entries[name] = (hashlib.sha256(content).hexdigest(), len(content))
+    return Path(srcdir).as_uri(), entries
+
+
+def _engine(base_url, entries, **kw):
+    return ref_cache.RefCache('spike_models', lambda: (base_url, entries), **kw)
+
+
+def test_load_manifest_reads_toml(tmp_path):
+    m = tmp_path / 'm.toml'
+    m.write_text(
+        'base_url = "https://example.org/set/v1/"\n'
+        'version = "v1"\n\n'
+        '[[model]]\nname = "A.fits"\nsha256 = "aa"\nbytes = 3\n\n'
+        '[[model]]\nname = "B.fits"\nsha256 = "bb"\nbytes = 4\n'
+    )
+    base_url, entries = ref_cache.load_manifest(m, 'model')
+    assert base_url == 'https://example.org/set/v1'  # trailing / stripped
+    assert entries == {'A.fits': ('aa', 3), 'B.fits': ('bb', 4)}
+
+
+def test_load_manifest_unconfigured_is_lazy(tmp_path):
+    m = tmp_path / 'm.toml'
+    m.write_text('base_url = ""\n')
+    assert ref_cache.load_manifest(m, 'model') == ('', {})
+
+
+def test_ensure_downloads_verifies_and_is_idempotent(campfire_root, tmp_path):
+    files = {'A.fits': b'payload-a', 'B.fits': b'payload-b'}
+    eng = _engine(*_publish(tmp_path / 'remote', files))
+
+    assert eng.ensure(list(files)) == 2
+    cdir = Path(eng.cache_dir())
+    assert cdir == campfire_root / 'cache' / 'spike_models'
+    for n, content in files.items():
+        assert (cdir / n).read_bytes() == content
+
+    # Present files are trusted: second call fetches nothing.
+    assert eng.ensure(list(files)) == 0
+    assert not list(cdir.glob('*.part'))
+
+
+def test_ensure_checksum_mismatch_raises_and_leaves_nothing(campfire_root, tmp_path):
+    base_url, entries = _publish(tmp_path / 'remote', {'A.fits': b'real'})
+    entries['A.fits'] = ('0' * 64, entries['A.fits'][1])
+    eng = _engine(base_url, entries)
+
+    with pytest.raises(ref_cache.RefCacheError, match='checksum mismatch'):
+        eng.ensure(['A.fits'])
+    cdir = Path(eng.cache_dir())
+    assert not (cdir / 'A.fits').exists()
+    assert not list(cdir.glob('*.part'))
+
+
+def test_ensure_size_mismatch_raises(campfire_root, tmp_path):
+    base_url, entries = _publish(tmp_path / 'remote', {'A.fits': b'real'})
+    entries['A.fits'] = (entries['A.fits'][0], 999999)
+    with pytest.raises(ref_cache.RefCacheError, match='size mismatch'):
+        _engine(base_url, entries).ensure(['A.fits'])
+
+
+def test_ensure_no_base_url_raises_with_hint(campfire_root):
+    eng = _engine('', {'A.fits': ('a' * 64, 4)},
+                  no_base_url_hint='Regenerate with build_thing.py.')
+    with pytest.raises(ref_cache.RefCacheError, match='no base_url') as ei:
+        eng.ensure(['A.fits'])
+    assert 'build_thing.py' in str(ei.value)
+
+
+def test_ensure_unlisted_name_skips(campfire_root, tmp_path):
+    eng = _engine(*_publish(tmp_path / 'remote', {'A.fits': b'a'}))
+    # Unlisted name is skipped (caller gates "required"), listed one fetches.
+    assert eng.ensure(['NOT_LISTED.fits', 'A.fits']) == 1
+
+
+def test_custom_error_class(campfire_root):
+    class MyError(ref_cache.RefCacheError):
+        pass
+    eng = _engine('', {'A.fits': ('a' * 64, 4)}, error_cls=MyError)
+    with pytest.raises(MyError):
+        eng.ensure(['A.fits'])
+
+
+def test_resolve_prefers_cache_then_legacy(campfire_root, tmp_path):
+    eng = _engine('file:///nowhere', {})
+    legacy = tmp_path / 'legacy'
+    legacy.mkdir()
+
+    assert eng.resolve('A.fits', str(legacy)) is None
+    (legacy / 'A.fits').write_bytes(b'legacy')
+    assert eng.resolve('A.fits', str(legacy)) == str(legacy / 'A.fits')
+    cdir = Path(eng.cache_dir())
+    (cdir / 'A.fits').write_bytes(b'cached')
+    assert eng.resolve('A.fits', str(legacy)) == str(cdir / 'A.fits')
+
+
+def test_legacy_dir_skips_fetch(campfire_root, tmp_path):
+    # Manifest lists the file but the remote doesn't have it: a fetch would
+    # fail, so passing ensure() proves the legacy copy short-circuited it.
+    eng = _engine((tmp_path / 'empty-remote').as_uri(), {'A.fits': ('x' * 64, 1)})
+    legacy = tmp_path / 'legacy'
+    legacy.mkdir()
+    (legacy / 'A.fits').write_bytes(b'legacy')
+    assert eng.ensure(['A.fits'], legacy_dir=str(legacy)) == 0
+
+
+def test_manifest_fn_called_lazily(campfire_root, tmp_path):
+    """The manifest callable is consulted per ensure() call, not at bind time."""
+    calls = []
+
+    def manifest():
+        calls.append(1)
+        return _publish(tmp_path / 'remote', {'A.fits': b'a'})
+
+    eng = ref_cache.RefCache('spike_models', manifest)
+    assert not calls
+    eng.ensure(['A.fits'])
+    assert calls


### PR DESCRIPTION
## Summary

M1 of the spike-masking build plan (`docs/design-nircam-spike-masking.md` §6.1, on #440): extract the manifest-driven fetch+cache engine from `nircam/wisp_cache.py` into `common/ref_cache.py` so wisp templates and the spike footprint models (M3) share one engine instead of forked copies.

- **`common/ref_cache.py`** — `RefCache` engine parameterized by (cache kind, manifest callable, error class): manifest load, `ensure()`, atomic verified download (`.part` + size/sha256 + `os.replace`), per-file `flock`, fail-loud on listed-but-unfetchable.
- **`wisp_cache.py`** — thin wrapper, public surface unchanged; retains only wisp policy (template naming, detector set, required-set gating). `test_wisp_cache.py` passes **unmodified**.
- **`campfire-layout`** — one new cache kind: `spike_models` → `cache/spike_models/` (Python only; the TS mirror intentionally excludes `cache_path`).
- **`test_ref_cache.py`** — engine-level tests with a throwaway manifest bound to the new kind.

Pure refactor, no behavior or output changes.

## Changelog

One Infrastructure (PATCH) entry under Unreleased.

## Test plan

- `pytest pipeline/tests` — 514 passed (includes the 9 unmodified wisp tests + 11 new engine tests)

Generated with Claude Code