### PR TITLE
Auto-save mask edits on navigation; improve presign resilience

### DIFF
--- a/web/app/admin/nircam/[id]/page.tsx
+++ b/web/app/admin/nircam/[id]/page.tsx
@@ -696,7 +696,15 @@ function ExposureDetailPageInner() {
     // This dispatch takes responsibility for everything currently staged:
     // consume the dirty flags so a following navigation's flush doesn't
     // re-send the same decision. Anything keyed after this line re-dirties.
-    if (localEditsRef.current.forId === savedForId) {
+    // The consumed flags are KEPT for the failure path below — they are the
+    // only record of which fields held operator decisions; re-dirtying more
+    // than that would let a later flush push `values` entries that were never
+    // edited (stale seeds from targetEdits, or defaults) over server truth.
+    const ownedAtDispatch = localEditsRef.current.forId === savedForId;
+    const dirtyAtDispatch = ownedAtDispatch
+      ? { ...localEditsRef.current.dirty }
+      : null;
+    if (ownedAtDispatch) {
       localEditsRef.current.dirty = { reviewStatus: false, correction: false, notes: false };
     }
     setSaving(true);
@@ -724,16 +732,34 @@ function ExposureDetailPageInner() {
     endPendingSave(savedForId);
     setSaving(false);
     if (result.error) {
-      // The decision did NOT persist — put the dirty flags back (all of them:
-      // the values are the operator's current choices, and the flush diffs
-      // against the baseline row anyway) so a later navigation retries the
-      // save instead of treating it as already handled.
-      if (localEditsRef.current.forId === savedForId) {
-        localEditsRef.current.dirty = { reviewStatus: true, correction: true, notes: true };
+      // The decision did NOT persist. If the record still belongs to this
+      // exposure, restore EXACTLY the flags this dispatch consumed (unioned
+      // with any edits keyed since — those set their own flags and must
+      // survive) so a later navigation retries the operator's actual
+      // decisions and nothing more.
+      const ownedNow = localEditsRef.current.forId === savedForId;
+      if (ownedNow && dirtyAtDispatch) {
+        const cur = localEditsRef.current.dirty;
+        localEditsRef.current.dirty = {
+          reviewStatus: cur.reviewStatus || dirtyAtDispatch.reviewStatus,
+          correction: cur.correction || dirtyAtDispatch.correction,
+          notes: cur.notes || dirtyAtDispatch.notes,
+        };
       }
-      // Surfaced even if we've navigated on: a failed save means the operator's
-      // decision didn't stick, which they need to know about either way.
-      setError(result.error);
+      if (ownedNow) {
+        setError(result.error);
+      } else {
+        // The operator has moved on: the record now belongs to another
+        // exposure, so the flags can't be restored and the component-scoped
+        // error box would paint unattributed on the wrong screen. Raise the
+        // id-aware module banner instead — it names the exposure, links back,
+        // and survives further navigation (same UX as a failed nav flush).
+        setSaveError({
+          id: savedForId,
+          filename: s.exposure.filename,
+          message: result.error,
+        });
+      }
       return { ok: false };
     }
     // Keyed by the exposure's own id, so this is correct regardless of route.

--- a/web/app/admin/nircam/[id]/page.tsx
+++ b/web/app/admin/nircam/[id]/page.tsx
@@ -59,6 +59,14 @@ function blurOnMouseClick(e: React.MouseEvent<HTMLElement>) {
   if (e.detail > 0) e.currentTarget.blur();
 }
 
+// The operator's staged triage decision for one exposure — see localEditsRef.
+interface TriageEdits {
+  forId: number | null;
+  dirty: { reviewStatus: boolean; correction: boolean; notes: boolean };
+  values: { reviewStatus: string; correction: string; notes: string };
+  saved: boolean;
+}
+
 function ExposureDetailPageInner() {
   const params = useParams();
   const router = useRouter();
@@ -102,11 +110,15 @@ function ExposureDetailPageInner() {
   // The list page's filter+sort state, carried in the URL (see
   // lib/nircam-exposure-nav.ts). Defines the ordered set prev/next walks;
   // empty params (direct entry) = the full unfiltered set, so nav always works.
-  const navFilters = useMemo(
-    () => parseExposureNavParams(new URLSearchParams(searchParams.toString())),
-    [searchParams],
-  );
+  // Memoized on the query STRING, not the searchParams object: Next mints a
+  // fresh searchParams instance after every history.pushState (i.e. every
+  // prev/next step) even when the query is unchanged, and an identity-keyed
+  // memo re-fired the neighbors fetch below a second time per step.
   const navQuery = searchParams.toString();
+  const navFilters = useMemo(
+    () => parseExposureNavParams(new URLSearchParams(navQuery)),
+    [navQuery],
+  );
 
   const [exposure, setExposure] = useState<NircamExposure | null>(null);
   const [exposureForId, setExposureForId] = useState<number | null>(null);
@@ -143,371 +155,27 @@ function ExposureDetailPageInner() {
   // record — not React state — is the authoritative "what did the operator
   // decide, for which exposure". It is written synchronously on every edit,
   // so the save flush never depends on a re-render having happened.
-  const localEditsRef = useRef<{
-    forId: number | null;
-    dirty: { reviewStatus: boolean; correction: boolean; notes: boolean };
-    values: { reviewStatus: string; correction: string; notes: string };
-    saved: boolean;
-  }>({
+  const localEditsRef = useRef<TriageEdits>({
     forId: null,
     dirty: { reviewStatus: false, correction: false, notes: false },
     values: { reviewStatus: 'pending', correction: 'none', notes: '' },
     saved: false,
   });
-  // Every edit targets idRef.current — the exposure the operator believes is
-  // (or is about to be) on screen — NOT whatever the last committed render
-  // showed. The keyboard handler is a native document listener, so its
-  // setState calls get default priority and can lag: press `→` then `2`
-  // quickly and the `2` fires while the id transition is still uncommitted.
-  // Untargeted, that edit lands on the OLD record and the incoming render
-  // reset wipes it — the status flashes Approved for a frame, reverts to
-  // Pending, and the next flush has nothing dirty to save. Retargeting stages
-  // the edit for the incoming exposure; the reset below re-applies it instead
-  // of wiping it.
-  const targetEdits = useCallback(() => {
-    const target = idRef.current;
-    if (localEditsRef.current.forId !== target) {
-      localEditsRef.current = {
-        forId: target,
-        dirty: { reviewStatus: false, correction: false, notes: false },
-        // Baselines for as-yet-untouched fields; only dirty fields are ever
-        // read out of `values`, so stale entries here are never used.
-        values: {
-          reviewStatus: stateRef.current.reviewStatus,
-          correction: stateRef.current.correction,
-          notes: stateRef.current.notes,
-        },
-        saved: false,
-      };
-    }
-    return localEditsRef.current;
-  }, []);
-  const editStatus = useCallback((v: string) => {
-    const edits = targetEdits();
-    edits.dirty.reviewStatus = true;
-    edits.values.reviewStatus = v;
-    stateRef.current.reviewStatus = v;
-    setReviewStatus(v);
-  }, [targetEdits]);
-  const editCorrection = useCallback((v: string) => {
-    const edits = targetEdits();
-    edits.dirty.correction = true;
-    edits.values.correction = v;
-    stateRef.current.correction = v;
-    setCorrection(v);
-  }, [targetEdits]);
-  const editNotes = useCallback((v: string) => {
-    const edits = targetEdits();
-    edits.dirty.notes = true;
-    edits.values.notes = v;
-    stateRef.current.notes = v;
-    setNotes(v);
-  }, [targetEdits]);
-
-  // Sibling-exposure nav: the ±window neighbors + absolute position within
-  // the filtered, ordered set, from get_admin_exposure_neighbors. Survives
-  // refresh and direct entry because the filter context lives in the URL.
-  // Tagged with the id it was fetched for: `id` changes the instant we push, but
-  // the neighbors RPC for the new exposure takes another round trip to land.
-  const [navState, setNavState] = useState<
-    { forId: number; data: ExposureNeighbors } | null
-  >(null);
-  const [showHelp, setShowHelp] = useState(false);
-  // N4 (epic #261): live FITS render vs the legacy pre-generated PNG. Defaults
-  // to PNG; the toggle doubles as the pixel-parity check during the rollout.
-  const [viewMode, setViewMode] = useState<'png' | 'fits'>('png');
-  // Presigned OSN GET URLs (epic #261, N5) live in a MODULE-level cache
-  // (getCachedPngUrls) — NOT React state — because this page remounts on every
-  // prev/next, which would otherwise wipe them and force a fresh presign (new
-  // signature) on each step, flashing the spinner and missing the retained PNG.
-  // This reducer just forces a re-render when a presign lands so the pending
-  // spinner clears and the <img> picks up the freshly-cached URL.
-  const [, bumpPngUrls] = useReducer((n: number) => n + 1, 0);
-  useEffect(() => {
-    let cancelled = false;
-    getExposureNeighbors(id, { ...navFilters, window: PREFETCH_AHEAD }).then((res) => {
-      if (cancelled) return;
-      setNavState(res.error || res.total === 0 ? null : { forId: id, data: res });
-    });
-    return () => { cancelled = true; };
-  }, [id, navFilters]);
-
-  // While that RPC is in flight, `navState` still describes the exposure we just
-  // left, and using it verbatim mis-targets both arrows: → points at the current
-  // exposure (a no-op push, so hammering → appears to stick) and ← skips one.
-  // The stale window almost always already contains the new id, so re-derive
-  // prev/next/position from it — instant and correct for the single-step case.
-  // Only when the new id falls outside that window do we report "no nav" and let
-  // the arrows sit disabled for the ~100 ms until the fresh result lands.
-  const nav = useMemo<ExposureNeighbors | null>(() => {
-    if (!navState) return null;
-    if (navState.forId === id) return navState.data;
-    const stale = navState.data;
-    const idx = stale.windowIds.indexOf(id);
-    const fromIdx = stale.windowIds.indexOf(navState.forId);
-    if (idx < 0 || fromIdx < 0) return null;
-    return {
-      prevId: idx > 0 ? stale.windowIds[idx - 1] : null,
-      nextId: idx < stale.windowIds.length - 1 ? stale.windowIds[idx + 1] : null,
-      position: stale.position != null ? stale.position + (idx - fromIdx) : null,
-      total: stale.total,
-      windowIds: stale.windowIds,
-    };
-  }, [navState, id]);
-
-  // When the route id changes, reset state synchronously from the in-memory
-  // cache so the new exposure paints in the same frame as the URL change —
-  // no spinner, no flash of the previous exposure. The server is hit in the
-  // background to revalidate. (React's "set state during render" pattern,
-  // bounded by the exposureForId guard so we don't loop.)
-  if (exposureForId !== id) {
-    const cached = getCachedExposure(id);
-    // Edits keyed to the incoming id were staged by a keypress that raced this
-    // transition (see targetEdits) — they are the operator's decision for THIS
-    // exposure and must be applied over the cached baseline, not wiped.
-    const staged = localEditsRef.current.forId === id ? localEditsRef.current : null;
-    setExposureForId(id);
-    setExposure(cached);
-    setReviewStatus(staged?.dirty.reviewStatus
-      ? staged.values.reviewStatus : (cached?.review_status || 'pending'));
-    setCorrection(staged?.dirty.correction
-      ? staged.values.correction : (cached?.correction || 'none'));
-    setNotes(staged?.dirty.notes
-      ? staged.values.notes : (cached?.notes || ''));
-    setLoading(!cached);
-    setError(null);
-    setSaved(false);
-    if (!staged) {
-      localEditsRef.current = {
-        forId: id,
-        dirty: { reviewStatus: false, correction: false, notes: false },
-        values: {
-          reviewStatus: cached?.review_status || 'pending',
-          correction: cached?.correction || 'none',
-          notes: cached?.notes || '',
-        },
-        saved: false,
-      };
-    }
-  }
-
-  // Background revalidation against the DB on every id change. Auto-save on
-  // navigation has already flushed the *previous* exposure's triage state, so
-  // arriving clean means the server's values win. But this read races the
-  // operator: anything they've typed or keyed since arriving, and any save that
-  // has already landed, is newer than this response and must survive it.
-  useEffect(() => {
-    let cancelled = false;
-    // Captured before the read is issued: a save in flight NOW means the
-    // response may reflect pre-save state even if the save has finished (and
-    // cleared its pending marker) by the time the response resolves.
-    const pendingAtStart = hasPendingSave(id);
-    (async () => {
-      const result = await getNircamExposureById(id);
-      if (cancelled) return;
-      if (result.error) {
-        setError(result.error);
-        setLoading(false);
-        return;
-      }
-      if (result.exposure) {
-        // The edits record only speaks for this exposure when tagged with its
-        // id (a mid-transition keypress can retarget it — see targetEdits).
-        const edits = localEditsRef.current;
-        const ours = edits.forId === id;
-        // A save for this exposure already landed — our write is strictly newer
-        // than this read, so don't let it back into state *or* the cache. Same
-        // for a save in flight at either end of this read (fire-and-forget
-        // auto-save on nav, then a quick revisit): the optimistic or
-        // save-confirmed row is newer than what this read may have seen.
-        const pending = pendingAtStart || hasPendingSave(id);
-        if (!(ours && edits.saved) && !pending) {
-          setCachedExposure(result.exposure);
-          setExposure(result.exposure);
-        }
-        // Per field: an untouched control still takes the fresh server value.
-        if (!(ours && edits.dirty.reviewStatus) && !pending) setReviewStatus(result.exposure.review_status);
-        if (!(ours && edits.dirty.correction) && !pending) setCorrection(result.exposure.correction);
-        if (!(ours && edits.dirty.notes) && !pending) setNotes(result.exposure.notes || '');
-      }
-      setLoading(false);
-    })();
-    return () => { cancelled = true; };
-  }, [id]);
-
-  // Warm the sibling exposure *data* cache (prev/next) so navigation paints in
-  // the same frame — independent of PNG bytes.
-  useEffect(() => {
-    if (!nav) return;
-    for (const sibId of [nav.nextId, nav.prevId]) {
-      if (sibId == null || getCachedExposure(sibId)) continue;
-      getNircamExposureById(sibId).then((res) => {
-        // Re-checked at RESPONSE time, not just dispatch: the operator can
-        // arrive at this sibling and key a decision while this read is in
-        // flight (one slow round trip is all it takes). Any cache entry that
-        // appeared since dispatch — the optimistic row or a save confirmation
-        // — is strictly newer than what this read saw, and a pending save with
-        // no cache entry (row never loaded) outranks it too. Overwriting here
-        // painted the pre-decision row on the next revisit as if the decision
-        // had reverted.
-        if (!res.exposure) return;
-        if (getCachedExposure(sibId) || hasPendingSave(sibId)) return;
-        setCachedExposure(res.exposure);
-      });
-    }
-  }, [nav]);
-
-  // Presign the current exposure's PNGs + eagerly prefetch a window of upcoming
-  // ones (epic #261, N5). Keys are re-derived server-side; URLs go straight into
-  // <img> (no proxy hop). We warm the full-res mask surface (~5.7 MB) — the byte
-  // the editor actually renders — across the whole window, keyed off the
-  // *persistent* URL map so a sibling presigned by an earlier window is still
-  // warmed on every step. (Previously the warm keyed off only the freshly-signed
-  // ids, so once the next exposure had been presigned by a prior window its full
-  // PNG was never prefetched again — every Next reloaded it cold from OSN.)
-  useEffect(() => {
-    if (!nav) return;
-    // Derive the prefetch window from the neighbors RPC result: ahead-heavy
-    // slice of the ordered window ids around the current exposure.
-    const idx = nav.windowIds.indexOf(id);
-    if (idx < 0) return;
-    const win = [
-      ...nav.windowIds.slice(idx + 1, idx + 1 + PREFETCH_AHEAD),
-      ...nav.windowIds.slice(Math.max(0, idx - PREFETCH_BEHIND), idx),
-    ];
-    // Warm the exact byte the viewer will show for each windowed exposure: the
-    // full-res mask surface the editor renders, or the preview when there's no
-    // full PNG. Re-warming an already-cached URL is a browser cache hit, so the
-    // only new network per step is the frontier exposure entering the window.
-    const warm = () => {
-      for (const sib of win) {
-        const u = getCachedPngUrls(sib);
-        if (u) prefetchPng(u.full ?? u.preview);
-      }
-    };
-    // Only presign ids not already in the module cache (a cached sibling keeps
-    // its URL); when the whole window is already signed, just re-warm.
-    const batch = [id, ...win].filter((x) => getCachedPngUrls(x) === undefined);
-    if (batch.length === 0) {
-      warm();
-      return;
-    }
-    let cancelled = false;
-    presignExposurePngs(batch).then((urls) => {
-      // Populate the module cache even if this instance unmounted mid-flight —
-      // the URLs are valid for whichever instance renders the exposure next.
-      for (const [key, u] of Object.entries(urls)) setCachedPngUrls(Number(key), u);
-      if (cancelled) return;
-      bumpPngUrls();
-      warm();
-    });
-    return () => { cancelled = true; };
-  }, [id, nav]);
-
-  const hasChanges = !!(exposure && (
-    reviewStatus !== exposure.review_status ||
-    correction !== exposure.correction ||
-    notes !== (exposure.notes || '')
-  ));
-
-  // Latest-state ref so the keyboard handler doesn't capture stale closures.
-  const stateRef = useRef({ reviewStatus, correction, notes, hasChanges, exposure });
-  stateRef.current = { reviewStatus, correction, notes, hasChanges, exposure };
-
-  // The last failed fire-and-forget save (module store — survives the remount
-  // on navigation, so the failure surfaces even though the operator is several
-  // exposures ahead by the time the response lands).
-  useSyncExternalStore(subscribeSaveState, getSaveStateVersion, getSaveStateVersion);
-  const saveError = getSaveError();
-
-  // Warn before unload while fire-and-forget saves are still in flight — a
-  // closed tab takes the in-flight decision (and any failure banner) with it.
-  useEffect(() => {
-    const handler = (e: BeforeUnloadEvent) => {
-      if (hasAnyPendingSave()) e.preventDefault();
-    };
-    window.addEventListener('beforeunload', handler);
-    return () => window.removeEventListener('beforeunload', handler);
-  }, []);
-
-  // A failed save reverts the cached row to the server's truth; if that
-  // exposure is the one on screen, re-baseline `exposure` from the cache so
-  // hasChanges compares against reality and a retry actually fires (otherwise
-  // the optimistic row read at mount claims the decision already stuck).
-  useEffect(() => {
-    if (saveError?.id !== id) return;
-    const cached = getCachedExposure(id);
-    if (cached) setExposure(cached);
-  }, [saveError, id]);
-
-  const handleSave = useCallback(async (): Promise<{ ok: boolean }> => {
-    const s = stateRef.current;
-    // No baseline row yet (direct entry, still loading): the controls hold
-    // defaults, and saving them would overwrite the row's real correction and
-    // notes with 'none' / ''.
-    if (!s.exposure) return { ok: false };
-    // The exposure this save is for. The `S` shortcut fires handleSave
-    // un-awaited and mask saves aren't gated by navigation at all — so a
-    // response can land after the route moved on.
-    const savedForId = id;
-    setSaving(true);
-    setSaved(false);
-    setError(null);
-    // Same per-exposure queue as the fire-and-forget nav save, so an explicit
-    // save and a background one for this row can't commit out of order. Takes
-    // a dispatch generation for the same reason: a success here must be
-    // visible to an older failed save's suspended cleanup handler.
-    const saveSeq = nextSaveSeq(savedForId);
-    const result = await enqueueSave(savedForId, () => updateExposureReview(savedForId, {
-      review_status: s.reviewStatus as NircamExposure['review_status'],
-      correction: s.correction as NircamExposure['correction'],
-      // Always sent (even '') so clearing the notes field actually persists —
-      // an undefined key is dropped from the PATCH and leaves the old value.
-      notes: s.notes,
-    })).catch((err: unknown) => ({
-      exposure: null,
-      error: err instanceof Error ? err.message : 'Save failed',
-    }));
-    setSaving(false);
-    if (result.error) {
-      // Surfaced even if we've navigated on: a failed save means the operator's
-      // decision didn't stick, which they need to know about either way.
-      setError(result.error);
-      return { ok: false };
-    }
-    // Keyed by the exposure's own id, so this is correct regardless of route.
-    if (result.exposure) {
-      markSaveCommitted(savedForId, saveSeq);
-      // Same guard as the fire-and-forget success path: a newer save queued
-      // behind this one (edit + navigate before this resolved) has already
-      // written its optimistic row — don't put this older row over it.
-      if (!hasPendingSave(savedForId)) setCachedExposure(result.exposure);
-      // A retry that lands supersedes an earlier failure for this exposure —
-      // same rule as the fire-and-forget path, or the banner outlives the fix.
-      if (getSaveError()?.id === savedForId) setSaveError(null);
-    }
-    // Everything below writes state belonging to whatever is on screen *now* —
-    // only safe while that's still the exposure we saved. Otherwise this would
-    // render the old exposure under the new one's URL and set the new one's
-    // `saved` guard, permanently suppressing its revalidation.
-    if (localEditsRef.current.forId !== savedForId) return { ok: true };
-    if (result.exposure) {
-      localEditsRef.current.saved = true;
-      setExposure(result.exposure);
-    }
-    setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
-    return { ok: true };
-  }, [id]);
+  // An outgoing edits record displaced by the id-change reset below while
+  // still carrying un-dispatched edits — an id change that bypassed goTo
+  // (popstate, a route link). Render must stay side-effect free, so the reset
+  // stashes the record here and the effect right after it dispatches.
+  const pendingNavFlushRef = useRef<TriageEdits | null>(null);
 
   // Fire-and-forget flush of the operator's dirty triage state — the write
-  // half of auto-save-on-nav, also used by the back-to-list button. The
-  // decision goes into the row cache optimistically (that's what the next
-  // visit paints from) and the server action fires without blocking the
-  // caller. The pending-save registry keeps a quick revisit's revalidation
-  // from resurrecting the pre-save row; a failure reverts the cache to the
-  // server's truth and raises the module save-error banner, since this
-  // instance is usually gone by then.
+  // half of auto-save-on-nav, also used by the back-to-list button, the
+  // unmount cleanup, and the id-change reset's stash (navigations that bypass
+  // goTo: browser back/forward, in-app links). The decision goes into the row
+  // cache optimistically (that's what the next visit paints from) and the
+  // server action fires without blocking the caller. The pending-save registry
+  // keeps a quick revisit's revalidation from resurrecting the pre-save row; a
+  // failure reverts the cache to the server's truth and raises the module
+  // save-error banner, since this instance is usually gone by then.
   //
   // The save is built from the edits record ALONE — forId says which exposure,
   // dirty says which fields, values says what the operator chose, all written
@@ -517,12 +185,18 @@ function ExposureDetailPageInner() {
   // saves to the right row. The update is PARTIAL: only touched fields are
   // sent, so a not-yet-loaded row's untouched values can never be overwritten
   // with defaults.
-  const flushDirtySave = useCallback(() => {
+  //
+  // The record's dirty flags are consumed (cleared) synchronously at dispatch,
+  // which makes every caller idempotent: one navigation can route through
+  // several of them (goTo, then the reset stash, then unmount) and only the
+  // first with something dirty actually sends.
+  const flushDirtySave = useCallback((record?: TriageEdits) => {
     const s = stateRef.current;
-    const edits = localEditsRef.current;
+    const edits = record ?? localEditsRef.current;
     if (edits.forId == null) return;
     const savedForId = edits.forId;
-    const dirty = edits.dirty;
+    const dirty = { ...edits.dirty };
+    edits.dirty = { reviewStatus: false, correction: false, notes: false };
     if (!dirty.reviewStatus && !dirty.correction && !dirty.notes) return;
 
     // Baseline for no-op detection and the optimistic write: the on-screen row
@@ -619,6 +293,474 @@ function ExposureDetailPageInner() {
     }
   }, []);
 
+  // Every edit targets idRef.current — the exposure the operator believes is
+  // (or is about to be) on screen — NOT whatever the last committed render
+  // showed. The keyboard handler is a native document listener, so its
+  // setState calls get default priority and can lag: press `→` then `2`
+  // quickly and the `2` fires while the id transition is still uncommitted.
+  // Untargeted, that edit lands on the OLD record and the incoming render
+  // reset wipes it — the status flashes Approved for a frame, reverts to
+  // Pending, and the next flush has nothing dirty to save. Retargeting stages
+  // the edit for the incoming exposure; the reset below re-applies it instead
+  // of wiping it.
+  const targetEdits = useCallback(() => {
+    const target = idRef.current;
+    if (localEditsRef.current.forId !== target) {
+      // The outgoing record may still carry un-dispatched edits when the id
+      // changed without goTo (browser back/forward followed by an instant
+      // keypress) — dispatch them before the record is replaced, or the
+      // previous exposure's decision is silently dropped. Idempotent: goTo's
+      // own flush has already consumed the dirty flags on the normal path.
+      flushDirtySave();
+      localEditsRef.current = {
+        forId: target,
+        dirty: { reviewStatus: false, correction: false, notes: false },
+        // Baselines for as-yet-untouched fields; only dirty fields are ever
+        // read out of `values`, so stale entries here are never used.
+        values: {
+          reviewStatus: stateRef.current.reviewStatus,
+          correction: stateRef.current.correction,
+          notes: stateRef.current.notes,
+        },
+        saved: false,
+      };
+    }
+    return localEditsRef.current;
+  }, [flushDirtySave]);
+  const editStatus = useCallback((v: string) => {
+    const edits = targetEdits();
+    edits.dirty.reviewStatus = true;
+    edits.values.reviewStatus = v;
+    stateRef.current.reviewStatus = v;
+    setReviewStatus(v);
+  }, [targetEdits]);
+  const editCorrection = useCallback((v: string) => {
+    const edits = targetEdits();
+    edits.dirty.correction = true;
+    edits.values.correction = v;
+    stateRef.current.correction = v;
+    setCorrection(v);
+  }, [targetEdits]);
+  const editNotes = useCallback((v: string) => {
+    const edits = targetEdits();
+    edits.dirty.notes = true;
+    edits.values.notes = v;
+    stateRef.current.notes = v;
+    setNotes(v);
+  }, [targetEdits]);
+
+  // Sibling-exposure nav: the ±window neighbors + absolute position within
+  // the filtered, ordered set, from get_admin_exposure_neighbors. Survives
+  // refresh and direct entry because the filter context lives in the URL.
+  // Tagged with the id it was fetched for: `id` changes the instant we push, but
+  // the neighbors RPC for the new exposure takes another round trip to land.
+  const [navState, setNavState] = useState<
+    { forId: number; data: ExposureNeighbors } | null
+  >(null);
+  const [showHelp, setShowHelp] = useState(false);
+  // N4 (epic #261): live FITS render vs the legacy pre-generated PNG. Defaults
+  // to PNG; the toggle doubles as the pixel-parity check during the rollout.
+  const [viewMode, setViewMode] = useState<'png' | 'fits'>('png');
+  // Presigned OSN GET URLs (epic #261, N5) live in a MODULE-level cache
+  // (getCachedPngUrls) — NOT React state — because this page remounts on every
+  // prev/next, which would otherwise wipe them and force a fresh presign (new
+  // signature) on each step, flashing the spinner and missing the retained PNG.
+  // This reducer just forces a re-render when a presign lands so the pending
+  // spinner clears and the <img> picks up the freshly-cached URL.
+  const [, bumpPngUrls] = useReducer((n: number) => n + 1, 0);
+  // Ids with a presign batch currently in flight (the current-exposure sign
+  // and the window prefetch can otherwise race the same id into two batches),
+  // and ids whose last presign attempt failed — those render a retry panel
+  // instead of the spinner, which used to sit forever on a failed sign.
+  const presignInFlightRef = useRef<Set<number>>(new Set());
+  const [presignFailed, setPresignFailed] = useState<ReadonlySet<number>>(() => new Set());
+  const [presignRetry, bumpPresignRetry] = useReducer((n: number) => n + 1, 0);
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    // A transient RPC/transport failure used to kill navigation for this
+    // exposure outright (dead arrows until the id changed) — retry a couple
+    // of times with backoff before giving up.
+    const attempt = (tryNo: number) => {
+      getExposureNeighbors(id, { ...navFilters, window: PREFETCH_AHEAD })
+        .then(
+          (res) => {
+            if (cancelled) return;
+            if (res.error && tryNo < 2) {
+              timer = setTimeout(() => attempt(tryNo + 1), 1000 * (tryNo + 1));
+              return;
+            }
+            setNavState(res.error || res.total === 0 ? null : { forId: id, data: res });
+          },
+          () => {
+            if (cancelled) return;
+            if (tryNo < 2) timer = setTimeout(() => attempt(tryNo + 1), 1000 * (tryNo + 1));
+            else setNavState(null);
+          },
+        );
+    };
+    attempt(0);
+    return () => {
+      cancelled = true;
+      if (timer !== undefined) clearTimeout(timer);
+    };
+  }, [id, navFilters]);
+
+  // While that RPC is in flight, `navState` still describes the exposure we just
+  // left, and using it verbatim mis-targets both arrows: → points at the current
+  // exposure (a no-op push, so hammering → appears to stick) and ← skips one.
+  // The stale window almost always already contains the new id, so re-derive
+  // prev/next/position from it — instant and correct for the single-step case.
+  // Only when the new id falls outside that window do we report "no nav" and let
+  // the arrows sit disabled for the ~100 ms until the fresh result lands.
+  const nav = useMemo<ExposureNeighbors | null>(() => {
+    if (!navState) return null;
+    if (navState.forId === id) return navState.data;
+    const stale = navState.data;
+    const idx = stale.windowIds.indexOf(id);
+    const fromIdx = stale.windowIds.indexOf(navState.forId);
+    if (idx < 0 || fromIdx < 0) return null;
+    return {
+      prevId: idx > 0 ? stale.windowIds[idx - 1] : null,
+      nextId: idx < stale.windowIds.length - 1 ? stale.windowIds[idx + 1] : null,
+      position: stale.position != null ? stale.position + (idx - fromIdx) : null,
+      total: stale.total,
+      windowIds: stale.windowIds,
+    };
+  }, [navState, id]);
+
+  // When the route id changes, reset state synchronously from the in-memory
+  // cache so the new exposure paints in the same frame as the URL change —
+  // no spinner, no flash of the previous exposure. The server is hit in the
+  // background to revalidate. (React's "set state during render" pattern,
+  // bounded by the exposureForId guard so we don't loop.)
+  if (exposureForId !== id) {
+    const cached = getCachedExposure(id);
+    // Edits keyed to the incoming id were staged by a keypress that raced this
+    // transition (see targetEdits) — they are the operator's decision for THIS
+    // exposure and must be applied over the cached baseline, not wiped.
+    const staged = localEditsRef.current.forId === id ? localEditsRef.current : null;
+    setExposureForId(id);
+    setExposure(cached);
+    setReviewStatus(staged?.dirty.reviewStatus
+      ? staged.values.reviewStatus : (cached?.review_status || 'pending'));
+    setCorrection(staged?.dirty.correction
+      ? staged.values.correction : (cached?.correction || 'none'));
+    setNotes(staged?.dirty.notes
+      ? staged.values.notes : (cached?.notes || ''));
+    setLoading(!cached);
+    setError(null);
+    setSaved(false);
+    if (!staged) {
+      // The record being displaced belongs to the exposure we just left. On
+      // the goTo path its dirty flags were already consumed; when the id
+      // changed some other way (browser back/forward, a route link) they can
+      // still be live — stash the record for the flush effect below instead
+      // of silently dropping the decision with it.
+      const outgoing = localEditsRef.current;
+      if (outgoing.forId !== null && outgoing.forId !== id &&
+          (outgoing.dirty.reviewStatus || outgoing.dirty.correction || outgoing.dirty.notes)) {
+        pendingNavFlushRef.current = outgoing;
+      }
+      localEditsRef.current = {
+        forId: id,
+        dirty: { reviewStatus: false, correction: false, notes: false },
+        values: {
+          reviewStatus: cached?.review_status || 'pending',
+          correction: cached?.correction || 'none',
+          notes: cached?.notes || '',
+        },
+        saved: false,
+      };
+    }
+  }
+
+  // Dispatch a record stashed by the reset above. No dep array: the stash can
+  // be written by any render, and the check is a ref read — nearly always null.
+  useEffect(() => {
+    const record = pendingNavFlushRef.current;
+    if (record) {
+      pendingNavFlushRef.current = null;
+      flushDirtySave(record);
+    }
+  });
+
+  // Leaving the page entirely (list link, sidebar, any route change that
+  // unmounts this instance) must not drop a keyed decision either.
+  useEffect(() => () => flushDirtySave(), [flushDirtySave]);
+
+  // Background revalidation against the DB on every id change. Auto-save on
+  // navigation has already flushed the *previous* exposure's triage state, so
+  // arriving clean means the server's values win. But this read races the
+  // operator: anything they've typed or keyed since arriving, and any save that
+  // has already landed, is newer than this response and must survive it.
+  useEffect(() => {
+    let cancelled = false;
+    // Captured before the read is issued: a save in flight NOW means the
+    // response may reflect pre-save state even if the save has finished (and
+    // cleared its pending marker) by the time the response resolves.
+    const pendingAtStart = hasPendingSave(id);
+    (async () => {
+      const result = await getNircamExposureById(id);
+      if (cancelled) return;
+      if (result.error) {
+        setError(result.error);
+        setLoading(false);
+        return;
+      }
+      if (result.exposure) {
+        // The edits record only speaks for this exposure when tagged with its
+        // id (a mid-transition keypress can retarget it — see targetEdits).
+        const edits = localEditsRef.current;
+        const ours = edits.forId === id;
+        // A save for this exposure already landed — our write is strictly newer
+        // than this read, so don't let it back into state *or* the cache. Same
+        // for a save in flight at either end of this read (fire-and-forget
+        // auto-save on nav, then a quick revisit): the optimistic or
+        // save-confirmed row is newer than what this read may have seen.
+        const pending = pendingAtStart || hasPendingSave(id);
+        if (!(ours && edits.saved) && !pending) {
+          setCachedExposure(result.exposure);
+          setExposure(result.exposure);
+        }
+        // Per field: an untouched control still takes the fresh server value.
+        // `saved` shields every field, not just dirty ones: once a save has
+        // landed, its dirty flags are consumed, but this read may still
+        // predate the save — its values are stale for anything the save wrote.
+        if (!(ours && (edits.dirty.reviewStatus || edits.saved)) && !pending) setReviewStatus(result.exposure.review_status);
+        if (!(ours && (edits.dirty.correction || edits.saved)) && !pending) setCorrection(result.exposure.correction);
+        if (!(ours && (edits.dirty.notes || edits.saved)) && !pending) setNotes(result.exposure.notes || '');
+      }
+      setLoading(false);
+    })();
+    return () => { cancelled = true; };
+  }, [id]);
+
+  // Warm the sibling exposure *data* cache (prev/next) so navigation paints in
+  // the same frame — independent of PNG bytes.
+  useEffect(() => {
+    if (!nav) return;
+    for (const sibId of [nav.nextId, nav.prevId]) {
+      if (sibId == null || getCachedExposure(sibId)) continue;
+      getNircamExposureById(sibId).then((res) => {
+        // Re-checked at RESPONSE time, not just dispatch: the operator can
+        // arrive at this sibling and key a decision while this read is in
+        // flight (one slow round trip is all it takes). Any cache entry that
+        // appeared since dispatch — the optimistic row or a save confirmation
+        // — is strictly newer than what this read saw, and a pending save with
+        // no cache entry (row never loaded) outranks it too. Overwriting here
+        // painted the pre-decision row on the next revisit as if the decision
+        // had reverted.
+        if (!res.exposure) return;
+        if (getCachedExposure(sibId) || hasPendingSave(sibId)) return;
+        setCachedExposure(res.exposure);
+      });
+    }
+  }, [nav]);
+
+  // Presign the current exposure's PNGs + eagerly prefetch a window of upcoming
+  // ones (epic #261, N5). Keys are re-derived server-side; URLs go straight into
+  // <img> (no proxy hop). We warm the full-res mask surface (~5.7 MB) — the byte
+  // the editor actually renders — across the whole window, keyed off the
+  // *persistent* URL map so a sibling presigned by an earlier window is still
+  // warmed on every step. (Previously the warm keyed off only the freshly-signed
+  // ids, so once the next exposure had been presigned by a prior window its full
+  // PNG was never prefetched again — every Next reloaded it cold from OSN.)
+  //
+  // The CURRENT exposure is signed even while `nav` is null: the neighbors RPC
+  // returns nothing for an exposure outside the URL's filter set (e.g.
+  // revisiting an approved exposure with review=pending still in the query),
+  // and gating the sign on it left the image panel on a spinner forever.
+  useEffect(() => {
+    // Prefetch window from the neighbors RPC result, when available:
+    // ahead-heavy slice of the ordered window ids around the current exposure.
+    const win: number[] = [];
+    if (nav) {
+      const idx = nav.windowIds.indexOf(id);
+      if (idx >= 0) {
+        win.push(
+          ...nav.windowIds.slice(idx + 1, idx + 1 + PREFETCH_AHEAD),
+          ...nav.windowIds.slice(Math.max(0, idx - PREFETCH_BEHIND), idx),
+        );
+      }
+    }
+    // Warm the exact byte the viewer will show for each windowed exposure: the
+    // full-res mask surface the editor renders, or the preview when there's no
+    // full PNG. Re-warming an already-cached URL is a browser cache hit, so the
+    // only new network per step is the frontier exposure entering the window.
+    const warm = () => {
+      for (const sib of win) {
+        const u = getCachedPngUrls(sib);
+        if (u) prefetchPng(u.full ?? u.preview);
+      }
+    };
+    // Only presign ids not already in the module cache (a cached sibling keeps
+    // its URL) and not already being signed by an earlier run of this effect;
+    // when the whole window is already covered, just re-warm.
+    const inflight = presignInFlightRef.current;
+    const batch = [id, ...win].filter(
+      (x) => getCachedPngUrls(x) === undefined && !inflight.has(x),
+    );
+    if (batch.length === 0) {
+      warm();
+      return;
+    }
+    for (const x of batch) inflight.add(x);
+    presignExposurePngs(batch)
+      .then(
+        (res) => {
+          // Populate the module cache even if this instance unmounted
+          // mid-flight — the URLs are valid for whichever instance renders
+          // the exposure next. Ids the action could not sign are absent from
+          // `res.urls` and deliberately NOT cached: a transient failure
+          // cached as "no PNG" used to blank the viewer for ~50 minutes.
+          for (const [key, u] of Object.entries(res.urls)) {
+            setCachedPngUrls(Number(key), u);
+          }
+        },
+        // Transport-level rejection (previously unhandled: the spinner sat
+        // forever) — every batched id stays uncached and gets marked failed.
+        () => {},
+      )
+      .then(() => {
+        for (const x of batch) inflight.delete(x);
+        // Anything still uncached after the response failed to sign — flip it
+        // to the retry panel; anything now cached clears its failure mark.
+        // Deliberately NOT gated on this effect instance still being live: a
+        // later run skipped these in-flight ids, so this response is the only
+        // thing that can clear their spinner (a post-unmount set is a no-op).
+        const missing = batch.filter((x) => getCachedPngUrls(x) === undefined);
+        setPresignFailed((prev) => {
+          const next = new Set(prev);
+          for (const x of batch) next.delete(x);
+          for (const x of missing) next.add(x);
+          return next;
+        });
+        bumpPngUrls();
+        warm();
+      });
+  }, [id, nav, presignRetry]);
+
+  const hasChanges = !!(exposure && (
+    reviewStatus !== exposure.review_status ||
+    correction !== exposure.correction ||
+    notes !== (exposure.notes || '')
+  ));
+
+  // Latest-state ref so the keyboard handler doesn't capture stale closures.
+  const stateRef = useRef({ reviewStatus, correction, notes, hasChanges, exposure });
+  stateRef.current = { reviewStatus, correction, notes, hasChanges, exposure };
+
+  // The last failed fire-and-forget save (module store — survives the remount
+  // on navigation, so the failure surfaces even though the operator is several
+  // exposures ahead by the time the response lands).
+  useSyncExternalStore(subscribeSaveState, getSaveStateVersion, getSaveStateVersion);
+  const saveError = getSaveError();
+
+  // Warn before unload while fire-and-forget saves are still in flight — a
+  // closed tab takes the in-flight decision (and any failure banner) with it.
+  // Dirty-but-undispatched edits warn too: a keyed decision that hasn't been
+  // followed by a navigation (e.g. `2` on the last exposure of the queue) has
+  // not even started saving, and unload would silently drop it.
+  useEffect(() => {
+    const handler = (e: BeforeUnloadEvent) => {
+      const d = localEditsRef.current.dirty;
+      if (hasAnyPendingSave() || d.reviewStatus || d.correction || d.notes) {
+        e.preventDefault();
+      }
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, []);
+
+  // A failed save reverts the cached row to the server's truth; if that
+  // exposure is the one on screen, re-baseline `exposure` from the cache so
+  // hasChanges compares against reality and a retry actually fires (otherwise
+  // the optimistic row read at mount claims the decision already stuck).
+  useEffect(() => {
+    if (saveError?.id !== id) return;
+    const cached = getCachedExposure(id);
+    if (cached) setExposure(cached);
+  }, [saveError, id]);
+
+  const handleSave = useCallback(async (): Promise<{ ok: boolean }> => {
+    const s = stateRef.current;
+    // No baseline row yet (direct entry, still loading): the controls hold
+    // defaults, and saving them would overwrite the row's real correction and
+    // notes with 'none' / ''.
+    if (!s.exposure) return { ok: false };
+    // The exposure this save is for. The `S` shortcut fires handleSave
+    // un-awaited and mask saves aren't gated by navigation at all — so a
+    // response can land after the route moved on.
+    const savedForId = id;
+    // This dispatch takes responsibility for everything currently staged:
+    // consume the dirty flags so a following navigation's flush doesn't
+    // re-send the same decision. Anything keyed after this line re-dirties.
+    if (localEditsRef.current.forId === savedForId) {
+      localEditsRef.current.dirty = { reviewStatus: false, correction: false, notes: false };
+    }
+    setSaving(true);
+    setSaved(false);
+    setError(null);
+    // Same per-exposure queue as the fire-and-forget nav save, so an explicit
+    // save and a background one for this row can't commit out of order. Takes
+    // a dispatch generation for the same reason: a success here must be
+    // visible to an older failed save's suspended cleanup handler. Marked
+    // pending like every other save so an in-flight revalidation (dispatched
+    // before this save, resolving after) can't write the pre-save row back
+    // over the operator's decision now that the dirty flags are consumed.
+    const saveSeq = nextSaveSeq(savedForId);
+    beginPendingSave(savedForId);
+    const result = await enqueueSave(savedForId, () => updateExposureReview(savedForId, {
+      review_status: s.reviewStatus as NircamExposure['review_status'],
+      correction: s.correction as NircamExposure['correction'],
+      // Always sent (even '') so clearing the notes field actually persists —
+      // an undefined key is dropped from the PATCH and leaves the old value.
+      notes: s.notes,
+    })).catch((err: unknown) => ({
+      exposure: null,
+      error: err instanceof Error ? err.message : 'Save failed',
+    }));
+    endPendingSave(savedForId);
+    setSaving(false);
+    if (result.error) {
+      // The decision did NOT persist — put the dirty flags back (all of them:
+      // the values are the operator's current choices, and the flush diffs
+      // against the baseline row anyway) so a later navigation retries the
+      // save instead of treating it as already handled.
+      if (localEditsRef.current.forId === savedForId) {
+        localEditsRef.current.dirty = { reviewStatus: true, correction: true, notes: true };
+      }
+      // Surfaced even if we've navigated on: a failed save means the operator's
+      // decision didn't stick, which they need to know about either way.
+      setError(result.error);
+      return { ok: false };
+    }
+    // Keyed by the exposure's own id, so this is correct regardless of route.
+    if (result.exposure) {
+      markSaveCommitted(savedForId, saveSeq);
+      // Same guard as the fire-and-forget success path: a newer save queued
+      // behind this one (edit + navigate before this resolved) has already
+      // written its optimistic row — don't put this older row over it.
+      if (!hasPendingSave(savedForId)) setCachedExposure(result.exposure);
+      // A retry that lands supersedes an earlier failure for this exposure —
+      // same rule as the fire-and-forget path, or the banner outlives the fix.
+      if (getSaveError()?.id === savedForId) setSaveError(null);
+    }
+    // Everything below writes state belonging to whatever is on screen *now* —
+    // only safe while that's still the exposure we saved. Otherwise this would
+    // render the old exposure under the new one's URL and set the new one's
+    // `saved` guard, permanently suppressing its revalidation.
+    if (localEditsRef.current.forId !== savedForId) return { ok: true };
+    if (result.exposure) {
+      localEditsRef.current.saved = true;
+      setExposure(result.exposure);
+    }
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+    return { ok: true };
+  }, [id]);
+
   // Auto-save on nav: flush the dirty triage state (fire-and-forget), then
   // swap the exposure locally in the same tick — the operator can blast
   // through a queue with arrow keys without losing state or waiting on any
@@ -705,6 +847,80 @@ function ExposureDetailPageInner() {
     return () => document.removeEventListener('keydown', handler);
   }, [handleNext, handlePrev, handleSave, approveAndNext, showHelp, editStatus]);
 
+  // Mask saves run from the editor's toolbar or its auto-flush on navigation,
+  // outside `goTo`'s dirty check — so responses routinely land after the route
+  // moved on. `forKey` echoes the exposureKey the payload belongs to (the
+  // editor dispatches flushes mid-swap, when the on-screen exposure is already
+  // the next one); `background` marks saves the editor can't report inline.
+  //
+  // Serialized through the SAME per-exposure queue as the triage saves.
+  // Unqueued, a mask save and a nav triage save for this row could commit
+  // at the database in either order, and each confirmation only reflects
+  // the fields the database held at ITS commit — so whichever response was
+  // snapshotted first is missing the other's write, and no response-time
+  // guard can reassemble the truth from two partial rows. Queued, dispatch
+  // order is commit order and each later confirmation contains every
+  // earlier write. Marked pending for the same reason as triage saves:
+  // revalidation and the sibling prefetch must not resurrect the pre-save
+  // row while this write is in flight.
+  //
+  // useCallback with no deps (everything flows through refs/params): a stable
+  // reference is what lets the memoized MaskEditor skip re-rendering on
+  // unrelated page state changes (notes keystrokes, saved-flag timers).
+  const handleSaveMasks = useCallback(async (
+    regions: MaskRegionsPayload,
+    forKey?: number,
+    background?: boolean,
+  ): Promise<{ error?: string }> => {
+    const savedForId = forKey ?? idRef.current;
+    beginPendingSave(savedForId);
+    let res: Awaited<ReturnType<typeof saveExposureMaskRegions>>;
+    try {
+      res = await enqueueSave(savedForId, () =>
+        saveExposureMaskRegions(savedForId, regions));
+    } catch (err) {
+      res = {
+        exposure: null,
+        error: err instanceof Error ? err.message : 'Save failed',
+      };
+    } finally {
+      endPendingSave(savedForId);
+    }
+    if (res.exposure) {
+      // A save queued behind this one (triage flush during the mask round
+      // trip) has already written its optimistic row, and — because the queue
+      // serializes commits — its confirmation will carry this mask write too.
+      // Only the newest pending state may own the cache.
+      if (!hasPendingSave(savedForId)) setCachedExposure(res.exposure);
+      // Same newer-than-the-read rule as the triage save: a mask write must not
+      // be undone by an in-flight revalidation landing after it — but only for
+      // the exposure it was issued for (see handleSave).
+      if (localEditsRef.current.forId === savedForId) {
+        localEditsRef.current.saved = true;
+        setExposure(res.exposure);
+      }
+    } else if (res.error && (background || idRef.current !== savedForId)) {
+      // Nothing on screen can show this failure inline (a background flush,
+      // or the operator has stepped on) — raise the module banner, same as a
+      // failed triage auto-save.
+      const filename =
+        getCachedExposure(savedForId)?.filename ?? `exposure #${savedForId}`;
+      setSaveError({
+        id: savedForId,
+        filename,
+        message: `mask save failed: ${res.error}`,
+      });
+    }
+    return { error: res.error };
+  }, []);
+
+  // Event-time "is this editor's exposure still the navigation target"
+  // check for the mask clipboard — see MaskEditor's clipboardLive prop.
+  const isExposureLive = useCallback(
+    (key?: number) => key != null && idRef.current === key,
+    [],
+  );
+
   if (loading) {
     return (
       <div className="flex items-center justify-center py-16">
@@ -755,51 +971,6 @@ function ExposureDetailPageInner() {
     fitsKey && exposure.image_width && exposure.image_height,
   );
 
-  const handleSaveMasks = async (regions: MaskRegionsPayload) => {
-    // Mask saves run from the editor's own toolbar, outside `goTo`'s dirty
-    // check — so the operator can navigate away while one is still in flight.
-    //
-    // Serialized through the SAME per-exposure queue as the triage saves.
-    // Unqueued, a mask save and a nav triage save for this row could commit
-    // at the database in either order, and each confirmation only reflects
-    // the fields the database held at ITS commit — so whichever response was
-    // snapshotted first is missing the other's write, and no response-time
-    // guard can reassemble the truth from two partial rows. Queued, dispatch
-    // order is commit order and each later confirmation contains every
-    // earlier write. Marked pending for the same reason as triage saves:
-    // revalidation and the sibling prefetch must not resurrect the pre-save
-    // row while this write is in flight.
-    const savedForId = exposure.id;
-    beginPendingSave(savedForId);
-    let res: Awaited<ReturnType<typeof saveExposureMaskRegions>>;
-    try {
-      res = await enqueueSave(savedForId, () =>
-        saveExposureMaskRegions(savedForId, regions));
-    } catch (err) {
-      res = {
-        exposure: null,
-        error: err instanceof Error ? err.message : 'Save failed',
-      };
-    } finally {
-      endPendingSave(savedForId);
-    }
-    if (res.exposure) {
-      // A save queued behind this one (triage flush during the mask round
-      // trip) has already written its optimistic row, and — because the queue
-      // serializes commits — its confirmation will carry this mask write too.
-      // Only the newest pending state may own the cache.
-      if (!hasPendingSave(savedForId)) setCachedExposure(res.exposure);
-      // Same newer-than-the-read rule as the triage save: a mask write must not
-      // be undone by an in-flight revalidation landing after it — but only for
-      // the exposure it was issued for (see handleSave).
-      if (localEditsRef.current.forId === savedForId) {
-        localEditsRef.current.saved = true;
-        setExposure(res.exposure);
-      }
-    }
-    return { error: res.error };
-  };
-
   return (
     <div>
       {/* Header */}
@@ -824,29 +995,34 @@ function ExposureDetailPageInner() {
             {exposure.field} / {exposure.filter} / {exposure.detector}
           </p>
         </div>
-        {nav && (
-          <div className="flex items-center gap-1 text-sm text-text-secondary">
-            <button
-              onClick={(e) => { blurOnMouseClick(e); handlePrev(); }}
-              disabled={nav.prevId == null}
-              title="Previous (← / P)"
-              className="p-1.5 rounded hover:bg-card-hover disabled:opacity-30 disabled:cursor-not-allowed"
-            >
-              <ChevronLeft className="w-5 h-5" />
-            </button>
-            <span className="font-mono tabular-nums text-xs px-1">
-              {nav.position} / {nav.total}
-            </span>
-            <button
-              onClick={(e) => { blurOnMouseClick(e); handleNext(); }}
-              disabled={nav.nextId == null}
-              title="Next (→ / N)"
-              className="p-1.5 rounded hover:bg-card-hover disabled:opacity-30 disabled:cursor-not-allowed"
-            >
-              <ChevronRight className="w-5 h-5" />
-            </button>
-          </div>
-        )}
+        {/* Rendered even while nav is unknown (RPC in flight or the exposure
+            isn't in the URL's filter set) — disabled arrows and a placeholder
+            beat the whole cluster popping in and out of the header. */}
+        <div className="flex items-center gap-1 text-sm text-text-secondary">
+          <button
+            onClick={(e) => { blurOnMouseClick(e); handlePrev(); }}
+            disabled={!nav || nav.prevId == null}
+            title="Previous (← / P)"
+            className="p-1.5 rounded hover:bg-card-hover disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            <ChevronLeft className="w-5 h-5" />
+          </button>
+          <span
+            className="font-mono tabular-nums text-xs px-1"
+            title={nav ? undefined
+              : 'Position unknown — still loading, or this exposure is outside the current filter set'}
+          >
+            {nav ? `${nav.position ?? '—'} / ${nav.total}` : '— / —'}
+          </span>
+          <button
+            onClick={(e) => { blurOnMouseClick(e); handleNext(); }}
+            disabled={!nav || nav.nextId == null}
+            title="Next (→ / N)"
+            className="p-1.5 rounded hover:bg-card-hover disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            <ChevronRight className="w-5 h-5" />
+          </button>
+        </div>
         <button
           onClick={(e) => { blurOnMouseClick(e); setShowHelp(prev => !prev); }}
           title="Keyboard shortcuts (?)"
@@ -875,8 +1051,9 @@ function ExposureDetailPageInner() {
             <div className="flex justify-between"><dt>Paste masks</dt><dd className="font-mono text-text-secondary">Ctrl/⌘ V</dd></div>
           </dl>
           <p className="mt-2 text-xs text-text-secondary">
-            Navigation auto-saves the triage panel in the background if there are unsaved changes. Mask edits save separately from the editor toolbar.
+            Navigation auto-saves the triage panel and any unsaved mask edits in the background (the editor&apos;s Save button persists masks immediately).
             Copied masks paste onto any exposure with the same pixel dimensions (positions are detector pixels, not sky coordinates).
+            When filtering by review status, each decision removes the exposure from the queue, so the position counter shifts as you work.
           </p>
         </div>
       )}
@@ -900,7 +1077,7 @@ function ExposureDetailPageInner() {
             >
               {saveError.filename}
             </Link>
-            : {saveError.message}. Its review status was not changed — revisit it to re-apply your decision.
+            : {saveError.message}. The change did not persist — revisit it to re-apply your decision.
           </p>
           <button
             onClick={(e) => { blurOnMouseClick(e); setSaveError(null); }}
@@ -935,30 +1112,56 @@ function ExposureDetailPageInner() {
               <div className="h-[80vh]">
                 <MaskEditor
                   fitsKey={fitsKey!}
+                  exposureKey={exposure.id}
                   imageWidth={exposure.image_width!}
                   imageHeight={exposure.image_height!}
                   initialRegions={exposure.mask_regions}
                   onSave={handleSaveMasks}
                   clipboardSource={exposure.filename}
-                  clipboardLive={() => idRef.current === exposure.id}
+                  clipboardLive={isExposureLive}
                 />
               </div>
             ) : pngPresignPending ? (
-              // Presign round-trip for the PNG hasn't landed yet — don't flash
-              // "No PNG" before we know whether one exists.
-              <div className="flex items-center justify-center py-24">
-                <Loader2 className="w-8 h-8 animate-spin text-text-secondary" />
-              </div>
+              presignFailed.has(id) ? (
+                // The presign attempt failed (transport or signing) — offer a
+                // retry instead of the indefinite spinner this used to be.
+                <div className="flex flex-col items-center justify-center gap-3 py-24">
+                  <p className="text-text-secondary">
+                    Couldn&apos;t load this exposure&apos;s image.
+                  </p>
+                  <Button
+                    size="sm"
+                    onClick={(e) => {
+                      blurOnMouseClick(e);
+                      setPresignFailed((prev) => {
+                        const next = new Set(prev);
+                        next.delete(id);
+                        return next;
+                      });
+                      bumpPresignRetry();
+                    }}
+                  >
+                    Retry
+                  </Button>
+                </div>
+              ) : (
+                // Presign round-trip for the PNG hasn't landed yet — don't
+                // flash "No PNG" before we know whether one exists.
+                <div className="flex items-center justify-center py-24">
+                  <Loader2 className="w-8 h-8 animate-spin text-text-secondary" />
+                </div>
+              )
             ) : editorAvailable ? (
               <div className="h-[80vh]">
                 <MaskEditor
                   pngUrl={fullPngUrl!}
+                  exposureKey={exposure.id}
                   imageWidth={exposure.image_width!}
                   imageHeight={exposure.image_height!}
                   initialRegions={exposure.mask_regions}
                   onSave={handleSaveMasks}
                   clipboardSource={exposure.filename}
-                  clipboardLive={() => idRef.current === exposure.id}
+                  clipboardLive={isExposureLive}
                 />
               </div>
             ) : pngUrl ? (

--- a/web/app/admin/nircam/[id]/page.tsx
+++ b/web/app/admin/nircam/[id]/page.tsx
@@ -606,6 +606,16 @@ function ExposureDetailPageInner() {
       return;
     }
     for (const x of batch) inflight.add(x);
+    // A dispatched id is being retried NOW — drop any stale failure mark so
+    // the viewer shows the spinner, not a misleading "Couldn't load" panel,
+    // for the duration of this round trip (navigating to a previously-failed
+    // exposure re-batches it here without passing through the Retry button).
+    setPresignFailed((prev) => {
+      if (!batch.some((x) => prev.has(x))) return prev;
+      const next = new Set(prev);
+      for (const x of batch) next.delete(x);
+      return next;
+    });
     presignExposurePngs(batch)
       .then(
         (res) => {

--- a/web/app/admin/nirspec/rate/[id]/page.tsx
+++ b/web/app/admin/nirspec/rate/[id]/page.tsx
@@ -294,10 +294,13 @@ function RateDetailPageInner() {
     exposure.storage_key && exposure.image_width && exposure.image_height,
   );
 
-  const handleSaveMasks = async (regions: MaskRegionsPayload) => {
-    // Mask saves run from the editor's own toolbar, outside `goTo`'s dirty
-    // check — so the operator can navigate away while one is still in flight.
-    const savedForId = exposure.id;
+  const handleSaveMasks = async (regions: MaskRegionsPayload, forKey?: number) => {
+    // Mask saves run from the editor's own toolbar or its auto-flush on
+    // navigation, outside `goTo`'s dirty check — so the operator can navigate
+    // away while one is still in flight. `forKey` echoes the exposureKey the
+    // payload belongs to: a flush dispatches mid-swap, when `exposure` is
+    // already the next row, and saving to it would mask the wrong exposure.
+    const savedForId = forKey ?? exposure.id;
     const res = await saveRateMaskRegions(savedForId, regions);
     if (res.exposure) {
       setCachedRate(res.exposure);
@@ -380,7 +383,7 @@ function RateDetailPageInner() {
             <div className="flex justify-between"><dt>Help</dt><dd className="font-mono text-text-secondary">?</dd></div>
           </dl>
           <p className="mt-2 text-xs text-text-secondary">
-            Navigation auto-saves the triage panel if there are unsaved changes. Mask edits save separately from the editor toolbar.
+            Navigation auto-saves the triage panel and any unsaved mask edits (the editor&apos;s Save button persists masks immediately).
           </p>
         </div>
       )}
@@ -399,6 +402,7 @@ function RateDetailPageInner() {
               <div className="h-[80vh]">
                 <MaskEditor
                   fitsKey={exposure.storage_key!}
+                  exposureKey={exposure.id}
                   imageWidth={exposure.image_width!}
                   imageHeight={exposure.image_height!}
                   initialRegions={exposure.mask_regions}

--- a/web/app/admin/nirspec/rate/[id]/page.tsx
+++ b/web/app/admin/nirspec/rate/[id]/page.tsx
@@ -25,6 +25,12 @@ function RateDetailPageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const id = Number(params.id);
+  // Synchronous mirror of the route id for callbacks whose closures can
+  // outlive a navigation (the mask save handler below): "is the operator
+  // still on the row this response is about" must be answered with the id as
+  // of NOW, not as of the render the closure was created in.
+  const idRef = useRef(id);
+  idRef.current = id;
 
   // The list page's filter+sort state, carried in the URL (see
   // lib/nirspec-rate-nav.ts). Defines the ordered set prev/next walks; empty
@@ -294,14 +300,27 @@ function RateDetailPageInner() {
     exposure.storage_key && exposure.image_width && exposure.image_height,
   );
 
-  const handleSaveMasks = async (regions: MaskRegionsPayload, forKey?: number) => {
+  const handleSaveMasks = async (
+    regions: MaskRegionsPayload,
+    forKey?: number,
+    background?: boolean,
+  ) => {
     // Mask saves run from the editor's own toolbar or its auto-flush on
     // navigation, outside `goTo`'s dirty check — so the operator can navigate
     // away while one is still in flight. `forKey` echoes the exposureKey the
     // payload belongs to: a flush dispatches mid-swap, when `exposure` is
     // already the next row, and saving to it would mask the wrong exposure.
+    // `background` marks flushes the editor can't report inline.
     const savedForId = forKey ?? exposure.id;
-    const res = await saveRateMaskRegions(savedForId, regions);
+    let res: Awaited<ReturnType<typeof saveRateMaskRegions>>;
+    try {
+      res = await saveRateMaskRegions(savedForId, regions);
+    } catch (err) {
+      res = {
+        exposure: null,
+        error: err instanceof Error ? err.message : 'Save failed',
+      };
+    }
     if (res.exposure) {
       setCachedRate(res.exposure);
       // Same newer-than-the-read rule as the triage save: a mask write must not
@@ -311,6 +330,17 @@ function RateDetailPageInner() {
         localEditsRef.current.saved = true;
         setExposure(res.exposure);
       }
+    } else if (res.error && (background || idRef.current !== savedForId)) {
+      // The editor swallows background-flush outcomes and resets to the next
+      // exposure before this lands, so a failure here would otherwise discard
+      // the drawn polygons with no signal anywhere — the exact silent loss the
+      // auto-save exists to prevent. Surface it on the page banner, naming the
+      // row. (Best effort: the banner clears on the next id change, like the
+      // triage-save failure path on this page.)
+      setError(
+        `Mask auto-save failed for exposure #${savedForId}: ${res.error}. ` +
+        'The masks were NOT persisted — revisit the exposure to redraw them.',
+      );
     }
     return { error: res.error };
   };

--- a/web/components/nircam/MaskEditor.tsx
+++ b/web/components/nircam/MaskEditor.tsx
@@ -583,18 +583,26 @@ function MaskEditor({
     // then describes the NEW exposure and must not be touched; the host owns
     // reporting a departed save's outcome.
     const savedForKey = editedRef.current.key;
+    // Snapshot the dispatched list: drawing is NOT blocked while the request
+    // is in flight (only the Save button is), so by the time it resolves the
+    // canvas may hold polygons newer than this payload.
+    const dispatched = polygons;
     setSaving(true);
     setSaveError(null);
     try {
-      const result = await onSave(toPayload(polygons, imageHeight), savedForKey);
+      const result = await onSave(toPayload(dispatched, imageHeight), savedForKey);
       if (editedRef.current.key !== savedForKey) return;
       if (result.error) {
         setSaveError(result.error);
-      } else {
+      } else if (polygonsRef.current === dispatched) {
         dirtyRef.current = false;
         setDirty(false);
         setSavedAt(Date.now());
       }
+      // else: edits landed mid-flight. Leave dirty set — clearing it here
+      // would let the resync effect overwrite the canvas from the host's
+      // just-refreshed row (which predates those edits) and stop the
+      // nav auto-flush from ever persisting them.
     } finally {
       setSaving(false);
     }

--- a/web/components/nircam/MaskEditor.tsx
+++ b/web/components/nircam/MaskEditor.tsx
@@ -19,7 +19,7 @@
  *   ds9 image → svg:  svg_x = X - 0.5,  svg_y = H + 0.5 - Y
  */
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
 import {
   MousePointer2, PencilLine, Hand, Trash2, Save, Loader2, Check,
   Copy, ClipboardPaste,
@@ -58,7 +58,29 @@ interface Props {
   imageWidth: number;        // image width in pixels (= exposure NAXIS1)
   imageHeight: number;       // image height in pixels (= exposure NAXIS2)
   initialRegions: MaskRegionsPayload | null;
-  onSave: (regions: MaskRegionsPayload) => Promise<{ error?: string }>;
+  /**
+   * Persist the polygon list. `exposureKey` echoes the `exposureKey` prop the
+   * payload belongs to — the host must save to THAT row, not whatever is on
+   * screen when the call lands (a background flush dispatches while the host
+   * is already swapping exposures). `background` marks saves the operator
+   * didn't trigger from the toolbar (auto-flush on swap/unmount): the editor
+   * can't show their errors inline, so the host owns surfacing them.
+   */
+  onSave: (
+    regions: MaskRegionsPayload,
+    exposureKey?: number,
+    background?: boolean,
+  ) => Promise<{ error?: string }>;
+  /**
+   * Identity of the exposure being edited. When it changes, the editor resets
+   * to `initialRegions` — auto-flushing any unsaved edits for the previous
+   * exposure first. While it is UNCHANGED, a new `initialRegions` object
+   * (background revalidation, a triage save's row refresh) only resyncs when
+   * the editor has no unsaved edits: keying the reset off object identity
+   * wiped in-progress polygons every time the host refetched the same row.
+   * Omit only for hosts that remount the editor per exposure.
+   */
+  exposureKey?: number;
   /**
    * Enables the mask clipboard (copy/paste between exposures); the value is
    * the current exposure's filename, stamped onto pasted polygons as
@@ -69,12 +91,14 @@ interface Props {
   /**
    * Returns false while the host page is mid-transition to another exposure —
    * a navigation target set synchronously (keypress) that this editor hasn't
-   * re-rendered for yet. Clipboard actions check it at event time and no-op
-   * in that gap: a paste keyed there would land in the outgoing exposure's
-   * editor state and be wiped by the resync, and a copy would capture (and be
-   * attributed to) the exposure being left. Omit to always allow.
+   * re-rendered for yet. Called with this editor's `exposureKey` so the host
+   * compares against its own navigation target. Clipboard actions check it at
+   * event time and no-op in that gap: a paste keyed there would land in the
+   * outgoing exposure's editor state and be wiped by the resync, and a copy
+   * would capture (and be attributed to) the exposure being left. Omit to
+   * always allow.
    */
-  clipboardLive?: () => boolean;
+  clipboardLive?: (exposureKey?: number) => boolean;
 }
 
 function uuid() {
@@ -133,9 +157,9 @@ function toPayload(polys: SvgPolygon[], h: number): MaskRegionsPayload {
   return { version: 1, polygons };
 }
 
-export default function MaskEditor({
+function MaskEditor({
   pngUrl, fitsKey, imageWidth, imageHeight, initialRegions, onSave,
-  clipboardSource, clipboardLive,
+  exposureKey, clipboardSource, clipboardLive,
 }: Props) {
   const [polygons, setPolygons] = useState<SvgPolygon[]>(
     () => fromPayload(initialRegions, imageHeight)
@@ -221,14 +245,76 @@ export default function MaskEditor({
     ]);
   }, [imageWidth, imageHeight]);
 
-  // Re-sync if parent swaps exposure under us.
+  // Which exposure (and frame height) the editor state currently belongs to,
+  // plus event-time mirrors of `polygons`/`dirty` — the swap flush below runs
+  // from effects and cleanups, which must read the values as of NOW, not as of
+  // the render their closure was created in.
+  const editedRef = useRef({ key: exposureKey, height: imageHeight });
+  const dirtyRef = useRef(false);
+  const polygonsRef = useRef(polygons);
+  polygonsRef.current = polygons;
+  const onSaveRef = useRef(onSave);
+  onSaveRef.current = onSave;
+
+  // Dispatch unsaved edits for the exposure being left (fire-and-forget; the
+  // host serializes per-exposure saves and surfaces failures). Converted with
+  // the height their vertices were laid out against — the incoming exposure's
+  // dims may differ.
+  const flushEdits = useCallback(() => {
+    const edited = editedRef.current;
+    if (!dirtyRef.current || edited.key == null) return;
+    dirtyRef.current = false;
+    // Swallow transport-level rejections: background-save outcomes (including
+    // failures) are the host's to surface, and this editor instance is already
+    // showing a different exposure by the time one lands.
+    onSaveRef.current(
+      toPayload(polygonsRef.current, edited.height), edited.key, true,
+    ).catch(() => {});
+  }, []);
+
+  // Re-sync when the parent swaps or refreshes the exposure under us. The
+  // reset is keyed to `exposureKey` — NOT to `initialRegions` object identity,
+  // which changes on every same-row refetch (the background revalidation that
+  // lands 100-300 ms after arrival, a triage save's row refresh) and used to
+  // wipe in-progress polygons mid-edit. A same-key refresh only resyncs when
+  // there are no unsaved edits: the operator's working set is newer than
+  // whatever the refetch read.
   useEffect(() => {
-    setPolygons(fromPayload(initialRegions, imageHeight));
-    setDirty(false);
-    setSelectedId(null);
-    setDraftVertices([]);
-    setClipMsg(null);
-  }, [initialRegions, imageHeight]);
+    const keyChanged = editedRef.current.key !== exposureKey;
+    if (keyChanged) {
+      // Leaving an exposure with unsaved mask edits persists them, matching
+      // the triage panel's auto-save-on-nav (silently discarding drawn
+      // polygons was the old behavior, and read as data loss).
+      flushEdits();
+      editedRef.current = { key: exposureKey, height: imageHeight };
+      setPolygons(fromPayload(initialRegions, imageHeight));
+      setDirty(false);
+      dirtyRef.current = false;
+      setSelectedId(null);
+      setDraftVertices([]);
+      setClipMsg(null);
+      setSaveError(null);
+      setSavedAt(null);
+    } else {
+      editedRef.current = { key: exposureKey, height: imageHeight };
+      if (!dirtyRef.current) {
+        setPolygons(fromPayload(initialRegions, imageHeight));
+      }
+    }
+  }, [initialRegions, imageHeight, exposureKey, flushEdits]);
+
+  // Unmount still flushes: the editor unmounts on the PNG↔FITS toggle, on the
+  // host's loading state (stepping to an uncached exposure), and on leaving
+  // the page — none of which should drop drawn polygons.
+  useEffect(() => flushEdits, [flushEdits]);
+
+  // A tab close can't run the flush reliably — warn instead.
+  useEffect(() => {
+    if (!dirty) return;
+    const handler = (e: BeforeUnloadEvent) => e.preventDefault();
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [dirty]);
 
   useEffect(() => {
     if (!clipMsg) return;
@@ -255,7 +341,11 @@ export default function MaskEditor({
     return () => { cancelled = true; };
   }, [pngUrl]);
 
-  const markDirty = useCallback(() => { setDirty(true); setSavedAt(null); }, []);
+  const markDirty = useCallback(() => {
+    dirtyRef.current = true;
+    setDirty(true);
+    setSavedAt(null);
+  }, []);
 
   // ----- coordinate conversion: client (screen) → svg (PNG pixel) -----
   const clientToSvg = useCallback((clientX: number, clientY: number): SvgVertex | null => {
@@ -327,7 +417,7 @@ export default function MaskEditor({
 
   const handleCopy = useCallback(() => {
     if (!clipboardSource || polygons.length === 0) return;
-    if (clipboardLive && !clipboardLive()) return;
+    if (clipboardLive && !clipboardLive(exposureKey)) return;
     setMaskClipboard({
       polygons: toPayload(polygons, imageHeight).polygons,
       imageWidth,
@@ -336,11 +426,11 @@ export default function MaskEditor({
       copiedAt: new Date().toISOString(),
     });
     setClipMsg({ text: `copied ${polygons.length} polygon${polygons.length === 1 ? '' : 's'}` });
-  }, [clipboardSource, clipboardLive, polygons, imageWidth, imageHeight]);
+  }, [clipboardSource, clipboardLive, exposureKey, polygons, imageWidth, imageHeight]);
 
   const handlePaste = useCallback(() => {
     if (!clipboardSource) return;
-    if (clipboardLive && !clipboardLive()) return;
+    if (clipboardLive && !clipboardLive(exposureKey)) return;
     const clip = getMaskClipboard();
     if (!clip) {
       setClipMsg({ text: 'mask clipboard is empty', error: true });
@@ -374,7 +464,7 @@ export default function MaskEditor({
     setPolygons((ps) => [...ps, ...pasted]);
     markDirty();
     setClipMsg({ text: `pasted ${pasted.length} from ${clip.sourceFilename}` });
-  }, [clipboardSource, clipboardLive, imageWidth, imageHeight, markDirty]);
+  }, [clipboardSource, clipboardLive, exposureKey, imageWidth, imageHeight, markDirty]);
 
   // ----- pointer interactions -----
   const onPointerDown = useCallback((e: React.PointerEvent) => {
@@ -488,13 +578,20 @@ export default function MaskEditor({
       clipboardSource, polygons.length, handleCopy, handlePaste]);
 
   const handleSave = useCallback(async () => {
+    // The exposure this save belongs to. The response can land after the host
+    // swapped exposures under this (non-remounting) instance — editor state
+    // then describes the NEW exposure and must not be touched; the host owns
+    // reporting a departed save's outcome.
+    const savedForKey = editedRef.current.key;
     setSaving(true);
     setSaveError(null);
     try {
-      const result = await onSave(toPayload(polygons, imageHeight));
+      const result = await onSave(toPayload(polygons, imageHeight), savedForKey);
+      if (editedRef.current.key !== savedForKey) return;
       if (result.error) {
         setSaveError(result.error);
       } else {
+        dirtyRef.current = false;
         setDirty(false);
         setSavedAt(Date.now());
       }
@@ -750,6 +847,12 @@ export default function MaskEditor({
     </div>
   );
 }
+
+// Memoized: the host detail page re-renders on every notes keystroke and
+// saved-flag timer tick; with stable props (the host passes useCallback'd
+// onSave/clipboardLive) those renders skip the whole editor tree — polygon
+// SVG included, which is the part that grows with mask complexity.
+export default memo(MaskEditor);
 
 // ---------------------------------------------------------------------------
 // Polygon SVG shape (with vertex handles in edit mode)

--- a/web/lib/actions/nircam-exposures.ts
+++ b/web/lib/actions/nircam-exposures.ts
@@ -289,17 +289,22 @@ export async function presignExposurePngs(
 
     let anyFailed = false;
     for (const r of data) {
-      if ((r.png_path && failedKeys.has(r.png_path)) ||
-          (r.full_png_path && failedKeys.has(r.full_png_path))) {
-        // Retryable, not "no PNG": omit the id entirely.
+      const rowFailed =
+        (r.png_path && failedKeys.has(r.png_path)) ||
+        (r.full_png_path && failedKeys.has(r.full_png_path));
+      if (rowFailed) anyFailed = true;
+      const preview = r.png_path ? urlByKey.get(r.png_path) ?? null : null;
+      const full = r.full_png_path ? urlByKey.get(r.full_png_path) ?? null : null;
+      if (rowFailed && preview === null && full === null) {
+        // Nothing signed for this row — retryable, not "no PNG": omit the id
+        // entirely so the client doesn't cache the failure.
         delete out[r.id];
-        anyFailed = true;
         continue;
       }
-      out[r.id] = {
-        preview: r.png_path ? urlByKey.get(r.png_path) ?? null : null,
-        full: r.full_png_path ? urlByKey.get(r.full_png_path) ?? null : null,
-      };
+      // Per-key, not per-row: one unsignable key (e.g. a mixed-backend row
+      // whose other backend is misconfigured) must not sink a URL that DID
+      // sign — the viewer falls back full↔preview on its own.
+      out[r.id] = { preview, full };
     }
     return anyFailed
       ? { urls: out, error: 'Failed to sign some exposure image URLs' }

--- a/web/lib/actions/nircam-exposures.ts
+++ b/web/lib/actions/nircam-exposures.ts
@@ -204,6 +204,20 @@ export async function getNircamExposureById(id: number): Promise<{
 
 const PNG_PRESIGN_TTL_SECONDS = 3600;
 
+export interface PresignExposurePngsResult {
+  /**
+   * Presigned urls per requested id. An id maps to null urls when the
+   * exposure genuinely has no PNG (cacheable by the client), and is ABSENT
+   * when its urls could not be produced this call (retryable) — the
+   * distinction matters because the client caches these for ~50 min, and a
+   * transient failure cached as "no PNG" used to blank the viewer for the
+   * rest of the session.
+   */
+  urls: Record<number, ExposurePngUrls>;
+  /** Set when any requested id could not be signed (those ids are omitted). */
+  error?: string;
+}
+
 /**
  * Presigned GET URLs for a batch of exposures' preview + full PNGs, keyed by
  * exposure id (epic #261, N5). The admin UI puts these straight in `<img src>`
@@ -217,30 +231,32 @@ const PNG_PRESIGN_TTL_SECONDS = 3600;
  * `OSN_READ_ENABLED`-gated dual-read helper, which would divert to R2 when the
  * flag is off, and legacy R2 rows still resolve via their `r2` registry entry).
  *
- * ALWAYS returns an entry for every requested id (null urls when a PNG is
- * absent or a single sign fails) so the caller can distinguish "no PNG" from
- * "still presigning" and never wedges on a spinner. URLs live ~1h (covers a
- * viewing session + the sibling prefetch window).
+ * URLs live ~1h (covers a viewing session + the sibling prefetch window).
  */
 export async function presignExposurePngs(
   ids: number[],
-): Promise<Record<number, ExposurePngUrls>> {
-  const out: Record<number, ExposurePngUrls> = Object.fromEntries(
-    ids.map((i) => [i, { preview: null, full: null } as ExposurePngUrls]),
-  );
-  if (ids.length === 0) return out;
+): Promise<PresignExposurePngsResult> {
+  if (ids.length === 0) return { urls: {} };
   try {
     const supabase = await requireSession();
     const { data, error } = await supabase
       .from('nircam_exposures')
       .select('id, png_path, full_png_path')
       .in('id', ids);
-    if (error || !data) return out;
+    if (error || !data) {
+      return { urls: {}, error: error?.message ?? 'Exposure lookup failed' };
+    }
+
+    // An id the select didn't return doesn't exist (or isn't visible) — no
+    // PNG will ever materialize for it, so a null-urls entry is cacheable.
+    const out: Record<number, ExposurePngUrls> = Object.fromEntries(
+      ids.map((i) => [i, { preview: null, full: null } as ExposurePngUrls]),
+    );
 
     const keys = [...new Set(
       data.flatMap((r) => [r.png_path, r.full_png_path].filter(Boolean) as string[]),
     )];
-    if (keys.length === 0) return out;
+    if (keys.length === 0) return { urls: out };
 
     // Resolve each object's home backend from the registry (admin RLS sees all
     // rows); default OSN for anything unregistered — canonical PNGs are OSN.
@@ -255,6 +271,7 @@ export async function presignExposurePngs(
 
     // Presign per key, resilient: one unsignable key doesn't sink the batch.
     const urlByKey = new Map<string, string>();
+    const failedKeys = new Set<string>();
     await Promise.all(keys.map(async (k) => {
       try {
         const backend: DataBackend = backendByKey.get(k) === 'r2' ? 'r2' : 'osn';
@@ -266,18 +283,32 @@ export async function presignExposurePngs(
         urlByKey.set(k, url);
       } catch (err) {
         console.error(`presignExposurePngs: failed to sign ${k}:`, err);
+        failedKeys.add(k);
       }
     }));
 
+    let anyFailed = false;
     for (const r of data) {
+      if ((r.png_path && failedKeys.has(r.png_path)) ||
+          (r.full_png_path && failedKeys.has(r.full_png_path))) {
+        // Retryable, not "no PNG": omit the id entirely.
+        delete out[r.id];
+        anyFailed = true;
+        continue;
+      }
       out[r.id] = {
         preview: r.png_path ? urlByKey.get(r.png_path) ?? null : null,
         full: r.full_png_path ? urlByKey.get(r.full_png_path) ?? null : null,
       };
     }
-    return out;
-  } catch {
-    return out;
+    return anyFailed
+      ? { urls: out, error: 'Failed to sign some exposure image URLs' }
+      : { urls: out };
+  } catch (err) {
+    return {
+      urls: {},
+      error: err instanceof Error ? err.message : 'Presign failed',
+    };
   }
 }
 


### PR DESCRIPTION
## Summary

This PR enhances the NIRCam exposure detail page with auto-save functionality for mask edits during navigation, improves presign robustness against transient failures, and refactors the save pipeline to handle edge cases around exposure transitions.

## Key Changes

### Mask Editor Auto-Save
- **MaskEditor**: Added `exposureKey` prop to track which exposure is being edited; auto-flushes unsaved mask edits when the exposure changes or the component unmounts
- **MaskEditor**: Refactored to use refs (`editedRef`, `dirtyRef`, `polygonsRef`) for event-time state access, enabling reliable flush dispatch from effects and cleanup handlers
- **MaskEditor**: Updated `onSave` signature to accept `exposureKey` and `background` flags, allowing the host to route saves to the correct exposure even when navigation is in flight
- **MaskEditor**: Added `clipboardLive` callback parameter to check exposure identity at event time, preventing clipboard operations during exposure transitions
- **MaskEditor**: Wrapped component with `memo` to prevent unnecessary re-renders on unrelated parent state changes

### Exposure Detail Page Refactoring
- **ExposureDetailPageInner**: Extracted `TriageEdits` interface for the staged triage decision record
- **ExposureDetailPageInner**: Moved `flushDirtySave` callback earlier in the component and enhanced it to accept an optional record parameter, enabling flush of stashed edits from navigation bypasses
- **ExposureDetailPageInner**: Added `pendingNavFlushRef` to stash outgoing edits when exposure id changes via browser back/forward or route links (bypassing `goTo`)
- **ExposureDetailPageInner**: Added effect to dispatch stashed edits after id-change reset, ensuring no decision is silently dropped during non-goTo navigations
- **ExposureDetailPageInner**: Added unmount cleanup effect to flush any remaining dirty edits when leaving the page
- **ExposureDetailPageInner**: Refactored `targetEdits` to call `flushDirtySave` when exposure id changes, preventing loss of edits during rapid transitions
- **ExposureDetailPageInner**: Enhanced `handleSave` to mark saves as pending and restore dirty flags on failure, enabling retry on subsequent navigation
- **ExposureDetailPageInner**: Refactored `handleSaveMasks` to accept `forKey` and `background` parameters, matching the new MaskEditor signature and supporting background flushes
- **ExposureDetailPageInner**: Added `isExposureLive` callback for MaskEditor's clipboard liveness check

### Presign Resilience
- **ExposureDetailPageInner**: Added retry logic with exponential backoff (up to 2 retries) for `getExposureNeighbors` RPC failures
- **ExposureDetailPageInner**: Added `presignInFlightRef` to track ids currently being presigned, preventing duplicate batches
- **ExposureDetailPageInner**: Added `presignFailed` state to track ids whose presign attempts failed, rendering a retry panel instead of an indefinite spinner
- **ExposureDetailPageInner**: Enhanced presign effect to handle transport-level rejections and mark failed ids for retry
- **ExposureDetailPageInner**: Removed early return when `nav` is null, allowing the current exposure to be presigned even when it's outside the URL's filter set
- **ExposureDetailPageInner**: Updated presign effect to always include the current exposure in the sign batch, fixing blank viewer when revisiting filtered-out exposures

### Save Pipeline Improvements
- **ExposureDetailPageInner**: Added `saved` flag to `TriageEdits` to shield fields from stale revalidation reads after a save has landed
- **ExposureDetailPageInner**: Enhanced revalidation logic to check both dirty flags and `saved` flag, preventing pre-save values from overwriting confirmed writes
- **ExposureDetailPageInner**: Added `beginPendingSave`/`endPendingSave` calls to explicit save handler, marking saves as pending to block revalidation resurrection
- **ExposureDetailPageInner**: Improved beforeunload warning to include dirty-but-undispat

https://claude.ai/code/session_01UUMC8gE1THDaN3t8num7Bo