### PR TITLE
Add All/Any/None mode selector to the tag filter

### DIFF
--- a/supabase/migrations/20260729180000_add_list_ids_mode_to_filter_functions.sql
+++ b/supabase/migrations/20260729180000_add_list_ids_mode_to_filter_functions.sql
@@ -1,0 +1,1633 @@
+-- =============================================================================
+-- Migration: Add p_list_ids_mode (any/all/none) to tag/list filter functions
+-- =============================================================================
+-- Issue #443: the NIRSpec catalog's tag filter only supported OR ("any")
+-- semantics across selected tags, unlike the Any/All/None mode selector
+-- already available for the gratings and DQ-flags filters. This adds the
+-- same v_list_ids_mode pattern (see v_gratings_mode) to the six RPCs that
+-- accept p_list_ids: 'all' requires an object to carry every selected tag
+-- (COUNT DISTINCT matched list_id = array_length(p_list_ids)), 'none'
+-- excludes objects carrying any selected tag, 'any' keeps the prior
+-- behavior and remains the default so existing callers are unaffected.
+-- =============================================================================
+
+DROP FUNCTION IF EXISTS public.get_filtered_spectra_paginated;
+
+CREATE OR REPLACE FUNCTION public.get_filtered_spectra_paginated(
+  p_program_slugs TEXT[],
+  p_filter_programs TEXT[] DEFAULT NULL,
+  p_fields TEXT[] DEFAULT NULL,
+  p_gratings TEXT[] DEFAULT NULL,
+  p_gratings_mode TEXT DEFAULT 'any',
+  p_observations TEXT[] DEFAULT NULL,
+  p_redshift_quality INTEGER[] DEFAULT NULL,
+  p_redshift_min DOUBLE PRECISION DEFAULT NULL,
+  p_redshift_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_snr_min DOUBLE PRECISION DEFAULT NULL,
+  p_max_snr_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_exposure_time_min DOUBLE PRECISION DEFAULT NULL,
+  p_max_exposure_time_max DOUBLE PRECISION DEFAULT NULL,
+  p_dq_flags_include_any INTEGER DEFAULT NULL,
+  p_dq_flags_include_all INTEGER DEFAULT NULL,
+  p_dq_flags_exclude INTEGER DEFAULT NULL,
+  p_list_ids INTEGER[] DEFAULT NULL,
+  p_list_ids_mode TEXT DEFAULT 'any',
+  p_search TEXT DEFAULT NULL,
+  p_inspected_only BOOLEAN DEFAULT NULL,
+  p_needs_review BOOLEAN DEFAULT NULL,
+  p_has_photometry BOOLEAN DEFAULT NULL,
+  p_comment_search TEXT DEFAULT NULL,
+  p_comment_search_scope TEXT DEFAULT NULL,
+  p_comment_user_id UUID DEFAULT NULL,
+  p_coord_ra DOUBLE PRECISION DEFAULT NULL,
+  p_coord_dec DOUBLE PRECISION DEFAULT NULL,
+  p_radius_degrees DOUBLE PRECISION DEFAULT NULL,
+  p_sort_column TEXT DEFAULT 'target_id',
+  p_sort_direction TEXT DEFAULT 'asc',
+  p_page INTEGER DEFAULT 1,
+  p_page_size INTEGER DEFAULT 50,
+  p_include_thumbnails BOOLEAN DEFAULT false,
+  p_include_unpublished BOOLEAN DEFAULT false
+)
+RETURNS TABLE(targets JSONB, total_count BIGINT, page INTEGER, page_size INTEGER)
+LANGUAGE plpgsql STABLE
+SET plan_cache_mode = 'force_custom_plan'
+AS $$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_list_filter_active BOOLEAN;
+  v_list_ids_mode TEXT;
+  v_offset INTEGER;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
+    v_gratings_mode := 'any';
+  END IF;
+
+  v_list_filter_active := (p_list_ids IS NOT NULL AND array_length(p_list_ids, 1) > 0);
+  v_list_ids_mode := COALESCE(p_list_ids_mode, 'any');
+  IF v_list_ids_mode NOT IN ('any', 'all', 'none') THEN
+    v_list_ids_mode := 'any';
+  END IF;
+
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN
+    p_sort_direction := 'asc';
+  END IF;
+
+  IF NOT (p_sort_column IN (
+    'target_id', 'spectrum_id', 'field', 'observation', 'program_slug', 'ra', 'dec', 'redshift',
+    'redshift_quality', 'redshift_auto', 'signal_to_noise', 'exposure_time', 'grating'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'spectrum_id';
+  END IF;
+
+  IF v_coord_search_active AND p_sort_column IN ('target_id', 'spectrum_id') AND p_sort_direction = 'asc' THEN
+    p_sort_column := 'distance';
+  END IF;
+
+  v_offset := (COALESCE(p_page, 1) - 1) * COALESCE(p_page_size, 50);
+
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(
+      SELECT unnest(p_program_slugs)
+      INTERSECT
+      SELECT unnest(p_filter_programs)
+    ) INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN QUERY SELECT '[]'::jsonb, 0::BIGINT, p_page, p_page_size;
+    RETURN;
+  END IF;
+
+  -- Single-pass CTE: filtered_spectra is referenced by both distance_filtered
+  -- and the count subquery, so PostgreSQL materializes it once.
+  RETURN QUERY
+  WITH filtered_spectra AS (
+    SELECT
+      t.id AS tgt_db_id,
+      t.target_id,
+      t.program_slug,
+      t.field,
+      t.observation,
+      t.ra,
+      t.dec,
+      -- Phase D: redshift / redshift_quality / inspected flags now live on the
+      -- parent object. LEFT JOIN so spectra whose target has no object FK
+      -- (shouldn't happen post-reconcile, but safe) still appear.
+      o.redshift,
+      o.redshift_quality,
+      o.redshift_inspected,
+      o.last_inspected_at,
+      o.last_inspected_by,
+      o.is_active AS object_is_active,
+      o.has_photometry AS object_has_photometry,
+      o.object_id AS parent_object_id,
+      t.max_snr,
+      t.max_exposure_time,
+      t.created_at,
+      t.updated_at,
+      s.id AS spectrum_pk,
+      s.spectrum_id,
+      s.grating,
+      s.fits_path,
+      s.signal_to_noise,
+      s.exposure_time,
+      s.redshift_auto,
+      COALESCE(s.dq_flags, 0) AS dq_flags,
+      s.file_hash,
+      s.file_size,
+      s.thumbnail_svg_fnu,
+      s.thumbnail_svg_flambda,
+      CASE
+        WHEN v_coord_search_active THEN
+          2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(t.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(t.dec)) *
+            POWER(SIN(RADIANS(t.ra - p_coord_ra) / 2), 2)
+          )))
+        ELSE NULL
+      END AS distance
+    FROM targets t
+    JOIN spectra s ON s.target_id = t.target_id
+    LEFT JOIN objects o ON o.id = t.object_id
+    WHERE
+      t.program_slug = ANY(v_filtered_program_slugs)
+      -- Hide spectra whose parent object was soft-deleted.
+      AND (o.id IS NULL OR o.is_active = true)
+      AND (NOT v_grating_filter_active OR s.grating = ANY(p_gratings))
+      -- B1: hide unpublished spectra (fail-closed; admin opt-in only).
+      AND (p_include_unpublished OR s.deploy_status = 'published')
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR t.field = ANY(p_fields))
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR t.observation = ANY(p_observations))
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR s.signal_to_noise >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR s.signal_to_noise <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR s.exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR s.exposure_time <= p_max_exposure_time_max)
+      AND (p_dq_flags_include_any IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_any) != 0)
+      AND (p_dq_flags_include_all IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_all) = p_dq_flags_include_all)
+      AND (p_dq_flags_exclude IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_exclude) = 0)
+      AND (
+        NOT v_list_filter_active
+        OR (v_list_ids_mode = 'any' AND t.object_id IN (
+            SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+        OR (v_list_ids_mode = 'all' AND (
+            SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
+            WHERE olm.object_id = t.object_id AND olm.list_id = ANY(p_list_ids)
+        ) = array_length(p_list_ids, 1))
+        OR (v_list_ids_mode = 'none' AND t.object_id NOT IN (
+            SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+      )
+      AND (p_search IS NULL OR s.id IN (SELECT __s.id FROM public.spectra __s WHERE __s.search_text ILIKE '%' || p_search || '%'))
+      AND (
+        p_inspected_only IS NULL
+        OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+        OR (p_inspected_only = FALSE AND COALESCE(o.redshift_quality, 0) = 0)
+      )
+      AND (
+        p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+      )
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (
+        NOT v_comment_search_active
+        -- Uncorrelated semijoin: build the set of matching target_ids ONCE
+        -- (trgm/seq scan over the tiny comments table) instead of re-probing
+        -- comments per outer row. Correlated EXISTS-inside-OR can't be pulled
+        -- up and re-executes per spectrum -> timeouts on broad access. See the
+        -- objects path below for the object-level analogue.
+        OR t.id IN (
+          SELECT c.target_id FROM comments c
+          WHERE c.target_id IS NOT NULL
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+        )
+      )
+      AND (
+        NOT v_coord_search_active
+        OR (
+          t.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+          AND t.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+        )
+      )
+  ),
+  distance_filtered AS (
+    SELECT fs.*
+    FROM filtered_spectra fs
+    WHERE NOT v_coord_search_active OR fs.distance <= p_radius_degrees
+  ),
+  page_rows AS (
+    SELECT *, ROW_NUMBER() OVER () as row_num
+    FROM (
+      SELECT * FROM distance_filtered
+      ORDER BY
+        CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN distance END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN distance END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'target_id' AND p_sort_direction = 'asc' THEN target_id END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'target_id' AND p_sort_direction = 'desc' THEN target_id END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'spectrum_id' AND p_sort_direction = 'asc' THEN spectrum_id END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'spectrum_id' AND p_sort_direction = 'desc' THEN spectrum_id END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN field END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN field END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'observation' AND p_sort_direction = 'asc' THEN observation END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'observation' AND p_sort_direction = 'desc' THEN observation END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'program_slug' AND p_sort_direction = 'asc' THEN program_slug END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'program_slug' AND p_sort_direction = 'desc' THEN program_slug END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN ra END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN ra END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN "dec" END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN "dec" END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN redshift END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN redshift END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN redshift_quality END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN redshift_quality END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift_auto' AND p_sort_direction = 'asc' THEN redshift_auto END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'redshift_auto' AND p_sort_direction = 'desc' THEN redshift_auto END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'signal_to_noise' AND p_sort_direction = 'asc' THEN signal_to_noise END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'signal_to_noise' AND p_sort_direction = 'desc' THEN signal_to_noise END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'exposure_time' AND p_sort_direction = 'asc' THEN exposure_time END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'exposure_time' AND p_sort_direction = 'desc' THEN exposure_time END DESC NULLS LAST,
+        CASE WHEN p_sort_column = 'grating' AND p_sort_direction = 'asc' THEN grating END ASC NULLS LAST,
+        CASE WHEN p_sort_column = 'grating' AND p_sort_direction = 'desc' THEN grating END DESC NULLS LAST,
+        target_id ASC, grating ASC
+      LIMIT p_page_size OFFSET v_offset
+    ) sorted_page
+  )
+  SELECT
+    COALESCE(jsonb_agg(jsonb_build_object(
+      'id', r.tgt_db_id,
+      'target_id', r.target_id,
+      'parent_object_id', r.parent_object_id,
+      'program_slug', r.program_slug,
+      'program_name', pr.program_name,
+      'field', r.field,
+      'observation', r.observation,
+      'ra', r.ra,
+      'dec', r.dec,
+      -- Phase D: redshift fields are object-level reads
+      'redshift', r.redshift,
+      'redshift_inspected', r.redshift_inspected,
+      'redshift_quality', r.redshift_quality,
+      'last_inspected_at', r.last_inspected_at,
+      'last_inspected_by', r.last_inspected_by,
+      'max_snr', r.max_snr,
+      'max_exposure_time', r.max_exposure_time,
+      'created_at', r.created_at,
+      'updated_at', r.updated_at,
+      'distance', CASE WHEN v_coord_search_active THEN r.distance ELSE NULL END,
+      'spectra', jsonb_build_array(jsonb_build_object(
+        'id', r.spectrum_pk,
+        'spectrum_id', r.spectrum_id,
+        'target_id', r.target_id,
+        'grating', r.grating,
+        'fits_path', r.fits_path,
+        'signal_to_noise', r.signal_to_noise,
+        'exposure_time', r.exposure_time,
+        -- Phase D: per-spectrum auto-z and DQ
+        'redshift_auto', r.redshift_auto,
+        'dq_flags', r.dq_flags,
+        'file_hash', r.file_hash,
+        'file_size', r.file_size,
+        'thumbnail_svg_fnu', CASE WHEN p_include_thumbnails THEN r.thumbnail_svg_fnu ELSE NULL END,
+        'thumbnail_svg_flambda', CASE WHEN p_include_thumbnails THEN r.thumbnail_svg_flambda ELSE NULL END
+      ))
+    ) ORDER BY r.row_num), '[]'::jsonb),
+    (SELECT COUNT(*) FROM distance_filtered),
+    p_page,
+    p_page_size
+  FROM page_rows r
+  LEFT JOIN programs pr ON pr.slug = r.program_slug;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_filtered_spectra_paginated TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_filtered_spectra_paginated TO service_role;
+
+
+DROP FUNCTION IF EXISTS public.get_filtered_objects_paginated;
+
+CREATE OR REPLACE FUNCTION public.get_filtered_objects_paginated(
+  p_program_slugs TEXT[],
+  p_filter_programs TEXT[] DEFAULT NULL,
+  p_fields TEXT[] DEFAULT NULL,
+  p_gratings TEXT[] DEFAULT NULL,
+  p_gratings_mode TEXT DEFAULT 'any',
+  p_observations TEXT[] DEFAULT NULL,
+  p_redshift_quality INTEGER[] DEFAULT NULL,
+  p_redshift_min DOUBLE PRECISION DEFAULT NULL,
+  p_redshift_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_snr_min DOUBLE PRECISION DEFAULT NULL,
+  p_max_snr_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_exposure_time_min DOUBLE PRECISION DEFAULT NULL,
+  p_max_exposure_time_max DOUBLE PRECISION DEFAULT NULL,
+  p_search TEXT DEFAULT NULL,
+  p_inspected_only BOOLEAN DEFAULT NULL,
+  p_needs_review BOOLEAN DEFAULT NULL,
+  p_list_ids INTEGER[] DEFAULT NULL,
+  p_list_ids_mode TEXT DEFAULT 'any',
+  p_coord_ra DOUBLE PRECISION DEFAULT NULL,
+  p_coord_dec DOUBLE PRECISION DEFAULT NULL,
+  p_radius_degrees DOUBLE PRECISION DEFAULT NULL,
+  p_has_photometry BOOLEAN DEFAULT NULL,
+  p_photo_z_min DOUBLE PRECISION DEFAULT NULL,
+  p_photo_z_max DOUBLE PRECISION DEFAULT NULL,
+  p_comment_search TEXT DEFAULT NULL,
+  p_comment_search_scope TEXT DEFAULT NULL,
+  p_comment_user_id UUID DEFAULT NULL,
+  p_sort_column TEXT DEFAULT 'object_id',
+  p_sort_direction TEXT DEFAULT 'asc',
+  p_page INTEGER DEFAULT 1,
+  p_page_size INTEGER DEFAULT 50,
+  p_include_unpublished BOOLEAN DEFAULT false
+)
+RETURNS TABLE(targets JSONB, total_count BIGINT, page INTEGER, page_size INTEGER)
+LANGUAGE plpgsql STABLE
+SET plan_cache_mode = 'force_custom_plan'
+AS $$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_list_filter_active BOOLEAN;
+  v_list_ids_mode TEXT;
+  v_offset INTEGER;
+  v_total_count BIGINT;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
+    v_gratings_mode := 'any';
+  END IF;
+  v_list_filter_active := (p_list_ids IS NOT NULL AND array_length(p_list_ids, 1) > 0);
+  v_list_ids_mode := COALESCE(p_list_ids_mode, 'any');
+  IF v_list_ids_mode NOT IN ('any', 'all', 'none') THEN
+    v_list_ids_mode := 'any';
+  END IF;
+
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN
+    p_sort_direction := 'asc';
+  END IF;
+
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time', 'photo_z'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+
+  IF v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN
+    p_sort_column := 'distance';
+  END IF;
+
+  v_offset := (COALESCE(p_page, 1) - 1) * COALESCE(p_page_size, 50);
+
+  -- Intersect user-accessible programs with filter selection
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(
+      SELECT unnest(p_program_slugs)
+      INTERSECT
+      SELECT unnest(p_filter_programs)
+    ) INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN QUERY SELECT '[]'::jsonb, 0::BIGINT, p_page, p_page_size;
+    RETURN;
+  END IF;
+
+  -- Step 1: count
+  SELECT COUNT(*) INTO v_total_count
+  FROM objects o
+  WHERE
+    -- Access control: object must have at least one accessible program
+    o.programs && v_filtered_program_slugs
+    AND o.is_active = true
+    -- B1: hide objects with no published spectrum (fail-closed).
+    AND (p_include_unpublished OR o.has_published_spectrum)
+    AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+    AND (
+      NOT v_grating_filter_active
+      OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+      OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+      OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+    )
+    AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+    AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+    AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+    AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+    AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+    AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+    AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+    AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+    AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
+    AND (
+      p_inspected_only IS NULL
+      OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+      OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+    )
+    AND (
+      p_needs_review IS NULL
+      OR (p_needs_review = TRUE
+          AND o.staleness_reason IS NOT NULL
+          AND o.last_inspected_at IS NOT NULL
+          AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+      OR (p_needs_review = FALSE
+          AND (o.staleness_reason IS NULL
+               OR o.last_inspected_at IS NULL
+               OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+    )
+    AND (
+      NOT v_coord_search_active
+      OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+        AND 2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) <= p_radius_degrees
+      )
+    )
+    AND (
+      NOT v_list_filter_active
+      OR (v_list_ids_mode = 'any' AND o.id IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      OR (v_list_ids_mode = 'all' AND (
+          SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
+          WHERE olm.object_id = o.id AND olm.list_id = ANY(p_list_ids)
+      ) = array_length(p_list_ids, 1))
+      OR (v_list_ids_mode = 'none' AND o.id NOT IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+    )
+    AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+    AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+    AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+    AND (
+      NOT v_comment_search_active
+      -- Uncorrelated semijoin: collect the object_ids that have a matching
+      -- comment ONCE (object-level comments directly + target-level comments
+      -- mapped through their parent object), then probe o.id IN (...). The old
+      -- correlated EXISTS-inside-OR re-ran a per-object targets subquery for
+      -- every (object x matching-comment) pair -> 271k subplan executions /
+      -- ~870ms here, multi-second on broad terms or cold cache.
+      OR o.id IN (
+        SELECT c.object_id FROM comments c
+        WHERE c.object_id IS NOT NULL
+          AND c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (
+            p_comment_search_scope = 'everyone'
+            OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+          )
+        UNION
+        SELECT t.object_id FROM comments c
+        JOIN targets t ON t.id = c.target_id
+        WHERE c.target_id IS NOT NULL
+          AND c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (
+            p_comment_search_scope = 'everyone'
+            OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+          )
+      )
+    );
+
+  -- Step 2: fetch page
+  RETURN QUERY
+  WITH filtered_objects AS (
+    SELECT
+      o.id,
+      o.object_id,
+      o.field,
+      o.ra,
+      o.dec,
+      o.n_targets,
+      o.n_spectra,
+      o.programs,
+      o.gratings,
+      o.max_snr,
+      o.max_exposure_time,
+      o.redshift,
+      o.redshift_quality,
+      o.redshift_inspected,
+      o.redshift_auto,
+      o.inspected_used_auto,
+      o.last_inspected_at,
+      o.last_inspected_by,
+      o.last_data_change_at,
+      o.staleness_reason,
+      o.version,
+      o.is_active,
+      o.photo_z,
+      o.has_photometry,
+      o.created_at,
+      CASE
+        WHEN v_coord_search_active THEN
+          2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+            POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+          )))
+        ELSE NULL
+      END AS distance
+    FROM objects o
+    WHERE
+      o.programs && v_filtered_program_slugs
+      AND o.is_active = true
+      AND (p_include_unpublished OR o.has_published_spectrum)
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+        OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+        OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+      )
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
+      AND (
+        p_inspected_only IS NULL
+        OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+        OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+      )
+      AND (
+        p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+      )
+      AND (
+        NOT v_coord_search_active
+        OR (
+          o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+          AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+          AND 2 * DEGREES(ASIN(SQRT(
+            POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+            COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+            POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+          ))) <= p_radius_degrees
+        )
+      )
+      AND (
+        NOT v_list_filter_active
+        OR (v_list_ids_mode = 'any' AND o.id IN (
+            SELECT olm.object_id FROM object_list_members olm
+            WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+        OR (v_list_ids_mode = 'all' AND (
+            SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
+            WHERE olm.object_id = o.id AND olm.list_id = ANY(p_list_ids)
+        ) = array_length(p_list_ids, 1))
+        OR (v_list_ids_mode = 'none' AND o.id NOT IN (
+            SELECT olm.object_id FROM object_list_members olm
+            WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+      )
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+      AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+      AND (
+        NOT v_comment_search_active
+        -- Uncorrelated semijoin; see the count query above for the rationale.
+        OR o.id IN (
+          SELECT c.object_id FROM comments c
+          WHERE c.object_id IS NOT NULL
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+          UNION
+          SELECT t.object_id FROM comments c
+          JOIN targets t ON t.id = c.target_id
+          WHERE c.target_id IS NOT NULL
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+        )
+      )
+    ORDER BY
+      CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN
+        2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN
+        2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN o.object_id END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'desc' THEN o.object_id END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN o.field END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN o.field END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN o.ra END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN o.ra END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN o.dec END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN o.dec END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN o.redshift END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN o.redshift END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN o.redshift_quality END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN o.redshift_quality END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'asc' THEN o.n_targets END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'desc' THEN o.n_targets END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'asc' THEN o.n_spectra END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'desc' THEN o.n_spectra END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN o.max_snr END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN o.max_snr END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN o.max_exposure_time END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN o.max_exposure_time END DESC NULLS LAST,
+      CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'asc' THEN o.photo_z END ASC NULLS LAST,
+      CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'desc' THEN o.photo_z END DESC NULLS LAST,
+      o.object_id ASC
+    LIMIT p_page_size OFFSET v_offset
+  ),
+  with_members AS (
+    SELECT
+      jsonb_build_object(
+        'id', fo.id,
+        'object_id', fo.object_id,
+        'field', fo.field,
+        'ra', fo.ra,
+        'dec', fo.dec,
+        -- Aggregates scoped to the viewer's accessible programs so mixed-program
+        -- objects don't leak proprietary member metadata. Deliberately NOT
+        -- narrowed by p_filter_programs: a program filter selects which objects
+        -- appear (overlap test above), but each row still shows the object's
+        -- full accessible programs/observations. Filter and sort above run on
+        -- the global o.* columns; the substitution happens only on the
+        -- paginated result set.
+        'n_targets', sa.n_targets,
+        'n_spectra', sa.n_spectra,
+        'programs', sa.programs,
+        'gratings', sa.gratings,
+        'max_snr', sa.max_snr,
+        'max_exposure_time', sa.max_exposure_time,
+        'redshift', fo.redshift,
+        'redshift_quality', fo.redshift_quality,
+        'redshift_inspected', fo.redshift_inspected,
+        'redshift_auto', fo.redshift_auto,
+        'inspected_used_auto', fo.inspected_used_auto,
+        'last_inspected_at', fo.last_inspected_at,
+        'last_inspected_by', fo.last_inspected_by,
+        'last_data_change_at', fo.last_data_change_at,
+        'staleness_reason', fo.staleness_reason,
+        'version', fo.version,
+        'is_active', fo.is_active,
+        'photo_z', fo.photo_z,
+        'has_photometry', fo.has_photometry,
+        'created_at', fo.created_at,
+        'distance', fo.distance,
+        -- Phase D: member_targets becomes provenance only (target_id, program,
+        -- observation). Inspection state lives on the object now; redshift_auto
+        -- on targets is retained for transitional UI display until Phase E.
+        'member_targets', COALESCE(
+          (SELECT jsonb_agg(
+            jsonb_build_object(
+              'target_id', t.target_id,
+              'program_slug', t.program_slug,
+              'observation', t.observation,
+              'redshift_auto', t.redshift_auto
+            )
+          )
+          FROM targets t
+          WHERE t.object_id = fo.id
+            AND t.program_slug = ANY(p_program_slugs)
+            -- Same publication gate as object_scoped_aggregates: the RPC is
+            -- reached via the service-role client (/api/v1/objects), so RLS
+            -- won't hide draft-only members here.
+            AND (p_include_unpublished OR t.has_published_spectrum)
+          ),
+          '[]'::jsonb
+        ),
+        'lists', COALESCE(
+          (SELECT jsonb_agg(
+            jsonb_build_object(
+              'id', ol.id,
+              'name', ol.name,
+              'slug', ol.slug,
+              'icon', ol.icon,
+              'color', ol.color
+            ) ORDER BY ol.name
+          )
+          FROM object_list_members olm
+          JOIN object_lists ol ON ol.id = olm.list_id
+          WHERE olm.object_id = fo.id),
+          '[]'::jsonb
+        )
+      ) AS obj_json
+    FROM filtered_objects fo
+    LEFT JOIN LATERAL public.object_scoped_aggregates(fo.id, p_program_slugs, p_include_unpublished) sa ON true
+  )
+  SELECT
+    COALESCE(jsonb_agg(wm.obj_json), '[]'::jsonb),
+    v_total_count,
+    p_page,
+    p_page_size
+  FROM with_members wm;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_filtered_objects_paginated TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_filtered_objects_paginated TO service_role;
+
+
+DROP FUNCTION IF EXISTS public.get_filtered_object_ids;
+
+CREATE OR REPLACE FUNCTION public.get_filtered_object_ids(
+  p_program_slugs TEXT[],
+  p_filter_programs TEXT[] DEFAULT NULL,
+  p_fields TEXT[] DEFAULT NULL,
+  p_gratings TEXT[] DEFAULT NULL,
+  p_gratings_mode TEXT DEFAULT 'any',
+  p_observations TEXT[] DEFAULT NULL,
+  p_redshift_quality INTEGER[] DEFAULT NULL,
+  p_redshift_min DOUBLE PRECISION DEFAULT NULL,
+  p_redshift_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_snr_min DOUBLE PRECISION DEFAULT NULL,
+  p_max_snr_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_exposure_time_min DOUBLE PRECISION DEFAULT NULL,
+  p_max_exposure_time_max DOUBLE PRECISION DEFAULT NULL,
+  p_search TEXT DEFAULT NULL,
+  p_inspected_only BOOLEAN DEFAULT NULL,
+  p_needs_review BOOLEAN DEFAULT NULL,
+  p_list_ids INTEGER[] DEFAULT NULL,
+  p_list_ids_mode TEXT DEFAULT 'any',
+  p_coord_ra DOUBLE PRECISION DEFAULT NULL,
+  p_coord_dec DOUBLE PRECISION DEFAULT NULL,
+  p_radius_degrees DOUBLE PRECISION DEFAULT NULL,
+  p_has_photometry BOOLEAN DEFAULT NULL,
+  p_photo_z_min DOUBLE PRECISION DEFAULT NULL,
+  p_photo_z_max DOUBLE PRECISION DEFAULT NULL,
+  p_comment_search TEXT DEFAULT NULL,
+  p_comment_search_scope TEXT DEFAULT NULL,
+  p_comment_user_id UUID DEFAULT NULL,
+  p_sort_column TEXT DEFAULT 'object_id',
+  p_sort_direction TEXT DEFAULT 'asc',
+  p_include_unpublished BOOLEAN DEFAULT false
+)
+RETURNS TABLE(object_id TEXT)
+LANGUAGE plpgsql STABLE
+SET plan_cache_mode = 'force_custom_plan'
+AS $$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_list_filter_active BOOLEAN;
+  v_list_ids_mode TEXT;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
+    v_gratings_mode := 'any';
+  END IF;
+  v_list_filter_active := (p_list_ids IS NOT NULL AND array_length(p_list_ids, 1) > 0);
+  v_list_ids_mode := COALESCE(p_list_ids_mode, 'any');
+  IF v_list_ids_mode NOT IN ('any', 'all', 'none') THEN
+    v_list_ids_mode := 'any';
+  END IF;
+
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN
+    p_sort_direction := 'asc';
+  END IF;
+
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time', 'photo_z'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+
+  -- Intersect user-accessible programs with filter selection
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(
+      SELECT unnest(p_program_slugs)
+      INTERSECT
+      SELECT unnest(p_filter_programs)
+    ) INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  SELECT o.object_id
+  FROM objects o
+  WHERE
+    o.programs && v_filtered_program_slugs
+    AND o.is_active = true
+    AND (p_include_unpublished OR o.has_published_spectrum)
+    AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+    AND (
+      NOT v_grating_filter_active
+      OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+      OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+      OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+    )
+    AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+    AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+    AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+    AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+    AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+    AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+    AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+    AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+    AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
+    AND (
+      p_inspected_only IS NULL
+      OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+      OR (p_inspected_only = FALSE AND o.redshift_quality = 0)
+    )
+    AND (
+      p_needs_review IS NULL
+      OR (p_needs_review = TRUE
+          AND o.staleness_reason IS NOT NULL
+          AND o.last_inspected_at IS NOT NULL
+          AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+      OR (p_needs_review = FALSE
+          AND (o.staleness_reason IS NULL
+               OR o.last_inspected_at IS NULL
+               OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at)))
+    )
+    AND (
+      NOT v_coord_search_active
+      OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+        AND 2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        ))) <= p_radius_degrees
+      )
+    )
+    AND (
+      NOT v_list_filter_active
+      OR (v_list_ids_mode = 'any' AND o.id IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      OR (v_list_ids_mode = 'all' AND (
+          SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
+          WHERE olm.object_id = o.id AND olm.list_id = ANY(p_list_ids)
+      ) = array_length(p_list_ids, 1))
+      OR (v_list_ids_mode = 'none' AND o.id NOT IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+    )
+    AND (
+      NOT v_comment_search_active
+      -- Uncorrelated semijoin; see get_filtered_objects_paginated for rationale.
+      OR o.id IN (
+        SELECT c.object_id FROM comments c
+        WHERE c.object_id IS NOT NULL
+          AND c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (
+            p_comment_search_scope = 'everyone'
+            OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+          )
+        UNION
+        SELECT t.object_id FROM comments c
+        JOIN targets t ON t.id = c.target_id
+        WHERE c.target_id IS NOT NULL
+          AND c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (
+            p_comment_search_scope = 'everyone'
+            OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+          )
+      )
+    )
+  ORDER BY
+    CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'asc' THEN
+      2 * DEGREES(ASIN(SQRT(
+        POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+        COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+        POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+      ))) END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'distance' AND p_sort_direction = 'desc' THEN
+      2 * DEGREES(ASIN(SQRT(
+        POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+        COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+        POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+      ))) END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN o.object_id END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'object_id' AND p_sort_direction = 'desc' THEN o.object_id END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc' THEN o.field END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN o.field END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'asc' THEN o.ra END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'ra' AND p_sort_direction = 'desc' THEN o.ra END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'asc' THEN o.dec END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'dec' AND p_sort_direction = 'desc' THEN o.dec END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'asc' THEN o.redshift END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift' AND p_sort_direction = 'desc' THEN o.redshift END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'asc' THEN o.redshift_quality END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'redshift_quality' AND p_sort_direction = 'desc' THEN o.redshift_quality END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'asc' THEN o.n_targets END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_targets' AND p_sort_direction = 'desc' THEN o.n_targets END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'asc' THEN o.n_spectra END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'n_spectra' AND p_sort_direction = 'desc' THEN o.n_spectra END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'asc' THEN o.max_snr END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_snr' AND p_sort_direction = 'desc' THEN o.max_snr END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'asc' THEN o.max_exposure_time END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'max_exposure_time' AND p_sort_direction = 'desc' THEN o.max_exposure_time END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'asc' THEN o.photo_z END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'photo_z' AND p_sort_direction = 'desc' THEN o.photo_z END DESC NULLS LAST,
+    o.object_id ASC;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_filtered_object_ids TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_filtered_object_ids TO service_role;
+
+
+DROP FUNCTION IF EXISTS public.get_adjacent_objects;
+
+CREATE OR REPLACE FUNCTION public.get_adjacent_objects(
+  p_current_object_id TEXT,
+  p_program_slugs TEXT[],
+  p_filter_programs TEXT[] DEFAULT NULL,
+  p_fields TEXT[] DEFAULT NULL,
+  p_gratings TEXT[] DEFAULT NULL,
+  p_gratings_mode TEXT DEFAULT 'any',
+  p_observations TEXT[] DEFAULT NULL,
+  p_redshift_quality INTEGER[] DEFAULT NULL,
+  p_redshift_min DOUBLE PRECISION DEFAULT NULL,
+  p_redshift_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_snr_min DOUBLE PRECISION DEFAULT NULL,
+  p_max_snr_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_exposure_time_min DOUBLE PRECISION DEFAULT NULL,
+  p_max_exposure_time_max DOUBLE PRECISION DEFAULT NULL,
+  p_search TEXT DEFAULT NULL,
+  p_inspected_only BOOLEAN DEFAULT NULL,
+  p_needs_review BOOLEAN DEFAULT NULL,
+  p_list_ids INTEGER[] DEFAULT NULL,
+  p_list_ids_mode TEXT DEFAULT 'any',
+  p_coord_ra DOUBLE PRECISION DEFAULT NULL,
+  p_coord_dec DOUBLE PRECISION DEFAULT NULL,
+  p_radius_degrees DOUBLE PRECISION DEFAULT NULL,
+  p_sort_column TEXT DEFAULT 'object_id',
+  p_sort_direction TEXT DEFAULT 'asc',
+  p_has_photometry BOOLEAN DEFAULT NULL,
+  p_photo_z_min DOUBLE PRECISION DEFAULT NULL,
+  p_photo_z_max DOUBLE PRECISION DEFAULT NULL,
+  p_comment_search TEXT DEFAULT NULL,
+  p_comment_search_scope TEXT DEFAULT NULL,
+  p_comment_user_id UUID DEFAULT NULL,
+  p_include_unpublished BOOLEAN DEFAULT false
+)
+RETURNS TABLE(prev_object_id TEXT, next_object_id TEXT, current_index BIGINT, total_count BIGINT)
+LANGUAGE plpgsql STABLE
+SET plan_cache_mode = 'force_custom_plan'
+AS $$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_list_filter_active BOOLEAN;
+  v_list_ids_mode TEXT;
+  v_sort_is_text BOOLEAN;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN v_gratings_mode := 'any'; END IF;
+  v_list_filter_active := (p_list_ids IS NOT NULL AND array_length(p_list_ids, 1) > 0);
+  v_list_ids_mode := COALESCE(p_list_ids_mode, 'any');
+  IF v_list_ids_mode NOT IN ('any', 'all', 'none') THEN v_list_ids_mode := 'any'; END IF;
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
+  IF NOT (p_sort_column IN (
+    'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
+    'n_targets', 'n_spectra', 'max_snr', 'max_exposure_time'
+  ) OR (p_sort_column = 'distance' AND v_coord_search_active)) THEN
+    p_sort_column := 'object_id';
+  END IF;
+  IF v_coord_search_active AND p_sort_column = 'object_id' AND p_sort_direction = 'asc' THEN
+    p_sort_column := 'distance';
+    p_sort_direction := 'asc';
+  END IF;
+  v_sort_is_text := p_sort_column IN ('object_id', 'field');
+
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs))
+    INTO v_filtered_program_slugs;
+  ELSE
+    v_filtered_program_slugs := p_program_slugs;
+  END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN
+    RETURN QUERY SELECT NULL::TEXT, NULL::TEXT, 0::BIGINT, 0::BIGINT;
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  WITH filtered_objects AS MATERIALIZED (
+    SELECT
+      o.object_id,
+      CASE WHEN v_coord_search_active THEN
+        2 * DEGREES(ASIN(SQRT(
+          POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) +
+          COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) *
+          POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2)
+        )))
+      ELSE NULL END AS distance,
+      o.field, o.ra, o.dec, o.redshift, o.redshift_quality,
+      o.n_targets, o.n_spectra, o.max_snr, o.max_exposure_time
+    FROM objects o
+    WHERE
+      o.programs && v_filtered_program_slugs
+      AND o.is_active = true
+      AND (p_include_unpublished OR o.has_published_spectrum)
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+        OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+        OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+      )
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR o.observations && p_observations)
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
+      AND (p_inspected_only IS NULL
+        OR (p_inspected_only = TRUE AND o.redshift_quality > 0)
+        OR (p_inspected_only = FALSE AND o.redshift_quality = 0))
+      AND (p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at))))
+      AND (NOT v_coord_search_active OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+      ))
+      AND (
+        NOT v_list_filter_active
+        OR (v_list_ids_mode = 'any' AND o.id IN (
+            SELECT olm.object_id FROM object_list_members olm
+            WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+        OR (v_list_ids_mode = 'all' AND (
+            SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
+            WHERE olm.object_id = o.id AND olm.list_id = ANY(p_list_ids)
+        ) = array_length(p_list_ids, 1))
+        OR (v_list_ids_mode = 'none' AND o.id NOT IN (
+            SELECT olm.object_id FROM object_list_members olm
+            WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+      )
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+      AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+      AND (
+        NOT v_comment_search_active
+        -- Uncorrelated semijoin; see get_filtered_objects_paginated for rationale.
+        OR o.id IN (
+          SELECT c.object_id FROM comments c
+          WHERE c.object_id IS NOT NULL
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+          UNION
+          SELECT t.object_id FROM comments c
+          JOIN targets t ON t.id = c.target_id
+          WHERE c.target_id IS NOT NULL
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+        )
+      )
+  ),
+  distance_filtered AS MATERIALIZED (
+    SELECT
+      fo.*,
+      CASE p_sort_column
+        WHEN 'object_id' THEN fo.object_id WHEN 'field' THEN fo.field ELSE NULL
+      END AS sort_text,
+      CASE p_sort_column
+        WHEN 'ra' THEN fo.ra WHEN 'dec' THEN fo.dec
+        WHEN 'redshift' THEN fo.redshift
+        WHEN 'redshift_quality' THEN fo.redshift_quality::DOUBLE PRECISION
+        WHEN 'n_targets' THEN fo.n_targets::DOUBLE PRECISION
+        WHEN 'n_spectra' THEN fo.n_spectra::DOUBLE PRECISION
+        WHEN 'max_snr' THEN fo.max_snr WHEN 'max_exposure_time' THEN fo.max_exposure_time
+        WHEN 'distance' THEN fo.distance ELSE NULL
+      END AS sort_num
+    FROM filtered_objects fo
+    WHERE NOT v_coord_search_active OR fo.distance <= p_radius_degrees
+  ),
+  current_obj AS (
+    SELECT df.sort_text, df.sort_num, df.object_id FROM distance_filtered df WHERE df.object_id = p_current_object_id
+  )
+  SELECT
+    (SELECT df.object_id FROM distance_filtered df, current_obj c
+     WHERE CASE WHEN v_sort_is_text THEN
+       (CASE WHEN p_sort_direction = 'asc' THEN df.sort_text < c.sort_text ELSE df.sort_text > c.sort_text END)
+       OR (df.sort_text IS NOT DISTINCT FROM c.sort_text AND df.object_id < c.object_id)
+       OR (df.sort_text IS NOT NULL AND c.sort_text IS NULL)
+     ELSE
+       (CASE WHEN p_sort_direction = 'asc' THEN df.sort_num < c.sort_num ELSE df.sort_num > c.sort_num END)
+       OR (df.sort_num IS NOT DISTINCT FROM c.sort_num AND df.object_id < c.object_id)
+       OR (df.sort_num IS NOT NULL AND c.sort_num IS NULL)
+     END
+     ORDER BY
+       CASE WHEN v_sort_is_text AND p_sort_direction = 'asc' THEN df.sort_text END DESC NULLS FIRST,
+       CASE WHEN v_sort_is_text AND p_sort_direction = 'desc' THEN df.sort_text END ASC NULLS FIRST,
+       CASE WHEN NOT v_sort_is_text AND p_sort_direction = 'asc' THEN df.sort_num END DESC NULLS FIRST,
+       CASE WHEN NOT v_sort_is_text AND p_sort_direction = 'desc' THEN df.sort_num END ASC NULLS FIRST,
+       df.object_id DESC
+     LIMIT 1
+    ) AS prev_object_id,
+    (SELECT df.object_id FROM distance_filtered df, current_obj c
+     WHERE CASE WHEN v_sort_is_text THEN
+       (CASE WHEN p_sort_direction = 'asc' THEN df.sort_text > c.sort_text ELSE df.sort_text < c.sort_text END)
+       OR (df.sort_text IS NOT DISTINCT FROM c.sort_text AND df.object_id > c.object_id)
+       OR (c.sort_text IS NOT NULL AND df.sort_text IS NULL)
+     ELSE
+       (CASE WHEN p_sort_direction = 'asc' THEN df.sort_num > c.sort_num ELSE df.sort_num < c.sort_num END)
+       OR (df.sort_num IS NOT DISTINCT FROM c.sort_num AND df.object_id > c.object_id)
+       OR (c.sort_num IS NOT NULL AND df.sort_num IS NULL)
+     END
+     ORDER BY
+       CASE WHEN v_sort_is_text AND p_sort_direction = 'asc' THEN df.sort_text END ASC NULLS LAST,
+       CASE WHEN v_sort_is_text AND p_sort_direction = 'desc' THEN df.sort_text END DESC NULLS LAST,
+       CASE WHEN NOT v_sort_is_text AND p_sort_direction = 'asc' THEN df.sort_num END ASC NULLS LAST,
+       CASE WHEN NOT v_sort_is_text AND p_sort_direction = 'desc' THEN df.sort_num END DESC NULLS LAST,
+       df.object_id ASC
+     LIMIT 1
+    ) AS next_object_id,
+    CASE WHEN EXISTS (SELECT 1 FROM current_obj) THEN (
+      SELECT COUNT(*) + 1
+      FROM distance_filtered df, current_obj c
+      WHERE CASE WHEN v_sort_is_text THEN
+        (CASE WHEN p_sort_direction = 'asc' THEN df.sort_text < c.sort_text ELSE df.sort_text > c.sort_text END)
+        OR (df.sort_text IS NOT DISTINCT FROM c.sort_text AND df.object_id < c.object_id)
+        OR (df.sort_text IS NOT NULL AND c.sort_text IS NULL)
+      ELSE
+        (CASE WHEN p_sort_direction = 'asc' THEN df.sort_num < c.sort_num ELSE df.sort_num > c.sort_num END)
+        OR (df.sort_num IS NOT DISTINCT FROM c.sort_num AND df.object_id < c.object_id)
+        OR (df.sort_num IS NOT NULL AND c.sort_num IS NULL)
+      END
+    )::BIGINT ELSE 0::BIGINT END AS current_index,
+    (SELECT COUNT(*) FROM distance_filtered)::BIGINT AS total_count;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_adjacent_objects TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_adjacent_objects TO service_role;
+
+
+DROP FUNCTION IF EXISTS public.get_csv_export_spectra;
+
+CREATE OR REPLACE FUNCTION public.get_csv_export_spectra(
+  p_program_slugs TEXT[], p_filter_programs TEXT[] DEFAULT NULL,
+  p_fields TEXT[] DEFAULT NULL, p_gratings TEXT[] DEFAULT NULL,
+  p_gratings_mode TEXT DEFAULT 'any', p_observations TEXT[] DEFAULT NULL,
+  p_redshift_quality INTEGER[] DEFAULT NULL,
+  p_redshift_min DOUBLE PRECISION DEFAULT NULL, p_redshift_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_snr_min DOUBLE PRECISION DEFAULT NULL, p_max_snr_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_exposure_time_min DOUBLE PRECISION DEFAULT NULL, p_max_exposure_time_max DOUBLE PRECISION DEFAULT NULL,
+  p_dq_flags_include_any INTEGER DEFAULT NULL, p_dq_flags_include_all INTEGER DEFAULT NULL,
+  p_dq_flags_exclude INTEGER DEFAULT NULL,
+  p_list_ids INTEGER[] DEFAULT NULL,
+  p_list_ids_mode TEXT DEFAULT 'any',
+  p_search TEXT DEFAULT NULL, p_inspected_only BOOLEAN DEFAULT NULL,
+  p_needs_review BOOLEAN DEFAULT NULL,
+  p_has_photometry BOOLEAN DEFAULT NULL,
+  p_comment_search TEXT DEFAULT NULL, p_comment_search_scope TEXT DEFAULT NULL,
+  p_comment_user_id UUID DEFAULT NULL,
+  p_coord_ra DOUBLE PRECISION DEFAULT NULL, p_coord_dec DOUBLE PRECISION DEFAULT NULL,
+  p_radius_degrees DOUBLE PRECISION DEFAULT NULL,
+  p_include_unpublished BOOLEAN DEFAULT false,
+  p_after_id INTEGER DEFAULT NULL, p_page_size INTEGER DEFAULT 5000
+)
+RETURNS TABLE(
+  id INTEGER, spectrum_id TEXT, target_id TEXT, grating TEXT, field TEXT, observation TEXT,
+  ra DOUBLE PRECISION, "dec" DOUBLE PRECISION,
+  redshift NUMERIC, redshift_quality INTEGER, redshift_auto DOUBLE PRECISION,
+  signal_to_noise DOUBLE PRECISION,
+  exposure_time DOUBLE PRECISION, fits_path TEXT, program_slug TEXT, program_name TEXT,
+  last_inspected_at TIMESTAMPTZ, last_inspected_by TEXT, distance DOUBLE PRECISION,
+  dq_flags INTEGER,
+  lists TEXT
+)
+LANGUAGE plpgsql STABLE
+SET plan_cache_mode = 'force_custom_plan'
+SET statement_timeout = '120s'
+AS $$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_list_filter_active BOOLEAN;
+  v_list_ids_mode TEXT;
+  v_page_size INTEGER;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (p_comment_search IS NOT NULL AND p_comment_search != '' AND p_comment_search_scope IN ('just_me', 'everyone'));
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_list_filter_active := (p_list_ids IS NOT NULL AND array_length(p_list_ids, 1) > 0);
+  v_list_ids_mode := COALESCE(p_list_ids_mode, 'any');
+  IF v_list_ids_mode NOT IN ('any', 'all', 'none') THEN v_list_ids_mode := 'any'; END IF;
+  v_page_size := LEAST(GREATEST(COALESCE(p_page_size, 5000), 1), 10000);
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs)) INTO v_filtered_program_slugs;
+  ELSE v_filtered_program_slugs := p_program_slugs; END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN RETURN; END IF;
+
+  RETURN QUERY
+  WITH visible_lists AS (
+    SELECT olm.object_id, string_agg(ol.slug, ';' ORDER BY ol.slug) AS lists
+    FROM object_list_members olm
+    JOIN object_lists ol ON ol.id = olm.list_id
+    WHERE ol.created_by = auth.uid() OR ol.visibility IN ('public_read', 'public_edit')
+    GROUP BY olm.object_id
+  ),
+  filtered_spectra AS (
+    SELECT s.id, s.spectrum_id, t.target_id, s.grating, t.field, t.ra, t.dec,
+      o.redshift, o.redshift_quality,
+      s.redshift_auto,
+      s.signal_to_noise, s.exposure_time, s.fits_path, t.program_slug, t.observation,
+      o.last_inspected_at, o.last_inspected_by,
+      CASE WHEN v_coord_search_active THEN
+        2 * DEGREES(ASIN(SQRT(POWER(SIN(RADIANS(t.dec - p_coord_dec) / 2), 2) + COS(RADIANS(p_coord_dec)) * COS(RADIANS(t.dec)) * POWER(SIN(RADIANS(t.ra - p_coord_ra) / 2), 2))))
+      ELSE NULL END AS distance,
+      COALESCE(s.dq_flags, 0) AS dq_flags,
+      vl.lists
+    FROM targets t
+    JOIN spectra s ON s.target_id = t.target_id
+    LEFT JOIN objects o ON o.id = t.object_id
+    LEFT JOIN visible_lists vl ON vl.object_id = t.object_id
+    WHERE t.program_slug = ANY(v_filtered_program_slugs)
+      AND (p_after_id IS NULL OR s.id > p_after_id)
+      AND (o.id IS NULL OR o.is_active = true)
+      AND (NOT v_grating_filter_active OR s.grating = ANY(p_gratings))
+      -- B1: hide unpublished spectra (fail-closed; admin opt-in only).
+      AND (p_include_unpublished OR s.deploy_status = 'published')
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR t.field = ANY(p_fields))
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR t.observation = ANY(p_observations))
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min) AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR s.signal_to_noise >= p_max_snr_min) AND (p_max_snr_max IS NULL OR s.signal_to_noise <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR s.exposure_time >= p_max_exposure_time_min) AND (p_max_exposure_time_max IS NULL OR s.exposure_time <= p_max_exposure_time_max)
+      AND (p_dq_flags_include_any IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_any) != 0)
+      AND (p_dq_flags_include_all IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_all) = p_dq_flags_include_all)
+      AND (p_dq_flags_exclude IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_exclude) = 0)
+      AND (
+        NOT v_list_filter_active
+        OR (v_list_ids_mode = 'any' AND t.object_id IN (
+            SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+        OR (v_list_ids_mode = 'all' AND (
+            SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
+            WHERE olm.object_id = t.object_id AND olm.list_id = ANY(p_list_ids)
+        ) = array_length(p_list_ids, 1))
+        OR (v_list_ids_mode = 'none' AND t.object_id NOT IN (
+            SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+      )
+      AND (p_search IS NULL OR s.id IN (SELECT __s.id FROM public.spectra __s WHERE __s.search_text ILIKE '%' || p_search || '%'))
+      AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.redshift_quality > 0) OR (p_inspected_only = FALSE AND COALESCE(o.redshift_quality, 0) = 0))
+      AND (p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at))))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (NOT v_comment_search_active OR t.id IN (
+        SELECT c.target_id FROM comments c WHERE c.target_id IS NOT NULL AND c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (p_comment_search_scope = 'everyone' OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id))))
+      AND (NOT v_coord_search_active OR (
+        t.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND t.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)))
+  ),
+  distance_filtered AS (SELECT fs.* FROM filtered_spectra fs WHERE NOT v_coord_search_active OR fs.distance <= p_radius_degrees)
+  SELECT df.id, df.spectrum_id, df.target_id, df.grating, df.field, df.observation,
+    df.ra, df.dec, df.redshift, df.redshift_quality, df.redshift_auto,
+    df.signal_to_noise, df.exposure_time, df.fits_path, df.program_slug,
+    pr.program_name, df.last_inspected_at, up.full_name AS last_inspected_by,
+    df.distance, df.dq_flags, df.lists
+  FROM distance_filtered df
+  LEFT JOIN programs pr ON pr.slug = df.program_slug
+  LEFT JOIN user_profiles up ON up.user_id = df.last_inspected_by
+  ORDER BY df.id ASC
+  LIMIT v_page_size;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_csv_export_spectra TO authenticated;
+
+
+DROP FUNCTION IF EXISTS public.get_csv_export_objects;
+
+CREATE OR REPLACE FUNCTION public.get_csv_export_objects(
+  p_program_slugs TEXT[], p_filter_programs TEXT[] DEFAULT NULL,
+  p_fields TEXT[] DEFAULT NULL, p_gratings TEXT[] DEFAULT NULL,
+  p_gratings_mode TEXT DEFAULT 'any',
+  p_redshift_quality INTEGER[] DEFAULT NULL,
+  p_redshift_min DOUBLE PRECISION DEFAULT NULL, p_redshift_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_snr_min DOUBLE PRECISION DEFAULT NULL, p_max_snr_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_exposure_time_min DOUBLE PRECISION DEFAULT NULL, p_max_exposure_time_max DOUBLE PRECISION DEFAULT NULL,
+  p_search TEXT DEFAULT NULL, p_inspected_only BOOLEAN DEFAULT NULL,
+  p_needs_review BOOLEAN DEFAULT NULL,
+  p_list_ids INTEGER[] DEFAULT NULL,
+  p_list_ids_mode TEXT DEFAULT 'any',
+  p_coord_ra DOUBLE PRECISION DEFAULT NULL, p_coord_dec DOUBLE PRECISION DEFAULT NULL,
+  p_radius_degrees DOUBLE PRECISION DEFAULT NULL,
+  p_has_photometry BOOLEAN DEFAULT NULL,
+  p_photo_z_min DOUBLE PRECISION DEFAULT NULL, p_photo_z_max DOUBLE PRECISION DEFAULT NULL,
+  p_comment_search TEXT DEFAULT NULL, p_comment_search_scope TEXT DEFAULT NULL,
+  p_comment_user_id UUID DEFAULT NULL,
+  p_include_unpublished BOOLEAN DEFAULT false,
+  p_after_object_id TEXT DEFAULT NULL, p_page_size INTEGER DEFAULT 5000
+)
+RETURNS TABLE(
+  object_id TEXT, field TEXT, ra DOUBLE PRECISION, "dec" DOUBLE PRECISION,
+  redshift NUMERIC, redshift_quality INTEGER,
+  redshift_inspected NUMERIC, redshift_auto DOUBLE PRECISION,
+  last_inspected_at TIMESTAMPTZ, last_inspected_by TEXT,
+  last_data_change_at TIMESTAMPTZ, staleness_reason TEXT, version INTEGER,
+  n_targets INTEGER, n_spectra INTEGER,
+  programs TEXT, gratings TEXT,
+  max_snr DOUBLE PRECISION, max_exposure_time DOUBLE PRECISION,
+  member_target_ids TEXT, distance DOUBLE PRECISION,
+  lists TEXT,
+  has_photometry BOOLEAN, photo_z DOUBLE PRECISION,
+  photo_z_err_lo DOUBLE PRECISION, photo_z_err_hi DOUBLE PRECISION,
+  photometry JSONB
+)
+LANGUAGE plpgsql STABLE
+SET plan_cache_mode = 'force_custom_plan'
+SET statement_timeout = '120s'
+AS $$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_list_filter_active BOOLEAN;
+  v_list_ids_mode TEXT;
+  v_page_size INTEGER;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN v_gratings_mode := 'any'; END IF;
+  v_list_filter_active := (p_list_ids IS NOT NULL AND array_length(p_list_ids, 1) > 0);
+  v_list_ids_mode := COALESCE(p_list_ids_mode, 'any');
+  IF v_list_ids_mode NOT IN ('any', 'all', 'none') THEN v_list_ids_mode := 'any'; END IF;
+  v_page_size := LEAST(GREATEST(COALESCE(p_page_size, 5000), 1), 10000);
+
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs)) INTO v_filtered_program_slugs;
+  ELSE v_filtered_program_slugs := p_program_slugs; END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN RETURN; END IF;
+
+  RETURN QUERY
+  WITH member_targets AS (
+    SELECT t.object_id, string_agg(t.target_id, ';' ORDER BY t.target_id) AS member_target_ids
+    FROM targets t
+    WHERE t.program_slug = ANY(v_filtered_program_slugs)
+    GROUP BY t.object_id
+  ),
+  visible_lists AS (
+    SELECT olm.object_id, string_agg(ol.slug, ';' ORDER BY ol.slug) AS lists
+    FROM object_list_members olm
+    JOIN object_lists ol ON ol.id = olm.list_id
+    WHERE ol.created_by = auth.uid() OR ol.visibility IN ('public_read', 'public_edit')
+    GROUP BY olm.object_id
+  ),
+  filtered_objects AS (
+    SELECT o.object_id, o.field, o.ra, o.dec,
+      o.redshift, o.redshift_quality,
+      o.redshift_inspected, o.redshift_auto,
+      o.last_inspected_at, up.full_name AS last_inspected_by,
+      o.last_data_change_at, o.staleness_reason, o.version,
+      -- Aggregates scoped to accessible (+ filtered) programs so mixed-program
+      -- objects don't export proprietary member metadata. See
+      -- object_scoped_aggregates().
+      sa.n_targets, sa.n_spectra,
+      array_to_string(sa.programs, ';') AS programs,
+      array_to_string(sa.gratings, ';') AS gratings,
+      sa.max_snr, sa.max_exposure_time,
+      mt.member_target_ids,
+      CASE WHEN v_coord_search_active THEN
+        2 * DEGREES(ASIN(SQRT(POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) + COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) * POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2))))
+      ELSE NULL END AS distance,
+      vl.lists,
+      o.has_photometry, o.photo_z, o.photo_z_err_lo, o.photo_z_err_hi,
+      phot.photometry
+    FROM objects o
+    LEFT JOIN member_targets mt ON mt.object_id = o.id
+    LEFT JOIN visible_lists vl ON vl.object_id = o.id
+    LEFT JOIN user_profiles up ON up.user_id = o.last_inspected_by
+    LEFT JOIN LATERAL public.object_scoped_aggregates(o.id, v_filtered_program_slugs, p_include_unpublished) sa ON true
+    LEFT JOIN LATERAL (
+      SELECT op.photometry FROM object_photometry op
+      WHERE op.object_id = o.id ORDER BY op.updated_at DESC LIMIT 1
+    ) phot ON true
+    WHERE o.programs && v_filtered_program_slugs
+      AND (p_after_object_id IS NULL OR o.object_id > p_after_object_id)
+      AND o.is_active = true
+      AND (p_include_unpublished OR o.has_published_spectrum)
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+        OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+        OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+      )
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
+      AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.redshift_quality > 0) OR (p_inspected_only = FALSE AND o.redshift_quality = 0))
+      AND (p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at))))
+      AND (NOT v_coord_search_active OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+      ))
+      AND (
+        NOT v_list_filter_active
+        OR (v_list_ids_mode = 'any' AND o.id IN (
+            SELECT olm.object_id FROM object_list_members olm
+            WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+        OR (v_list_ids_mode = 'all' AND (
+            SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
+            WHERE olm.object_id = o.id AND olm.list_id = ANY(p_list_ids)
+        ) = array_length(p_list_ids, 1))
+        OR (v_list_ids_mode = 'none' AND o.id NOT IN (
+            SELECT olm.object_id FROM object_list_members olm
+            WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+      )
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+      AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+      AND (
+        NOT v_comment_search_active
+        -- Uncorrelated semijoin; see get_filtered_objects_paginated for rationale.
+        OR o.id IN (
+          SELECT c.object_id FROM comments c
+          WHERE c.object_id IS NOT NULL
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+          UNION
+          SELECT t.object_id FROM comments c
+          JOIN targets t ON t.id = c.target_id
+          WHERE c.target_id IS NOT NULL
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+        )
+      )
+  ),
+  distance_filtered AS (SELECT fo.* FROM filtered_objects fo WHERE NOT v_coord_search_active OR fo.distance <= p_radius_degrees)
+  SELECT df.object_id, df.field, df.ra, df.dec,
+    df.redshift, df.redshift_quality,
+    df.redshift_inspected, df.redshift_auto,
+    df.last_inspected_at, df.last_inspected_by,
+    df.last_data_change_at, df.staleness_reason, df.version,
+    df.n_targets, df.n_spectra,
+    df.programs, df.gratings,
+    df.max_snr, df.max_exposure_time,
+    df.member_target_ids, df.distance, df.lists,
+    df.has_photometry, df.photo_z, df.photo_z_err_lo, df.photo_z_err_hi,
+    df.photometry
+  FROM distance_filtered df
+  ORDER BY df.object_id ASC
+  LIMIT v_page_size;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_csv_export_objects TO authenticated;

--- a/supabase/migrations/20260729180000_add_list_ids_mode_to_filter_functions.sql
+++ b/supabase/migrations/20260729180000_add_list_ids_mode_to_filter_functions.sql
@@ -6,9 +6,11 @@
 -- already available for the gratings and DQ-flags filters. This adds the
 -- same v_list_ids_mode pattern (see v_gratings_mode) to the six RPCs that
 -- accept p_list_ids: 'all' requires an object to carry every selected tag
--- (COUNT DISTINCT matched list_id = array_length(p_list_ids)), 'none'
--- excludes objects carrying any selected tag, 'any' keeps the prior
--- behavior and remains the default so existing callers are unaffected.
+-- (COUNT DISTINCT matched list_id = COUNT DISTINCT p_list_ids, so duplicate
+-- ids in the array can't cause false negatives), 'none' excludes objects
+-- carrying any selected tag (spectra whose target has no parent object have
+-- no tags, so they match 'none'), 'any' keeps the prior behavior and
+-- remains the default so existing callers are unaffected.
 -- =============================================================================
 
 DROP FUNCTION IF EXISTS public.get_filtered_spectra_paginated;
@@ -194,10 +196,10 @@ BEGIN
         OR (v_list_ids_mode = 'all' AND (
             SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
             WHERE olm.object_id = t.object_id AND olm.list_id = ANY(p_list_ids)
-        ) = array_length(p_list_ids, 1))
-        OR (v_list_ids_mode = 'none' AND t.object_id NOT IN (
+        ) = (SELECT COUNT(DISTINCT __list_id) FROM unnest(p_list_ids) __list_id))
+        OR (v_list_ids_mode = 'none' AND (t.object_id IS NULL OR t.object_id NOT IN (
             SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
-        ))
+        )))
       )
       AND (p_search IS NULL OR s.id IN (SELECT __s.id FROM public.spectra __s WHERE __s.search_text ILIKE '%' || p_search || '%'))
       AND (
@@ -499,7 +501,7 @@ BEGIN
       OR (v_list_ids_mode = 'all' AND (
           SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
           WHERE olm.object_id = o.id AND olm.list_id = ANY(p_list_ids)
-      ) = array_length(p_list_ids, 1))
+      ) = (SELECT COUNT(DISTINCT __list_id) FROM unnest(p_list_ids) __list_id))
       OR (v_list_ids_mode = 'none' AND o.id NOT IN (
           SELECT olm.object_id FROM object_list_members olm
           WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
@@ -634,7 +636,7 @@ BEGIN
         OR (v_list_ids_mode = 'all' AND (
             SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
             WHERE olm.object_id = o.id AND olm.list_id = ANY(p_list_ids)
-        ) = array_length(p_list_ids, 1))
+        ) = (SELECT COUNT(DISTINCT __list_id) FROM unnest(p_list_ids) __list_id))
         OR (v_list_ids_mode = 'none' AND o.id NOT IN (
             SELECT olm.object_id FROM object_list_members olm
             WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
@@ -945,7 +947,7 @@ BEGIN
       OR (v_list_ids_mode = 'all' AND (
           SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
           WHERE olm.object_id = o.id AND olm.list_id = ANY(p_list_ids)
-      ) = array_length(p_list_ids, 1))
+      ) = (SELECT COUNT(DISTINCT __list_id) FROM unnest(p_list_ids) __list_id))
       OR (v_list_ids_mode = 'none' AND o.id NOT IN (
           SELECT olm.object_id FROM object_list_members olm
           WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
@@ -1162,7 +1164,7 @@ BEGIN
         OR (v_list_ids_mode = 'all' AND (
             SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
             WHERE olm.object_id = o.id AND olm.list_id = ANY(p_list_ids)
-        ) = array_length(p_list_ids, 1))
+        ) = (SELECT COUNT(DISTINCT __list_id) FROM unnest(p_list_ids) __list_id))
         OR (v_list_ids_mode = 'none' AND o.id NOT IN (
             SELECT olm.object_id FROM object_list_members olm
             WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
@@ -1380,10 +1382,10 @@ BEGIN
         OR (v_list_ids_mode = 'all' AND (
             SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
             WHERE olm.object_id = t.object_id AND olm.list_id = ANY(p_list_ids)
-        ) = array_length(p_list_ids, 1))
-        OR (v_list_ids_mode = 'none' AND t.object_id NOT IN (
+        ) = (SELECT COUNT(DISTINCT __list_id) FROM unnest(p_list_ids) __list_id))
+        OR (v_list_ids_mode = 'none' AND (t.object_id IS NULL OR t.object_id NOT IN (
             SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
-        ))
+        )))
       )
       AND (p_search IS NULL OR s.id IN (SELECT __s.id FROM public.spectra __s WHERE __s.search_text ILIKE '%' || p_search || '%'))
       AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.redshift_quality > 0) OR (p_inspected_only = FALSE AND COALESCE(o.redshift_quality, 0) = 0))
@@ -1578,7 +1580,7 @@ BEGIN
         OR (v_list_ids_mode = 'all' AND (
             SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
             WHERE olm.object_id = o.id AND olm.list_id = ANY(p_list_ids)
-        ) = array_length(p_list_ids, 1))
+        ) = (SELECT COUNT(DISTINCT __list_id) FROM unnest(p_list_ids) __list_id))
         OR (v_list_ids_mode = 'none' AND o.id NOT IN (
             SELECT olm.object_id FROM object_list_members olm
             WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -1112,10 +1112,10 @@ BEGIN
         OR (v_list_ids_mode = 'all' AND (
             SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
             WHERE olm.object_id = t.object_id AND olm.list_id = ANY(p_list_ids)
-        ) = array_length(p_list_ids, 1))
-        OR (v_list_ids_mode = 'none' AND t.object_id NOT IN (
+        ) = (SELECT COUNT(DISTINCT __list_id) FROM unnest(p_list_ids) __list_id))
+        OR (v_list_ids_mode = 'none' AND (t.object_id IS NULL OR t.object_id NOT IN (
             SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
-        ))
+        )))
       )
       AND (p_search IS NULL OR s.id IN (SELECT __s.id FROM public.spectra __s WHERE __s.search_text ILIKE '%' || p_search || '%'))
       AND (
@@ -1422,7 +1422,7 @@ BEGIN
       OR (v_list_ids_mode = 'all' AND (
           SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
           WHERE olm.object_id = o.id AND olm.list_id = ANY(p_list_ids)
-      ) = array_length(p_list_ids, 1))
+      ) = (SELECT COUNT(DISTINCT __list_id) FROM unnest(p_list_ids) __list_id))
       OR (v_list_ids_mode = 'none' AND o.id NOT IN (
           SELECT olm.object_id FROM object_list_members olm
           WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
@@ -1557,7 +1557,7 @@ BEGIN
         OR (v_list_ids_mode = 'all' AND (
             SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
             WHERE olm.object_id = o.id AND olm.list_id = ANY(p_list_ids)
-        ) = array_length(p_list_ids, 1))
+        ) = (SELECT COUNT(DISTINCT __list_id) FROM unnest(p_list_ids) __list_id))
         OR (v_list_ids_mode = 'none' AND o.id NOT IN (
             SELECT olm.object_id FROM object_list_members olm
             WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
@@ -1873,7 +1873,7 @@ BEGIN
       OR (v_list_ids_mode = 'all' AND (
           SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
           WHERE olm.object_id = o.id AND olm.list_id = ANY(p_list_ids)
-      ) = array_length(p_list_ids, 1))
+      ) = (SELECT COUNT(DISTINCT __list_id) FROM unnest(p_list_ids) __list_id))
       OR (v_list_ids_mode = 'none' AND o.id NOT IN (
           SELECT olm.object_id FROM object_list_members olm
           WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
@@ -2095,7 +2095,7 @@ BEGIN
         OR (v_list_ids_mode = 'all' AND (
             SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
             WHERE olm.object_id = o.id AND olm.list_id = ANY(p_list_ids)
-        ) = array_length(p_list_ids, 1))
+        ) = (SELECT COUNT(DISTINCT __list_id) FROM unnest(p_list_ids) __list_id))
         OR (v_list_ids_mode = 'none' AND o.id NOT IN (
             SELECT olm.object_id FROM object_list_members olm
             WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
@@ -2338,10 +2338,10 @@ BEGIN
         OR (v_list_ids_mode = 'all' AND (
             SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
             WHERE olm.object_id = t.object_id AND olm.list_id = ANY(p_list_ids)
-        ) = array_length(p_list_ids, 1))
-        OR (v_list_ids_mode = 'none' AND t.object_id NOT IN (
+        ) = (SELECT COUNT(DISTINCT __list_id) FROM unnest(p_list_ids) __list_id))
+        OR (v_list_ids_mode = 'none' AND (t.object_id IS NULL OR t.object_id NOT IN (
             SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
-        ))
+        )))
       )
       AND (p_search IS NULL OR s.id IN (SELECT __s.id FROM public.spectra __s WHERE __s.search_text ILIKE '%' || p_search || '%'))
       AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.redshift_quality > 0) OR (p_inspected_only = FALSE AND COALESCE(o.redshift_quality, 0) = 0))
@@ -2555,7 +2555,7 @@ BEGIN
         OR (v_list_ids_mode = 'all' AND (
             SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
             WHERE olm.object_id = o.id AND olm.list_id = ANY(p_list_ids)
-        ) = array_length(p_list_ids, 1))
+        ) = (SELECT COUNT(DISTINCT __list_id) FROM unnest(p_list_ids) __list_id))
         OR (v_list_ids_mode = 'none' AND o.id NOT IN (
             SELECT olm.object_id FROM object_list_members olm
             WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -929,6 +929,8 @@ DROP FUNCTION IF EXISTS public.get_filtered_spectra_paginated(
   DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION, TEXT, TEXT, INTEGER, INTEGER, BOOLEAN
 );
 
+DROP FUNCTION IF EXISTS public.get_filtered_spectra_paginated;
+
 CREATE OR REPLACE FUNCTION public.get_filtered_spectra_paginated(
   p_program_slugs TEXT[],
   p_filter_programs TEXT[] DEFAULT NULL,
@@ -947,6 +949,7 @@ CREATE OR REPLACE FUNCTION public.get_filtered_spectra_paginated(
   p_dq_flags_include_all INTEGER DEFAULT NULL,
   p_dq_flags_exclude INTEGER DEFAULT NULL,
   p_list_ids INTEGER[] DEFAULT NULL,
+  p_list_ids_mode TEXT DEFAULT 'any',
   p_search TEXT DEFAULT NULL,
   p_inspected_only BOOLEAN DEFAULT NULL,
   p_needs_review BOOLEAN DEFAULT NULL,
@@ -974,6 +977,8 @@ DECLARE
   v_comment_search_active BOOLEAN;
   v_grating_filter_active BOOLEAN;
   v_gratings_mode TEXT;
+  v_list_filter_active BOOLEAN;
+  v_list_ids_mode TEXT;
   v_offset INTEGER;
 BEGIN
   v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
@@ -989,6 +994,12 @@ BEGIN
   v_gratings_mode := COALESCE(p_gratings_mode, 'any');
   IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
     v_gratings_mode := 'any';
+  END IF;
+
+  v_list_filter_active := (p_list_ids IS NOT NULL AND array_length(p_list_ids, 1) > 0);
+  v_list_ids_mode := COALESCE(p_list_ids_mode, 'any');
+  IF v_list_ids_mode NOT IN ('any', 'all', 'none') THEN
+    v_list_ids_mode := 'any';
   END IF;
 
   IF p_sort_direction NOT IN ('asc', 'desc') THEN
@@ -1093,9 +1104,19 @@ BEGIN
       AND (p_dq_flags_include_any IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_any) != 0)
       AND (p_dq_flags_include_all IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_all) = p_dq_flags_include_all)
       AND (p_dq_flags_exclude IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_exclude) = 0)
-      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR t.object_id IN (
-          SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
-      ))
+      AND (
+        NOT v_list_filter_active
+        OR (v_list_ids_mode = 'any' AND t.object_id IN (
+            SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+        OR (v_list_ids_mode = 'all' AND (
+            SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
+            WHERE olm.object_id = t.object_id AND olm.list_id = ANY(p_list_ids)
+        ) = array_length(p_list_ids, 1))
+        OR (v_list_ids_mode = 'none' AND t.object_id NOT IN (
+            SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+      )
       AND (p_search IS NULL OR s.id IN (SELECT __s.id FROM public.spectra __s WHERE __s.search_text ILIKE '%' || p_search || '%'))
       AND (
         p_inspected_only IS NULL
@@ -1238,6 +1259,8 @@ GRANT EXECUTE ON FUNCTION public.get_filtered_spectra_paginated TO service_role;
 -- (one row per unique sky position, cross-matched across programs)
 -- =============================================================================
 
+DROP FUNCTION IF EXISTS public.get_filtered_objects_paginated;
+
 CREATE OR REPLACE FUNCTION public.get_filtered_objects_paginated(
   p_program_slugs TEXT[],
   p_filter_programs TEXT[] DEFAULT NULL,
@@ -1256,6 +1279,7 @@ CREATE OR REPLACE FUNCTION public.get_filtered_objects_paginated(
   p_inspected_only BOOLEAN DEFAULT NULL,
   p_needs_review BOOLEAN DEFAULT NULL,
   p_list_ids INTEGER[] DEFAULT NULL,
+  p_list_ids_mode TEXT DEFAULT 'any',
   p_coord_ra DOUBLE PRECISION DEFAULT NULL,
   p_coord_dec DOUBLE PRECISION DEFAULT NULL,
   p_radius_degrees DOUBLE PRECISION DEFAULT NULL,
@@ -1281,6 +1305,8 @@ DECLARE
   v_comment_search_active BOOLEAN;
   v_grating_filter_active BOOLEAN;
   v_gratings_mode TEXT;
+  v_list_filter_active BOOLEAN;
+  v_list_ids_mode TEXT;
   v_offset INTEGER;
   v_total_count BIGINT;
 BEGIN
@@ -1294,6 +1320,11 @@ BEGIN
   v_gratings_mode := COALESCE(p_gratings_mode, 'any');
   IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
     v_gratings_mode := 'any';
+  END IF;
+  v_list_filter_active := (p_list_ids IS NOT NULL AND array_length(p_list_ids, 1) > 0);
+  v_list_ids_mode := COALESCE(p_list_ids_mode, 'any');
+  IF v_list_ids_mode NOT IN ('any', 'all', 'none') THEN
+    v_list_ids_mode := 'any';
   END IF;
 
   IF p_sort_direction NOT IN ('asc', 'desc') THEN
@@ -1382,10 +1413,21 @@ BEGIN
         ))) <= p_radius_degrees
       )
     )
-    AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
-        SELECT olm.object_id FROM object_list_members olm
-        WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
-    ))
+    AND (
+      NOT v_list_filter_active
+      OR (v_list_ids_mode = 'any' AND o.id IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      OR (v_list_ids_mode = 'all' AND (
+          SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
+          WHERE olm.object_id = o.id AND olm.list_id = ANY(p_list_ids)
+      ) = array_length(p_list_ids, 1))
+      OR (v_list_ids_mode = 'none' AND o.id NOT IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+    )
     AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
     AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
     AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
@@ -1506,10 +1548,21 @@ BEGIN
           ))) <= p_radius_degrees
         )
       )
-      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
-          SELECT olm.object_id FROM object_list_members olm
-          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
-      ))
+      AND (
+        NOT v_list_filter_active
+        OR (v_list_ids_mode = 'any' AND o.id IN (
+            SELECT olm.object_id FROM object_list_members olm
+            WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+        OR (v_list_ids_mode = 'all' AND (
+            SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
+            WHERE olm.object_id = o.id AND olm.list_id = ANY(p_list_ids)
+        ) = array_length(p_list_ids, 1))
+        OR (v_list_ids_mode = 'none' AND o.id NOT IN (
+            SELECT olm.object_id FROM object_list_members olm
+            WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+      )
       AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
       AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
       AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
@@ -1670,6 +1723,8 @@ GRANT EXECUTE ON FUNCTION public.get_filtered_objects_paginated TO service_role;
 -- (lightweight: returns only object_id strings for map marker filtering)
 -- =============================================================================
 
+DROP FUNCTION IF EXISTS public.get_filtered_object_ids;
+
 CREATE OR REPLACE FUNCTION public.get_filtered_object_ids(
   p_program_slugs TEXT[],
   p_filter_programs TEXT[] DEFAULT NULL,
@@ -1688,6 +1743,7 @@ CREATE OR REPLACE FUNCTION public.get_filtered_object_ids(
   p_inspected_only BOOLEAN DEFAULT NULL,
   p_needs_review BOOLEAN DEFAULT NULL,
   p_list_ids INTEGER[] DEFAULT NULL,
+  p_list_ids_mode TEXT DEFAULT 'any',
   p_coord_ra DOUBLE PRECISION DEFAULT NULL,
   p_coord_dec DOUBLE PRECISION DEFAULT NULL,
   p_radius_degrees DOUBLE PRECISION DEFAULT NULL,
@@ -1711,6 +1767,8 @@ DECLARE
   v_comment_search_active BOOLEAN;
   v_grating_filter_active BOOLEAN;
   v_gratings_mode TEXT;
+  v_list_filter_active BOOLEAN;
+  v_list_ids_mode TEXT;
 BEGIN
   v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
   v_comment_search_active := (
@@ -1722,6 +1780,11 @@ BEGIN
   v_gratings_mode := COALESCE(p_gratings_mode, 'any');
   IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN
     v_gratings_mode := 'any';
+  END IF;
+  v_list_filter_active := (p_list_ids IS NOT NULL AND array_length(p_list_ids, 1) > 0);
+  v_list_ids_mode := COALESCE(p_list_ids_mode, 'any');
+  IF v_list_ids_mode NOT IN ('any', 'all', 'none') THEN
+    v_list_ids_mode := 'any';
   END IF;
 
   IF p_sort_direction NOT IN ('asc', 'desc') THEN
@@ -1801,10 +1864,21 @@ BEGIN
         ))) <= p_radius_degrees
       )
     )
-    AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
-        SELECT olm.object_id FROM object_list_members olm
-        WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
-    ))
+    AND (
+      NOT v_list_filter_active
+      OR (v_list_ids_mode = 'any' AND o.id IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+      OR (v_list_ids_mode = 'all' AND (
+          SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
+          WHERE olm.object_id = o.id AND olm.list_id = ANY(p_list_ids)
+      ) = array_length(p_list_ids, 1))
+      OR (v_list_ids_mode = 'none' AND o.id NOT IN (
+          SELECT olm.object_id FROM object_list_members olm
+          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+      ))
+    )
     AND (
       NOT v_comment_search_active
       -- Uncorrelated semijoin; see get_filtered_objects_paginated for rationale.
@@ -1877,6 +1951,8 @@ GRANT EXECUTE ON FUNCTION public.get_filtered_object_ids TO service_role;
 -- get_adjacent_objects
 -- =============================================================================
 
+DROP FUNCTION IF EXISTS public.get_adjacent_objects;
+
 CREATE OR REPLACE FUNCTION public.get_adjacent_objects(
   p_current_object_id TEXT,
   p_program_slugs TEXT[],
@@ -1896,6 +1972,7 @@ CREATE OR REPLACE FUNCTION public.get_adjacent_objects(
   p_inspected_only BOOLEAN DEFAULT NULL,
   p_needs_review BOOLEAN DEFAULT NULL,
   p_list_ids INTEGER[] DEFAULT NULL,
+  p_list_ids_mode TEXT DEFAULT 'any',
   p_coord_ra DOUBLE PRECISION DEFAULT NULL,
   p_coord_dec DOUBLE PRECISION DEFAULT NULL,
   p_radius_degrees DOUBLE PRECISION DEFAULT NULL,
@@ -1919,6 +1996,8 @@ DECLARE
   v_comment_search_active BOOLEAN;
   v_grating_filter_active BOOLEAN;
   v_gratings_mode TEXT;
+  v_list_filter_active BOOLEAN;
+  v_list_ids_mode TEXT;
   v_sort_is_text BOOLEAN;
 BEGIN
   v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
@@ -1930,6 +2009,9 @@ BEGIN
   v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
   v_gratings_mode := COALESCE(p_gratings_mode, 'any');
   IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN v_gratings_mode := 'any'; END IF;
+  v_list_filter_active := (p_list_ids IS NOT NULL AND array_length(p_list_ids, 1) > 0);
+  v_list_ids_mode := COALESCE(p_list_ids_mode, 'any');
+  IF v_list_ids_mode NOT IN ('any', 'all', 'none') THEN v_list_ids_mode := 'any'; END IF;
   IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
   IF NOT (p_sort_column IN (
     'object_id', 'field', 'ra', 'dec', 'redshift', 'redshift_quality',
@@ -2004,10 +2086,21 @@ BEGIN
         o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
         AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
       ))
-      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
-          SELECT olm.object_id FROM object_list_members olm
-          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
-      ))
+      AND (
+        NOT v_list_filter_active
+        OR (v_list_ids_mode = 'any' AND o.id IN (
+            SELECT olm.object_id FROM object_list_members olm
+            WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+        OR (v_list_ids_mode = 'all' AND (
+            SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
+            WHERE olm.object_id = o.id AND olm.list_id = ANY(p_list_ids)
+        ) = array_length(p_list_ids, 1))
+        OR (v_list_ids_mode = 'none' AND o.id NOT IN (
+            SELECT olm.object_id FROM object_list_members olm
+            WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+      )
       AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
       AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
       AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
@@ -2140,6 +2233,8 @@ DROP FUNCTION IF EXISTS public.get_csv_export_spectra(
   DOUBLE PRECISION, DOUBLE PRECISION, DOUBLE PRECISION, TEXT, TEXT, BOOLEAN
 );
 
+DROP FUNCTION IF EXISTS public.get_csv_export_spectra;
+
 CREATE OR REPLACE FUNCTION public.get_csv_export_spectra(
   p_program_slugs TEXT[], p_filter_programs TEXT[] DEFAULT NULL,
   p_fields TEXT[] DEFAULT NULL, p_gratings TEXT[] DEFAULT NULL,
@@ -2151,6 +2246,7 @@ CREATE OR REPLACE FUNCTION public.get_csv_export_spectra(
   p_dq_flags_include_any INTEGER DEFAULT NULL, p_dq_flags_include_all INTEGER DEFAULT NULL,
   p_dq_flags_exclude INTEGER DEFAULT NULL,
   p_list_ids INTEGER[] DEFAULT NULL,
+  p_list_ids_mode TEXT DEFAULT 'any',
   p_search TEXT DEFAULT NULL, p_inspected_only BOOLEAN DEFAULT NULL,
   p_needs_review BOOLEAN DEFAULT NULL,
   p_has_photometry BOOLEAN DEFAULT NULL,
@@ -2180,11 +2276,16 @@ DECLARE
   v_coord_search_active BOOLEAN;
   v_comment_search_active BOOLEAN;
   v_grating_filter_active BOOLEAN;
+  v_list_filter_active BOOLEAN;
+  v_list_ids_mode TEXT;
   v_page_size INTEGER;
 BEGIN
   v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
   v_comment_search_active := (p_comment_search IS NOT NULL AND p_comment_search != '' AND p_comment_search_scope IN ('just_me', 'everyone'));
   v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_list_filter_active := (p_list_ids IS NOT NULL AND array_length(p_list_ids, 1) > 0);
+  v_list_ids_mode := COALESCE(p_list_ids_mode, 'any');
+  IF v_list_ids_mode NOT IN ('any', 'all', 'none') THEN v_list_ids_mode := 'any'; END IF;
   v_page_size := LEAST(GREATEST(COALESCE(p_page_size, 5000), 1), 10000);
   IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
     SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs)) INTO v_filtered_program_slugs;
@@ -2229,9 +2330,19 @@ BEGIN
       AND (p_dq_flags_include_any IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_any) != 0)
       AND (p_dq_flags_include_all IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_all) = p_dq_flags_include_all)
       AND (p_dq_flags_exclude IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_exclude) = 0)
-      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR t.object_id IN (
-          SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
-      ))
+      AND (
+        NOT v_list_filter_active
+        OR (v_list_ids_mode = 'any' AND t.object_id IN (
+            SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+        OR (v_list_ids_mode = 'all' AND (
+            SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
+            WHERE olm.object_id = t.object_id AND olm.list_id = ANY(p_list_ids)
+        ) = array_length(p_list_ids, 1))
+        OR (v_list_ids_mode = 'none' AND t.object_id NOT IN (
+            SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+      )
       AND (p_search IS NULL OR s.id IN (SELECT __s.id FROM public.spectra __s WHERE __s.search_text ILIKE '%' || p_search || '%'))
       AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.redshift_quality > 0) OR (p_inspected_only = FALSE AND COALESCE(o.redshift_quality, 0) = 0))
       AND (p_needs_review IS NULL
@@ -2288,6 +2399,8 @@ DROP FUNCTION IF EXISTS public.get_csv_export_objects(
   BOOLEAN, DOUBLE PRECISION, DOUBLE PRECISION, TEXT, TEXT, UUID, TEXT, TEXT, BOOLEAN
 );
 
+DROP FUNCTION IF EXISTS public.get_csv_export_objects;
+
 CREATE OR REPLACE FUNCTION public.get_csv_export_objects(
   p_program_slugs TEXT[], p_filter_programs TEXT[] DEFAULT NULL,
   p_fields TEXT[] DEFAULT NULL, p_gratings TEXT[] DEFAULT NULL,
@@ -2299,6 +2412,7 @@ CREATE OR REPLACE FUNCTION public.get_csv_export_objects(
   p_search TEXT DEFAULT NULL, p_inspected_only BOOLEAN DEFAULT NULL,
   p_needs_review BOOLEAN DEFAULT NULL,
   p_list_ids INTEGER[] DEFAULT NULL,
+  p_list_ids_mode TEXT DEFAULT 'any',
   p_coord_ra DOUBLE PRECISION DEFAULT NULL, p_coord_dec DOUBLE PRECISION DEFAULT NULL,
   p_radius_degrees DOUBLE PRECISION DEFAULT NULL,
   p_has_photometry BOOLEAN DEFAULT NULL,
@@ -2333,6 +2447,8 @@ DECLARE
   v_comment_search_active BOOLEAN;
   v_grating_filter_active BOOLEAN;
   v_gratings_mode TEXT;
+  v_list_filter_active BOOLEAN;
+  v_list_ids_mode TEXT;
   v_page_size INTEGER;
 BEGIN
   v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
@@ -2344,6 +2460,9 @@ BEGIN
   v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
   v_gratings_mode := COALESCE(p_gratings_mode, 'any');
   IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN v_gratings_mode := 'any'; END IF;
+  v_list_filter_active := (p_list_ids IS NOT NULL AND array_length(p_list_ids, 1) > 0);
+  v_list_ids_mode := COALESCE(p_list_ids_mode, 'any');
+  IF v_list_ids_mode NOT IN ('any', 'all', 'none') THEN v_list_ids_mode := 'any'; END IF;
   v_page_size := LEAST(GREATEST(COALESCE(p_page_size, 5000), 1), 10000);
 
   IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
@@ -2427,10 +2546,21 @@ BEGIN
         o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
         AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
       ))
-      AND (p_list_ids IS NULL OR array_length(p_list_ids, 1) IS NULL OR o.id IN (
-          SELECT olm.object_id FROM object_list_members olm
-          WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
-      ))
+      AND (
+        NOT v_list_filter_active
+        OR (v_list_ids_mode = 'any' AND o.id IN (
+            SELECT olm.object_id FROM object_list_members olm
+            WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+        OR (v_list_ids_mode = 'all' AND (
+            SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
+            WHERE olm.object_id = o.id AND olm.list_id = ANY(p_list_ids)
+        ) = array_length(p_list_ids, 1))
+        OR (v_list_ids_mode = 'none' AND o.id NOT IN (
+            SELECT olm.object_id FROM object_list_members olm
+            WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+      )
       AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
       AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
       AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)

--- a/web/app/api/v1/objects/route.ts
+++ b/web/app/api/v1/objects/route.ts
@@ -115,6 +115,7 @@ export async function GET(request: NextRequest) {
       p_inspected_only: inspectedOnly,
       p_needs_review: needsReview,
       p_list_ids: listIds,
+      p_list_ids_mode: searchParams.get('list_ids_mode') || 'any',
       p_coord_ra: coordRa,
       p_coord_dec: coordDec,
       p_radius_degrees: radiusDegrees,

--- a/web/app/api/v1/spectra/list/route.ts
+++ b/web/app/api/v1/spectra/list/route.ts
@@ -127,6 +127,7 @@ export async function GET(request: NextRequest) {
       p_dq_flags_include_all: dq.all,
       p_dq_flags_exclude: dq.none,
       p_list_ids: listIds,
+      p_list_ids_mode: searchParams.get('list_ids_mode') || 'any',
       p_search: searchParams.get('search') || null,
       p_inspected_only: inspectedOnly,
       p_needs_review: needsReview,

--- a/web/components/spectra/AdvancedFiltersPanel.tsx
+++ b/web/components/spectra/AdvancedFiltersPanel.tsx
@@ -245,6 +245,7 @@ export function AdvancedFiltersPanel({
       max_exposure_time_min: null,
       max_exposure_time_max: null,
       list_ids: [],
+      list_ids_mode: 'any',
       dq_flags: [],
       dq_flags_mode: 'any',
     });
@@ -542,9 +543,8 @@ export function AdvancedFiltersPanel({
                 options={listOptions}
                 selected={filters.list_ids ?? []}
                 onChange={(s) => onFiltersChange({ ...filters, list_ids: s as number[] })}
-                mode="any"
-                onModeChange={() => {}}
-                hideModeSelector
+                mode={filters.list_ids_mode}
+                onModeChange={(m) => onFiltersChange({ ...filters, list_ids_mode: m })}
               />
             </div>
           )}

--- a/web/components/spectra/SpectraFilterBar.tsx
+++ b/web/components/spectra/SpectraFilterBar.tsx
@@ -190,6 +190,7 @@ export const SpectraFilterBar: React.FC<SpectraFilterBarProps> = ({
       max_exposure_time_min: null,
       max_exposure_time_max: null,
       list_ids: [],
+      list_ids_mode: 'any',
       dq_flags: [],
       dq_flags_mode: 'any',
     });

--- a/web/lib/actions/filter-params.ts
+++ b/web/lib/actions/filter-params.ts
@@ -43,6 +43,7 @@ export interface FilterOptions {
   search_scope: SearchScope;
   gratings_mode: FilterMode;
   dq_flags_mode: FilterMode;
+  list_ids_mode: FilterMode;
 }
 
 export const DEFAULT_FILTERS: FilterOptions = {
@@ -67,6 +68,7 @@ export const DEFAULT_FILTERS: FilterOptions = {
   search_scope: 'target_id',
   gratings_mode: 'any',
   dq_flags_mode: 'any',
+  list_ids_mode: 'any',
 };
 
 /**
@@ -92,6 +94,7 @@ export interface FilterRpcParams {
   p_max_exposure_time_min: number | null;
   p_max_exposure_time_max: number | null;
   p_list_ids: number[] | null;
+  p_list_ids_mode: string;
   p_dq_flags_include_any: number | null;
   p_dq_flags_include_all: number | null;
   p_dq_flags_exclude: number | null;
@@ -168,6 +171,7 @@ export function buildFilterParams(
     p_max_exposure_time_min: filters?.max_exposure_time_min ?? null,
     p_max_exposure_time_max: filters?.max_exposure_time_max ?? null,
     p_list_ids: filters?.list_ids?.length ? filters.list_ids : null,
+    p_list_ids_mode: filters?.list_ids_mode || 'any',
     p_dq_flags_include_any: dqMode === 'any' ? dqFlagsMask : null,
     p_dq_flags_include_all: dqMode === 'all' ? dqFlagsMask : null,
     p_dq_flags_exclude: dqMode === 'none' ? dqFlagsMask : null,

--- a/web/lib/actions/map.ts
+++ b/web/lib/actions/map.ts
@@ -282,6 +282,7 @@ export async function getFilteredObjectIds(
       p_needs_review: baseParams.p_needs_review,
       p_has_photometry: baseParams.p_has_photometry,
       p_list_ids: baseParams.p_list_ids,
+      p_list_ids_mode: baseParams.p_list_ids_mode,
       p_coord_ra: baseParams.p_coord_ra,
       p_coord_dec: baseParams.p_coord_dec,
       p_radius_degrees: baseParams.p_radius_degrees,

--- a/web/lib/actions/spectra.ts
+++ b/web/lib/actions/spectra.ts
@@ -124,6 +124,7 @@ export async function getSpectra(
         p_needs_review: rpcParams.p_needs_review,
         p_has_photometry: rpcParams.p_has_photometry,
         p_list_ids: rpcParams.p_list_ids,
+        p_list_ids_mode: rpcParams.p_list_ids_mode,
         p_coord_ra: rpcParams.p_coord_ra,
         p_coord_dec: rpcParams.p_coord_dec,
         p_radius_degrees: rpcParams.p_radius_degrees,

--- a/web/lib/utils/url-params.ts
+++ b/web/lib/utils/url-params.ts
@@ -89,6 +89,7 @@ export function parseFiltersFromURL(searchParams: URLSearchParams): AdvancedFilt
     // Filter modes (default to 'any')
     gratings_mode: parseMode('gratings_mode'),
     dq_flags_mode: parseMode('dq_flags_mode'),
+    list_ids_mode: parseMode('tags_mode'),
   };
 }
 
@@ -209,6 +210,9 @@ export function filtersToURLParams(
   }
   if (filters.dq_flags.length > 0 && filters.dq_flags_mode && filters.dq_flags_mode !== 'any') {
     params.set('dq_flags_mode', filters.dq_flags_mode);
+  }
+  if (filters.list_ids.length > 0 && filters.list_ids_mode && filters.list_ids_mode !== 'any') {
+    params.set('tags_mode', filters.list_ids_mode);
   }
   // Only include pagination params if not default values
   if (page > 1) {


### PR DESCRIPTION
## Summary

The NIRSpec catalog's Tags filter previously only supported OR ("any") semantics across selected tags, unlike the Any/All/None mode selector already available for the Gratings and DQ-flags filters. This adds the same pattern for tags:

- **Database**: added a `p_list_ids_mode` parameter to the six RPCs that accept `p_list_ids` (`get_filtered_spectra_paginated`, `get_filtered_objects_paginated`, `get_filtered_object_ids`, `get_adjacent_objects`, `get_csv_export_spectra`, `get_csv_export_objects`). `all` requires an object to carry every selected tag; `none` excludes objects carrying any selected tag; `any` preserves prior behavior and stays the default.
- **Web**: `list_ids_mode` flows through `filter-params.ts` → URL params (`tags_mode`) → the catalog REST API routes → the `AdvancedFiltersPanel` Tags section, which now shows the same Any/All/None button group as Gratings.

Closes #443.

## Test plan

- [ ] `npm run build` in `web/` (not run in this session due to sandbox restrictions)
- [ ] Apply the migration to a preview/local Supabase instance and confirm it matches `supabase/schemas/functions.sql`
- [ ] In the NIRSpec catalog, select multiple tags and verify Any/All/None filtering behaves as expected in both Objects and Spectra view modes, on the map page, and in CSV export

Generated with [Claude Code](https://claude.ai/code)