### PR TITLE
Fix double background subtraction via CFP_BKGS stamp (issue #427)

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -28,6 +28,28 @@ Release procedure: edit the `## Unreleased` section below, then run
 
 ## Unreleased
 
+### Algorithm
+- **Mosaic background subtraction is now recorded by a `CFP_BKGS` stamp on the
+  i2d primary header, making `_i2d_before_bkgsub.fits` deletable** (issue
+  #427). Previously the snapshot's *existence on disk* was the only
+  bkgsub-done record, so deleting one of these full-size copies (~7.5 TB
+  pinned across the products tree) made the next up-to-date `resample` run
+  silently subtract the background a **second time**, in place — and then
+  re-snapshot the corrupted data, concealing the damage. The stamp (written
+  onto the subtracted output before it is renamed into place, so pixels and
+  record land atomically) now drives the skip decision; its value carries the
+  bkgsub algorithm version and a hash of the pixel-affecting settings for
+  provenance. Legacy mosaics stamped before this change fall back to the
+  snapshot's existence and get the stamp **backfilled** on their next
+  up-to-date run — so run the pipeline once over a field before deleting its
+  snapshots. New `[nircam.resample].keep_pre_bkgsub` (default `true`) skips
+  writing the snapshot entirely (cost: no rollback copy, no `_bkgsub.png`
+  before/after plot). Regression-tested against the double-subtraction
+  (`tests/test_nircam_resample_bkgsub_stamp.py`; the test measurably fails on
+  the pre-fix code). Pixels are unchanged for every correctly-skipped or
+  rebuilt tile — the only behavior removed is the corruption path — but the
+  new header keyword is an (additive) output-structure change.
+
 ### Infrastructure
 - The drizzle **CONTEXT extension is now written tile-compressed** (GZIP_1,
   lossless), controlled by `[nircam.resample].compress_context` (default

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -42,7 +42,11 @@ Release procedure: edit the `## Unreleased` section below, then run
   provenance. Legacy mosaics stamped before this change fall back to the
   snapshot's existence and get the stamp **backfilled** on their next
   up-to-date run — so run the pipeline once over a field before deleting its
-  snapshots. New `[nircam.resample].keep_pre_bkgsub` (default `true`) skips
+  snapshots. The backfill is gated on the i2d carrying the `SRCMASK`
+  extension (which `SubtractBackground` always appends and the snapshot
+  never has), so a rollback that *copies* the snapshot over the i2d is
+  recognized as restored pre-bkgsub data and re-subtracted rather than
+  wrongly stamped as done. New `[nircam.resample].keep_pre_bkgsub` (default `true`) skips
   writing the snapshot entirely (cost: no rollback copy, no `_bkgsub.png`
   before/after plot). Regression-tested against the double-subtraction
   (`tests/test_nircam_resample_bkgsub_stamp.py`; the test measurably fails on

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -757,6 +757,13 @@
     pixfrac = 1
     kernel = "square"
     background_subtract = true
+    # Keep the full-size _i2d_before_bkgsub.fits rollback snapshot after
+    # subtracting the mosaic background. The bkgsub-done record is the
+    # CFP_BKGS stamp on the i2d itself (issue #427), so the snapshot is a
+    # pure convenience copy: deletable at any time to reclaim space, and
+    # skippable up front by setting this false (its only cost is losing the
+    # rollback and the _bkgsub.png before/after plot).
+    keep_pre_bkgsub = true
     ring_radius_in = 80
     ring_width = 4
     ring_downsample = 4

--- a/pipeline/campfire_pipeline/nircam/manifest.py
+++ b/pipeline/campfire_pipeline/nircam/manifest.py
@@ -171,6 +171,34 @@ BKGSUB_PIXEL_DEFAULTS = {
 }
 
 
+# Primary-header keyword stamped on a mosaic i2d once its on-disk pixels have
+# been background-subtracted (issue #427). This stamp — not the existence of
+# the ``_i2d_before_bkgsub.fits`` snapshot — is the authoritative bkgsub-done
+# record, so the snapshot is a pure rollback convenience that can be deleted
+# to reclaim space. Not part of the ``cfp`` exposure keysets: those track the
+# per-exposure canonical chain, while this lives on the per-tile mosaic.
+MOSAIC_BKGSUB_KEY = 'CFP_BKGS'
+
+
+def bkgsub_stamp_value(resample_cfg):
+    """Value for the :data:`MOSAIC_BKGSUB_KEY` mosaic stamp.
+
+    Records *what* ran, not just that it ran: the bkgsub algorithm version
+    plus a short hash of every pixel-affecting SubtractBackground setting
+    (:data:`BKGSUB_PIXEL_DEFAULTS`, and ``wht_aware`` when non-default —
+    the same fields :func:`_resample_config_hash` folds in). Readers decide
+    skip-vs-rerun from the stamp's *presence*; the value is provenance for
+    after-the-fact debugging.
+    """
+    params = {k: resample_cfg.get(k, d)
+              for k, d in BKGSUB_PIXEL_DEFAULTS.items()}
+    if not resample_cfg.get('wht_aware', True):
+        params['wht_aware'] = False
+    digest = hashlib.sha256(
+        json.dumps(params, sort_keys=True).encode()).hexdigest()[:12]
+    return f'v{_BKGSUB_ALGORITHM_VERSION} cfg={digest}'
+
+
 def _resample_config_hash(resample_cfg, pixel_scale):
     """Hash the resample config fields that affect mosaic pixels.
 
@@ -180,8 +208,10 @@ def _resample_config_hash(resample_cfg, pixel_scale):
     setting that changes pixels (:data:`BKGSUB_PIXEL_DEFAULTS`) plus the
     bkgsub algorithm version, so both tuning changes and behavior changes
     at identical settings mark tiles stale — resample_step skips bkgsub
-    entirely for a tile whose manifest and ``_i2d_before_bkgsub.fits``
-    exist, so a stale hash is the *only* thing that reruns it.
+    entirely for a tile whose manifest is current and whose i2d carries the
+    :data:`MOSAIC_BKGSUB_KEY` stamp (legacy fallback: an existing
+    ``_i2d_before_bkgsub.fits``), so a stale hash is the *only* thing that
+    reruns it.
     ``wht_aware`` is folded in only when *disabled* (non-default), keeping
     historical hashes for the common case.
     """

--- a/pipeline/campfire_pipeline/nircam/steps/resample.py
+++ b/pipeline/campfire_pipeline/nircam/steps/resample.py
@@ -338,17 +338,31 @@ def resample_step(filtname, exposure_files, field, step_config,
             if needs_rebuild:
                 bkgsub_done = False  # freshly drizzled, stamp gone with it
             else:
-                bkgsub_done = MOSAIC_BKGSUB_KEY in fits.getheader(mosaic_file)
+                with fits.open(mosaic_file) as hdul:
+                    bkgsub_done = MOSAIC_BKGSUB_KEY in hdul[0].header
+                    has_srcmask = 'SRCMASK' in hdul
                 if not bkgsub_done and os.path.exists(pre_bkg):
-                    # Mosaic subtracted before the stamp existed. The manifest
-                    # config check passed to get here, so the current bkgsub
-                    # settings are the ones that produced it — backfill the
-                    # stamp so the snapshot becomes deletable from now on.
-                    bkgsub_done = True
-                    log(f"  backfilling {MOSAIC_BKGSUB_KEY} stamp on "
-                        f"pre-stamp mosaic {os.path.basename(mosaic_file)}")
-                    with fits.open(mosaic_file, mode='update') as hdul:
-                        hdul[0].header[MOSAIC_BKGSUB_KEY] = stamp_card
+                    # No stamp but a snapshot on disk: either a legacy mosaic
+                    # subtracted before the stamp existed, or a rollback where
+                    # the snapshot was copied over the i2d (restoring
+                    # unsubtracted pixels) with the snapshot left in place.
+                    # SubtractBackground always appends a SRCMASK extension
+                    # and the snapshot (copied from the pre-subtraction
+                    # drizzle output) never carries one, so SRCMASK presence
+                    # tells the two apart.
+                    if has_srcmask:
+                        # Legacy subtracted mosaic. The manifest config check
+                        # passed to get here, so the current bkgsub settings
+                        # are the ones that produced it — backfill the stamp
+                        # so the snapshot becomes deletable from now on.
+                        bkgsub_done = True
+                        log(f"  backfilling {MOSAIC_BKGSUB_KEY} stamp on "
+                            f"pre-stamp mosaic {os.path.basename(mosaic_file)}")
+                        with fits.open(mosaic_file, mode='update') as hdul:
+                            hdul[0].header[MOSAIC_BKGSUB_KEY] = stamp_card
+                    else:
+                        log("  snapshot present but i2d has no SRCMASK — "
+                            "restored pre-bkgsub data; re-running bkgsub")
 
             if not bkgsub_done:
                 if os.path.exists(pre_bkg):

--- a/pipeline/campfire_pipeline/nircam/steps/resample.py
+++ b/pipeline/campfire_pipeline/nircam/steps/resample.py
@@ -214,8 +214,9 @@ def resample_step(filtname, exposure_files, field, step_config,
         epoch segment.
     """
     from campfire_pipeline.nircam.manifest import (
-        BKGSUB_PIXEL_DEFAULTS, build_mosaic_name, check_config_changed,
-        check_inputs_changed, create_manifest, write_manifest,
+        BKGSUB_PIXEL_DEFAULTS, MOSAIC_BKGSUB_KEY, bkgsub_stamp_value,
+        build_mosaic_name, check_config_changed, check_inputs_changed,
+        create_manifest, write_manifest,
     )
 
     pixel_scale, pixel_scale_str = _resolve_pixel_scale(
@@ -322,9 +323,35 @@ def resample_step(filtname, exposure_files, field, step_config,
             from campfire_pipeline.nircam.bkgsub import SubtractBackground
 
             pre_bkg = mosaic_file.replace('_i2d.fits', '_i2d_before_bkgsub.fits')
-            bkgsub_done = os.path.exists(pre_bkg)
-            if needs_rebuild or not bkgsub_done:
-                if needs_rebuild and bkgsub_done:
+            stamp_card = (
+                bkgsub_stamp_value(step_config),
+                'campfire: mosaic bkgsub (alg ver, params hash)',
+            )
+
+            # The CFP_BKGS primary-header stamp on the i2d — not the existence
+            # of the _i2d_before_bkgsub.fits snapshot — is the record that the
+            # on-disk pixels are already background-subtracted (issue #427):
+            # deriving bkgsub_done from the snapshot made a deleted snapshot
+            # silently subtract the background a second time. The snapshot is
+            # a rollback convenience copy, deletable once its mosaic carries
+            # the stamp.
+            if needs_rebuild:
+                bkgsub_done = False  # freshly drizzled, stamp gone with it
+            else:
+                bkgsub_done = MOSAIC_BKGSUB_KEY in fits.getheader(mosaic_file)
+                if not bkgsub_done and os.path.exists(pre_bkg):
+                    # Mosaic subtracted before the stamp existed. The manifest
+                    # config check passed to get here, so the current bkgsub
+                    # settings are the ones that produced it — backfill the
+                    # stamp so the snapshot becomes deletable from now on.
+                    bkgsub_done = True
+                    log(f"  backfilling {MOSAIC_BKGSUB_KEY} stamp on "
+                        f"pre-stamp mosaic {os.path.basename(mosaic_file)}")
+                    with fits.open(mosaic_file, mode='update') as hdul:
+                        hdul[0].header[MOSAIC_BKGSUB_KEY] = stamp_card
+
+            if not bkgsub_done:
+                if os.path.exists(pre_bkg):
                     os.remove(pre_bkg)
 
                 # Pixel-affecting settings and their defaults come from the
@@ -340,8 +367,19 @@ def resample_step(filtname, exposure_files, field, step_config,
                 )
                 bkg.call(mosaic_file)
 
-                log(f"  copying input → {os.path.basename(pre_bkg)}")
-                shutil.copy2(mosaic_file, pre_bkg)
+                # Stamp the subtracted output *before* it is renamed into
+                # place, so stamp and pixels land together atomically and the
+                # pre-bkgsub snapshot (copied from the un-stamped input) never
+                # carries the stamp.
+                with fits.open(bkg.outfile, mode='update') as hdul:
+                    hdul[0].header[MOSAIC_BKGSUB_KEY] = stamp_card
+
+                if step_config.get('keep_pre_bkgsub', True):
+                    log(f"  copying input → {os.path.basename(pre_bkg)}")
+                    shutil.copy2(mosaic_file, pre_bkg)
+                else:
+                    log("  keep_pre_bkgsub = false; "
+                        "not snapshotting the pre-bkgsub mosaic")
 
                 log(f"  renaming {os.path.basename(bkg.outfile)} → "
                     f"{os.path.basename(mosaic_file)}")

--- a/pipeline/tests/test_nircam_manifest_hash.py
+++ b/pipeline/tests/test_nircam_manifest_hash.py
@@ -1,7 +1,8 @@
 """Tests for the resample config hash (tile staleness detection).
 
 The resample step skips background subtraction entirely for a tile whose
-manifest and ``_i2d_before_bkgsub.fits`` both exist, so the config hash is
+manifest is current and whose i2d carries the ``CFP_BKGS`` stamp (legacy
+fallback: an existing ``_i2d_before_bkgsub.fits``), so the config hash is
 the only thing that reruns bkgsub on existing tiles. It must therefore
 cover every bkgsub setting that changes mosaic pixels, plus an algorithm
 version for behavior changes at identical settings (the guard rollout).

--- a/pipeline/tests/test_nircam_resample_bkgsub_stamp.py
+++ b/pipeline/tests/test_nircam_resample_bkgsub_stamp.py
@@ -47,6 +47,11 @@ class FakeSubtractBackground:
         self.outfile = filepath.replace('.fits', '_bkgsub.fits')
         with fits.open(filepath) as hdul:
             hdul['SCI'].data = hdul['SCI'].data - BKG
+            # The real SubtractBackground always appends SRCMASK; the skip
+            # logic uses its presence to tell a subtracted i2d from a
+            # restored pre-bkgsub snapshot.
+            hdul.append(fits.ImageHDU(
+                np.zeros((4, 4), dtype=np.uint8), name='SRCMASK'))
             hdul.writeto(self.outfile, overwrite=True)
         return self.outfile
 
@@ -61,7 +66,7 @@ def _pre_bkg_path(tmp_path):
                                           '_i2d_before_bkgsub.fits')
 
 
-def _write_mosaic(path, sci_level, stamped=False):
+def _write_mosaic(path, sci_level, stamped=False, srcmask=False):
     sci = fits.ImageHDU(np.full((4, 4), sci_level, dtype=np.float32),
                         name='SCI')
     err = fits.ImageHDU(np.ones((4, 4), dtype=np.float32), name='ERR')
@@ -69,7 +74,11 @@ def _write_mosaic(path, sci_level, stamped=False):
     primary = fits.PrimaryHDU()
     if stamped:
         primary.header[MOSAIC_BKGSUB_KEY] = 'v0 cfg=deadbeef0000'
-    fits.HDUList([primary, sci, err, wht]).writeto(path, overwrite=True)
+    hdus = [primary, sci, err, wht]
+    if srcmask:
+        hdus.append(fits.ImageHDU(np.zeros((4, 4), dtype=np.uint8),
+                                  name='SRCMASK'))
+    fits.HDUList(hdus).writeto(path, overwrite=True)
 
 
 def _sci_level(path):
@@ -157,11 +166,12 @@ def test_snapshot_never_carries_the_stamp(tmp_path, monkeypatch):
 
 def test_legacy_mosaic_skips_via_snapshot_and_backfills(tmp_path, monkeypatch):
     # A mosaic subtracted before the stamp existed: no CFP_BKGS, snapshot on
-    # disk. It must keep skipping, and the skip must backfill the stamp so
-    # the snapshot becomes deletable.
+    # disk, SRCMASK extension present (SubtractBackground always appends it).
+    # It must keep skipping, and the skip must backfill the stamp so the
+    # snapshot becomes deletable.
     mosaic = _mosaic_path(tmp_path)
     pre_bkg = _pre_bkg_path(tmp_path)
-    _write_mosaic(mosaic, SKY - BKG)
+    _write_mosaic(mosaic, SKY - BKG, srcmask=True)
     _write_mosaic(pre_bkg, SKY)
 
     logs = _run(tmp_path, monkeypatch)
@@ -174,6 +184,29 @@ def test_legacy_mosaic_skips_via_snapshot_and_backfills(tmp_path, monkeypatch):
     logs = _run(tmp_path, monkeypatch)
     assert _skipped(logs)
     assert _sci_level(mosaic) == SKY - BKG
+
+
+def test_restored_snapshot_reruns_instead_of_backfilling(tmp_path, monkeypatch):
+    # Rollback by *copying* the snapshot over the i2d, leaving the snapshot
+    # in place: the restored i2d has unsubtracted pixels, no stamp, and no
+    # SRCMASK extension. The fallback must NOT mistake it for a legacy
+    # subtracted mosaic (which would backfill the stamp and permanently skip
+    # subtraction on unsubtracted data) — it must re-run bkgsub.
+    import shutil
+
+    mosaic = _mosaic_path(tmp_path)
+    pre_bkg = _pre_bkg_path(tmp_path)
+    _write_mosaic(mosaic, SKY)
+
+    _run(tmp_path, monkeypatch)  # subtract once: SCI -> SKY - BKG, snapshot
+    shutil.copy2(pre_bkg, mosaic)  # rollback, snapshot left behind
+    assert _sci_level(mosaic) == SKY
+
+    logs = _run(tmp_path, monkeypatch)
+    assert not _skipped(logs)
+    assert _sci_level(mosaic) == SKY - BKG  # re-subtracted exactly once
+    assert MOSAIC_BKGSUB_KEY in fits.getheader(mosaic)
+    assert _sci_level(pre_bkg) == SKY  # fresh snapshot of the restored input
 
 
 def test_stamped_mosaic_skips_without_snapshot(tmp_path, monkeypatch):

--- a/pipeline/tests/test_nircam_resample_bkgsub_stamp.py
+++ b/pipeline/tests/test_nircam_resample_bkgsub_stamp.py
@@ -1,0 +1,220 @@
+"""Regression tests for the mosaic bkgsub-done record (issue #427).
+
+``_i2d_before_bkgsub.fits`` existence used to be the *only* record that
+background subtraction had already run on a mosaic tile, so deleting the
+(20–130 GB) snapshot to reclaim space made the next up-to-date run silently
+subtract the background a second time, in place. The record is now the
+``CFP_BKGS`` stamp on the i2d primary header; the snapshot is a deletable
+rollback convenience, with its existence kept only as a legacy fallback
+(which backfills the stamp).
+
+These tests drive the real ``resample_step`` control flow with the manifest
+staleness checks stubbed to "up-to-date" and a fake ``SubtractBackground``
+that subtracts a constant — so a double subtraction is directly measurable
+in the SCI pixels.
+"""
+
+import os
+import sys
+import types
+
+import numpy as np
+from astropy.io import fits
+
+import campfire_pipeline.nircam.manifest as manifest_mod
+import campfire_pipeline.nircam.steps.resample as resample_mod
+from campfire_pipeline.nircam.manifest import (
+    MOSAIC_BKGSUB_KEY, bkgsub_stamp_value, build_mosaic_name,
+)
+
+SKY = 10.0  # constant SCI level of the fixture mosaic
+BKG = 1.0   # constant the fake SubtractBackground removes
+
+
+class FakeSubtractBackground:
+    """Stand-in for SubtractBackground: subtracts the constant ``BKG``.
+
+    Matches the real interface used by resample_step: constructed with the
+    full kwarg soup, ``call(path)`` writes ``<path>_bkgsub.fits`` and sets
+    ``self.outfile``. Each application shifts SCI down by ``BKG``, so a
+    double subtraction is visible as SKY - 2*BKG.
+    """
+
+    def __init__(self, **kwargs):
+        self.outfile = None
+
+    def call(self, filepath):
+        self.outfile = filepath.replace('.fits', '_bkgsub.fits')
+        with fits.open(filepath) as hdul:
+            hdul['SCI'].data = hdul['SCI'].data - BKG
+            hdul.writeto(self.outfile, overwrite=True)
+        return self.outfile
+
+
+def _mosaic_path(tmp_path):
+    name = build_mosaic_name('f444w', 'cosmos', '30mas', 'T1')
+    return os.path.join(str(tmp_path), f'{name}_i2d.fits')
+
+
+def _pre_bkg_path(tmp_path):
+    return _mosaic_path(tmp_path).replace('_i2d.fits',
+                                          '_i2d_before_bkgsub.fits')
+
+
+def _write_mosaic(path, sci_level, stamped=False):
+    sci = fits.ImageHDU(np.full((4, 4), sci_level, dtype=np.float32),
+                        name='SCI')
+    err = fits.ImageHDU(np.ones((4, 4), dtype=np.float32), name='ERR')
+    wht = fits.ImageHDU(np.ones((4, 4), dtype=np.float32), name='WHT')
+    primary = fits.PrimaryHDU()
+    if stamped:
+        primary.header[MOSAIC_BKGSUB_KEY] = 'v0 cfg=deadbeef0000'
+    fits.HDUList([primary, sci, err, wht]).writeto(path, overwrite=True)
+
+
+def _sci_level(path):
+    return float(fits.getdata(path, extname='SCI')[0, 0])
+
+
+def _run(tmp_path, monkeypatch, step_config=None):
+    """Run resample_step on the fixture tile; returns the captured log."""
+    captured = []
+    monkeypatch.setattr(resample_mod, 'select_overlapping_files',
+                        lambda files, poly: ['exp1.fits'])
+    monkeypatch.setattr(resample_mod, 'log', captured.append)
+    monkeypatch.setattr(manifest_mod, 'check_inputs_changed',
+                        lambda *a, **k: (False, []))
+    monkeypatch.setattr(manifest_mod, 'check_config_changed',
+                        lambda *a, **k: False)
+    # resample_step imports SubtractBackground lazily from
+    # campfire_pipeline.nircam.bkgsub; pre-seeding sys.modules intercepts
+    # that import without loading the real module (and its jwst/photutils
+    # stack), which the control flow under test never needs.
+    fake_bkgsub_mod = types.ModuleType('campfire_pipeline.nircam.bkgsub')
+    fake_bkgsub_mod.SubtractBackground = FakeSubtractBackground
+    monkeypatch.setitem(sys.modules, 'campfire_pipeline.nircam.bkgsub',
+                        fake_bkgsub_mod)
+
+    field = types.SimpleNamespace(
+        name='cosmos',
+        tiles={'T1': None},
+        filter_dir=lambda f: str(tmp_path),
+        get_tile_corners=lambda t: [(0, 0), (0, 1), (1, 1), (1, 0)],
+    )
+    cfg = {'pixel_scale': '30mas', 'split_extensions': False, 'plot': False}
+    cfg.update(step_config or {})
+    resample_mod.resample_step(
+        'f444w', ['exp1.fits'], field, cfg, 'v0.0.0', overwrite=False,
+    )
+    return captured
+
+
+def _skipped(logs):
+    return any('skipping background subtraction' in m for m in logs)
+
+
+# ---------------------------------------------------------------------------
+# The issue-#427 failure mode
+# ---------------------------------------------------------------------------
+
+def test_deleting_snapshot_does_not_double_subtract(tmp_path, monkeypatch):
+    mosaic = _mosaic_path(tmp_path)
+    pre_bkg = _pre_bkg_path(tmp_path)
+    _write_mosaic(mosaic, SKY)
+
+    # First up-to-date pass: mosaic exists but is unsubtracted (no stamp, no
+    # snapshot), so bkgsub runs once.
+    logs = _run(tmp_path, monkeypatch)
+    assert not _skipped(logs)
+    assert _sci_level(mosaic) == SKY - BKG
+    assert MOSAIC_BKGSUB_KEY in fits.getheader(mosaic)
+    assert _sci_level(pre_bkg) == SKY  # snapshot holds the unsubtracted data
+
+    # The failure mode: delete the snapshot to reclaim space, re-run.
+    # Pre-fix, existence of the snapshot was the only bkgsub-done record, so
+    # this run subtracted again (SCI -> SKY - 2*BKG). The stamp must prevent
+    # that.
+    os.remove(pre_bkg)
+    logs = _run(tmp_path, monkeypatch)
+    assert _skipped(logs)
+    assert _sci_level(mosaic) == SKY - BKG
+    assert not os.path.exists(pre_bkg)  # skip does not resurrect the snapshot
+
+
+def test_snapshot_never_carries_the_stamp(tmp_path, monkeypatch):
+    # Restoring the snapshot over the i2d is the rollback path; if the
+    # snapshot carried the stamp, the rolled-back (unsubtracted) mosaic
+    # would wrongly skip bkgsub forever after.
+    mosaic = _mosaic_path(tmp_path)
+    _write_mosaic(mosaic, SKY)
+    _run(tmp_path, monkeypatch)
+    assert MOSAIC_BKGSUB_KEY not in fits.getheader(_pre_bkg_path(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# Legacy fallback + backfill
+# ---------------------------------------------------------------------------
+
+def test_legacy_mosaic_skips_via_snapshot_and_backfills(tmp_path, monkeypatch):
+    # A mosaic subtracted before the stamp existed: no CFP_BKGS, snapshot on
+    # disk. It must keep skipping, and the skip must backfill the stamp so
+    # the snapshot becomes deletable.
+    mosaic = _mosaic_path(tmp_path)
+    pre_bkg = _pre_bkg_path(tmp_path)
+    _write_mosaic(mosaic, SKY - BKG)
+    _write_mosaic(pre_bkg, SKY)
+
+    logs = _run(tmp_path, monkeypatch)
+    assert _skipped(logs)
+    assert _sci_level(mosaic) == SKY - BKG
+    assert MOSAIC_BKGSUB_KEY in fits.getheader(mosaic)
+
+    # Now the snapshot is deletable: the next run skips via the stamp alone.
+    os.remove(pre_bkg)
+    logs = _run(tmp_path, monkeypatch)
+    assert _skipped(logs)
+    assert _sci_level(mosaic) == SKY - BKG
+
+
+def test_stamped_mosaic_skips_without_snapshot(tmp_path, monkeypatch):
+    mosaic = _mosaic_path(tmp_path)
+    _write_mosaic(mosaic, SKY - BKG, stamped=True)
+    logs = _run(tmp_path, monkeypatch)
+    assert _skipped(logs)
+    assert _sci_level(mosaic) == SKY - BKG
+
+
+# ---------------------------------------------------------------------------
+# keep_pre_bkgsub opt-out
+# ---------------------------------------------------------------------------
+
+def test_keep_pre_bkgsub_false_skips_snapshot(tmp_path, monkeypatch):
+    mosaic = _mosaic_path(tmp_path)
+    _write_mosaic(mosaic, SKY)
+    cfg = {'keep_pre_bkgsub': False}
+
+    logs = _run(tmp_path, monkeypatch, step_config=cfg)
+    assert not _skipped(logs)
+    assert _sci_level(mosaic) == SKY - BKG
+    assert MOSAIC_BKGSUB_KEY in fits.getheader(mosaic)
+    assert not os.path.exists(_pre_bkg_path(tmp_path))
+
+    # And the stamp still guards the next run.
+    logs = _run(tmp_path, monkeypatch, step_config=cfg)
+    assert _skipped(logs)
+    assert _sci_level(mosaic) == SKY - BKG
+
+
+# ---------------------------------------------------------------------------
+# Stamp value
+# ---------------------------------------------------------------------------
+
+def test_stamp_value_tracks_pixel_settings_only():
+    base = bkgsub_stamp_value({})
+    assert base.startswith(f'v{manifest_mod._BKGSUB_ALGORITHM_VERSION} cfg=')
+    # Pixel-affecting setting changes the hash...
+    assert bkgsub_stamp_value({'ring_radius_in': 99}) != base
+    assert bkgsub_stamp_value({'wht_aware': False}) != base
+    # ...pixel-neutral settings do not.
+    assert bkgsub_stamp_value({'keep_pre_bkgsub': False}) == base
+    assert bkgsub_stamp_value({'split_extensions': False}) == base


### PR DESCRIPTION
## Summary

Fixes issue #427 where deleting the `_i2d_before_bkgsub.fits` snapshot to reclaim space caused the next up-to-date `resample` run to silently subtract the background a second time. The snapshot's existence was the only bkgsub-done record; now a `CFP_BKGS` stamp on the i2d primary header is the authoritative record, making the snapshot safely deletable.

## Key Changes

- **Added `CFP_BKGS` primary header stamp** on mosaic i2d files to record that background subtraction has been applied, replacing reliance on snapshot file existence
  - Stamp value includes bkgsub algorithm version and hash of pixel-affecting settings for provenance
  - Written atomically onto the subtracted output before renaming into place

- **Implemented legacy fallback + backfill** for mosaics subtracted before the stamp existed
  - Detects pre-stamp mosaics via snapshot existence when stamp is absent
  - Backfills the stamp on next up-to-date run so snapshot becomes deletable

- **Added `keep_pre_bkgsub` config option** (default `true`) to skip writing the snapshot entirely
  - Allows users to opt out of snapshot creation to save space upfront
  - Stamp still guards against re-running bkgsub

- **Updated skip logic** to check stamp presence instead of snapshot existence
  - Freshly drizzled mosaics (stamp removed) always run bkgsub
  - Stamped mosaics skip bkgsub regardless of snapshot presence

## Implementation Details

- New `bkgsub_stamp_value()` function generates stamp values with algorithm version and config hash
- Stamp is written before the bkgsub output is renamed into place, ensuring pixels and record land atomically
- Pre-bkgsub snapshot never carries the stamp, preventing rollback issues
- Comprehensive regression tests verify the double-subtraction failure mode is fixed and legacy behavior is preserved

https://claude.ai/code/session_01GHFoZbcHS7TzfnjyweC7TW