### PR TITLE
Add per-user tag sharing with viewer/editor roles (issue #450)

### DIFF
--- a/supabase/migrations/20260731200000_tag_sharing.sql
+++ b/supabase/migrations/20260731200000_tag_sharing.sql
@@ -1,0 +1,838 @@
+-- =============================================================================
+-- Migration: Tag sharing (issue #450)
+-- =============================================================================
+-- Adds per-user view/edit sharing of tags (object_lists):
+--
+-- 1. New table object_list_shares (list_id, user_id, role viewer|editor):
+--    a share makes the list visible to the grantee regardless of its
+--    visibility setting; role=editor additionally allows adding/removing
+--    members (same scope as public_edit — list metadata stays owner-only).
+--    Owners manage shares; grantees can delete their own share (leave).
+-- 2. New SECURITY DEFINER helpers viewable_list_ids() /
+--    member_editable_list_ids() — the single authority for "which lists can
+--    the caller see / edit members of" — now used by the object_lists,
+--    object_list_members and list_audit_log RLS policies.
+-- 3. The four RPCs that re-embed the list-visibility predicate
+--    (get_objects_for_sync, get_lists_for_sync, get_csv_export_spectra,
+--    get_csv_export_objects) learn the share clause.
+-- =============================================================================
+
+
+-- -----------------------------------------------------------------------------
+-- 1. Table
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS "public"."object_list_shares" (
+    "id" integer NOT NULL,
+    "list_id" integer NOT NULL,
+    "user_id" "uuid" NOT NULL,
+    "role" "text" DEFAULT 'viewer'::"text" NOT NULL,
+    "granted_by" "uuid",
+    "granted_at" timestamp with time zone DEFAULT "now"(),
+    CONSTRAINT "object_list_shares_role_check" CHECK (("role" = ANY (ARRAY['viewer'::"text", 'editor'::"text"])))
+);
+
+ALTER TABLE "public"."object_list_shares" OWNER TO "postgres";
+
+COMMENT ON TABLE "public"."object_list_shares" IS 'Per-user sharing grants on object_lists (issue #450). A share gives the grantee visibility of the list regardless of its visibility setting; role=editor additionally allows adding/removing members (same scope as public_edit — list metadata stays owner-only). Owner manages shares; grantees can remove their own share (leave).';
+
+CREATE SEQUENCE IF NOT EXISTS "public"."object_list_shares_id_seq"
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE "public"."object_list_shares_id_seq" OWNER TO "postgres";
+
+ALTER SEQUENCE "public"."object_list_shares_id_seq" OWNED BY "public"."object_list_shares"."id";
+
+ALTER TABLE ONLY "public"."object_list_shares" ALTER COLUMN "id" SET DEFAULT "nextval"('"public"."object_list_shares_id_seq"'::"regclass");
+
+ALTER TABLE ONLY "public"."object_list_shares"
+    ADD CONSTRAINT "object_list_shares_pkey" PRIMARY KEY ("id");
+
+ALTER TABLE ONLY "public"."object_list_shares"
+    ADD CONSTRAINT "object_list_shares_list_id_user_id_key" UNIQUE ("list_id", "user_id");
+
+ALTER TABLE ONLY "public"."object_list_shares"
+    ADD CONSTRAINT "object_list_shares_list_id_fkey" FOREIGN KEY ("list_id") REFERENCES "public"."object_lists"("id") ON DELETE CASCADE;
+
+ALTER TABLE ONLY "public"."object_list_shares"
+    ADD CONSTRAINT "object_list_shares_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "auth"."users"("id") ON DELETE CASCADE;
+
+ALTER TABLE ONLY "public"."object_list_shares"
+    ADD CONSTRAINT "object_list_shares_granted_by_fkey" FOREIGN KEY ("granted_by") REFERENCES "auth"."users"("id");
+
+GRANT ALL ON TABLE "public"."object_list_shares" TO "anon";
+GRANT ALL ON TABLE "public"."object_list_shares" TO "authenticated";
+GRANT ALL ON TABLE "public"."object_list_shares" TO "service_role";
+
+GRANT ALL ON SEQUENCE "public"."object_list_shares_id_seq" TO "anon";
+GRANT ALL ON SEQUENCE "public"."object_list_shares_id_seq" TO "authenticated";
+GRANT ALL ON SEQUENCE "public"."object_list_shares_id_seq" TO "service_role";
+
+CREATE INDEX IF NOT EXISTS idx_list_shares_user_id
+    ON public.object_list_shares USING btree (user_id);
+
+
+-- -----------------------------------------------------------------------------
+-- 2. RLS helper functions
+-- -----------------------------------------------------------------------------
+
+
+-- Tag sharing (issue #450). These two helpers are the single authority for
+-- "which lists can the caller see / edit members of": owner + public visibility
+-- + per-user object_list_shares grants. SECURITY DEFINER so RLS policies on
+-- object_lists / object_list_members / list_audit_log can call them without
+-- recursing into each table's own policies.
+CREATE OR REPLACE FUNCTION public.viewable_list_ids()
+RETURNS SETOF integer
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT id FROM object_lists
+  WHERE created_by = auth.uid()
+     OR visibility IN ('public_read', 'public_edit')
+     OR id IN (SELECT list_id FROM object_list_shares WHERE user_id = auth.uid());
+$$;
+
+GRANT EXECUTE ON FUNCTION public.viewable_list_ids() TO authenticated;
+
+-- Lists whose MEMBERS the caller may add/remove (list metadata stays
+-- owner-only): owner + public_edit + editor-role shares.
+CREATE OR REPLACE FUNCTION public.member_editable_list_ids()
+RETURNS SETOF integer
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT id FROM object_lists
+  WHERE created_by = auth.uid()
+     OR visibility = 'public_edit'
+     OR id IN (SELECT list_id FROM object_list_shares WHERE user_id = auth.uid() AND role = 'editor');
+$$;
+
+GRANT EXECUTE ON FUNCTION public.member_editable_list_ids() TO authenticated;
+
+
+-- -----------------------------------------------------------------------------
+-- 3. RPCs that embed the list-visibility predicate
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.get_objects_for_sync(
+  p_program_slugs TEXT[],
+  p_user_id UUID DEFAULT NULL,
+  p_updated_since TIMESTAMPTZ DEFAULT NULL,
+  p_limit INTEGER DEFAULT 1000,
+  p_offset INTEGER DEFAULT 0,
+  p_include_counts BOOLEAN DEFAULT TRUE,
+  p_include_unpublished BOOLEAN DEFAULT false,
+  -- Keyset cursor (#103): the object_id of the last row of the previous page.
+  -- When non-NULL the scan seeks straight to the next id via the
+  -- objects_object_id_key UNIQUE btree, so each page costs O(log N + limit)
+  -- instead of OFFSET's O(offset + limit). p_offset is kept for old clients.
+  p_after_object_id TEXT DEFAULT NULL
+)
+RETURNS TABLE(objects JSONB, total_count BIGINT, total_accessible_count BIGINT)
+LANGUAGE plpgsql STABLE
+SET plan_cache_mode = 'force_custom_plan'
+-- Keyset clients (p_after_object_id) never touch this timeout: each page is a
+-- shallow index range scan. It is retained only for legacy OFFSET clients,
+-- whose deep pages must materialize the ordered scan up to `offset` plus run
+-- three aggregate CTEs and were tipping past the default service_role timeout
+-- around page ~29 of a 30k-object --full sync. Drop this SET once offset
+-- clients are gone (see #103 follow-up).
+SET statement_timeout = '120s'
+AS $$
+BEGIN
+  RETURN QUERY
+  -- matched is MATERIALIZED so the three aggregate CTEs below each see the
+  -- same ~p_limit-row set without re-evaluating the WHERE/ORDER/LIMIT.
+  WITH matched AS MATERIALIZED (
+    SELECT o.id, o.object_id, o.field, o.ra, o.dec,
+           o.n_targets, o.n_spectra, o.programs, o.gratings,
+           o.max_snr, o.max_exposure_time,
+           o.redshift, o.redshift_quality,
+           o.redshift_inspected, o.redshift_auto,
+           o.inspected_used_auto,
+           o.last_inspected_at, o.last_inspected_by,
+           o.last_data_change_at, o.staleness_reason,
+           o.version, o.is_active,
+           o.has_photometry, o.photo_z, o.photo_z_err_lo, o.photo_z_err_hi,
+           o.created_at, o.updated_at
+    FROM objects o
+    WHERE o.programs && p_program_slugs
+      -- Phase D: hide soft-deleted objects from sync. Reactivation rewrites
+      -- updated_at, so re-activated rows get re-synced naturally on next pull.
+      AND o.is_active = true
+      -- B1: drop objects with no published spectrum (fail-closed).
+      AND (p_include_unpublished OR o.has_published_spectrum)
+      AND (p_updated_since IS NULL OR o.updated_at > p_updated_since)
+      -- Keyset (#103): seek past the previous page's last object_id. object_id
+      -- is UNIQUE, so a strict > needs no (sort_col, id) tiebreaker. Any future
+      -- change to this ORDER BY must keep the ordering column UNIQUE (or switch
+      -- to a row-value cursor) or keyset will skip/duplicate rows.
+      AND (p_after_object_id IS NULL OR o.object_id > p_after_object_id)
+    ORDER BY o.object_id
+    LIMIT p_limit OFFSET p_offset
+  ),
+  member_targets_agg AS (
+    SELECT t.object_id,
+           jsonb_agg(t.target_id ORDER BY t.target_id) AS target_ids
+    FROM targets t
+    WHERE t.object_id IN (SELECT id FROM matched)
+      AND t.program_slug = ANY(p_program_slugs)
+    GROUP BY t.object_id
+  ),
+  -- Phase D: per-spectrum payload (per design doc) so the Python client
+  -- can render redshift_auto and dq_flags per grating without a second
+  -- round-trip.
+  spectra_agg AS (
+    SELECT t.object_id,
+           jsonb_agg(jsonb_build_object(
+             'id', s.id,
+             'target_id', s.target_id,
+             'grating', s.grating,
+             'signal_to_noise', s.signal_to_noise,
+             'exposure_time', s.exposure_time,
+             'redshift_auto', s.redshift_auto,
+             'dq_flags', s.dq_flags
+           ) ORDER BY s.target_id, s.grating) AS spectra
+    FROM spectra s
+    JOIN targets t ON t.target_id = s.target_id
+    WHERE t.object_id IN (SELECT id FROM matched)
+      AND t.program_slug = ANY(p_program_slugs)
+      AND (p_include_unpublished OR s.deploy_status = 'published')
+    GROUP BY t.object_id
+  ),
+  lists_agg AS (
+    SELECT olm.object_id,
+           jsonb_agg(ol.slug ORDER BY ol.slug) AS list_slugs
+    FROM object_list_members olm
+    JOIN object_lists ol ON ol.id = olm.list_id
+    WHERE olm.object_id IN (SELECT id FROM matched)
+      AND (ol.created_by = p_user_id
+           OR ol.visibility IN ('public_read', 'public_edit')
+           OR ol.id IN (SELECT list_id FROM object_list_shares WHERE user_id = p_user_id))
+    GROUP BY olm.object_id
+  ),
+  -- Count CTEs are gated on p_include_counts; when FALSE the planner
+  -- collapses them to One-Time Filter: false and skips the scan.
+  total AS (
+    SELECT COUNT(*) AS cnt
+    FROM objects o
+    WHERE p_include_counts
+      AND o.programs && p_program_slugs
+      AND o.is_active = true
+      AND (p_include_unpublished OR o.has_published_spectrum)
+      AND (p_updated_since IS NULL OR o.updated_at > p_updated_since)
+  ),
+  accessible AS (
+    SELECT COUNT(*) AS cnt
+    FROM objects o
+    WHERE p_include_counts
+      AND o.programs && p_program_slugs
+      AND o.is_active = true
+      AND (p_include_unpublished OR o.has_published_spectrum)
+  )
+  SELECT
+    COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'id', m.id,
+        'object_id', m.object_id,
+        'field', m.field,
+        'ra', m.ra,
+        'dec', m.dec,
+        -- Aggregates scoped to the caller's accessible programs so a sync that
+        -- pulls a mixed-program object doesn't leak proprietary member metadata
+        -- into the Python catalog. See object_scoped_aggregates().
+        'n_targets', sa.n_targets,
+        'n_spectra', sa.n_spectra,
+        'programs', sa.programs,
+        'gratings', sa.gratings,
+        'max_snr', sa.max_snr,
+        'max_exposure_time', sa.max_exposure_time,
+        'redshift', m.redshift,
+        'redshift_quality', m.redshift_quality,
+        'redshift_inspected', m.redshift_inspected,
+        'redshift_auto', m.redshift_auto,
+        'inspected_used_auto', m.inspected_used_auto,
+        'last_inspected_at', m.last_inspected_at,
+        'last_inspected_by', m.last_inspected_by,
+        'last_data_change_at', m.last_data_change_at,
+        'staleness_reason', m.staleness_reason,
+        'version', m.version,
+        'is_active', m.is_active,
+        'has_photometry', m.has_photometry,
+        'photo_z', m.photo_z,
+        'photo_z_err_lo', m.photo_z_err_lo,
+        'photo_z_err_hi', m.photo_z_err_hi,
+        'created_at', m.created_at,
+        'updated_at', m.updated_at,
+        'member_target_ids', COALESCE(mt.target_ids, '[]'::jsonb),
+        'spectra',           COALESCE(sp.spectra,    '[]'::jsonb),
+        'lists',             COALESCE(la.list_slugs, '[]'::jsonb)
+      )
+      -- Keyset (#103): the client uses the LAST element's object_id as the next
+      -- page's cursor, so the page array MUST be in object_id order. matched is
+      -- ORDER BY object_id, but the LEFT JOINs below can reorder it, so pin the
+      -- aggregate order explicitly.
+      ORDER BY m.object_id
+    ), '[]'::jsonb),
+    COALESCE((SELECT cnt FROM total), 0)::BIGINT,
+    COALESCE((SELECT cnt FROM accessible), 0)::BIGINT
+  FROM matched m
+  LEFT JOIN member_targets_agg mt ON mt.object_id = m.id
+  LEFT JOIN spectra_agg         sp ON sp.object_id = m.id
+  LEFT JOIN lists_agg           la ON la.object_id = m.id
+  LEFT JOIN LATERAL public.object_scoped_aggregates(m.id, p_program_slugs, p_include_unpublished) sa ON true;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_objects_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN, TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_objects_for_sync(TEXT[], UUID, TIMESTAMPTZ, INTEGER, INTEGER, BOOLEAN, BOOLEAN, TEXT) TO service_role;
+
+
+DROP FUNCTION IF EXISTS public.get_lists_for_sync(UUID);
+
+CREATE OR REPLACE FUNCTION public.get_lists_for_sync(
+  p_user_id UUID DEFAULT NULL,
+  p_include_unpublished BOOLEAN DEFAULT false
+)
+RETURNS JSONB
+LANGUAGE plpgsql STABLE
+AS $$
+BEGIN
+  RETURN COALESCE(
+    (SELECT jsonb_agg(jsonb_build_object(
+      'id', ol.id,
+      'slug', ol.slug,
+      'name', ol.name,
+      'description', ol.description,
+      'visibility', ol.visibility,
+      'is_system', ol.is_system,
+      'created_by', ol.created_by,
+      'created_at', ol.created_at,
+      'updated_at', ol.updated_at,
+      -- B1: count only members whose object has a published spectrum (unlinked
+      -- coordinate-keyed members, object_id IS NULL, still count). Fail-closed.
+      'member_count', (
+        SELECT COUNT(*) FROM object_list_members olm
+        LEFT JOIN objects o ON o.id = olm.object_id
+        WHERE olm.list_id = ol.id
+          AND (p_include_unpublished OR olm.object_id IS NULL OR o.has_published_spectrum)
+      )
+    ) ORDER BY ol.is_system DESC, ol.name)
+    FROM object_lists ol
+    WHERE ol.created_by = p_user_id
+       OR ol.visibility IN ('public_read', 'public_edit')
+       OR ol.id IN (SELECT list_id FROM object_list_shares WHERE user_id = p_user_id)),
+    '[]'::jsonb
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_lists_for_sync(UUID, BOOLEAN) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_lists_for_sync(UUID, BOOLEAN) TO service_role;
+
+
+CREATE OR REPLACE FUNCTION public.get_csv_export_spectra(
+  p_program_slugs TEXT[], p_filter_programs TEXT[] DEFAULT NULL,
+  p_fields TEXT[] DEFAULT NULL, p_gratings TEXT[] DEFAULT NULL,
+  p_gratings_mode TEXT DEFAULT 'any', p_observations TEXT[] DEFAULT NULL,
+  p_redshift_quality INTEGER[] DEFAULT NULL,
+  p_redshift_min DOUBLE PRECISION DEFAULT NULL, p_redshift_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_snr_min DOUBLE PRECISION DEFAULT NULL, p_max_snr_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_exposure_time_min DOUBLE PRECISION DEFAULT NULL, p_max_exposure_time_max DOUBLE PRECISION DEFAULT NULL,
+  p_dq_flags_include_any INTEGER DEFAULT NULL, p_dq_flags_include_all INTEGER DEFAULT NULL,
+  p_dq_flags_exclude INTEGER DEFAULT NULL,
+  p_list_ids INTEGER[] DEFAULT NULL,
+  p_list_ids_mode TEXT DEFAULT 'any',
+  p_search TEXT DEFAULT NULL, p_inspected_only BOOLEAN DEFAULT NULL,
+  p_needs_review BOOLEAN DEFAULT NULL,
+  p_has_photometry BOOLEAN DEFAULT NULL,
+  p_comment_search TEXT DEFAULT NULL, p_comment_search_scope TEXT DEFAULT NULL,
+  p_comment_user_id UUID DEFAULT NULL,
+  p_coord_ra DOUBLE PRECISION DEFAULT NULL, p_coord_dec DOUBLE PRECISION DEFAULT NULL,
+  p_radius_degrees DOUBLE PRECISION DEFAULT NULL,
+  p_include_unpublished BOOLEAN DEFAULT false,
+  p_after_id INTEGER DEFAULT NULL, p_page_size INTEGER DEFAULT 5000
+)
+RETURNS TABLE(
+  id INTEGER, spectrum_id TEXT, target_id TEXT, grating TEXT, field TEXT, observation TEXT,
+  ra DOUBLE PRECISION, "dec" DOUBLE PRECISION,
+  redshift NUMERIC, redshift_quality INTEGER, redshift_auto DOUBLE PRECISION,
+  signal_to_noise DOUBLE PRECISION,
+  exposure_time DOUBLE PRECISION, fits_path TEXT, program_slug TEXT, program_name TEXT,
+  last_inspected_at TIMESTAMPTZ, last_inspected_by TEXT, distance DOUBLE PRECISION,
+  dq_flags INTEGER,
+  lists TEXT
+)
+LANGUAGE plpgsql STABLE
+SET plan_cache_mode = 'force_custom_plan'
+SET statement_timeout = '120s'
+AS $$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_list_filter_active BOOLEAN;
+  v_list_ids_mode TEXT;
+  v_page_size INTEGER;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (p_comment_search IS NOT NULL AND p_comment_search != '' AND p_comment_search_scope IN ('just_me', 'everyone'));
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_list_filter_active := (p_list_ids IS NOT NULL AND array_length(p_list_ids, 1) > 0);
+  v_list_ids_mode := COALESCE(p_list_ids_mode, 'any');
+  IF v_list_ids_mode NOT IN ('any', 'all', 'none') THEN v_list_ids_mode := 'any'; END IF;
+  v_page_size := LEAST(GREATEST(COALESCE(p_page_size, 5000), 1), 10000);
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs)) INTO v_filtered_program_slugs;
+  ELSE v_filtered_program_slugs := p_program_slugs; END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN RETURN; END IF;
+
+  RETURN QUERY
+  WITH visible_lists AS (
+    SELECT olm.object_id, string_agg(ol.slug, ';' ORDER BY ol.slug) AS lists
+    FROM object_list_members olm
+    JOIN object_lists ol ON ol.id = olm.list_id
+    WHERE ol.created_by = auth.uid() OR ol.visibility IN ('public_read', 'public_edit')
+       OR ol.id IN (SELECT list_id FROM object_list_shares WHERE user_id = auth.uid())
+    GROUP BY olm.object_id
+  ),
+  filtered_spectra AS (
+    SELECT s.id, s.spectrum_id, t.target_id, s.grating, t.field, t.ra, t.dec,
+      o.redshift, o.redshift_quality,
+      s.redshift_auto,
+      s.signal_to_noise, s.exposure_time, s.fits_path, t.program_slug, t.observation,
+      o.last_inspected_at, o.last_inspected_by,
+      CASE WHEN v_coord_search_active THEN
+        2 * DEGREES(ASIN(SQRT(POWER(SIN(RADIANS(t.dec - p_coord_dec) / 2), 2) + COS(RADIANS(p_coord_dec)) * COS(RADIANS(t.dec)) * POWER(SIN(RADIANS(t.ra - p_coord_ra) / 2), 2))))
+      ELSE NULL END AS distance,
+      COALESCE(s.dq_flags, 0) AS dq_flags,
+      vl.lists
+    FROM targets t
+    JOIN spectra s ON s.target_id = t.target_id
+    LEFT JOIN objects o ON o.id = t.object_id
+    LEFT JOIN visible_lists vl ON vl.object_id = t.object_id
+    WHERE t.program_slug = ANY(v_filtered_program_slugs)
+      AND (p_after_id IS NULL OR s.id > p_after_id)
+      AND (o.id IS NULL OR o.is_active = true)
+      AND (NOT v_grating_filter_active OR s.grating = ANY(p_gratings))
+      -- B1: hide unpublished spectra (fail-closed; admin opt-in only).
+      AND (p_include_unpublished OR s.deploy_status = 'published')
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR t.field = ANY(p_fields))
+      AND (p_observations IS NULL OR array_length(p_observations, 1) IS NULL OR t.observation = ANY(p_observations))
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min) AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR s.signal_to_noise >= p_max_snr_min) AND (p_max_snr_max IS NULL OR s.signal_to_noise <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR s.exposure_time >= p_max_exposure_time_min) AND (p_max_exposure_time_max IS NULL OR s.exposure_time <= p_max_exposure_time_max)
+      AND (p_dq_flags_include_any IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_any) != 0)
+      AND (p_dq_flags_include_all IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_include_all) = p_dq_flags_include_all)
+      AND (p_dq_flags_exclude IS NULL OR (COALESCE(s.dq_flags, 0) & p_dq_flags_exclude) = 0)
+      AND (
+        NOT v_list_filter_active
+        OR (v_list_ids_mode = 'any' AND t.object_id IN (
+            SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+        OR (v_list_ids_mode = 'all' AND (
+            SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
+            WHERE olm.object_id = t.object_id AND olm.list_id = ANY(p_list_ids)
+        ) = (SELECT COUNT(DISTINCT __list_id) FROM unnest(p_list_ids) __list_id))
+        OR (v_list_ids_mode = 'none' AND (t.object_id IS NULL OR t.object_id NOT IN (
+            SELECT olm.object_id FROM object_list_members olm WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        )))
+      )
+      AND (p_search IS NULL OR s.id IN (SELECT __s.id FROM public.spectra __s WHERE __s.search_text ILIKE '%' || p_search || '%'))
+      AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.redshift_quality > 0) OR (p_inspected_only = FALSE AND COALESCE(o.redshift_quality, 0) = 0))
+      AND (p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at))))
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (NOT v_comment_search_active OR t.id IN (
+        SELECT c.target_id FROM comments c WHERE c.target_id IS NOT NULL AND c.is_deleted = false
+          AND c.content ILIKE '%' || p_comment_search || '%'
+          AND (p_comment_search_scope = 'everyone' OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id))))
+      AND (NOT v_coord_search_active OR (
+        t.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND t.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)))
+  ),
+  distance_filtered AS (SELECT fs.* FROM filtered_spectra fs WHERE NOT v_coord_search_active OR fs.distance <= p_radius_degrees)
+  SELECT df.id, df.spectrum_id, df.target_id, df.grating, df.field, df.observation,
+    df.ra, df.dec, df.redshift, df.redshift_quality, df.redshift_auto,
+    df.signal_to_noise, df.exposure_time, df.fits_path, df.program_slug,
+    pr.program_name, df.last_inspected_at, up.full_name AS last_inspected_by,
+    df.distance, df.dq_flags, df.lists
+  FROM distance_filtered df
+  LEFT JOIN programs pr ON pr.slug = df.program_slug
+  LEFT JOIN user_profiles up ON up.user_id = df.last_inspected_by
+  ORDER BY df.id ASC
+  LIMIT v_page_size;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_csv_export_spectra TO authenticated;
+
+
+CREATE OR REPLACE FUNCTION public.get_csv_export_objects(
+  p_program_slugs TEXT[], p_filter_programs TEXT[] DEFAULT NULL,
+  p_fields TEXT[] DEFAULT NULL, p_gratings TEXT[] DEFAULT NULL,
+  p_gratings_mode TEXT DEFAULT 'any',
+  p_redshift_quality INTEGER[] DEFAULT NULL,
+  p_redshift_min DOUBLE PRECISION DEFAULT NULL, p_redshift_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_snr_min DOUBLE PRECISION DEFAULT NULL, p_max_snr_max DOUBLE PRECISION DEFAULT NULL,
+  p_max_exposure_time_min DOUBLE PRECISION DEFAULT NULL, p_max_exposure_time_max DOUBLE PRECISION DEFAULT NULL,
+  p_search TEXT DEFAULT NULL, p_inspected_only BOOLEAN DEFAULT NULL,
+  p_needs_review BOOLEAN DEFAULT NULL,
+  p_list_ids INTEGER[] DEFAULT NULL,
+  p_list_ids_mode TEXT DEFAULT 'any',
+  p_coord_ra DOUBLE PRECISION DEFAULT NULL, p_coord_dec DOUBLE PRECISION DEFAULT NULL,
+  p_radius_degrees DOUBLE PRECISION DEFAULT NULL,
+  p_has_photometry BOOLEAN DEFAULT NULL,
+  p_photo_z_min DOUBLE PRECISION DEFAULT NULL, p_photo_z_max DOUBLE PRECISION DEFAULT NULL,
+  p_comment_search TEXT DEFAULT NULL, p_comment_search_scope TEXT DEFAULT NULL,
+  p_comment_user_id UUID DEFAULT NULL,
+  p_include_unpublished BOOLEAN DEFAULT false,
+  p_after_object_id TEXT DEFAULT NULL, p_page_size INTEGER DEFAULT 5000
+)
+RETURNS TABLE(
+  object_id TEXT, field TEXT, ra DOUBLE PRECISION, "dec" DOUBLE PRECISION,
+  redshift NUMERIC, redshift_quality INTEGER,
+  redshift_inspected NUMERIC, redshift_auto DOUBLE PRECISION,
+  last_inspected_at TIMESTAMPTZ, last_inspected_by TEXT,
+  last_data_change_at TIMESTAMPTZ, staleness_reason TEXT, version INTEGER,
+  n_targets INTEGER, n_spectra INTEGER,
+  programs TEXT, gratings TEXT,
+  max_snr DOUBLE PRECISION, max_exposure_time DOUBLE PRECISION,
+  member_target_ids TEXT, distance DOUBLE PRECISION,
+  lists TEXT,
+  has_photometry BOOLEAN, photo_z DOUBLE PRECISION,
+  photo_z_err_lo DOUBLE PRECISION, photo_z_err_hi DOUBLE PRECISION,
+  photometry JSONB
+)
+LANGUAGE plpgsql STABLE
+SET plan_cache_mode = 'force_custom_plan'
+SET statement_timeout = '120s'
+AS $$
+DECLARE
+  v_filtered_program_slugs TEXT[];
+  v_coord_search_active BOOLEAN;
+  v_comment_search_active BOOLEAN;
+  v_grating_filter_active BOOLEAN;
+  v_gratings_mode TEXT;
+  v_list_filter_active BOOLEAN;
+  v_list_ids_mode TEXT;
+  v_page_size INTEGER;
+BEGIN
+  v_coord_search_active := (p_coord_ra IS NOT NULL AND p_coord_dec IS NOT NULL AND p_radius_degrees IS NOT NULL);
+  v_comment_search_active := (
+    p_comment_search IS NOT NULL
+    AND p_comment_search != ''
+    AND p_comment_search_scope IN ('just_me', 'everyone')
+  );
+  v_grating_filter_active := (p_gratings IS NOT NULL AND array_length(p_gratings, 1) > 0);
+  v_gratings_mode := COALESCE(p_gratings_mode, 'any');
+  IF v_gratings_mode NOT IN ('any', 'all', 'none') THEN v_gratings_mode := 'any'; END IF;
+  v_list_filter_active := (p_list_ids IS NOT NULL AND array_length(p_list_ids, 1) > 0);
+  v_list_ids_mode := COALESCE(p_list_ids_mode, 'any');
+  IF v_list_ids_mode NOT IN ('any', 'all', 'none') THEN v_list_ids_mode := 'any'; END IF;
+  v_page_size := LEAST(GREATEST(COALESCE(p_page_size, 5000), 1), 10000);
+
+  IF p_filter_programs IS NOT NULL AND array_length(p_filter_programs, 1) > 0 THEN
+    SELECT ARRAY(SELECT unnest(p_program_slugs) INTERSECT SELECT unnest(p_filter_programs)) INTO v_filtered_program_slugs;
+  ELSE v_filtered_program_slugs := p_program_slugs; END IF;
+  IF v_filtered_program_slugs IS NULL OR array_length(v_filtered_program_slugs, 1) IS NULL THEN RETURN; END IF;
+
+  RETURN QUERY
+  WITH member_targets AS (
+    SELECT t.object_id, string_agg(t.target_id, ';' ORDER BY t.target_id) AS member_target_ids
+    FROM targets t
+    WHERE t.program_slug = ANY(v_filtered_program_slugs)
+    GROUP BY t.object_id
+  ),
+  visible_lists AS (
+    SELECT olm.object_id, string_agg(ol.slug, ';' ORDER BY ol.slug) AS lists
+    FROM object_list_members olm
+    JOIN object_lists ol ON ol.id = olm.list_id
+    WHERE ol.created_by = auth.uid() OR ol.visibility IN ('public_read', 'public_edit')
+       OR ol.id IN (SELECT list_id FROM object_list_shares WHERE user_id = auth.uid())
+    GROUP BY olm.object_id
+  ),
+  filtered_objects AS (
+    SELECT o.object_id, o.field, o.ra, o.dec,
+      o.redshift, o.redshift_quality,
+      o.redshift_inspected, o.redshift_auto,
+      o.last_inspected_at, up.full_name AS last_inspected_by,
+      o.last_data_change_at, o.staleness_reason, o.version,
+      -- Aggregates scoped to accessible (+ filtered) programs so mixed-program
+      -- objects don't export proprietary member metadata. See
+      -- object_scoped_aggregates().
+      sa.n_targets, sa.n_spectra,
+      array_to_string(sa.programs, ';') AS programs,
+      array_to_string(sa.gratings, ';') AS gratings,
+      sa.max_snr, sa.max_exposure_time,
+      mt.member_target_ids,
+      CASE WHEN v_coord_search_active THEN
+        2 * DEGREES(ASIN(SQRT(POWER(SIN(RADIANS(o.dec - p_coord_dec) / 2), 2) + COS(RADIANS(p_coord_dec)) * COS(RADIANS(o.dec)) * POWER(SIN(RADIANS(o.ra - p_coord_ra) / 2), 2))))
+      ELSE NULL END AS distance,
+      vl.lists,
+      o.has_photometry, o.photo_z, o.photo_z_err_lo, o.photo_z_err_hi,
+      phot.photometry
+    FROM objects o
+    LEFT JOIN member_targets mt ON mt.object_id = o.id
+    LEFT JOIN visible_lists vl ON vl.object_id = o.id
+    LEFT JOIN user_profiles up ON up.user_id = o.last_inspected_by
+    LEFT JOIN LATERAL public.object_scoped_aggregates(o.id, v_filtered_program_slugs, p_include_unpublished) sa ON true
+    LEFT JOIN LATERAL (
+      SELECT op.photometry FROM object_photometry op
+      WHERE op.object_id = o.id ORDER BY op.updated_at DESC LIMIT 1
+    ) phot ON true
+    WHERE o.programs && v_filtered_program_slugs
+      AND (p_after_object_id IS NULL OR o.object_id > p_after_object_id)
+      AND o.is_active = true
+      AND (p_include_unpublished OR o.has_published_spectrum)
+      AND (p_fields IS NULL OR array_length(p_fields, 1) IS NULL OR o.field = ANY(p_fields))
+      AND (
+        NOT v_grating_filter_active
+        OR (v_gratings_mode = 'any' AND o.gratings && p_gratings)
+        OR (v_gratings_mode = 'all' AND o.gratings @> p_gratings)
+        OR (v_gratings_mode = 'none' AND NOT o.gratings && p_gratings)
+      )
+      AND (p_redshift_quality IS NULL OR array_length(p_redshift_quality, 1) IS NULL OR o.redshift_quality = ANY(p_redshift_quality))
+      AND (p_redshift_min IS NULL OR o.redshift >= p_redshift_min)
+      AND (p_redshift_max IS NULL OR o.redshift <= p_redshift_max)
+      AND (p_max_snr_min IS NULL OR o.max_snr >= p_max_snr_min)
+      AND (p_max_snr_max IS NULL OR o.max_snr <= p_max_snr_max)
+      AND (p_max_exposure_time_min IS NULL OR o.max_exposure_time >= p_max_exposure_time_min)
+      AND (p_max_exposure_time_max IS NULL OR o.max_exposure_time <= p_max_exposure_time_max)
+      AND (p_search IS NULL OR o.id IN (SELECT __o.id FROM public.objects __o WHERE __o.search_text ILIKE '%' || p_search || '%'))
+      AND (p_inspected_only IS NULL OR (p_inspected_only = TRUE AND o.redshift_quality > 0) OR (p_inspected_only = FALSE AND o.redshift_quality = 0))
+      AND (p_needs_review IS NULL
+        OR (p_needs_review = TRUE
+            AND o.staleness_reason IS NOT NULL
+            AND o.last_inspected_at IS NOT NULL
+            AND (o.last_data_change_at IS NULL OR o.last_data_change_at > o.last_inspected_at))
+        OR (p_needs_review = FALSE
+            AND (o.staleness_reason IS NULL
+                 OR o.last_inspected_at IS NULL
+                 OR (o.last_data_change_at IS NOT NULL AND o.last_data_change_at <= o.last_inspected_at))))
+      AND (NOT v_coord_search_active OR (
+        o.ra BETWEEN (p_coord_ra - p_radius_degrees) AND (p_coord_ra + p_radius_degrees)
+        AND o.dec BETWEEN (p_coord_dec - p_radius_degrees) AND (p_coord_dec + p_radius_degrees)
+      ))
+      AND (
+        NOT v_list_filter_active
+        OR (v_list_ids_mode = 'any' AND o.id IN (
+            SELECT olm.object_id FROM object_list_members olm
+            WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+        OR (v_list_ids_mode = 'all' AND (
+            SELECT COUNT(DISTINCT olm.list_id) FROM object_list_members olm
+            WHERE olm.object_id = o.id AND olm.list_id = ANY(p_list_ids)
+        ) = (SELECT COUNT(DISTINCT __list_id) FROM unnest(p_list_ids) __list_id))
+        OR (v_list_ids_mode = 'none' AND o.id NOT IN (
+            SELECT olm.object_id FROM object_list_members olm
+            WHERE olm.list_id = ANY(p_list_ids) AND olm.object_id IS NOT NULL
+        ))
+      )
+      AND (p_has_photometry IS NULL OR o.has_photometry = p_has_photometry)
+      AND (p_photo_z_min IS NULL OR o.photo_z >= p_photo_z_min)
+      AND (p_photo_z_max IS NULL OR o.photo_z <= p_photo_z_max)
+      AND (
+        NOT v_comment_search_active
+        -- Uncorrelated semijoin; see get_filtered_objects_paginated for rationale.
+        OR o.id IN (
+          SELECT c.object_id FROM comments c
+          WHERE c.object_id IS NOT NULL
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+          UNION
+          SELECT t.object_id FROM comments c
+          JOIN targets t ON t.id = c.target_id
+          WHERE c.target_id IS NOT NULL
+            AND c.is_deleted = false
+            AND c.content ILIKE '%' || p_comment_search || '%'
+            AND (
+              p_comment_search_scope = 'everyone'
+              OR (p_comment_search_scope = 'just_me' AND c.user_id = p_comment_user_id)
+            )
+        )
+      )
+  ),
+  distance_filtered AS (SELECT fo.* FROM filtered_objects fo WHERE NOT v_coord_search_active OR fo.distance <= p_radius_degrees)
+  SELECT df.object_id, df.field, df.ra, df.dec,
+    df.redshift, df.redshift_quality,
+    df.redshift_inspected, df.redshift_auto,
+    df.last_inspected_at, df.last_inspected_by,
+    df.last_data_change_at, df.staleness_reason, df.version,
+    df.n_targets, df.n_spectra,
+    df.programs, df.gratings,
+    df.max_snr, df.max_exposure_time,
+    df.member_target_ids, df.distance, df.lists,
+    df.has_photometry, df.photo_z, df.photo_z_err_lo, df.photo_z_err_hi,
+    df.photometry
+  FROM distance_filtered df
+  ORDER BY df.object_id ASC
+  LIMIT v_page_size;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_csv_export_objects TO authenticated;
+
+
+-- -----------------------------------------------------------------------------
+-- 4. RLS policies
+-- -----------------------------------------------------------------------------
+
+-- Users can see: their own lists + public lists + public_edit lists + lists
+-- shared with them (issue #450). viewable_list_ids() (SECURITY DEFINER,
+-- functions.sql) is the single authority for that predicate.
+DROP POLICY IF EXISTS "select_lists" ON object_lists;
+CREATE POLICY "select_lists"
+  ON object_lists FOR SELECT TO authenticated
+  USING (id IN (SELECT public.viewable_list_ids()));
+
+
+
+-- Members visible if:
+--   1. The list is visible to the user (owner / public / shared), AND
+--   2. The matched object (if any) has at least one accessible program
+-- Members with NULL object_id (orphaned) are visible to anyone who can edit
+-- the list's members (owner, public_edit, editor-role share) — co-editors
+-- need to see orphans; read-only viewers don't.
+DROP POLICY IF EXISTS "select_list_members" ON object_list_members;
+CREATE POLICY "select_list_members"
+  ON object_list_members FOR SELECT TO authenticated
+  USING (
+    list_id IN (SELECT public.viewable_list_ids())
+    AND (
+      (object_id IS NULL AND list_id IN (SELECT public.member_editable_list_ids()))
+      OR object_id IN (
+        SELECT o.id FROM objects o
+        WHERE o.programs && (SELECT public.accessible_program_slugs())
+          -- B1 (#217): list members matched to an unpublished-only object are
+          -- hidden from non-admins (the object itself is invisible).
+          AND (o.has_published_spectrum OR (SELECT public.is_admin()))
+      )
+    )
+  );
+
+-- can_comment users can add members to own lists + public_edit lists +
+-- editor-role shared lists.
+DROP POLICY IF EXISTS "insert_list_members" ON object_list_members;
+CREATE POLICY "insert_list_members"
+  ON object_list_members FOR INSERT TO authenticated
+  WITH CHECK (
+    (SELECT public.can_comment())
+    AND list_id IN (SELECT public.member_editable_list_ids())
+  );
+
+-- can_comment users can update members in member-editable lists
+-- (needed for upsert ON CONFLICT DO UPDATE when re-linking coordinate entries).
+DROP POLICY IF EXISTS "update_list_members" ON object_list_members;
+CREATE POLICY "update_list_members"
+  ON object_list_members FOR UPDATE TO authenticated
+  USING (
+    (SELECT public.can_comment())
+    AND list_id IN (SELECT public.member_editable_list_ids())
+  )
+  WITH CHECK (
+    (SELECT public.can_comment())
+    AND list_id IN (SELECT public.member_editable_list_ids())
+  );
+
+-- can_comment users can remove members from member-editable lists.
+DROP POLICY IF EXISTS "delete_list_members" ON object_list_members;
+CREATE POLICY "delete_list_members"
+  ON object_list_members FOR DELETE TO authenticated
+  USING (
+    (SELECT public.can_comment())
+    AND list_id IN (SELECT public.member_editable_list_ids())
+  );
+
+-- Audit log visible if the parent list is visible (owner / public / shared).
+DROP POLICY IF EXISTS "select_list_audit" ON list_audit_log;
+CREATE POLICY "select_list_audit"
+  ON list_audit_log FOR SELECT TO authenticated
+  USING (list_id IN (SELECT public.viewable_list_ids()));
+
+-- =============================================================================
+-- object_list_shares  (tag sharing, issue #450)
+-- =============================================================================
+-- NOTE: policies here reference object_lists via plain subqueries; that is
+-- safe from RLS recursion because the object_lists policies reach shares only
+-- through the SECURITY DEFINER helpers (viewable_list_ids et al.), which do
+-- not re-enter policy evaluation.
+
+ALTER TABLE object_list_shares ENABLE ROW LEVEL SECURITY;
+
+-- Grantees see their own share rows; list owners see all shares on their lists.
+DROP POLICY IF EXISTS "select_list_shares" ON object_list_shares;
+CREATE POLICY "select_list_shares"
+  ON object_list_shares FOR SELECT TO authenticated
+  USING (
+    user_id = (SELECT auth.uid())
+    OR list_id IN (
+      SELECT id FROM object_lists WHERE created_by = (SELECT auth.uid())
+    )
+  );
+
+-- Only the list owner grants shares, on their own non-system lists. granted_by
+-- is stamped with the grantor; self-shares are pointless and disallowed.
+DROP POLICY IF EXISTS "insert_list_shares" ON object_list_shares;
+CREATE POLICY "insert_list_shares"
+  ON object_list_shares FOR INSERT TO authenticated
+  WITH CHECK (
+    granted_by = (SELECT auth.uid())
+    AND user_id <> (SELECT auth.uid())
+    AND list_id IN (
+      SELECT id FROM object_lists
+      WHERE created_by = (SELECT auth.uid()) AND is_system = false
+    )
+  );
+
+-- Only the list owner changes a share's role.
+DROP POLICY IF EXISTS "update_list_shares" ON object_list_shares;
+CREATE POLICY "update_list_shares"
+  ON object_list_shares FOR UPDATE TO authenticated
+  USING (
+    list_id IN (
+      SELECT id FROM object_lists WHERE created_by = (SELECT auth.uid())
+    )
+  )
+  WITH CHECK (
+    list_id IN (
+      SELECT id FROM object_lists WHERE created_by = (SELECT auth.uid())
+    )
+  );
+
+-- The list owner revokes shares; grantees can remove their own share (leave).
+DROP POLICY IF EXISTS "delete_list_shares" ON object_list_shares;
+CREATE POLICY "delete_list_shares"
+  ON object_list_shares FOR DELETE TO authenticated
+  USING (
+    user_id = (SELECT auth.uid())
+    OR list_id IN (
+      SELECT id FROM object_lists WHERE created_by = (SELECT auth.uid())
+    )
+  );
+
+-- Admins can manage all shares.
+DROP POLICY IF EXISTS "admin_manage_list_shares" ON object_list_shares;
+CREATE POLICY "admin_manage_list_shares"
+  ON object_list_shares
+  USING ((SELECT public.is_admin()));
+

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -96,6 +96,39 @@ $$;
 
 GRANT EXECUTE ON FUNCTION public.accessible_program_slugs() TO authenticated;
 
+-- Tag sharing (issue #450). These two helpers are the single authority for
+-- "which lists can the caller see / edit members of": owner + public visibility
+-- + per-user object_list_shares grants. SECURITY DEFINER so RLS policies on
+-- object_lists / object_list_members / list_audit_log can call them without
+-- recursing into each table's own policies.
+CREATE OR REPLACE FUNCTION public.viewable_list_ids()
+RETURNS SETOF integer
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT id FROM object_lists
+  WHERE created_by = auth.uid()
+     OR visibility IN ('public_read', 'public_edit')
+     OR id IN (SELECT list_id FROM object_list_shares WHERE user_id = auth.uid());
+$$;
+
+GRANT EXECUTE ON FUNCTION public.viewable_list_ids() TO authenticated;
+
+-- Lists whose MEMBERS the caller may add/remove (list metadata stays
+-- owner-only): owner + public_edit + editor-role shares.
+CREATE OR REPLACE FUNCTION public.member_editable_list_ids()
+RETURNS SETOF integer
+LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT id FROM object_lists
+  WHERE created_by = auth.uid()
+     OR visibility = 'public_edit'
+     OR id IN (SELECT list_id FROM object_list_shares WHERE user_id = auth.uid() AND role = 'editor');
+$$;
+
+GRANT EXECUTE ON FUNCTION public.member_editable_list_ids() TO authenticated;
+
 
 -- Whether a FitsGL dataset (epic #337, Phase 3) is public: every backing mosaic it
 -- was built from is published. The pyramid in the public tiles bucket is built from
@@ -575,7 +608,8 @@ BEGIN
     JOIN object_lists ol ON ol.id = olm.list_id
     WHERE olm.object_id IN (SELECT id FROM matched)
       AND (ol.created_by = p_user_id
-           OR ol.visibility IN ('public_read', 'public_edit'))
+           OR ol.visibility IN ('public_read', 'public_edit')
+           OR ol.id IN (SELECT list_id FROM object_list_shares WHERE user_id = p_user_id))
     GROUP BY olm.object_id
   ),
   -- Count CTEs are gated on p_include_counts; when FALSE the planner
@@ -898,7 +932,8 @@ BEGIN
     ) ORDER BY ol.is_system DESC, ol.name)
     FROM object_lists ol
     WHERE ol.created_by = p_user_id
-       OR ol.visibility IN ('public_read', 'public_edit')),
+       OR ol.visibility IN ('public_read', 'public_edit')
+       OR ol.id IN (SELECT list_id FROM object_list_shares WHERE user_id = p_user_id)),
     '[]'::jsonb
   );
 END;
@@ -2298,6 +2333,7 @@ BEGIN
     FROM object_list_members olm
     JOIN object_lists ol ON ol.id = olm.list_id
     WHERE ol.created_by = auth.uid() OR ol.visibility IN ('public_read', 'public_edit')
+       OR ol.id IN (SELECT list_id FROM object_list_shares WHERE user_id = auth.uid())
     GROUP BY olm.object_id
   ),
   filtered_spectra AS (
@@ -2482,6 +2518,7 @@ BEGIN
     FROM object_list_members olm
     JOIN object_lists ol ON ol.id = olm.list_id
     WHERE ol.created_by = auth.uid() OR ol.visibility IN ('public_read', 'public_edit')
+       OR ol.id IN (SELECT list_id FROM object_list_shares WHERE user_id = auth.uid())
     GROUP BY olm.object_id
   ),
   filtered_objects AS (

--- a/supabase/schemas/indexes.sql
+++ b/supabase/schemas/indexes.sql
@@ -132,6 +132,15 @@ CREATE INDEX IF NOT EXISTS idx_list_members_coords
 
 
 -- =============================================================================
+-- object_list_shares  (tag sharing, issue #450)
+-- =============================================================================
+-- (list_id, user_id) lookups are covered by the table's unique constraint.
+
+CREATE INDEX IF NOT EXISTS idx_list_shares_user_id
+    ON public.object_list_shares USING btree (user_id);
+
+
+-- =============================================================================
 -- list_audit_log
 -- =============================================================================
 

--- a/supabase/schemas/policies.sql
+++ b/supabase/schemas/policies.sql
@@ -338,14 +338,13 @@ CREATE POLICY "admin_object_photometry_delete"
 
 ALTER TABLE object_lists ENABLE ROW LEVEL SECURITY;
 
--- Users can see: their own lists + public lists + public_edit lists.
+-- Users can see: their own lists + public lists + public_edit lists + lists
+-- shared with them (issue #450). viewable_list_ids() (SECURITY DEFINER,
+-- functions.sql) is the single authority for that predicate.
 DROP POLICY IF EXISTS "select_lists" ON object_lists;
 CREATE POLICY "select_lists"
   ON object_lists FOR SELECT TO authenticated
-  USING (
-    created_by = (SELECT auth.uid())
-    OR visibility IN ('public_read', 'public_edit')
-  );
+  USING (id IN (SELECT public.viewable_list_ids()));
 
 -- Users can create lists (owned by them, non-system, non-group-account).
 DROP POLICY IF EXISTS "insert_lists" ON object_lists;
@@ -385,24 +384,18 @@ CREATE POLICY "admin_manage_lists"
 ALTER TABLE object_list_members ENABLE ROW LEVEL SECURITY;
 
 -- Members visible if:
---   1. The list is visible to the user, AND
+--   1. The list is visible to the user (owner / public / shared), AND
 --   2. The matched object (if any) has at least one accessible program
--- Members with NULL object_id (orphaned) are visible to the list owner
--- OR to anyone if the list is public_edit (so co-editors can see orphans).
+-- Members with NULL object_id (orphaned) are visible to anyone who can edit
+-- the list's members (owner, public_edit, editor-role share) — co-editors
+-- need to see orphans; read-only viewers don't.
 DROP POLICY IF EXISTS "select_list_members" ON object_list_members;
 CREATE POLICY "select_list_members"
   ON object_list_members FOR SELECT TO authenticated
   USING (
-    list_id IN (
-      SELECT id FROM object_lists
-      WHERE created_by = (SELECT auth.uid())
-         OR visibility IN ('public_read', 'public_edit')
-    )
+    list_id IN (SELECT public.viewable_list_ids())
     AND (
-      (object_id IS NULL AND list_id IN (
-        SELECT id FROM object_lists
-        WHERE created_by = (SELECT auth.uid()) OR visibility = 'public_edit'
-      ))
+      (object_id IS NULL AND list_id IN (SELECT public.member_editable_list_ids()))
       OR object_id IN (
         SELECT o.id FROM objects o
         WHERE o.programs && (SELECT public.accessible_program_slugs())
@@ -413,52 +406,37 @@ CREATE POLICY "select_list_members"
     )
   );
 
--- can_comment users can add members to own lists + public_edit lists.
+-- can_comment users can add members to own lists + public_edit lists +
+-- editor-role shared lists.
 DROP POLICY IF EXISTS "insert_list_members" ON object_list_members;
 CREATE POLICY "insert_list_members"
   ON object_list_members FOR INSERT TO authenticated
   WITH CHECK (
     (SELECT public.can_comment())
-    AND list_id IN (
-      SELECT id FROM object_lists
-      WHERE created_by = (SELECT auth.uid())
-         OR visibility = 'public_edit'
-    )
+    AND list_id IN (SELECT public.member_editable_list_ids())
   );
 
--- can_comment users can update members in own lists + public_edit lists
+-- can_comment users can update members in member-editable lists
 -- (needed for upsert ON CONFLICT DO UPDATE when re-linking coordinate entries).
 DROP POLICY IF EXISTS "update_list_members" ON object_list_members;
 CREATE POLICY "update_list_members"
   ON object_list_members FOR UPDATE TO authenticated
   USING (
     (SELECT public.can_comment())
-    AND list_id IN (
-      SELECT id FROM object_lists
-      WHERE created_by = (SELECT auth.uid())
-         OR visibility = 'public_edit'
-    )
+    AND list_id IN (SELECT public.member_editable_list_ids())
   )
   WITH CHECK (
     (SELECT public.can_comment())
-    AND list_id IN (
-      SELECT id FROM object_lists
-      WHERE created_by = (SELECT auth.uid())
-         OR visibility = 'public_edit'
-    )
+    AND list_id IN (SELECT public.member_editable_list_ids())
   );
 
--- can_comment users can remove members from own lists + public_edit lists.
+-- can_comment users can remove members from member-editable lists.
 DROP POLICY IF EXISTS "delete_list_members" ON object_list_members;
 CREATE POLICY "delete_list_members"
   ON object_list_members FOR DELETE TO authenticated
   USING (
     (SELECT public.can_comment())
-    AND list_id IN (
-      SELECT id FROM object_lists
-      WHERE created_by = (SELECT auth.uid())
-         OR visibility = 'public_edit'
-    )
+    AND list_id IN (SELECT public.member_editable_list_ids())
   );
 
 -- Admins can manage all list members.
@@ -474,22 +452,84 @@ CREATE POLICY "admin_manage_list_members"
 
 ALTER TABLE list_audit_log ENABLE ROW LEVEL SECURITY;
 
--- Audit log visible if the parent list is visible.
+-- Audit log visible if the parent list is visible (owner / public / shared).
 DROP POLICY IF EXISTS "select_list_audit" ON list_audit_log;
 CREATE POLICY "select_list_audit"
   ON list_audit_log FOR SELECT TO authenticated
-  USING (
-    list_id IN (
-      SELECT id FROM object_lists
-      WHERE created_by = (SELECT auth.uid())
-         OR visibility IN ('public_read', 'public_edit')
-    )
-  );
+  USING (list_id IN (SELECT public.viewable_list_ids()));
 
 -- Admins can see all list audit entries.
 DROP POLICY IF EXISTS "admin_select_list_audit" ON list_audit_log;
 CREATE POLICY "admin_select_list_audit"
   ON list_audit_log FOR SELECT TO authenticated
+  USING ((SELECT public.is_admin()));
+
+
+-- =============================================================================
+-- object_list_shares  (tag sharing, issue #450)
+-- =============================================================================
+-- NOTE: policies here reference object_lists via plain subqueries; that is
+-- safe from RLS recursion because the object_lists policies reach shares only
+-- through the SECURITY DEFINER helpers (viewable_list_ids et al.), which do
+-- not re-enter policy evaluation.
+
+ALTER TABLE object_list_shares ENABLE ROW LEVEL SECURITY;
+
+-- Grantees see their own share rows; list owners see all shares on their lists.
+DROP POLICY IF EXISTS "select_list_shares" ON object_list_shares;
+CREATE POLICY "select_list_shares"
+  ON object_list_shares FOR SELECT TO authenticated
+  USING (
+    user_id = (SELECT auth.uid())
+    OR list_id IN (
+      SELECT id FROM object_lists WHERE created_by = (SELECT auth.uid())
+    )
+  );
+
+-- Only the list owner grants shares, on their own non-system lists. granted_by
+-- is stamped with the grantor; self-shares are pointless and disallowed.
+DROP POLICY IF EXISTS "insert_list_shares" ON object_list_shares;
+CREATE POLICY "insert_list_shares"
+  ON object_list_shares FOR INSERT TO authenticated
+  WITH CHECK (
+    granted_by = (SELECT auth.uid())
+    AND user_id <> (SELECT auth.uid())
+    AND list_id IN (
+      SELECT id FROM object_lists
+      WHERE created_by = (SELECT auth.uid()) AND is_system = false
+    )
+  );
+
+-- Only the list owner changes a share's role.
+DROP POLICY IF EXISTS "update_list_shares" ON object_list_shares;
+CREATE POLICY "update_list_shares"
+  ON object_list_shares FOR UPDATE TO authenticated
+  USING (
+    list_id IN (
+      SELECT id FROM object_lists WHERE created_by = (SELECT auth.uid())
+    )
+  )
+  WITH CHECK (
+    list_id IN (
+      SELECT id FROM object_lists WHERE created_by = (SELECT auth.uid())
+    )
+  );
+
+-- The list owner revokes shares; grantees can remove their own share (leave).
+DROP POLICY IF EXISTS "delete_list_shares" ON object_list_shares;
+CREATE POLICY "delete_list_shares"
+  ON object_list_shares FOR DELETE TO authenticated
+  USING (
+    user_id = (SELECT auth.uid())
+    OR list_id IN (
+      SELECT id FROM object_lists WHERE created_by = (SELECT auth.uid())
+    )
+  );
+
+-- Admins can manage all shares.
+DROP POLICY IF EXISTS "admin_manage_list_shares" ON object_list_shares;
+CREATE POLICY "admin_manage_list_shares"
+  ON object_list_shares
   USING ((SELECT public.is_admin()));
 
 

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -634,6 +634,24 @@ ALTER TABLE "public"."list_audit_log" OWNER TO "postgres";
 
 
 
+CREATE TABLE IF NOT EXISTS "public"."object_list_shares" (
+    "id" integer NOT NULL,
+    "list_id" integer NOT NULL,
+    "user_id" "uuid" NOT NULL,
+    "role" "text" DEFAULT 'viewer'::"text" NOT NULL,
+    "granted_by" "uuid",
+    "granted_at" timestamp with time zone DEFAULT "now"(),
+    CONSTRAINT "object_list_shares_role_check" CHECK (("role" = ANY (ARRAY['viewer'::"text", 'editor'::"text"])))
+);
+
+
+ALTER TABLE "public"."object_list_shares" OWNER TO "postgres";
+
+
+COMMENT ON TABLE "public"."object_list_shares" IS 'Per-user sharing grants on object_lists (issue #450). A share gives the grantee visibility of the list regardless of its visibility setting; role=editor additionally allows adding/removing members (same scope as public_edit — list metadata stays owner-only). Owner manages shares; grantees can remove their own share (leave).';
+
+
+
 CREATE TABLE IF NOT EXISTS "public"."observations" (
     "name" "text" NOT NULL,
     "program_slug" "text" NOT NULL,
@@ -1454,6 +1472,22 @@ ALTER SEQUENCE "public"."list_audit_log_id_seq" OWNED BY "public"."list_audit_lo
 
 
 
+CREATE SEQUENCE IF NOT EXISTS "public"."object_list_shares_id_seq"
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE "public"."object_list_shares_id_seq" OWNER TO "postgres";
+
+
+ALTER SEQUENCE "public"."object_list_shares_id_seq" OWNED BY "public"."object_list_shares"."id";
+
+
+
 CREATE TABLE IF NOT EXISTS "public"."user_profiles" (
     "user_id" "uuid" NOT NULL,
     "username" "text" NOT NULL,
@@ -1562,6 +1596,10 @@ ALTER TABLE ONLY "public"."object_photometry" ALTER COLUMN "id" SET DEFAULT "nex
 
 
 ALTER TABLE ONLY "public"."list_audit_log" ALTER COLUMN "id" SET DEFAULT "nextval"('"public"."list_audit_log_id_seq"'::"regclass");
+
+
+
+ALTER TABLE ONLY "public"."object_list_shares" ALTER COLUMN "id" SET DEFAULT "nextval"('"public"."object_list_shares_id_seq"'::"regclass");
 
 
 
@@ -1815,6 +1853,16 @@ ALTER TABLE ONLY "public"."object_list_members"
     ADD CONSTRAINT "object_list_members_list_id_ra_dec_key" UNIQUE ("list_id", "ra", "dec");
 
 
+
+ALTER TABLE ONLY "public"."object_list_shares"
+    ADD CONSTRAINT "object_list_shares_pkey" PRIMARY KEY ("id");
+
+
+
+ALTER TABLE ONLY "public"."object_list_shares"
+    ADD CONSTRAINT "object_list_shares_list_id_user_id_key" UNIQUE ("list_id", "user_id");
+
+
 ALTER TABLE ONLY "public"."object_photometry"
     ADD CONSTRAINT "object_photometry_pkey" PRIMARY KEY ("id");
 
@@ -1977,6 +2025,21 @@ ALTER TABLE ONLY "public"."list_audit_log"
 
 ALTER TABLE ONLY "public"."list_audit_log"
     ADD CONSTRAINT "list_audit_log_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "auth"."users"("id");
+
+
+
+ALTER TABLE ONLY "public"."object_list_shares"
+    ADD CONSTRAINT "object_list_shares_list_id_fkey" FOREIGN KEY ("list_id") REFERENCES "public"."object_lists"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."object_list_shares"
+    ADD CONSTRAINT "object_list_shares_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "auth"."users"("id") ON DELETE CASCADE;
+
+
+
+ALTER TABLE ONLY "public"."object_list_shares"
+    ADD CONSTRAINT "object_list_shares_granted_by_fkey" FOREIGN KEY ("granted_by") REFERENCES "auth"."users"("id");
 
 
 
@@ -2205,6 +2268,12 @@ GRANT ALL ON TABLE "public"."list_audit_log" TO "service_role";
 
 
 
+GRANT ALL ON TABLE "public"."object_list_shares" TO "anon";
+GRANT ALL ON TABLE "public"."object_list_shares" TO "authenticated";
+GRANT ALL ON TABLE "public"."object_list_shares" TO "service_role";
+
+
+
 GRANT ALL ON TABLE "public"."observations" TO "anon";
 GRANT ALL ON TABLE "public"."observations" TO "authenticated";
 GRANT ALL ON TABLE "public"."observations" TO "service_role";
@@ -2425,6 +2494,12 @@ GRANT ALL ON SEQUENCE "public"."object_photometry_id_seq" TO "service_role";
 GRANT ALL ON SEQUENCE "public"."list_audit_log_id_seq" TO "anon";
 GRANT ALL ON SEQUENCE "public"."list_audit_log_id_seq" TO "authenticated";
 GRANT ALL ON SEQUENCE "public"."list_audit_log_id_seq" TO "service_role";
+
+
+
+GRANT ALL ON SEQUENCE "public"."object_list_shares_id_seq" TO "anon";
+GRANT ALL ON SEQUENCE "public"."object_list_shares_id_seq" TO "authenticated";
+GRANT ALL ON SEQUENCE "public"."object_list_shares_id_seq" TO "service_role";
 
 
 

--- a/web/app/nirspec/tags/[...slug]/page.tsx
+++ b/web/app/nirspec/tags/[...slug]/page.tsx
@@ -11,7 +11,7 @@ import { ListBadge } from '@/components/lists/ListBadge';
 import { ListForm } from '@/components/lists/ListForm';
 import { ListMembersTable } from '@/components/lists/ListMembersTable';
 import { useListDetailQuery } from '@/lib/hooks/useListsQuery';
-import { deleteList } from '@/lib/actions/lists';
+import { deleteList, leaveSharedList } from '@/lib/actions/lists';
 import { useAuth } from '@/lib/contexts/AuthContext';
 import {
   LogIn,
@@ -24,6 +24,7 @@ import {
   Users,
   Calendar,
   Hash,
+  LogOut,
 } from 'lucide-react';
 
 export default function ListDetailPage() {
@@ -35,6 +36,7 @@ export default function ListDetailPage() {
   const [page, setPage] = useState(1);
   const [isEditing, setIsEditing] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [leaving, setLeaving] = useState(false);
 
   const { data, isLoading, refetch } = useListDetailQuery(slug, page, !authLoading && !!user);
   const list = data?.list ?? null;
@@ -54,6 +56,20 @@ export default function ListDetailPage() {
     if (result.error) {
       alert(result.error);
       setDeleting(false);
+    } else {
+      router.push('/nirspec/tags');
+    }
+  };
+
+  const handleLeave = async () => {
+    if (!list || !confirm(`Leave "${list.name}"? You will lose access unless it is public or shared with you again.`)) {
+      return;
+    }
+    setLeaving(true);
+    const result = await leaveSharedList(list.id);
+    if (result.error) {
+      alert(result.error);
+      setLeaving(false);
     } else {
       router.push('/nirspec/tags');
     }
@@ -176,6 +192,23 @@ export default function ListDetailPage() {
                       )}
                     </Button>
                   </div>
+                )}
+
+                {!isOwner && list.shared_role && (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={handleLeave}
+                    disabled={leaving}
+                    title="Remove your access to this shared tag"
+                  >
+                    {leaving ? (
+                      <Loader2 className="w-4 h-4 animate-spin mr-1" />
+                    ) : (
+                      <LogOut className="w-4 h-4 mr-1" />
+                    )}
+                    Leave
+                  </Button>
                 )}
               </div>
 

--- a/web/app/nirspec/tags/[...slug]/page.tsx
+++ b/web/app/nirspec/tags/[...slug]/page.tsx
@@ -21,6 +21,7 @@ import {
   Edit2,
   Trash2,
   User,
+  Users,
   Calendar,
   Hash,
 } from 'lucide-react';
@@ -145,6 +146,12 @@ export default function ListDetailPage() {
                     <div className="mt-1 flex items-center gap-2">
                       <span className="text-sm font-mono text-text-secondary">#{list.slug}</span>
                       <ListBadge visibility={list.visibility} isSystem={list.is_system} size="md" />
+                      {!isOwner && list.shared_role && (
+                        <span className="inline-flex items-center gap-1 rounded-full font-medium text-xs px-2 py-0.5 bg-violet-50 dark:bg-violet-950 text-violet-700 dark:text-violet-300">
+                          <Users className="w-3 h-3" />
+                          Shared with you · {list.shared_role === 'editor' ? 'can edit' : 'can view'}
+                        </span>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/web/app/nirspec/tags/page.tsx
+++ b/web/app/nirspec/tags/page.tsx
@@ -7,14 +7,94 @@ import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
 import { ListBadge } from '@/components/lists/ListBadge';
 import { Card } from '@/components/ui/Card';
 import { useListsOverviewQuery } from '@/lib/hooks/useListsQuery';
-import { LogIn, Loader2, Tag, Hash, User, Shield } from 'lucide-react';
+import { LogIn, Loader2, Tag, Hash, User, Shield, Users } from 'lucide-react';
 import { useAuth } from '@/lib/contexts/AuthContext';
+import type { ObjectListOverview } from '@/lib/types';
+
+function TagsTable({ lists }: { lists: ObjectListOverview[] }) {
+  return (
+    <Card className="overflow-hidden">
+      <table className="w-full">
+        <thead>
+          <tr className="bg-table-header border-b border-border">
+            <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wider text-text-secondary">Tag</th>
+            <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wider text-text-secondary hidden md:table-cell">Description</th>
+            <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wider text-text-secondary">Type</th>
+            <th className="px-4 py-2.5 text-right text-xs font-medium uppercase tracking-wider text-text-secondary">Objects</th>
+            <th className="px-4 py-2.5 text-right text-xs font-medium uppercase tracking-wider text-text-secondary hidden sm:table-cell">Creator</th>
+          </tr>
+        </thead>
+        <tbody>
+          {lists.map(list => (
+            <tr key={list.id} className="border-b border-border last:border-0 hover:bg-card-hover transition-colors">
+              <td className="px-4 py-3">
+                <Link href={`/nirspec/tags/${list.slug}`} className="flex items-center gap-2.5">
+                  {list.icon ? (
+                    <span className="text-lg flex-shrink-0">{list.icon}</span>
+                  ) : list.color ? (
+                    <span className="w-4 h-4 rounded-full flex-shrink-0" style={{ backgroundColor: list.color }} />
+                  ) : (
+                    <Tag className="w-4 h-4 text-text-secondary flex-shrink-0" />
+                  )}
+                  <div className="min-w-0">
+                    <span className="font-medium text-text-primary">{list.name}</span>
+                    <span className="ml-2 text-xs font-mono text-text-secondary">#{list.slug}</span>
+                  </div>
+                </Link>
+              </td>
+              <td className="px-4 py-3 hidden md:table-cell">
+                <span className="text-sm text-text-secondary line-clamp-1">{list.description || '—'}</span>
+              </td>
+              <td className="px-4 py-3">
+                <span className="inline-flex items-center gap-1">
+                  <ListBadge visibility={list.visibility} />
+                  {list.shared_role && (
+                    <span className="inline-flex items-center gap-1 rounded-full font-medium text-[10px] px-1.5 py-0.5 bg-violet-50 dark:bg-violet-950 text-violet-700 dark:text-violet-300">
+                      <Users className="w-2.5 h-2.5" />
+                      {list.shared_role === 'editor' ? 'Can edit' : 'Can view'}
+                    </span>
+                  )}
+                </span>
+              </td>
+              <td className="px-4 py-3 text-right">
+                <span className="inline-flex items-center gap-1 text-sm text-text-secondary">
+                  <Hash className="w-3 h-3" />
+                  {list.member_count.toLocaleString()}
+                </span>
+              </td>
+              <td className="px-4 py-3 text-right hidden sm:table-cell">
+                {list.is_system ? (
+                  <span className="inline-flex items-center gap-1 rounded-full font-medium text-[10px] px-1.5 py-0.5 bg-amber-50 dark:bg-amber-950 text-amber-700 dark:text-amber-300">
+                    <Shield className="w-2.5 h-2.5" />
+                    System
+                  </span>
+                ) : list.creator_name ? (
+                  <span className="inline-flex items-center gap-1 text-sm text-text-secondary">
+                    <User className="w-3 h-3" />
+                    {list.creator_name}
+                  </span>
+                ) : (
+                  <span className="text-sm text-text-secondary">—</span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </Card>
+  );
+}
 
 export default function ListsPage() {
   const { user, loading: authLoading } = useAuth();
   const { data, isLoading } = useListsOverviewQuery(!authLoading && !!user);
   const lists = data?.lists ?? [];
   const error = data?.error ?? null;
+
+  // Tags shared with the current user (issue #450) get their own grouping.
+  const sharedLists = lists.filter(l => l.shared_role && l.created_by !== user?.id);
+  const sharedIds = new Set(sharedLists.map(l => l.id));
+  const otherLists = lists.filter(l => !sharedIds.has(l.id));
 
   const breadcrumbs = [
     { label: 'CAMPFIRE', href: '/' },
@@ -80,67 +160,26 @@ export default function ListsPage() {
           <p className="text-text-secondary">No tags available yet.</p>
         </div>
       ) : (
-        <Card className="overflow-hidden">
-          <table className="w-full">
-            <thead>
-              <tr className="bg-table-header border-b border-border">
-                <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wider text-text-secondary">Tag</th>
-                <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wider text-text-secondary hidden md:table-cell">Description</th>
-                <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wider text-text-secondary">Type</th>
-                <th className="px-4 py-2.5 text-right text-xs font-medium uppercase tracking-wider text-text-secondary">Objects</th>
-                <th className="px-4 py-2.5 text-right text-xs font-medium uppercase tracking-wider text-text-secondary hidden sm:table-cell">Creator</th>
-              </tr>
-            </thead>
-            <tbody>
-              {lists.map(list => (
-                <tr key={list.id} className="border-b border-border last:border-0 hover:bg-card-hover transition-colors">
-                  <td className="px-4 py-3">
-                    <Link href={`/nirspec/tags/${list.slug}`} className="flex items-center gap-2.5">
-                      {list.icon ? (
-                        <span className="text-lg flex-shrink-0">{list.icon}</span>
-                      ) : list.color ? (
-                        <span className="w-4 h-4 rounded-full flex-shrink-0" style={{ backgroundColor: list.color }} />
-                      ) : (
-                        <Tag className="w-4 h-4 text-text-secondary flex-shrink-0" />
-                      )}
-                      <div className="min-w-0">
-                        <span className="font-medium text-text-primary">{list.name}</span>
-                        <span className="ml-2 text-xs font-mono text-text-secondary">#{list.slug}</span>
-                      </div>
-                    </Link>
-                  </td>
-                  <td className="px-4 py-3 hidden md:table-cell">
-                    <span className="text-sm text-text-secondary line-clamp-1">{list.description || '—'}</span>
-                  </td>
-                  <td className="px-4 py-3">
-                    <ListBadge visibility={list.visibility} />
-                  </td>
-                  <td className="px-4 py-3 text-right">
-                    <span className="inline-flex items-center gap-1 text-sm text-text-secondary">
-                      <Hash className="w-3 h-3" />
-                      {list.member_count.toLocaleString()}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-right hidden sm:table-cell">
-                    {list.is_system ? (
-                      <span className="inline-flex items-center gap-1 rounded-full font-medium text-[10px] px-1.5 py-0.5 bg-amber-50 dark:bg-amber-950 text-amber-700 dark:text-amber-300">
-                        <Shield className="w-2.5 h-2.5" />
-                        System
-                      </span>
-                    ) : list.creator_name ? (
-                      <span className="inline-flex items-center gap-1 text-sm text-text-secondary">
-                        <User className="w-3 h-3" />
-                        {list.creator_name}
-                      </span>
-                    ) : (
-                      <span className="text-sm text-text-secondary">—</span>
-                    )}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </Card>
+        <div className="space-y-8">
+          {sharedLists.length > 0 && (
+            <div>
+              <h2 className="flex items-center gap-2 text-lg font-semibold text-text-primary mb-3">
+                <Users className="w-5 h-5 text-primary" />
+                Shared with you
+              </h2>
+              <TagsTable lists={sharedLists} />
+            </div>
+          )}
+          <div>
+            {sharedLists.length > 0 && (
+              <h2 className="flex items-center gap-2 text-lg font-semibold text-text-primary mb-3">
+                <Tag className="w-5 h-5 text-primary" />
+                All tags
+              </h2>
+            )}
+            <TagsTable lists={otherLists} />
+          </div>
+        </div>
       )}
     </div>
   );

--- a/web/components/lists/ListForm.tsx
+++ b/web/components/lists/ListForm.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/Button';
 import { createList, updateList, checkSlugAvailability } from '@/lib/actions/lists';
 import { ListEmojiPicker } from './ListEmojiPicker';
 import { ListColorPicker } from './ListColorPicker';
+import { ListShareManager } from './ListShareManager';
 import { useAuth } from '@/lib/contexts/AuthContext';
 import type { ObjectList } from '@/lib/types';
 
@@ -23,8 +24,11 @@ function nameToSlugFragment(name: string): string {
 }
 
 export function ListForm({ mode, list, initialName, onSuccess, onCreated, onCancel }: ListFormProps) {
-  const { userProfile } = useAuth();
+  const { user, userProfile } = useAuth();
   const username = userProfile?.username ?? '';
+  // Sharing is owner-only (and meaningless on system tags)
+  const canManageSharing =
+    mode === 'edit' && !!list && !list.is_system && !!user && list.created_by === user.id;
 
   const [name, setName] = useState(list?.name ?? initialName ?? '');
   const [slug, setSlug] = useState(list?.slug ?? '');
@@ -254,6 +258,12 @@ export function ListForm({ mode, list, initialName, onSuccess, onCreated, onCanc
             <option value="public_edit">Collaborative — others can add/remove objects</option>
           </select>
         </div>
+
+        {canManageSharing && (
+          <div className="pt-3 border-t border-border">
+            <ListShareManager listId={list!.id} />
+          </div>
+        )}
       </div>
 
       <div className="flex gap-2 mt-4">

--- a/web/components/lists/ListShareManager.tsx
+++ b/web/components/lists/ListShareManager.tsx
@@ -118,6 +118,8 @@ export function ListShareManager({ listId }: ListShareManagerProps) {
   };
 
   const handleRemove = async (share: ObjectListShareWithUser) => {
+    const who = share.full_name ?? share.username ?? 'this user';
+    if (!confirm(`Revoke ${who}'s access to this tag?`)) return;
     setBusy(true);
     setError(null);
     const result = await removeListShare(share.id);
@@ -155,6 +157,8 @@ export function ListShareManager({ listId }: ListShareManagerProps) {
             type="text"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
+            // Block implicit submission of the surrounding ListForm on Enter
+            onKeyDown={(e) => { if (e.key === 'Enter') e.preventDefault(); }}
             placeholder="Search by username or name..."
             disabled={busy}
             className="w-full px-3 py-2 text-sm border border-border-strong rounded-md bg-background text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"

--- a/web/components/lists/ListShareManager.tsx
+++ b/web/components/lists/ListShareManager.tsx
@@ -1,0 +1,244 @@
+'use client';
+
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { Loader2, UserPlus, X as XIcon, Users } from 'lucide-react';
+import {
+  getListShares,
+  searchUsersForSharing,
+  addListShare,
+  updateListShare,
+  removeListShare,
+} from '@/lib/actions/lists';
+import type { ObjectListShareWithUser, ListShareRole } from '@/lib/types';
+
+interface ListShareManagerProps {
+  listId: number;
+}
+
+interface UserCandidate {
+  user_id: string;
+  username: string;
+  full_name: string;
+}
+
+const ROLE_LABELS: Record<ListShareRole, string> = {
+  viewer: 'Can view',
+  editor: 'Can edit',
+};
+
+/**
+ * Owner-facing management of per-user tag shares (issue #450): search users,
+ * grant view/edit access, change roles, revoke. Rendered inside the tag edit
+ * form (ListForm), which is only reachable by the tag owner.
+ */
+export function ListShareManager({ listId }: ListShareManagerProps) {
+  const [shares, setShares] = useState<ObjectListShareWithUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [query, setQuery] = useState('');
+  const [candidates, setCandidates] = useState<UserCandidate[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [newRole, setNewRole] = useState<ListShareRole>('viewer');
+  const [busy, setBusy] = useState(false);
+  const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const loadShares = useCallback(async () => {
+    const result = await getListShares(listId);
+    if (result.error) {
+      setError(result.error);
+    } else {
+      setShares(result.shares);
+    }
+    setLoading(false);
+  }, [listId]);
+
+  useEffect(() => {
+    loadShares();
+  }, [loadShares]);
+
+  // Debounced user search
+  useEffect(() => {
+    if (searchTimer.current) clearTimeout(searchTimer.current);
+    const trimmed = query.trim();
+    if (trimmed.length < 2) {
+      setCandidates([]);
+      setSearching(false);
+      return;
+    }
+    setSearching(true);
+    searchTimer.current = setTimeout(async () => {
+      const { users } = await searchUsersForSharing(trimmed);
+      const sharedIds = new Set(shares.map(s => s.user_id));
+      setCandidates(users.filter(u => !sharedIds.has(u.user_id)));
+      setSearching(false);
+    }, 300);
+    return () => {
+      if (searchTimer.current) clearTimeout(searchTimer.current);
+    };
+  }, [query, shares]);
+
+  // Close the candidate dropdown on outside click
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setCandidates([]);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
+
+  const handleAdd = async (candidate: UserCandidate) => {
+    setBusy(true);
+    setError(null);
+    const result = await addListShare(listId, candidate.user_id, newRole);
+    if (result.error) {
+      setError(result.error);
+    } else {
+      setQuery('');
+      setCandidates([]);
+      await loadShares();
+    }
+    setBusy(false);
+  };
+
+  const handleRoleChange = async (share: ObjectListShareWithUser, role: ListShareRole) => {
+    if (role === share.role) return;
+    setBusy(true);
+    setError(null);
+    const result = await updateListShare(share.id, role);
+    if (result.error) {
+      setError(result.error);
+    } else {
+      setShares(prev => prev.map(s => (s.id === share.id ? { ...s, role } : s)));
+    }
+    setBusy(false);
+  };
+
+  const handleRemove = async (share: ObjectListShareWithUser) => {
+    setBusy(true);
+    setError(null);
+    const result = await removeListShare(share.id);
+    if (result.error) {
+      setError(result.error);
+    } else {
+      setShares(prev => prev.filter(s => s.id !== share.id));
+    }
+    setBusy(false);
+  };
+
+  return (
+    <div ref={containerRef}>
+      <label className="block text-xs font-medium text-text-secondary mb-1">
+        <span className="inline-flex items-center gap-1">
+          <Users className="w-3.5 h-3.5" />
+          Share with users
+        </span>
+      </label>
+      <p className="mb-2 text-[11px] text-text-secondary dark:text-text-tertiary">
+        Give specific users access to this tag regardless of its visibility. Editors can add and
+        remove objects; viewers can only see the tag.
+      </p>
+
+      {error && (
+        <div className="mb-2 p-2 bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-900 rounded text-xs text-red-800 dark:text-red-400">
+          {error}
+        </div>
+      )}
+
+      {/* Add user */}
+      <div className="flex gap-2">
+        <div className="relative flex-1">
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search by username or name..."
+            disabled={busy}
+            className="w-full px-3 py-2 text-sm border border-border-strong rounded-md bg-background text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+          />
+          {searching && (
+            <span className="absolute right-3 top-1/2 -translate-y-1/2">
+              <Loader2 className="w-3.5 h-3.5 animate-spin text-text-secondary dark:text-text-tertiary" />
+            </span>
+          )}
+          {candidates.length > 0 && (
+            <div className="absolute z-10 mt-1 w-full border border-border rounded-md bg-card shadow-lg overflow-hidden">
+              {candidates.map(candidate => (
+                <button
+                  key={candidate.user_id}
+                  type="button"
+                  onClick={() => handleAdd(candidate)}
+                  disabled={busy}
+                  className="w-full flex items-center gap-2 px-3 py-2 text-left text-sm hover:bg-card-hover transition-colors"
+                >
+                  <UserPlus className="w-3.5 h-3.5 text-text-secondary flex-shrink-0" />
+                  <span className="text-text-primary">{candidate.full_name}</span>
+                  <span className="text-xs font-mono text-text-secondary">@{candidate.username}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <select
+          value={newRole}
+          onChange={(e) => setNewRole(e.target.value as ListShareRole)}
+          disabled={busy}
+          className="px-2 py-2 text-sm border border-border-strong rounded-md bg-background text-text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+        >
+          <option value="viewer">{ROLE_LABELS.viewer}</option>
+          <option value="editor">{ROLE_LABELS.editor}</option>
+        </select>
+      </div>
+
+      {/* Current shares */}
+      {loading ? (
+        <div className="flex items-center gap-2 py-3 text-xs text-text-secondary">
+          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          Loading shares...
+        </div>
+      ) : shares.length > 0 ? (
+        <ul className="mt-2 divide-y divide-border border border-border rounded-md">
+          {shares.map(share => (
+            <li key={share.id} className="flex items-center gap-2 px-3 py-2">
+              <div className="flex-1 min-w-0 flex items-baseline gap-2">
+                <span className="text-sm text-text-primary truncate">
+                  {share.full_name ?? 'Unknown user'}
+                </span>
+                {share.username && (
+                  <span className="text-xs font-mono text-text-secondary flex-shrink-0">
+                    @{share.username}
+                  </span>
+                )}
+              </div>
+              <select
+                value={share.role}
+                onChange={(e) => handleRoleChange(share, e.target.value as ListShareRole)}
+                disabled={busy}
+                className="px-1.5 py-1 text-xs border border-border-strong rounded-md bg-background text-text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+              >
+                <option value="viewer">{ROLE_LABELS.viewer}</option>
+                <option value="editor">{ROLE_LABELS.editor}</option>
+              </select>
+              <button
+                type="button"
+                onClick={() => handleRemove(share)}
+                disabled={busy}
+                className="p-1 rounded text-text-secondary hover:bg-red-50 dark:hover:bg-red-950 hover:text-red-600 dark:hover:text-red-400 transition-colors"
+                title="Revoke access"
+              >
+                <XIcon className="w-3.5 h-3.5" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-2 text-xs text-text-secondary dark:text-text-tertiary">
+          Not shared with anyone yet.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/components/spectra/ObjectListsSection.tsx
+++ b/web/components/spectra/ObjectListsSection.tsx
@@ -71,10 +71,10 @@ export function ObjectListsSection({ objectId, ra, dec, dropdownPlacement = 'bot
   const { user, userProfile } = useAuth();
   const canEdit = !!userProfile?.can_comment;
 
-  /** Check if the current user can edit a specific list (owner or public_edit). */
+  /** Check if the current user can edit a specific list (owner, public_edit, or editor share). */
   const canEditList = useCallback((list: ObjectListWithMembership) => {
     if (!canEdit) return false;
-    return list.created_by === user?.id || list.visibility === 'public_edit';
+    return list.created_by === user?.id || list.visibility === 'public_edit' || list.shared_role === 'editor';
   }, [canEdit, user?.id]);
 
   const [lists, setLists] = useState<ObjectListWithMembership[]>([]);

--- a/web/lib/actions/lists.ts
+++ b/web/lib/actions/lists.ts
@@ -7,7 +7,56 @@ import type {
   ObjectListWithMembership,
   ObjectListOverview,
   ObjectListMemberWithObject,
+  ObjectListShareWithUser,
+  ListShareRole,
 } from '@/lib/types';
+
+type ServerSupabase = Awaited<ReturnType<typeof createClient>>;
+
+/**
+ * Fetch the current user's share roles (issue #450), keyed by list id.
+ * Used to attach `shared_role` to lists returned by the read actions.
+ */
+async function fetchMyShareRoles(
+  supabase: ServerSupabase,
+  userId: string | undefined,
+): Promise<Map<number, ListShareRole>> {
+  if (!userId) return new Map();
+  const { data } = await supabase
+    .from('object_list_shares')
+    .select('list_id, role')
+    .eq('user_id', userId);
+  return new Map((data ?? []).map(s => [s.list_id, s.role as ListShareRole]));
+}
+
+/**
+ * Whether the user may add/remove members of a list: owner, public_edit,
+ * or an editor-role share. Mirrors public.member_editable_list_ids() (RLS
+ * is the real enforcement; this exists for friendly error messages).
+ */
+async function canEditListMembers(
+  supabase: ServerSupabase,
+  listId: number,
+  userId: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const { data: list } = await supabase
+    .from('object_lists')
+    .select('created_by, visibility')
+    .eq('id', listId)
+    .single();
+  if (!list) return { ok: false, error: 'Tag not found' };
+  if (list.created_by === userId || list.visibility === 'public_edit') {
+    return { ok: true };
+  }
+  const { data: share } = await supabase
+    .from('object_list_shares')
+    .select('role')
+    .eq('list_id', listId)
+    .eq('user_id', userId)
+    .maybeSingle();
+  if (share?.role === 'editor') return { ok: true };
+  return { ok: false };
+}
 
 /**
  * Get all lists that an object belongs to, plus available lists for the add dropdown.
@@ -32,7 +81,8 @@ export async function getListsForObject(objectId: number): Promise<{
 
 /**
  * Get all lists available to the current user (for filter dropdowns and add-to-list UI).
- * Returns system lists + user's own lists + public_edit lists.
+ * Returns system lists + user's own lists + public lists + lists shared with the user
+ * (RLS does the filtering); each list carries the user's shared_role, if any.
  */
 export async function getAvailableLists(): Promise<{
   lists: ObjectList[];
@@ -40,17 +90,27 @@ export async function getAvailableLists(): Promise<{
 }> {
   const supabase = await createClient();
 
-  const { data, error } = await supabase
-    .from('object_lists')
-    .select('*')
-    .order('is_system', { ascending: false })
-    .order('name');
+  const { data: { user } } = await supabase.auth.getUser();
+
+  const [{ data, error }, shareRoles] = await Promise.all([
+    supabase
+      .from('object_lists')
+      .select('*')
+      .order('is_system', { ascending: false })
+      .order('name'),
+    fetchMyShareRoles(supabase, user?.id),
+  ]);
 
   if (error) {
     return { lists: [], error: error.message };
   }
 
-  return { lists: data ?? [] };
+  const lists: ObjectList[] = (data ?? []).map(list => ({
+    ...list,
+    shared_role: shareRoles.get(list.id) ?? null,
+  }));
+
+  return { lists };
 }
 
 /**
@@ -62,7 +122,9 @@ export async function getListsWithMembership(objectId: number): Promise<{
 }> {
   const supabase = await createClient();
 
-  const [listsResult, membersResult] = await Promise.all([
+  const { data: { user } } = await supabase.auth.getUser();
+
+  const [listsResult, membersResult, shareRoles] = await Promise.all([
     supabase
       .from('object_lists')
       .select('*')
@@ -72,6 +134,7 @@ export async function getListsWithMembership(objectId: number): Promise<{
       .from('object_list_members')
       .select('list_id')
       .eq('object_id', objectId),
+    fetchMyShareRoles(supabase, user?.id),
   ]);
 
   if (listsResult.error) return { lists: [], error: listsResult.error.message };
@@ -82,6 +145,7 @@ export async function getListsWithMembership(objectId: number): Promise<{
   const lists: ObjectListWithMembership[] = (listsResult.data ?? []).map(list => ({
     ...list,
     is_member: memberListIds.has(list.id),
+    shared_role: shareRoles.get(list.id) ?? null,
   }));
 
   return { lists };
@@ -109,15 +173,10 @@ export async function addObjectToList(
     .single();
   if (!profile?.can_comment) return { error: 'You do not have permission to edit tags' };
 
-  // Verify user can edit this list (owner or public_edit)
-  const { data: list } = await supabase
-    .from('object_lists')
-    .select('created_by, visibility')
-    .eq('id', listId)
-    .single();
-  if (!list) return { error: 'Tag not found' };
-  if (list.created_by !== user.id && list.visibility !== 'public_edit') {
-    return { error: 'You do not have permission to add objects to this tag' };
+  // Verify user can edit this list (owner, public_edit, or editor share)
+  const { ok, error: checkError } = await canEditListMembers(supabase, listId, user.id);
+  if (!ok) {
+    return { error: checkError ?? 'You do not have permission to add objects to this tag' };
   }
 
   const { error } = await supabase
@@ -154,15 +213,10 @@ export async function removeObjectFromList(
     .single();
   if (!profile?.can_comment) return { error: 'You do not have permission to edit tags' };
 
-  // Verify user can edit this list (owner or public_edit)
-  const { data: list } = await supabase
-    .from('object_lists')
-    .select('created_by, visibility')
-    .eq('id', listId)
-    .single();
-  if (!list) return { error: 'Tag not found' };
-  if (list.created_by !== user.id && list.visibility !== 'public_edit') {
-    return { error: 'You do not have permission to remove objects from this tag' };
+  // Verify user can edit this list (owner, public_edit, or editor share)
+  const { ok, error: checkError } = await canEditListMembers(supabase, listId, user.id);
+  if (!ok) {
+    return { error: checkError ?? 'You do not have permission to remove objects from this tag' };
   }
 
   const { error } = await supabase
@@ -439,11 +493,16 @@ export async function getListsOverview(): Promise<{
 }> {
   const supabase = await createClient();
 
-  const { data, error } = await supabase
-    .from('object_lists')
-    .select('*, object_list_members(count)')
-    .order('is_system', { ascending: false })
-    .order('name');
+  const { data: { user } } = await supabase.auth.getUser();
+
+  const [{ data, error }, shareRoles] = await Promise.all([
+    supabase
+      .from('object_lists')
+      .select('*, object_list_members(count)')
+      .order('is_system', { ascending: false })
+      .order('name'),
+    fetchMyShareRoles(supabase, user?.id),
+  ]);
 
   if (error) {
     return { lists: [], error: error.message };
@@ -458,6 +517,7 @@ export async function getListsOverview(): Promise<{
       ...list,
       member_count: object_list_members?.[0]?.count ?? 0,
       creator_name: list.created_by ? nameMap.get(list.created_by) ?? null : null,
+      shared_role: shareRoles.get(list.id) ?? null,
     };
   });
 
@@ -490,10 +550,21 @@ export async function getListBySlug(
     return { list: null, members: [], totalMembers: 0, error: listError.message };
   }
 
-  // Creator name
-  const nameMap = listData.created_by
-    ? await fetchCreatorNames(supabase, [listData.created_by])
-    : new Map<string, string>();
+  // Creator name + current user's share role (issue #450)
+  const { data: { user } } = await supabase.auth.getUser();
+  const [nameMap, shareResult] = await Promise.all([
+    listData.created_by
+      ? fetchCreatorNames(supabase, [listData.created_by])
+      : Promise.resolve(new Map<string, string>()),
+    user
+      ? supabase
+          .from('object_list_shares')
+          .select('role')
+          .eq('list_id', listData.id)
+          .eq('user_id', user.id)
+          .maybeSingle()
+      : Promise.resolve({ data: null }),
+  ]);
 
   const { object_list_members: countArr, ...listFields } = listData;
   const totalMembers = countArr?.[0]?.count ?? 0;
@@ -501,6 +572,7 @@ export async function getListBySlug(
     ...listFields,
     member_count: totalMembers,
     creator_name: listFields.created_by ? nameMap.get(listFields.created_by) ?? null : null,
+    shared_role: (shareResult.data?.role as ListShareRole | undefined) ?? null,
   };
 
   // Fetch paginated members with joined object data. NOTE: n_spectra / max_snr
@@ -596,4 +668,182 @@ export async function getMyLists(): Promise<{
   });
 
   return { lists };
+}
+
+// =============================================================================
+// Tag sharing (issue #450)
+// =============================================================================
+// RLS on object_list_shares enforces owner-only grant/role-change/revoke (a
+// grantee may only delete their own share); the checks here exist for
+// friendly error messages.
+
+/**
+ * Get the shares on a list, with grantee names (owner-facing management UI).
+ */
+export async function getListShares(listId: number): Promise<{
+  shares: ObjectListShareWithUser[];
+  error?: string;
+}> {
+  const supabase = await createClient();
+
+  const { data: shares, error } = await supabase
+    .from('object_list_shares')
+    .select('*')
+    .eq('list_id', listId)
+    .order('granted_at', { ascending: true });
+
+  if (error) {
+    return { shares: [], error: error.message };
+  }
+  if (!shares || shares.length === 0) {
+    return { shares: [] };
+  }
+
+  // No PostgREST-resolvable FK from shares.user_id to user_profiles (it
+  // references auth.users), so join manually.
+  const userIds = [...new Set(shares.map(s => s.user_id))];
+  const { data: profiles } = await supabase
+    .from('user_profiles')
+    .select('user_id, username, full_name')
+    .in('user_id', userIds);
+  const profileMap = new Map((profiles ?? []).map(p => [p.user_id, p]));
+
+  return {
+    shares: shares.map(s => ({
+      ...s,
+      username: profileMap.get(s.user_id)?.username ?? null,
+      full_name: profileMap.get(s.user_id)?.full_name ?? null,
+    })),
+  };
+}
+
+/**
+ * Search users to share a tag with (autocomplete). Matches username or full
+ * name; excludes the current user.
+ */
+export async function searchUsersForSharing(query: string): Promise<{
+  users: { user_id: string; username: string; full_name: string }[];
+  error?: string;
+}> {
+  const trimmed = query.trim();
+  if (trimmed.length < 2) return { users: [] };
+
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { users: [], error: 'Not authenticated' };
+
+  // Escape PostgREST ilike wildcards in user input
+  const escaped = trimmed.replace(/[%_\\]/g, ch => `\\${ch}`);
+
+  const { data, error } = await supabase
+    .from('user_profiles')
+    .select('user_id, username, full_name')
+    .neq('user_id', user.id)
+    .or(`username.ilike.%${escaped}%,full_name.ilike.%${escaped}%`)
+    .order('username')
+    .limit(8);
+
+  if (error) {
+    return { users: [], error: error.message };
+  }
+
+  return { users: data ?? [] };
+}
+
+/**
+ * Share a tag with another user (owner only, non-system tags).
+ */
+export async function addListShare(
+  listId: number,
+  granteeUserId: string,
+  role: ListShareRole,
+): Promise<{ error?: string }> {
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: 'Not authenticated' };
+
+  const { data: list } = await supabase
+    .from('object_lists')
+    .select('created_by, is_system')
+    .eq('id', listId)
+    .single();
+  if (!list) return { error: 'Tag not found' };
+  if (list.is_system) return { error: 'System tags cannot be shared' };
+  if (list.created_by !== user.id) return { error: 'Only the tag owner can manage sharing' };
+  if (granteeUserId === user.id) return { error: 'You cannot share a tag with yourself' };
+
+  const { error } = await supabase
+    .from('object_list_shares')
+    .insert({
+      list_id: listId,
+      user_id: granteeUserId,
+      role,
+      granted_by: user.id,
+    });
+
+  if (error) {
+    if (error.code === '23505') {
+      return { error: 'This tag is already shared with that user' };
+    }
+    return { error: error.message };
+  }
+
+  return {};
+}
+
+/**
+ * Change a share's role (owner only).
+ */
+export async function updateListShare(
+  shareId: number,
+  role: ListShareRole,
+): Promise<{ error?: string }> {
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: 'Not authenticated' };
+
+  const { data, error } = await supabase
+    .from('object_list_shares')
+    .update({ role })
+    .eq('id', shareId)
+    .select('id');
+
+  if (error) {
+    return { error: error.message };
+  }
+  // RLS silently filters rows the caller may not update
+  if (!data || data.length === 0) {
+    return { error: 'Share not found or permission denied' };
+  }
+
+  return {};
+}
+
+/**
+ * Revoke a share. The owner can revoke any share on their tag; a grantee can
+ * remove their own share (leave the tag).
+ */
+export async function removeListShare(shareId: number): Promise<{ error?: string }> {
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: 'Not authenticated' };
+
+  const { data, error } = await supabase
+    .from('object_list_shares')
+    .delete()
+    .eq('id', shareId)
+    .select('id');
+
+  if (error) {
+    return { error: error.message };
+  }
+  if (!data || data.length === 0) {
+    return { error: 'Share not found or permission denied' };
+  }
+
+  return {};
 }

--- a/web/lib/actions/lists.ts
+++ b/web/lib/actions/lists.ts
@@ -733,14 +733,16 @@ export async function searchUsersForSharing(query: string): Promise<{
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return { users: [], error: 'Not authenticated' };
 
-  // Escape PostgREST ilike wildcards in user input
-  const escaped = trimmed.replace(/[%_\\]/g, ch => `\\${ch}`);
+  // Escape ILIKE wildcards, then double-quote the value for the or() filter —
+  // PostgREST's or() grammar splits on bare commas/parens, so an unquoted
+  // "Doe, John" would be parsed as two malformed conditions (HTTP 400).
+  const escaped = trimmed.replace(/[%_\\]/g, ch => `\\${ch}`).replace(/"/g, '\\"');
 
   const { data, error } = await supabase
     .from('user_profiles')
     .select('user_id, username, full_name')
     .neq('user_id', user.id)
-    .or(`username.ilike.%${escaped}%,full_name.ilike.%${escaped}%`)
+    .or(`username.ilike."%${escaped}%",full_name.ilike."%${escaped}%"`)
     .order('username')
     .limit(8);
 
@@ -817,6 +819,32 @@ export async function updateListShare(
   // RLS silently filters rows the caller may not update
   if (!data || data.length === 0) {
     return { error: 'Share not found or permission denied' };
+  }
+
+  return {};
+}
+
+/**
+ * Leave a tag that was shared with the current user (delete own share).
+ */
+export async function leaveSharedList(listId: number): Promise<{ error?: string }> {
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: 'Not authenticated' };
+
+  const { data, error } = await supabase
+    .from('object_list_shares')
+    .delete()
+    .eq('list_id', listId)
+    .eq('user_id', user.id)
+    .select('id');
+
+  if (error) {
+    return { error: error.message };
+  }
+  if (!data || data.length === 0) {
+    return { error: 'This tag is not shared with you' };
   }
 
   return {};

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -244,6 +244,26 @@ export interface ObjectList {
   created_by: string | null;
   created_at: string;
   updated_at: string;
+  // Role granted to the CURRENT user via object_list_shares (issue #450).
+  // Attached by the list server actions; null/undefined when not shared.
+  shared_role?: ListShareRole | null;
+}
+
+// Per-user sharing grants on lists (issue #450)
+export type ListShareRole = 'viewer' | 'editor';
+
+export interface ObjectListShare {
+  id: number;
+  list_id: number;
+  user_id: string;
+  role: ListShareRole;
+  granted_by: string | null;
+  granted_at: string;
+}
+
+export interface ObjectListShareWithUser extends ObjectListShare {
+  username: string | null;
+  full_name: string | null;
 }
 
 export interface ObjectListMember {


### PR DESCRIPTION
## Summary
Implements per-user sharing of tags (object_lists) with granular access control, allowing owners to grant specific users view or edit access regardless of the tag's visibility setting.

## Key Changes

### Database Schema
- **New table `object_list_shares`**: Stores per-user sharing grants with `list_id`, `user_id`, `role` (viewer|editor), `granted_by`, and `granted_at` fields
  - Unique constraint on (list_id, user_id) to prevent duplicate shares
  - Foreign keys with CASCADE delete for referential integrity
  - Role check constraint limiting values to 'viewer' or 'editor'

### RLS & Authorization
- **Two new SECURITY DEFINER helper functions** (`viewable_list_ids()` and `member_editable_list_ids()`) that serve as the single authority for list visibility:
  - `viewable_list_ids()`: Returns lists the user owns, public lists, or lists shared with them
  - `member_editable_list_ids()`: Returns lists where the user can add/remove members (owner, public_edit, or editor-role shares)
- Updated RLS policies on `object_lists`, `object_list_members`, and `list_audit_log` to use these helpers instead of inline predicates
- List metadata (name, description, etc.) remains owner-only; shares only grant member visibility/editability

### API & RPC Functions
- Updated four RPCs (`get_objects_for_sync`, `get_lists_for_sync`, `get_csv_export_spectra`, `get_csv_export_objects`) to include the share clause in their list-visibility predicates
- Added `lists_agg` CTE in `get_objects_for_sync` to filter visible lists by shares

### Server Actions (`web/lib/actions/lists.ts`)
- **New helper `fetchMyShareRoles()`**: Fetches current user's share roles keyed by list ID
- **New helper `canEditListMembers()`**: Checks if user can edit list members (mirrors `member_editable_list_ids()` for friendly error messages)
- **New RPC actions**:
  - `getListShares(listId)`: Fetch all shares for a list (owner-only)
  - `searchUsersForSharing(query)`: Search users by username/name for sharing
  - `addListShare(listId, userId, role)`: Grant a user access
  - `updateListShare(shareId, role)`: Change a share's role
  - `removeListShare(shareId)`: Revoke a share (owner or grantee can remove)
- Updated existing list actions (`getAvailableLists`, `getListsWithMembership`, `addObjectToList`, `removeObjectFromList`, `getListsOverview`, `getListBySlug`) to:
  - Fetch and attach `shared_role` to returned lists
  - Use `canEditListMembers()` for permission checks instead of inline logic

### UI Components
- **New `ListShareManager` component**: Owner-facing UI for managing shares
  - Search users by username/name with debouncing
  - Grant viewer or editor access
  - Change roles via dropdown
  - Revoke shares with confirmation
  - Displays error messages and loading states
- Updated `ListForm` to include the share manager (owner-only)
- Updated tags page and list detail page to display `shared_role` badge when user has access via a share

### Type Definitions
- Added `ListShareRole` type ('viewer' | 'editor')
- Added `ObjectListShare` and `ObjectListShareWithUser` interfaces
- Extended `ObjectList` interface with optional `shared_role` field

## Implementation Details
- Shares are independent of list visibility: a private list can be shared with specific users, and a public list can still have per-user shares
- Editors can add/remove members but cannot modify list metadata (name, description, visibility)
- Grantees can remove their own share (leave)
- The RLS helpers use SECURITY DEFINER to avoid recursion when called from policies
- Share grants are audited via `granted_by` and `granted_at` fields

https://claude.ai/code/session_018gZmriccrYg6pH6PAjZMNc