### PR TITLE
Fix tag members table linking to wrong NIRSpec object page

### DIFF
--- a/web/components/lists/ListMembersTable.tsx
+++ b/web/components/lists/ListMembersTable.tsx
@@ -73,7 +73,7 @@ export function ListMembersTable({ members, totalMembers, page, pageSize, onPage
                     <td className="px-4 py-3">
                       {hasObject ? (
                         <Link
-                          href={`/nirspec/objects/${obj.id}`}
+                          href={`/nirspec/objects/${encodeURIComponent(obj.object_id)}`}
                           className="text-primary hover:underline font-mono text-xs"
                         >
                           {obj.object_id}


### PR DESCRIPTION
The tag detail page's members table built object links from the numeric
database id (obj.id), but the /nirspec/objects/[id] route looks objects
up by their string object_id, so links 404'd (or hit the wrong page).
Use the encoded object_id like every other object link in the app.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016U2TDmcYbfmHijpyLupBGM