### PR TITLE
Fit the NMF wisp model on the template core (t50), not MASK_hSNR

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -54,6 +54,32 @@ Release procedure: edit the `## Unreleased` section below, then run
   rebuilt tile — the only behavior removed is the corruption path — but the
   new header keyword is an (additive) output-structure change.
 
+### Calibration
+- **The NMF wisp fit now scores only pixels above 50% of the template peak
+  (`[nircam.wisp].nmf_fit_region` `"hsnr"` -> `"t50"`). SW wisp-detector pixel
+  values change.** `nmfwisp` fits over the template's `MASK_hSNR` extension,
+  which is misnamed: on A2744 F200W nrcb4 it is ~511k pixels of which ~90% lie
+  below 20% of the template peak, and a mirrored-model null test recovers as
+  much signal from those as from the real ones — they measure large-scale
+  background, not wisp. Being ~200x more numerous they set the fit, and NNLS
+  responds by zeroing the components that carry the filament: `W=[0.54,0,0]`.
+  At `t50` the same exposure gives `W=[0.84,0.70,0.75]`, all three components
+  live, and the filament clears.
+  **Validated on the delivered frame, not just the rate frame**: both arms were
+  run through the identical `wisp -> image2 -> edge -> bkg` chain (with
+  `subtract_2d`) on 12 exposures spanning 4 detectors, 5 filters, 1/2/3-
+  component templates and two fields. Under `hsnr` the filament **survives
+  `bkg` into the delivered product** — a 64 px background mesh cannot follow a
+  narrow filament — and under `t50` it does not. Diffuse over/under-subtraction
+  is not part of this: `bkg`'s applied 2-D background already absorbs it (79%
+  of a wisp-shaped signal at box 64), which is why the region, not the source
+  mask or a background term, is the lever that matters.
+  `nmf_fit_sigma` stays `"ivar"`: `"flat"` removes a real ERR-correlation bias
+  but over-subtracts across the matrix (mean core residual -0.38 sigma, worst
+  -1.54) and has blown up to `W=16` on low-wisp frames.
+  Amplitudes are recorded in `CFP_WISP`, so old- and new-fit products are
+  distinguishable and the subtraction stays invertible.
+
 ### Infrastructure
 - **The NMF wisp amplitude solve now lives in campfire, and `CFP_WISP` records
   what the fit decided.** `_fit_nmf` previously called `nmfwisp.fit_wisp`, which

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -55,6 +55,27 @@ Release procedure: edit the `## Unreleased` section below, then run
   new header keyword is an (additive) output-structure change.
 
 ### Infrastructure
+- **The NMF wisp amplitude solve now lives in campfire, and `CFP_WISP` records
+  what the fit decided.** `_fit_nmf` previously called `nmfwisp.fit_wisp`, which
+  hardcodes both the fit region (the template's `MASK_hSNR`) and the pixel
+  weighting (the ERR array) — neither reachable through its public API, and both
+  since measured to bias the amplitude low. The new `_nmf_amplitudes` does the
+  same solve with those two exposed as `[nircam.wisp].nmf_fit_region`
+  (`hsnr` | `tNN`, pixels above NN% of the template peak) and `nmf_fit_sigma`
+  (`ivar` | `flat`). `nmfwisp` remains the template provider; no private
+  function is imported. **Defaults (`hsnr`/`ivar`) reproduce
+  `estimate_wisp_standard` bit-for-bit** — verified against the production path
+  on four A2744 F200W detectors spanning 1- and 3-component templates: max
+  relative amplitude difference `1.4e-12`, max model difference `5e-16` of the
+  pixel noise. Pixel values are therefore **unchanged** until a config opts in,
+  so this is Infrastructure; flipping the defaults later is a separate
+  Calibration change. `CFP_WISP` grows from `nmf <ver>` to
+  `nmf <ver> region=<r> sigma=<s> W=<a1>,<a2>,...`, which (a) makes an otherwise
+  destructive in-place step invertible, since the model is exactly
+  `W . templates` over versioned reference data, and (b) is the only way to tell
+  an old-fit product from a new-fit one — the `nmfwisp` version string does not
+  change when the fit configuration does. The `nmf_correct_1f=True` path still
+  delegates to `fit_wisp`, as the 1/f correction has no campfire equivalent.
 - The drizzle **CONTEXT extension is now written tile-compressed** (GZIP_1,
   lossless), controlled by `[nircam.resample].compress_context` (default
   `true`) and applied on **both** `implementation` backends. `CON` carries one

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -54,6 +54,29 @@ Release procedure: edit the `## Unreleased` section below, then run
   rebuilt tile — the only behavior removed is the corruption path — but the
   new header keyword is an (additive) output-structure change.
 
+- **The NMF wisp amplitude solve now lives in campfire, and `CFP_WISP` records
+  what the fit decided.** `_fit_nmf` previously called `nmfwisp.fit_wisp`, which
+  hardcodes both the fit region (the template's `MASK_hSNR`) and the pixel
+  weighting (the ERR array) — neither reachable through its public API, and both
+  since measured to bias the amplitude low. The new `_nmf_amplitudes` does the
+  same solve with those two exposed as `[nircam.wisp].nmf_fit_region`
+  (`hsnr` | `tNN`, pixels above NN% of the template peak) and `nmf_fit_sigma`
+  (`ivar` | `flat`). `nmfwisp` remains the template provider; no private
+  function is imported. **Defaults (`hsnr`/`ivar`) reproduce
+  `estimate_wisp_standard` bit-for-bit** — verified against the production path
+  on four A2744 F200W detectors spanning 1- and 3-component templates: max
+  relative amplitude difference `1.4e-12`, max model difference `5e-16` of the
+  pixel noise. Pixel values are **unchanged** until a config opts in — this is
+  Algorithm rather than Calibration because it is the `CFP_WISP` output
+  structure that changes, additively, not the pixels (same basis as the
+  `CFP_BKGS` entry above); the default flip that *does* move pixels is the
+  separate Calibration entry below. `CFP_WISP` grows from `nmf <ver>` to
+  `nmf <ver> region=<r> sigma=<s> W=<a1>,<a2>,...`, which (a) makes an otherwise
+  destructive in-place step invertible, since the model is exactly
+  `W . templates` over versioned reference data, and (b) is the only way to tell
+  an old-fit product from a new-fit one — the `nmfwisp` version string does not
+  change when the fit configuration does. The `nmf_correct_1f=True` path still
+  delegates to `fit_wisp`, as the 1/f correction has no campfire equivalent.
 ### Calibration
 - **The NMF wisp fit now scores only pixels above 50% of the template peak
   (`[nircam.wisp].nmf_fit_region` `"hsnr"` -> `"t50"`). SW wisp-detector pixel
@@ -81,27 +104,6 @@ Release procedure: edit the `## Unreleased` section below, then run
   distinguishable and the subtraction stays invertible.
 
 ### Infrastructure
-- **The NMF wisp amplitude solve now lives in campfire, and `CFP_WISP` records
-  what the fit decided.** `_fit_nmf` previously called `nmfwisp.fit_wisp`, which
-  hardcodes both the fit region (the template's `MASK_hSNR`) and the pixel
-  weighting (the ERR array) — neither reachable through its public API, and both
-  since measured to bias the amplitude low. The new `_nmf_amplitudes` does the
-  same solve with those two exposed as `[nircam.wisp].nmf_fit_region`
-  (`hsnr` | `tNN`, pixels above NN% of the template peak) and `nmf_fit_sigma`
-  (`ivar` | `flat`). `nmfwisp` remains the template provider; no private
-  function is imported. **Defaults (`hsnr`/`ivar`) reproduce
-  `estimate_wisp_standard` bit-for-bit** — verified against the production path
-  on four A2744 F200W detectors spanning 1- and 3-component templates: max
-  relative amplitude difference `1.4e-12`, max model difference `5e-16` of the
-  pixel noise. Pixel values are therefore **unchanged** until a config opts in,
-  so this is Infrastructure; flipping the defaults later is a separate
-  Calibration change. `CFP_WISP` grows from `nmf <ver>` to
-  `nmf <ver> region=<r> sigma=<s> W=<a1>,<a2>,...`, which (a) makes an otherwise
-  destructive in-place step invertible, since the model is exactly
-  `W . templates` over versioned reference data, and (b) is the only way to tell
-  an old-fit product from a new-fit one — the `nmfwisp` version string does not
-  change when the fit configuration does. The `nmf_correct_1f=True` path still
-  delegates to `fit_wisp`, as the 1/f correction has no campfire equivalent.
 - The drizzle **CONTEXT extension is now written tile-compressed** (GZIP_1,
   lossless), controlled by `[nircam.resample].compress_context` (default
   `true`) and applied on **both** `implementation` backends. `CON` carries one

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -168,6 +168,27 @@
                                # before fitting, to swallow wings past the nsigma
                                # isophote (0 disables). Secondary to mask_nsigma;
                                # nsigma=3 + dilate=8 sit on the converged plateau.
+    # Which pixels the NMF amplitude solve scores. "hsnr" = the template's own
+    # MASK_hSNR extension (nmfwisp behaviour); "tNN" = pixels above NN% of the
+    # summed template's peak. MASK_hSNR is misnamed — on nrcb4 F200W it is
+    # ~511k pixels of which ~90% sit below 20% of the template peak, and a
+    # mirrored-model null test returns as much signal from those as the real
+    # ones, i.e. they measure large-scale background. Being ~200x more numerous
+    # they set the fit, and NNLS then zeros the components that carry the
+    # filament (W=[0.54,0,0] on nrcb4 F200W). At "t50" the same exposure gives
+    # [0.84,0.70,0.75] and the filament clears — including in the DELIVERED
+    # frame, where it otherwise survives bkg (a 64 px background mesh cannot
+    # follow a narrow filament).
+    nmf_fit_region = "t50"
+    # Pixel weighting for the solve. "ivar" = the ERR array (nmfwisp
+    # behaviour); "flat" = uniform. ERR carries a Poisson term computed from
+    # the *measured* signal (spearman(err, data) = +0.63..+0.70 on every wisp
+    # detector), so positive excesses are down-weighted and the amplitude is
+    # biased low. "flat" removes that bias but is DANGEROUS on low-wisp frames:
+    # across a 23-pair matrix it over-subtracts (mean core residual -0.38 sigma
+    # at hsnr, worst -1.54), and on frames with little wisp it has blown up to
+    # W=16. Prefer moving nmf_fit_region over switching this.
+    nmf_fit_sigma = "ivar"
     apply_flat = true          # template method: flat-field the fitting copy
     use_custom_flat = false
     plot = true

--- a/pipeline/campfire_pipeline/nircam/steps/wisp.py
+++ b/pipeline/campfire_pipeline/nircam/steps/wisp.py
@@ -206,6 +206,23 @@ def _calc_variance(data, template, coeff):
     return mad ** 2
 
 
+def _fit_region_mask(tmpl, hsnr, region):
+    """Pixels the NMF amplitude solve scores, before source masking.
+
+    ``'hsnr'`` is the template's own ``MASK_hSNR`` extension; ``'tNN'`` is
+    pixels above NN% of the summed template's peak.
+    """
+    tmpl = np.asarray(tmpl, dtype=np.float64)
+    if tmpl.ndim == 2:
+        tmpl = tmpl[None]
+    if region == 'hsnr':
+        return np.asarray(hsnr, bool)
+    if region.startswith('t') and region[1:].isdigit():
+        tot = tmpl.sum(0)
+        return tot > (int(region[1:]) / 100.0) * float(np.nanmax(tot))
+    raise ValueError(f'unknown nmf_fit_region {region!r}')
+
+
 def _nmf_amplitudes(sci, err, srcmask, tmpl, wmask, hsnr,
                     region='hsnr', sigma='ivar'):
     """Solve for the NMF template amplitudes. Returns ``(W, model, sky)``.
@@ -253,13 +270,7 @@ def _nmf_amplitudes(sci, err, srcmask, tmpl, wmask, hsnr,
     ref = ~(mask | np.asarray(wmask, bool))
     sky = float(np.nanmedian(sci[ref])) if ref.any() else 0.0
 
-    if region == 'hsnr':
-        reg = np.asarray(hsnr, bool)
-    elif region.startswith('t') and region[1:].isdigit():
-        tot = tmpl.sum(0)
-        reg = tot > (int(region[1:]) / 100.0) * float(np.nanmax(tot))
-    else:
-        raise ValueError(f'unknown nmf_fit_region {region!r}')
+    reg = _fit_region_mask(tmpl, hsnr, region)
 
     fit = reg & ~mask
     ncomp = tmpl.shape[0]
@@ -382,24 +393,28 @@ def _fit_nmf(exposure_file, step_config, rootname, detector, filtname):
 
     plot = step_config.get('plot', True)
     correct_1f = step_config.get('nmf_correct_1f', False)
-    nsigma = step_config.get('mask_nsigma', 3.0)
-    dilate = step_config.get('mask_dilate', 8)
-    # Defaults reproduce nmfwisp exactly; the A/B decides whether they move.
-    fit_region = step_config.get('nmf_fit_region', 'hsnr')
+    # 'hsnr'/'ivar' reproduce nmfwisp exactly; the region default is t50 (see
+    # config_default.toml for why). Both land verbatim in CFP_WISP below.
+    fit_region_name = step_config.get('nmf_fit_region', 't50')
     fit_sigma = step_config.get('nmf_fit_sigma', 'ivar')
 
     log(f"Running NMF wisp subtraction on {rootname}")
     model = ImageModel(exposure_file, memmap=False)
     sci_before = model.data.copy()
 
-    mask, found = _source_mask(model.data, nsigma=nsigma, dilate=dilate)
+    # wisp_path is the case shim when the installed nmfwisp needs it, else None
+    # (upstream default). See _nmfwisp_case_shim.
+    shim = _nmfwisp_case_shim()
+
+    mask, found = _source_mask(
+        model.data,
+        nsigma=step_config.get('mask_nsigma', 3.0),
+        dilate=step_config.get('mask_dilate', 8),
+    )
     if not found:
         log(f"Source detection found nothing for {rootname}; "
             "fitting NMF without a source mask")
 
-    # wisp_path is the case shim when the installed nmfwisp needs it, else None
-    # (upstream default). See _nmfwisp_case_shim.
-    shim = _nmfwisp_case_shim()
     if correct_1f:
         # the 1/f path lives entirely inside nmfwisp; no campfire equivalent
         from nmfwisp import fit_wisp
@@ -416,7 +431,7 @@ def _fit_nmf(exposure_file, step_config, rootname, detector, filtname):
             shim, detector, filtname.upper())
         W, wisp, _sky = _nmf_amplitudes(
             sci_before, model.err, mask, tmpl, wmask, hsnr,
-            region=fit_region, sigma=fit_sigma)
+            region=fit_region_name, sigma=fit_sigma)
     wisp = np.nan_to_num(np.asarray(wisp, dtype=np.float64), nan=0.0)
     wisp[sci_before == 0] = 0
     model.data = (sci_before - wisp).astype(model.data.dtype)
@@ -436,7 +451,7 @@ def _fit_nmf(exposure_file, step_config, rootname, detector, filtname):
     # from a deployed product. It is also the only way to tell an old-fit
     # product from a new-fit one, since the nmfwisp version string does not
     # change when the region/sigma defaults do.
-    prov = f'nmf {ver} region={fit_region} sigma={fit_sigma}'
+    prov = f'nmf {ver} region={fit_region_name} sigma={fit_sigma}'
     if W is not None:
         prov += ' W=' + ','.join(f'{x:.5g}' for x in np.atleast_1d(W))
     else:

--- a/pipeline/campfire_pipeline/nircam/steps/wisp.py
+++ b/pipeline/campfire_pipeline/nircam/steps/wisp.py
@@ -206,6 +206,87 @@ def _calc_variance(data, template, coeff):
     return mad ** 2
 
 
+def _nmf_amplitudes(sci, err, srcmask, tmpl, wmask, hsnr,
+                    region='hsnr', sigma='ivar'):
+    """Solve for the NMF template amplitudes. Returns ``(W, model, sky)``.
+
+    campfire's own reproduction of the amplitude solve, so the two things that
+    actually set the answer — the *fit region* and the *pixel weighting* — are
+    reachable. ``nmfwisp`` stays the template provider; nothing private is
+    imported. Defaults reproduce ``nmfwisp.estimate_wisp_standard`` exactly.
+
+    ``region``
+        ``'hsnr'``  the template's ``MASK_hSNR`` extension (nmfwisp behaviour).
+        ``'tNN'``   pixels where the summed template exceeds NN% of its peak.
+
+        ``MASK_hSNR`` is misnamed: on nrcb4 F200W it is ~511k pixels of which
+        ~90% sit below 20% of the template peak. A mirrored-model null test
+        (project the data onto a left-right flipped copy of the model, where no
+        wisp is) returns a_null of 1.7-70 in those bins — as large as or larger
+        than the signal, i.e. they measure large-scale background, not wisp.
+        Being ~200x more numerous they set the fit, dragging the filament
+        amplitude to ~0.5x and letting NNLS zero the components that carry it.
+
+    ``sigma``
+        ``'ivar'``  weight by the ERR array (nmfwisp behaviour).
+        ``'flat'``  uniform weight.
+
+        ERR carries a Poisson term computed from the *measured* signal, so
+        ``spearman(err, data) = +0.63..+0.70`` on every wisp detector: any pixel
+        with a positive excess — the wisp, or an unmasked source wing — gets a
+        larger err and is down-weighted, biasing the amplitude low. With the
+        region held fixed this is worth -25% on nrcb3 and -14% on nrca4. It is
+        independent of the region and pushes the same way (under-subtraction).
+    """
+    from scipy.optimize import nnls
+
+    tmpl = np.asarray(tmpl, dtype=np.float64)
+    if tmpl.ndim == 2:
+        tmpl = tmpl[None]
+
+    # nmfwisp.process_data: refpix border + non-finite are hard-masked, the sky
+    # is one median over everything that is neither source nor wisp.
+    bad = ~np.isfinite(sci) | ~np.isfinite(err) | (err <= 0)
+    bad[:4] = bad[-4:] = True
+    bad[:, :4] = bad[:, -4:] = True
+    mask = np.asarray(srcmask, bool) | bad
+    ref = ~(mask | np.asarray(wmask, bool))
+    sky = float(np.nanmedian(sci[ref])) if ref.any() else 0.0
+
+    if region == 'hsnr':
+        reg = np.asarray(hsnr, bool)
+    elif region.startswith('t') and region[1:].isdigit():
+        tot = tmpl.sum(0)
+        reg = tot > (int(region[1:]) / 100.0) * float(np.nanmax(tot))
+    else:
+        raise ValueError(f'unknown nmf_fit_region {region!r}')
+
+    fit = reg & ~mask
+    ncomp = tmpl.shape[0]
+    if fit.sum() < 50 * ncomp:
+        log(f'NMF fit region has only {int(fit.sum())} usable pixels for '
+            f'{ncomp} component(s); falling back to the full hSNR region')
+        fit = np.asarray(hsnr, bool) & ~mask
+        if fit.sum() < 50 * ncomp:
+            return np.zeros(ncomp), np.zeros_like(sci, dtype=np.float64), sky
+
+    if sigma == 'flat':
+        sig = np.ones(int(fit.sum()), dtype=np.float64)
+    elif sigma == 'ivar':
+        sig = err[fit].astype(np.float64)
+    else:
+        raise ValueError(f'unknown nmf_fit_sigma {sigma!r}')
+
+    A = (tmpl[:, fit] / sig[None, :]).T
+    b = (sci[fit] - sky) / sig
+    ok = np.isfinite(b) & np.all(np.isfinite(A), axis=1)
+    if ok.sum() < 50 * ncomp:
+        return np.zeros(ncomp), np.zeros_like(sci, dtype=np.float64), sky
+
+    W, _ = nnls(A[ok], b[ok])
+    return W, np.einsum('i,imn->mn', W, tmpl), sky
+
+
 def _source_mask(data, nsigma=3.0, npixels=55, dilate=8):
     """Boolean mask (True = exclude): sources + non-finite pixels.
 
@@ -297,13 +378,15 @@ def _fit_nmf(exposure_file, step_config, rootname, detector, filtname):
     fielded frame.
     """
     import nmfwisp
-    from nmfwisp import fit_wisp
     from jwst.datamodels import ImageModel
 
     plot = step_config.get('plot', True)
     correct_1f = step_config.get('nmf_correct_1f', False)
     nsigma = step_config.get('mask_nsigma', 3.0)
     dilate = step_config.get('mask_dilate', 8)
+    # Defaults reproduce nmfwisp exactly; the A/B decides whether they move.
+    fit_region = step_config.get('nmf_fit_region', 'hsnr')
+    fit_sigma = step_config.get('nmf_fit_sigma', 'ivar')
 
     log(f"Running NMF wisp subtraction on {rootname}")
     model = ImageModel(exposure_file, memmap=False)
@@ -317,12 +400,23 @@ def _fit_nmf(exposure_file, step_config, rootname, detector, filtname):
     # wisp_path is the case shim when the installed nmfwisp needs it, else None
     # (upstream default). See _nmfwisp_case_shim.
     shim = _nmfwisp_case_shim()
-    wisp, _wisp_e = fit_wisp(
-        sci_before, model.err, mask,
-        wisp_path=shim,
-        detector_name=detector, filter_name=filtname.upper(),
-        correct_1f=correct_1f,
-    )
+    if correct_1f:
+        # the 1/f path lives entirely inside nmfwisp; no campfire equivalent
+        from nmfwisp import fit_wisp
+        wisp, _wisp_e = fit_wisp(
+            sci_before, model.err, mask,
+            wisp_path=shim,
+            detector_name=detector, filter_name=filtname.upper(),
+            correct_1f=True,
+        )
+        W = None
+    else:
+        from nmfwisp.nmfwisp import load_wisp_templates
+        tmpl, _terr, wmask, hsnr = load_wisp_templates(
+            shim, detector, filtname.upper())
+        W, wisp, _sky = _nmf_amplitudes(
+            sci_before, model.err, mask, tmpl, wmask, hsnr,
+            region=fit_region, sigma=fit_sigma)
     wisp = np.nan_to_num(np.asarray(wisp, dtype=np.float64), nan=0.0)
     wisp[sci_before == 0] = 0
     model.data = (sci_before - wisp).astype(model.data.dtype)
@@ -336,9 +430,21 @@ def _fit_nmf(exposure_file, step_config, rootname, detector, filtname):
         f'arXiv:2601.15958) {now}'
     ))
 
+    # Record what the fit DECIDED, not just that it ran. The model is exactly
+    # W . templates over versioned reference data, so storing W makes this
+    # otherwise-destructive step invertible: the pre-wisp frame is recoverable
+    # from a deployed product. It is also the only way to tell an old-fit
+    # product from a new-fit one, since the nmfwisp version string does not
+    # change when the region/sigma defaults do.
+    prov = f'nmf {ver} region={fit_region} sigma={fit_sigma}'
+    if W is not None:
+        prov += ' W=' + ','.join(f'{x:.5g}' for x in np.atleast_1d(W))
+    else:
+        prov += ' correct_1f=True'
+
     atomic_save(
         model, exposure_file,
-        header_updates=cfp.format(CFP_WISP=f'nmf {ver}'),
+        header_updates=cfp.format(CFP_WISP=prov),
     )
     model.close()
     log(f"Wisp removed (NMF {ver}): {rootname}")

--- a/pipeline/campfire_pipeline/nircam/steps/wisp.py
+++ b/pipeline/campfire_pipeline/nircam/steps/wisp.py
@@ -225,7 +225,15 @@ def _fit_region_mask(tmpl, hsnr, region):
 
 def _nmf_amplitudes(sci, err, srcmask, tmpl, wmask, hsnr,
                     region='hsnr', sigma='ivar'):
-    """Solve for the NMF template amplitudes. Returns ``(W, model, sky)``.
+    """Solve for the NMF template amplitudes.
+
+    Returns ``(W, model, sky, region_used)``. ``region_used`` is the region the
+    solve actually scored — ``region``, or ``'hsnr(fallback)'`` when the
+    requested one was too starved to fit, or **None** when even hSNR was, in
+    which case ``W`` and ``model`` are zeros and the caller must not treat the
+    exposure as subtracted. Reporting it is what keeps ``CFP_WISP`` honest: the
+    header would otherwise claim the configured region on an exposure that
+    silently fell back to the legacy one.
 
     campfire's own reproduction of the amplitude solve, so the two things that
     actually set the answer — the *fit region* and the *pixel weighting* — are
@@ -274,12 +282,14 @@ def _nmf_amplitudes(sci, err, srcmask, tmpl, wmask, hsnr,
 
     fit = reg & ~mask
     ncomp = tmpl.shape[0]
+    used = region
     if fit.sum() < 50 * ncomp:
         log(f'NMF fit region has only {int(fit.sum())} usable pixels for '
             f'{ncomp} component(s); falling back to the full hSNR region')
         fit = np.asarray(hsnr, bool) & ~mask
+        used = 'hsnr(fallback)'
         if fit.sum() < 50 * ncomp:
-            return np.zeros(ncomp), np.zeros_like(sci, dtype=np.float64), sky
+            return np.zeros(ncomp), np.zeros_like(sci, dtype=np.float64), sky, None
 
     if sigma == 'flat':
         sig = np.ones(int(fit.sum()), dtype=np.float64)
@@ -292,10 +302,10 @@ def _nmf_amplitudes(sci, err, srcmask, tmpl, wmask, hsnr,
     b = (sci[fit] - sky) / sig
     ok = np.isfinite(b) & np.all(np.isfinite(A), axis=1)
     if ok.sum() < 50 * ncomp:
-        return np.zeros(ncomp), np.zeros_like(sci, dtype=np.float64), sky
+        return np.zeros(ncomp), np.zeros_like(sci, dtype=np.float64), sky, None
 
     W, _ = nnls(A[ok], b[ok])
-    return W, np.einsum('i,imn->mn', W, tmpl), sky
+    return W, np.einsum('i,imn->mn', W, tmpl), sky, used
 
 
 def _source_mask(data, nsigma=3.0, npixels=55, dilate=8):
@@ -416,7 +426,11 @@ def _fit_nmf(exposure_file, step_config, rootname, detector, filtname):
             "fitting NMF without a source mask")
 
     if correct_1f:
-        # the 1/f path lives entirely inside nmfwisp; no campfire equivalent
+        # The 1/f path lives entirely inside nmfwisp; no campfire equivalent.
+        # fit_wisp always runs nmfwisp's own hSNR/ivar solve, so the configured
+        # region/sigma are NOT honoured here — record what actually ran, not
+        # what was asked for, or the header would claim a calibration this
+        # exposure never received.
         from nmfwisp import fit_wisp
         wisp, _wisp_e = fit_wisp(
             sci_before, model.err, mask,
@@ -425,13 +439,36 @@ def _fit_nmf(exposure_file, step_config, rootname, detector, filtname):
             correct_1f=True,
         )
         W = None
+        if (fit_region_name, fit_sigma) != ('hsnr', 'ivar'):
+            log(f'nmf_correct_1f=True delegates to nmfwisp, which always fits '
+                f'hsnr/ivar; the configured {fit_region_name}/{fit_sigma} is '
+                f'not applied and is not recorded for {rootname}')
+        region_used, sigma_used = 'hsnr', 'ivar'
     else:
         from nmfwisp.nmfwisp import load_wisp_templates
         tmpl, _terr, wmask, hsnr = load_wisp_templates(
             shim, detector, filtname.upper())
-        W, wisp, _sky = _nmf_amplitudes(
+        W, wisp, _sky, region_used = _nmf_amplitudes(
             sci_before, model.err, mask, tmpl, wmask, hsnr,
             region=fit_region_name, sigma=fit_sigma)
+        sigma_used = fit_sigma
+        if region_used is None:
+            # Nothing left to fit. Subtracting the all-zero model and stamping
+            # success would mark an UNSUBTRACTED exposure as processed, and
+            # should_skip would then never revisit it. Leave SCI untouched and
+            # stamp a distinct sentinel instead.
+            log(f'NMF fit region is exhausted for {rootname} (source mask '
+                f'leaves too few pixels in both {fit_region_name} and hSNR); '
+                f'stamping skipped, SCI left untouched')
+            # model.data is still pristine here — the subtraction happens below
+            atomic_save(
+                model, exposure_file,
+                header_updates=cfp.format(
+                    CFP_WISP=f'skipped (fit region exhausted: '
+                             f'{fit_region_name})'),
+            )
+            model.close()
+            return
     wisp = np.nan_to_num(np.asarray(wisp, dtype=np.float64), nan=0.0)
     wisp[sci_before == 0] = 0
     model.data = (sci_before - wisp).astype(model.data.dtype)
@@ -451,7 +488,7 @@ def _fit_nmf(exposure_file, step_config, rootname, detector, filtname):
     # from a deployed product. It is also the only way to tell an old-fit
     # product from a new-fit one, since the nmfwisp version string does not
     # change when the region/sigma defaults do.
-    prov = f'nmf {ver} region={fit_region_name} sigma={fit_sigma}'
+    prov = f'nmf {ver} region={region_used} sigma={sigma_used}'
     if W is not None:
         prov += ' W=' + ','.join(f'{x:.5g}' for x in np.atleast_1d(W))
     else:

--- a/pipeline/tests/test_nircam_wisp_nmf_parity.py
+++ b/pipeline/tests/test_nircam_wisp_nmf_parity.py
@@ -44,8 +44,9 @@ def _fake(ncomp=3, n=192, seed=11):
 def test_legacy_defaults_match_nmfwisp(ncomp):
     sci, err, src, tmpl, wmask, hsnr = _fake(ncomp=ncomp)
 
-    W_cf, model_cf, _sky = _nmf_amplitudes(
+    W_cf, model_cf, _sky, used = _nmf_amplitudes(
         sci, err, src, tmpl, wmask, hsnr, region='hsnr', sigma='ivar')
+    assert used == 'hsnr'
 
     data2, err2, mask2 = nmfwisp.process_data(
         sci.copy(), err.copy(), src.copy(), wmask)
@@ -64,10 +65,10 @@ def test_legacy_defaults_match_nmfwisp(ncomp):
 def test_region_and_sigma_knobs_change_the_fit():
     """Guard against the knobs silently becoming no-ops."""
     sci, err, src, tmpl, wmask, hsnr = _fake()
-    W_legacy, _m, _s = _nmf_amplitudes(sci, err, src, tmpl, wmask, hsnr,
-                                       region='hsnr', sigma='ivar')
-    W_new, _m2, _s2 = _nmf_amplitudes(sci, err, src, tmpl, wmask, hsnr,
-                                      region='t30', sigma='flat')
+    W_legacy, _m, _s, _u = _nmf_amplitudes(sci, err, src, tmpl, wmask, hsnr,
+                                           region='hsnr', sigma='ivar')
+    W_new, _m2, _s2, _u2 = _nmf_amplitudes(sci, err, src, tmpl, wmask, hsnr,
+                                           region='t30', sigma='flat')
     assert not np.allclose(W_legacy, W_new)
     assert np.all(W_new >= 0), 'NNLS must stay non-negative'
 
@@ -75,10 +76,14 @@ def test_region_and_sigma_knobs_change_the_fit():
 def test_degenerate_region_falls_back_rather_than_crashing():
     """A threshold that starves the fit must fall back, not raise or return junk."""
     sci, err, src, tmpl, wmask, hsnr = _fake()
-    W, model, _sky = _nmf_amplitudes(sci, err, src, tmpl, wmask, hsnr,
-                                     region='t99', sigma='flat')
+    W, model, _sky, used = _nmf_amplitudes(sci, err, src, tmpl, wmask, hsnr,
+                                           region='t99', sigma='flat')
     assert W.shape == (tmpl.shape[0],)
     assert np.all(np.isfinite(model))
+    # the fallback must be REPORTED, not silent -- CFP_WISP is stamped from
+    # this value, so a silent swap would claim t99 on an hSNR fit
+    assert used == 'hsnr(fallback)', (
+        f'starved region fell back but reported {used!r}')
 
 
 def test_unknown_options_are_rejected():
@@ -87,3 +92,31 @@ def test_unknown_options_are_rejected():
         _nmf_amplitudes(sci, err, src, tmpl, wmask, hsnr, region='nope')
     with pytest.raises(ValueError):
         _nmf_amplitudes(sci, err, src, tmpl, wmask, hsnr, sigma='nope')
+
+
+def test_exhausted_region_reports_none_rather_than_a_silent_no_op():
+    """Both regions starved must be distinguishable from a successful fit.
+
+    Returning zeros with no signal let ``_fit_nmf`` subtract nothing, stamp
+    ``CFP_WISP``, and log success — after which ``should_skip`` treats an
+    unsubtracted exposure as processed forever. The caller can only stamp the
+    ``skipped`` sentinel if the solve says it failed, so assert the contract:
+    ``region_used is None`` and the model is exactly zero.
+    """
+    sci, err, _src, tmpl, wmask, hsnr = _fake()
+    everything = np.ones(sci.shape, bool)          # nothing survives masking
+    W, model, _sky, used = _nmf_amplitudes(
+        sci, err, everything, tmpl, wmask, hsnr, region='t50', sigma='ivar')
+    assert used is None, f'exhausted fit reported {used!r} instead of None'
+    assert not np.any(model), 'exhausted fit must return an all-zero model'
+    assert W.shape == (tmpl.shape[0],)
+    assert not np.any(W)
+
+
+def test_successful_fit_reports_the_region_it_used():
+    """The happy path must echo the requested region, not a fallback."""
+    sci, err, src, tmpl, wmask, hsnr = _fake()
+    for region in ('hsnr', 't30'):
+        _W, _m, _s, used = _nmf_amplitudes(
+            sci, err, src, tmpl, wmask, hsnr, region=region, sigma='ivar')
+        assert used == region, f'{region} reported as {used!r}'

--- a/pipeline/tests/test_nircam_wisp_nmf_parity.py
+++ b/pipeline/tests/test_nircam_wisp_nmf_parity.py
@@ -1,0 +1,89 @@
+"""campfire's NMF amplitude solve must reproduce nmfwisp at its legacy defaults.
+
+``_nmf_amplitudes`` replaced the ``nmfwisp.fit_wisp`` call so the fit region and
+the pixel weighting become reachable, but its defaults (``hsnr``/``ivar``) are
+supposed to be *bit-for-bit* what ``estimate_wisp_standard`` did. Two things can
+break that silently: an edit to our solve, or an nmfwisp release that changes
+theirs. Either would move deployed pixel values with no config change and no
+version signal, so it is worth a guard.
+
+Synthetic data on purpose -- no staged frames needed, so this runs anywhere
+nmfwisp is importable.
+"""
+import numpy as np
+import pytest
+
+from campfire_pipeline.nircam.steps.wisp import _nmf_amplitudes
+
+nmfwisp = pytest.importorskip('nmfwisp.nmfwisp')
+
+
+def _fake(ncomp=3, n=192, seed=11):
+    """A wisp-like scene: smooth positive components + sources + noise."""
+    rng = np.random.default_rng(seed)
+    yy, xx = np.mgrid[0:n, 0:n].astype(float)
+    tmpl = np.empty((ncomp, n, n))
+    for c in range(ncomp):
+        cy, cx = 60 + 25 * c, 70 - 15 * c
+        tmpl[c] = np.exp(-(((yy - cy) / (34.0 + 9 * c)) ** 2
+                           + ((xx - cx) / (19.0 + 6 * c)) ** 2))
+    truth = np.array([0.9, 0.35, 0.6])[:ncomp]
+    sci = np.einsum('i,imn->mn', truth, tmpl) + 0.05
+    sci += rng.normal(0, 0.01, sci.shape)
+    for _ in range(12):                       # a few sources to be masked
+        sy, sx = rng.integers(10, n - 10, 2)
+        sci[sy - 3:sy + 3, sx - 3:sx + 3] += 3.0
+    err = np.full((n, n), 0.01) + 0.004 * np.sqrt(np.maximum(sci, 0))
+    src = sci > 0.6
+    wmask = tmpl.sum(0) > 0.05 * tmpl.sum(0).max()
+    hsnr = tmpl.sum(0) > 0.01 * tmpl.sum(0).max()
+    return sci, err, src, tmpl, wmask, hsnr
+
+
+@pytest.mark.parametrize('ncomp', [1, 2, 3])
+def test_legacy_defaults_match_nmfwisp(ncomp):
+    sci, err, src, tmpl, wmask, hsnr = _fake(ncomp=ncomp)
+
+    W_cf, model_cf, _sky = _nmf_amplitudes(
+        sci, err, src, tmpl, wmask, hsnr, region='hsnr', sigma='ivar')
+
+    data2, err2, mask2 = nmfwisp.process_data(
+        sci.copy(), err.copy(), src.copy(), wmask)
+    _wsub, model_nw, _we, W_nw, _We = nmfwisp._subtract_wisp(
+        data2, tmpl, err2, mask2, None, hsnr, bool_weighted=False)
+
+    W_nw = np.asarray(W_nw).ravel()
+    scale = max(float(np.max(np.abs(W_nw))), 1e-12)
+    assert np.max(np.abs(W_cf - W_nw)) / scale < 1e-9, (
+        f'amplitudes diverged from nmfwisp: {W_cf} vs {W_nw}')
+
+    fin = np.isfinite(model_cf) & np.isfinite(model_nw)
+    assert np.max(np.abs(model_cf[fin] - model_nw[fin])) < 1e-9
+
+
+def test_region_and_sigma_knobs_change_the_fit():
+    """Guard against the knobs silently becoming no-ops."""
+    sci, err, src, tmpl, wmask, hsnr = _fake()
+    W_legacy, _m, _s = _nmf_amplitudes(sci, err, src, tmpl, wmask, hsnr,
+                                       region='hsnr', sigma='ivar')
+    W_new, _m2, _s2 = _nmf_amplitudes(sci, err, src, tmpl, wmask, hsnr,
+                                      region='t30', sigma='flat')
+    assert not np.allclose(W_legacy, W_new)
+    assert np.all(W_new >= 0), 'NNLS must stay non-negative'
+
+
+def test_degenerate_region_falls_back_rather_than_crashing():
+    """A threshold that starves the fit must fall back, not raise or return junk."""
+    sci, err, src, tmpl, wmask, hsnr = _fake()
+    W, model, _sky = _nmf_amplitudes(sci, err, src, tmpl, wmask, hsnr,
+                                     region='t99', sigma='flat')
+    assert W.shape == (tmpl.shape[0],)
+    assert np.all(np.isfinite(model))
+
+
+def test_unknown_options_are_rejected():
+    sci, err, src, tmpl, wmask, hsnr = _fake()
+    with pytest.raises(ValueError):
+        _nmf_amplitudes(sci, err, src, tmpl, wmask, hsnr, region='nope')
+    with pytest.raises(ValueError):
+        _nmf_amplitudes(sci, err, src, tmpl, wmask, hsnr, sigma='nope')


### PR DESCRIPTION
## What

Two changes to the NIRCam wisp step:

1. **Infrastructure** — the NMF amplitude solve moves out of `nmfwisp.fit_wisp` and into campfire (`_nmf_amplitudes`), exposing the fit region and pixel weighting that `fit_wisp` hardcodes. `CFP_WISP` grows to record the solved amplitudes, which makes an otherwise destructive in-place step invertible and is the only way to tell an old-fit product from a new-fit one. Defaults `hsnr`/`ivar` reproduce `estimate_wisp_standard` bit-for-bit.
2. **Calibration (MINOR)** — the shipped default fit region moves `hsnr` → `t50`. **SW wisp-detector pixel values change.**

## Why

`nmfwisp` fits over the template's `MASK_hSNR` extension, which is misnamed. On A2744 F200W nrcb4 it is ~511k pixels of which **~90% lie below 20% of the template peak**. A mirrored-model null test — projecting the data onto a flipped copy of the model, where no wisp sits — recovers as much signal from those pixels as from the real ones, so they are measuring large-scale background, not wisp. Being ~200× more numerous they set the fit, and NNLS responds by **zeroing the components that carry the filament**:

| region | nrcb4 F200W |
|---|---|
| `hsnr` (current) | `W = [0.54, 0.00, 0.00]` — filament left behind |
| `t50` | `W = [0.84, 0.70, 0.75]` — all three components live, filament clears |

## Validation

Validated on the **delivered** frame, not the rate frame. Both arms ran the identical `wisp → image2 → edge → bkg` chain (with `subtract_2d`) from identical staged pre-wisp input, across **12 exposures spanning 4 detectors, 5 filters, `n_comp` 1/2/3, and two fields (A2744 + EGS)**. Only `nmf_fit_region` differed.

Under `hsnr` the filament **survives `bkg` into the delivered product** — a 64 px background mesh cannot follow a narrow filament — and under `t50` it does not.

## Scope — what this deliberately does not do

Diffuse over/under-subtraction is not addressed here, because `bkg`'s applied 2-D background already absorbs it. Measured by projecting a `Background2D` fit back onto the pure wisp model:

| mesh | 64 (bkg applied) | 128 | 256 (bkg detrend) | 512 |
|---|---|---|---|---|
| fraction of wisp absorbed | **79%** | 63% | 37% | 3% |

That degeneracy is also why the wisp fit cannot usefully be merged into `bkg`, and why the fit region — not the source mask, and not a background term inside the wisp fit — is the lever that matters. Both alternatives were implemented and measured during this work:

- a **tiered source mask** (reusing `bkgsub.SubtractBackground`) plus a brightness-scaled giant-source pre-tier — real, but secondary; it tempers `t50` overshoot rather than fixing the filament
- a **coarse fit-only 2-D detrend** inside the objective — confirmed that 20–50% of the amplitude fitted at `hsnr` is background, but largely redundant with the region change (~2% effect at `t50`)

Both were **removed before this PR** to keep it focused. Findings are recorded in the changelog and in the session notes.

`nmf_fit_sigma` stays `"ivar"`. `"flat"` removes a real ERR-correlation bias (`spearman(err, data) = +0.63…+0.70` on every wisp detector) but over-subtracts across a 23-pair matrix (mean core residual −0.38σ, worst −1.54) and has blown up to `W = 16` on low-wisp frames.

## Also

- `nmf_fit_region` / `nmf_fit_sigma` are now in `config_default.toml`; they previously existed only as code fallbacks, so `cfpipe config` never surfaced them.
- The `_fit_nmf` fallback is aligned with the shipped default.
- New `tests/test_nircam_wisp_nmf_parity.py` guards the bit-for-bit equivalence at legacy settings (6 tests, `n_comp` 1/2/3), so neither an edit here nor an `nmfwisp` release can silently move pixel values.

## Testing

- 17 wisp tests pass
- End-to-end `wisp → image2 → edge → bkg` with the **shipped defaults**: `CFP_WISP = nmf 1.1.4 region=t50 sigma=ivar W=0.87144`

## Reviewer notes

- The first commit (`ab31147`) is a rescued WIP; its message describes an interim state and its caveats no longer apply — the parity claim is now verified and the test runs green.
- Deploying products built before this change and after it will mix fit configurations; `CFP_WISP` distinguishes them.

Generated with Claude Code

https://claude.ai/code/session_01GRD2gK26WC2UdCXJDUNi3d
