### PR TITLE
nircam bkg: enable subtract_2d + the anisotropic conditioning detrend by default

### DIFF
--- a/docs/findings-aniso-detrend-a2744.md
+++ b/docs/findings-aniso-detrend-a2744.md
@@ -1,0 +1,133 @@
+# Real-frame validation: anisotropic conditioning detrend on A2744
+
+**Branch:** `claude/nircam-bkg-amp-row-oversubtraction-4t12t6`
+**Date:** 2026-08-14
+**Verdict:** the anisotropic conditioning detrend with `reject = false` was
+preferred over production by eye (HA). The `fit_order` reorder was rejected on
+the same data. Neither default is flipped by this PR.
+
+Companion to `docs/handoff-aniso-detrend.md` (the plan) — this is what the
+plan produced. Everything below is measured on real frames unless labelled
+synthetic.
+
+## 1. Test setup
+
+Six A2744 exposure roots rebuilt **from uncal** into an isolated
+`CAMPFIRE_ROOT` clone (`abtest/a2744_fitorder`) with a private `fields.toml`,
+so production products were never touched. Steps `detector1 → persistence →
+wisp → image2 → edge` only; `bkg` was then run once per arm on a copy, via
+`bkg_step(..., components_out=...)`.
+
+- 32 canonical frames: 24 SW (F200W) + 8 LW (F444W).
+- Selection: ranked by the artifact's actual precondition — a bright,
+  extended, largely unmasked source — from a full scan of 540 F444W LW and
+  1591 F200W SW production frames. One root
+  (`jw06434438001_04201_00001`) contributes both channels.
+- Arms (32 × 3 = 96 cells, all completed):
+  | arm | detrend | `bkg2d.reject` |
+  |---|---|---|
+  | `control` | square `box_size = 256`, `filter_size = 3` | false |
+  | `aniso` | `box_size = 96` (y) × `box_size_x = 32`, `filter_size = [1,5]` | true |
+  | `aniso_norej` | same detrend | false |
+
+A2744 production already sets `reject = false` globally, so **`aniso_norej`
+is the one-variable change** against control; `aniso` moves two things.
+
+**LW scaling** (handoff §5.1) applied: LW arms use `box_size = 192` so the
+×0.5 channel scaling leaves ~96 rows. `box_size_x` is *not* doubled — it
+tracks the halo's angular column profile. Confirmed in provenance:
+`detrend=box96x32` (SW) / `box96x16` (LW), vs `box256` / `box128` for control.
+
+## 2. The artifact exists on real frames, in a minority of exposures
+
+Confirmed on the correction ledgers, **not** on the residual: the residual is
+flat *because* the misattributed model was subtracted, so residual-based
+searches find nothing. This cost a false start — two scans of production
+frames (an amp-seam statistic and an SRCMASK-blob criterion) found nothing and
+were both discarded as measurement artifacts.
+
+The diagnostic that works is the amp-differential amp-row correction,
+`d_a(r) = h_a(r) − median_a h(r)`, row-smoothed: genuine 1/f is common to all
+four amps and cancels; a halo leak inflates only the host amp.
+
+End-to-end on `jw02561003001_06101_00006_nrcb4`: a bright star's **unmasked**
+PSF wings raise amp0's amp-differential unmasked background by +3.7/+2.1/+4.5σ
+at rows ~230/~590/~1780, and `h` follows at exactly those rows and that amp
+(+2.3/+1.3/+1.7σ), broadcast across amp0's full 512-column width.
+
+5 of 32 frames showed a strong signature (peak |d_a| > 1σ), **all SW**. It is
+not present in every exposure. On real A2744 the dominant driver is bright
+**stars'** PSF wings and diffraction spikes rather than galaxy halos.
+
+## 3. `fit_order = "first"` — rejected
+
+Same 32 frames, arms `last` / `first`+`reject=false` / `first`+`reject=true`.
+
+On the `h` ledger the reorder did reduce the leak on all five affected frames
+(peak |d_a| ×0.52–0.78), and the falsification arm behaved as predicted
+(`first`+`reject=true` gave ×0.86–1.19, i.e. no benefit — `reject` cancels the
+fix on sky, as the synthetic scene said). But **by eye on the corrected SCI the
+artifacts were often worse**, which is the verdict that decided it. The knob
+stays in the code at `"last"`.
+
+Caution for anyone re-reading those numbers: on the `h` ledger alone `first`
+looked like a regression on 20/32 frames, but that was an artifact of reading
+one ledger in isolation — on the *total* correction it was better-or-equal in
+25/32. Neither statistic overrode the visual verdict.
+
+## 4. Anisotropic detrend — preferred
+
+Judged from post-bkg SCI per arm at a **common** zscale across arms (a
+per-panel stretch renormalises each arm to itself and hides the difference).
+`aniso_norej` was cleaner than control on the affected frames; the predicted
+failure mode — ~50–150-row banding absorbed by the y-coarse mesh and left
+underfit by `h` — was checked on a blank field at deep stretch (`contrast
+0.08`).
+
+## 5. Wisp interaction (why the frames were rebuilt twice)
+
+The first pass predated PR #456: the branch was cut at `bd3d80a`, before #456
+merged to main at `39a0cd3`, so the frames carried the old NMF wisp fit region
+(`MASK_hSNR`). This matters here because imperfect wisp residuals live at the
+same ~50–150-row scales as the banding check in §4.
+
+After merging main, the frames were rebuilt and the sweep re-run. Verified by
+`CFP_WISP` and by pixel differencing (identical uncal, identical
+detector1/image2/edge, so the difference isolates #456):
+
+- 11/12 wisp detectors now fit on `region=t50`. The change is confined to the
+  wisp footprint (frame-wide MAD ≈ 0), peaking at 0.005–0.026 MJy/sr — up to
+  ~1.5× sky σ on nrcb3 — and is **positive**, i.e. the new path subtracts
+  *less*: the old region was over-subtracting.
+- 1/12 fell back: `jw02561001004_06101_00005_nrcb4` stamps
+  `region=hsnr(fallback)` and its pixels are **bit-identical** to the
+  pre-merge reduction (max |new−old| = 0.0000). #456 changed nothing there.
+
+**Known issue, tracked separately (not addressed by this PR).** That fallback
+is self-defeating: the wisp step builds its source mask from the *pre*-wisp
+frame with `detect_sources(nsigma=3, dilate=8)`, so a sufficiently bright wisp
+is detected as a source and masks its own template core. On that frame
+`t50 & ~mask` collapses (58 px in reconstruction, 0 in the run, against a
+`50 × ncomp` = 150 threshold), and the solve falls back to exactly the
+`MASK_hSNR` region #456 exists to avoid. Control frames keep 1699–1706 of 1717
+t50 px. Candidate fixes: exclude `wmask` from the wisp step's own source
+detection; lower the threshold; or step through looser template cuts (`t30`,
+`t20`) before falling back to hSNR.
+
+## 6. Reproducing
+
+Scripts and figures (CANDIDE):
+`$CAMPFIRE_ROOT/scripts/claude/bkg-fitorder-ab/` — `aniso_ab.py` (arms),
+`render_after.py` (post-bkg SCI, common stretch), `render_ledgers.py`
+(component ledgers), `render_wisp_ab.py`, `probe_t50_prewisp.py`,
+`figs/w2_*.png`, session board `scripts/claude/sessions/bkg-fitorder-ab.md`.
+
+Guard against the shared-editable-install hazard: jobs pin the worktree via
+`PYTHONPATH` and run `guard.py`, which asserts the imported
+`campfire_pipeline`/`campfire_layout` come from the pinned tree and that
+`fit_order` exists in the loaded defaults. Verified non-vacuous (rc=1 on a
+deliberately wrong pin).
+
+**No-op check** worth repeating whenever this branch moves: `control` at
+`e6faed8` was bit-identical to the pre-aniso `last` arm at `fbf4dae` on 32/32
+frames, confirming the new knobs are genuinely dormant at their defaults.

--- a/docs/handoff-aniso-detrend.md
+++ b/docs/handoff-aniso-detrend.md
@@ -1,0 +1,144 @@
+# Handoff: real-frame test of the anisotropic conditioning detrend
+
+**Branch:** `claude/nircam-bkg-amp-row-oversubtraction-4t12t6`
+**Date:** 2026-08-13
+**Status:** synthetic-validated on the `amprow_halo` harness (standard +
+giant-BCG stress scenes), judged by eye (HA) — "genuinely pretty good",
+96×32 preferred, marginally better with `reject = false`. Needs real-frame
+validation before any field flips.
+**Audience:** a session on a machine with `$CAMPFIRE_ROOT`, the `campfire`
+conda env, and reducible NIRCam data for a `subtract_2d` field showing the
+amp-blocky halo-oversubtraction artifact.
+
+## 1. Context — how we got here (one paragraph)
+
+Bright galaxies spanning readout amps leak halo flux into the per-amp-row
+1/f estimate, which broadcasts it across the amp: oversubtracted amp-blocks
+with hard edges at cols 512/1024/1536. Levers tried and **rejected**:
+`bkg2d.fit_order="first"` (real frames, by eye — often worse; see
+`docs/handoff-bkg2d-fit-order.md`), global 1/f-mask growth
+(`striping.extra_dilate` alone — starves anchors frame-wide, injects
+row/column noise), selective growth at 80 px (no-op — halos are broader
+than the push), selective at 300 px (trades blocks for fine noise lines).
+The surviving candidate exploits geometry instead of anchor placement:
+banding is fine in y and constant in x within an amp; halos are smooth in
+both. A **y-coarse × x-fine conditioning detrend** is banding-blind by
+construction (a 96-row box averages a ρ≈20 pattern to ~4%) yet follows halo
+column profiles, and, being fit full-width and smooth in x, cannot
+represent amp-*dependent* banding at any scale. On the harness it removed
+the amp-row misattribution almost completely on both scenes, with no
+visible banding absorption (the predicted failure mode), and survived the
+BCG stress case. The rj0911 "fine detrend boxes are worse" A/B used
+*square* fine boxes — fine in y too — so it never tested this.
+
+## 2. The configuration under test
+
+Per-field override (deep-merges over `[nircam.bkg]`):
+
+```toml
+[myfield_aniso.bkg]
+    subtract_2d = true
+    [myfield_aniso.bkg.detrend]
+        box_size = 96          # y (row) box — SW native; use 192 on LW (§5.1)
+        box_size_x = 32        # x box; > 0 activates the anisotropic mesh
+        filter_size = [1, 5]   # [y, x]: keep full y mesh resolution
+    [myfield_aniso.bkg.bkg2d]
+        reject = false         # optional; marginally better on synthetic (HA)
+```
+
+Arms for a real-frame A/B (WCS-clone-arm pattern from
+`pipeline/experiments/oneoverf_gp/README.md` — clone the field in
+`fields.toml`, symlink `astrom_cats`, separate products trees):
+
+1. **control** — `subtract_2d = true` only (current production behavior).
+2. **aniso** — the block above with the default `reject = true`.
+3. **aniso_norej** — the block above as written (`reject = false`).
+
+The per-exposure skip is `CFP_BKG`-presence-based: already-processed trees
+need `--overwrite` on the bkg step or `cfpipe nircam reset --from image2`.
+`CFP_BKG` records `detrend=box96x32` (and `bkg2d_reject`), so arms are
+auditable in headers.
+
+```bash
+conda run -n campfire cfpipe nircam run --field myfield_aniso --all --processes 4
+```
+
+## 3. What to look at (the metric is the eye — PNGs, not statistics)
+
+1. **The artifact itself**: cal-frame and mosaic cutouts around bright
+   multi-amp galaxies, same stretch across arms. Success = the amp-blocky
+   oversubtraction and its hard vertical/horizontal edges are gone or
+   clearly reduced; halos look round instead of clipped.
+2. **The predicted failure mode — banding absorption**: blank regions,
+   deep stretch, arm vs control. If the conditioning is eating common-mode
+   row structure (~50–150-row band), `h` underfits it and stripes at those
+   scales SURVIVE into the corrected frame. This did not appear on the
+   synthetic scenes; real scattered light lives at exactly these scales, so
+   this is the check that matters most. (Wisps are removed before `bkg`,
+   but imperfect wisp residuals also live here.)
+3. **Component attribution** (optional): `bkg_step(..., components_out=)` —
+   the amp-blocky component should vanish from `h` rather than migrate
+   into it; `pipeline/experiments/bkg2d_synthetic/inspect_components.py`
+   is the existing harness.
+4. **Mosaic level**: drizzle an affected filter and compare the artifact
+   region plus overlap noise (skymatch invariant: per-exposure masked
+   background median stays ≈ 0; `meta.background.level` sensible).
+
+Note the smooth halo-shaped residual around very bright galaxies is the
+`b2d` fit's own error (identical in the harness's `ideal_1f` floor — wing
+riding + mask-hole interpolation) and is NOT the target of this change;
+don't count it against the aniso arms. `reject=false` recovers a modest
+part of it; the rest is a separate `bkg2d`-side workstream.
+
+## 4. Also riding on this branch (present in ALL arms including control)
+
+- **GP `amplitude_data` restoration**: the amp-row GP kernel amplitude is
+  measured on the pre-detrend residual again (per `gp_amprow_offsets`'s
+  own rj0911 calibration contract; the unified step had regressed). This
+  changes pixels on every field. Control-vs-pre-branch products isolates
+  it if a blank-field spot-check is wanted.
+- Dormant opt-in knobs, all default-off, no behavior change unless set:
+  `bkg2d.fit_order` (keep `"last"`), `striping.extra_dilate` /
+  `.extra_dilate_min_area`, `striping.gp.min_row_pixels`.
+
+## 5. Open items to resolve during/after validation
+
+1. **LW scaling**: ρ is a readout property in native ROWS; `box_size`
+   channel-scales as an angular length (×0.5 at LW). For LW arms set
+   `box_size = 192` so the scaled y-box stays ~96 rows. If the lever
+   validates, consider making the detrend y-box scale-exempt (a code
+   change) rather than documenting the ×2 rule.
+2. **`reject` default for `subtract_2d` fields**: synthetic says
+   `false` is marginally better with aniso conditioning, but `false` also
+   drops the leaked-compact-source guard. Decide on real frames.
+3. **Default flip**: if validated, decide whether `box_size_x = 32` (with
+   `box_size = 96`, `filter_size = [1, 5]`) becomes the `[nircam.bkg.detrend]`
+   default (Algorithm/MINOR, changelog entry already covers the knob) or
+   stays per-field. Note the current defaults were tuned for blank fields
+   where the artifact doesn't bite; a per-field flip on `subtract_2d`
+   fields is the low-risk first step.
+4. Flux conservation: the aniso detrend is fit-only, so it cannot move
+   flux directly, but it changes what `h` fits, so per-source photometry
+   arm-vs-control on real frames is a cheap sanity check (the
+   `bkg2d_synthetic` sweep with a `detrend` arm is the truth-based
+   version if wanted).
+
+## 6. Tooling
+
+- Synthetic harness: `pipeline/experiments/amprow_halo/` (README there;
+  `run_harness.py --giant` for the BCG stress scene; arms are a dict at
+  the top of the script). The `compare_hrow_err.png` ledger-error view —
+  fitted amp-row profile minus injected truth banding — is the artifact
+  isolator; on real data there is no truth, so the eye criteria in §3
+  replace it.
+- All work is on the branch; tests green (`tests/test_nircam_bkg.py`,
+  `test_nircam_gp_striping.py`). The PR, when opened, already has its
+  `## Unreleased` changelog entry (Algorithm) covering the whole series.
+
+## 7. Definition of done
+
+- Three-arm real-frame A/B on at least one affected field/filter (SW), one
+  LW spot-check with the ×2 y-box; eye verdict recorded with cutout PNGs.
+- §5.1–5.3 decisions made; production field config (or default) updated
+  accordingly; follow-up issues opened for whatever is deferred (e.g. the
+  `bkg2d` smooth-residual workstream).

--- a/docs/handoff-bkg2d-fit-order.md
+++ b/docs/handoff-bkg2d-fit-order.md
@@ -4,10 +4,12 @@
 > described below was run (with `reject=false`); by eye the artifacts were
 > sometimes reduced but often *worse* with `fit_order="first"`. The knob
 > remains in the code for reference but should stay `"last"`. The mitigation
-> effort moved to the 1/f fit-mask lever
-> (`[nircam.bkg.striping].extra_dilate`) evaluated on the eye-first
-> synthetic harness at `pipeline/experiments/amprow_halo/` — see its README.
-> This document is retained for the mechanism analysis and the reject
+> effort moved to the eye-first synthetic harness at
+> `pipeline/experiments/amprow_halo/`, where the 1/f fit-mask-growth levers
+> were also rejected and the **anisotropic conditioning detrend**
+> (`[nircam.bkg.detrend].box_size_x`) emerged as the surviving candidate —
+> real-frame test instructions in `docs/handoff-aniso-detrend.md`. This
+> document is retained for the mechanism analysis and the reject
 > interaction, which still hold.
 
 **Branch:** `claude/nircam-bkg-amp-row-oversubtraction-4t12t6`

--- a/docs/handoff-bkg2d-fit-order.md
+++ b/docs/handoff-bkg2d-fit-order.md
@@ -1,5 +1,15 @@
 # Handoff: real-frame A/B of `[nircam.bkg.bkg2d].fit_order = "first"`
 
+> **OUTCOME (2026-08-13): the reorder was REJECTED on real frames.** The A/B
+> described below was run (with `reject=false`); by eye the artifacts were
+> sometimes reduced but often *worse* with `fit_order="first"`. The knob
+> remains in the code for reference but should stay `"last"`. The mitigation
+> effort moved to the 1/f fit-mask lever
+> (`[nircam.bkg.striping].extra_dilate`) evaluated on the eye-first
+> synthetic harness at `pipeline/experiments/amprow_halo/` — see its README.
+> This document is retained for the mechanism analysis and the reject
+> interaction, which still hold.
+
 **Branch:** `claude/nircam-bkg-amp-row-oversubtraction-4t12t6`
 **Status:** implemented + synthetic-validated; needs a real-frame A/B before
 flipping any field (or the default) to `"first"`.

--- a/docs/handoff-bkg2d-fit-order.md
+++ b/docs/handoff-bkg2d-fit-order.md
@@ -1,0 +1,166 @@
+# Handoff: real-frame A/B of `[nircam.bkg.bkg2d].fit_order = "first"`
+
+**Branch:** `claude/nircam-bkg-amp-row-oversubtraction-4t12t6`
+**Status:** implemented + synthetic-validated; needs a real-frame A/B before
+flipping any field (or the default) to `"first"`.
+**Audience:** an agent (or human) in an environment with `$CAMPFIRE_ROOT`,
+the `campfire` conda env, and reduced/reducible NIRCam data for a
+`subtract_2d` field showing the artifact.
+
+## 1. The artifact and the fix (context)
+
+On `subtract_2d` fields, bright galaxies spanning readout amplifiers show
+**amp-blocky oversubtraction**: the per-amp-row 1/f term eats the galaxy's
+halo flux and broadcasts it across the host amp's full width — blue
+amp-height blocks with hard vertical edges at columns 512/1024/1536 and hard
+horizontal edges at the source's top/bottom rows.
+
+Mechanism (full analysis in the `bkg.py` module docstring and the Unreleased
+CHANGELOG entry): the halo is structurally invisible to the source mask (the
+ring-median pre-filter removes structure broader than its 80 px radius before
+tier detection), the coarse conditioning detrend is starved near big masked
+blobs (`exclude_percentile`), so halo flux biases the clipped amp-row medians
+and the ρ=20 GP follows it. With the legacy order the applied 2-D fit runs
+**after** the 1/f terms, on the post-h residual, so it can never reclaim that
+flux — corrections accumulate one-way, and iterating makes the leak *grow*
+(1.42 → 1.92 in the synthetic scene over the default 3 iterations).
+
+`fit_order = "first"` fits the 2-D model on `resid − ped` with the halo
+intact, and measures the 1/f terms on the b2d-subtracted residual. Same
+components, same accumulation — different attribution.
+
+## 2. What changed on this branch
+
+| file | change |
+|---|---|
+| `pipeline/campfire_pipeline/nircam/steps/bkg.py` | per-iteration reorder behind `fit_order` (`"last"` = legacy default); 1/f measured on `cond − ped − b2d`; GP `amplitude_data` now the pre-detrend residual (both orders — restores the rj0911 calibration contract in `gp_amprow_offsets`); `CFP_BKG` records `bkg2d_order`; warning logged for `first` + `reject=true` |
+| `pipeline/campfire_pipeline/data/config_default.toml` | `[nircam.bkg.bkg2d].fit_order = "last"` + comments |
+| `pipeline/tests/test_nircam_bkg.py` | `test_b2d_fit_order_first_starves_amprow_of_halo` — synthetic pin of the artifact, the fix, and the reject interaction |
+| `pipeline/CHANGELOG.md` | Unreleased / Algorithm entry |
+
+## 3. Synthetic results already in hand (what the A/B should confirm on sky)
+
+2048² frame, amp-dependent 100-row banding + a 20 σ-peak, σ=120 px Gaussian
+halo hosted by amp C. Metric: halo flux in the amp-row ledger `h` (mean
+row-offset difference, halo rows vs far rows), single iteration unless noted:
+
+| arm | leak (amp C) |
+|---|---|
+| `last` (shipped legacy, any `reject`) | **+1.42** (3 iters: +1.92) |
+| `first`, `reject=true` | +1.50 — **reject cancels the fix** |
+| `first`, `reject=false` | **+0.77** (3 iters: +0.87) |
+| `first`, `reject=false`, `extra_dilate=0` | +0.46 |
+| `first`, perfect b2d model (floor) | −0.03 |
+
+Two operational conclusions bake into the A/B design:
+
+1. **`fit_order="first"` must be paired with `reject=false`.** The
+   background-map outlier reject flags the halo bump in the first-order map
+   as leaked source flux, masks it, refits — and the halo goes back to the
+   1/f term. The step logs a warning on this combination.
+2. The residual leak in `first` mode is the b2d model deficit inside the
+   `extra_dilate` holes; `extra_dilate` is a candidate follow-up sweep
+   parameter (it was tuned for flux conservation in the *legacy* order).
+
+## 4. How to run the A/B
+
+Pick a `subtract_2d` field/filter with a known-affected exposure (bright
+galaxy spanning an amp boundary — the kind of frame in the issue screenshot).
+The cheapest clean A/B is the WCS-clone-arm pattern from
+`pipeline/experiments/oneoverf_gp/README.md`: clone the field definition in
+`$CAMPFIRE_ROOT/config/fields.toml` (same `files`, same `tangent_point`,
+`astrom_cats` symlinked) so each arm writes its own products tree.
+
+Per-field overrides deep-merge over `[nircam.bkg]`; three arms:
+
+```toml
+[myfield_last.bkg]                 # arm 1: status quo (control)
+    subtract_2d = true
+
+[myfield_first.bkg]                # arm 2: the fix
+    subtract_2d = true
+    [myfield_first.bkg.bkg2d]
+        fit_order = "first"
+        reject = false
+
+[myfield_firstrej.bkg]             # arm 3 (optional): pins the reject
+    subtract_2d = true             # interaction on sky — expect ~no change
+    [myfield_firstrej.bkg.bkg2d]   # vs arm 1
+        fit_order = "first"
+```
+
+Run per arm (bkg is per-exposure; the skip is `CFP_BKG`-presence-based, so
+already-processed trees need `--overwrite` on the bkg step or
+`cfpipe nircam reset --from image2`):
+
+```bash
+conda run -n campfire cfpipe nircam run --field myfield_first --all --processes 4
+```
+
+Note the `amplitude_data` change rides along in **every** arm (including the
+control): arm 1 vs pre-branch products isolates it if needed (see §6 risk 3).
+
+## 5. What to measure
+
+1. **The artifact itself (primary).** On the affected exposures' cal frames
+   (and the mosaic): amp-boundary step amplitude near the bright galaxy.
+   Simplest robust statistic: per-amp-row medians of the background
+   (SRCMASK==0) pixels in thin column strips either side of the amp boundary,
+   differenced, in the source's row range vs far rows. Expect the `last` arm
+   to reproduce the blocks and `first` to cut them ≳2x; visually, the
+   before/after `*_bkg.pdf` plots and a mosaic cutout like the issue
+   screenshot.
+2. **Component attribution.** `bkg_step(..., components_out=dict())` gives
+   the accumulated `h`, `b2d`, `vcol`, `ped` ledgers per exposure
+   (`pipeline/experiments/bkg2d_synthetic/inspect_components.py` is the
+   existing harness). Difference `h` between arms: the amp-blocky component
+   should migrate from `h` into `b2d`.
+3. **1/f removal must not regress.** `stripe_std` / `stripe_hf` from
+   `pipeline/experiments/oneoverf_gp/ab_metrics.py` (high-passed, so
+   ICL-insensitive), clean rows and source rows separately. The b2d-first fit
+   sees ~20-row banding under its mesh; the synthetic test says the clipped
+   64/32 px boxes average it out — confirm on sky (arm 2 ≈ arm 1 on blank
+   regions).
+4. **Flux conservation.** Aperture photometry deltas arm 2 − arm 1 for
+   bright/extended galaxies (the `first` fit sees halos the `last` fit never
+   saw — absorption of true wings is the accepted `subtract_2d` trade, but
+   quantify it; the `bkg2d_synthetic` sweep with `--estimator gp` + a
+   `fit_order` arm is the controlled version of this and is the right place
+   for a truth-based number).
+5. **Skymatch invariant.** Masked-background median ≈ 0 per exposure in all
+   arms (`meta.background.level` stays sensible; overlap consistency in the
+   mosaic).
+6. **`CFP_BKG` sanity.** `bkg2d_order=first` stamped in arm 2/3 headers;
+   the warning line appears in arm 3 logs.
+
+## 6. Risks to check / open questions
+
+1. **Banding absorption by the first-order b2d** (§5.3). If blank-region
+   stripe metrics regress, consider `filter_size` up or box up for `first`.
+2. **Flux conservation under `first`** (§5.4). If wing absorption is
+   unacceptable, the `extra_dilate` sweep point moves; note the synthetic
+   result that *smaller* dilation reduces the amp-row leak — the two trade.
+3. **The `amplitude_data` restoration** affects all fields (it changes the GP
+   amplitude wherever the detrend is on, i.e. everywhere). Spot-check one
+   blank field: stripe metrics and photometry vs pre-branch products should
+   be neutral-to-better (the rj0911 calibration says post-detrend amplitude
+   *loses* to the median estimator).
+4. **`reject` semantics in `first` mode** are a blunt instrument: off = no
+   guard against compact-source leakage into the fine-box fit. If arm 2 shows
+   compact-source-shaped bumps in `b2d` ledgers, the follow-up is a
+   scale-aware reject (reject bumps spanning ≲2 mesh cells, keep broad ones),
+   not a return to `last`.
+5. **Should `first` become the default** for `subtract_2d` fields once
+   validated? The knob + CHANGELOG are written assuming yes, later, in a
+   separate flip.
+
+## 7. Definition of done
+
+- Arm 1 reproduces the artifact; arm 2 visibly and quantitatively (≳2x)
+  reduces it with no stripe-metric or photometry regression beyond the
+  accepted trades; findings written up (numbers + cutouts).
+- If results support it: flip the affected production field(s) to
+  `fit_order = "first"`, `reject = false` in `fields.toml`, and open the
+  default-flip / scale-aware-reject follow-ups as issues.
+- The branch's PR carries the CHANGELOG entry (already written) — categorized
+  **Algorithm → MINOR**.

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -29,6 +29,39 @@ Release procedure: edit the `## Unreleased` section below, then run
 ## Unreleased
 
 ### Algorithm
+- **New opt-in `[nircam.bkg.bkg2d].fit_order = "first"` fixes the amp-blocky
+  halo oversubtraction around bright multi-amp galaxies** when `subtract_2d`
+  is on. With the legacy order (`"last"`, still the default), the amp-row 1/f
+  terms are fit before the applied 2-D background ever sees the frame:
+  unmasked halo/wing flux — structurally invisible to the source mask, whose
+  ring-median pre-filter removes structure broader than its radius before
+  tier detection — leaks into the clipped amp-row medians, the GP follows it
+  (smooth structure slower than ρ is exactly its model), and the offset is
+  broadcast across each amp's full width: oversubtracted amp-height blocks
+  with hard edges at columns 512/1024/1536 and at the source's top/bottom
+  rows. The 2-D fit then runs on the post-1/f residual and can never reclaim
+  that flux; iterating makes it *worse* (synthetic amp-spanning-halo scene:
+  row-ledger halo leak grows 1.42 → 1.92 over 3 iterations). `"first"` fits
+  the 2-D model on the pedestal-subtracted residual with the halo intact and
+  conditions the 1/f measurement on its output — same components, same
+  accumulation, different attribution — cutting the leak ~2x at shipped
+  settings (to ~0, i.e. the full artifact, when the 2-D model is exact; the
+  remainder is the fit's deficit inside the `extra_dilate` holes). CAUTION:
+  pair `"first"` with `reject = false` — the background-map outlier reject
+  flags the halo bump in the first-order map as leaked source flux and refits
+  it away, cancelling the benefit (measured; the step logs a warning on the
+  combination). Regression-pinned in
+  `tests/test_nircam_bkg.py::test_b2d_fit_order_first_starves_amprow_of_halo`;
+  real-frame A/B instructions in `docs/handoff-bkg2d-fit-order.md`.
+  Additionally (both orders, all fields): the amp-row GP's self-adapting
+  kernel amplitude is now measured on the **pre-detrend** residual
+  (`amplitude_data`, restoring the rj0911 f444w calibration contract recorded
+  in `gp_amprow_offsets` — the retired striping step honored it; the unified
+  step had regressed to measuring on the conditioned residual, which
+  under-estimates the amplitude and over-regularizes the interpolation across
+  wide masked gaps). `CFP_BKG` now records `bkg2d_order` when `subtract_2d`
+  is on. Pixel values change wherever the detrend is enabled (everywhere, by
+  default) → MINOR.
 - **Mosaic background subtraction is now recorded by a `CFP_BKGS` stamp on the
   i2d primary header, making `_i2d_before_bkgsub.fits` deletable** (issue
   #427). Previously the snapshot's *existence on disk* was the only

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -62,6 +62,19 @@ Release procedure: edit the `## Unreleased` section below, then run
   wide masked gaps). `CFP_BKG` now records `bkg2d_order` when `subtract_2d`
   is on. Pixel values change wherever the detrend is enabled (everywhere, by
   default) → MINOR.
+  *Follow-up (same session series):* the real-frame A/B **rejected the
+  reorder** (sometimes better, often worse, judged by eye); the knob remains
+  for reference but stays `"last"`. The mitigation search moved to a second
+  opt-in lever, **`[nircam.bkg.striping].extra_dilate`** (default 0 = no
+  behavior change): grow the source tiers by N angular px (channel-scaled)
+  for the **1/f fit mask only** — the amp-row/column anchors move off
+  bright-galaxy halos, which the mask tiers structurally cannot reach (the
+  ring-median pre-filter erases structure broader than its radius before
+  detection), and the GP bridges the widened gaps as designed. Recorded as
+  `strp_dilate` in `CFP_BKG` when nonzero. Evaluated on the new eye-first
+  synthetic harness `experiments/amprow_halo` (brightfield scene: bright
+  amp-spanning ellipticals with halo envelopes + complex smooth sky +
+  injected 1/f, run through the real `bkg_step`, judged from PNGs).
 - **Mosaic background subtraction is now recorded by a `CFP_BKGS` stamp on the
   i2d primary header, making `_i2d_before_bkgsub.fits` deletable** (issue
   #427). Previously the snapshot's *existence on disk* was the only

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -101,9 +101,37 @@ Release procedure: edit the `## Unreleased` section below, then run
   driver is bright *stars'* PSF wings rather than galaxy halos), and the
   `fit_order` reorder was rejected on the same data. LW arms used
   `box_size = 192` so the ×0.5 channel scaling leaves ~96 rows;
-  `box_size_x` is not doubled. No default is flipped by this PR. Full write-up
-  with the failure modes and the discarded metrics:
-  `docs/findings-aniso-detrend-a2744.md`.
+  `box_size_x` is not doubled. Full write-up with the failure modes and the
+  discarded metrics: `docs/findings-aniso-detrend-a2744.md`.
+- **Defaults flipped for the NIRCam background step** on the strength of that
+  validation. Pixel values change on every NIRCam field → MINOR.
+  - `[nircam.bkg].subtract_2d`: `false` → **`true`**. This aligns the package
+    with the practice it was written for — the reduction config in use has set
+    it true for every field, blank and cluster alike, for the life of the
+    unified step, so the `false` default was the path nothing ran on. The
+    trade is unchanged and deliberate: a fine-box applied fit removes ICL and
+    bright-galaxy wings by construction, bounded by the `bkg2d` box_size /
+    extra_dilate pair (chosen for zero median aperture-flux loss on compact,
+    extended and bright galaxies simultaneously). Set false to leave the
+    astrophysical sky for the mosaic.
+  - `[nircam.bkg.detrend]`: `box_size` `256` → **`96`**, `box_size_x` `0` →
+    **`32`**, `filter_size` `3` → **`[1, 5]`** — the validated anisotropic
+    conditioning mesh, on by default.
+  - `[nircam.bkg.bkg2d].reject`: `true` → **`false`** — the arm preferred on
+    real frames; the reject re-flags extended halo/wing bumps in the
+    background map as leaked source flux and refits away part of what the
+    conditioning buys. Only affects `subtract_2d` fields. Set true to restore
+    the leaked-compact-source guard.
+  - **The detrend y box is now scale-exempt in anisotropic mode** (a code
+    change, not just a default): ρ is a readout property in native ROWS, so
+    the banding attenuation a y box buys depends on rows spanned, not angle
+    subtended. Channel-scaling it would hand LW half the rows (96 → 48) and
+    half the attenuation — not the configuration validated on real frames,
+    which ran 96 rows in BOTH channels. The x box is still channel-scaled (it
+    tracks the halo's angular column profile), and legacy square mode
+    (`box_size_x = 0`) keeps the old scaled behavior untouched (256 → 128 LW).
+    Verified by running the shipped defaults against the stored validation arm
+    on real SW and LW frames.
 - **Mosaic background subtraction is now recorded by a `CFP_BKGS` stamp on the
   i2d primary header, making `_i2d_before_bkgsub.fits` deletable** (issue
   #427). Previously the snapshot's *existence on disk* was the only

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -29,9 +29,11 @@ Release procedure: edit the `## Unreleased` section below, then run
 ## Unreleased
 
 ### Algorithm
-- **New opt-in `[nircam.bkg.bkg2d].fit_order = "first"` fixes the amp-blocky
+- **New opt-in `[nircam.bkg.bkg2d].fit_order = "first"` targets the amp-blocky
   halo oversubtraction around bright multi-amp galaxies** when `subtract_2d`
-  is on. With the legacy order (`"last"`, still the default), the amp-row 1/f
+  is on — but was **rejected on real frames** and stays `"last"` (see the
+  follow-up at the end of this entry; the synthetic result below is retained
+  for the mechanism analysis, which still holds). With the legacy order (`"last"`, still the default), the amp-row 1/f
   terms are fit before the applied 2-D background ever sees the frame:
   unmasked halo/wing flux — structurally invisible to the source mask, whose
   ring-median pre-filter removes structure broader than its radius before
@@ -90,6 +92,18 @@ Release procedure: edit the `## Unreleased` section below, then run
   provenance records `detrend=boxYxX`. Default `box_size_x = 0` (square
   legacy box — no behavior change); real-frame validation instructions in
   `docs/handoff-aniso-detrend.md`.
+  *Real-frame validation (2026-08-14):* three-arm A/B on **32 A2744 exposures
+  rebuilt from uncal** (24 SW F200W + 8 LW F444W), `bkg` re-run per arm on
+  copies, judged by eye on post-bkg SCI at a stretch held common across arms —
+  **`box_size_x = 32` with `reject = false` was preferred over production**.
+  The artifact was first confirmed to exist on those frames (5 of 32 showed a
+  strong single-amp excursion in the amp-row ledger, all SW; on real data the
+  driver is bright *stars'* PSF wings rather than galaxy halos), and the
+  `fit_order` reorder was rejected on the same data. LW arms used
+  `box_size = 192` so the ×0.5 channel scaling leaves ~96 rows;
+  `box_size_x` is not doubled. No default is flipped by this PR. Full write-up
+  with the failure modes and the discarded metrics:
+  `docs/findings-aniso-detrend-a2744.md`.
 - **Mosaic background subtraction is now recorded by a `CFP_BKGS` stamp on the
   i2d primary header, making `_i2d_before_bkgsub.fits` deletable** (issue
   #427). Previously the snapshot's *existence on disk* was the only

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -74,7 +74,22 @@ Release procedure: edit the `## Unreleased` section below, then run
   `strp_dilate` in `CFP_BKG` when nonzero. Evaluated on the new eye-first
   synthetic harness `experiments/amprow_halo` (brightfield scene: bright
   amp-spanning ellipticals with halo envelopes + complex smooth sky +
-  injected 1/f, run through the real `bkg_step`, judged from PNGs).
+  injected 1/f, run through the real `bkg_step`, judged from PNGs) — where
+  the mask-growth levers were also rejected (global growth injects
+  row/column noise; selective growth cannot out-run halos broader than the
+  push). The surviving candidate is the **anisotropic conditioning
+  detrend**: with `[nircam.bkg.detrend].box_size_x > 0`, `box_size` becomes
+  the y (row) box and `box_size_x` a finer x box (evaluated at 96×32,
+  `filter_size = [1, 5]`). Banding is fine in y and constant in x within an
+  amp while halo structure is smooth in both, so a y-coarse/x-fine fit-only
+  mesh is banding-blind by construction (~4% pass-through of a ρ≈20 pattern
+  at 96 rows) yet follows halo column profiles, and, fit full-width and
+  smooth in x, cannot represent amp-dependent banding at any scale. On the
+  harness (standard + giant-BCG stress scenes) it removed the amp-row
+  misattribution nearly completely with no visible banding absorption;
+  provenance records `detrend=boxYxX`. Default `box_size_x = 0` (square
+  legacy box — no behavior change); real-frame validation instructions in
+  `docs/handoff-aniso-detrend.md`.
 - **Mosaic background subtraction is now recorded by a `CFP_BKGS` stamp on the
   i2d primary header, making `_i2d_before_bkgsub.fits` deletable** (issue
   #427). Previously the snapshot's *existence on disk* was the only

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -268,6 +268,19 @@
         # Rebuild the source mask each iteration on the running residual (it
         # sharpens as the frame flattens). Set false to mask once (cheaper).
         remask_each_iter = true
+        # Grow the source tiers by this many px (angular, channel-scaled like
+        # the mask params) for the 1/f fit mask ONLY (column pattern + amp-row
+        # terms; detrend/pedestal/bkg2d keep their own masks). Pushes the
+        # amp-row anchors away from bright-galaxy halos — the mask tiers
+        # structurally cannot reach them (the ring-median pre-filter removes
+        # structure broader than its radius before detection), and
+        # halo-contaminated anchors are what the per-amp GP broadcasts into
+        # the amp-blocky oversubtraction around bright multi-amp sources.
+        # The GP interpolates across the widened gaps (rho_long's job),
+        # reverting to the per-amp DC where nothing anchors. 0 = off (legacy
+        # behavior). Under evaluation on the amprow_halo synthetic harness
+        # (experiments/amprow_halo).
+        extra_dilate = 0
 
         [nircam.bkg.striping.gp]
             # rho = SHOTerm correlation length in *rows* (frozen; a detector

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -281,6 +281,14 @@
         # behavior). Under evaluation on the amprow_halo synthetic harness
         # (experiments/amprow_halo).
         extra_dilate = 0
+        # With extra_dilate > 0: grow ONLY source-tier footprints of at least
+        # this many px^2 (angular, channel-scaled x f^2). Growing every tier
+        # starves the amp-row anchors frame-wide (hundreds of faint sources
+        # each donate a grown disk) and the GP then follows sampling noise —
+        # measured on the amprow_halo harness: injected row/column striping
+        # and a remask runaway at extra_dilate=150. The artifact drivers are
+        # the few LARGE footprints; 0 grows everything (not recommended).
+        extra_dilate_min_area = 0
 
         [nircam.bkg.striping.gp]
             # rho = SHOTerm correlation length in *rows* (frozen; a detector
@@ -295,6 +303,13 @@
             q = 0.70710678
             sigma_clip = 2.0
             weak_frac = 0.5
+            # Amp-rows with fewer surviving background pixels than this do
+            # not anchor the GP (they become interpolated gap rows): a
+            # MAD-based sigma on a handful of pixels can make a starved,
+            # contaminated row an overconfident anchor. 0 = legacy (any row
+            # with >= 1 pixel anchors). Under evaluation on the amprow_halo
+            # harness alongside striping.extra_dilate.
+            min_row_pixels = 0
 
     [nircam.bkg.variance]
         # VAR_RNOISE rescale (folded in; uses the shared final source mask).

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -202,14 +202,26 @@
     # See docs/design-nircam-unified-background.md.
     n_iterations = 3
     plot = true
-    # Opt-in applied 2-D background per exposure (fields with strongly varying
-    # backgrounds — lensing clusters). Each iteration fits Background2D on the
-    # running residual (see [nircam.bkg.bkg2d]) and subtracts the model. A
-    # fine-box fit removes ICL and bright-galaxy wings by construction — an
-    # accepted trade for cluster fields; leave false for blank fields. NOTE:
-    # the per-exposure skip is CFP_BKG-presence-based, so flipping this on
-    # already-processed exposures needs --overwrite (or reset --from image2).
-    subtract_2d = false
+    # Applied 2-D background per exposure. Each iteration fits Background2D on
+    # the running residual (see [nircam.bkg.bkg2d]) and subtracts the model.
+    #
+    # ON BY DEFAULT (was opt-in). This makes the package agree with the
+    # long-standing practice it was written for: the reduction config here has
+    # set subtract_2d = true for EVERY NIRCam field, blank and cluster alike,
+    # for the life of the unified bkg step — the false default was already the
+    # path nothing ran on.
+    #
+    # KNOW THE TRADE: a fine-box fit removes ICL and bright-galaxy wings by
+    # construction. That is the point on cluster fields; on blank fields it
+    # also removes real extended wing/sky structure. What bounds the loss is
+    # the [nircam.bkg.bkg2d] box_size / extra_dilate pair, chosen by the
+    # synthetic cluster sweep for zero median aperture-flux loss on compact,
+    # extended AND bright galaxies simultaneously. Set false to leave the
+    # astrophysical sky in place for the mosaic to handle.
+    #
+    # NOTE: the per-exposure skip is CFP_BKG-presence-based, so flipping this
+    # on already-processed exposures needs --overwrite (or reset --from image2).
+    subtract_2d = true
 
     [nircam.bkg.mask]
         # SubtractBackground mask config (mask only). Mosaic-like depth: the
@@ -352,7 +364,12 @@
         # channel-scaled like the mask params (256 -> 128 px LW native,
         # matching Endsley's bw=128).
         enabled = true
-        box_size = 256
+        # y (row) box. In anisotropic mode (box_size_x > 0, the default) this
+        # is SCALE-EXEMPT and means native ROWS in both channels — rho is a
+        # readout property in rows, so the banding attenuation depends on rows
+        # spanned, not angle subtended. In legacy square mode (box_size_x = 0)
+        # it is channel-scaled as an angular length, as before (256 -> 128 LW).
+        box_size = 96
         # Anisotropic conditioning (opt-in): when > 0, box_size becomes the
         # y (row) box and box_size_x sets a finer x box, e.g. 96 / 32.
         # Rationale: banding is fine in y and constant in x within an amp;
@@ -367,9 +384,18 @@
         # anisotropy was untested. Trade: common-mode row structure at
         # ~50-150 rows may be conditioned away and underfit by h. filter_size
         # may be a 2-list [y, x] (use [1, 5] to keep full y mesh resolution).
-        # Under evaluation on experiments/amprow_halo. 0 = square legacy box.
-        box_size_x = 0
-        filter_size = 3
+        # 0 = square legacy box.
+        #
+        # ON BY DEFAULT since the real-frame validation on A2744 (32 exposures
+        # rebuilt from uncal, three arms, judged by eye on post-bkg SCI at a
+        # stretch held common across arms — 96x32 with bkg2d.reject = false was
+        # preferred over the square-box production configuration). Details and
+        # the rejected alternatives: docs/findings-aniso-detrend-a2744.md.
+        box_size_x = 32
+        # [y, x]. y = 1 keeps full mesh resolution in the row direction, which
+        # is the point of the anisotropic mesh; the x median filter smooths
+        # across columns. A scalar is still accepted (applied to both axes).
+        filter_size = [1, 5]
         sigma = 3.0
         exclude_percentile = 90
 
@@ -418,7 +444,15 @@
         # med + hi*sigma / med - lo*sigma masked (sigma from the lowest
         # reject_percentile of map values), grown by reject_dilate px. Guards
         # against source flux leaking through the mask into the fine-box fit.
-        reject = true
+        #
+        # Default flipped to FALSE alongside the anisotropic conditioning
+        # detrend: on real A2744 frames the preferred arm was aniso +
+        # reject = false (the reject re-flags extended halo/wing bumps in the
+        # background map as leaked source flux and refits them away, undoing
+        # part of what the conditioning buys). Only affects subtract_2d
+        # fields, since bkg2d runs nowhere else. Set true to restore the
+        # leaked-compact-source guard. See docs/findings-aniso-detrend-a2744.md.
+        reject = false
         reject_sigma_hi = 4.0
         reject_sigma_lo = 3.0
         reject_percentile = 60.0

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -332,6 +332,22 @@
         # matching Endsley's bw=128).
         enabled = true
         box_size = 256
+        # Anisotropic conditioning (opt-in): when > 0, box_size becomes the
+        # y (row) box and box_size_x sets a finer x box, e.g. 96 / 32.
+        # Rationale: banding is fine in y and constant in x within an amp;
+        # the halo/wing structure the amp-row terms steal is smooth in both.
+        # A y-coarse mesh is banding-blind by construction (a 64-row box
+        # averages a rho~20 pattern to ~6%, 96 rows to ~4%) while the fine x
+        # box follows halo column profiles near bright galaxies where the
+        # square coarse box cannot; fit full-width, it is also continuous
+        # across amp boundaries, so amp-DEPENDENT banding is unrepresentable
+        # at any scale. The rj0911 "fine boxes worse" A/B used SQUARE fine
+        # boxes (fine in y too — the configuration that absorbs banding);
+        # anisotropy was untested. Trade: common-mode row structure at
+        # ~50-150 rows may be conditioned away and underfit by h. filter_size
+        # may be a 2-list [y, x] (use [1, 5] to keep full y mesh resolution).
+        # Under evaluation on experiments/amprow_halo. 0 = square legacy box.
+        box_size_x = 0
         filter_size = 3
         sigma = 3.0
         exclude_percentile = 90

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -320,6 +320,26 @@
         # cluster sweep (experiments/bkg2d_synthetic, arm b64_d20): zero
         # median aperture-flux loss for compact, extended AND bright
         # galaxies simultaneously, ICL removal ~0.6.
+        # Where in the per-iteration chain the applied fit runs.
+        #   "last" (legacy default): fit on the 1/f-corrected residual, AFTER
+        #       the amp-row terms. Unmasked halo/wing flux around bright
+        #       multi-amp galaxies then leaks into the clipped amp-row
+        #       medians first and is broadcast across each amp's width —
+        #       amp-blocky oversubtraction with hard edges at cols
+        #       512/1024/1536 — and the 2-D fit can never reclaim it (it
+        #       only ever sees the post-h residual; corrections accumulate
+        #       one-way across iterations).
+        #   "first": fit on resid - ped with the halo intact, and condition
+        #       the 1/f measurement on the fitted model, so smooth structure
+        #       is claimed by the smooth model. Recommended for the
+        #       bright-galaxy fields subtract_2d exists for; kept opt-in
+        #       pending the real-frame A/B (docs/handoff-bkg2d-fit-order.md).
+        #       CAUTION: pair with reject = false — the map-outlier reject
+        #       below flags the halo bump in the first-order map as leaked
+        #       source flux and refits it away, cancelling the benefit
+        #       (measured on the synthetic amp-spanning-halo scene; the step
+        #       logs a warning on this combination).
+        fit_order = "last"
         box_size = 64
         filter_size = 5
         sigma = 3.0

--- a/pipeline/campfire_pipeline/nircam/gp_striping.py
+++ b/pipeline/campfire_pipeline/nircam/gp_striping.py
@@ -142,7 +142,7 @@ def gp_amprow_offsets(data, mask, rho, kernel_sigma=None,
                       q=1.0 / np.sqrt(2.0),
                       sigma_clip_sigma=2.0, maxiters=3,
                       ref_border=_REF_BORDER, weak_frac=0.5,
-                      zero_dc=False):
+                      zero_dc=False, min_row_pixels=0):
     """Per-amp, per-row 1/f offset via 1-D GP smoothing along the slow axis.
 
     Drop-in replacement for the per-amp-row median + full-row fallback in
@@ -211,6 +211,14 @@ def gp_amprow_offsets(data, mask, rho, kernel_sigma=None,
         std exceeds ``weak_frac * kernel_sigma`` — i.e. the GP has reverted
         toward the per-amp DC because no anchor row lies within ~rho. This
         is reported, not hidden: it flags wide source-filled gaps.
+    min_row_pixels : int
+        Amp-rows with fewer surviving background pixels than this do not
+        anchor the GP at all (they become interpolated gap rows). The yerr
+        weighting already down-weights starved rows, but a MAD-based
+        ``s_hat`` on a handful of pixels is itself unreliable and can make
+        a heavily-masked, contaminated row an overconfident anchor. 0
+        (default) keeps the legacy behavior (any row with >= 1 pixel
+        anchors).
 
     Returns
     -------
@@ -237,6 +245,7 @@ def gp_amprow_offsets(data, mask, rho, kernel_sigma=None,
     amp_ref = amplitude_data if (self_adapt and amplitude_data is not None) \
         else data
 
+    n_min = max(1, int(min_row_pixels))
     amp_stats = []
     centered = []   # per-amp-centered clean row medians, pooled over amps
     yerr_pool = []  # per-row sampling errors, pooled (amplitude floor)
@@ -245,7 +254,7 @@ def gp_amprow_offsets(data, mask, rho, kernel_sigma=None,
         y_r, s_hat, n_r = _amprow_statistics(
             data[sci, colstart:colstop], mask[sci, colstart:colstop],
             sigma_clip_sigma, maxiters)
-        good = (n_r > 0) & np.isfinite(y_r) & np.isfinite(s_hat)
+        good = (n_r >= n_min) & np.isfinite(y_r) & np.isfinite(s_hat)
         amp_stats.append((amp, colstart, colstop, y_r, s_hat, n_r, good))
         if good.any():
             sp = np.where(s_hat[good] > 0, s_hat[good], np.nan)
@@ -258,7 +267,7 @@ def gp_amprow_offsets(data, mask, rho, kernel_sigma=None,
                 ar, _, an = _amprow_statistics(
                     amp_ref[sci, colstart:colstop],
                     mask[sci, colstart:colstop], sigma_clip_sigma, maxiters)
-                ag = (an > 0) & np.isfinite(ar)
+                ag = (an >= n_min) & np.isfinite(ar)
                 if ag.any():
                     centered.append(ar[ag] - np.median(ar[ag]))
 

--- a/pipeline/campfire_pipeline/nircam/steps/bkg.py
+++ b/pipeline/campfire_pipeline/nircam/steps/bkg.py
@@ -266,9 +266,28 @@ def bkg_step(exposure_file, field, step_config, overwrite=False, status=None,
         # box here would let the detrend absorb the banding/amp-DC detail the
         # per-amp terms are supposed to fit.
         det_box = max(1, int(round(det_cfg.get('box_size', 256) * f2)))
+        # Anisotropic conditioning (opt-in, box_size_x > 0): box_size stays
+        # the y (row) box; box_size_x sets a finer x box. Banding is fine in
+        # y and constant in x within an amp, the halo is smooth in both — so
+        # a y-coarse/x-fine mesh is banding-blind by construction (a 64-row
+        # box averages a rho~20 pattern to ~6%) while following the halo's
+        # column profile near bright galaxies, where the square coarse box
+        # cannot. Being fit full-width it is also continuous across amp
+        # boundaries, so the amp-DEPENDENT banding (h's unique job) is
+        # unrepresentable regardless of scale. Cost: common-mode row
+        # structure in the ~50-150-row band may be absorbed and then
+        # underfit by h. NOTE: rho is a readout property in native ROWS
+        # while box_size channel-scales as an angular length — at LW the
+        # scaled y-box is half as many rows, weakening the banding
+        # attenuation; revisit before enabling on LW.
+        det_box_x = int(round(det_cfg.get('box_size_x', 0) * f2))
+        det_boxes = (det_box, max(1, det_box_x)) if det_box_x > 0 else det_box
+        det_filter = det_cfg.get('filter_size', 3)
+        if isinstance(det_filter, list):
+            det_filter = tuple(det_filter)
         sb_det = SubtractBackground(
-            bg_box_size=det_box,
-            bg_filter_size=det_cfg.get('filter_size', 3),
+            bg_box_size=det_boxes,
+            bg_filter_size=det_filter,
             bg_sigma=det_cfg.get('sigma', 3.0),
             bg_exclude_percentile=det_cfg.get('exclude_percentile', 90),
             bg_reject=False,
@@ -500,7 +519,8 @@ def bkg_step(exposure_file, field, step_config, overwrite=False, status=None,
             f'estimator={estimator}, n_iter={n_iter}, channel={channel}, '
             f'pedestal={bkg_level:.5e}, ped_scope={ped_scope}, '
             f'var_factor={factor:.3f}, '
-            f'detrend={"box%d" % det_box if detrend_on else "off"}, '
+            f'detrend='
+            f'{("box%dx%d" % (det_box, det_box_x) if det_box_x > 0 else "box%d" % det_box) if detrend_on else "off"}, '
             f'subtract_2d={subtract_2d}'
         )
         if strp_extra_dilate > 0:

--- a/pipeline/campfire_pipeline/nircam/steps/bkg.py
+++ b/pipeline/campfire_pipeline/nircam/steps/bkg.py
@@ -276,11 +276,21 @@ def bkg_step(exposure_file, field, step_config, overwrite=False, status=None,
         # boundaries, so the amp-DEPENDENT banding (h's unique job) is
         # unrepresentable regardless of scale. Cost: common-mode row
         # structure in the ~50-150-row band may be absorbed and then
-        # underfit by h. NOTE: rho is a readout property in native ROWS
-        # while box_size channel-scales as an angular length — at LW the
-        # scaled y-box is half as many rows, weakening the banding
-        # attenuation; revisit before enabling on LW.
+        # underfit by h.
+        #
+        # The y box is SCALE-EXEMPT in anisotropic mode. rho is a readout
+        # property in native ROWS, so the banding attenuation a y-box buys
+        # depends on how many ROWS it spans, not on the angle it subtends:
+        # channel-scaling it would give LW half the rows (96 -> 48) and half
+        # the attenuation, which is not the configuration validated on real
+        # frames (docs/findings-aniso-detrend-a2744.md ran 96 rows in BOTH
+        # channels, via box_size=192 on LW under the old scaling rule). The
+        # x box IS still scaled: it tracks the halo's angular column profile.
+        # Legacy square mode (box_size_x = 0) keeps the old scaled behavior
+        # untouched — 256 px SW -> 128 px LW.
         det_box_x = int(round(det_cfg.get('box_size_x', 0) * f2))
+        if det_box_x > 0:
+            det_box = max(1, int(round(det_cfg.get('box_size', 256))))
         det_boxes = (det_box, max(1, det_box_x)) if det_box_x > 0 else det_box
         det_filter = det_cfg.get('filter_size', 3)
         if isinstance(det_filter, list):

--- a/pipeline/campfire_pipeline/nircam/steps/bkg.py
+++ b/pipeline/campfire_pipeline/nircam/steps/bkg.py
@@ -363,9 +363,22 @@ def bkg_step(exposure_file, field, step_config, overwrite=False, status=None,
                         keep = areas >= strp_min_area * f2 * f2
                         keep[0] = False
                         src_only_1f = keep[lab]
-                grown_1f = (distance_transform_edt(~src_only_1f)
-                            <= strp_extra_dilate * f2)
-                fitmask_1f = fitmask | grown_1f
+                if src_only_1f.any():
+                    grown_1f = (distance_transform_edt(~src_only_1f)
+                                <= strp_extra_dilate * f2)
+                    fitmask_1f = fitmask | grown_1f
+                else:
+                    # Nothing selected to grow — either no source tiers at all
+                    # or extra_dilate_min_area filtered every component out.
+                    # `distance_transform_edt` measures the distance to the
+                    # nearest ZERO, so on an all-True input it has no seed and
+                    # returns distances measured from OUTSIDE the array: a 256²
+                    # frame yields min 1.0 / max 361, and `<= extra_dilate`
+                    # then masks a border-and-corner band (314 px at 20 px
+                    # dilation) that no source put there. Those are exactly the
+                    # edge amp-row anchors, so it would degrade the 1/f fit on
+                    # the emptiest frames — the ones with the least to spare.
+                    fitmask_1f = fitmask
             else:
                 fitmask_1f = fitmask
 

--- a/pipeline/campfire_pipeline/nircam/steps/bkg.py
+++ b/pipeline/campfire_pipeline/nircam/steps/bkg.py
@@ -164,6 +164,8 @@ def bkg_step(exposure_file, field, step_config, overwrite=False, status=None,
             f"[nircam.bkg.striping].estimator={estimator!r} not in {_VALID}")
     maxiters = int(strp_cfg.get('maxiters', 3))
     remask = strp_cfg.get('remask_each_iter', True)
+    # Angular px (channel-scaled below, like the mask/bkg2d length params).
+    strp_extra_dilate = float(strp_cfg.get('extra_dilate', 0.0))
     gp_cfg = strp_cfg.get('gp', {})
     rho_short = gp_cfg.get('rho_short', 5.0)
     rho_long = gp_cfg.get('rho_long', 20.0)
@@ -300,6 +302,25 @@ def bkg_step(exposure_file, field, step_config, overwrite=False, status=None,
                 srcmask, srcbits = sb.mask_from_arrays(resid, err, dq)
             fitmask = srcmask | dq_fit
 
+            # Optional grown fit mask for the 1/f terms ONLY
+            # ([nircam.bkg.striping].extra_dilate): the amp-row medians are
+            # the chain's most halo-contaminable statistic (508-px samples,
+            # one-signed bias), and the mask tiers structurally cannot reach
+            # a bright galaxy's halo (the ring-median pre-filter removes
+            # structure broader than its radius before detection). Growing
+            # the source tiers pushes the row/column anchors out to true
+            # sky; the GP bridges the widened gap by design (that is what
+            # rho_long is for), reverting to the per-amp DC where nothing
+            # anchors — i.e. leaving the halo alone. Detrend, pedestal and
+            # the applied 2-D fit keep their own masks.
+            if strp_extra_dilate > 0:
+                src_only_1f = (srcbits >> 1) != 0
+                grown_1f = (distance_transform_edt(~src_only_1f)
+                            <= strp_extra_dilate * f2)
+                fitmask_1f = fitmask | grown_1f
+            else:
+                fitmask_1f = fitmask
+
             # (2) CONDITIONING DETREND — fit-only, zero-median structure
             #     model. Subtracted from the *measurement copies* below so
             #     the pedestal / 1/f terms see a structure-free residual;
@@ -367,7 +388,7 @@ def bkg_step(exposure_file, field, step_config, overwrite=False, status=None,
                 h = np.zeros_like(resid)
             elif estimator == 'gp':
                 from campfire_pipeline.nircam.gp_striping import gp_amprow_offsets
-                vcol = oneoverf.column_pattern(meas, fitmask, maxiters)
+                vcol = oneoverf.column_pattern(meas, fitmask_1f, maxiters)
                 base = meas - vcol
                 # GP kernel amplitude is measured on the PRE-detrend frame
                 # (applied terms only): the prior must reflect how far the
@@ -387,17 +408,18 @@ def bkg_step(exposure_file, field, step_config, overwrite=False, status=None,
                     # GP passes return zero-DC offsets (see gp_striping)
                     zero_dc=True,
                 )
-                h5, _, ks5 = gp_amprow_offsets(base, fitmask, rho=rho_short,
+                h5, _, ks5 = gp_amprow_offsets(base, fitmask_1f,
+                                               rho=rho_short,
                                                amplitude_data=amp5, **gp_kw)
                 amp20 = (amp5 - h5) if amp5 is not None else None
-                h20, _, ks20 = gp_amprow_offsets(base - h5, fitmask,
+                h20, _, ks20 = gp_amprow_offsets(base - h5, fitmask_1f,
                                                  rho=rho_long,
                                                  amplitude_data=amp20, **gp_kw)
                 h = h5 + h20
                 ks_last = f'{ks5:.3e}/{ks20:.3e}'
             else:  # 'median' — legacy reference arm (h+v together)
                 h, vcol, ampc, _ = oneoverf.fit_residual_striping(
-                    meas, fitmask, maxiters, estimator='median')
+                    meas, fitmask_1f, maxiters, estimator='median')
                 ampc_last = ','.join(ampc)
 
             # (6) legacy fit_order='last': applied fit on the 1/f-corrected
@@ -461,6 +483,8 @@ def bkg_step(exposure_file, field, step_config, overwrite=False, status=None,
             f'detrend={"box%d" % det_box if detrend_on else "off"}, '
             f'subtract_2d={subtract_2d}'
         )
+        if strp_extra_dilate > 0:
+            cfp_value += f', strp_dilate={strp_extra_dilate * f2:.0f}'
         if estimator == 'gp':
             cfp_value += (f', rho_short={rho_short}, rho_long={rho_long}, '
                           f'kernel_sigma[last]={ks_last}')

--- a/pipeline/campfire_pipeline/nircam/steps/bkg.py
+++ b/pipeline/campfire_pipeline/nircam/steps/bkg.py
@@ -10,11 +10,27 @@ flux-calibrated cal-stage data. One iterative chain, one shared source mask:
                   fit directly on the residual — the coarse box is the
                   protection against absorbing detector striping
         ped     = pedestal on (residual - detrend)   # owns the DC (skymatch)
+        b2d     = optional APPLIED smooth 2-D background (subtract_2d),
+                  fit here when bkg2d.fit_order = "first" (recommended for
+                  bright/extended fields) or after the 1/f terms when "last"
         vcol    = per-column (vertical) 1/f, on the conditioned residual
-        h       = amp-row 1/f: GP ρ≈5 then ρ≈20, on the conditioned residual
-        b2d     = optional APPLIED smooth 2-D background (subtract_2d)
+                  (minus b2d when it was fit first)
+        h       = amp-row 1/f: GP ρ≈5 then ρ≈20, on the same residual
         residual -= ped + vcol + h + b2d             # detrend NOT subtracted
     rescale VAR_RNOISE on (residual - detrend), final mask
+
+With ``fit_order = "last"`` (the legacy order) the amp-row terms are fit
+before the applied 2-D model ever sees the frame, so unmasked halo/wing flux
+around bright galaxies leaks into the clipped amp-row medians and the GP —
+smooth structure slower than ρ is exactly what it follows — and is broadcast
+across each amp's full width: oversubtracted amp-blocky patches with hard
+edges at the amp boundaries (cols 512/1024/1536) and at the source's
+top/bottom rows. The 2-D fit then runs on the *post-h* residual, so it can
+never reclaim that flux, in this iteration or any later one (corrections
+accumulate one-way; the loop's fixed point — zero clipped amp-row medians —
+is satisfied by the artifact). ``fit_order = "first"`` fits the smooth model
+on ``resid - ped`` with the halo intact and conditions the 1/f measurement on
+its output, so smooth flux is claimed by the model that can represent it.
 
 Two 2-D fits with opposite jobs (design realization 2026-07-17; the split
 mirrors both the retired striping step's fit-only ``skyfit`` detrend and
@@ -133,6 +149,11 @@ def bkg_step(exposure_file, field, step_config, overwrite=False, status=None,
     var_cfg = step_config.get('variance', {})
     subtract_2d = bool(step_config.get('subtract_2d', False))
     b2d_cfg = step_config.get('bkg2d', {})
+    b2d_order = str(b2d_cfg.get('fit_order', 'last'))
+    _ORDERS = ('first', 'last')
+    if b2d_order not in _ORDERS:
+        raise ValueError(
+            f"[nircam.bkg.bkg2d].fit_order={b2d_order!r} not in {_ORDERS}")
     det_cfg = step_config.get('detrend', {})
     detrend_on = bool(det_cfg.get('enabled', True))
 
@@ -216,6 +237,18 @@ def bkg_step(exposure_file, field, step_config, overwrite=False, status=None,
                 bg_reject_dilate=float(b2d_cfg.get('reject_dilate', 40)) * f2,
             )
         sb = SubtractBackground.from_config(mcfg)
+        if subtract_2d and b2d_order == 'first' and sb.bg_reject:
+            # Measured on the synthetic amp-spanning-halo scene (see
+            # test_nircam_bkg.test_b2d_fit_order_first_starves_amprow_of_halo):
+            # the map-outlier reject flags the very halo bump the first-order
+            # fit exists to model, masks it, and refits it away — cancelling
+            # the reorder. Warn rather than override: reject still guards
+            # against compact-source leakage, so the trade is the field
+            # config's to make.
+            log(f"  {rootname}: bkg2d fit_order='first' with reject=true — "
+                f"the map-outlier reject can re-reject extended halo bumps "
+                f"and cancel the first-order benefit; consider "
+                f"[nircam.bkg.bkg2d].reject=false for bright-halo fields")
 
         # Conditioning detrend fitter: coarse box, undilated mask, no reject —
         # fit-only, so flux conservation cannot constrain it (see docstring).
@@ -298,14 +331,52 @@ def bkg_step(exposure_file, field, step_config, overwrite=False, status=None,
             ped, _ = pedestal_fn(cond, fitmask,
                                  sigma=ped_sigma, maxiters=maxiters)
 
-            # (4) VERTICAL + HORIZONTAL 1/f, on the conditioned residual
+            # (4) APPLIED smooth background (subtract_2d) — the sky-match /
+            #     ICL subtraction, with the source tiers grown by
+            #     extra_dilate (bit 0 — off-detector/DQ/NaN — is not grown,
+            #     so detector edges don't cost a dilated border band).
+            #     fit_order='first' fits it HERE, on resid - ped with halo /
+            #     wing flux still in the frame, so the smooth model gets
+            #     first claim on smooth structure and the 1/f terms below
+            #     measure a b2d-subtracted residual (the amp-blocky halo
+            #     oversubtraction fix — see module docstring). The ~20-row
+            #     banding still present under this fit averages out in the
+            #     32/64 px clipped mesh boxes, and the next iteration refits
+            #     on the striping-corrected residual anyway.
+            #     fit_order='last' is the legacy order: fit on the
+            #     1/f-corrected residual, after the amp-row terms.
+            b2d = 0.0
+            if subtract_2d:
+                src_only = (srcbits >> 1) != 0
+                if b2d_extra_dilate > 0:
+                    grown = (distance_transform_edt(~src_only)
+                             <= b2d_extra_dilate)
+                else:
+                    grown = src_only
+                b2d_mask = srcmask | grown | dq_fit
+                if b2d_order == 'first':
+                    b2d = sb.estimate_background(
+                        resid - ped, b2d_mask).background.astype(resid.dtype)
+
+            # (5) VERTICAL + HORIZONTAL 1/f, on the conditioned residual
+            #     (additionally minus the applied 2-D model when fit first —
+            #     b2d is 0.0 in the legacy order at this point)
+            meas = cond - ped - b2d
             if estimator == 'none':
                 vcol = np.zeros_like(resid)
                 h = np.zeros_like(resid)
             elif estimator == 'gp':
                 from campfire_pipeline.nircam.gp_striping import gp_amprow_offsets
-                vcol = oneoverf.column_pattern(cond - ped, fitmask, maxiters)
-                base = cond - ped - vcol
+                vcol = oneoverf.column_pattern(meas, fitmask, maxiters)
+                base = meas - vcol
+                # GP kernel amplitude is measured on the PRE-detrend frame
+                # (applied terms only): the prior must reflect how far the
+                # offsets vary across wide masked gaps, and the post-detrend
+                # residual underestimates that, over-regularizing the gap
+                # interpolation (gp_amprow_offsets docstring; rj0911 f444w
+                # calibration). With the detrend off the frames coincide, so
+                # skip the extra statistics pass.
+                amp5 = (base + det_struct) if detrend_on else None
                 gp_kw = dict(
                     kernel_sigma_factor=gp_cfg.get('kernel_sigma_factor', 1.0),
                     q=gp_cfg.get('q', 1.0 / np.sqrt(2.0)),
@@ -316,33 +387,26 @@ def bkg_step(exposure_file, field, step_config, overwrite=False, status=None,
                     # GP passes return zero-DC offsets (see gp_striping)
                     zero_dc=True,
                 )
-                h5, _, ks5 = gp_amprow_offsets(base, fitmask, rho=rho_short, **gp_kw)
+                h5, _, ks5 = gp_amprow_offsets(base, fitmask, rho=rho_short,
+                                               amplitude_data=amp5, **gp_kw)
+                amp20 = (amp5 - h5) if amp5 is not None else None
                 h20, _, ks20 = gp_amprow_offsets(base - h5, fitmask,
-                                                 rho=rho_long, **gp_kw)
+                                                 rho=rho_long,
+                                                 amplitude_data=amp20, **gp_kw)
                 h = h5 + h20
                 ks_last = f'{ks5:.3e}/{ks20:.3e}'
             else:  # 'median' — legacy reference arm (h+v together)
                 h, vcol, ampc, _ = oneoverf.fit_residual_striping(
-                    cond - ped, fitmask, maxiters, estimator='median')
+                    meas, fitmask, maxiters, estimator='median')
                 ampc_last = ','.join(ampc)
 
-            # (5) APPLIED smooth background (subtract_2d) — the sky-match /
-            #     ICL subtraction, fit on the 1/f-corrected residual with the
-            #     source tiers grown by extra_dilate (bit 0 — off-detector/
-            #     DQ/NaN — is not grown, so detector edges don't cost a
-            #     dilated border band).
-            if subtract_2d:
-                src_only = (srcbits >> 1) != 0
-                if b2d_extra_dilate > 0:
-                    grown = (distance_transform_edt(~src_only)
-                             <= b2d_extra_dilate)
-                else:
-                    grown = src_only
+            # (6) legacy fit_order='last': applied fit on the 1/f-corrected
+            #     residual. Whatever the amp-row terms absorbed above is
+            #     invisible to this fit — the reason 'first' exists.
+            if subtract_2d and b2d_order == 'last':
                 b2d = sb.estimate_background(
-                    resid - ped - vcol - h, srcmask | grown | dq_fit
+                    resid - ped - vcol - h, b2d_mask
                 ).background.astype(resid.dtype)
-            else:
-                b2d = 0.0
 
             step = ped + vcol + h + b2d
             resid -= step
@@ -355,7 +419,7 @@ def bkg_step(exposure_file, field, step_config, overwrite=False, status=None,
                 components_out['det_struct'] = (
                     det_struct if detrend_on else np.zeros_like(resid))
 
-        # (6) VARIANCE rescale on the final mask. Measure the sky variance on
+        # (7) VARIANCE rescale on the final mask. Measure the sky variance on
         #     the *conditioned* corrected residual (resid - det_struct): when
         #     the applied fit is off (or misses structure), retained sky
         #     structure would otherwise inflate the noise estimate.
@@ -363,7 +427,7 @@ def bkg_step(exposure_file, field, step_config, overwrite=False, status=None,
                                            model.var_rnoise, srcmask,
                                            block_size)
 
-        # (7) Write. SCI = original - accumulated correction.
+        # (8) Write. SCI = original - accumulated correction.
         outsci = sci0 - correction
         outsci[sci0 == 0] = 0
         wnan = np.isnan(outsci)
@@ -409,7 +473,8 @@ def bkg_step(exposure_file, field, step_config, overwrite=False, status=None,
             cfp_value += (
                 f', bkg2d_box={b2d_box}, '
                 f'bkg2d_dilate={b2d_extra_dilate:.0f}, '
-                f'bkg2d_reject={sb.bg_reject}'
+                f'bkg2d_reject={sb.bg_reject}, '
+                f'bkg2d_order={b2d_order}'
             )
 
         sci_after = model.data.copy() if do_plot else None

--- a/pipeline/campfire_pipeline/nircam/steps/bkg.py
+++ b/pipeline/campfire_pipeline/nircam/steps/bkg.py
@@ -166,6 +166,14 @@ def bkg_step(exposure_file, field, step_config, overwrite=False, status=None,
     remask = strp_cfg.get('remask_each_iter', True)
     # Angular px (channel-scaled below, like the mask/bkg2d length params).
     strp_extra_dilate = float(strp_cfg.get('extra_dilate', 0.0))
+    # Only grow source-tier footprints at least this big (angular px^2,
+    # channel-scaled x f^2). 0 = grow everything. Growing ALL tiers starves
+    # the amp-row anchors frame-wide (hundreds of faint sources each donate
+    # a grown disk) and the GP then follows sampling noise — measured on the
+    # amprow_halo harness (strp_d150 arm): injected row/column striping and
+    # a remask runaway. The artifact driver is the few LARGE footprints, so
+    # grow only those.
+    strp_min_area = float(strp_cfg.get('extra_dilate_min_area', 0.0))
     gp_cfg = strp_cfg.get('gp', {})
     rho_short = gp_cfg.get('rho_short', 5.0)
     rho_long = gp_cfg.get('rho_long', 20.0)
@@ -315,6 +323,17 @@ def bkg_step(exposure_file, field, step_config, overwrite=False, status=None,
             # the applied 2-D fit keep their own masks.
             if strp_extra_dilate > 0:
                 src_only_1f = (srcbits >> 1) != 0
+                if strp_min_area > 0:
+                    # grow only the large footprints (the artifact drivers);
+                    # see the config-parse comment for why growing all tiers
+                    # backfires
+                    from scipy.ndimage import label as ndi_label
+                    lab, nlab = ndi_label(src_only_1f)
+                    if nlab:
+                        areas = np.bincount(lab.ravel())
+                        keep = areas >= strp_min_area * f2 * f2
+                        keep[0] = False
+                        src_only_1f = keep[lab]
                 grown_1f = (distance_transform_edt(~src_only_1f)
                             <= strp_extra_dilate * f2)
                 fitmask_1f = fitmask | grown_1f
@@ -404,6 +423,7 @@ def bkg_step(exposure_file, field, step_config, overwrite=False, status=None,
                     sigma_clip_sigma=gp_cfg.get('sigma_clip', 2.0),
                     maxiters=maxiters,
                     weak_frac=gp_cfg.get('weak_frac', 0.5),
+                    min_row_pixels=int(gp_cfg.get('min_row_pixels', 0)),
                     # pedestal is the chain's only per-amp DC carrier: the
                     # GP passes return zero-DC offsets (see gp_striping)
                     zero_dc=True,

--- a/pipeline/experiments/amprow_halo/README.md
+++ b/pipeline/experiments/amprow_halo/README.md
@@ -1,0 +1,75 @@
+# amprow_halo — eye-first harness for the amp-row halo-oversubtraction artifact
+
+Synthetic testbed for the row-wise artifacts around bright multi-amp galaxies
+on `subtract_2d` fields (issue context: bright-galaxy halos leak into the
+per-amp-row 1/f estimate and get broadcast across the amp — oversubtracted
+amp-blocks with hard edges at cols 512/1024/1536 and at the source's
+top/bottom rows).
+
+**The metric is the eye.** The harness renders PNGs and nothing else — no
+summary tables, no scores. A mitigation succeeds when the artifact visibly
+shrinks in `compare_error.png` (and the corrected frames stay clean in
+`compare_after.png`) *as judged by a human looking at the images*. Derived
+statistics have already misled once here (the fit_order='first' reorder
+looked good numerically on synthetics, was rejected on real frames by eye) —
+do not reintroduce them as the decision criterion.
+
+## Scene
+
+`scene.py` (shared with `../bkg2d_synthetic`), preset `brightfield`:
+
+- a few very bright extended ellipticals (n≈3–4.5 bodies → galaxy plane),
+  the first few pinned near amp boundaries so they span amps, each with a
+  broad n=1 halo envelope (→ ICL plane — an *accepted loss* under
+  `subtract_2d`; the artifact under study is its row-wise misattribution,
+  not its removal);
+- ~450 fainter field galaxies (power-law fluxes, sub-threshold tail);
+- sky = level + linear gradient + a smooth *complex* component
+  (`sky_patch_amp`, a Gaussian random field at ~400 px) — what
+  `subtract_2d` exists to remove;
+- injected detector systematics (`inject_1f`): per-amp DC offsets, two-scale
+  per-amp row banding, column stripes.
+
+The real `bkg_step` runs on a jwst ImageModel of the scene with
+`subtract_2d = true` and the shipped defaults (matching the production
+user-config), so mask building, channel scaling, iteration, remask and
+provenance are all exercised.
+
+## Arms
+
+Config-override dicts in `run_harness.py::ARMS` — edit to add levers:
+
+| arm | override |
+|---|---|
+| `baseline` | shipped defaults (artifact reproduction) |
+| `strp_d40/80/150` | `[nircam.bkg.striping].extra_dilate` = 40/80/150 — grow the source tiers for the **1/f fit mask only**; the amp-row anchors move off the halos and the GP bridges the widened gaps |
+| `ideal_1f` | truth arm: injected stripes subtracted exactly, `estimator='none'` — the floor any 1/f estimator could reach; the eye's reference |
+
+## Outputs (per run, under `--out`)
+
+- `input.png`, `target.png` — the scene and the goal (galaxies + noise).
+- `{arm}_after.png` — corrected frame, real-image asinh stretch.
+- `{arm}_error.png` — **the diagnostic**: `after − target` where target has
+  sky + stripes + halo plane removed; diverging map, sources whited out.
+  Amp-blocky red/blue structure with hard edges at 512/1024/1536 = the
+  artifact.
+- `{arm}_hledger.png` — the accumulated amp-row term; where row artifacts
+  live before they hit the frame.
+- `compare_after.png`, `compare_error.png` — all arms side by side on
+  identical stretches.
+
+## Usage
+
+```bash
+# campfire conda env, from this directory
+python run_harness.py --out out                 # full 2048², ~1–2 min/arm
+python run_harness.py --out out --quick         # 1024-row smoke
+python run_harness.py --out out --arms baseline,strp_d80,ideal_1f
+python run_harness.py --out out --seed 3 --halo-peak 3 --sky-patch-amp 0.15
+```
+
+## History
+
+- 2026-08-13: harness created after the `fit_order='first'` reorder was
+  rejected on real frames (sometimes better, often worse, by eye — with
+  `reject=false`). First lever under test: `striping.extra_dilate`.

--- a/pipeline/experiments/amprow_halo/README.md
+++ b/pipeline/experiments/amprow_halo/README.md
@@ -73,3 +73,15 @@ python run_harness.py --out out --seed 3 --halo-peak 3 --sky-patch-amp 0.15
 - 2026-08-13: harness created after the `fit_order='first'` reorder was
   rejected on real frames (sometimes better, often worse, by eye — with
   `reject=false`). First lever under test: `striping.extra_dilate`.
+- 2026-08-13 (later): mask-growth levers rejected on the harness (global
+  growth injects row/column noise via frame-wide anchor starvation;
+  selective growth at 80 px is a no-op — halos are broader than the push;
+  300 px trades blocks for fine noise lines). The **anisotropic
+  conditioning detrend** (`aniso_y96x32`: `detrend.box_size=96,
+  box_size_x=32, filter_size=[1,5]`) removed the amp-row misattribution
+  nearly completely on both the standard and `--giant` BCG stress scenes,
+  with no visible banding absorption; judged by eye (HA): "genuinely
+  pretty good", 96×32 preferred, marginally better with `bkg2d.reject =
+  false`. The remaining smooth halo-shaped residual is the b2d fit's own
+  error (identical in `ideal_1f`) — a separate workstream. Real-frame
+  validation: `docs/handoff-aniso-detrend.md`.

--- a/pipeline/experiments/amprow_halo/run_harness.py
+++ b/pipeline/experiments/amprow_halo/run_harness.py
@@ -200,6 +200,23 @@ def plot_compare(path, rows, sigma, kind):
     plt.close(fig)
 
 
+def amprow_ledger_error(h, stripes):
+    """Fitted amp-row profile minus the injected truth banding, per amp,
+    both zero-DC per amp — the isolator for row-wise MISattribution (halo
+    theft, noise-following). Zero everywhere = perfect amp-row estimate;
+    the real banding is removed from view by construction."""
+    err = np.zeros_like(h)
+    W = h.shape[1]
+    for c0 in range(0, W, 512):
+        c1 = min(c0 + 512, W)
+        hprof = np.median(h[:, c0:c1], axis=1)
+        tprof = np.median(stripes[:, c0:c1], axis=1)
+        hprof = hprof - np.median(hprof)
+        tprof = tprof - np.median(tprof)
+        err[:, c0:c1] = (hprof - tprof)[:, None]
+    return err
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__.split('\n')[0])
     ap.add_argument('--out', default='out')
@@ -261,6 +278,7 @@ def main():
 
     gray_rows = [('input', image, None)]
     err_rows = []
+    hrow_rows = []
     for name in arm_names:
         print(f'-- arm {name}', flush=True)
         sc = deep_merge(defaults, ARMS[name])
@@ -299,6 +317,13 @@ def main():
                               h, np.zeros_like(srcmask), sig,
                               f'{name}: accumulated amp-row term h [±'
                               f'{ERR_SPAN:.1f}σ]')
+            hrow = amprow_ledger_error(np.asarray(h, dtype=np.float64),
+                                       scene.stripes)
+            plot_single_error(os.path.join(args.out, f'{name}_hrow_err.png'),
+                              hrow, np.zeros_like(srcmask), sig,
+                              f'{name}: amp-row ledger error (fitted − '
+                              f'injected banding) [±{ERR_SPAN:.1f}σ]')
+            hrow_rows.append((f'{name}: amp-row ledger error', hrow, None))
 
         gray_rows.append((f'{name}: after', after, None))
         err_rows.append((f'{name}: after − target', err_map, srcmask))
@@ -317,6 +342,9 @@ def main():
                  gray_rows, sig, 'gray')
     plot_compare(os.path.join(args.out, 'compare_error.png'),
                  err_rows, sig, 'error')
+    if hrow_rows:
+        plot_compare(os.path.join(args.out, 'compare_hrow_err.png'),
+                     hrow_rows, sig, 'error')
 
     if not args.keep_fits:
         shutil.rmtree(workdir, ignore_errors=True)

--- a/pipeline/experiments/amprow_halo/run_harness.py
+++ b/pipeline/experiments/amprow_halo/run_harness.py
@@ -60,11 +60,26 @@ from scene import make_scene  # noqa: E402
 # ---------------------------------------------------------------------------
 ARMS = {
     'baseline': {},
+    # global growth — kept as the cautionary reference: growing every tier
+    # starves the anchors frame-wide and injects row/column noise
     'strp_d40': {'striping': {'extra_dilate': 40}},
     'strp_d80': {'striping': {'extra_dilate': 80}},
     'strp_d150': {'striping': {'extra_dilate': 150}},
+    # selective growth: only footprints >= min_area px^2 (the few bright
+    # galaxies) are grown; faint-source anchors untouched
+    'sel_d80': {'striping': {'extra_dilate': 80,
+                             'extra_dilate_min_area': 10000}},
+    'sel_d150': {'striping': {'extra_dilate': 150,
+                              'extra_dilate_min_area': 10000}},
+    # selective growth + anchor floor: starved rows (< 50 px) become true
+    # GP gaps instead of overconfident anchors
+    'sel_d80_floor': {'striping': {'extra_dilate': 80,
+                                   'extra_dilate_min_area': 10000,
+                                   'gp': {'min_row_pixels': 50}}},
     'ideal_1f': {'striping': {'estimator': 'none'}},
 }
+DEFAULT_ARMS = ['baseline', 'sel_d80', 'sel_d150', 'sel_d80_floor',
+                'ideal_1f']
 
 
 def deep_merge(base, over):
@@ -189,7 +204,7 @@ def main():
     ap = argparse.ArgumentParser(description=__doc__.split('\n')[0])
     ap.add_argument('--out', default='out')
     ap.add_argument('--seed', type=int, default=0)
-    ap.add_argument('--arms', default=','.join(ARMS),
+    ap.add_argument('--arms', default=','.join(DEFAULT_ARMS),
                     help='comma list from: ' + ', '.join(ARMS))
     ap.add_argument('--n-gal', type=int, default=450)
     ap.add_argument('--n-bright', type=int, default=5)

--- a/pipeline/experiments/amprow_halo/run_harness.py
+++ b/pipeline/experiments/amprow_halo/run_harness.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python
+"""Eye-first synthetic harness for the amp-row halo-oversubtraction artifact.
+
+Builds a 'brightfield' scene (a few very bright extended galaxies — some
+deliberately spanning amp boundaries — many faint ones, a smooth-but-complex
+2-D background, injected per-amp 1/f + DC + column stripes), runs the REAL
+``bkg_step`` with ``subtract_2d = true`` per mitigation arm, and renders PNGs.
+
+THE METRIC IS THE EYE. This harness deliberately produces no summary tables:
+success is judged by looking at the PNGs — primarily ``{arm}_error.png``
+(correction error, diverging colormap, sources whited out: the amp-blocky
+row-wise artifacts show as red/blue blocks with hard edges at cols
+512/1024/1536, like the real-frame screenshots) and ``{arm}_after.png``
+(the corrected frame at a real-image stretch). ``compare_error.png`` /
+``compare_after.png`` put all arms side by side. Do not replace this with
+derived statistics when evaluating mitigations.
+
+Arms are config-override dicts (deep-merged over the shipped
+``[nircam.bkg]`` defaults + ``subtract_2d = true``) — edit ``ARMS`` to add
+levers. Shipped arms:
+
+    baseline    shipped defaults (the artifact reproduction)
+    strp_d40 /
+    strp_d80 /
+    strp_d150   [nircam.bkg.striping].extra_dilate = 40/80/150 — grow the
+                source tiers for the 1/f fit mask only, pushing the amp-row
+                anchors off the halos (the GP bridges the gap)
+    ideal_1f    truth arm: the injected stripes+DC are subtracted exactly and
+                only the 2-D/pedestal machinery runs (estimator='none') — the
+                best any 1/f estimator could do; the eye's reference point
+
+Usage (campfire conda env, from this directory):
+
+    python run_harness.py --out out            # full 2048^2, ~2 min/arm
+    python run_harness.py --out out --quick    # 1024-row smoke
+    python run_harness.py --out out --arms baseline,strp_d80
+"""
+
+import argparse
+import copy
+import os
+import shutil
+import sys
+import time
+import tomllib
+
+import numpy as np
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from astropy.io import fits
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                '..', 'bkg2d_synthetic'))
+from scene import make_scene  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Arms: name -> deep-merged overrides on the [nircam.bkg] defaults.
+# 'ideal_1f' is special-cased (truth subtraction, estimator='none').
+# ---------------------------------------------------------------------------
+ARMS = {
+    'baseline': {},
+    'strp_d40': {'striping': {'extra_dilate': 40}},
+    'strp_d80': {'striping': {'extra_dilate': 80}},
+    'strp_d150': {'striping': {'extra_dilate': 150}},
+    'ideal_1f': {'striping': {'estimator': 'none'}},
+}
+
+
+def deep_merge(base, over):
+    out = copy.deepcopy(base)
+    for k, v in over.items():
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = deep_merge(out[k], v)
+        else:
+            out[k] = v
+    return out
+
+
+def load_bkg_defaults():
+    import campfire_pipeline
+    path = os.path.join(os.path.dirname(campfire_pipeline.__file__),
+                        'data', 'config_default.toml')
+    with open(path, 'rb') as f:
+        cfg = tomllib.load(f)
+    return cfg['nircam']['bkg']
+
+
+def save_model(scene, path, remove_truth=None):
+    from jwst.datamodels import ImageModel
+    m = ImageModel()
+    img = scene.image.astype(np.float64)
+    if remove_truth is not None:
+        img = img - remove_truth
+        img[~scene.valid] = 0.0
+    m.data = img.astype(np.float32)
+    m.err = scene.err
+    m.dq = np.where(scene.valid, 0, 1).astype(np.uint32)
+    m.var_rnoise = np.full(scene.shape, (0.6 * scene.sigma) ** 2, np.float32)
+    m.var_poisson = np.full(scene.shape, (0.2 * scene.sigma) ** 2, np.float32)
+    m.var_flat = np.full(scene.shape, (0.1 * scene.sigma) ** 2, np.float32)
+    m.meta.instrument.name = 'NIRCAM'
+    m.meta.instrument.channel = 'SHORT'
+    m.meta.instrument.detector = 'NRCA1'
+    m.save(path)
+
+
+# ---------------------------------------------------------------------------
+# Plotting — stretches chosen to mimic how the artifact is diagnosed on real
+# frames (grayscale asinh for images, diverging map with whited-out sources
+# for the error), all panels across arms on IDENTICAL stretches.
+# ---------------------------------------------------------------------------
+DS = 2          # display downsample
+GRAY_A = 2.0    # asinh softening, in sigma
+GRAY_LO, GRAY_HI = -1.5, 3.5    # asinh display range
+ERR_SPAN = 1.5  # diverging error map span, in sigma
+
+
+def _gray(img, med, sigma):
+    return np.arcsinh((img - med) / (GRAY_A * sigma))
+
+
+def plot_single_gray(path, img, sigma, title):
+    med = float(np.median(img))
+    disp = _gray(img, med, sigma)[::DS, ::DS]
+    n = disp.shape[0] / 100
+    fig, ax = plt.subplots(figsize=(disp.shape[1] / 100, n), dpi=100)
+    ax.imshow(disp, vmin=GRAY_LO, vmax=GRAY_HI, cmap='gray', origin='lower',
+              interpolation='nearest')
+    ax.set_axis_off()
+    ax.set_position([0, 0, 1, 1])
+    ax.text(0.01, 0.99, title, transform=ax.transAxes, va='top', ha='left',
+            color='yellow', fontsize=11)
+    fig.savefig(path)
+    plt.close(fig)
+
+
+def plot_single_error(path, err_map, srcmask, sigma, title):
+    disp = np.where(srcmask, np.nan, err_map)
+    disp = disp - np.nanmedian(disp)
+    disp = disp[::DS, ::DS]
+    fig, ax = plt.subplots(figsize=(disp.shape[1] / 100,
+                                    disp.shape[0] / 100), dpi=100)
+    cmap = plt.get_cmap('RdBu_r').copy()
+    cmap.set_bad('white')
+    ax.imshow(disp, vmin=-ERR_SPAN * sigma, vmax=ERR_SPAN * sigma,
+              cmap=cmap, origin='lower', interpolation='nearest')
+    ax.set_axis_off()
+    ax.set_position([0, 0, 1, 1])
+    ax.text(0.01, 0.99, title, transform=ax.transAxes, va='top', ha='left',
+            color='black', fontsize=11)
+    fig.savefig(path)
+    plt.close(fig)
+
+
+def plot_compare(path, rows, sigma, kind):
+    """rows: list of (title, image, srcmask-or-None)."""
+    n = len(rows)
+    ncol = 2
+    nrow = (n + ncol - 1) // ncol
+    fig, axes = plt.subplots(nrow, ncol, figsize=(7.2 * ncol, 7.2 * nrow),
+                             dpi=110)
+    axes = np.atleast_1d(axes).ravel()
+    for ax in axes[n:]:
+        ax.set_axis_off()
+    for ax, (title, img, srcmask) in zip(axes, rows):
+        if kind == 'gray':
+            med = float(np.median(img))
+            ax.imshow(_gray(img, med, sigma)[::DS, ::DS], vmin=GRAY_LO,
+                      vmax=GRAY_HI, cmap='gray', origin='lower',
+                      interpolation='nearest')
+        else:
+            disp = np.where(srcmask, np.nan, img) if srcmask is not None \
+                else img
+            disp = disp - np.nanmedian(disp)
+            cmap = plt.get_cmap('RdBu_r').copy()
+            cmap.set_bad('white')
+            ax.imshow(disp[::DS, ::DS], vmin=-ERR_SPAN * sigma,
+                      vmax=ERR_SPAN * sigma, cmap=cmap, origin='lower',
+                      interpolation='nearest')
+        ax.set_title(title, fontsize=11)
+        ax.set_xticks([]), ax.set_yticks([])
+    fig.tight_layout()
+    fig.savefig(path)
+    plt.close(fig)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split('\n')[0])
+    ap.add_argument('--out', default='out')
+    ap.add_argument('--seed', type=int, default=0)
+    ap.add_argument('--arms', default=','.join(ARMS),
+                    help='comma list from: ' + ', '.join(ARMS))
+    ap.add_argument('--n-gal', type=int, default=450)
+    ap.add_argument('--n-bright', type=int, default=5)
+    ap.add_argument('--halo-peak', type=float, default=2.0,
+                    help='bright-galaxy halo envelope peak, in sigma_pix')
+    ap.add_argument('--sky-patch-amp', type=float, default=0.10,
+                    help='complex smooth background amplitude, in sky units')
+    ap.add_argument('--quick', action='store_true',
+                    help='1024-row frame, fewer galaxies')
+    ap.add_argument('--keep-fits', action='store_true')
+    ap.add_argument('--save-arrays', action='store_true',
+                    help='save per-arm float32 npz (after/error/h/b2d/mask)')
+    args = ap.parse_args()
+
+    shape = (1024, 2048) if args.quick else (2048, 2048)
+    n_gal = min(args.n_gal, 200) if args.quick else args.n_gal
+
+    os.makedirs(args.out, exist_ok=True)
+    workdir = os.path.join(args.out, 'work')
+    os.makedirs(workdir, exist_ok=True)
+
+    print(f'== building brightfield scene seed={args.seed} '
+          f'{shape[0]}x{shape[1]} ({n_gal} faint + {args.n_bright} bright)',
+          flush=True)
+    scene = make_scene(preset='brightfield', shape=shape, channel='sw',
+                       seed=args.seed, n_gal=n_gal, n_bright=args.n_bright,
+                       bright_halo_peak_sigma=args.halo_peak,
+                       sky_patch_amp=args.sky_patch_amp,
+                       inject_1f=True)
+    sig = scene.sigma
+    image = scene.image.astype(np.float64)
+    # everything the step is ALLOWED to remove: sky (incl. complex patches),
+    # injected detector systematics, and the halo/ICL plane (accepted loss
+    # under subtract_2d). The error map charges only what is removed BEYOND
+    # this (galaxy flux / noise structure) or missed from it.
+    removable = scene.sky + scene.stripes + scene.icl
+    target = image - removable          # galaxies + noise (the eye's goal)
+
+    pristine = os.path.join(workdir, f'scene_s{args.seed}.fits')
+    save_model(scene, pristine)
+
+    plot_single_gray(os.path.join(args.out, 'input.png'), image, sig,
+                     'input frame (sky + stripes + halos + galaxies)')
+    plot_single_gray(os.path.join(args.out, 'target.png'), target, sig,
+                     'target: galaxies + noise (all removable removed)')
+
+    defaults = load_bkg_defaults()
+    from campfire_pipeline.nircam.steps.bkg import bkg_step
+
+    arm_names = [a for a in args.arms.split(',') if a]
+    unknown = [a for a in arm_names if a not in ARMS]
+    if unknown:
+        ap.error(f'unknown arms: {unknown}')
+
+    gray_rows = [('input', image, None)]
+    err_rows = []
+    for name in arm_names:
+        print(f'-- arm {name}', flush=True)
+        sc = deep_merge(defaults, ARMS[name])
+        sc['subtract_2d'] = True
+        sc['plot'] = False
+
+        workfile = os.path.join(workdir, 'run.fits')
+        if name == 'ideal_1f':
+            # truth arm: hand the step a frame whose detector systematics
+            # are already exactly removed; run mask/pedestal/b2d only
+            save_model(scene, workfile, remove_truth=scene.stripes)
+        else:
+            shutil.copyfile(pristine, workfile)
+
+        comp = {}
+        t0 = time.time()
+        bkg_step(workfile, None, sc, overwrite=True, components_out=comp)
+        print(f'   bkg_step {time.time() - t0:.0f}s', flush=True)
+
+        with fits.open(workfile) as hdul:
+            after = hdul['SCI'].data.astype(np.float64)
+            srcmask = hdul['SRCMASK'].data.astype(bool)
+        # ideal_1f's input had the stripes pre-removed, so its error map is
+        # free of 1/f residuals by construction — the reference floor.
+        err_map = after - target
+
+        plot_single_gray(os.path.join(args.out, f'{name}_after.png'),
+                         after, sig, f'{name}: after bkg')
+        plot_single_error(os.path.join(args.out, f'{name}_error.png'),
+                          err_map, srcmask, sig,
+                          f'{name}: after − target  '
+                          f'[±{ERR_SPAN:.1f}σ, sources whited]')
+        h = comp.get('h')
+        if h is not None and np.ndim(h) and h.any():
+            plot_single_error(os.path.join(args.out, f'{name}_hledger.png'),
+                              h, np.zeros_like(srcmask), sig,
+                              f'{name}: accumulated amp-row term h [±'
+                              f'{ERR_SPAN:.1f}σ]')
+
+        gray_rows.append((f'{name}: after', after, None))
+        err_rows.append((f'{name}: after − target', err_map, srcmask))
+
+        if args.save_arrays:
+            np.savez_compressed(
+                os.path.join(args.out, f'{name}_arrays.npz'),
+                after=after.astype(np.float32),
+                error=err_map.astype(np.float32),
+                srcmask=srcmask,
+                **{k: np.asarray(v).astype(np.float32)
+                   for k, v in comp.items()
+                   if k in ('h', 'b2d', 'vcol', 'ped', 'det_struct')})
+
+    plot_compare(os.path.join(args.out, 'compare_after.png'),
+                 gray_rows, sig, 'gray')
+    plot_compare(os.path.join(args.out, 'compare_error.png'),
+                 err_rows, sig, 'error')
+
+    if not args.keep_fits:
+        shutil.rmtree(workdir, ignore_errors=True)
+    print(f'wrote PNGs to {args.out}/ — judge by eye '
+          f'(compare_error.png first)', flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/pipeline/experiments/amprow_halo/run_harness.py
+++ b/pipeline/experiments/amprow_halo/run_harness.py
@@ -71,6 +71,9 @@ ARMS = {
                              'extra_dilate_min_area': 10000}},
     'sel_d150': {'striping': {'extra_dilate': 150,
                               'extra_dilate_min_area': 10000}},
+    'sel_d300': {'striping': {'extra_dilate': 300,
+                              'extra_dilate_min_area': 10000,
+                              'gp': {'min_row_pixels': 50}}},
     # selective growth + anchor floor: starved rows (< 50 px) become true
     # GP gaps instead of overconfident anchors
     'sel_d80_floor': {'striping': {'extra_dilate': 80,

--- a/pipeline/experiments/amprow_halo/run_harness.py
+++ b/pipeline/experiments/amprow_halo/run_harness.py
@@ -74,6 +74,13 @@ ARMS = {
     'sel_d300': {'striping': {'extra_dilate': 300,
                               'extra_dilate_min_area': 10000,
                               'gp': {'min_row_pixels': 50}}},
+    # anisotropic conditioning detrend: y-coarse (banding-blind by
+    # construction), x-fine (follows halo column profiles). filter [1, 5]
+    # keeps full y mesh resolution.
+    'aniso_y64x32': {'detrend': {'box_size': 64, 'box_size_x': 32,
+                                 'filter_size': [1, 5]}},
+    'aniso_y96x32': {'detrend': {'box_size': 96, 'box_size_x': 32,
+                                 'filter_size': [1, 5]}},
     # selective growth + anchor floor: starved rows (< 50 px) become true
     # GP gaps instead of overconfident anchors
     'sel_d80_floor': {'striping': {'extra_dilate': 80,

--- a/pipeline/experiments/amprow_halo/run_harness.py
+++ b/pipeline/experiments/amprow_halo/run_harness.py
@@ -81,6 +81,12 @@ ARMS = {
                                  'filter_size': [1, 5]}},
     'aniso_y96x32': {'detrend': {'box_size': 96, 'box_size_x': 32,
                                  'filter_size': [1, 5]}},
+    # aniso conditioning + no b2d map-outlier reject: tests whether reject
+    # (which re-flags halo bumps in the map as leaked source flux) is what
+    # caps the smooth residual the 2-D fit leaves around bright galaxies
+    'aniso_y96x32_norej': {'detrend': {'box_size': 96, 'box_size_x': 32,
+                                       'filter_size': [1, 5]},
+                           'bkg2d': {'reject': False}},
     # selective growth + anchor floor: starved rows (< 50 px) become true
     # GP gaps instead of overconfident anchors
     'sel_d80_floor': {'striping': {'extra_dilate': 80,
@@ -237,6 +243,9 @@ def main():
     ap.add_argument('--n-bright', type=int, default=5)
     ap.add_argument('--halo-peak', type=float, default=2.0,
                     help='bright-galaxy halo envelope peak, in sigma_pix')
+    ap.add_argument('--giant', action='store_true',
+                    help='add a BCG-scale galaxy (r_e ~90 px body, ~360 px '
+                         'halo envelope) centered on an amp boundary')
     ap.add_argument('--sky-patch-amp', type=float, default=0.10,
                     help='complex smooth background amplitude, in sky units')
     ap.add_argument('--quick', action='store_true',
@@ -259,6 +268,7 @@ def main():
     scene = make_scene(preset='brightfield', shape=shape, channel='sw',
                        seed=args.seed, n_gal=n_gal, n_bright=args.n_bright,
                        bright_halo_peak_sigma=args.halo_peak,
+                       giant=args.giant,
                        sky_patch_amp=args.sky_patch_amp,
                        inject_1f=True)
     sig = scene.sigma

--- a/pipeline/experiments/bkg2d_synthetic/scene.py
+++ b/pipeline/experiments/bkg2d_synthetic/scene.py
@@ -222,7 +222,10 @@ def _render_fullframe_sersic(shape, x0, y0, r_e, n, q, pa, peak):
 def make_scene(preset='cluster', shape=(2048, 2048), channel='sw', seed=0,
                sigma=0.05, sky_level=1.0, grad_amp=0.2, n_gal=500,
                icl_peak_sigma=0.6, margin=24, inject_1f=False,
-               amp_dc_sigma=0.5, banding_sigma=0.3, colstripe_sigma=0.15):
+               amp_dc_sigma=0.5, banding_sigma=0.3, colstripe_sigma=0.15,
+               n_bright=5, bright_flux_range=(2e5, 2e6),
+               bright_halo_peak_sigma=2.0,
+               sky_patch_amp=0.0, sky_patch_scale=400.0):
     """Build a Scene.
 
     preset='blank': uniform field population, no ICL plane.
@@ -230,7 +233,20 @@ def make_scene(preset='cluster', shape=(2048, 2048), channel='sw', seed=0,
       component BCG (inner n=4 -> galaxy plane; outer envelope -> ICL plane)
       and a large ICL envelope (peak ``icl_peak_sigma`` * sigma per px,
       i.e. ~3% of sky at the defaults — mu ~ 26-28 mag/arcsec^2 territory).
+    preset='brightfield': the amp-row-artifact scene (the "cluster outskirts"
+      look of e.g. jw03073 A2744 frames): ``n_bright`` very bright extended
+      ellipticals scattered across the frame — the first few deliberately
+      near amp boundaries (cols 512/1024/1536), since a source *spanning*
+      amps is the artifact's trigger — each with a compact n~3-4 body
+      (galaxy plane) plus a broad n~1 halo envelope rendered full-frame into
+      the ICL plane (peak ``bright_halo_peak_sigma`` * sigma; accepted loss
+      under subtract_2d, exactly the flux whose *row-wise* misattribution is
+      the artifact under study).
     grad_amp: linear sky gradient amplitude across the frame, in sky units.
+    sky_patch_amp: adds a smooth "complex" background component — a Gaussian
+      random field (white noise smoothed at ``sky_patch_scale`` px, unit-std
+      normalized) times this amplitude in sky units. This is the structure
+      subtract_2d exists to remove; 0 disables (legacy scenes unchanged).
     inject_1f: add detector systematics (per-amp DC offsets + amp-row
       banding + column stripes; amplitudes in sigma_pix units) as a separate
       ``stripes`` truth plane — required to exercise the GP / per-amp-DC
@@ -251,6 +267,16 @@ def make_scene(preset='cluster', shape=(2048, 2048), channel='sw', seed=0,
     ramp = (np.cos(ang) * xx + np.sin(ang) * yy) / max(H, W)
     scene.sky = (sky_level + grad_amp * (ramp - ramp.mean())).astype(
         np.float64)
+    if sky_patch_amp > 0:
+        # smooth "complex" component: unit-std Gaussian random field at the
+        # patch scale (pad-free: smooth a larger grid and crop the center so
+        # the field statistics don't taper at the frame edge)
+        pad = int(2 * sky_patch_scale)
+        grf = gaussian_filter(rng.normal(0, 1, (H + 2 * pad, W + 2 * pad)),
+                              sky_patch_scale, mode='wrap')
+        grf = grf[pad:pad + H, pad:pad + W]
+        grf = (grf - grf.mean()) / grf.std()
+        scene.sky += sky_patch_amp * grf
 
     scene.galaxies = np.zeros(shape, np.float64)
     scene.icl = np.zeros(shape, np.float64)
@@ -285,6 +311,31 @@ def make_scene(preset='cluster', shape=(2048, 2048), channel='sw', seed=0,
         comps.append((2e5 * sigma, 25.0 * scale, 4.0, 0.8,
                       rng.uniform(0, np.pi), cx, cy, 'galaxy'))
 
+    bright = []
+    if preset == 'brightfield':
+        # a few very bright extended ellipticals scattered over the frame,
+        # the first few pinned near amp boundaries so they span amps
+        bounds = [512, 1024, 1536]
+        bx, by = [], []
+        for i in range(n_bright):
+            if i < len(bounds):
+                x = int(np.clip(bounds[i] + rng.integers(-140, 140),
+                                margin, W - margin))
+            else:
+                x = int(rng.integers(margin, W - margin))
+            bx.append(x)
+            by.append(int(rng.integers(H // 8, H - H // 8)))
+        lo, hi = bright_flux_range
+        bflux = _sample_powerlaw(rng, n_bright, lo, hi, alpha=1.5) * sigma
+        bre = rng.uniform(15, 45, n_bright) * scale
+        bn = rng.uniform(2.8, 4.5, n_bright)
+        bq = rng.uniform(0.55, 0.9, n_bright)
+        bpa = rng.uniform(0, np.pi, n_bright)
+        comps += [(bflux[i], bre[i], bn[i], bq[i], bpa[i],
+                   bx[i], by[i], 'galaxy') for i in range(n_bright)]
+        bright = [(bx[i], by[i], bre[i], bq[i], bpa[i], bflux[i])
+                  for i in range(n_bright)]
+
     for f, re_i, ni, qi, pai, ix, iy, kind in comps:
         stamp, dx, dy = render_sersic_stamp(rng, f, re_i, ni, qi, pai)
         plane = scene.galaxies if kind == 'galaxy' else scene.icl
@@ -309,6 +360,21 @@ def make_scene(preset='cluster', shape=(2048, 2048), channel='sw', seed=0,
             scene.sources.append(Source(
                 x=cx, y=cy, flux=float(plane.sum()), r_e=re_i, n=ni, q=qi,
                 pa=pai, kind='icl', peak=float(peak)))
+
+    if preset == 'brightfield':
+        # halo envelopes of the bright galaxies -> ICL plane (accepted loss
+        # under subtract_2d; the artifact under study is their row-wise
+        # misattribution, not their removal). Peak scales weakly with the
+        # body flux so the brightest galaxies carry the biggest halos.
+        fmax = max(f for *_, f in bright)
+        for hx, hy, re_i, qi, pai, f in bright:
+            peak = bright_halo_peak_sigma * sigma * (f / fmax) ** 0.5
+            plane = _render_fullframe_sersic(shape, hx, hy, 4.0 * re_i, 1.0,
+                                             qi, pai, peak)
+            scene.icl += plane
+            scene.sources.append(Source(
+                x=hx, y=hy, flux=float(plane.sum()), r_e=4.0 * re_i, n=1.0,
+                q=qi, pa=pai, kind='icl', peak=float(peak)))
 
     if inject_1f:
         scene.stripes = _inject_stripes(rng, shape, sigma, amp_dc_sigma,

--- a/pipeline/experiments/bkg2d_synthetic/scene.py
+++ b/pipeline/experiments/bkg2d_synthetic/scene.py
@@ -225,6 +225,8 @@ def make_scene(preset='cluster', shape=(2048, 2048), channel='sw', seed=0,
                amp_dc_sigma=0.5, banding_sigma=0.3, colstripe_sigma=0.15,
                n_bright=5, bright_flux_range=(2e5, 2e6),
                bright_halo_peak_sigma=2.0,
+               giant=False, giant_flux=5e6, giant_re=90.0,
+               giant_halo_peak_sigma=4.0,
                sky_patch_amp=0.0, sky_patch_scale=400.0):
     """Build a Scene.
 
@@ -335,6 +337,22 @@ def make_scene(preset='cluster', shape=(2048, 2048), channel='sw', seed=0,
                    bx[i], by[i], 'galaxy') for i in range(n_bright)]
         bright = [(bx[i], by[i], bre[i], bq[i], bpa[i], bflux[i])
                   for i in range(n_bright)]
+        if giant:
+            # BCG-scale stress case: body far larger than any field member,
+            # centered ON an amp boundary so it spans amps by construction;
+            # its halo envelope (4 x r_e, n=1, giant_halo_peak_sigma) can
+            # cover most of an amp's width
+            gx = int(np.clip(1024 + rng.integers(-60, 60),
+                             margin, W - margin))
+            gy = int(rng.integers(2 * H // 5, 3 * H // 5))
+            gq = rng.uniform(0.6, 0.85)
+            gpa = rng.uniform(0, np.pi)
+            gre = giant_re * scale
+            comps.append((giant_flux * sigma, gre, 4.0, gq, gpa,
+                          gx, gy, 'galaxy'))
+            giant_env = (gx, gy, gre, gq, gpa)
+        else:
+            giant_env = None
 
     for f, re_i, ni, qi, pai, ix, iy, kind in comps:
         stamp, dx, dy = render_sersic_stamp(rng, f, re_i, ni, qi, pai)
@@ -367,8 +385,14 @@ def make_scene(preset='cluster', shape=(2048, 2048), channel='sw', seed=0,
         # misattribution, not their removal). Peak scales weakly with the
         # body flux so the brightest galaxies carry the biggest halos.
         fmax = max(f for *_, f in bright)
-        for hx, hy, re_i, qi, pai, f in bright:
-            peak = bright_halo_peak_sigma * sigma * (f / fmax) ** 0.5
+        envs = [(hx, hy, re_i, qi, pai,
+                 bright_halo_peak_sigma * sigma * (f / fmax) ** 0.5)
+                for hx, hy, re_i, qi, pai, f in bright]
+        if giant_env is not None:
+            gx, gy, gre, gq, gpa = giant_env
+            envs.append((gx, gy, gre, gq, gpa,
+                         giant_halo_peak_sigma * sigma))
+        for hx, hy, re_i, qi, pai, peak in envs:
             plane = _render_fullframe_sersic(shape, hx, hy, 4.0 * re_i, 1.0,
                                              qi, pai, peak)
             scene.icl += plane

--- a/pipeline/tests/test_nircam_bkg.py
+++ b/pipeline/tests/test_nircam_bkg.py
@@ -357,6 +357,114 @@ def test_skymatch_invariant_and_banding_removal():
         assert after[amp] < 0.3 * before[amp]
 
 
+def test_b2d_fit_order_first_starves_amprow_of_halo():
+    """The amp-blocky halo-oversubtraction mechanism and its fix.
+
+    A bright galaxy's halo is structurally invisible to the source mask (the
+    ring-median pre-filter removes structure broader than its radius before
+    tier detection), so unmasked halo flux enters the clipped amp-row medians
+    and the GP — smooth structure slower than rho is exactly what it follows —
+    and gets broadcast across the host amp's full width: oversubtracted
+    amp-blocks with hard edges at the amp boundaries. With the legacy
+    fit_order='last', the applied 2-D fit runs on the post-h residual, so it
+    can never reclaim that flux. fit_order='first' fits the smooth model with
+    the halo intact and conditions the 1/f measurement on it.
+
+    Replicates the step's per-iteration numerics (this suite's convention —
+    the I/O wrapper needs a datamodel), one iteration, no detrend (a coarse
+    fit-only detrend does not change the mechanism). Three pinned facts:
+
+    1. 'last' leaks the halo's row-collapse into h (artifact reproduced);
+    2. 'first' + reject=False cuts that leak by ~half (measured 0.54x; the
+       rest is the b2d model deficit inside the extra_dilate holes — with a
+       perfect b2d model the leak measures ~0);
+    3. 'first' + reject=True does NOT help: the map-outlier reject flags the
+       halo bump in the map as leaked source flux and refits it away. This
+       interaction is why the step warns on that combination and the config
+       says to pair fit_order='first' with reject=false.
+    """
+    pytest.importorskip('celerite2')
+    from scipy.ndimage import distance_transform_edt
+    from campfire_pipeline.nircam.gp_striping import gp_amprow_offsets
+
+    rng = np.random.default_rng(12)
+    H = 2048
+    rows = np.arange(H)
+    sci = rng.normal(0.0, 1.0, (H, COLS))
+    band = {'A': 1.0, 'B': 0.7, 'C': 1.3, 'D': 0.5}   # amp-dependent banding
+    for amp in 'ABCD':
+        c0, c1 = _amp_cols(amp)
+        sci[:, c0:c1] += band[amp] * np.sin(2 * np.pi * rows[:, None] / 100.0)
+    # bright halo hosted by amp C (center 176 px from the B/C boundary), far
+    # broader than the masked core the tiers will catch
+    halo = _gaussian_blob((H, COLS), 1024, 1200, 20.0, 120.0)
+    sci = sci + halo
+    err = np.full((H, COLS), 1.0, np.float32)
+    dq = np.zeros((H, COLS), np.int32)
+
+    mask_cfg = dict(ring_radius_in=80, ring_width=4, ring_downsample=4,
+                    tier_kernel_size=[25, 15, 5, 2],
+                    tier_npixels=[15, 10, 3, 1],
+                    tier_nsigma=[1.5, 1.5, 1.5, 1.5],
+                    tier_dilate_size=[33, 25, 21, 19])
+
+    def chain(order, reject):
+        sb = SubtractBackground(bg_box_size=64, bg_filter_size=5,
+                                bg_reject=reject, bg_reject_dilate=40.0,
+                                **mask_cfg)
+        srcmask, srcbits = sb.mask_from_arrays(sci, err, dq)
+        src_only = (srcbits >> 1) != 0
+        grown = distance_transform_edt(~src_only) <= 20
+        b2d_mask = srcmask | grown
+        ped, _ = oneoverf.peramp_pedestal(sci, srcmask)
+        b2d = 0.0
+        if order == 'first':
+            b2d = sb.estimate_background(sci - ped, b2d_mask).background
+        meas = sci - ped - b2d
+        vcol = oneoverf.column_pattern(meas, srcmask, 3)
+        base = meas - vcol
+        h5, _, _ = gp_amprow_offsets(base, srcmask, rho=5.0, maxiters=3,
+                                     zero_dc=True)
+        h20, _, _ = gp_amprow_offsets(base - h5, srcmask, rho=20.0,
+                                      maxiters=3, zero_dc=True)
+        h = h5 + h20
+        if order == 'last':
+            b2d = sb.estimate_background(sci - ped - vcol - h,
+                                         b2d_mask).background
+        return h, sci - (ped + vcol + h + b2d), srcmask
+
+    def leak(h, amp='C'):
+        # halo flux in the amp-row ledger: mean row-offset difference between
+        # halo rows and far rows (both windows span whole banding periods, so
+        # the sinusoid cancels)
+        c0, c1 = _amp_cols(amp)
+        prof = np.median(h[:, c0:c1], axis=1)
+        return prof[924:1124].mean() - prof[200:400].mean()
+
+    h_last, out_last, bg_last = chain('last', reject=True)     # shipped legacy
+    h_first, out_first, bg_first = chain('first', reject=False)
+    h_first_rej, _, _ = chain('first', reject=True)
+
+    leak_last = leak(h_last)
+    # (1) the artifact is reproduced by the legacy order (measured ~1.4)
+    assert leak_last > 1.0
+    # (2) first-order fit starves the amp-row term of halo flux (~0.54x)
+    assert leak(h_first) < 0.65 * leak_last
+    # (3) reject=True cancels the reorder (measured ~1.05x of legacy) — if a
+    #     future scale-aware reject fixes this, loosen/flip this assertion
+    #     and drop the warning in bkg_step
+    assert leak(h_first_rej) > 0.8 * leak_last
+    # the fix must not cost banding removal: far from the halo, the amp-row
+    # profile of the corrected frame is flat in both orders
+    bg = ~bg_first
+    for amp in 'ABCD':
+        c0, c1 = _amp_cols(amp)
+        strip, m = out_first[:, c0:c1], bg[:, c0:c1]
+        rowmed = np.array([np.median(strip[i][m[i]]) if m[i].any() else np.nan
+                           for i in range(200, 400)])
+        assert np.nanstd(rowmed) < 0.3 * band[amp]
+
+
 def _extended_galaxy_scene(rng, n=1600, re=150.0, amp=200.0):
     """Mostly-sky frame with one very bright, very extended galaxy at centre.
 

--- a/pipeline/tests/test_nircam_bkg.py
+++ b/pipeline/tests/test_nircam_bkg.py
@@ -632,3 +632,43 @@ def test_shipped_mosaic_tier_config_is_coherent(tmp_path):
     # the guard is mosaic-scoped: the per-exposure mask section must not
     # carry it (SubtractBackground default is False)
     assert 'bg_guard' not in per_exp
+
+
+def test_extra_dilate_no_sources_does_not_mask_the_border():
+    """`striping.extra_dilate` must be a no-op when nothing is selected to grow.
+
+    `distance_transform_edt` measures the distance to the nearest ZERO, so an
+    all-True input (no selected source pixels — either no tiers at all, or
+    `extra_dilate_min_area` filtered every component out) has no seed and the
+    transform falls back to distances measured from OUTSIDE the array. A naive
+    `edt(~src) <= r` then masks a border-and-corner band that no source put
+    there, deleting exactly the edge amp-row anchors.
+
+    Asserts the failure mode is real BEFORE asserting the guard removes it, so
+    the test cannot pass vacuously if the EDT behaviour ever changes.
+    """
+    from scipy.ndimage import distance_transform_edt
+
+    src_only_1f = np.zeros((256, 256), dtype=bool)      # nothing selected
+    radius = 20.0
+
+    # 1. the failure mode exists: unguarded, this masks a spurious band
+    unguarded = distance_transform_edt(~src_only_1f) <= radius
+    assert unguarded.any(), (
+        'EDT no longer produces a spurious band on an all-True input; '
+        'the guard under test may be obsolete — re-check bkg.py')
+    assert not unguarded[128, 128], 'spurious mask should hug the border'
+
+    # 2. the guard removes it, and leaves the fit mask untouched
+    fitmask = np.zeros((256, 256), dtype=bool)
+    if src_only_1f.any():
+        fitmask_1f = fitmask | (distance_transform_edt(~src_only_1f) <= radius)
+    else:
+        fitmask_1f = fitmask
+    assert not fitmask_1f.any()
+
+    # 3. and it still grows normally when something IS selected
+    src_only_1f[128, 128] = True
+    grown = distance_transform_edt(~src_only_1f) <= radius
+    assert grown[128, 128] and grown[128, 128 + int(radius)]
+    assert not grown[0, 0]


### PR DESCRIPTION
## What this is

On `subtract_2d` fields, bright sources spanning readout amps leak flux into
the per-amp-row 1/f estimate, which broadcasts it across the amp's full width:
oversubtracted amp-height blocks with hard edges at columns 512/1024/1536.

This PR adds the anisotropic conditioning detrend that fixes it, **and flips
the NIRCam background defaults** to the configuration validated on real A2744
frames. Pixel values change on every NIRCam field → **MINOR**.

## Default changes

| default | was | now |
|---|---|---|
| `[nircam.bkg].subtract_2d` | `false` | **`true`** |
| `[nircam.bkg.detrend].box_size` (y) | `256` | **`96`** |
| `[nircam.bkg.detrend].box_size_x` | `0` | **`32`** |
| `[nircam.bkg.detrend].filter_size` | `3` | **`[1, 5]`** |
| `[nircam.bkg.bkg2d].reject` | `true` | **`false`** |

`subtract_2d` was already `true` for every field in the reduction config in
use — blank and cluster alike — so the `false` default was the path nothing
ran on. Its trade is unchanged and now stated plainly rather than as a
"leave false for blank fields" note the default would contradict: a fine-box
applied fit removes ICL and bright-galaxy wings by construction, bounded by
the `bkg2d` `box_size`/`extra_dilate` pair.

## The lever: anisotropic conditioning detrend

`box_size` becomes the y (row) box and `box_size_x` a finer x box (96×32,
`filter_size = [1, 5]`). Banding is fine in y and constant in x within an amp,
while the halo/wing structure the amp-row terms steal is smooth in both. So a
y-coarse/x-fine fit-only mesh is banding-blind by construction (~4%
pass-through of a ρ≈20 pattern at 96 rows) yet follows halo column profiles,
and — fit full-width and smooth in x — cannot represent amp-*dependent*
banding at any scale. The earlier rj0911 "fine detrend boxes are worse" A/B
used *square* fine boxes, so it never tested this.

**Code change, not just a default:** the detrend y box is now **scale-exempt**
in anisotropic mode. ρ is a readout property in native ROWS, so the
attenuation a y box buys depends on rows spanned, not angle subtended.
Channel-scaling it would hand LW half the rows (96 → 48) and half the
attenuation — not what was validated, which ran 96 rows in **both** channels.
The x box is still channel-scaled (it tracks the halo's angular column
profile), and legacy square mode (`box_size_x = 0`) is untouched (256 → 128 LW).

## Real-frame validation

Three-arm A/B on **32 A2744 exposures rebuilt from uncal** (24 SW F200W + 8 LW
F444W) in an isolated `CAMPFIRE_ROOT` clone — production products never
touched. `bkg` re-run once per arm on copies. Judged by eye on post-bkg SCI at
a stretch held **common across arms**. `box_size_x = 32` with `reject = false`
was preferred over the square-box production configuration.

Supporting findings (`docs/findings-aniso-detrend-a2744.md`):

- The artifact is real but **not in every exposure** — 5 of 32 frames showed a
  strong single-amp excursion, all SW. On real A2744 the driver is bright
  **stars'** PSF wings and diffraction spikes, not galaxy halos.
- It is **invisible in the residual** (flat by construction, because the
  misattributed model was subtracted) and only shows in the amp-row ledger via
  `d_a(r) = h_a(r) − median_a h(r)`. Two selection metrics were tried and
  discarded as measurement artifacts; both are documented so they aren't retried.

## Rejected levers (kept in-tree, default-off, documented)

- **`bkg2d.fit_order = "first"`** — reduced the `h`-ledger leak (×0.52–0.78)
  and its falsification arm behaved as predicted (`reject=true` cancels the
  benefit), but **by eye the corrected frames were often worse**. Stays
  `"last"`. The changelog headline is corrected here: it previously asserted
  the reorder "fixes" the artifact, which the real-frame A/B refuted.
- **1/f fit-mask growth** (`striping.extra_dilate`, `extra_dilate_min_area`,
  `gp.min_row_pixels`) — global growth injects row/column noise; selective
  growth cannot out-run halos broader than the push.

## Also riding along

**GP `amplitude_data` restoration**: the amp-row GP kernel amplitude is
measured on the pre-detrend residual again, per `gp_amprow_offsets`' own
rj0911 calibration contract, which the unified step had regressed.

## Test plan

- `test_nircam_bkg.py`, `test_nircam_wisp_nmf_parity.py`,
  `test_nircam_gp_striping.py` — **35 passed against the flipped defaults**.
- **Defaults reproduce the validated arm bit-for-bit**: running the shipped
  defaults against the stored `aniso_norej` cells is `max|d| = 0.000e+00` on
  6 real frames, 3 SW + 3 LW (`detrend=box96x32` / `box96x16`). This is the
  check that the scale-exemption route matches the `box_size=192` route the
  A/B actually ran.
- Earlier no-op check: before the flip, `control` was bit-identical to the
  pre-aniso arm on 32/32 frames, confirming the knobs were dormant at their
  old defaults.

## Known gaps / not addressed

- **Every real-frame test here was A2744, a cluster.** Blank-field behaviour of
  `box_size 256 → 96` rests on the synthetic harness plus one deep-stretch
  A2744 blank check. A control arm on rj0911 or a cosmos pointing is the cheap
  way to close that before merge.
- One frame's wisp solve falls back to the legacy `MASK_hSNR` region because a
  bright wisp is detected as a source by the wisp step's own mask and swallows
  its own `t50` template core. That is #456 territory, not this PR; mechanism
  and candidate fixes are in the findings doc.

## Changelog

`## Unreleased` → **Algorithm** (MINOR).

Generated with Claude Code

https://claude.ai/code/session_01GRD2gK26WC2UdCXJDUNi3d