### PR TITLE
Fix git timeout handling in version resolution (#463)

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -234,6 +234,26 @@ Release procedure: edit the `## Unreleased` section below, then run
   distinguishable and the subtraction stays invertible.
 
 ### Infrastructure
+- **A git timeout can no longer masquerade as a version answer (#463).**
+  `CMPFRVER` resolution shells out to `git`, and under NFS contention any of
+  those calls can time out; each timeout previously fell into a different
+  silent fallback, so one reduction from one pinned commit could stamp three
+  different strings — including a bare release string (`0.5.1` with distance
+  and sha silently dropped) that `campfire deploy`'s non-release warning waved
+  through. `_run_git` now distinguishes "git answered no" (nonzero exit) from
+  "git could not answer" (timeout / missing binary, raised as
+  `_GitUnavailable`), and any resolution touched by the latter keeps whatever
+  was reliably determined but always carries a local segment ending in
+  `unresolved` (with the HEAD sha whenever obtainable, e.g.
+  `0.5.1+g066d8ab.unresolved`) — so it can never match deploy's
+  `_is_release_version()` and always trips the warn-and-confirm path. A
+  timed-out dirty check likewise marks the string unresolved instead of
+  stamping the tree clean, a garbage `rev-list` answer is no longer collapsed
+  to distance 0, and a degraded resolution logs a warning. The per-call git
+  timeout is raised 5 s → 30 s: resolution is `lru_cache`d per process, so
+  this is a once-per-run cap, and a blown timeout now permanently degrades
+  that process's stamped provenance. Version strings from fully-answering git
+  are byte-identical to before; no scientific output changes.
 - **Spike-model packaging (M2 of the diffraction-spike masking plan,
   `docs/design-nircam-spike-masking.md` §6.1).** New
   `scripts/build_spike_models.py` repacks the raw WebbPSF PSF+scattered-light

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -249,11 +249,15 @@ Release procedure: edit the `## Unreleased` section below, then run
   `_is_release_version()` and always trips the warn-and-confirm path. A
   timed-out dirty check likewise marks the string unresolved instead of
   stamping the tree clean, a garbage `rev-list` answer is no longer collapsed
-  to distance 0, and a degraded resolution logs a warning. The per-call git
-  timeout is raised 5 s → 30 s: resolution is `lru_cache`d per process, so
-  this is a once-per-run cap, and a blown timeout now permanently degrades
-  that process's stamped provenance. Version strings from fully-answering git
-  are byte-identical to before; no scientific output changes.
+  to distance 0, and a degraded resolution logs a warning. The git time
+  allowance is raised 5 s-per-call → 30 s, but as a **single wall-clock
+  budget shared by all probes of one resolution** (a deadline, not a
+  per-call timeout — once a hung git exhausts it, remaining probes fail
+  instantly), so worst-case startup stall is 30 s total: resolution is
+  `lru_cache`d per process, so this is a once-per-run cap, and a blown
+  budget now permanently degrades that process's stamped provenance.
+  Version strings from fully-answering git are byte-identical to before;
+  no scientific output changes.
 - **Spike-model packaging (M2 of the diffraction-spike masking plan,
   `docs/design-nircam-spike-masking.md` §6.1).** New
   `scripts/build_spike_models.py` repacks the raw WebbPSF PSF+scattered-light

--- a/pipeline/campfire_pipeline/common/version.py
+++ b/pipeline/campfire_pipeline/common/version.py
@@ -27,8 +27,10 @@ use ``git describe --abbrev=0`` to get just the tag, ``git rev-list
     tag pipeline-v0.4.0, 0 pipeline commits since, dirty -> 0.4.0+d20260504
     (no matching tag yet)                                -> 0.0.0.dev0+g7f4e2c1[.d20260504]
 
-**Failure is not an answer** (#463). Each ``git`` call runs with a timeout,
-and under NFS contention any of them can time out. A timeout (or a missing
+**Failure is not an answer** (#463). All git probes of one resolution share
+a single wall-clock budget (``_GIT_TIME_BUDGET`` — a deadline, so a hung git
+stalls startup once, not once per probe), and under NFS contention any of
+them can time out. A timeout (or a missing
 ``git`` binary) must never be mistaken for a real answer — historically a
 timed-out ``rev-list`` collapsed the distance to 0 and stamped a bare release
 string (e.g. ``0.5.1``) onto data actually built 178 commits past the tag,
@@ -52,6 +54,7 @@ from __future__ import annotations
 import logging
 import re
 import subprocess
+import time
 from datetime import datetime, timezone
 from functools import lru_cache
 from pathlib import Path
@@ -81,13 +84,22 @@ class _GitUnavailable(Exception):
     """
 
 
-# Generous because the result is cached per process, so this is a once-per-run
-# cap, and a timeout here permanently degrades the CMPFRVER provenance for
-# everything the process writes (#463: git on contended NFS blew a 5 s budget).
-_GIT_TIMEOUT = 30
+# Total wall-clock budget shared by ALL git probes of one resolution — a
+# deadline, not a per-call timeout, so a hung git costs at most this much
+# even though up to four probes run. Generous because the result is cached
+# per process, so this is a once-per-run cap, and blowing it permanently
+# degrades the CMPFRVER provenance for everything the process writes
+# (#463: git on contended NFS blew a 5 s budget).
+_GIT_TIME_BUDGET = 30
 
 
-def _run_git(args: list[str], cwd: Path) -> str | None:
+def _run_git(args: list[str], cwd: Path, deadline: float | None = None) -> str | None:
+    if deadline is None:
+        timeout: float = _GIT_TIME_BUDGET
+    else:
+        timeout = deadline - time.monotonic()
+        if timeout <= 0:
+            raise _GitUnavailable(f"git {args[0]}: shared git deadline exhausted")
     try:
         result = subprocess.run(
             ['git', *args],
@@ -95,7 +107,7 @@ def _run_git(args: list[str], cwd: Path) -> str | None:
             check=True,
             capture_output=True,
             text=True,
-            timeout=_GIT_TIMEOUT,
+            timeout=timeout,
         )
     except subprocess.CalledProcessError:
         return None
@@ -163,15 +175,15 @@ def _describe_to_pep440(described: str, dirty: bool) -> str | None:
     )
 
 
-def _pipeline_dirty(repo: Path) -> bool:
+def _pipeline_dirty(repo: Path, deadline: float | None = None) -> bool:
     # `git describe --dirty` checks the entire working tree; we only care
     # about edits to pipeline/ since that's what the version string scopes.
     # Raises _GitUnavailable on timeout — a tree of unknown state must not
     # be stamped clean.
-    return bool(_run_git(['status', '--porcelain', '--', 'pipeline'], repo))
+    return bool(_run_git(['status', '--porcelain', '--', 'pipeline'], repo, deadline))
 
 
-def _pipeline_distance(repo: Path, tag: str) -> int | None:
+def _pipeline_distance(repo: Path, tag: str, deadline: float | None = None) -> int | None:
     """Commits between *tag* and HEAD that touched ``pipeline/``.
 
     ``git describe --long`` reports the whole-monorepo count, which would
@@ -184,7 +196,9 @@ def _pipeline_distance(repo: Path, tag: str) -> int | None:
     Neither must ever be collapsed to 0 — that is the false-release bug
     of #463.
     """
-    out = _run_git(['rev-list', f'{tag}..HEAD', '--count', '--', 'pipeline'], repo)
+    out = _run_git(
+        ['rev-list', f'{tag}..HEAD', '--count', '--', 'pipeline'], repo, deadline,
+    )
     if out is None or not out.isdigit():
         return None
     return int(out)
@@ -199,12 +213,16 @@ def _git_version() -> str | None:
     # "could not answer" (_GitUnavailable: timeout, missing binary). The latter
     # marks the whole resolution unresolved — we keep whatever was reliably
     # determined, but the result must never look like a clean release (#463).
+    # All probes share one deadline: a hung git costs _GIT_TIME_BUDGET total,
+    # not per probe — once the budget is gone, remaining probes fail instantly.
     unresolved = False
+    deadline = time.monotonic() + _GIT_TIME_BUDGET
 
     try:
         tag = _run_git(
             ['describe', '--tags', '--abbrev=0', '--match', 'pipeline-v*'],
             repo,
+            deadline,
         )
     except _GitUnavailable:
         tag = None
@@ -220,7 +238,7 @@ def _git_version() -> str | None:
     distance: int | None = None
     if base is not None:
         try:
-            distance = _pipeline_distance(repo, tag)
+            distance = _pipeline_distance(repo, tag, deadline)
         except _GitUnavailable:
             distance = None
         if distance is None:
@@ -229,7 +247,7 @@ def _git_version() -> str | None:
             unresolved = True
 
     try:
-        dirty = _pipeline_dirty(repo)
+        dirty = _pipeline_dirty(repo, deadline)
     except _GitUnavailable:
         dirty = False
         unresolved = True
@@ -239,7 +257,7 @@ def _git_version() -> str | None:
     sha = None
     if distance or unresolved or base is None:
         try:
-            sha = _run_git(['rev-parse', '--short=7', 'HEAD'], repo)
+            sha = _run_git(['rev-parse', '--short=7', 'HEAD'], repo, deadline)
         except _GitUnavailable:
             sha = None
             unresolved = True

--- a/pipeline/campfire_pipeline/common/version.py
+++ b/pipeline/campfire_pipeline/common/version.py
@@ -26,10 +26,30 @@ use ``git describe --abbrev=0`` to get just the tag, ``git rev-list
     tag pipeline-v0.4.0, 3 pipeline commits since, dirty -> 0.4.1.dev3+g7f4e2c1.d20260504
     tag pipeline-v0.4.0, 0 pipeline commits since, dirty -> 0.4.0+d20260504
     (no matching tag yet)                                -> 0.0.0.dev0+g7f4e2c1[.d20260504]
+
+**Failure is not an answer** (#463). Each ``git`` call runs with a timeout,
+and under NFS contention any of them can time out. A timeout (or a missing
+``git`` binary) must never be mistaken for a real answer — historically a
+timed-out ``rev-list`` collapsed the distance to 0 and stamped a bare release
+string (e.g. ``0.5.1``) onto data actually built 178 commits past the tag,
+which ``campfire deploy``'s release check then waved through silently. Now any
+call that *cannot answer* (as opposed to answering "no") marks the resolution
+unresolved: the result keeps whatever was reliably determined, always carries
+a local segment ending in ``unresolved``, and therefore always fails deploy's
+``_is_release_version()`` and trips its warn-and-confirm path.
+
+    tag ok, distance timed out                 -> 0.4.0+g7f4e2c1.unresolved
+    describe timed out                         -> 0.0.0.dev0+g7f4e2c1.unresolved
+    everything timed out                       -> 0.0.0.dev0+unresolved
+    tag+distance ok, dirty check timed out     -> 0.4.1.dev3+g7f4e2c1.unresolved
+
+Resolution is cached per process (``lru_cache``), so every product a process
+writes carries the same string and the git cost is paid once.
 """
 
 from __future__ import annotations
 
+import logging
 import re
 import subprocess
 from datetime import datetime, timezone
@@ -37,6 +57,8 @@ from functools import lru_cache
 from pathlib import Path
 
 import campfire_pipeline
+
+logger = logging.getLogger(__name__)
 
 
 _DESCRIBE_RE = re.compile(
@@ -51,6 +73,20 @@ def _repo_root() -> Path:
     return Path(campfire_pipeline.__file__).resolve().parent.parent.parent
 
 
+class _GitUnavailable(Exception):
+    """git could not answer — timed out or the binary is missing.
+
+    Distinct from a nonzero exit (git *answering* "no", e.g. ``describe``
+    finding no matching tag), which ``_run_git`` reports as ``None``.
+    """
+
+
+# Generous because the result is cached per process, so this is a once-per-run
+# cap, and a timeout here permanently degrades the CMPFRVER provenance for
+# everything the process writes (#463: git on contended NFS blew a 5 s budget).
+_GIT_TIMEOUT = 30
+
+
 def _run_git(args: list[str], cwd: Path) -> str | None:
     try:
         result = subprocess.run(
@@ -59,10 +95,12 @@ def _run_git(args: list[str], cwd: Path) -> str | None:
             check=True,
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=_GIT_TIMEOUT,
         )
-    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+    except subprocess.CalledProcessError:
         return None
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        raise _GitUnavailable(f"git {args[0]}: {exc}") from exc
     return result.stdout.strip() or None
 
 
@@ -75,16 +113,30 @@ def _today_local_segment() -> str:
     return datetime.now(timezone.utc).strftime('d%Y%m%d')
 
 
-def _build_pep440(base: str, distance: int, sha: str | None, dirty: bool) -> str:
-    if distance == 0:
-        version = base
-        local_parts: list[str] = []
-    else:
+def _build_pep440(
+    base: str,
+    distance: int | None,
+    sha: str | None,
+    dirty: bool,
+    unresolved: bool = False,
+) -> str:
+    if distance:
         version = f"{_bump_patch(base)}.dev{distance}"
-        local_parts = [f"g{sha}"] if sha else []
+    else:
+        # distance 0 (exactly at the tag) or None (git could not answer;
+        # only reachable with unresolved=True — never bump on a guess).
+        version = base
+
+    # The sha is normally only stamped alongside a nonzero distance, but an
+    # unresolved version needs it regardless: it is the one field that still
+    # pins the code exactly when distance/dirtiness are unknown.
+    local_parts = [f"g{sha}"] if sha and (distance or unresolved) else []
 
     if dirty:
         local_parts.append(_today_local_segment())
+
+    if unresolved:
+        local_parts.append('unresolved')
 
     if local_parts:
         version = f"{version}+{'.'.join(local_parts)}"
@@ -114,6 +166,8 @@ def _describe_to_pep440(described: str, dirty: bool) -> str | None:
 def _pipeline_dirty(repo: Path) -> bool:
     # `git describe --dirty` checks the entire working tree; we only care
     # about edits to pipeline/ since that's what the version string scopes.
+    # Raises _GitUnavailable on timeout — a tree of unknown state must not
+    # be stamped clean.
     return bool(_run_git(['status', '--porcelain', '--', 'pipeline'], repo))
 
 
@@ -124,6 +178,11 @@ def _pipeline_distance(repo: Path, tag: str) -> int | None:
     bump ``.devN`` for any ``web/`` or ``python/`` commit even when pipeline
     code is byte-identical to *tag*. ``rev-list -- pipeline`` reports the
     count we actually want stamped onto reduced data.
+
+    Returns ``None`` when git answered but the output is not a count;
+    raises :class:`_GitUnavailable` when git could not answer at all.
+    Neither must ever be collapsed to 0 — that is the false-release bug
+    of #463.
     """
     out = _run_git(['rev-list', f'{tag}..HEAD', '--count', '--', 'pipeline'], repo)
     if out is None or not out.isdigit():
@@ -136,25 +195,79 @@ def _git_version() -> str | None:
     if not (repo / '.git').exists():
         return None
 
-    tag = _run_git(
-        ['describe', '--tags', '--abbrev=0', '--match', 'pipeline-v*'],
-        repo,
-    )
-    if tag:
+    # Each git query distinguishes "answered no" (proceed on that answer) from
+    # "could not answer" (_GitUnavailable: timeout, missing binary). The latter
+    # marks the whole resolution unresolved — we keep whatever was reliably
+    # determined, but the result must never look like a clean release (#463).
+    unresolved = False
+
+    try:
+        tag = _run_git(
+            ['describe', '--tags', '--abbrev=0', '--match', 'pipeline-v*'],
+            repo,
+        )
+    except _GitUnavailable:
+        tag = None
+        unresolved = True
+
+    base = None
+    if tag is not None:
         m = _TAG_RE.match(tag)
         if not m:
             return None
-        distance = _pipeline_distance(repo, tag) or 0
-        sha = _run_git(['rev-parse', '--short=7', 'HEAD'], repo) if distance else None
-        return _build_pep440(m.group('base'), distance, sha, _pipeline_dirty(repo))
+        base = m.group('base')
 
-    # No matching tag yet — synthesize a 0.0.0.dev0 string from HEAD.
-    sha = _run_git(['rev-parse', '--short=7', 'HEAD'], repo)
-    if not sha:
+    distance: int | None = None
+    if base is not None:
+        try:
+            distance = _pipeline_distance(repo, tag)
+        except _GitUnavailable:
+            distance = None
+        if distance is None:
+            # Timed out, or rev-list answered garbage — either way the
+            # distance is unknown, not zero.
+            unresolved = True
+
+    try:
+        dirty = _pipeline_dirty(repo)
+    except _GitUnavailable:
+        dirty = False
+        unresolved = True
+
+    # The sha is needed for a nonzero distance, for the no-tag synthetic
+    # version, and for any unresolved result (it alone still pins the code).
+    sha = None
+    if distance or unresolved or base is None:
+        try:
+            sha = _run_git(['rev-parse', '--short=7', 'HEAD'], repo)
+        except _GitUnavailable:
+            sha = None
+            unresolved = True
+
+    if base is not None:
+        version = _build_pep440(base, distance, sha, dirty, unresolved=unresolved)
+    elif not sha and not unresolved:
+        # Genuinely no matching tag and no sha to synthesize from — fall
+        # through to the packaged version.
         return None
-    dirty_local = _today_local_segment() if _pipeline_dirty(repo) else None
-    local = f"g{sha}" + (f".{dirty_local}" if dirty_local else "")
-    return f"0.0.0.dev0+{local}"
+    else:
+        # No matching tag yet (or describe couldn't answer) — synthesize a
+        # 0.0.0.dev0 string from whatever survived.
+        local_parts = [f"g{sha}"] if sha else []
+        if dirty:
+            local_parts.append(_today_local_segment())
+        if unresolved:
+            local_parts.append('unresolved')
+        version = '0.0.0.dev0'
+        if local_parts:
+            version = f"{version}+{'.'.join(local_parts)}"
+
+    if unresolved:
+        logger.warning(
+            "git could not fully resolve the pipeline version (timeout or "
+            "missing git); stamping degraded provenance %r", version,
+        )
+    return version
 
 
 def _packaged_version() -> str | None:

--- a/pipeline/tests/test_version.py
+++ b/pipeline/tests/test_version.py
@@ -51,7 +51,7 @@ def _fake_git(
     """
     captured: list[list[str]] = []
 
-    def fake_run_git(args, cwd):
+    def fake_run_git(args, cwd, deadline=None):
         captured.append(args)
         if args[0] in unavailable:
             raise version_mod._GitUnavailable(f'git {args[0]}: simulated timeout')
@@ -349,3 +349,56 @@ class TestGitUnavailable:
             side_effect=subprocess.CalledProcessError(128, ['git']),
         ):
             assert version_mod._run_git(['describe'], tmp_path) is None
+
+
+class TestSharedDeadline:
+    """All git probes of one resolution share a single wall-clock budget, so a
+    hung git stalls startup for at most _GIT_TIME_BUDGET total — not once per
+    probe (PR #464 review)."""
+
+    def test_git_version_passes_one_deadline_to_every_probe(self, tmp_path):
+        (tmp_path / '.git').mkdir()
+        deadlines = []
+
+        def fake_run_git(args, cwd, deadline=None):
+            deadlines.append(deadline)
+            if args[0] == 'describe':
+                return 'pipeline-v0.4.0'
+            if args[0] == 'rev-list':
+                return '3'
+            if args[0] == 'rev-parse':
+                return '7f4e2c1'
+            if args[0] == 'status':
+                return ''
+            return None
+
+        with (
+            mock.patch.object(version_mod, '_repo_root', return_value=tmp_path),
+            mock.patch.object(version_mod, '_run_git', side_effect=fake_run_git),
+        ):
+            version_mod._git_version()
+
+        assert len(deadlines) >= 3, 'expected describe/rev-list/status/rev-parse probes'
+        assert all(d is not None for d in deadlines), 'every probe must get the deadline'
+        assert len(set(deadlines)) == 1, f'probes must share ONE deadline: {deadlines}'
+
+    def test_exhausted_deadline_fails_instantly_without_running_git(self, tmp_path):
+        with mock.patch.object(version_mod.subprocess, 'run') as run:
+            try:
+                version_mod._run_git(
+                    ['status'], tmp_path, deadline=version_mod.time.monotonic() - 1,
+                )
+            except version_mod._GitUnavailable:
+                pass
+            else:
+                raise AssertionError('expired deadline must raise _GitUnavailable')
+        run.assert_not_called()
+
+    def test_remaining_budget_becomes_the_subprocess_timeout(self, tmp_path):
+        with mock.patch.object(version_mod.subprocess, 'run') as run:
+            run.return_value = mock.Mock(stdout='ok\n')
+            version_mod._run_git(
+                ['status'], tmp_path, deadline=version_mod.time.monotonic() + 7.0,
+            )
+        timeout = run.call_args.kwargs['timeout']
+        assert 0 < timeout <= 7.0, f'timeout must be the remaining budget, got {timeout}'

--- a/pipeline/tests/test_version.py
+++ b/pipeline/tests/test_version.py
@@ -1,5 +1,6 @@
 """Tests for pipeline version string resolution."""
 
+import re
 from unittest import mock
 
 from campfire_pipeline.common import version as version_mod
@@ -35,12 +36,25 @@ class TestDescribeToPep440:
         assert version_mod._describe_to_pep440('not-a-pipeline-tag', dirty=False) is None
 
 
-def _fake_git(*, tag='pipeline-v0.4.0', pipeline_distance='0', sha='7f4e2c1', status=''):
-    """Build a `_run_git` mock with controllable per-command return values."""
+def _fake_git(
+    *,
+    tag='pipeline-v0.4.0',
+    pipeline_distance='0',
+    sha='7f4e2c1',
+    status='',
+    unavailable=(),
+):
+    """Build a `_run_git` mock with controllable per-command return values.
+
+    Commands listed in *unavailable* raise ``_GitUnavailable``, simulating a
+    timeout (or missing git binary) for that specific invocation (#463).
+    """
     captured: list[list[str]] = []
 
     def fake_run_git(args, cwd):
         captured.append(args)
+        if args[0] in unavailable:
+            raise version_mod._GitUnavailable(f'git {args[0]}: simulated timeout')
         if args[0] == 'describe':
             return tag
         if args[0] == 'rev-list':
@@ -229,3 +243,109 @@ class TestGitVersion:
             mock.patch.object(version_mod, '_today_local_segment', return_value='d20260504'),
         ):
             assert version_mod._git_version() == '0.4.1.dev3+g7f4e2c1.d20260504'
+
+
+def _git_version_with(fake_run_git, repo):
+    with (
+        mock.patch.object(version_mod, '_repo_root', return_value=repo),
+        mock.patch.object(version_mod, '_run_git', side_effect=fake_run_git),
+    ):
+        return version_mod._git_version()
+
+
+class TestGitUnavailable:
+    """Regression coverage for #463: a git timeout must never masquerade as
+    an answer, and no fallback path may emit a bare release string that
+    passes deploy's `_is_release_version()` check.
+    """
+
+    RELEASE_RE = re.compile(r'^\d+\.\d+\.\d+$')  # mirrors deploy.py's _RELEASE_VERSION_RE
+
+    def _repo(self, tmp_path):
+        (tmp_path / '.git').mkdir()
+        return tmp_path
+
+    def test_distance_timeout_never_emits_bare_release(self, tmp_path):
+        """The f460m case: tag resolves, rev-list times out. Previously the
+        distance collapsed to 0 and a clean `0.4.0` was stamped."""
+        fake_run_git, _ = _fake_git(unavailable={'rev-list'})
+        result = _git_version_with(fake_run_git, self._repo(tmp_path))
+        assert result == '0.4.0+g7f4e2c1.unresolved'
+        assert not self.RELEASE_RE.match(result)
+
+    def test_distance_garbage_output_is_unresolved_not_zero(self, tmp_path):
+        """rev-list answering non-numeric garbage is equally not a distance of 0."""
+        fake_run_git, _ = _fake_git(pipeline_distance='fatal: bad revision')
+        result = _git_version_with(fake_run_git, self._repo(tmp_path))
+        assert result == '0.4.0+g7f4e2c1.unresolved'
+
+    def test_describe_timeout_does_not_fall_into_no_tag_branch(self, tmp_path):
+        """The f182m..f444w case: describe times out. Previously this was
+        indistinguishable from 'no tag exists' and stamped 0.0.0.dev0+gSHA;
+        now the string is additionally marked unresolved."""
+        fake_run_git, _ = _fake_git(unavailable={'describe'})
+        result = _git_version_with(fake_run_git, self._repo(tmp_path))
+        assert result == '0.0.0.dev0+g7f4e2c1.unresolved'
+
+    def test_dirty_check_timeout_is_not_stamped_clean(self, tmp_path):
+        """A tree of unknown dirtiness must not produce a clean release string."""
+        fake_run_git, _ = _fake_git(pipeline_distance='0', unavailable={'status'})
+        result = _git_version_with(fake_run_git, self._repo(tmp_path))
+        assert result == '0.4.0+g7f4e2c1.unresolved'
+        assert not self.RELEASE_RE.match(result)
+
+    def test_dirty_check_timeout_with_distance_keeps_dev_segment(self, tmp_path):
+        fake_run_git, _ = _fake_git(pipeline_distance='3', unavailable={'status'})
+        result = _git_version_with(fake_run_git, self._repo(tmp_path))
+        assert result == '0.4.1.dev3+g7f4e2c1.unresolved'
+
+    def test_everything_times_out(self, tmp_path):
+        fake_run_git, _ = _fake_git(
+            unavailable={'describe', 'rev-list', 'rev-parse', 'status'},
+        )
+        result = _git_version_with(fake_run_git, self._repo(tmp_path))
+        assert result == '0.0.0.dev0+unresolved'
+
+    def test_genuinely_no_tag_is_unchanged(self, tmp_path):
+        """describe answering 'no matching tag' (nonzero exit -> None) keeps
+        the historical synthetic string, with no unresolved marker."""
+        fake_run_git, _ = _fake_git(tag=None)
+        result = _git_version_with(fake_run_git, self._repo(tmp_path))
+        assert result == '0.0.0.dev0+g7f4e2c1'
+
+    def test_run_git_timeout_raises_git_unavailable(self, tmp_path):
+        """The real _run_git must map TimeoutExpired to _GitUnavailable, not None."""
+        import subprocess
+
+        with mock.patch.object(
+            version_mod.subprocess,
+            'run',
+            side_effect=subprocess.TimeoutExpired(cmd=['git'], timeout=1),
+        ):
+            try:
+                version_mod._run_git(['status'], tmp_path)
+            except version_mod._GitUnavailable:
+                pass
+            else:
+                raise AssertionError('TimeoutExpired must raise _GitUnavailable')
+
+    def test_run_git_missing_binary_raises_git_unavailable(self, tmp_path):
+        with mock.patch.object(
+            version_mod.subprocess, 'run', side_effect=FileNotFoundError('git'),
+        ):
+            try:
+                version_mod._run_git(['status'], tmp_path)
+            except version_mod._GitUnavailable:
+                pass
+            else:
+                raise AssertionError('FileNotFoundError must raise _GitUnavailable')
+
+    def test_nonzero_exit_still_returns_none(self, tmp_path):
+        import subprocess
+
+        with mock.patch.object(
+            version_mod.subprocess,
+            'run',
+            side_effect=subprocess.CalledProcessError(128, ['git']),
+        ):
+            assert version_mod._run_git(['describe'], tmp_path) is None


### PR DESCRIPTION
## Summary

Fix a critical bug where git timeouts during version string resolution could silently produce bare release strings (e.g., `0.5.1`) that bypass deploy's release validation. The fix distinguishes between "git answered no" (nonzero exit) and "git could not answer" (timeout/missing binary), marking any unresolved version with an `unresolved` local segment to ensure it always fails the release check.

## Key Changes

- **New `_GitUnavailable` exception**: Distinguishes timeouts and missing git binary from normal git command failures (nonzero exits)
- **Enhanced `_run_git()` error handling**: 
  - Raises `_GitUnavailable` on `TimeoutExpired` or `FileNotFoundError`
  - Returns `None` only for `CalledProcessError` (git answered "no")
  - Increased timeout from 5s to 30s (safe because result is cached per-process)
- **Refactored `_git_version()` logic**:
  - Tracks `unresolved` flag across all git queries
  - Any `_GitUnavailable` exception sets the flag and preserves partial results
  - Handles distance as `int | None` to distinguish "unknown" from "zero"
  - Validates `rev-list` output is numeric; garbage output marks version unresolved
  - Timed-out dirty check no longer stamps tree as clean
- **Updated `_build_pep440()`**: 
  - Accepts `distance: int | None` parameter
  - Includes HEAD sha in unresolved versions (pins code when distance/dirtiness unknown)
  - Appends `unresolved` to local segment when needed
- **Added logging**: Warns when version resolution is degraded due to git unavailability
- **Comprehensive test coverage**: New `TestGitUnavailable` class with 10 regression tests covering timeout scenarios, garbage output, and edge cases

## Notable Details

- Version strings from fully-answering git are byte-identical to before; no scientific output changes
- Resolution is `lru_cache`d per process, so the 30s timeout is a once-per-run cap
- All unresolved versions carry the `unresolved` local segment, ensuring they fail `deploy._is_release_version()` and trigger the warn-and-confirm path
- Handles cascading failures gracefully: if describe times out, the no-tag synthetic version is still marked unresolved

https://claude.ai/code/session_012rJaau51z3ia818ejE1ixA