### PR TITLE
Add --no-mosaics to the NIRCam field deploy

### DIFF
--- a/python/campfire/deploy/cli.py
+++ b/python/campfire/deploy/cli.py
@@ -209,6 +209,10 @@ def source_ids_option(f):
                    'the field; mutually exclusive with --obs.')
 @click.option('--filter', 'filter_names', multiple=True, cls=_VariadicOption,
               help='NIRCam filter(s) to deploy with --field (default: all).')
+@click.option('--no-mosaics', 'no_mosaics', is_flag=True,
+              help='NIRCam --field only: deploy exposures/expmaps/layout and '
+                   'skip the mosaic stage. For the inspect-then-rebuild loop, '
+                   'where mosaics built before masking are superseded anyway.')
 @click.option('--dry-run', is_flag=True, help='Show what would happen without making changes.')
 @click.option('--source-ids', multiple=True, type=str, default=None,
               cls=_VariadicOption, callback=_parse_source_ids,
@@ -233,8 +237,8 @@ def source_ids_option(f):
                    '(bypasses RLS + presigned URLs). For unattended / CI deploys. '
                    'Equivalent to CAMPFIRE_DEPLOY_MODE=service-role.')
 @click.pass_context
-def deploy_group(ctx, config_path, obs, field, filter_names, dry_run, source_ids,
-                 supabase_only, force_overwrite, auto_approve,
+def deploy_group(ctx, config_path, obs, field, filter_names, no_mosaics, dry_run,
+                 source_ids, supabase_only, force_overwrite, auto_approve,
                  no_shutters, no_photometry, skip_astrometry, draft, local,
                  service_role):
     """Deploy CAMPFIRE pipeline products to Supabase + object storage.
@@ -264,6 +268,10 @@ def deploy_group(ctx, config_path, obs, field, filter_names, dry_run, source_ids
         if field and obs:
             print("Error: --field (NIRCam) and --obs (NIRSpec) are mutually exclusive.")
             sys.exit(1)
+        if no_mosaics and not field:
+            print("Error: --no-mosaics applies to the NIRCam field deploy; "
+                  "use it with --field.")
+            sys.exit(1)
         if field:
             config = load_config(config_path, local=local,
                                  service_role=ctx.obj['service_role'])
@@ -271,7 +279,8 @@ def deploy_group(ctx, config_path, obs, field, filter_names, dry_run, source_ids
             from campfire.deploy.nircam import deploy_nircam
             deploy_nircam(field, config,
                           filters=list(filter_names) if filter_names else None,
-                          dry_run=dry_run, draft=draft)
+                          dry_run=dry_run, draft=draft,
+                          skip_mosaics=no_mosaics)
             return
         if not obs:
             print("Error: --obs (NIRSpec) or --field (NIRCam) is required for full deployment.")

--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -471,7 +471,8 @@ def _read_field_provenance(dirs, field, filters):
     return None, None, None
 
 
-def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
+def deploy_nircam(field, config, filters=None, dry_run=False, draft=False,
+                  skip_mosaics=False):
     """Push NIRCam exposure state to OSN + Supabase (epic #261, N1).
 
     Records a **field-scoped deployment** (provenance + the draft->published
@@ -500,6 +501,13 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
     draft : bool
         If True, record the deployment as ``draft`` (admin-only) for review;
         otherwise ``published`` (public) immediately.
+    skip_mosaics : bool
+        If True, deploy exposures/expmaps/layout only and skip the mosaic
+        stage entirely (no discovery, no upload, no ``mosaics`` rows). For the
+        inspect-then-rebuild loop: a reviewer needs the exposures in the portal
+        to draw masks, but the mosaics built *before* those masks exist are
+        superseded by the post-mask re-combine, so shipping them is wasted
+        transfer over a slow link. The mosaics ride the next deploy.
     """
     dirs = _resolve_nircam_dirs(field)
 
@@ -529,12 +537,21 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
     # Scope mosaic discovery to what the current fields.toml declares — a stray
     # on-disk tile/epoch from a former config must not ride into the cloud (this is
     # the guard; the count + the actual upload both use this same scoped list).
-    try:
-        mosaics_to_deploy = scope_mosaics_to_fields_toml(
-            deployable_mosaics(discover_mosaics(dirs, field, filters)), field)
-    except ValueError as e:
-        print(f"Error: {e}")
-        sys.exit(1)
+    if skip_mosaics:
+        # Skip discovery too, not just the upload: with no mosaic shipping this
+        # run, a stray on-disk tile is not this deploy's problem, and the
+        # fields.toml scope check would otherwise abort a perfectly good
+        # exposure deploy over a mosaic we were never going to send.
+        mosaics_to_deploy = []
+        print("Mosaics: SKIPPED (--no-mosaics) — exposures, expmaps and "
+              "layout only.")
+    else:
+        try:
+            mosaics_to_deploy = scope_mosaics_to_fields_toml(
+                deployable_mosaics(discover_mosaics(dirs, field, filters)), field)
+        except ValueError as e:
+            print(f"Error: {e}")
+            sys.exit(1)
     n_mosaics = len(mosaics_to_deploy)
     print(f"Discovered {len(exposures)} canonical exposure(s), "
           f"{len(expmap_tasks)} expmap file(s), {n_mosaics} mosaic(s), "
@@ -701,9 +718,12 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False):
     # --- Mosaics: deploy under the same field deployment (epic #261, N2) ----
     # Reuse the fields.toml-scoped list computed up front (single discovery +
     # single skip-log; stray tiles/epochs were already filtered out above).
-    mosaic_stats = _deploy_field_mosaics(dirs, field, config, client, filters,
-                                         deployment_id, draft, user_id, store=store,
-                                         mosaics=mosaics_to_deploy)
+    if skip_mosaics:
+        mosaic_stats = None
+    else:
+        mosaic_stats = _deploy_field_mosaics(dirs, field, config, client, filters,
+                                             deployment_id, draft, user_id, store=store,
+                                             mosaics=mosaics_to_deploy)
 
     # --- Field registry: upsert the fields.toml config + deploy-computed survey
     # area (issue #303). Rides the deploy so a field row exists exactly for fields

--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -434,7 +434,7 @@ def _provenance_from_header(path):
         return None, None, None
 
 
-def _read_field_provenance(dirs, field, filters):
+def _read_field_provenance(dirs, field, filters, *, prefer_mosaic=True):
     """Best-effort ``(cfpipe_version, jwst_version, crds_context)`` for a field.
 
     Prefer the local ``i2d`` mosaic header (the combined science product) — the
@@ -448,9 +448,15 @@ def _read_field_provenance(dirs, field, filters):
     exposure deploy (no mosaic yet) now records real provenance instead of NULL
     (audit B2). Returns ``(None, None, None)`` only when the field has neither a
     readable i2d nor a readable exposure.
+
+    ``prefer_mosaic=False`` skips the mosaic entirely and reads the exposures.
+    Set it when the mosaics are not part of this deployment (``--no-mosaics``):
+    an on-disk i2d left over from an earlier reduction would otherwise stamp the
+    deployment with the provenance of a product it is not shipping, and the
+    whole point of that mode is that the exposures have moved on from it.
     """
     try:
-        mosaics = discover_mosaics(dirs, field, filters)
+        mosaics = discover_mosaics(dirs, field, filters) if prefer_mosaic else []
     except Exception:
         mosaics = []
     if mosaics:
@@ -635,7 +641,10 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False,
     # the version cards, so an exposure-only --draft deploy (no mosaic yet)
     # records NULL provenance — the pipeline version that produced the exposures
     # is not stamped on exposure headers.
-    cfpipe_version, jwst_version, crds_context = _read_field_provenance(dirs, field, filters)
+    # With --no-mosaics the mosaics are not part of this deployment, so a stale
+    # on-disk i2d must not supply its provenance: read the exposures instead.
+    cfpipe_version, jwst_version, crds_context = _read_field_provenance(
+        dirs, field, filters, prefer_mosaic=not skip_mosaics)
 
     # Record the field-scoped deployment up front — it is the provenance anchor and
     # the draft/published visibility gate every registered object hangs off.

--- a/python/tests/test_cli_storage_plane.py
+++ b/python/tests/test_cli_storage_plane.py
@@ -83,3 +83,69 @@ def test_verify_has_cloud_and_json_flags():
     cli = _cli()
     params = {p.name for p in cli.commands['verify'].params}
     assert {'cloud', 'as_json', 'obs_filter'} <= params
+
+
+# --- deploy --no-mosaics ----------------------------------------------------
+# The exposures-only field deploy: a reviewer needs the exposures in the portal
+# to draw masks, but mosaics built *before* those masks exist are superseded by
+# the post-mask re-combine, so shipping them is wasted transfer.
+
+def test_deploy_has_no_mosaics_flag():
+    cli = _cli()
+    params = {p.name for p in cli.commands['deploy'].params}
+    assert 'no_mosaics' in params
+
+
+def test_no_mosaics_rejected_without_field():
+    """It scopes the NIRCam mosaic stage, so it is meaningless on a NIRSpec
+    --obs deploy and must not silently no-op there."""
+    cli = _cli()
+    res = CliRunner().invoke(cli, ['deploy', '--obs', 'ember_uds_p4',
+                                   '--no-mosaics', '--dry-run'])
+    assert res.exit_code != 0
+    assert '--no-mosaics' in res.output
+
+
+def test_no_mosaics_threads_through_to_deploy_nircam(monkeypatch):
+    """The flag must reach deploy_nircam as skip_mosaics; a dropped kwarg would
+    ship ~60 GB of superseded mosaics without any visible error."""
+    import campfire.deploy.cli as dcli
+    import campfire.deploy.nircam as dn
+
+    seen = {}
+
+    def _fake_deploy_nircam(field, config, **kw):
+        seen['field'] = field
+        seen.update(kw)
+
+    monkeypatch.setattr(dn, 'deploy_nircam', _fake_deploy_nircam)
+    monkeypatch.setattr(dcli, 'load_config', lambda *a, **k: {})
+    monkeypatch.setattr(dcli, '_announce_auth_mode', lambda *a, **k: None)
+    monkeypatch.setattr(dcli, '_gate_admin', lambda *a, **k: None)
+
+    cli = _cli()
+    res = CliRunner().invoke(cli, ['deploy', '--field', 'egs',
+                                   '--filter', 'f070w', '--no-mosaics'])
+    assert res.exit_code == 0, res.output
+    assert seen['field'] == 'egs'
+    assert seen['skip_mosaics'] is True
+    assert seen['filters'] == ['f070w']
+
+
+def test_mosaics_deployed_by_default(monkeypatch):
+    """Absent the flag, skip_mosaics must be False — the default path is
+    unchanged."""
+    import campfire.deploy.cli as dcli
+    import campfire.deploy.nircam as dn
+
+    seen = {}
+    monkeypatch.setattr(dn, 'deploy_nircam',
+                        lambda field, config, **kw: seen.update(kw))
+    monkeypatch.setattr(dcli, 'load_config', lambda *a, **k: {})
+    monkeypatch.setattr(dcli, '_announce_auth_mode', lambda *a, **k: None)
+    monkeypatch.setattr(dcli, '_gate_admin', lambda *a, **k: None)
+
+    cli = _cli()
+    res = CliRunner().invoke(cli, ['deploy', '--field', 'egs'])
+    assert res.exit_code == 0, res.output
+    assert seen['skip_mosaics'] is False

--- a/python/tests/test_cli_storage_plane.py
+++ b/python/tests/test_cli_storage_plane.py
@@ -96,9 +96,21 @@ def test_deploy_has_no_mosaics_flag():
     assert 'no_mosaics' in params
 
 
-def test_no_mosaics_rejected_without_field():
+def test_no_mosaics_rejected_without_field(monkeypatch):
     """It scopes the NIRCam mosaic stage, so it is meaningless on a NIRSpec
-    --obs deploy and must not silently no-op there."""
+    --obs deploy and must not silently no-op there.
+
+    load_config/_gate_admin are stubbed because deploy_group runs
+    `_gate_admin(load_config(...))` *before* this validation: unstubbed, a
+    sandbox with no `campfire login` session exits 1 on "Not logged in" and the
+    assertion below would pass for entirely the wrong reason.
+    """
+    import campfire.deploy.cli as dcli
+
+    monkeypatch.setattr(dcli, 'load_config', lambda *a, **k: {})
+    monkeypatch.setattr(dcli, '_announce_auth_mode', lambda *a, **k: None)
+    monkeypatch.setattr(dcli, '_gate_admin', lambda *a, **k: None)
+
     cli = _cli()
     res = CliRunner().invoke(cli, ['deploy', '--obs', 'ember_uds_p4',
                                    '--no-mosaics', '--dry-run'])

--- a/python/tests/test_nircam_deploy.py
+++ b/python/tests/test_nircam_deploy.py
@@ -434,3 +434,46 @@ def test_upload_workers_env_override(monkeypatch):
     assert nc._upload_workers() == 1            # clamped to >= 1
     monkeypatch.setenv("CAMPFIRE_DEPLOY_UPLOAD_WORKERS", "not-a-number")
     assert nc._upload_workers() == 16           # falls back to default
+
+
+# --- provenance under --no-mosaics ------------------------------------------
+
+def test_provenance_prefers_mosaic_by_default(tmp_path, monkeypatch):
+    """Default: the i2d mosaic header wins (it is the only mosaic product
+    carrying the version cards)."""
+    p = _make_exposure(tmp_path / "m_i2d.fits", np.zeros((2, 2)), np.zeros((2, 2)),
+                       extra_header={'CMPFRVER': '9.9.9', 'CAL_VER': '1.2.3',
+                                     'CRDS_CTX': 'jwst_9999.pmap'})
+    monkeypatch.setattr(nc, 'discover_mosaics',
+                        lambda *a, **k: [{'path': str(p), 'extension': 'i2d'}])
+    prov = nc._read_field_provenance({}, 'egs', ['f070w'])
+    assert prov[0] == '9.9.9'
+
+
+def test_provenance_skips_mosaic_when_not_deploying_it(tmp_path, monkeypatch):
+    """--no-mosaics: a stale on-disk i2d must NOT stamp the deployment, since
+    the mosaics are not part of it.
+
+    The stub RECORDS the call rather than raising: ``_read_field_provenance``
+    wraps discovery in ``except Exception``, which would swallow an
+    AssertionError and let this pass with the guard removed.
+    """
+    calls = []
+    stale = _make_exposure(tmp_path / "stale_i2d.fits", np.zeros((2, 2)),
+                           np.zeros((2, 2)),
+                           extra_header={'CMPFRVER': 'STALE', 'CAL_VER': '0.0.0',
+                                         'CRDS_CTX': 'jwst_0000.pmap'})
+    exp = _make_exposure(tmp_path / "e.fits", np.zeros((2, 2)), np.zeros((2, 2)),
+                         extra_header={'CMPFRVER': '1.1.1', 'CAL_VER': '4.5.6',
+                                       'CRDS_CTX': 'jwst_1111.pmap'})
+
+    def _record(*a, **k):
+        calls.append(a)
+        return [{'path': str(stale), 'extension': 'i2d'}]
+
+    monkeypatch.setattr(nc, 'discover_mosaics', _record)
+    monkeypatch.setattr(nc, 'discover_exposures',
+                        lambda *a, **k: {'e': {'path': str(exp)}})
+    prov = nc._read_field_provenance({}, 'egs', ['f070w'], prefer_mosaic=False)
+    assert calls == [], "discover_mosaics consulted with prefer_mosaic=False"
+    assert prov[0] == '1.1.1', "provenance came from the stale mosaic, not the exposures"


### PR DESCRIPTION
## Problem

`campfire deploy --field X` always runs the mosaic stage — the only scoping is `--field` and `--filter`. That forces the inspect-then-rebuild loop to ship mosaics it is about to invalidate: a reviewer needs the **exposures** in the portal to draw masks, but the mosaics built *before* those masks exist are superseded by the post-mask re-combine.

This came out of reducing EGS F070W. Deploying it for review meant 46.8 GB of exposures plus **~60 GB of mosaics that were replaced hours later** — over a slow CANDIDE→OSN link, and published before the masking they were waiting on.

## Change

`--no-mosaics` skips the mosaic stage entirely: no discovery, no upload, no mosaic rows.

Discovery is skipped too, not just the upload. Otherwise a stray on-disk tile from a former `fields.toml` could abort an otherwise fine exposure deploy through `scope_mosaics_to_fields_toml`, over mosaics that were never going to be sent.

The mosaics ride the next deploy, where content-hash dedup makes the already-landed exposures free.

Rejected with `--obs`: it scopes the NIRCam mosaic stage and would otherwise silently no-op on a NIRSpec deploy.

**Default behaviour is unchanged** — `skip_mosaics` defaults to `False` and the mosaic path is untouched.

## Verification

Exercised on the real EGS tree during the F070W reduction:

| invocation | mosaics discovered |
|---|---|
| `--field egs --filter f070w --no-mosaics` | **0** |
| `--field egs --filter f070w` (default) | **24** |
| `--obs ember_uds_p4 --no-mosaics` | clean error, exit 1 |

The real exposures-only deploy ran as deployment #386: `43 uploaded, 1112 unchanged skipped`, zero mosaics.

Four CLI-wiring tests added to `test_cli_storage_plane.py`: flag registration, the `--obs` rejection, threading through to `deploy_nircam` as `skip_mosaics=True`, and `skip_mosaics=False` by default.

**Tests verified non-vacuous** — temporarily dropping the `skip_mosaics` kwarg at the call site fails two of the four. Full suite: 574 passed, 9 skipped.

## Notes

- Touches `python/` only, so no `pipeline/CHANGELOG.md` entry per AGENTS.md.
- No `web/` changes, so `npm run build` is unaffected.
- Branched off `6316d81`; the two changed files have no other commits against them since.

Generated with Claude Code

https://claude.ai/code/session_01CFs7JaSymLf15oM8wUzHzV