### PR TITLE
Make NIRCam triage saves durable: outbox + retrying route-handler transport

### DIFF
--- a/supabase/migrations/20260817120000_nircam_review_decided_at.sql
+++ b/supabase/migrations/20260817120000_nircam_review_decided_at.sql
@@ -1,0 +1,8 @@
+-- Last-writer-wins guard for NIRCam triage review writes. The web triage
+-- outbox retries dropped/hung saves and flushes with keepalive on unload, so
+-- the same decision can legitimately arrive more than once and out of order.
+-- Each staged decision carries the client-side time it was made; the review
+-- API applies an update only when this column is null or <= that stamp, so a
+-- delayed duplicate of an older decision can never overwrite a newer one.
+alter table "public"."nircam_exposures"
+    add column "review_decided_at" timestamp with time zone;

--- a/supabase/migrations/20260817213000_get_admin_exposures_review_decided_at.sql
+++ b/supabase/migrations/20260817213000_get_admin_exposures_review_decided_at.sql
@@ -1,0 +1,104 @@
+-- Add review_decided_at to get_admin_exposures so the web client's
+-- review-decision overlay can compare its acked/queued stamps against list
+-- rows. Without it every list row arrives stampless and a session's older
+-- acked decision could shadow a newer decision made from another device.
+--
+-- Changing a RETURNS TABLE shape requires drop + recreate (CREATE OR REPLACE
+-- cannot alter a function's return type); the GRANT is re-applied because it
+-- drops with the function.
+DROP FUNCTION IF EXISTS public.get_admin_exposures(text, text, text, text, text, text, text, text, integer, integer);
+
+CREATE OR REPLACE FUNCTION public.get_admin_exposures(
+  p_field text DEFAULT NULL,
+  p_filter text DEFAULT NULL,
+  p_detector text DEFAULT NULL,
+  p_review_status text DEFAULT NULL,
+  p_stage text DEFAULT NULL,
+  p_correction text DEFAULT NULL,
+  p_sort_column text DEFAULT 'filename',   -- 'filename' = the compound (field, filter, filename) list order
+  p_sort_direction text DEFAULT 'asc',
+  p_page integer DEFAULT 1,
+  p_page_size integer DEFAULT 50
+)
+RETURNS TABLE (
+  id integer,
+  field text,
+  filter text,
+  detector text,
+  filename text,
+  visit text,
+  date_obs timestamp without time zone,
+  ra_center double precision,
+  dec_center double precision,
+  stage text,
+  review_status text,
+  correction text,
+  png_path text,
+  full_png_path text,
+  image_width integer,
+  image_height integer,
+  mask_regions jsonb,
+  notes text,
+  review_decided_at timestamptz,
+  created_at timestamp without time zone,
+  updated_at timestamp without time zone,
+  total_count bigint
+)
+LANGUAGE plpgsql STABLE
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_limit integer := LEAST(GREATEST(COALESCE(p_page_size, 50), 1), 200);
+  v_offset integer := GREATEST(COALESCE(p_page, 1) - 1, 0) * LEAST(GREATEST(COALESCE(p_page_size, 50), 1), 200);
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
+  IF p_sort_column NOT IN ('filename', 'field', 'filter', 'detector', 'stage',
+                           'review_status', 'date_obs', 'updated_at') THEN
+    p_sort_column := 'filename';
+  END IF;
+
+  RETURN QUERY
+  SELECT e.id, e.field, e.filter, e.detector, e.filename, e.visit, e.date_obs,
+         e.ra_center, e.dec_center, e.stage, e.review_status,
+         e.correction, e.png_path, e.full_png_path, e.image_width,
+         e.image_height, e.mask_regions, e.notes, e.review_decided_at,
+         e.created_at, e.updated_at,
+         count(*) OVER ()
+  FROM nircam_exposures e
+  WHERE (p_field IS NULL OR e.field = p_field)
+    AND (p_filter IS NULL OR e.filter = p_filter)
+    AND (p_detector IS NULL OR e.detector = p_detector)
+    AND (p_review_status IS NULL OR e.review_status = p_review_status)
+    AND (p_stage IS NULL OR e.stage = p_stage)
+    AND (p_correction IS NULL OR e.correction = p_correction)
+  ORDER BY
+    -- Keep in lockstep with get_admin_exposure_neighbors.
+    CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'asc'  THEN e.field END ASC,
+    CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'asc'  THEN e.filter END ASC,
+    CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'asc'  THEN e.filename END ASC,
+    CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'desc' THEN e.field END DESC,
+    CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'desc' THEN e.filter END DESC,
+    CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'desc' THEN e.filename END DESC,
+    CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc'  THEN e.field END ASC,
+    CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN e.field END DESC,
+    CASE WHEN p_sort_column = 'filter' AND p_sort_direction = 'asc'  THEN e.filter END ASC,
+    CASE WHEN p_sort_column = 'filter' AND p_sort_direction = 'desc' THEN e.filter END DESC,
+    CASE WHEN p_sort_column = 'detector' AND p_sort_direction = 'asc'  THEN e.detector END ASC,
+    CASE WHEN p_sort_column = 'detector' AND p_sort_direction = 'desc' THEN e.detector END DESC,
+    CASE WHEN p_sort_column = 'stage' AND p_sort_direction = 'asc'  THEN e.stage END ASC,
+    CASE WHEN p_sort_column = 'stage' AND p_sort_direction = 'desc' THEN e.stage END DESC,
+    CASE WHEN p_sort_column = 'review_status' AND p_sort_direction = 'asc'  THEN e.review_status END ASC,
+    CASE WHEN p_sort_column = 'review_status' AND p_sort_direction = 'desc' THEN e.review_status END DESC,
+    CASE WHEN p_sort_column = 'date_obs' AND p_sort_direction = 'asc'  THEN e.date_obs END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'date_obs' AND p_sort_direction = 'desc' THEN e.date_obs END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'updated_at' AND p_sort_direction = 'asc'  THEN e.updated_at END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'updated_at' AND p_sort_direction = 'desc' THEN e.updated_at END DESC NULLS LAST,
+    e.id ASC
+  OFFSET v_offset LIMIT v_limit;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_admin_exposures TO authenticated;

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -4066,6 +4066,11 @@ RETURNS TABLE (
   image_height integer,
   mask_regions jsonb,
   notes text,
+  -- Carried so the web client's review-decision overlay can compare its
+  -- acked/queued stamps against the row instead of treating list rows as
+  -- stampless (which would let a stale overlay shadow a newer decision made
+  -- from another device for the rest of the session).
+  review_decided_at timestamptz,
   created_at timestamp without time zone,
   updated_at timestamp without time zone,
   total_count bigint
@@ -4090,7 +4095,8 @@ BEGIN
   SELECT e.id, e.field, e.filter, e.detector, e.filename, e.visit, e.date_obs,
          e.ra_center, e.dec_center, e.stage, e.review_status,
          e.correction, e.png_path, e.full_png_path, e.image_width,
-         e.image_height, e.mask_regions, e.notes, e.created_at, e.updated_at,
+         e.image_height, e.mask_regions, e.notes, e.review_decided_at,
+         e.created_at, e.updated_at,
          count(*) OVER ()
   FROM nircam_exposures e
   WHERE (p_field IS NULL OR e.field = p_field)

--- a/supabase/schemas/tables.sql
+++ b/supabase/schemas/tables.sql
@@ -871,6 +871,14 @@ CREATE TABLE IF NOT EXISTS "public"."nircam_exposures" (
     "image_height" integer,
     "mask_regions" "jsonb",
     "notes" "text",
+    -- Last-writer-wins guard for triage review writes (web outbox): the
+    -- client stamps each staged decision with its decision time, and the
+    -- review API only applies an update when this column is null or <= the
+    -- incoming stamp — so a delayed retry or keepalive duplicate of an older
+    -- decision can never overwrite a newer one. timestamptz (unlike the
+    -- legacy created/updated columns) because it round-trips a client epoch
+    -- unambiguously.
+    "review_decided_at" timestamp with time zone,
     "created_at" timestamp without time zone DEFAULT "now"(),
     "updated_at" timestamp without time zone DEFAULT "now"()
 );

--- a/web/app/admin/nircam/[id]/page.tsx
+++ b/web/app/admin/nircam/[id]/page.tsx
@@ -11,7 +11,6 @@ import {
 import {
   getNircamExposureById,
   getExposureNeighbors,
-  updateExposureReview,
   saveExposureMaskRegions,
   presignExposurePngs,
   type ExposureNeighbors,
@@ -24,7 +23,6 @@ import { parseExposureNavParams } from '@/lib/nircam-exposure-nav';
 import {
   getCachedExposure,
   setCachedExposure,
-  deleteCachedExposure,
   prefetchPng,
   isPngCached,
   getCachedPngUrls,
@@ -38,10 +36,16 @@ import {
   subscribeSaveState,
   getSaveStateVersion,
   enqueueSave,
-  nextSaveSeq,
-  markSaveCommitted,
-  hasNewerCommittedSave,
 } from '@/lib/nircam-exposure-cache';
+import {
+  stageReviewDecision,
+  ensureReviewOutboxRunning,
+  overlayReviewDecisions,
+  queuedReviewCount,
+  subscribeReviewOutbox,
+  getReviewOutboxVersion,
+  type ReviewDecisionFields,
+} from '@/lib/nircam-review-outbox';
 
 // Eager PNG prefetch window: warm the full-res mask surface (~5.7 MB) the
 // editor actually renders for a few exposures ahead + one back, so stepping
@@ -73,7 +77,6 @@ interface TriageEdits {
   forId: number | null;
   dirty: { reviewStatus: boolean; correction: boolean; notes: boolean };
   values: { reviewStatus: string; correction: string; notes: string };
-  saved: boolean;
 }
 
 function ExposureDetailPageInner() {
@@ -132,22 +135,24 @@ function ExposureDetailPageInner() {
   const [exposure, setExposure] = useState<NircamExposure | null>(null);
   const [exposureForId, setExposureForId] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Replay any decisions stranded by a previous session's reload and keep
+  // the outbox delivery loop running while the operator works here.
+  useEffect(() => { ensureReviewOutboxRunning(); }, []);
 
   // Editable fields
   const [reviewStatus, setReviewStatus] = useState<string>('pending');
   const [correction, setCorrection] = useState<string>('none');
   const [notes, setNotes] = useState<string>('');
 
-  // Which triage fields the operator has touched, and whether a save has landed,
-  // for the exposure currently on screen. The background revalidation below fires
-  // on arrival and lands 100-300 ms later — long after a fast operator has
-  // already pressed 2 — so it must not write over what they set. Without these
-  // guards the status visibly flips back to the DB value, `hasChanges` goes
-  // false, and the auto-save on → silently skips: the exposure flashes Approved
-  // for a frame and stays Pending.
+  // Which triage fields the operator has touched, for the exposure currently
+  // on screen. The background revalidation below fires on arrival and lands
+  // 100-300 ms later — long after a fast operator has already pressed 2 — so
+  // it must not write over what they set but haven't staged yet. (Anything
+  // already STAGED is covered separately: overlayReviewDecisions folds queued
+  // and acked decisions over every server read.)
   //
   // `dirty` is per-field rather than one flag: with a stale cached row, editing
   // a single field would otherwise pin *every* control to its cached value while
@@ -156,9 +161,9 @@ function ExposureDetailPageInner() {
   // a newer server decision.
   //
   // `forId` tags the whole record with the exposure it describes (same pattern
-  // as `navState` below), so a save resolving after we've navigated away can
-  // tell that it no longer owns this state. Reset on every id change (below),
-  // so arriving at a fresh exposure still takes the server's values.
+  // as `navState` below), so an id change can tell the record no longer owns
+  // the screen. Reset on every id change (below), so arriving at a fresh
+  // exposure still takes the server's values.
   //
   // `values` carries the operator's edited values alongside the flags: this
   // record — not React state — is the authoritative "what did the operator
@@ -168,7 +173,6 @@ function ExposureDetailPageInner() {
     forId: null,
     dirty: { reviewStatus: false, correction: false, notes: false },
     values: { reviewStatus: 'pending', correction: 'none', notes: '' },
-    saved: false,
   });
   // An outgoing edits record displaced by the id-change reset below while
   // still carrying un-dispatched edits — an id change that bypassed goTo
@@ -176,15 +180,10 @@ function ExposureDetailPageInner() {
   // stashes the record here and the effect right after it dispatches.
   const pendingNavFlushRef = useRef<TriageEdits | null>(null);
 
-  // Fire-and-forget flush of the operator's dirty triage state — the write
-  // half of auto-save-on-nav, also used by the back-to-list button, the
-  // unmount cleanup, and the id-change reset's stash (navigations that bypass
-  // goTo: browser back/forward, in-app links). The decision goes into the row
-  // cache optimistically (that's what the next visit paints from) and the
-  // server action fires without blocking the caller. The pending-save registry
-  // keeps a quick revisit's revalidation from resurrecting the pre-save row; a
-  // failure reverts the cache to the server's truth and raises the module
-  // save-error banner, since this instance is usually gone by then.
+  // Flush of the operator's dirty triage state — the write half of
+  // auto-save-on-nav, also used by the back-to-list button, the unmount
+  // cleanup, the unload handlers, and the id-change reset's stash
+  // (navigations that bypass goTo: browser back/forward, in-app links).
   //
   // The save is built from the edits record ALONE — forId says which exposure,
   // dirty says which fields, values says what the operator chose, all written
@@ -195,12 +194,17 @@ function ExposureDetailPageInner() {
   // sent, so a not-yet-loaded row's untouched values can never be overwritten
   // with defaults.
   //
+  // Staging is the commit point. Everything after it — durable persistence
+  // across reloads, delivery with timeout/retry/keepalive, the failure
+  // banner, cache reconciliation on ack — belongs to the outbox
+  // (lib/nircam-review-outbox.ts), which also writes the staged decision into
+  // the row cache so the next visit paints the operator's latest state.
+  //
   // The record's dirty flags are consumed (cleared) synchronously at dispatch,
   // which makes every caller idempotent: one navigation can route through
   // several of them (goTo, then the reset stash, then unmount) and only the
-  // first with something dirty actually sends.
+  // first with something dirty actually stages.
   const flushDirtySave = useCallback((record?: TriageEdits) => {
-    const s = stateRef.current;
     const edits = record ?? localEditsRef.current;
     if (edits.forId == null) return;
     const savedForId = edits.forId;
@@ -208,98 +212,26 @@ function ExposureDetailPageInner() {
     edits.dirty = { reviewStatus: false, correction: false, notes: false };
     if (!dirty.reviewStatus && !dirty.correction && !dirty.notes) return;
 
-    // Baseline for no-op detection and the optimistic write: the on-screen row
-    // when it is this record's row, else the cache. May be null (row never
-    // loaded) — the save still goes out, just without a diff to skip on.
-    const exp = s.exposure && s.exposure.id === savedForId
-      ? s.exposure
-      : getCachedExposure(savedForId);
+    // Deliberately NO "already equal" diff against the cached row: the cache
+    // can hold an optimistic value from an earlier staging of this same
+    // decision, and skipping writes that compare equal against it is exactly
+    // what used to make a lost save unrepairable — re-applying the decision
+    // looked like a no-op and never re-sent. A redundant send is one tiny
+    // idempotent POST; the server's review_decided_at guard makes it harmless.
+    const fields: ReviewDecisionFields = {};
+    if (dirty.reviewStatus) {
+      fields.review_status = edits.values.reviewStatus as NircamExposure['review_status'];
+    }
+    if (dirty.correction) {
+      fields.correction = edits.values.correction as NircamExposure['correction'];
+    }
+    if (dirty.notes) {
+      fields.notes = edits.values.notes; // sent even as '' so clearing persists
+    }
 
-    const updates: Parameters<typeof updateExposureReview>[1] = {};
-    if (dirty.reviewStatus && (!exp || edits.values.reviewStatus !== exp.review_status)) {
-      updates.review_status = edits.values.reviewStatus as NircamExposure['review_status'];
-    }
-    if (dirty.correction && (!exp || edits.values.correction !== exp.correction)) {
-      updates.correction = edits.values.correction as NircamExposure['correction'];
-    }
-    if (dirty.notes && (!exp || edits.values.notes !== (exp.notes || ''))) {
-      updates.notes = edits.values.notes; // sent even as '' so clearing persists
-    }
-    if (Object.keys(updates).length === 0) return;
-
-    const savedFilename = exp?.filename ?? `exposure #${savedForId}`;
-    if (exp) {
-      setCachedExposure({
-        ...exp,
-        review_status: updates.review_status ?? exp.review_status,
-        correction: updates.correction ?? exp.correction,
-        notes: updates.notes !== undefined ? (updates.notes || null) : exp.notes,
-      });
-    }
-    {
-      beginPendingSave(savedForId);
-      // endPendingSave must run exactly once per beginPendingSave on every
-      // path — including a transport rejection, which would otherwise leave
-      // the id pending for the rest of the tab session (blocking revalidation
-      // and the failure banner alike).
-      let ended = false;
-      const endPending = () => {
-        if (ended) return;
-        ended = true;
-        endPendingSave(savedForId);
-      };
-      // Queued per exposure id so a second save for the same row (revisit +
-      // re-edit before the first lands) can never commit or report out of
-      // order with this one. The dispatch generation lets the failure handler
-      // below — which awaits, so it can resume after a newer save has fully
-      // committed — recognize that it has been superseded.
-      const saveSeq = nextSaveSeq(savedForId);
-      enqueueSave(savedForId, () => updateExposureReview(savedForId, updates))
-        .then(async (result) => {
-        if (result.exposure && !result.error) {
-          endPending();
-          markSaveCommitted(savedForId, saveSeq);
-          // A newer save queued behind this one has already written its own
-          // optimistic row — don't put this (older) confirmed row over it.
-          if (!hasPendingSave(savedForId)) setCachedExposure(result.exposure);
-          // A retry that lands supersedes an earlier failure for this exposure.
-          if (getSaveError()?.id === savedForId) setSaveError(null);
-          return;
-        }
-        throw new Error(result.error || 'Save failed');
-      }).catch(async (err: unknown) => {
-        endPending();
-        // Put the server's row back over the optimistic one (best effort —
-        // the transport may be down), then tell the operator: they may be
-        // several exposures ahead by now. Both steps are void if a newer save
-        // for this row committed while this handler was suspended: the revert
-        // snapshot predates that save, and the banner would report a failure
-        // for a decision that did persist.
-        const owned = () =>
-          !hasPendingSave(savedForId) && !hasNewerCommittedSave(savedForId, saveSeq);
-        try {
-          const fresh = await getNircamExposureById(savedForId);
-          if (fresh.exposure) {
-            if (owned()) setCachedExposure(fresh.exposure);
-          } else if (owned()) {
-            // The revert read failed too. Don't leave the never-persisted
-            // optimistic row posing as truth (a revisit would paint it as
-            // saved, with hasChanges false and no way to retry) — drop the
-            // entry so the next visit misses the cache and refetches.
-            deleteCachedExposure(savedForId);
-          }
-        } catch {
-          if (owned()) deleteCachedExposure(savedForId);
-        }
-        if (!hasNewerCommittedSave(savedForId, saveSeq)) {
-          setSaveError({
-            id: savedForId,
-            filename: savedFilename,
-            message: err instanceof Error ? err.message : 'Save failed',
-          });
-        }
-      });
-    }
+    const s = stateRef.current;
+    const exp = s.exposure && s.exposure.id === savedForId ? s.exposure : null;
+    stageReviewDecision(savedForId, fields, exp?.filename ?? null);
   }, []);
 
   // Every edit targets idRef.current — the exposure the operator believes is
@@ -331,7 +263,6 @@ function ExposureDetailPageInner() {
           correction: stateRef.current.correction,
           notes: stateRef.current.notes,
         },
-        saved: false,
       };
     }
     return localEditsRef.current;
@@ -479,7 +410,6 @@ function ExposureDetailPageInner() {
           correction: cached?.correction || 'none',
           notes: cached?.notes || '',
         },
-        saved: false,
       };
     }
   }
@@ -499,16 +429,20 @@ function ExposureDetailPageInner() {
   useEffect(() => () => flushDirtySave(), [flushDirtySave]);
 
   // Background revalidation against the DB on every id change. Auto-save on
-  // navigation has already flushed the *previous* exposure's triage state, so
-  // arriving clean means the server's values win. But this read races the
-  // operator: anything they've typed or keyed since arriving, and any save that
-  // has already landed, is newer than this response and must survive it.
+  // navigation has already staged the *previous* exposure's triage state, so
+  // arriving clean means the server's values win. This read still races the
+  // operator and the outbox — but staged/committed review decisions no longer
+  // need to SUPPRESS it: overlayReviewDecisions folds every queued or acked
+  // decision for this row over the response, so a read snapshotted before a
+  // commit reconverges instead of resurrecting pre-decision state. (The old
+  // suppression had a failure mode where a wedged save marker froze the row
+  // on optimistic values forever.)
   useEffect(() => {
     let cancelled = false;
-    // Captured before the read is issued: a save in flight NOW means the
-    // response may reflect pre-save state even if the save has finished (and
-    // cleared its pending marker) by the time the response resolves.
-    const pendingAtStart = hasPendingSave(id);
+    // Mask saves are the one write the overlay does NOT cover (it only knows
+    // review fields), so a mask save in flight at either end of this read
+    // still suppresses the row write — the mask confirm rewrites the cache.
+    const maskPendingAtStart = hasPendingSave(id);
     (async () => {
       const result = await getNircamExposureById(id);
       if (cancelled) return;
@@ -518,27 +452,21 @@ function ExposureDetailPageInner() {
         return;
       }
       if (result.exposure) {
+        const merged = overlayReviewDecisions(result.exposure);
         // The edits record only speaks for this exposure when tagged with its
         // id (a mid-transition keypress can retarget it — see targetEdits).
         const edits = localEditsRef.current;
         const ours = edits.forId === id;
-        // A save for this exposure already landed — our write is strictly newer
-        // than this read, so don't let it back into state *or* the cache. Same
-        // for a save in flight at either end of this read (fire-and-forget
-        // auto-save on nav, then a quick revisit): the optimistic or
-        // save-confirmed row is newer than what this read may have seen.
-        const pending = pendingAtStart || hasPendingSave(id);
-        if (!(ours && edits.saved) && !pending) {
-          setCachedExposure(result.exposure);
-          setExposure(result.exposure);
+        if (!maskPendingAtStart && !hasPendingSave(id)) {
+          setCachedExposure(merged);
+          setExposure(merged);
         }
-        // Per field: an untouched control still takes the fresh server value.
-        // `saved` shields every field, not just dirty ones: once a save has
-        // landed, its dirty flags are consumed, but this read may still
-        // predate the save — its values are stale for anything the save wrote.
-        if (!(ours && (edits.dirty.reviewStatus || edits.saved)) && !pending) setReviewStatus(result.exposure.review_status);
-        if (!(ours && (edits.dirty.correction || edits.saved)) && !pending) setCorrection(result.exposure.correction);
-        if (!(ours && (edits.dirty.notes || edits.saved)) && !pending) setNotes(result.exposure.notes || '');
+        // Per field: an untouched control still takes the freshest value.
+        // Dirty fields hold typing/keying the operator hasn't staged yet —
+        // strictly newer than both this read and the overlay.
+        if (!(ours && edits.dirty.reviewStatus)) setReviewStatus(merged.review_status);
+        if (!(ours && edits.dirty.correction)) setCorrection(merged.correction);
+        if (!(ours && edits.dirty.notes)) setNotes(merged.notes || '');
       }
       setLoading(false);
     })();
@@ -578,14 +506,15 @@ function ExposureDetailPageInner() {
         // Re-checked at RESPONSE time, not just dispatch: the operator can
         // arrive at this sibling and key a decision while this read is in
         // flight (one slow round trip is all it takes). Any cache entry that
-        // appeared since dispatch — the optimistic row or a save confirmation
-        // — is strictly newer than what this read saw, and a pending save with
-        // no cache entry (row never loaded) outranks it too. Overwriting here
-        // painted the pre-decision row on the next revisit as if the decision
-        // had reverted.
+        // appeared since dispatch — a staged decision's row or a save
+        // confirmation — is newer than what this read saw, and a mask save in
+        // flight outranks it too. Review fields are additionally overlaid
+        // with any queued/acked decision, so even a first write for a row the
+        // operator has already triaged (staged while the row was unloaded)
+        // paints their decision, not the pre-decision snapshot.
         if (!res.exposure) return;
         if (getCachedExposure(sibId) || hasPendingSave(sibId)) return;
-        setCachedExposure(res.exposure);
+        setCachedExposure(overlayReviewDecisions(res.exposure));
       }, () => inflight.delete(sibId));
     }
   }, [nav, id]);
@@ -700,32 +629,41 @@ function ExposureDetailPageInner() {
   const stateRef = useRef({ reviewStatus, correction, notes, hasChanges, exposure });
   stateRef.current = { reviewStatus, correction, notes, hasChanges, exposure };
 
-  // The last failed fire-and-forget save (module store — survives the remount
-  // on navigation, so the failure surfaces even though the operator is several
-  // exposures ahead by the time the response lands).
+  // The last failed save (module store — survives the remount on navigation,
+  // so the failure surfaces even though the operator is several exposures
+  // ahead by the time it lands) and the outbox backlog for the syncing pill.
   useSyncExternalStore(subscribeSaveState, getSaveStateVersion, getSaveStateVersion);
+  useSyncExternalStore(subscribeReviewOutbox, getReviewOutboxVersion, getReviewOutboxVersion);
   const saveError = getSaveError();
+  const queuedSaves = queuedReviewCount();
 
-  // Warn before unload while fire-and-forget saves are still in flight — a
-  // closed tab takes the in-flight decision (and any failure banner) with it.
-  // Dirty-but-undispatched edits warn too: a keyed decision that hasn't been
-  // followed by a navigation (e.g. `2` on the last exposure of the queue) has
-  // not even started saving, and unload would silently drop it.
+  // Unload no longer endangers triage decisions: stage anything still dirty
+  // right here (covers `2` on the last exposure with no navigation after it)
+  // — staging persists it to the outbox, whose in-flight sends are keepalive
+  // and whose stragglers replay on the next visit. Only mask saves still ride
+  // the plain server-action transport, so they alone keep the leave-site
+  // warning (hasAnyPendingSave now counts only mask saves). pagehide is the
+  // belt-and-braces flush for tab discards where beforeunload never fires.
   useEffect(() => {
-    const handler = (e: BeforeUnloadEvent) => {
-      const d = localEditsRef.current.dirty;
-      if (hasAnyPendingSave() || d.reviewStatus || d.correction || d.notes) {
-        e.preventDefault();
-      }
+    const warnHandler = (e: BeforeUnloadEvent) => {
+      flushDirtySave();
+      if (hasAnyPendingSave()) e.preventDefault();
     };
-    window.addEventListener('beforeunload', handler);
-    return () => window.removeEventListener('beforeunload', handler);
-  }, []);
+    const flushHandler = () => flushDirtySave();
+    window.addEventListener('beforeunload', warnHandler);
+    window.addEventListener('pagehide', flushHandler);
+    return () => {
+      window.removeEventListener('beforeunload', warnHandler);
+      window.removeEventListener('pagehide', flushHandler);
+    };
+  }, [flushDirtySave]);
 
-  // A failed save reverts the cached row to the server's truth; if that
-  // exposure is the one on screen, re-baseline `exposure` from the cache so
-  // hasChanges compares against reality and a retry actually fires (otherwise
-  // the optimistic row read at mount claims the decision already stuck).
+  // When a save failure names the exposure on screen, re-baseline `exposure`
+  // from the cache so hasChanges compares against reality. For a PERMANENT
+  // failure the outbox has reverted the cache to server truth, so the
+  // controls light up as unsaved and the operator can re-apply. For a
+  // RETRYING failure the cache still holds the staged decision (delivery is
+  // the outbox's problem, not the operator's), so this is a no-op by design.
   useEffect(() => {
     if (saveError?.id !== id) return;
     const cached = getCachedExposure(id);
@@ -738,101 +676,33 @@ function ExposureDetailPageInner() {
     // defaults, and saving them would overwrite the row's real correction and
     // notes with 'none' / ''.
     if (!s.exposure) return { ok: false };
-    // The exposure this save is for. The `S` shortcut fires handleSave
-    // un-awaited and mask saves aren't gated by navigation at all — so a
-    // response can land after the route moved on.
     const savedForId = id;
     // This dispatch takes responsibility for everything currently staged:
     // consume the dirty flags so a following navigation's flush doesn't
     // re-send the same decision. Anything keyed after this line re-dirties.
-    // The consumed flags are KEPT for the failure path below — they are the
-    // only record of which fields held operator decisions; re-dirtying more
-    // than that would let a later flush push `values` entries that were never
-    // edited (stale seeds from targetEdits, or defaults) over server truth.
-    const ownedAtDispatch = localEditsRef.current.forId === savedForId;
-    const dirtyAtDispatch = ownedAtDispatch
-      ? { ...localEditsRef.current.dirty }
-      : null;
-    if (ownedAtDispatch) {
+    if (localEditsRef.current.forId === savedForId) {
       localEditsRef.current.dirty = { reviewStatus: false, correction: false, notes: false };
     }
-    setSaving(true);
-    setSaved(false);
-    setError(null);
-    // Same per-exposure queue as the fire-and-forget nav save, so an explicit
-    // save and a background one for this row can't commit out of order. Takes
-    // a dispatch generation for the same reason: a success here must be
-    // visible to an older failed save's suspended cleanup handler. Marked
-    // pending like every other save so an in-flight revalidation (dispatched
-    // before this save, resolving after) can't write the pre-save row back
-    // over the operator's decision now that the dirty flags are consumed.
-    const saveSeq = nextSaveSeq(savedForId);
-    beginPendingSave(savedForId);
-    const result = await enqueueSave(savedForId, () => updateExposureReview(savedForId, {
+    // Explicit save persists the whole visible triple — the operator is
+    // saying "what's on screen is my decision".
+    stageReviewDecision(savedForId, {
       review_status: s.reviewStatus as NircamExposure['review_status'],
       correction: s.correction as NircamExposure['correction'],
       // Always sent (even '') so clearing the notes field actually persists —
-      // an undefined key is dropped from the PATCH and leaves the old value.
+      // an undefined key is dropped from the update and leaves the old value.
       notes: s.notes,
-    })).catch((err: unknown) => ({
-      exposure: null,
-      error: err instanceof Error ? err.message : 'Save failed',
-    }));
-    endPendingSave(savedForId);
-    setSaving(false);
-    if (result.error) {
-      // The decision did NOT persist. If the record still belongs to this
-      // exposure, restore EXACTLY the flags this dispatch consumed (unioned
-      // with any edits keyed since — those set their own flags and must
-      // survive) so a later navigation retries the operator's actual
-      // decisions and nothing more.
-      const ownedNow = localEditsRef.current.forId === savedForId;
-      if (ownedNow && dirtyAtDispatch) {
-        const cur = localEditsRef.current.dirty;
-        localEditsRef.current.dirty = {
-          reviewStatus: cur.reviewStatus || dirtyAtDispatch.reviewStatus,
-          correction: cur.correction || dirtyAtDispatch.correction,
-          notes: cur.notes || dirtyAtDispatch.notes,
-        };
-      }
-      if (ownedNow) {
-        setError(result.error);
-      } else {
-        // The operator has moved on: the record now belongs to another
-        // exposure, so the flags can't be restored and the component-scoped
-        // error box would paint unattributed on the wrong screen. Raise the
-        // id-aware module banner instead — it names the exposure, links back,
-        // and survives further navigation (same UX as a failed nav flush).
-        setSaveError({
-          id: savedForId,
-          filename: s.exposure.filename,
-          message: result.error,
-        });
-      }
-      return { ok: false };
+    }, s.exposure.filename);
+    // Staged == durable: the outbox delivers it (with retry, surviving
+    // reloads) or raises the module banner. Reflect that on screen without
+    // holding the UI on the round trip — same contract as auto-save-on-nav.
+    // Re-baselining `exposure` from the just-staged cache row is what flips
+    // hasChanges off; only correct while the screen still shows this row.
+    if (localEditsRef.current.forId === savedForId) {
+      const cached = getCachedExposure(savedForId);
+      if (cached) setExposure(cached);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
     }
-    // Keyed by the exposure's own id, so this is correct regardless of route.
-    if (result.exposure) {
-      markSaveCommitted(savedForId, saveSeq);
-      // Same guard as the fire-and-forget success path: a newer save queued
-      // behind this one (edit + navigate before this resolved) has already
-      // written its optimistic row — don't put this older row over it.
-      if (!hasPendingSave(savedForId)) setCachedExposure(result.exposure);
-      // A retry that lands supersedes an earlier failure for this exposure —
-      // same rule as the fire-and-forget path, or the banner outlives the fix.
-      if (getSaveError()?.id === savedForId) setSaveError(null);
-    }
-    // Everything below writes state belonging to whatever is on screen *now* —
-    // only safe while that's still the exposure we saved. Otherwise this would
-    // render the old exposure under the new one's URL and set the new one's
-    // `saved` guard, permanently suppressing its revalidation.
-    if (localEditsRef.current.forId !== savedForId) return { ok: true };
-    if (result.exposure) {
-      localEditsRef.current.saved = true;
-      setExposure(result.exposure);
-    }
-    setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
     return { ok: true };
   }, [id]);
 
@@ -928,16 +798,15 @@ function ExposureDetailPageInner() {
   // editor dispatches flushes mid-swap, when the on-screen exposure is already
   // the next one); `background` marks saves the editor can't report inline.
   //
-  // Serialized through the SAME per-exposure queue as the triage saves.
-  // Unqueued, a mask save and a nav triage save for this row could commit
-  // at the database in either order, and each confirmation only reflects
-  // the fields the database held at ITS commit — so whichever response was
-  // snapshotted first is missing the other's write, and no response-time
-  // guard can reassemble the truth from two partial rows. Queued, dispatch
-  // order is commit order and each later confirmation contains every
-  // earlier write. Marked pending for the same reason as triage saves:
-  // revalidation and the sibling prefetch must not resurrect the pre-save
-  // row while this write is in flight.
+  // Serialized through the per-exposure queue so two mask saves for one row
+  // (toolbar Save racing the nav auto-flush) can't commit out of order.
+  // Triage saves no longer share this queue — they ride the outbox — so a
+  // mask confirmation's row snapshot can predate a triage commit that
+  // happened during its round trip; overlayReviewDecisions repairs exactly
+  // that when the confirmed row is written below. Marked pending so
+  // revalidation and the sibling prefetch don't resurrect the pre-save
+  // mask_regions while this write is in flight (masks are the one field
+  // family the overlay can't reconstruct).
   //
   // useCallback with no deps (everything flows through refs/params): a stable
   // reference is what lets the memoized MaskEditor skip re-rendering on
@@ -962,17 +831,16 @@ function ExposureDetailPageInner() {
       endPendingSave(savedForId);
     }
     if (res.exposure) {
-      // A save queued behind this one (triage flush during the mask round
-      // trip) has already written its optimistic row, and — because the queue
-      // serializes commits — its confirmation will carry this mask write too.
-      // Only the newest pending state may own the cache.
-      if (!hasPendingSave(savedForId)) setCachedExposure(res.exposure);
-      // Same newer-than-the-read rule as the triage save: a mask write must not
-      // be undone by an in-flight revalidation landing after it — but only for
+      const merged = overlayReviewDecisions(res.exposure);
+      // A mask save queued behind this one has already written its own
+      // pending state — only the newest pending save may own the cache; its
+      // confirmation (serialized after this one) will carry this write too.
+      if (!hasPendingSave(savedForId)) setCachedExposure(merged);
+      // A mask write must not be undone by an in-flight revalidation landing
+      // after it — but re-baselining the on-screen row is only correct for
       // the exposure it was issued for (see handleSave).
       if (localEditsRef.current.forId === savedForId) {
-        localEditsRef.current.saved = true;
-        setExposure(res.exposure);
+        setExposure(merged);
       }
     } else if (res.error && (background || idRef.current !== savedForId)) {
       // Nothing on screen can show this failure inline (a background flush,
@@ -1098,6 +966,14 @@ function ExposureDetailPageInner() {
             <ChevronRight className="w-5 h-5" />
           </button>
         </div>
+        {queuedSaves > 0 && (
+          <span
+            className="text-xs text-text-tertiary tabular-nums whitespace-nowrap"
+            title="Decisions saved locally and being delivered — safe to keep working. They survive a refresh and finish syncing on their own."
+          >
+            syncing {queuedSaves}…
+          </span>
+        )}
         <button
           onClick={(e) => { blurOnMouseClick(e); setShowHelp(prev => !prev); }}
           title="Keyboard shortcuts (?)"
@@ -1139,10 +1015,32 @@ function ExposureDetailPageInner() {
         </div>
       )}
 
-      {/* A background auto-save (fire-and-forget on nav) failed — possibly for
-          an exposure several steps back. Persistent until dismissed or a retry
-          for the same exposure lands. */}
-      {saveError && (
+      {/* A background save is struggling — possibly for an exposure several
+          steps back. 'retrying' (amber): the outbox still holds the decision
+          and keeps retrying; clears itself when a retry lands. 'permanent'
+          (red): the write was rejected and dropped — the operator must
+          re-apply. Persistent until dismissed or superseded. */}
+      {saveError && (saveError.kind === 'retrying' ? (
+        <div className="bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-900 rounded-lg p-4 mb-6 flex items-start justify-between gap-4">
+          <p className="text-amber-800 dark:text-amber-400">
+            Trouble saving{' '}
+            <Link
+              href={`/admin/nircam/${saveError.id}${navQuery ? `?${navQuery}` : ''}`}
+              className="font-mono underline"
+            >
+              {saveError.filename}
+            </Link>
+            : {saveError.message}. Your decision is stored locally and will keep
+            retrying in the background (it survives a refresh).
+          </p>
+          <button
+            onClick={(e) => { blurOnMouseClick(e); setSaveError(null); }}
+            className="text-xs text-amber-800 dark:text-amber-400 hover:underline flex-shrink-0"
+          >
+            Dismiss
+          </button>
+        </div>
+      ) : (
         <div className="bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-900 rounded-lg p-4 mb-6 flex items-start justify-between gap-4">
           <p className="text-red-800 dark:text-red-400">
             Failed to save{' '}
@@ -1161,7 +1059,7 @@ function ExposureDetailPageInner() {
             Dismiss
           </button>
         </div>
-      )}
+      ))}
 
       <div className="flex gap-6">
         {/* Image viewer: live FITS render (N4) or the legacy PNG / mask editor */}
@@ -1376,12 +1274,10 @@ function ExposureDetailPageInner() {
 
               <Button
                 onClick={(e) => { blurOnMouseClick(e); handleSave(); }}
-                disabled={saving || !hasChanges}
+                disabled={!hasChanges}
                 className="w-full"
               >
-                {saving ? (
-                  <><Loader2 className="w-4 h-4 mr-2 animate-spin" /> Saving...</>
-                ) : saved ? (
+                {saved ? (
                   <><Check className="w-4 h-4 mr-2" /> Saved</>
                 ) : (
                   <><Save className="w-4 h-4 mr-2" /> Save Changes</>

--- a/web/app/admin/nircam/page.tsx
+++ b/web/app/admin/nircam/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useMemo, useState } from 'react';
+import { Suspense, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useQuery } from '@tanstack/react-query';
 import type { ColumnDef } from '@tanstack/react-table';
@@ -17,6 +17,10 @@ import {
   type ReductionProgress,
 } from '@/lib/actions/nircam-exposures';
 import { EXPOSURE_SORT_KEYS } from '@/lib/admin/sort-keys';
+import {
+  ensureReviewOutboxRunning,
+  overlayReviewDecisions,
+} from '@/lib/nircam-review-outbox';
 import type { NircamExposure } from '@/lib/types';
 import { stageBadgeClasses, NIRCAM_STAGES } from '@/lib/nircam-stages';
 import { buildExposureNavQuery } from '@/lib/nircam-exposure-nav';
@@ -367,6 +371,10 @@ function AdminNircamPageInner() {
     defaultSort: DEFAULT_SORT,
   });
 
+  // Replay triage decisions stranded by a reload as soon as the operator is
+  // back in the tool — the list page is where sessions land.
+  useEffect(() => { ensureReviewOutboxRunning(); }, []);
+
   const exposures = useAdminTableQuery<NircamExposure>({
     scope: 'admin-nircam-exposures',
     filters: state.debouncedFilters,
@@ -387,7 +395,15 @@ function AdminNircamPageInner() {
         page,
         pageSize: state.pageSize,
       });
-      return { rows: res.exposures, total: res.total, error: res.error };
+      return {
+        // Fold not-yet-delivered triage decisions over the server rows, so
+        // returning to the table right after a fast run shows what the
+        // operator decided rather than statuses the outbox hasn't finished
+        // syncing (the queue drains in the background either way).
+        rows: res.exposures.map(overlayReviewDecisions),
+        total: res.total,
+        error: res.error,
+      };
     },
   });
 

--- a/web/app/api/admin/nircam/review/route.ts
+++ b/web/app/api/admin/nircam/review/route.ts
@@ -35,10 +35,17 @@ import { createClient } from '@/lib/supabase/server';
 const REVIEW_STATUS_VALUES = new Set(['pending', 'approved', 'excluded']);
 const CORRECTION_VALUES = new Set(['none', 'needed', 'done']);
 const MAX_NOTES_LENGTH = 20_000;
-// Tolerated clock skew for the client-supplied decision stamp. A stamp far in
-// the future would wedge the row (every later honest decision < the poisoned
-// review_decided_at), so absurd values are rejected rather than stored.
-const MAX_FUTURE_SKEW_MS = 24 * 60 * 60 * 1000;
+// Tolerated FUTURE clock skew for the client-supplied decision stamp. The
+// stamp orders decisions (last-writer-wins), so a fast client clock could
+// shadow genuinely-later decisions from other devices until real time
+// catches up — this cap bounds that window to minutes. Kept as a client
+// stamp (not a server-assigned version) deliberately: within one device the
+// stamp is exactly monotonic, which is what makes at-least-once retries and
+// cross-session replays idempotent, and a server version can't distinguish
+// a retry from a new write without the client carrying an identity anyway.
+// Cross-device skew inside this window is the accepted residual for a
+// single-operator triage tool.
+const MAX_FUTURE_SKEW_MS = 5 * 60 * 1000;
 
 interface ReviewFields {
   review_status?: 'pending' | 'approved' | 'excluded';
@@ -52,8 +59,7 @@ function parseBody(body: unknown): { id: number; decidedAt: number; fields: Revi
   const id = b.id;
   const decidedAt = b.decidedAt;
   if (typeof id !== 'number' || !Number.isInteger(id) || id <= 0) return null;
-  if (typeof decidedAt !== 'number' || !Number.isFinite(decidedAt)) return null;
-  if (decidedAt <= 0 || decidedAt > Date.now() + MAX_FUTURE_SKEW_MS) return null;
+  if (typeof decidedAt !== 'number' || !Number.isFinite(decidedAt) || decidedAt <= 0) return null;
   const rawFields = b.fields;
   if (typeof rawFields !== 'object' || rawFields === null) return null;
   const f = rawFields as Record<string, unknown>;
@@ -80,6 +86,15 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid review payload' }, { status: 400 });
   }
   const { id, decidedAt, fields } = parsed;
+  if (decidedAt > Date.now() + MAX_FUTURE_SKEW_MS) {
+    // Named specifically (still a permanent 400): the fix is on the client's
+    // machine, and a generic validation error would send the operator
+    // hunting through the app instead of at their clock.
+    return NextResponse.json(
+      { error: 'Decision timestamp is ahead of server time — check this machine\'s clock' },
+      { status: 400 },
+    );
+  }
 
   const supabase = await createClient();
   const { data: { session } } = await supabase.auth.getSession();

--- a/web/app/api/admin/nircam/review/route.ts
+++ b/web/app/api/admin/nircam/review/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+/**
+ * POST /api/admin/nircam/review — persist a NIRCam triage decision.
+ *
+ * The transport target for the triage outbox (lib/nircam-review-outbox.ts).
+ * This is deliberately a route handler rather than a server action: the
+ * outbox needs a fetch it controls — request timeout, retry-on-drop, and
+ * `keepalive` so a flush survives the page being torn down — none of which
+ * the server-action transport exposes. Route handlers also run in parallel
+ * with the action lane, so saves never queue behind the triage page's read
+ * traffic.
+ *
+ * Body: {
+ *   id: number,                       // nircam_exposures.id
+ *   decidedAt: number,                // ms epoch of the operator's decision
+ *   fields: {                         // partial — only operator-touched keys
+ *     review_status?, correction?, notes?,
+ *   },
+ * }
+ *
+ * Retries make delivery at-least-once, so writes must be safe to replay and
+ * to arrive out of order: the update carries a last-writer-wins guard on
+ * review_decided_at. An equal stamp re-applies (idempotent retry); an older
+ * stamp is skipped and the current row is returned with `superseded: true`
+ * so the client treats the outrun decision as settled.
+ *
+ * Auth mirrors the triage server actions' requireSession fast path: confirm a
+ * session exists and let nircam_exposures RLS be the authority — a non-admin
+ * update matches zero rows, which (with the row invisible to the follow-up
+ * read) surfaces as 404, never as data.
+ */
+
+const REVIEW_STATUS_VALUES = new Set(['pending', 'approved', 'excluded']);
+const CORRECTION_VALUES = new Set(['none', 'needed', 'done']);
+const MAX_NOTES_LENGTH = 20_000;
+// Tolerated clock skew for the client-supplied decision stamp. A stamp far in
+// the future would wedge the row (every later honest decision < the poisoned
+// review_decided_at), so absurd values are rejected rather than stored.
+const MAX_FUTURE_SKEW_MS = 24 * 60 * 60 * 1000;
+
+interface ReviewFields {
+  review_status?: 'pending' | 'approved' | 'excluded';
+  correction?: 'none' | 'needed' | 'done';
+  notes?: string;
+}
+
+function parseBody(body: unknown): { id: number; decidedAt: number; fields: ReviewFields } | null {
+  if (typeof body !== 'object' || body === null) return null;
+  const b = body as Record<string, unknown>;
+  const id = b.id;
+  const decidedAt = b.decidedAt;
+  if (typeof id !== 'number' || !Number.isInteger(id) || id <= 0) return null;
+  if (typeof decidedAt !== 'number' || !Number.isFinite(decidedAt)) return null;
+  if (decidedAt <= 0 || decidedAt > Date.now() + MAX_FUTURE_SKEW_MS) return null;
+  const rawFields = b.fields;
+  if (typeof rawFields !== 'object' || rawFields === null) return null;
+  const f = rawFields as Record<string, unknown>;
+  const fields: ReviewFields = {};
+  if (f.review_status !== undefined) {
+    if (typeof f.review_status !== 'string' || !REVIEW_STATUS_VALUES.has(f.review_status)) return null;
+    fields.review_status = f.review_status as ReviewFields['review_status'];
+  }
+  if (f.correction !== undefined) {
+    if (typeof f.correction !== 'string' || !CORRECTION_VALUES.has(f.correction)) return null;
+    fields.correction = f.correction as ReviewFields['correction'];
+  }
+  if (f.notes !== undefined) {
+    if (typeof f.notes !== 'string' || f.notes.length > MAX_NOTES_LENGTH) return null;
+    fields.notes = f.notes;
+  }
+  if (Object.keys(fields).length === 0) return null;
+  return { id, decidedAt, fields };
+}
+
+export async function POST(request: NextRequest) {
+  const parsed = parseBody(await request.json().catch(() => null));
+  if (!parsed) {
+    return NextResponse.json({ error: 'Invalid review payload' }, { status: 400 });
+  }
+  const { id, decidedAt, fields } = parsed;
+
+  const supabase = await createClient();
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+
+  const decidedIso = new Date(decidedAt).toISOString();
+  const { data, error } = await supabase
+    .from('nircam_exposures')
+    .update({
+      ...fields,
+      review_decided_at: decidedIso,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', id)
+    // The LWW guard. `.or` ANDs with `.eq` above; <= (not <) so an exact
+    // retry of the same decision still succeeds instead of reporting stale.
+    .or(`review_decided_at.is.null,review_decided_at.lte.${decidedIso}`)
+    .select()
+    .maybeSingle();
+
+  if (error) {
+    // Database/transport-level failure: retryable by the outbox.
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  if (data) {
+    return NextResponse.json({ exposure: data });
+  }
+
+  // Zero rows: the guard rejected an older stamp, or the row doesn't exist /
+  // isn't visible under RLS. Disambiguate with a plain read.
+  const { data: row, error: readError } = await supabase
+    .from('nircam_exposures')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle();
+  if (readError) {
+    return NextResponse.json({ error: readError.message }, { status: 500 });
+  }
+  if (!row) {
+    return NextResponse.json({ error: 'Exposure not found' }, { status: 404 });
+  }
+  return NextResponse.json({ exposure: row, superseded: true });
+}

--- a/web/lib/actions/nircam-exposures.ts
+++ b/web/lib/actions/nircam-exposures.ts
@@ -321,39 +321,12 @@ export async function presignExposurePngs(
 // Update
 // ---------------------------------------------------------------------------
 
-export async function updateExposureReview(
-  id: number,
-  updates: {
-    review_status?: 'pending' | 'approved' | 'excluded';
-    correction?: 'none' | 'needed' | 'done';
-    notes?: string;
-  },
-): Promise<{ exposure: NircamExposure | null; error?: string }> {
-  try {
-    const supabase = await requireSession();
-
-    const { data, error } = await supabase
-      .from('nircam_exposures')
-      .update({
-        ...updates,
-        updated_at: new Date().toISOString(),
-      })
-      .eq('id', id)
-      .select()
-      .single();
-
-    if (error) {
-      return { exposure: null, error: error.message };
-    }
-
-    return { exposure: data };
-  } catch (err) {
-    return {
-      exposure: null,
-      error: err instanceof Error ? err.message : 'Failed to update exposure',
-    };
-  }
-}
+// Triage review updates (review_status / correction / notes) intentionally
+// have no server action: they go through POST /api/admin/nircam/review via
+// the durable outbox (lib/nircam-review-outbox.ts), which needs a transport
+// with timeout, retry, and keepalive — none of which server actions expose.
+// The route carries the review_decided_at last-writer-wins guard that makes
+// its at-least-once delivery safe.
 
 // ---------------------------------------------------------------------------
 // Mask polygons

--- a/web/lib/nircam-exposure-cache.ts
+++ b/web/lib/nircam-exposure-cache.ts
@@ -140,20 +140,23 @@ export function setCachedPngUrls(id: number, urls: ExposurePngUrls): void {
 }
 
 /**
- * In-flight triage saves + the most recent save failure.
+ * In-flight MASK saves + the most recent save failure.
  *
- * The detail page's auto-save-on-nav no longer blocks navigation on the save
- * round trip: it writes the operator's decision into the row cache
- * optimistically, fires the server action, and pushes the route immediately.
- * Module scope (surviving the page remount) is what lets the next page
- * instance still see the two things that flow leaves behind:
+ * Triage review decisions no longer register here — they ride the durable
+ * outbox (lib/nircam-review-outbox.ts), whose queued/acked state is what
+ * readers consult (via overlayReviewDecisions) instead of a suppression
+ * marker. Mask saves still use the plain server-action transport, so their
+ * in-flight ids are tracked here at module scope (surviving the page remount)
+ * for two consumers:
  *
- *  - which exposure ids have a save still in flight, so the background
- *    revalidation of a quickly-revisited exposure doesn't overwrite the
- *    optimistic row with the pre-save DB state; and
- *  - the most recent failed save, so the operator — possibly several
- *    exposures ahead by the time the failure lands — is told their decision
- *    didn't stick, with a way back to re-apply it.
+ *  - the background revalidation and sibling prefetch, which must not
+ *    overwrite the cache with a row snapshotted before an in-flight mask
+ *    write commits (mask_regions is the one field family the review overlay
+ *    cannot reconstruct); and
+ *  - the beforeunload warning, since an in-flight mask save dies with the
+ *    tab.
+ *
+ * The save-failure banner is shared: mask saves and the outbox both raise it.
  *
  * Subscribed via useSyncExternalStore: the snapshot is a monotonic version
  * counter; consumers read the actual values after the version changes.
@@ -163,6 +166,14 @@ export interface ExposureSaveError {
   id: number;
   filename: string;
   message: string;
+  /**
+   * How the failure should read to the operator. 'retrying' — the outbox
+   * still holds the decision and keeps retrying (transient transport/server
+   * trouble); the banner is informational and clears itself when a retry
+   * lands. 'permanent' (default when absent) — the write was rejected and
+   * dropped; the operator must re-apply the decision.
+   */
+  kind?: 'retrying' | 'permanent';
 }
 
 const pendingSaveIds = new Map<number, number>(); // id → in-flight save count
@@ -215,43 +226,17 @@ export function setSaveError(err: ExposureSaveError | null): void {
 }
 
 /**
- * Per-exposure save queue: saves for the same row run strictly in dispatch
- * order. Fire-and-forget saves mean two updates for one exposure can be in
- * flight together (navigate away, revisit before the save lands, edit,
- * navigate away again); if the transport reordered them, the older decision
- * would win in the database and the cache. Chaining per id makes dispatch
- * order the commit order regardless of transport behavior. Saves for
- * different exposures stay independent.
+ * Per-exposure save queue for MASK saves: saves for the same row run strictly
+ * in dispatch order. Fire-and-forget flushes mean two mask writes for one
+ * exposure can be in flight together (toolbar Save racing the editor's
+ * auto-flush on navigation); if the transport reordered them, the older
+ * polygons would win in the database and the cache. Chaining per id makes
+ * dispatch order the commit order regardless of transport behavior. Saves
+ * for different exposures stay independent. (Triage review writes don't
+ * queue here — the outbox's review_decided_at last-writer-wins guard handles
+ * their ordering server-side.)
  */
 const saveQueues = new Map<number, Promise<unknown>>();
-
-/**
- * Per-id monotonic save generations. The queue orders the server-action tasks,
- * but a failed save's cleanup handler awaits a revert refetch — and in that
- * window a newer save for the same id can dispatch, run, and fully commit
- * (dropping the in-flight count back to zero). The resuming handler must be
- * able to tell "a newer save has already committed" apart from "nothing newer
- * happened", or it reverts the cache to a pre-newer-save snapshot and raises a
- * failure banner for a decision that actually persisted. Each save takes a
- * dispatch sequence number; successful saves record theirs as committed.
- */
-const saveDispatchSeq = new Map<number, number>();
-const saveCommitSeq = new Map<number, number>();
-
-export function nextSaveSeq(id: number): number {
-  const n = (saveDispatchSeq.get(id) ?? 0) + 1;
-  saveDispatchSeq.set(id, n);
-  return n;
-}
-
-export function markSaveCommitted(id: number, seq: number): void {
-  if ((saveCommitSeq.get(id) ?? 0) < seq) saveCommitSeq.set(id, seq);
-}
-
-/** True when a save dispatched after `seq` has already committed for `id`. */
-export function hasNewerCommittedSave(id: number, seq: number): boolean {
-  return (saveCommitSeq.get(id) ?? 0) > seq;
-}
 
 export function enqueueSave<T>(id: number, task: () => Promise<T>): Promise<T> {
   const prev = saveQueues.get(id) ?? Promise.resolve();

--- a/web/lib/nircam-review-outbox.ts
+++ b/web/lib/nircam-review-outbox.ts
@@ -151,11 +151,25 @@ function parseStoredEntries(raw: string | null): OutboxEntry[] {
   return out;
 }
 
-/** True when this tab has seen a commit at least as new as `entry` — the
- *  entry is settled and must not be (re)adopted or re-persisted. */
+/** Stamps this tab has RETIRED, by exposure id: the send settled — delivered,
+ *  outrun by a newer decision (superseded), or permanently rejected — and the
+ *  entry must leave durable storage. Kept separately from ackedReview because
+ *  only *committed* fields may be overlaid onto server rows: a superseded or
+ *  rejected decision is settled but its fields never became truth. Without
+ *  this, persist()'s merge resurrected such entries into storage forever —
+ *  every reload re-adopted and re-sent them, re-raising the failure banner. */
+const retiredReview = new Map<number, number>();
+
+function markRetired(id: number, decidedAt: number): void {
+  if ((retiredReview.get(id) ?? 0) < decidedAt) retiredReview.set(id, decidedAt);
+}
+
+/** True when this tab has seen `entry`'s stamp settle (commit, superseded, or
+ *  permanent rejection) — the entry must not be (re)adopted or re-persisted. */
 function isSettled(entry: OutboxEntry): boolean {
   const acked = ackedReview.get(entry.id);
-  return acked !== undefined && acked.decidedAt >= entry.decidedAt;
+  if (acked !== undefined && acked.decidedAt >= entry.decidedAt) return true;
+  return (retiredReview.get(entry.id) ?? 0) >= entry.decidedAt;
 }
 
 /** Fold entries found in shared storage (another tab's work, or a previous
@@ -285,9 +299,17 @@ export function stageReviewDecision(
   if (!isBrowser || Object.keys(fields).length === 0) return;
   ensureLoaded();
   const existing = entries.get(id);
-  // Strictly monotonic per entry even within one ms, so an in-flight send's
-  // snapshot compares unequal to a re-edited entry.
-  const decidedAt = Math.max(Date.now(), (existing?.decidedAt ?? 0) + 1);
+  // Strictly monotonic per exposure even within one ms — above the live
+  // entry (so an in-flight send's snapshot compares unequal to a re-edit)
+  // AND above every settled stamp (so a decision re-applied right after an
+  // ack or a permanent rejection can never mint a stamp that isSettled()
+  // would judge already-retired and silently drop from durable storage).
+  const decidedAt = Math.max(
+    Date.now(),
+    (existing?.decidedAt ?? 0) + 1,
+    (retiredReview.get(id) ?? 0) + 1,
+    (ackedReview.get(id)?.decidedAt ?? 0) + 1,
+  );
   const entry: OutboxEntry = {
     id,
     fields: { ...existing?.fields, ...fields },
@@ -404,19 +426,26 @@ async function attemptEntry(id: number): Promise<void> {
   try {
     const result = await postReview(snapshot);
 
-    // Settled. Retire the entry unless it changed mid-flight.
-    reattempt = changedMidFlight();
-    if (!reattempt) {
-      entries.delete(id);
-      persist();
-    }
+    // Settled — delivered or outrun. Both bookkeeping writes MUST precede
+    // persist(): its merge treats any storage entry not provably settled as
+    // another tab's live work and writes it back, so retiring after
+    // persisting would leave this entry in storage to replay on next load.
     consecutiveFailures.delete(id);
     if (!result.superseded) {
       // Remember what committed so later stale reads can be overlaid. On a
       // superseded response our snapshot did NOT commit — a newer decision
       // (another tab, or a pre-teardown keepalive from a previous session)
-      // already owns the row, and the returned row reflects it.
+      // already owns the row, and the returned row reflects it — so its
+      // fields must never be overlaid; it is retired without an ack.
       ackedReview.set(id, { fields: { ...snapshot.fields }, decidedAt: snapshot.decidedAt });
+    }
+    markRetired(id, snapshot.decidedAt);
+    // Drop the entry unless it changed mid-flight (then the merged, newer
+    // entry goes back out — its stamp is above the retirement mark).
+    reattempt = changedMidFlight();
+    if (!reattempt) {
+      entries.delete(id);
+      persist();
     }
     if (result.exposure) cacheConfirmedRow(result.exposure);
     if (getSaveError()?.id === id) setSaveError(null);
@@ -424,6 +453,11 @@ async function attemptEntry(id: number): Promise<void> {
     const message = err instanceof Error ? err.message : 'Save failed';
     const filename = snapshot.filename ?? `exposure #${id}`;
     if (err instanceof PermanentSaveError) {
+      // This stamp can never succeed — retire it (before any persist) so it
+      // leaves durable storage instead of replaying the same rejection on
+      // every future load. A mid-flight re-edit carries a higher stamp and
+      // is unaffected.
+      markRetired(id, snapshot.decidedAt);
       if (changedMidFlight()) {
         // The rejection judged a payload the operator has since replaced —
         // the merged entry deserves its own verdict. Re-send it; if it is

--- a/web/lib/nircam-review-outbox.ts
+++ b/web/lib/nircam-review-outbox.ts
@@ -1,0 +1,406 @@
+/**
+ * Durable outbox for NIRCam triage decisions.
+ *
+ * The triage flow's original transport was a fire-and-forget server action:
+ * a decision existed only in JS memory between the keypress and the server
+ * ack, the action POST had no timeout and could not be retried or marked
+ * keepalive, and all actions from the tab shared one serialized dispatch
+ * lane. A single dropped POST therefore lost the decision silently — and
+ * left a stuck "save in flight" marker that suppressed revalidation, so the
+ * UI kept showing the decision as applied until a full reload.
+ *
+ * This module makes the space-bar press itself the durable commit:
+ *
+ *  1. `stageReviewDecision` merges the decision into a localStorage-backed
+ *     outbox entry (one per exposure, newest-wins per field) BEFORE anything
+ *     touches the network. A refresh, crash, or closed laptop lid loses
+ *     nothing — entries replay on the next visit to the triage pages.
+ *  2. A flush loop delivers entries to POST /api/admin/nircam/review with a
+ *     request timeout, capped-backoff retries, and `keepalive` (so a flush
+ *     dispatched during page teardown still completes). Delivery is
+ *     at-least-once; the server's review_decided_at last-writer-wins guard
+ *     makes replays and reordering harmless.
+ *  3. `overlayReviewDecisions` lets row readers reconstruct truth as
+ *     "server row + not-yet-acked decisions" instead of trusting a cached
+ *     optimistic row that might be stale.
+ *
+ * Failure surface: transient errors (network, timeout, 5xx) retry forever
+ * with capped backoff and raise the module save-error banner (kind
+ * 'retrying') after a few consecutive misses; permanent rejections (4xx —
+ * auth, validation, vanished row) drop the entry, revert the row cache to
+ * server truth, and raise the banner as before (kind 'permanent').
+ *
+ * Multi-tab: tabs share the storage key. Each tab flushes its own in-memory
+ * view; duplicate sends are idempotent under the server guard, and a tab
+ * re-persisting an entry another tab already delivered only causes one more
+ * no-op send. Not worth a cross-tab lock for an admin tool.
+ */
+
+import type { NircamExposure } from '@/lib/types';
+import {
+  getCachedExposure,
+  setCachedExposure,
+  deleteCachedExposure,
+  getSaveError,
+  setSaveError,
+} from '@/lib/nircam-exposure-cache';
+import { getNircamExposureById } from '@/lib/actions/nircam-exposures';
+
+export interface ReviewDecisionFields {
+  review_status?: NircamExposure['review_status'];
+  correction?: NircamExposure['correction'];
+  notes?: string;
+}
+
+interface OutboxEntry {
+  id: number;
+  fields: ReviewDecisionFields;
+  /** ms epoch of the newest edit folded into this entry (strictly monotonic
+   *  per entry, so "did it change while a send was in flight" is one compare). */
+  decidedAt: number;
+  /** For save-failure banners; entries can outlive the row cache. */
+  filename: string | null;
+}
+
+const STORAGE_KEY = 'campfire.nircam-review-outbox.v1';
+const ENDPOINT = '/api/admin/nircam/review';
+const REQUEST_TIMEOUT_MS = 12_000;
+// Consecutive transient failures for one entry before the operator is told
+// (the entry keeps retrying either way).
+const FAILURES_BEFORE_BANNER = 3;
+const RETRY_BACKOFF_MS = [1_000, 2_000, 4_000, 8_000, 15_000, 30_000];
+// Replay after a reload can hold a whole session's tail; don't stampede.
+const MAX_CONCURRENT_FLUSHES = 6;
+
+const isBrowser = typeof window !== 'undefined';
+
+const entries = new Map<number, OutboxEntry>();
+/** Review fields whose server commit this tab has seen, by exposure id.
+ *  Overlaid onto any server read whose row predates the commit, so a slow
+ *  response snapshotted pre-commit can't resurrect the old decision. */
+const ackedReview = new Map<number, { fields: ReviewDecisionFields; decidedAt: number }>();
+const inFlight = new Set<number>();
+const consecutiveFailures = new Map<number, number>();
+const retryTimers = new Map<number, ReturnType<typeof setTimeout>>();
+let activeFlushes = 0;
+const waitingIds: number[] = [];
+
+let version = 0;
+const listeners = new Set<() => void>();
+function emit(): void {
+  version++;
+  for (const listener of listeners) listener();
+}
+
+export function subscribeReviewOutbox(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function getReviewOutboxVersion(): number {
+  return version;
+}
+
+/** Entries staged or in flight — decisions not yet acknowledged by the server. */
+export function queuedReviewCount(): number {
+  return entries.size;
+}
+
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+let loaded = false;
+
+function ensureLoaded(): void {
+  if (loaded || !isBrowser) return;
+  loaded = true;
+  let raw: string | null = null;
+  try {
+    raw = window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return; // storage unavailable (private mode etc.) — memory-only outbox
+  }
+  if (!raw) return;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return;
+    for (const item of parsed) {
+      if (typeof item !== 'object' || item === null) continue;
+      const e = item as Partial<OutboxEntry>;
+      if (typeof e.id !== 'number' || !Number.isInteger(e.id) || e.id <= 0) continue;
+      if (typeof e.decidedAt !== 'number' || !Number.isFinite(e.decidedAt)) continue;
+      if (typeof e.fields !== 'object' || e.fields === null) continue;
+      const fields: ReviewDecisionFields = {};
+      if (e.fields.review_status !== undefined
+          && ['pending', 'approved', 'excluded'].includes(e.fields.review_status)) {
+        fields.review_status = e.fields.review_status;
+      }
+      if (e.fields.correction !== undefined
+          && ['none', 'needed', 'done'].includes(e.fields.correction)) {
+        fields.correction = e.fields.correction;
+      }
+      if (typeof e.fields.notes === 'string') fields.notes = e.fields.notes;
+      if (Object.keys(fields).length === 0) continue;
+      entries.set(e.id, {
+        id: e.id,
+        fields,
+        decidedAt: e.decidedAt,
+        filename: typeof e.filename === 'string' ? e.filename : null,
+      });
+    }
+  } catch {
+    // Corrupt payload: drop it rather than wedge every future stage() call.
+    try { window.localStorage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
+  }
+}
+
+function persist(): void {
+  if (!isBrowser) return;
+  try {
+    if (entries.size === 0) window.localStorage.removeItem(STORAGE_KEY);
+    else window.localStorage.setItem(STORAGE_KEY, JSON.stringify([...entries.values()]));
+  } catch {
+    // Quota/private mode: the in-memory outbox still flushes this session.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Overlay
+// ---------------------------------------------------------------------------
+
+function applyFields(
+  row: NircamExposure,
+  fields: ReviewDecisionFields,
+  decidedAt: number,
+): NircamExposure {
+  return {
+    ...row,
+    ...(fields.review_status !== undefined ? { review_status: fields.review_status } : null),
+    ...(fields.correction !== undefined ? { correction: fields.correction } : null),
+    // '' is a deliberate clear and stores as null, mirroring the server.
+    ...(fields.notes !== undefined ? { notes: fields.notes || null } : null),
+    review_decided_at: new Date(decidedAt).toISOString(),
+  };
+}
+
+/**
+ * Reconstruct current truth for a server-read row: acked-but-possibly-unseen
+ * decisions first (skipped when the row already carries an equal-or-newer
+ * review_decided_at), then still-queued decisions, which are newer by
+ * construction. Pass every freshly fetched exposure row through this before
+ * caching or rendering it — it makes stale reads harmless instead of needing
+ * to be suppressed.
+ */
+export function overlayReviewDecisions(row: NircamExposure): NircamExposure {
+  ensureLoaded();
+  let out = row;
+  const acked = ackedReview.get(row.id);
+  if (acked) {
+    const rowStamp = out.review_decided_at ? Date.parse(out.review_decided_at) : 0;
+    if (!(rowStamp >= acked.decidedAt)) {
+      out = applyFields(out, acked.fields, acked.decidedAt);
+    }
+  }
+  const entry = entries.get(row.id);
+  if (entry) out = applyFields(out, entry.fields, entry.decidedAt);
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Staging
+// ---------------------------------------------------------------------------
+
+/**
+ * Record a triage decision durably and schedule its delivery. This is the
+ * commit point: once this returns, the decision survives refresh/close and
+ * will reach the server unless it is permanently rejected (which raises the
+ * save-error banner). Also applies the decision to the cached row so
+ * navigation keeps painting the operator's latest state.
+ */
+export function stageReviewDecision(
+  id: number,
+  fields: ReviewDecisionFields,
+  filename?: string | null,
+): void {
+  if (!isBrowser || Object.keys(fields).length === 0) return;
+  ensureLoaded();
+  const existing = entries.get(id);
+  // Strictly monotonic per entry even within one ms, so an in-flight send's
+  // snapshot compares unequal to a re-edited entry.
+  const decidedAt = Math.max(Date.now(), (existing?.decidedAt ?? 0) + 1);
+  const entry: OutboxEntry = {
+    id,
+    fields: { ...existing?.fields, ...fields },
+    decidedAt,
+    filename: filename ?? existing?.filename ?? getCachedExposure(id)?.filename ?? null,
+  };
+  entries.set(id, entry);
+  persist();
+  const cached = getCachedExposure(id);
+  if (cached) setCachedExposure(applyFields(cached, entry.fields, entry.decidedAt));
+  emit();
+  void attemptEntry(id);
+}
+
+/**
+ * Load persisted entries and (re)start delivery. Idempotent; call from the
+ * triage pages on mount so decisions stranded by a reload replay as soon as
+ * the operator is back in the tool.
+ */
+export function ensureReviewOutboxRunning(): void {
+  if (!isBrowser) return;
+  ensureLoaded();
+  for (const id of entries.keys()) void attemptEntry(id);
+}
+
+// ---------------------------------------------------------------------------
+// Delivery
+// ---------------------------------------------------------------------------
+
+class PermanentSaveError extends Error {}
+
+async function postReview(entry: OutboxEntry): Promise<{
+  exposure: NircamExposure | null;
+  superseded?: boolean;
+}> {
+  let res: Response;
+  try {
+    res = await fetch(ENDPOINT, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id: entry.id, decidedAt: entry.decidedAt, fields: entry.fields }),
+      // Survives page teardown — the beforeunload flush depends on this.
+      keepalive: true,
+      // A hung request becomes a retryable error instead of a wedged save.
+      signal: typeof AbortSignal.timeout === 'function'
+        ? AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+        : undefined,
+    });
+  } catch (err) {
+    // Network failure / timeout: retryable.
+    throw err instanceof Error ? err : new Error('Network error');
+  }
+  let body: { exposure?: NircamExposure | null; superseded?: boolean; error?: string } | null = null;
+  try {
+    body = await res.json();
+  } catch {
+    body = null;
+  }
+  if (res.ok) return { exposure: body?.exposure ?? null, superseded: body?.superseded };
+  const message = body?.error || `Save failed (HTTP ${res.status})`;
+  // 401 is deliberately retryable, not permanent: an expired session must not
+  // drop the decision. The entry stays durable, the banner says saving is
+  // stuck, and once the operator is signed in again (this session or after a
+  // reload — entries replay) delivery completes.
+  if (res.status >= 500 || res.status === 401 || res.status === 408 || res.status === 429) {
+    throw new Error(message); // retryable
+  }
+  throw new PermanentSaveError(message);
+}
+
+function scheduleRetry(id: number, failureCount: number): void {
+  const delay = RETRY_BACKOFF_MS[Math.min(failureCount - 1, RETRY_BACKOFF_MS.length - 1)];
+  const existing = retryTimers.get(id);
+  if (existing !== undefined) clearTimeout(existing);
+  retryTimers.set(id, setTimeout(() => {
+    retryTimers.delete(id);
+    void attemptEntry(id);
+  }, delay));
+}
+
+/** Write a server-confirmed row into the cache unless the cached row is
+ *  strictly newer (a mask save confirmed while this response was in flight —
+ *  both paths bump updated_at server-side). */
+function cacheConfirmedRow(row: NircamExposure): void {
+  const cached = getCachedExposure(row.id);
+  if (cached?.updated_at && row.updated_at
+      && Date.parse(row.updated_at) < Date.parse(cached.updated_at)) {
+    return;
+  }
+  setCachedExposure(overlayReviewDecisions(row));
+}
+
+async function attemptEntry(id: number): Promise<void> {
+  if (!entries.has(id) || inFlight.has(id)) return;
+  if (activeFlushes >= MAX_CONCURRENT_FLUSHES) {
+    if (!waitingIds.includes(id)) waitingIds.push(id);
+    return;
+  }
+  const snapshot = entries.get(id)!;
+  activeFlushes++;
+  inFlight.add(id);
+  emit();
+  // True when the operator re-edited this exposure while the send was in
+  // flight: the current entry is then a superset of the snapshot's fields
+  // with a newer stamp, and it must go back out — never be retired (on ack)
+  // or dropped (on permanent rejection) on the strength of the snapshot's
+  // outcome alone. The re-send is deferred to `finally`: attemptEntry bails
+  // on in-flight ids, and this one stays marked in-flight until then.
+  const changedMidFlight = () => {
+    const current = entries.get(id);
+    return current !== undefined && current.decidedAt !== snapshot.decidedAt;
+  };
+  let reattempt = false;
+  try {
+    const result = await postReview(snapshot);
+
+    // Settled. Retire the entry unless it changed mid-flight.
+    reattempt = changedMidFlight();
+    if (!reattempt) {
+      entries.delete(id);
+      persist();
+    }
+    consecutiveFailures.delete(id);
+    if (!result.superseded) {
+      // Remember what committed so later stale reads can be overlaid. On a
+      // superseded response our snapshot did NOT commit — a newer decision
+      // (another tab, or a pre-teardown keepalive from a previous session)
+      // already owns the row, and the returned row reflects it.
+      ackedReview.set(id, { fields: { ...snapshot.fields }, decidedAt: snapshot.decidedAt });
+    }
+    if (result.exposure) cacheConfirmedRow(result.exposure);
+    if (getSaveError()?.id === id) setSaveError(null);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Save failed';
+    const filename = snapshot.filename ?? `exposure #${id}`;
+    if (err instanceof PermanentSaveError) {
+      if (changedMidFlight()) {
+        // The rejection judged a payload the operator has since replaced —
+        // the merged entry deserves its own verdict. Re-send it; if it is
+        // rejected too, THAT failure drops and reports it.
+        consecutiveFailures.delete(id);
+        reattempt = true;
+      } else {
+        // The server rejected the write — retrying the same payload can't
+        // succeed. Drop the decision LOUDLY: revert the cached row to server
+        // truth (best effort) and tell the operator to re-apply.
+        entries.delete(id);
+        persist();
+        consecutiveFailures.delete(id);
+        try {
+          const fresh = await getNircamExposureById(id);
+          if (fresh.exposure) cacheConfirmedRow(fresh.exposure);
+          else deleteCachedExposure(id);
+        } catch {
+          deleteCachedExposure(id);
+        }
+        setSaveError({ id, filename, message, kind: 'permanent' });
+      }
+    } else {
+      const failures = (consecutiveFailures.get(id) ?? 0) + 1;
+      consecutiveFailures.set(id, failures);
+      if (failures >= FAILURES_BEFORE_BANNER) {
+        setSaveError({ id, filename, message, kind: 'retrying' });
+      }
+      scheduleRetry(id, failures);
+    }
+  } finally {
+    activeFlushes--;
+    inFlight.delete(id);
+    emit();
+    if (reattempt) void attemptEntry(id);
+    const next = waitingIds.shift();
+    if (next !== undefined) void attemptEntry(next);
+  }
+}

--- a/web/lib/nircam-review-outbox.ts
+++ b/web/lib/nircam-review-outbox.ts
@@ -30,10 +30,13 @@
  * auth, validation, vanished row) drop the entry, revert the row cache to
  * server truth, and raise the banner as before (kind 'permanent').
  *
- * Multi-tab: tabs share the storage key. Each tab flushes its own in-memory
- * view; duplicate sends are idempotent under the server guard, and a tab
- * re-persisting an entry another tab already delivered only causes one more
- * no-op send. Not worth a cross-tab lock for an admin tool.
+ * Multi-tab: tabs share the storage key, and every write MERGES with what's
+ * in storage instead of overwriting it (per id, the newer decidedAt wins;
+ * entries this tab has seen acknowledged are dropped), so one tab persisting
+ * can never evict another tab's undelivered decision. Tabs also adopt each
+ * other's entries via storage events and both flush them — duplicate sends
+ * are idempotent under the server guard, and the worst cross-tab race is one
+ * redundant no-op send of an already-delivered decision.
  */
 
 import type { NircamExposure } from '@/lib/types';
@@ -112,19 +115,12 @@ export function queuedReviewCount(): number {
 
 let loaded = false;
 
-function ensureLoaded(): void {
-  if (loaded || !isBrowser) return;
-  loaded = true;
-  let raw: string | null = null;
-  try {
-    raw = window.localStorage.getItem(STORAGE_KEY);
-  } catch {
-    return; // storage unavailable (private mode etc.) — memory-only outbox
-  }
-  if (!raw) return;
+function parseStoredEntries(raw: string | null): OutboxEntry[] {
+  if (!raw) return [];
+  const out: OutboxEntry[] = [];
   try {
     const parsed: unknown = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return;
+    if (!Array.isArray(parsed)) return [];
     for (const item of parsed) {
       if (typeof item !== 'object' || item === null) continue;
       const e = item as Partial<OutboxEntry>;
@@ -142,7 +138,7 @@ function ensureLoaded(): void {
       }
       if (typeof e.fields.notes === 'string') fields.notes = e.fields.notes;
       if (Object.keys(fields).length === 0) continue;
-      entries.set(e.id, {
+      out.push({
         id: e.id,
         fields,
         decidedAt: e.decidedAt,
@@ -150,16 +146,79 @@ function ensureLoaded(): void {
       });
     }
   } catch {
+    return [];
+  }
+  return out;
+}
+
+/** True when this tab has seen a commit at least as new as `entry` — the
+ *  entry is settled and must not be (re)adopted or re-persisted. */
+function isSettled(entry: OutboxEntry): boolean {
+  const acked = ackedReview.get(entry.id);
+  return acked !== undefined && acked.decidedAt >= entry.decidedAt;
+}
+
+/** Fold entries found in shared storage (another tab's work, or a previous
+ *  session's) into this tab's map: per id the newer decidedAt wins, settled
+ *  entries are ignored. Returns the adopted ids so callers can kick flushes. */
+function adoptEntries(found: OutboxEntry[]): number[] {
+  const adopted: number[] = [];
+  for (const e of found) {
+    if (isSettled(e)) continue;
+    const mine = entries.get(e.id);
+    if (mine !== undefined && mine.decidedAt >= e.decidedAt) continue;
+    entries.set(e.id, e);
+    adopted.push(e.id);
+  }
+  return adopted;
+}
+
+function ensureLoaded(): void {
+  if (loaded || !isBrowser) return;
+  loaded = true;
+  let raw: string | null = null;
+  try {
+    raw = window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return; // storage unavailable (private mode etc.) — memory-only outbox
+  }
+  if (raw && parseStoredEntries(raw).length === 0) {
     // Corrupt payload: drop it rather than wedge every future stage() call.
     try { window.localStorage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
   }
+  adoptEntries(parseStoredEntries(raw));
+  // Another tab staging or retiring decisions fires this (storage events
+  // never fire in the tab that wrote). Adopt anything newer and deliver it
+  // here too — duplicates are idempotent; retirement is handled by acks, not
+  // by events, so a tab never drops an entry just because another tab wrote.
+  window.addEventListener('storage', (ev) => {
+    if (ev.key !== STORAGE_KEY) return;
+    const adopted = adoptEntries(parseStoredEntries(ev.newValue));
+    if (adopted.length > 0) {
+      emit();
+      for (const id of adopted) void attemptEntry(id);
+    }
+  });
 }
 
 function persist(): void {
   if (!isBrowser) return;
   try {
-    if (entries.size === 0) window.localStorage.removeItem(STORAGE_KEY);
-    else window.localStorage.setItem(STORAGE_KEY, JSON.stringify([...entries.values()]));
+    // MERGE with storage rather than overwrite: another tab's undelivered
+    // entries must survive this tab's write. Per id the newer decidedAt
+    // wins; entries this tab has seen acknowledged are dropped (that is the
+    // only retirement path — a tab that merely didn't have an entry in
+    // memory can never evict it).
+    const merged = new Map<number, OutboxEntry>();
+    for (const e of parseStoredEntries(window.localStorage.getItem(STORAGE_KEY))) {
+      if (!isSettled(e)) merged.set(e.id, e);
+    }
+    for (const e of entries.values()) {
+      const theirs = merged.get(e.id);
+      if (theirs === undefined || theirs.decidedAt <= e.decidedAt) merged.set(e.id, e);
+    }
+    if (merged.size === 0) window.localStorage.removeItem(STORAGE_KEY);
+    else window.localStorage.setItem(STORAGE_KEY, JSON.stringify([...merged.values()]));
   } catch {
     // Quota/private mode: the in-memory outbox still flushes this session.
   }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -470,6 +470,13 @@ export interface NircamExposure {
   image_height: number | null;
   mask_regions: MaskRegionsPayload | null;
   notes: string | null;
+  /**
+   * When the review fields were last decided (client decision time, ISO).
+   * Last-writer-wins token for the triage review API: a retried or duplicated
+   * save carrying an older stamp is rejected server-side. Null until the row
+   * has been triaged through the outbox path.
+   */
+  review_decided_at: string | null;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Problem

Triage decisions in `/admin/nircam/[id]` were saved fire-and-forget through a server action — a transport with no timeout, no retry, and no keepalive, sharing one serialized dispatch lane with all of the page's read traffic (row prefetch, neighbors RPC, presigns, revalidation). A dropped or hung POST lost the decision **silently**: the DB kept `pending`, the optimistic cache said `approved`, and the stuck "save in flight" marker suppressed revalidation indefinitely — so the triage box kept claiming "approved" until a full reload, and re-applying the decision no-op'd against the lying cache. This is the "a handful of exposures come back pending at the end of a session" bug.

## Fix: the space-bar press is now the durable commit

- **`web/lib/nircam-review-outbox.ts`** (new): localStorage-backed outbox. Decisions are staged (merged per exposure, newest-wins) *before* any network I/O, survive refresh/close, and replay on the next visit to either triage page. The flush loop delivers with a 12 s request timeout, capped-backoff retries, `keepalive` sends, and a concurrency cap. Transient failures (network, 5xx, 401) retry forever, raising an amber "still retrying" banner after three misses; permanent rejections drop the entry loudly (red banner + cache revert). `overlayReviewDecisions` reconstructs truth as "server row + not-yet-acked decisions" for every row reader. Storage writes merge across tabs (newer stamp wins, acknowledged entries retire), so one tab can never evict another's undelivered decision.
- **`POST /api/admin/nircam/review`** (new): replaces the `updateExposureReview` server action. Route handlers run in parallel with the action lane and accept a caller-controlled fetch — timeout, retry, and keepalive become possible, and saves can no longer queue behind reads.
- **`nircam_exposures.review_decided_at`** (schema + migration `20260817120000`): last-writer-wins guard stamped with the client decision time. Makes at-least-once delivery safe: an equal stamp re-applies idempotently (retries), an older stamp is skipped and reported `superseded` (replays, zombie keepalive sends, multi-tab). Future clock skew is capped at 5 minutes, with a named error pointing at the machine's clock beyond that.
- **`get_admin_exposures` returns the stamp** (schema + migration `20260817213000`, drop/recreate since the return shape changed) so the list overlay compares stamps instead of treating rows as stampless.
- **Triage detail page**: flushes and explicit saves stage into the outbox; revalidation/prefetch writes go through the overlay instead of being suppressed by pending markers (mask saves keep suppression — the overlay can't reconstruct `mask_regions`); the "already equal" diff is removed so re-applying a decision always re-sends; unload stages dirty edits instead of only warning; a "syncing N…" pill shows the backlog.
- **Triage list page**: starts the outbox on mount (replay lands as soon as the operator is back) and overlays queued decisions onto table rows.

## Notes for review

- Both migrations are hand-authored; the preview branch applied them and re-seeded green, which exercises the same path production will take.
- `supabase/seed.sql` contains no `nircam_exposures` rows, so no seed regeneration is needed for the new nullable column.
- Verified with `cd web && npm run build` (clean; only pre-existing lint warnings).

Generated with Claude Code

https://claude.ai/code/session_01EMHbzzqbcHgKTiDrjwDeDL