### PR TITLE
feat(nircam bkg): retune bkg2d mesh to 32/3 — remove common-mode row banding

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -51,10 +51,11 @@ Release procedure: edit the `## Unreleased` section below, then run
   Validated by five arms re-run from uncal through the real pipeline on 6 frames
   spanning the banding distribution, with a deliberately-too-coarse 256/5
   control that confirms the metrics move in the physically correct direction.
-  Known cost: a highly elongated feature loses ~1% of its flux (one satellite
-  trail, elongation 22: -1.03%) versus -0.03% for compact sources in the same
-  frame; trails and diffraction spikes are contamination rather than photometric
-  targets, and the intermediate/large source bins are flat. Expect all NIRCam
+  Known cost: a highly elongated feature loses ~1% of its flux (one segment of
+  elongation 22 spanning 4,832 px: -1.03%) versus -0.03% for compact sources in
+  the same frame; the intermediate/large source bins are flat, so this is not a
+  general extended-source loss. The feature was not identified — only its
+  geometry was measured. Expect all NIRCam
   exposures to need reprocessing from uncal to pick this up (`bkg` is
   SCI-mutating and has no backup, so `reset --from bkg` is refused).
 - **New NIRCam `jackknife` step: re-zeros jump-segmented ramp fits against the

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -29,6 +29,34 @@ Release procedure: edit the `## Unreleased` section below, then run
 ## Unreleased
 
 ### Calibration
+- **`[nircam.bkg.bkg2d]` mesh retuned to `box_size = 32` / `filter_size = 3`
+  (was 64 / 5) — removes common-mode row banding that was costing mosaic
+  depth.** Delivered SW exposures carried coherent horizontal banding at ~128-row
+  scales: row-median rms 1.76x the pure-noise expectation (median over 6 COSMOS
+  f150w frames, worst frame 2.42x), correlated across all four amps (pairwise
+  0.80-0.90) and coherent out past 600 rows. Because it differs between
+  exposures, stacking un-sky-matched frames adds variance that never averages
+  down, so the loss is in mosaic DEPTH; the mosaic-level bkgsub removing the
+  mean structure afterwards cannot recover it. Root cause: `filter_size` is a
+  median filter over the LOW-RESOLUTION MESH in units of MESH CELLS, so 5 x 64 px
+  gave a ~320 px (~10") footprint — far too coarse for ~4" structure — while the
+  fit-only conditioning detrend (96 rows, `filter_size = [1, 5]`, i.e. full row
+  resolution) *can* represent it, absorbs it into a model that is never
+  subtracted, and leaves the amp-row GP nothing to fit. This is the trade
+  already documented under `[nircam.bkg.detrend]` ("common-mode row structure at
+  ~50-150 rows may be conditioned away and underfit by h"), now measured on real
+  data. Retuning the applied mesh takes banding to 0.57x noise (a 10x drop in
+  coherence, 0.258 -> 0.023) at unchanged pixel sigma (0.998 of production) and
+  aperture-flux changes of +0.24% compact / -0.05% intermediate / -0.01% large.
+  Validated by five arms re-run from uncal through the real pipeline on 6 frames
+  spanning the banding distribution, with a deliberately-too-coarse 256/5
+  control that confirms the metrics move in the physically correct direction.
+  Known cost: a highly elongated feature loses ~1% of its flux (one satellite
+  trail, elongation 22: -1.03%) versus -0.03% for compact sources in the same
+  frame; trails and diffraction spikes are contamination rather than photometric
+  targets, and the intermediate/large source bins are flat. Expect all NIRCam
+  exposures to need reprocessing from uncal to pick this up (`bkg` is
+  SCI-mutating and has no backup, so `reset --from bkg` is refused).
 - **New NIRCam `jackknife` step: re-zeros jump-segmented ramp fits against the
   exposure's frame-common ramp curvature** (`[nircam.jackknife]`, enabled by
   default; runs between `detector1` and `persistence`). The mean calibrated

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -51,11 +51,15 @@ Release procedure: edit the `## Unreleased` section below, then run
   Validated by five arms re-run from uncal through the real pipeline on 6 frames
   spanning the banding distribution, with a deliberately-too-coarse 256/5
   control that confirms the metrics move in the physically correct direction.
-  Known cost: a highly elongated feature loses ~1% of its flux (one segment of
-  elongation 22 spanning 4,832 px: -1.03%) versus -0.03% for compact sources in
-  the same frame; the intermediate/large source bins are flat, so this is not a
-  general extended-source loss. The feature was not identified — only its
-  geometry was measured. Expect all NIRCam
+  Known cost: DIFFRACTION-SPIKE FLUX. The finer mesh removes ~1% of the flux in
+  a bright star's diffraction spike (-1.03% over 4,832 px; verified as a spike by
+  radial alignment — two segments 1,530 and 1,745 px from the star, major axes
+  9.0 and 7.9 deg from the star-centroid position angle, sharing PA -29.3 deg).
+  This is REAL PSF FLUX, not contamination, so it is relevant to PSF modelling
+  and to bright-star photometry in large apertures. Compact sources in the same
+  frame change by -0.03% and the intermediate (-0.05%) / large (-0.01%) bins are
+  flat, so the loss is confined to the extended PSF, not to source photometry
+  generally. Measured on one star in one frame. Expect all NIRCam
   exposures to need reprocessing from uncal to pick this up (`bkg` is
   SCI-mutating and has no backup, so `reset --from bkg` is refused).
 - **New NIRCam `jackknife` step: re-zeros jump-segmented ramp fits against the

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -432,10 +432,46 @@
         # (box_size, extra_dilate, reject_dilate) are angular scales in px
         # tuned at SW native ~31 mas; rescaled per channel via
         # [nircam.bkg.mask.pixel_scale_factor] like the mask params.
-        # box_size 64 px SW (~2") + extra_dilate 20 chosen by the synthetic
-        # cluster sweep (experiments/bkg2d_synthetic, arm b64_d20): zero
-        # median aperture-flux loss for compact, extended AND bright
-        # galaxies simultaneously, ICL removal ~0.6.
+        # box_size 32 px SW (~1") + filter_size 3 + extra_dilate 20.
+        #
+        # WAS box_size 64 / filter_size 5, chosen by the synthetic cluster
+        # sweep (experiments/bkg2d_synthetic, arm b64_d20) for zero median
+        # aperture-flux loss with ICL removal ~0.6. That pair leaves COMMON-MODE
+        # ROW BANDING in the delivered exposures, which costs mosaic DEPTH:
+        # un-sky-matched frames stacked together add variance that never
+        # averages down, and the mosaic bkgsub removing the mean structure
+        # afterwards cannot recover it.
+        #
+        # WHY 64/5 could not remove it: filter_size is a median filter over the
+        # LOW-RESOLUTION MESH, in units of MESH CELLS — so 5 cells x 64 px is a
+        # ~320 px (~10") footprint, far too coarse for the ~128-row (~4")
+        # structure. Meanwhile the fit-only conditioning detrend (96 rows,
+        # filter_size [1,5] -> full row resolution) CAN represent that
+        # structure, absorbs it into a model that is never subtracted, and so
+        # leaves the amp-row GP nothing to fit. See the trade already noted in
+        # [nircam.bkg.detrend]: "common-mode row structure at ~50-150 rows may
+        # be conditioned away and underfit by h".
+        #
+        # MEASURED on 6 COSMOS f150w frames, real pipeline reruns from uncal
+        # spanning the banding distribution (docs + scripts/claude/cosmos-reproc):
+        #   arm            banding(x noise)  compact  intermed  large   pixel sigma
+        #   64/5 (was)          1.76          ref      ref      ref      1.000
+        #   64/1                0.56        -0.21%   -0.01%   +0.01%     0.998
+        #   32/3 (now)          0.57        +0.24%   -0.05%   -0.01%     0.998
+        #   10/5 (mosaic mesh)  0.60        -0.58%   -0.02%   -0.08%     0.998
+        #   256/5 (control)     3.36        +1.60%   +0.15%   +0.06%     1.012
+        # 32/3 and 64/1 are statistically tied; 32/3 is chosen because
+        # filter_size 3 retains mesh outlier rejection that filter_size 1
+        # discards entirely. The 256/5 control confirms the metrics respond in
+        # the physically correct direction (a too-coarse mesh under-subtracts,
+        # inflating apertures).
+        #
+        # KNOWN COST: a highly elongated feature loses ~1% of its flux
+        # (satellite trail, elongation 22, -1.03%) against -0.03% for compact
+        # sources in the same frame. Trails and diffraction spikes are
+        # contamination rather than photometric targets, and the intermediate
+        # (-0.05%) and large (-0.01%) source bins are flat, so this is not a
+        # general extended-source loss. Measured on ONE trail in one frame.
         # Where in the per-iteration chain the applied fit runs.
         #   "last" (legacy default): fit on the 1/f-corrected residual, AFTER
         #       the amp-row terms. Unmasked halo/wing flux around bright
@@ -456,8 +492,8 @@
         #       (measured on the synthetic amp-spanning-halo scene; the step
         #       logs a warning on this combination).
         fit_order = "last"
-        box_size = 64
-        filter_size = 5
+        box_size = 32
+        filter_size = 3
         sigma = 3.0
         exclude_percentile = 90
         # Grow the source tiers (not off-detector/DQ) by this many px for the

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -466,13 +466,18 @@
         # the physically correct direction (a too-coarse mesh under-subtracts,
         # inflating apertures).
         #
-        # KNOWN COST: a highly elongated feature loses ~1% of its flux (one
-        # segment of elongation 22 spanning 4,832 px: -1.03%) against -0.03% for
-        # compact sources in the same frame. The intermediate (-0.05%) and large
-        # (-0.01%) source bins are flat, so this is not a general extended-source
-        # loss. The feature was NOT identified — only its geometry was measured;
-        # if elongated-feature photometry matters, characterise it first.
-        # Measured on ONE such feature in one frame.
+        # KNOWN COST: DIFFRACTION-SPIKE FLUX. The finer mesh removes ~1% of a
+        # bright star's diffraction spike (-1.03% over 4,832 px). Verified as a
+        # spike, not assumed: two elongated segments 1,530 and 1,745 px from the
+        # star, major axes 9.0 and 7.9 deg off the star-centroid position angle,
+        # both at PA -29.3 deg (one spike split by the detection threshold).
+        # This is REAL PSF FLUX, not contamination — it matters for PSF
+        # modelling and for bright-star photometry in large apertures.
+        # Compact sources in the same frame move -0.03%, and the intermediate
+        # (-0.05%) / large (-0.01%) bins are flat, so the loss is confined to the
+        # extended PSF rather than to source photometry generally.
+        # Measured on ONE star in ONE frame — characterise further before
+        # relying on spike photometry anywhere in the field.
         # Where in the per-iteration chain the applied fit runs.
         #   "last" (legacy default): fit on the 1/f-corrected residual, AFTER
         #       the amp-row terms. Unmasked halo/wing flux around bright

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -466,12 +466,13 @@
         # the physically correct direction (a too-coarse mesh under-subtracts,
         # inflating apertures).
         #
-        # KNOWN COST: a highly elongated feature loses ~1% of its flux
-        # (satellite trail, elongation 22, -1.03%) against -0.03% for compact
-        # sources in the same frame. Trails and diffraction spikes are
-        # contamination rather than photometric targets, and the intermediate
-        # (-0.05%) and large (-0.01%) source bins are flat, so this is not a
-        # general extended-source loss. Measured on ONE trail in one frame.
+        # KNOWN COST: a highly elongated feature loses ~1% of its flux (one
+        # segment of elongation 22 spanning 4,832 px: -1.03%) against -0.03% for
+        # compact sources in the same frame. The intermediate (-0.05%) and large
+        # (-0.01%) source bins are flat, so this is not a general extended-source
+        # loss. The feature was NOT identified — only its geometry was measured;
+        # if elongated-feature photometry matters, characterise it first.
+        # Measured on ONE such feature in one frame.
         # Where in the per-iteration chain the applied fit runs.
         #   "last" (legacy default): fit on the 1/f-corrected residual, AFTER
         #       the amp-row terms. Unmasked halo/wing flux around bright


### PR DESCRIPTION
## Summary

Delivered NIRCam SW exposures carry **coherent horizontal banding** at ~128-row scales that survives `bkg` despite `subtract_2d = true`. It is **common-mode across all four amps** (pairwise correlation 0.80–0.90) and coherent past 600 rows.

Because the residual differs between exposures, this **costs mosaic depth**: stacking un-sky-matched frames adds variance that never averages down. The mosaic-level `bkgsub` does remove the mean structure afterwards, but that cannot recover noise already baked into the stack.

This PR retunes `[nircam.bkg.bkg2d]` from `box_size = 64` / `filter_size = 5` to **`32` / `3`**.

## Root cause

`photutils` `filter_size` is a median filter applied to the **low-resolution background mesh**, in units of **mesh cells** — so `5 × 64 px` is a **~320 px (~10″) footprint**, far too coarse for ~4″ structure. Measured capture of the banding by each model on a delivered frame:

| model | captures |
|---|---|
| conditioning detrend 96×32, `filter_size=[1,5]` | **62.6%** — but it is *fit-only, never subtracted* |
| applied `bkg2d` 64, `filter_size=5` | **−25.6%** — it subtracts, but cannot represent it |

So the model that *can* see the banding never subtracts it, and the model that *does* subtract is smoothed too hard in y. This is exactly the trade already documented under `[nircam.bkg.detrend]` — *"common-mode row structure at ~50–150 rows may be conditioned away and underfit by `h`"* — now measured on real data.

## Validation

Five arms **re-run from uncal through the real pipeline** (not post-hoc model swaps) on 6 COSMOS f150w frames chosen to span the banding distribution (0.83× to 2.42×), in an isolated `CAMPFIRE_ROOT`:

| arm | banding (× noise) | coherence | compact | intermed | large | pixel σ |
|---|---|---|---|---|---|---|
| 64/5 *(was)* | 1.76 | 0.258 | ref | ref | ref | 1.000 |
| 64/1 | 0.56 | 0.024 | −0.21% | −0.01% | +0.01% | 0.998 |
| **32/3 *(this PR)*** | **0.57** | **0.023** | **+0.24%** | **−0.05%** | **−0.01%** | **0.998** |
| 10/5 *(mosaic mesh)* | 0.60 | 0.023 | −0.58% | −0.02% | −0.08% | 0.998 |
| 256/5 *(control)* | 3.36 | 0.328 | +1.60% | +0.15% | +0.06% | 1.012 |

Decision rule was pre-registered before the run: banding ≤ 1.4×, compact loss ≤ 1%, intermediate ≤ 2% (large explicitly unconstrained), pixel σ within 2%; largest passing `box_size` wins.

`32/3` and `64/1` are statistically tied. **`32/3` is chosen because `filter_size = 3` retains mesh outlier rejection that `filter_size = 1` discards entirely** — worth having across ~41k frames when only six were inspected.

The **256/5 control** did not behave as I predicted (I expected it to move nothing; it made banding *worse* and inflated apertures by +1.60%) — but that is physically coherent for a mesh too coarse to model the sky, and it confirms the metrics respond in the correct direction and sign.

Generated with Claude Code

https://claude.ai/code/session_01CFs7JaSymLf15oM8wUzHzV