### PR TITLE
Add durable PNG pre-download cache for NIRCam triage workflow

### DIFF
--- a/web/app/admin/nircam/[id]/page.tsx
+++ b/web/app/admin/nircam/[id]/page.tsx
@@ -46,6 +46,12 @@ import {
   getReviewOutboxVersion,
   type ReviewDecisionFields,
 } from '@/lib/nircam-review-outbox';
+import {
+  ensurePngStoreReady,
+  getStoredPng,
+  subscribePngStore,
+  getPngStoreVersion,
+} from '@/lib/nircam-png-store';
 
 // Eager PNG prefetch window: warm the full-res mask surface (~5.7 MB) the
 // editor actually renders for a few exposures ahead + one back, so stepping
@@ -141,6 +147,13 @@ function ExposureDetailPageInner() {
   // Replay any decisions stranded by a previous session's reload and keep
   // the outbox delivery loop running while the operator works here.
   useEffect(() => { ensureReviewOutboxRunning(); }, []);
+
+  // Hydrate the durable pre-downloaded PNG store (lib/nircam-png-store.ts).
+  // Idempotent and module-scoped, so on the remount-per-step this is a no-op;
+  // the subscription re-renders this instance when hydration (or a warm
+  // running in another tab of the flow) makes new blobs available.
+  useEffect(() => { ensurePngStoreReady(); }, []);
+  useSyncExternalStore(subscribePngStore, getPngStoreVersion, getPngStoreVersion);
 
   // Editable fields
   const [reviewStatus, setReviewStatus] = useState<string>('pending');
@@ -558,6 +571,11 @@ function ExposureDetailPageInner() {
     // only new network per step is the frontier exposure entering the window.
     const warm = () => {
       for (const sib of warmWin) {
+        // A pre-downloaded blob needs no network, but decoding ~6 MB still
+        // takes real time — run it through the retained-image cache too so a
+        // warmed sibling is paint-instant, not just fetch-instant.
+        const stored = getStoredPng(sib);
+        if (stored) { prefetchPng(stored.url); continue; }
         const u = getCachedPngUrls(sib);
         if (u) prefetchPng(u.full ?? u.preview);
       }
@@ -884,10 +902,19 @@ function ExposureDetailPageInner() {
   // Presigned OSN URLs for the current exposure (undefined until the presign
   // round-trip lands; null once resolved if the exposure has no PNG). Read from
   // the module cache so a prefetched sibling is already resolved on arrival.
+  // A pre-downloaded blob (lib/nircam-png-store.ts) outranks the presigned URL
+  // for the slot it covers — zero network, and immune to presign expiry. The
+  // store holds the display byte, so its kind says which slot: 'full' feeds
+  // the mask editor, 'preview' means the exposure never had a full PNG. With
+  // a stored blob in hand the viewer needn't wait on the presign round trip
+  // (it still runs in the background and fills the other slot's fallback).
+  const stored = getStoredPng(id);
   const currentUrls = getCachedPngUrls(id);
-  const pngUrl = currentUrls?.preview ?? null;
-  const fullPngUrl = currentUrls?.full ?? null;
-  const pngPresignPending = currentUrls === undefined;
+  const pngUrl =
+    (stored?.kind === 'preview' ? stored.url : null) ?? currentUrls?.preview ?? null;
+  const fullPngUrl =
+    (stored?.kind === 'full' ? stored.url : null) ?? currentUrls?.full ?? null;
+  const pngPresignPending = currentUrls === undefined && !stored;
   const editorAvailable = Boolean(
     exposure && fullPngUrl && exposure.image_width && exposure.image_height
   );
@@ -1126,11 +1153,12 @@ function ExposureDetailPageInner() {
               )
             ) : !exposure ? (
               // Row-cache miss mid-step (the prefetch was outrun): the panel
-              // stays mounted and shows the already-signed preview if one is
-              // cached — the operator keeps seeing THIS exposure's pixels
-              // while the row round-trips — else a spinner in place.
-              pngUrl ? (
-                <PreviewImage url={pngUrl} alt="Exposure quick-look" />
+              // stays mounted and shows this exposure's pixels from whatever
+              // is at hand — the already-signed preview, or the pre-downloaded
+              // blob (whose full-res byte serves fine as a quick-look) — while
+              // the row round-trips; else a spinner in place.
+              (pngUrl ?? stored?.url) ? (
+                <PreviewImage url={(pngUrl ?? stored!.url)} alt="Exposure quick-look" />
               ) : (
                 <div className="flex items-center justify-center py-24">
                   <Loader2 className="w-8 h-8 animate-spin text-text-secondary" />
@@ -1149,9 +1177,14 @@ function ExposureDetailPageInner() {
                   clipboardLive={isExposureLive}
                 />
               </div>
-            ) : pngUrl ? (
-              // Fallback: thumbnail-only view (full PNG hasn't been deployed yet).
-              <PreviewImage url={pngUrl} alt={`${exposure.filename} quick-look`} />
+            ) : (pngUrl ?? stored?.url) ? (
+              // Fallback: thumbnail-only view (full PNG hasn't been deployed
+              // yet, or the editor can't mount for want of pixel dims — a
+              // stored full-res blob still beats "No PNG available").
+              <PreviewImage
+                url={(pngUrl ?? stored!.url)}
+                alt={`${exposure.filename} quick-look`}
+              />
             ) : (
               <div className="flex items-center justify-center py-24 text-text-secondary">
                 No PNG available

--- a/web/app/admin/nircam/page.tsx
+++ b/web/app/admin/nircam/page.tsx
@@ -538,11 +538,7 @@ function AdminNircamPageInner() {
       {/* Pre-download the filtered set's PNGs for a no-network triage run —
           scoped to whatever the filter bar currently selects (a whole
           filter/detector pair, just the pending queue, ...). */}
-      <PngPrecacheControl
-        filters={state.debouncedFilters}
-        sort={state.sort}
-        total={exposures.total}
-      />
+      <PngPrecacheControl filters={state.debouncedFilters} sort={state.sort} />
 
       <AdminTable
         columns={columns}

--- a/web/app/admin/nircam/page.tsx
+++ b/web/app/admin/nircam/page.tsx
@@ -24,6 +24,7 @@ import {
 import type { NircamExposure } from '@/lib/types';
 import { stageBadgeClasses, NIRCAM_STAGES } from '@/lib/nircam-stages';
 import { buildExposureNavQuery } from '@/lib/nircam-exposure-nav';
+import { PngPrecacheControl } from '@/components/nircam/PngPrecacheControl';
 
 // ---------------------------------------------------------------------------
 // Status badge helpers
@@ -532,6 +533,15 @@ function AdminNircamPageInner() {
         values={state.filters}
         onChange={(key, value) => state.setFilters({ ...state.filters, [key]: value })}
         onReset={state.resetFilters}
+      />
+
+      {/* Pre-download the filtered set's PNGs for a no-network triage run —
+          scoped to whatever the filter bar currently selects (a whole
+          filter/detector pair, just the pending queue, ...). */}
+      <PngPrecacheControl
+        filters={state.debouncedFilters}
+        sort={state.sort}
+        total={exposures.total}
       />
 
       <AdminTable

--- a/web/app/api/nircam-png/manifest/route.ts
+++ b/web/app/api/nircam-png/manifest/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { EXPOSURE_SORT_KEYS } from '@/lib/admin/sort-keys';
+
+/**
+ * GET /api/nircam-png/manifest?field=..&filter=..&detector=..&review=..&stage=..&correction=..&sort=..&dir=..
+ *
+ * The PNG pre-download manifest for a filtered set: which exposures have a
+ * downloadable display PNG (full-res when deployed, else preview — the byte
+ * /api/nircam-png serves), in the list's inspection order, each with its
+ * exact size from the storage_objects registry. Exposures with no PNG are
+ * omitted — they can't download, so they must not count toward the
+ * pre-download button. Sizes are registry truth, not a per-image heuristic
+ * (full-res PNG size is content-dependent and varies ~2x between fields);
+ * keys the registry doesn't know come back bytes:null and the client's hint
+ * degrades to a lower bound.
+ *
+ * A plain GET on purpose, NOT a server action: Next serializes server
+ * actions per client, so this scan (row paging + chunked size lookups) as an
+ * action queued AHEAD of the list page's own table fetch on every filter
+ * change and froze the table until the manifest landed. As a route handler
+ * it runs alongside the actions, and the client aborts it when the filters
+ * change again. Reads run under the caller's RLS session (nircam_exposures
+ * and storage_objects are admin-gated at the database), so a non-admin gets
+ * an empty manifest, never data — same posture as the hot-path actions.
+ */
+export async function GET(request: NextRequest) {
+  const supabase = await createClient();
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) return new Response('Unauthorized', { status: 401 });
+
+  const sp = request.nextUrl.searchParams;
+  const sortParam = sp.get('sort');
+  const sortCol =
+    sortParam && (EXPOSURE_SORT_KEYS as readonly string[]).includes(sortParam)
+      ? sortParam
+      : 'filename';
+  const asc = sp.get('dir') !== 'desc';
+  const eq: [string, string][] = [];
+  for (const [param, column] of [
+    ['field', 'field'], ['filter', 'filter'], ['detector', 'detector'],
+    ['review', 'review_status'], ['stage', 'stage'], ['correction', 'correction'],
+  ] as const) {
+    const v = sp.get(param);
+    if (v) eq.push([column, v]);
+  }
+
+  const CHUNK = 1000;   // PostgREST caps a single response at 1000 rows
+  const CAP = 20000;    // runaway guard
+  // storage_objects lookups go out as GET query strings; ~100 keys per
+  // request keeps the URL comfortably under proxy limits.
+  const SIZE_CHUNK = 100;
+
+  try {
+    const rows: { id: number; key: string }[] = [];
+    for (let off = 0; off < CAP; off += CHUNK) {
+      let q = supabase.from('nircam_exposures').select('id, png_path, full_png_path');
+      for (const [col, v] of eq) q = q.eq(col, v);
+      // Mirror get_admin_exposures' ORDER BY: 'filename' is the compound
+      // (field, filter, filename) list order; everything gets the id tiebreak.
+      if (sortCol === 'filename') {
+        q = q
+          .order('field', { ascending: asc })
+          .order('filter', { ascending: asc })
+          .order('filename', { ascending: asc });
+      } else {
+        q = q.order(sortCol, { ascending: asc, nullsFirst: false });
+      }
+      q = q.order('id', { ascending: true }).range(off, off + CHUNK - 1);
+
+      const { data, error } = await q;
+      if (error) {
+        return Response.json({ entries: [], error: error.message }, { status: 500 });
+      }
+      for (const r of data ?? []) {
+        const key = (r.full_png_path ?? r.png_path) as string | null;
+        if (key) rows.push({ id: r.id as number, key });
+      }
+      if (!data || data.length < CHUNK) break;
+    }
+
+    const keys = [...new Set(rows.map((r) => r.key))];
+    const sizeByKey = new Map<string, number>();
+    const chunks: string[][] = [];
+    for (let i = 0; i < keys.length; i += SIZE_CHUNK) {
+      chunks.push(keys.slice(i, i + SIZE_CHUNK));
+    }
+    // Best-effort: a failed size lookup leaves those entries at bytes:null
+    // (hint degrades to a lower bound) rather than failing the manifest.
+    await Promise.all(chunks.map(async (chunk) => {
+      const { data } = await supabase
+        .from('storage_objects')
+        .select('storage_key, size_bytes')
+        .eq('status', 'active')
+        .in('storage_key', chunk);
+      for (const r of data ?? []) {
+        if (typeof r.size_bytes === 'number') sizeByKey.set(r.storage_key, r.size_bytes);
+      }
+    }));
+
+    return Response.json(
+      { entries: rows.map((r) => ({ id: r.id, bytes: sizeByKey.get(r.key) ?? null })) },
+      { headers: { 'Cache-Control': 'private, no-store' } },
+    );
+  } catch (err) {
+    console.error('nircam-png manifest error:', err);
+    return Response.json({ entries: [], error: 'Manifest failed' }, { status: 500 });
+  }
+}

--- a/web/app/api/nircam-png/route.ts
+++ b/web/app/api/nircam-png/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest } from 'next/server';
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+import {
+  getS3ClientForBackend,
+  getBucketNameForBackend,
+  type DataBackend,
+} from '@/lib/storage';
+import { createClient } from '@/lib/supabase/server';
+
+export const runtime = 'nodejs';
+
+/**
+ * GET /api/nircam-png?id=<exposure id>
+ *
+ * Admin-only same-origin proxy for one exposure's *display* PNG — the
+ * full-res mask surface when the exposure has one, else the preview — for the
+ * triage pre-download warm (lib/nircam-png-store.ts). Display rendering keeps
+ * using presigned OSN URLs in <img> (no CORS needed there); the warm has to
+ * READ the bytes to store them in IndexedDB, and OSN serves no CORS headers,
+ * so — exactly like /api/nircam-fits — the readable bytes come through this
+ * same-origin route. The storage key is re-derived server-side from
+ * nircam_exposures, never taken from the client, so the route can't be used
+ * as an arbitrary object read.
+ *
+ * X-Png-Kind says which byte was served ('full' | 'preview') so the store
+ * files it under the right slot. no-store: the caller persists the bytes
+ * itself, and letting the HTTP cache keep a second multi-GB copy helps nobody.
+ */
+export async function GET(request: NextRequest) {
+  const supabase = await createClient();
+
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return new Response('Unauthorized', { status: 401 });
+
+  const { data: profile } = await supabase
+    .from('user_profiles')
+    .select('is_admin')
+    .eq('user_id', user.id)
+    .single();
+  if (!profile?.is_admin) return new Response('Forbidden', { status: 403 });
+
+  const idParam = request.nextUrl.searchParams.get('id');
+  const id = Number(idParam);
+  if (!idParam || !Number.isInteger(id) || id <= 0) {
+    return new Response('Invalid id', { status: 400 });
+  }
+
+  const { data: row } = await supabase
+    .from('nircam_exposures')
+    .select('png_path, full_png_path')
+    .eq('id', id)
+    .maybeSingle();
+  if (!row) return new Response('Not Found', { status: 404 });
+
+  const key = row.full_png_path ?? row.png_path;
+  const kind = row.full_png_path ? 'full' : 'preview';
+  if (!key) return new Response('Not Found', { status: 404 });
+
+  try {
+    // Same backend resolution as presignExposurePngs: the object's home
+    // backend from the registry, defaulting OSN where canonical PNGs live.
+    const { data: soRow } = await supabase
+      .from('storage_objects')
+      .select('backend')
+      .eq('storage_key', key)
+      .eq('status', 'active')
+      .maybeSingle();
+    const backend: DataBackend = soRow?.backend === 'r2' ? 'r2' : 'osn';
+
+    const obj = await getS3ClientForBackend(backend).send(
+      new GetObjectCommand({
+        Bucket: getBucketNameForBackend(backend),
+        Key: key,
+      }),
+    );
+    if (!obj.Body) return new Response('Not Found', { status: 404 });
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'image/png',
+      'Cache-Control': 'private, no-store',
+      'X-Png-Kind': kind,
+    };
+    if (obj.ContentLength != null) headers['Content-Length'] = String(obj.ContentLength);
+
+    return new Response(obj.Body.transformToWebStream(), { status: 200, headers });
+  } catch (err: unknown) {
+    const e = err as { $metadata?: { httpStatusCode?: number }; name?: string };
+    if (e?.name === 'NoSuchKey' || e?.$metadata?.httpStatusCode === 404) {
+      return new Response('Not Found', { status: 404 });
+    }
+    console.error('nircam-png proxy error:', err);
+    return new Response('Internal Error', { status: 500 });
+  }
+}

--- a/web/components/nircam/PngPrecacheControl.tsx
+++ b/web/components/nircam/PngPrecacheControl.tsx
@@ -1,9 +1,12 @@
 'use client';
 
-import React, { useEffect, useState, useSyncExternalStore } from 'react';
-import { Download, HardDrive, Loader2, Trash2, X } from 'lucide-react';
+import React, { useEffect, useMemo, useState, useSyncExternalStore } from 'react';
+import { Check, Download, HardDrive, Loader2, Trash2, X } from 'lucide-react';
 import { Button } from '@/components/ui/Button';
-import { getNircamExposureIds } from '@/lib/actions/nircam-exposures';
+import {
+  getNircamExposurePngManifest,
+  type ExposurePngManifest,
+} from '@/lib/actions/nircam-exposures';
 import type { SortState } from '@/lib/hooks/useTableUrlState';
 import {
   cancelPngWarm,
@@ -12,6 +15,7 @@ import {
   estimateStorage,
   getPngStoreStats,
   getPngStoreVersion,
+  getStoredPng,
   getWarmState,
   startPngWarm,
   subscribePngStore,
@@ -28,10 +32,6 @@ function fmtBytes(n: number): string {
   return `${v} B`;
 }
 
-// Rough per-exposure budget for the pre-warm size hint (full-res PNGs run
-// ~5–6 MB); the progress readout shows real bytes once the warm is running.
-const EST_BYTES_PER_EXPOSURE = 6 * 1024 * 1024;
-
 function resultNotice(r: PngWarmResult): string | null {
   if (r.error) return r.error;
   if (r.aborted) {
@@ -47,32 +47,41 @@ interface PngPrecacheControlProps {
   /** The list page's active (debounced) filter values, by URL param key. */
   filters: Record<string, string>;
   sort: SortState;
-  /** Matching-exposure count from the table query (sizes the warm up front). */
-  total: number;
 }
 
 /**
  * "Pre-download all PNGs" control for the /admin/nircam list page (sits
  * between the filter bar and the table). Starts a warm of the display PNG of
- * every exposure in the CURRENT filtered set — in list order, resumable,
- * cancellable — into the durable IndexedDB store. The warm itself is module
- * state (lib/nircam-png-store.ts): this control only starts, renders, and
- * cancels it, so navigating into an exposure to begin inspecting does NOT
- * stop the download loop — coming back shows it still running. The cached
- * total and the explicit clear button live here too; expiry is otherwise
- * automatic (PNG_STORE_TTL_MS after each image is stored).
+ * every UNCACHED exposure in the CURRENT filtered set — in list order,
+ * resumable, cancellable — into the durable IndexedDB store. The warm itself
+ * is module state (lib/nircam-png-store.ts): this control only starts,
+ * renders, and cancels it, so navigating into an exposure to begin inspecting
+ * does NOT stop the download loop — coming back shows it still running.
+ *
+ * The button and the size hint are driven by the PNG manifest for the current
+ * filters (getNircamExposurePngManifest): downloadable exposures with their
+ * exact registry sizes. Cached ids are subtracted live, so the count is
+ * "what this click would download", the bytes are the registry truth rather
+ * than a per-image guess, and a fully-cached set greys the button out. The
+ * cached total and the explicit clear button live here too; expiry is
+ * otherwise automatic (PNG_STORE_TTL_MS after each image is stored).
  */
-export function PngPrecacheControl({ filters, sort, total }: PngPrecacheControlProps) {
+export function PngPrecacheControl({ filters, sort }: PngPrecacheControlProps) {
   useSyncExternalStore(subscribePngStore, getPngStoreVersion, getPngStoreVersion);
   const stats = getPngStoreStats();
   const warm = getWarmState();
 
-  // Covers the ids round trip between the click and the module warm starting,
-  // so the button can't double-fire; everything after that renders from the
-  // module's warm state.
+  // Covers the manifest round trip between the click and the module warm
+  // starting, so the button can't double-fire; everything after that renders
+  // from the module's warm state.
   const [starting, setStarting] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
   const [headroom, setHeadroom] = useState<{ usage: number; quota: number } | null>(null);
+  // Downloadable exposures + exact sizes for the current filters; null while
+  // loading or after a failed fetch (the button then falls back to a
+  // fetch-at-click flow rather than wedging).
+  const [manifest, setManifest] = useState<ExposurePngManifest['entries'] | null>(null);
+  const [manifestLoading, setManifestLoading] = useState(false);
 
   useEffect(() => {
     ensurePngStoreReady();
@@ -81,24 +90,75 @@ export function PngPrecacheControl({ filters, sort, total }: PngPrecacheControlP
     // operator steps into the triage flow — that's the point of warming.
   }, []);
 
+  const queryParams = useMemo(() => ({
+    field: filters.field || undefined,
+    filter: filters.filter || undefined,
+    detector: filters.detector || undefined,
+    reviewStatus: filters.review || undefined,
+    stage: filters.stage || undefined,
+    correction: filters.correction || undefined,
+    sortColumn: sort.column,
+    sortDirection: sort.direction,
+  }), [
+    filters.field, filters.filter, filters.detector,
+    filters.review, filters.stage, filters.correction,
+    sort.column, sort.direction,
+  ]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setManifest(null);
+    setManifestLoading(true);
+    getNircamExposurePngManifest(queryParams).then(
+      (res) => {
+        if (cancelled) return;
+        setManifestLoading(false);
+        if (!res.error) setManifest(res.entries);
+      },
+      () => { if (!cancelled) setManifestLoading(false); },
+    );
+    return () => { cancelled = true; };
+  }, [queryParams]);
+
+  // Live split of the manifest against the store: recomputed on every store
+  // change (hydration, each warmed image, clear), so the count is always
+  // "what this click would download" and flips to the all-cached state the
+  // moment the last image lands.
+  const uncached = useMemo(
+    () => manifest?.filter((e) => !getStoredPng(e.id)) ?? null,
+    // getPngStoreVersion() ties the memo to store changes surfaced by the
+    // useSyncExternalStore subscription above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [manifest, getPngStoreVersion()],
+  );
+  let knownBytes = 0;
+  let unknownSizes = 0;
+  if (uncached) {
+    for (const e of uncached) {
+      if (e.bytes != null) knownBytes += e.bytes;
+      else unknownSizes++;
+    }
+  }
+  const uncachedCount = uncached?.length ?? null;
+  const allCached = manifest !== null && manifest.length > 0 && uncachedCount === 0;
+
   const startWarm = async () => {
     setLocalError(null);
     setStarting(true);
     try {
-      const { ids, error } = await getNircamExposureIds({
-        field: filters.field || undefined,
-        filter: filters.filter || undefined,
-        detector: filters.detector || undefined,
-        reviewStatus: filters.review || undefined,
-        stage: filters.stage || undefined,
-        correction: filters.correction || undefined,
-        sortColumn: sort.column,
-        sortDirection: sort.direction,
-      });
-      if (error || ids.length === 0) {
-        setLocalError(error ?? 'No exposures match the current filters.');
-        return;
+      let ids = uncached?.map((e) => e.id) ?? null;
+      if (ids === null) {
+        // Manifest fetch failed or hasn't landed — get one now so the click
+        // still works (startPngWarm skips cached ids on its own).
+        const res = await getNircamExposurePngManifest(queryParams);
+        if (res.error) {
+          setLocalError(res.error);
+          return;
+        }
+        setManifest(res.entries);
+        ids = res.entries.map((e) => e.id);
       }
+      if (ids.length === 0) return;
       setStarting(false);
       // Module-scoped: outlives this component; result surfaces via
       // getWarmState().lastResult whenever a control is mounted to show it.
@@ -109,7 +169,6 @@ export function PngPrecacheControl({ filters, sort, total }: PngPrecacheControlP
     }
   };
 
-  const estNeeded = total * EST_BYTES_PER_EXPOSURE;
   const free = headroom ? Math.max(0, headroom.quota - headroom.usage) : null;
   const ttlHours = Math.round(PNG_STORE_TTL_MS / 3_600_000);
   const notice = localError ?? (warm.lastResult ? resultNotice(warm.lastResult) : null);
@@ -149,26 +208,36 @@ export function PngPrecacheControl({ filters, sort, total }: PngPrecacheControlP
       ) : (
         <div className="flex items-center gap-3 ml-auto">
           {notice && <span className="text-xs text-text-secondary">{notice}</span>}
-          {total > 0 && (
+          {uncached !== null && uncachedCount! > 0 && (
             <span
               className="text-xs text-text-tertiary tabular-nums whitespace-nowrap"
-              title="Rough size of the current filtered set at ~6 MB per exposure, against this browser's storage headroom (already-cached images are skipped, so re-runs only fetch what's missing)."
+              title="Exact size of the not-yet-cached images in the current filtered set (from the storage registry), against this browser's storage headroom."
             >
-              ~{fmtBytes(estNeeded)}{free != null && <> · {fmtBytes(free)} free</>}
+              {unknownSizes > 0 ? '≥' : ''}{fmtBytes(knownBytes)}
+              {free != null && <> · {fmtBytes(free)} free</>}
             </span>
           )}
           <Button
             size="sm"
             onClick={startWarm}
-            disabled={!stats.hydrated || starting || total === 0}
-            title="Download the display PNG of every exposure matching the current filters into this browser, so stepping through the queue never waits on the network. Keeps running if you start inspecting."
+            disabled={
+              !stats.hydrated || starting || manifestLoading ||
+              (manifest !== null && uncachedCount === 0)
+            }
+            title={allCached
+              ? 'Every image in the current filtered set is already cached in this browser.'
+              : 'Download the display PNG of every not-yet-cached exposure matching the current filters into this browser, so stepping through the queue never waits on the network. Keeps running if you start inspecting.'}
           >
-            {!stats.hydrated || starting ? (
-              <Loader2 className="w-3.5 h-3.5 mr-1 animate-spin" />
+            {!stats.hydrated || starting || manifestLoading ? (
+              <><Loader2 className="w-3.5 h-3.5 mr-1 animate-spin" /> Pre-download PNGs</>
+            ) : allCached ? (
+              <><Check className="w-3.5 h-3.5 mr-1" /> All PNGs cached</>
+            ) : uncachedCount !== null ? (
+              <><Download className="w-3.5 h-3.5 mr-1" /> Pre-download {uncachedCount} PNG{uncachedCount !== 1 ? 's' : ''}</>
             ) : (
-              <Download className="w-3.5 h-3.5 mr-1" />
+              // Manifest fetch failed — the click fetches one and proceeds.
+              <><Download className="w-3.5 h-3.5 mr-1" /> Pre-download PNGs</>
             )}
-            Pre-download {total > 0 ? total : ''} PNG{total !== 1 ? 's' : ''}
           </Button>
           {stats.count > 0 && (
             <Button

--- a/web/components/nircam/PngPrecacheControl.tsx
+++ b/web/components/nircam/PngPrecacheControl.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import React, { useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { Download, HardDrive, Loader2, Trash2, X } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { getNircamExposureIds } from '@/lib/actions/nircam-exposures';
+import type { SortState } from '@/lib/hooks/useTableUrlState';
+import {
+  clearPngStore,
+  ensurePngStoreReady,
+  estimateStorage,
+  getPngStoreStats,
+  getPngStoreVersion,
+  subscribePngStore,
+  warmPngStore,
+  PNG_STORE_TTL_MS,
+  type PngWarmProgress,
+} from '@/lib/nircam-png-store';
+
+function fmtBytes(n: number): string {
+  let v = Number(n);
+  for (const u of ['B', 'KB', 'MB', 'GB', 'TB', 'PB']) {
+    if (Math.abs(v) < 1024 || u === 'PB') return u === 'B' ? `${v} B` : `${v.toFixed(1)} ${u}`;
+    v /= 1024;
+  }
+  return `${v} B`;
+}
+
+// Rough per-exposure budget for the pre-warm size hint (full-res PNGs run
+// ~5–6 MB); the progress readout shows real bytes once the warm is running.
+const EST_BYTES_PER_EXPOSURE = 6 * 1024 * 1024;
+
+interface PngPrecacheControlProps {
+  /** The list page's active (debounced) filter values, by URL param key. */
+  filters: Record<string, string>;
+  sort: SortState;
+  /** Matching-exposure count from the table query (sizes the warm up front). */
+  total: number;
+}
+
+/**
+ * "Pre-download all PNGs" control for the /admin/nircam list page (sits
+ * between the filter bar and the table). Downloads the display PNG of every
+ * exposure in the CURRENT filtered set — in list order, resumable, cancellable
+ * — into the durable IndexedDB store (lib/nircam-png-store.ts), so a triage
+ * run over a whole filter/detector pair never waits on a fetch. The cached
+ * total and the explicit clear button live here too; expiry is otherwise
+ * automatic (PNG_STORE_TTL_MS after each image is stored).
+ */
+export function PngPrecacheControl({ filters, sort, total }: PngPrecacheControlProps) {
+  useSyncExternalStore(subscribePngStore, getPngStoreVersion, getPngStoreVersion);
+  const stats = getPngStoreStats();
+
+  const [warming, setWarming] = useState(false);
+  const [progress, setProgress] = useState<PngWarmProgress | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [headroom, setHeadroom] = useState<{ usage: number; quota: number } | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    ensurePngStoreReady();
+    estimateStorage().then(setHeadroom);
+    // Cancel a warm this page instance started if the operator navigates away
+    // mid-run; whatever already landed is kept (the warm is resumable).
+    return () => abortRef.current?.abort();
+  }, []);
+
+  const startWarm = async () => {
+    setNotice(null);
+    setWarming(true);
+    setProgress({ done: 0, total, bytes: 0, failed: 0 });
+    const controller = new AbortController();
+    abortRef.current = controller;
+    try {
+      const { ids, error } = await getNircamExposureIds({
+        field: filters.field || undefined,
+        filter: filters.filter || undefined,
+        detector: filters.detector || undefined,
+        reviewStatus: filters.review || undefined,
+        stage: filters.stage || undefined,
+        correction: filters.correction || undefined,
+        sortColumn: sort.column,
+        sortDirection: sort.direction,
+      });
+      if (error || ids.length === 0) {
+        setNotice(error ?? 'No exposures match the current filters.');
+        return;
+      }
+      const result = await warmPngStore(ids, {
+        signal: controller.signal,
+        onProgress: setProgress,
+      });
+      if (result.error) {
+        setNotice(result.error);
+      } else if (result.aborted) {
+        setNotice(`Stopped — ${result.done - result.failed}/${result.total} cached so far (resume any time).`);
+      } else if (result.failed > 0) {
+        setNotice(`Done with ${result.failed} failed download${result.failed !== 1 ? 's' : ''} — run again to retry them.`);
+      }
+      estimateStorage().then(setHeadroom);
+    } finally {
+      abortRef.current = null;
+      setWarming(false);
+      setProgress(null);
+    }
+  };
+
+  const estNeeded = total * EST_BYTES_PER_EXPOSURE;
+  const free = headroom ? Math.max(0, headroom.quota - headroom.usage) : null;
+  const ttlHours = Math.round(PNG_STORE_TTL_MS / 3_600_000);
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-2 mb-4 px-4 py-2.5 rounded-lg border border-border bg-card text-sm">
+      <div className="flex items-center gap-2 text-text-secondary">
+        <HardDrive className="w-4 h-4 shrink-0" />
+        {!stats.hydrated ? (
+          <span>Checking image cache…</span>
+        ) : stats.count > 0 ? (
+          <span className="tabular-nums">
+            {stats.count} image{stats.count !== 1 ? 's' : ''} cached ({fmtBytes(stats.bytes)})
+            <span className="text-text-tertiary"> · auto-clears {ttlHours} h after download</span>
+          </span>
+        ) : (
+          <span>No images cached</span>
+        )}
+      </div>
+
+      {warming && progress ? (
+        <div className="flex items-center gap-3 flex-1 min-w-48">
+          <div className="h-2 flex-1 min-w-24 rounded-full bg-surface-2 overflow-hidden">
+            <div
+              className="h-full rounded-full bg-primary transition-[width]"
+              style={{ width: `${progress.total > 0 ? (progress.done / progress.total) * 100 : 0}%` }}
+            />
+          </div>
+          <span className="text-xs tabular-nums text-text-secondary whitespace-nowrap">
+            {progress.done}/{progress.total} · {fmtBytes(progress.bytes)}
+            {progress.failed > 0 && <> · {progress.failed} failed</>}
+          </span>
+          <Button size="sm" variant="secondary" onClick={() => abortRef.current?.abort()}>
+            <X className="w-3.5 h-3.5 mr-1" /> Stop
+          </Button>
+        </div>
+      ) : (
+        <div className="flex items-center gap-3 ml-auto">
+          {notice && <span className="text-xs text-text-secondary">{notice}</span>}
+          {total > 0 && (
+            <span
+              className="text-xs text-text-tertiary tabular-nums whitespace-nowrap"
+              title="Rough size of the current filtered set at ~6 MB per exposure, against this browser's storage headroom (already-cached images are skipped, so re-runs only fetch what's missing)."
+            >
+              ~{fmtBytes(estNeeded)}{free != null && <> · {fmtBytes(free)} free</>}
+            </span>
+          )}
+          <Button
+            size="sm"
+            onClick={startWarm}
+            disabled={!stats.hydrated || total === 0}
+            title="Download the display PNG of every exposure matching the current filters into this browser, so stepping through the queue never waits on the network."
+          >
+            {!stats.hydrated ? (
+              <Loader2 className="w-3.5 h-3.5 mr-1 animate-spin" />
+            ) : (
+              <Download className="w-3.5 h-3.5 mr-1" />
+            )}
+            Pre-download {total > 0 ? total : ''} PNG{total !== 1 ? 's' : ''}
+          </Button>
+          {stats.count > 0 && (
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={() => { setNotice(null); clearPngStore(); estimateStorage().then(setHeadroom); }}
+              title="Delete all cached exposure images from this browser now."
+            >
+              <Trash2 className="w-3.5 h-3.5 mr-1" /> Clear
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/components/nircam/PngPrecacheControl.tsx
+++ b/web/components/nircam/PngPrecacheControl.tsx
@@ -1,20 +1,22 @@
 'use client';
 
-import React, { useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import React, { useEffect, useState, useSyncExternalStore } from 'react';
 import { Download, HardDrive, Loader2, Trash2, X } from 'lucide-react';
 import { Button } from '@/components/ui/Button';
 import { getNircamExposureIds } from '@/lib/actions/nircam-exposures';
 import type { SortState } from '@/lib/hooks/useTableUrlState';
 import {
+  cancelPngWarm,
   clearPngStore,
   ensurePngStoreReady,
   estimateStorage,
   getPngStoreStats,
   getPngStoreVersion,
+  getWarmState,
+  startPngWarm,
   subscribePngStore,
-  warmPngStore,
   PNG_STORE_TTL_MS,
-  type PngWarmProgress,
+  type PngWarmResult,
 } from '@/lib/nircam-png-store';
 
 function fmtBytes(n: number): string {
@@ -30,6 +32,17 @@ function fmtBytes(n: number): string {
 // ~5–6 MB); the progress readout shows real bytes once the warm is running.
 const EST_BYTES_PER_EXPOSURE = 6 * 1024 * 1024;
 
+function resultNotice(r: PngWarmResult): string | null {
+  if (r.error) return r.error;
+  if (r.aborted) {
+    return `Stopped — ${r.done - r.failed}/${r.total} cached so far (resume any time).`;
+  }
+  if (r.failed > 0) {
+    return `Done with ${r.failed} failed download${r.failed !== 1 ? 's' : ''} — run again to retry them.`;
+  }
+  return null;
+}
+
 interface PngPrecacheControlProps {
   /** The list page's active (debounced) filter values, by URL param key. */
   filters: Record<string, string>;
@@ -40,37 +53,37 @@ interface PngPrecacheControlProps {
 
 /**
  * "Pre-download all PNGs" control for the /admin/nircam list page (sits
- * between the filter bar and the table). Downloads the display PNG of every
- * exposure in the CURRENT filtered set — in list order, resumable, cancellable
- * — into the durable IndexedDB store (lib/nircam-png-store.ts), so a triage
- * run over a whole filter/detector pair never waits on a fetch. The cached
+ * between the filter bar and the table). Starts a warm of the display PNG of
+ * every exposure in the CURRENT filtered set — in list order, resumable,
+ * cancellable — into the durable IndexedDB store. The warm itself is module
+ * state (lib/nircam-png-store.ts): this control only starts, renders, and
+ * cancels it, so navigating into an exposure to begin inspecting does NOT
+ * stop the download loop — coming back shows it still running. The cached
  * total and the explicit clear button live here too; expiry is otherwise
  * automatic (PNG_STORE_TTL_MS after each image is stored).
  */
 export function PngPrecacheControl({ filters, sort, total }: PngPrecacheControlProps) {
   useSyncExternalStore(subscribePngStore, getPngStoreVersion, getPngStoreVersion);
   const stats = getPngStoreStats();
+  const warm = getWarmState();
 
-  const [warming, setWarming] = useState(false);
-  const [progress, setProgress] = useState<PngWarmProgress | null>(null);
-  const [notice, setNotice] = useState<string | null>(null);
+  // Covers the ids round trip between the click and the module warm starting,
+  // so the button can't double-fire; everything after that renders from the
+  // module's warm state.
+  const [starting, setStarting] = useState(false);
+  const [localError, setLocalError] = useState<string | null>(null);
   const [headroom, setHeadroom] = useState<{ usage: number; quota: number } | null>(null);
-  const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     ensurePngStoreReady();
     estimateStorage().then(setHeadroom);
-    // Cancel a warm this page instance started if the operator navigates away
-    // mid-run; whatever already landed is kept (the warm is resumable).
-    return () => abortRef.current?.abort();
+    // Deliberately NO abort on unmount: the warm keeps running while the
+    // operator steps into the triage flow — that's the point of warming.
   }, []);
 
   const startWarm = async () => {
-    setNotice(null);
-    setWarming(true);
-    setProgress({ done: 0, total, bytes: 0, failed: 0 });
-    const controller = new AbortController();
-    abortRef.current = controller;
+    setLocalError(null);
+    setStarting(true);
     try {
       const { ids, error } = await getNircamExposureIds({
         field: filters.field || undefined,
@@ -83,31 +96,23 @@ export function PngPrecacheControl({ filters, sort, total }: PngPrecacheControlP
         sortDirection: sort.direction,
       });
       if (error || ids.length === 0) {
-        setNotice(error ?? 'No exposures match the current filters.');
+        setLocalError(error ?? 'No exposures match the current filters.');
         return;
       }
-      const result = await warmPngStore(ids, {
-        signal: controller.signal,
-        onProgress: setProgress,
-      });
-      if (result.error) {
-        setNotice(result.error);
-      } else if (result.aborted) {
-        setNotice(`Stopped — ${result.done - result.failed}/${result.total} cached so far (resume any time).`);
-      } else if (result.failed > 0) {
-        setNotice(`Done with ${result.failed} failed download${result.failed !== 1 ? 's' : ''} — run again to retry them.`);
-      }
+      setStarting(false);
+      // Module-scoped: outlives this component; result surfaces via
+      // getWarmState().lastResult whenever a control is mounted to show it.
+      await startPngWarm(ids);
       estimateStorage().then(setHeadroom);
     } finally {
-      abortRef.current = null;
-      setWarming(false);
-      setProgress(null);
+      setStarting(false);
     }
   };
 
   const estNeeded = total * EST_BYTES_PER_EXPOSURE;
   const free = headroom ? Math.max(0, headroom.quota - headroom.usage) : null;
   const ttlHours = Math.round(PNG_STORE_TTL_MS / 3_600_000);
+  const notice = localError ?? (warm.lastResult ? resultNotice(warm.lastResult) : null);
 
   return (
     <div className="flex flex-wrap items-center gap-x-4 gap-y-2 mb-4 px-4 py-2.5 rounded-lg border border-border bg-card text-sm">
@@ -125,19 +130,19 @@ export function PngPrecacheControl({ filters, sort, total }: PngPrecacheControlP
         )}
       </div>
 
-      {warming && progress ? (
+      {warm.running && warm.progress ? (
         <div className="flex items-center gap-3 flex-1 min-w-48">
           <div className="h-2 flex-1 min-w-24 rounded-full bg-surface-2 overflow-hidden">
             <div
               className="h-full rounded-full bg-primary transition-[width]"
-              style={{ width: `${progress.total > 0 ? (progress.done / progress.total) * 100 : 0}%` }}
+              style={{ width: `${warm.progress.total > 0 ? (warm.progress.done / warm.progress.total) * 100 : 0}%` }}
             />
           </div>
           <span className="text-xs tabular-nums text-text-secondary whitespace-nowrap">
-            {progress.done}/{progress.total} · {fmtBytes(progress.bytes)}
-            {progress.failed > 0 && <> · {progress.failed} failed</>}
+            {warm.progress.done}/{warm.progress.total} · {fmtBytes(warm.progress.bytes)}
+            {warm.progress.failed > 0 && <> · {warm.progress.failed} failed</>}
           </span>
-          <Button size="sm" variant="secondary" onClick={() => abortRef.current?.abort()}>
+          <Button size="sm" variant="secondary" onClick={cancelPngWarm}>
             <X className="w-3.5 h-3.5 mr-1" /> Stop
           </Button>
         </div>
@@ -155,10 +160,10 @@ export function PngPrecacheControl({ filters, sort, total }: PngPrecacheControlP
           <Button
             size="sm"
             onClick={startWarm}
-            disabled={!stats.hydrated || total === 0}
-            title="Download the display PNG of every exposure matching the current filters into this browser, so stepping through the queue never waits on the network."
+            disabled={!stats.hydrated || starting || total === 0}
+            title="Download the display PNG of every exposure matching the current filters into this browser, so stepping through the queue never waits on the network. Keeps running if you start inspecting."
           >
-            {!stats.hydrated ? (
+            {!stats.hydrated || starting ? (
               <Loader2 className="w-3.5 h-3.5 mr-1 animate-spin" />
             ) : (
               <Download className="w-3.5 h-3.5 mr-1" />
@@ -169,7 +174,10 @@ export function PngPrecacheControl({ filters, sort, total }: PngPrecacheControlP
             <Button
               size="sm"
               variant="secondary"
-              onClick={() => { setNotice(null); clearPngStore(); estimateStorage().then(setHeadroom); }}
+              onClick={() => {
+                setLocalError(null);
+                clearPngStore().then(() => estimateStorage().then(setHeadroom));
+              }}
               title="Delete all cached exposure images from this browser now."
             >
               <Trash2 className="w-3.5 h-3.5 mr-1" /> Clear

--- a/web/components/nircam/PngPrecacheControl.tsx
+++ b/web/components/nircam/PngPrecacheControl.tsx
@@ -3,10 +3,6 @@
 import React, { useEffect, useMemo, useState, useSyncExternalStore } from 'react';
 import { Check, Download, HardDrive, Loader2, Trash2, X } from 'lucide-react';
 import { Button } from '@/components/ui/Button';
-import {
-  getNircamExposurePngManifest,
-  type ExposurePngManifest,
-} from '@/lib/actions/nircam-exposures';
 import type { SortState } from '@/lib/hooks/useTableUrlState';
 import {
   cancelPngWarm,
@@ -30,6 +26,27 @@ function fmtBytes(n: number): string {
     v /= 1024;
   }
   return `${v} B`;
+}
+
+interface PngManifestEntry {
+  id: number;
+  bytes: number | null;
+}
+
+/**
+ * GET /api/nircam-png/manifest — deliberately a route fetch, NOT a server
+ * action: Next serializes server actions per client, and this scan as an
+ * action queued ahead of the table's own fetch on every filter change,
+ * freezing the table until the manifest landed. A fetch runs alongside the
+ * actions and aborts cleanly when the filters change again.
+ */
+async function fetchPngManifest(
+  query: string,
+  signal?: AbortSignal,
+): Promise<{ entries: PngManifestEntry[]; error?: string }> {
+  const res = await fetch(`/api/nircam-png/manifest?${query}`, { signal });
+  if (!res.ok) return { entries: [], error: `Manifest fetch failed (HTTP ${res.status})` };
+  return res.json();
 }
 
 function resultNotice(r: PngWarmResult): string | null {
@@ -80,7 +97,7 @@ export function PngPrecacheControl({ filters, sort }: PngPrecacheControlProps) {
   // Downloadable exposures + exact sizes for the current filters; null while
   // loading or after a failed fetch (the button then falls back to a
   // fetch-at-click flow rather than wedging).
-  const [manifest, setManifest] = useState<ExposurePngManifest['entries'] | null>(null);
+  const [manifest, setManifest] = useState<PngManifestEntry[] | null>(null);
   const [manifestLoading, setManifestLoading] = useState(false);
 
   useEffect(() => {
@@ -90,35 +107,30 @@ export function PngPrecacheControl({ filters, sort }: PngPrecacheControlProps) {
     // operator steps into the triage flow — that's the point of warming.
   }, []);
 
-  const queryParams = useMemo(() => ({
-    field: filters.field || undefined,
-    filter: filters.filter || undefined,
-    detector: filters.detector || undefined,
-    reviewStatus: filters.review || undefined,
-    stage: filters.stage || undefined,
-    correction: filters.correction || undefined,
-    sortColumn: sort.column,
-    sortDirection: sort.direction,
-  }), [
-    filters.field, filters.filter, filters.detector,
-    filters.review, filters.stage, filters.correction,
-    sort.column, sort.direction,
-  ]);
+  const manifestQuery = useMemo(() => {
+    const sp = new URLSearchParams();
+    for (const key of ['field', 'filter', 'detector', 'review', 'stage', 'correction'] as const) {
+      if (filters[key]) sp.set(key, filters[key]);
+    }
+    sp.set('sort', sort.column);
+    sp.set('dir', sort.direction);
+    return sp.toString();
+  }, [filters, sort]);
 
   useEffect(() => {
-    let cancelled = false;
+    const controller = new AbortController();
     setManifest(null);
     setManifestLoading(true);
-    getNircamExposurePngManifest(queryParams).then(
+    fetchPngManifest(manifestQuery, controller.signal).then(
       (res) => {
-        if (cancelled) return;
+        if (controller.signal.aborted) return;
         setManifestLoading(false);
         if (!res.error) setManifest(res.entries);
       },
-      () => { if (!cancelled) setManifestLoading(false); },
+      () => { if (!controller.signal.aborted) setManifestLoading(false); },
     );
-    return () => { cancelled = true; };
-  }, [queryParams]);
+    return () => controller.abort();
+  }, [manifestQuery]);
 
   // Live split of the manifest against the store: recomputed on every store
   // change (hydration, each warmed image, clear), so the count is always
@@ -150,7 +162,7 @@ export function PngPrecacheControl({ filters, sort }: PngPrecacheControlProps) {
       if (ids === null) {
         // Manifest fetch failed or hasn't landed — get one now so the click
         // still works (startPngWarm skips cached ids on its own).
-        const res = await getNircamExposurePngManifest(queryParams);
+        const res = await fetchPngManifest(manifestQuery);
         if (res.error) {
           setLocalError(res.error);
           return;

--- a/web/lib/actions/nircam-exposures.ts
+++ b/web/lib/actions/nircam-exposures.ts
@@ -177,19 +177,38 @@ export async function getExposureNeighbors(
   }
 }
 
+export interface ExposurePngManifest {
+  /**
+   * One entry per exposure in the filtered set that HAS a display PNG (the
+   * full-res mask surface when deployed, else the preview — the byte
+   * /api/nircam-png serves), in the same order the list shows. Exposures with
+   * no PNG at all are omitted: they can't be downloaded, so they must not
+   * count toward the pre-download button or keep it enabled. `bytes` is the
+   * object's exact registry size, or null for a key the registry doesn't
+   * know (the size hint then reads as a lower bound).
+   */
+  entries: { id: number; bytes: number | null }[];
+  error?: string;
+}
+
 /**
- * Every exposure id in a filtered set, in the same order the list shows —
- * feeds the PNG pre-download warm (lib/nircam-png-store.ts), so images are
- * fetched in inspection order and the operator can start stepping while the
- * warm is still running. Ids only: the warm pulls bytes per id through
- * /api/nircam-png. Paged internally (PostgREST caps a single response at
- * 1000 rows) with a hard cap as a runaway guard.
+ * The PNG pre-download manifest for a filtered set: which exposures have a
+ * downloadable display PNG, in inspection order, each with its exact size
+ * from the storage_objects registry. Feeds both halves of the list page's
+ * pre-cache control — the warm's id list (lib/nircam-png-store.ts) and the
+ * bytes-needed hint, which is real registry data rather than a per-image
+ * heuristic (full-res PNG sizes are content-dependent and vary ~2× between
+ * fields). Paged internally (PostgREST caps a single response at 1000 rows)
+ * with a hard cap as a runaway guard.
  */
-export async function getNircamExposureIds(
+export async function getNircamExposurePngManifest(
   params?: ExposureFilters & ExposureSort,
-): Promise<{ ids: number[]; error?: string }> {
+): Promise<ExposurePngManifest> {
   const CHUNK = 1000;
   const CAP = 20000;
+  // storage_objects lookups go out as GET query strings; ~100 keys per
+  // request keeps the URL comfortably under proxy limits.
+  const SIZE_CHUNK = 100;
   try {
     const supabase = await requireSession();
     const sortCol =
@@ -198,9 +217,9 @@ export async function getNircamExposureIds(
         : 'filename';
     const asc = (params?.sortDirection ?? 'asc') === 'asc';
 
-    const ids: number[] = [];
+    const rows: { id: number; key: string }[] = [];
     for (let off = 0; off < CAP; off += CHUNK) {
-      let q = supabase.from('nircam_exposures').select('id');
+      let q = supabase.from('nircam_exposures').select('id, png_path, full_png_path');
       if (params?.field) q = q.eq('field', params.field);
       if (params?.filter) q = q.eq('filter', params.filter);
       if (params?.detector) q = q.eq('detector', params.detector);
@@ -220,15 +239,39 @@ export async function getNircamExposureIds(
       q = q.order('id', { ascending: true }).range(off, off + CHUNK - 1);
 
       const { data, error } = await q;
-      if (error) return { ids: [], error: error.message };
-      ids.push(...(data ?? []).map((r) => r.id as number));
+      if (error) return { entries: [], error: error.message };
+      for (const r of data ?? []) {
+        // Same display-byte rule as /api/nircam-png: full-res wins.
+        const key = (r.full_png_path ?? r.png_path) as string | null;
+        if (key) rows.push({ id: r.id as number, key });
+      }
       if (!data || data.length < CHUNK) break;
     }
-    return { ids };
+
+    const keys = [...new Set(rows.map((r) => r.key))];
+    const sizeByKey = new Map<string, number>();
+    const chunks: string[][] = [];
+    for (let i = 0; i < keys.length; i += SIZE_CHUNK) {
+      chunks.push(keys.slice(i, i + SIZE_CHUNK));
+    }
+    // Best-effort: a failed size lookup leaves those entries at bytes:null
+    // (hint degrades to a lower bound) rather than failing the manifest.
+    await Promise.all(chunks.map(async (chunk) => {
+      const { data } = await supabase
+        .from('storage_objects')
+        .select('storage_key, size_bytes')
+        .eq('status', 'active')
+        .in('storage_key', chunk);
+      for (const r of data ?? []) {
+        if (typeof r.size_bytes === 'number') sizeByKey.set(r.storage_key, r.size_bytes);
+      }
+    }));
+
+    return { entries: rows.map((r) => ({ id: r.id, bytes: sizeByKey.get(r.key) ?? null })) };
   } catch (err) {
     return {
-      ids: [],
-      error: err instanceof Error ? err.message : 'Failed to fetch exposure ids',
+      entries: [],
+      error: err instanceof Error ? err.message : 'Failed to fetch PNG manifest',
     };
   }
 }

--- a/web/lib/actions/nircam-exposures.ts
+++ b/web/lib/actions/nircam-exposures.ts
@@ -4,7 +4,6 @@ import { createClient } from '@/lib/supabase/server';
 import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { getS3ClientForBackend, getBucketNameForBackend, type DataBackend } from '@/lib/storage';
-import { EXPOSURE_SORT_KEYS } from '@/lib/admin/sort-keys';
 import type { NircamExposure, MaskRegionsPayload } from '@/lib/types';
 
 export interface ExposurePngUrls {
@@ -173,105 +172,6 @@ export async function getExposureNeighbors(
     return {
       ...empty,
       error: err instanceof Error ? err.message : 'Failed to fetch neighbors',
-    };
-  }
-}
-
-export interface ExposurePngManifest {
-  /**
-   * One entry per exposure in the filtered set that HAS a display PNG (the
-   * full-res mask surface when deployed, else the preview — the byte
-   * /api/nircam-png serves), in the same order the list shows. Exposures with
-   * no PNG at all are omitted: they can't be downloaded, so they must not
-   * count toward the pre-download button or keep it enabled. `bytes` is the
-   * object's exact registry size, or null for a key the registry doesn't
-   * know (the size hint then reads as a lower bound).
-   */
-  entries: { id: number; bytes: number | null }[];
-  error?: string;
-}
-
-/**
- * The PNG pre-download manifest for a filtered set: which exposures have a
- * downloadable display PNG, in inspection order, each with its exact size
- * from the storage_objects registry. Feeds both halves of the list page's
- * pre-cache control — the warm's id list (lib/nircam-png-store.ts) and the
- * bytes-needed hint, which is real registry data rather than a per-image
- * heuristic (full-res PNG sizes are content-dependent and vary ~2× between
- * fields). Paged internally (PostgREST caps a single response at 1000 rows)
- * with a hard cap as a runaway guard.
- */
-export async function getNircamExposurePngManifest(
-  params?: ExposureFilters & ExposureSort,
-): Promise<ExposurePngManifest> {
-  const CHUNK = 1000;
-  const CAP = 20000;
-  // storage_objects lookups go out as GET query strings; ~100 keys per
-  // request keeps the URL comfortably under proxy limits.
-  const SIZE_CHUNK = 100;
-  try {
-    const supabase = await requireSession();
-    const sortCol =
-      params?.sortColumn && (EXPOSURE_SORT_KEYS as readonly string[]).includes(params.sortColumn)
-        ? params.sortColumn
-        : 'filename';
-    const asc = (params?.sortDirection ?? 'asc') === 'asc';
-
-    const rows: { id: number; key: string }[] = [];
-    for (let off = 0; off < CAP; off += CHUNK) {
-      let q = supabase.from('nircam_exposures').select('id, png_path, full_png_path');
-      if (params?.field) q = q.eq('field', params.field);
-      if (params?.filter) q = q.eq('filter', params.filter);
-      if (params?.detector) q = q.eq('detector', params.detector);
-      if (params?.reviewStatus) q = q.eq('review_status', params.reviewStatus);
-      if (params?.stage) q = q.eq('stage', params.stage);
-      if (params?.correction) q = q.eq('correction', params.correction);
-      // Mirror get_admin_exposures' ORDER BY: 'filename' is the compound
-      // (field, filter, filename) list order; everything gets the id tiebreak.
-      if (sortCol === 'filename') {
-        q = q
-          .order('field', { ascending: asc })
-          .order('filter', { ascending: asc })
-          .order('filename', { ascending: asc });
-      } else {
-        q = q.order(sortCol, { ascending: asc, nullsFirst: false });
-      }
-      q = q.order('id', { ascending: true }).range(off, off + CHUNK - 1);
-
-      const { data, error } = await q;
-      if (error) return { entries: [], error: error.message };
-      for (const r of data ?? []) {
-        // Same display-byte rule as /api/nircam-png: full-res wins.
-        const key = (r.full_png_path ?? r.png_path) as string | null;
-        if (key) rows.push({ id: r.id as number, key });
-      }
-      if (!data || data.length < CHUNK) break;
-    }
-
-    const keys = [...new Set(rows.map((r) => r.key))];
-    const sizeByKey = new Map<string, number>();
-    const chunks: string[][] = [];
-    for (let i = 0; i < keys.length; i += SIZE_CHUNK) {
-      chunks.push(keys.slice(i, i + SIZE_CHUNK));
-    }
-    // Best-effort: a failed size lookup leaves those entries at bytes:null
-    // (hint degrades to a lower bound) rather than failing the manifest.
-    await Promise.all(chunks.map(async (chunk) => {
-      const { data } = await supabase
-        .from('storage_objects')
-        .select('storage_key, size_bytes')
-        .eq('status', 'active')
-        .in('storage_key', chunk);
-      for (const r of data ?? []) {
-        if (typeof r.size_bytes === 'number') sizeByKey.set(r.storage_key, r.size_bytes);
-      }
-    }));
-
-    return { entries: rows.map((r) => ({ id: r.id, bytes: sizeByKey.get(r.key) ?? null })) };
-  } catch (err) {
-    return {
-      entries: [],
-      error: err instanceof Error ? err.message : 'Failed to fetch PNG manifest',
     };
   }
 }

--- a/web/lib/actions/nircam-exposures.ts
+++ b/web/lib/actions/nircam-exposures.ts
@@ -4,6 +4,7 @@ import { createClient } from '@/lib/supabase/server';
 import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { getS3ClientForBackend, getBucketNameForBackend, type DataBackend } from '@/lib/storage';
+import { EXPOSURE_SORT_KEYS } from '@/lib/admin/sort-keys';
 import type { NircamExposure, MaskRegionsPayload } from '@/lib/types';
 
 export interface ExposurePngUrls {
@@ -172,6 +173,62 @@ export async function getExposureNeighbors(
     return {
       ...empty,
       error: err instanceof Error ? err.message : 'Failed to fetch neighbors',
+    };
+  }
+}
+
+/**
+ * Every exposure id in a filtered set, in the same order the list shows —
+ * feeds the PNG pre-download warm (lib/nircam-png-store.ts), so images are
+ * fetched in inspection order and the operator can start stepping while the
+ * warm is still running. Ids only: the warm pulls bytes per id through
+ * /api/nircam-png. Paged internally (PostgREST caps a single response at
+ * 1000 rows) with a hard cap as a runaway guard.
+ */
+export async function getNircamExposureIds(
+  params?: ExposureFilters & ExposureSort,
+): Promise<{ ids: number[]; error?: string }> {
+  const CHUNK = 1000;
+  const CAP = 20000;
+  try {
+    const supabase = await requireSession();
+    const sortCol =
+      params?.sortColumn && (EXPOSURE_SORT_KEYS as readonly string[]).includes(params.sortColumn)
+        ? params.sortColumn
+        : 'filename';
+    const asc = (params?.sortDirection ?? 'asc') === 'asc';
+
+    const ids: number[] = [];
+    for (let off = 0; off < CAP; off += CHUNK) {
+      let q = supabase.from('nircam_exposures').select('id');
+      if (params?.field) q = q.eq('field', params.field);
+      if (params?.filter) q = q.eq('filter', params.filter);
+      if (params?.detector) q = q.eq('detector', params.detector);
+      if (params?.reviewStatus) q = q.eq('review_status', params.reviewStatus);
+      if (params?.stage) q = q.eq('stage', params.stage);
+      if (params?.correction) q = q.eq('correction', params.correction);
+      // Mirror get_admin_exposures' ORDER BY: 'filename' is the compound
+      // (field, filter, filename) list order; everything gets the id tiebreak.
+      if (sortCol === 'filename') {
+        q = q
+          .order('field', { ascending: asc })
+          .order('filter', { ascending: asc })
+          .order('filename', { ascending: asc });
+      } else {
+        q = q.order(sortCol, { ascending: asc, nullsFirst: false });
+      }
+      q = q.order('id', { ascending: true }).range(off, off + CHUNK - 1);
+
+      const { data, error } = await q;
+      if (error) return { ids: [], error: error.message };
+      ids.push(...(data ?? []).map((r) => r.id as number));
+      if (!data || data.length < CHUNK) break;
+    }
+    return { ids };
+  } catch (err) {
+    return {
+      ids: [],
+      error: err instanceof Error ? err.message : 'Failed to fetch exposure ids',
     };
   }
 }

--- a/web/lib/nircam-png-store.ts
+++ b/web/lib/nircam-png-store.ts
@@ -276,9 +276,14 @@ function putRecord(rec: PngRecord): Promise<void> {
   return new Promise((resolve, reject) => {
     if (!db) { reject(new Error('PNG store unavailable')); return; }
     const tx = db.transaction(STORE, 'readwrite');
-    tx.objectStore(STORE).put(rec);
+    const req = tx.objectStore(STORE).put(rec);
     tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error ?? new Error('PNG store write failed'));
+    // Reject from the REQUEST's error handler: request.error is populated
+    // before its error event fires, while tx.error is still null when that
+    // event bubbles to the transaction (the abort that populates it happens
+    // after dispatch). Rejecting from tx.onerror surfaced a generic Error and
+    // made the warm's QuotaExceededError fatal-stop unreachable.
+    req.onerror = () => reject(req.error ?? new Error('PNG store write failed'));
     tx.onabort = () => reject(tx.error ?? new Error('PNG store write aborted'));
   });
 }

--- a/web/lib/nircam-png-store.ts
+++ b/web/lib/nircam-png-store.ts
@@ -17,13 +17,26 @@
  * storage quota (GBs on desktop — navigator.storage.estimate() is the truth).
  * A thousand full-res exposures is roughly 6 GB.
  *
- * Lifecycle: every record carries storedAt, and ensurePngStoreReady() —
- * called from both triage pages on mount — sweeps records older than
- * PNG_STORE_TTL_MS, so a finished inspection's cache clears itself after the
- * buffer window without the operator doing anything. clearPngStore() empties
- * it on demand. Object URLs are minted once at hydration (or store time) and
- * revoked when their record is dropped; blobs stay on disk until then, so the
- * in-memory map costs a few strings per exposure, not the image bytes.
+ * The warm itself is MODULE state, not component state: the control that
+ * starts it unmounts as soon as the operator opens an exposure (the whole
+ * point is inspecting while the warm continues), so the download loop and its
+ * progress live here and every page of the flow just subscribes. One warm at
+ * a time; navigation neither cancels nor duplicates it.
+ *
+ * Tabs cooperate through a BroadcastChannel: each stored image and each
+ * clear is announced, and other tabs fold the change into their own map — so
+ * warming in one tab feeds a triage session already running in another
+ * without a reload.
+ *
+ * Lifecycle: every record carries storedAt. Expiry (PNG_STORE_TTL_MS after
+ * download — inspection session + buffer) is enforced three ways so the
+ * "auto-clears" promise holds even for a long-lived SPA session: a sweep at
+ * first hydration, a read-time check in getStoredPng (an expired blob is
+ * never served), and a periodic re-sweep that actually deletes what expired
+ * while the tab stayed open. clearPngStore() empties everything on demand.
+ * Object URLs are minted once at hydration (or store time) and revoked when
+ * their record is dropped; blobs stay on disk until then, so the in-memory
+ * map costs a few strings per exposure, not the image bytes.
  */
 
 export const PNG_STORE_TTL_MS = 24 * 60 * 60 * 1000; // inspection session + buffer
@@ -31,9 +44,15 @@ export const PNG_STORE_TTL_MS = 24 * 60 * 60 * 1000; // inspection session + buf
 const DB_NAME = 'campfire-nircam-png-store';
 const DB_VERSION = 1;
 const STORE = 'pngs';
+const CHANNEL_NAME = 'campfire-nircam-png-store';
 // Modest parallelism: each request streams ~6 MB through a serverless
 // function; 4-way keeps the pipe full without hammering the proxy.
 const WARM_CONCURRENCY = 4;
+// How often a long-lived tab re-checks for records that expired while open.
+const SWEEP_INTERVAL_MS = 10 * 60 * 1000;
+// Progress emits are throttled so a warm running behind an active triage
+// session doesn't re-render the detail page once per downloaded image.
+const PROGRESS_EMIT_INTERVAL_MS = 250;
 
 interface PngRecord {
   id: number;                    // nircam_exposures.id (the IDB key)
@@ -47,12 +66,14 @@ export interface StoredPng {
   kind: 'full' | 'preview';
   url: string;                   // object URL backed by the stored blob
   bytes: number;
+  storedAt: number;
 }
 
 const mem = new Map<number, StoredPng>();
 let db: IDBDatabase | null = null;
 let hydrated = false;
 let readyPromise: Promise<void> | null = null;
+let channel: BroadcastChannel | null = null;
 
 // useSyncExternalStore plumbing (same version-counter pattern as the save
 // state in lib/nircam-exposure-cache.ts): consumers re-read the maps after
@@ -71,6 +92,17 @@ export function getPngStoreVersion(): number {
   return version;
 }
 
+function isExpired(storedAt: number): boolean {
+  return Date.now() - storedAt > PNG_STORE_TTL_MS;
+}
+
+function dropMemEntry(id: number): void {
+  const e = mem.get(id);
+  if (!e) return;
+  URL.revokeObjectURL(e.url);
+  mem.delete(id);
+}
+
 function openDb(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     const req = indexedDB.open(DB_NAME, DB_VERSION);
@@ -84,45 +116,132 @@ function openDb(): Promise<IDBDatabase> {
   });
 }
 
+function getRecord(id: number): Promise<PngRecord | undefined> {
+  return new Promise((resolve, reject) => {
+    if (!db) { resolve(undefined); return; }
+    const req = db.transaction(STORE, 'readonly').objectStore(STORE).get(id);
+    req.onsuccess = () => resolve(req.result as PngRecord | undefined);
+    req.onerror = () => reject(req.error ?? new Error('PNG store read failed'));
+  });
+}
+
+function deleteRecords(ids: number[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!db || ids.length === 0) { resolve(); return; }
+    const tx = db.transaction(STORE, 'readwrite');
+    const os = tx.objectStore(STORE);
+    for (const id of ids) os.delete(id);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error ?? new Error('PNG store delete failed'));
+  });
+}
+
 /**
- * Open the database, sweep expired records, and mint object URLs for the
- * rest. Idempotent single-flight; both triage pages call it on mount. If
- * IndexedDB is unavailable (private browsing, disabled storage) this resolves
- * with an empty store — the pages just fall back to the presigned-URL path.
+ * Drop everything past its TTL — from this tab's map and from disk. Runs at
+ * hydration and on a coarse interval afterwards, so records that age out
+ * while the SPA stays open still get deleted, not just hidden by the
+ * read-time check in getStoredPng.
+ */
+async function sweepExpired(): Promise<void> {
+  const expired: number[] = [];
+  for (const [id, e] of mem) {
+    if (isExpired(e.storedAt)) expired.push(id);
+  }
+  if (expired.length === 0) return;
+  for (const id of expired) dropMemEntry(id);
+  try {
+    await deleteRecords(expired);
+  } catch {
+    // Disk cleanup failed; the entries are already unservable here and the
+    // next hydration's sweep gets another shot.
+  }
+  emit();
+}
+
+// Cross-tab messages: 'stored' announces one new record (receivers pull it
+// from IndexedDB into their own map), 'cleared' announces a full clear.
+type ChannelMessage = { type: 'stored'; id: number } | { type: 'cleared' };
+
+function announce(msg: ChannelMessage): void {
+  try {
+    channel?.postMessage(msg);
+  } catch {
+    // Channel closed or serialization refused — cross-tab freshness only.
+  }
+}
+
+async function onChannelMessage(msg: ChannelMessage): Promise<void> {
+  if (msg.type === 'cleared') {
+    for (const e of mem.values()) URL.revokeObjectURL(e.url);
+    mem.clear();
+    emit();
+    return;
+  }
+  if (msg.type === 'stored' && typeof msg.id === 'number' && !mem.has(msg.id)) {
+    try {
+      const rec = await getRecord(msg.id);
+      if (rec && !isExpired(rec.storedAt) && !mem.has(rec.id)) {
+        mem.set(rec.id, {
+          kind: rec.kind,
+          url: URL.createObjectURL(rec.blob),
+          bytes: rec.bytes,
+          storedAt: rec.storedAt,
+        });
+        emit();
+      }
+    } catch {
+      // Reads race the writer tab; the record stays available on disk.
+    }
+  }
+}
+
+/**
+ * Open the database, sweep expired records, mint object URLs for the rest,
+ * and start the cross-tab channel + periodic re-sweep. Idempotent
+ * single-flight; both triage pages call it on mount. If IndexedDB is
+ * unavailable (private browsing, disabled storage) this resolves with an
+ * empty store — the pages just fall back to the presigned-URL path.
  */
 export function ensurePngStoreReady(): Promise<void> {
   if (readyPromise) return readyPromise;
   readyPromise = (async () => {
-    if (typeof indexedDB === 'undefined') { hydrated = true; return; }
-    try {
-      db = await openDb();
-      const cutoff = Date.now() - PNG_STORE_TTL_MS;
-      await new Promise<void>((resolve, reject) => {
-        const tx = db!.transaction(STORE, 'readwrite');
-        const cursorReq = tx.objectStore(STORE).openCursor();
-        cursorReq.onsuccess = () => {
-          const cursor = cursorReq.result;
-          if (!cursor) return; // tx.oncomplete resolves
-          const rec = cursor.value as PngRecord;
-          if (rec.storedAt < cutoff) {
-            cursor.delete();
-          } else {
-            mem.set(rec.id, {
-              kind: rec.kind,
-              url: URL.createObjectURL(rec.blob),
-              bytes: rec.bytes,
-            });
-          }
-          cursor.continue();
-        };
-        tx.oncomplete = () => resolve();
-        tx.onerror = () => reject(tx.error ?? new Error('PNG store sweep failed'));
-      });
-    } catch {
-      // Store unusable — behave as empty rather than breaking triage.
-      db = null;
-      for (const e of mem.values()) URL.revokeObjectURL(e.url);
-      mem.clear();
+    if (typeof indexedDB !== 'undefined') {
+      try {
+        db = await openDb();
+        const cutoff = Date.now() - PNG_STORE_TTL_MS;
+        await new Promise<void>((resolve, reject) => {
+          const tx = db!.transaction(STORE, 'readwrite');
+          const cursorReq = tx.objectStore(STORE).openCursor();
+          cursorReq.onsuccess = () => {
+            const cursor = cursorReq.result;
+            if (!cursor) return; // tx.oncomplete resolves
+            const rec = cursor.value as PngRecord;
+            if (rec.storedAt < cutoff) {
+              cursor.delete();
+            } else {
+              mem.set(rec.id, {
+                kind: rec.kind,
+                url: URL.createObjectURL(rec.blob),
+                bytes: rec.bytes,
+                storedAt: rec.storedAt,
+              });
+            }
+            cursor.continue();
+          };
+          tx.oncomplete = () => resolve();
+          tx.onerror = () => reject(tx.error ?? new Error('PNG store sweep failed'));
+        });
+        if (typeof BroadcastChannel !== 'undefined') {
+          channel = new BroadcastChannel(CHANNEL_NAME);
+          channel.onmessage = (ev) => { onChannelMessage(ev.data as ChannelMessage); };
+        }
+        setInterval(sweepExpired, SWEEP_INTERVAL_MS);
+      } catch {
+        // Store unusable — behave as empty rather than breaking triage.
+        db = null;
+        for (const e of mem.values()) URL.revokeObjectURL(e.url);
+        mem.clear();
+      }
     }
     hydrated = true;
     emit();
@@ -130,15 +249,27 @@ export function ensurePngStoreReady(): Promise<void> {
   return readyPromise;
 }
 
-/** Synchronous read for the render path; undefined until warmed/hydrated. */
+/**
+ * Synchronous read for the render path; undefined until warmed/hydrated.
+ * Expiry is enforced here too: a record past its TTL is never served, even
+ * before the periodic sweep gets around to deleting it.
+ */
 export function getStoredPng(id: number): StoredPng | undefined {
-  return mem.get(id);
+  const e = mem.get(id);
+  if (!e) return undefined;
+  if (isExpired(e.storedAt)) return undefined;
+  return e;
 }
 
 export function getPngStoreStats(): { count: number; bytes: number; hydrated: boolean } {
+  let count = 0;
   let bytes = 0;
-  for (const e of mem.values()) bytes += e.bytes;
-  return { count: mem.size, bytes, hydrated };
+  for (const e of mem.values()) {
+    if (isExpired(e.storedAt)) continue;
+    count++;
+    bytes += e.bytes;
+  }
+  return { count, bytes, hydrated };
 }
 
 function putRecord(rec: PngRecord): Promise<void> {
@@ -173,59 +304,99 @@ export interface PngWarmResult extends PngWarmProgress {
   error?: string;
 }
 
+// The single active warm + the last finished one, module-scoped so the run
+// survives the list page unmounting (navigating into an exposure) and so any
+// page can render its progress. State changes flow through emit().
+let activeWarm: { controller: AbortController; progress: PngWarmProgress } | null = null;
+let lastWarmResult: PngWarmResult | null = null;
+
+export function getWarmState(): {
+  running: boolean;
+  progress: PngWarmProgress | null;
+  lastResult: PngWarmResult | null;
+} {
+  return {
+    running: activeWarm !== null,
+    progress: activeWarm ? { ...activeWarm.progress } : null,
+    lastResult: lastWarmResult,
+  };
+}
+
+export function cancelPngWarm(): void {
+  activeWarm?.controller.abort();
+}
+
 /**
  * Download-and-store every id not already held, in the order given (= the
  * list's inspection order, so the exposures the operator will hit first are
- * warmed first — inspecting can start while the warm continues). Resumable
- * by construction: already-stored ids are skipped, so re-running after a
- * cancel or failure only fetches what's missing. A 404 (exposure has no PNG
- * deployed) is a silent skip, not a failure — those render "No PNG available"
- * in triage regardless.
+ * warmed first — inspecting can start while the warm continues; the run is
+ * module state, so navigating into the triage flow does NOT cancel it).
+ * Resumable by construction: already-stored ids are skipped, so re-running
+ * after a cancel or failure only fetches what's missing. A 404 (exposure has
+ * no PNG deployed) is a silent skip, not a failure — those render "No PNG
+ * available" in triage regardless. One warm at a time: starting while one is
+ * running returns null and leaves the active run alone.
  */
-export async function warmPngStore(
-  ids: number[],
-  opts: { signal?: AbortSignal; onProgress?: (p: PngWarmProgress) => void } = {},
-): Promise<PngWarmResult> {
+export async function startPngWarm(ids: number[]): Promise<PngWarmResult | null> {
+  if (activeWarm) return null;
   await ensurePngStoreReady();
-  const todo = ids.filter((i) => !mem.has(i));
+  const todo = ids.filter((i) => !getStoredPng(i));
   const progress: PngWarmProgress = {
     done: ids.length - todo.length,
     total: ids.length,
     bytes: 0,
     failed: 0,
   };
-  opts.onProgress?.({ ...progress });
+  const controller = new AbortController();
+  activeWarm = { controller, progress };
+  lastWarmResult = null;
+  emit();
   if (!db && todo.length > 0) {
-    return { ...progress, aborted: false, error: 'Browser storage is unavailable (private browsing?)' };
+    activeWarm = null;
+    lastWarmResult = {
+      ...progress, aborted: false,
+      error: 'Browser storage is unavailable (private browsing?)',
+    };
+    emit();
+    return lastWarmResult;
   }
+
+  let lastProgressEmit = 0;
+  const progressed = () => {
+    const now = Date.now();
+    if (now - lastProgressEmit >= PROGRESS_EMIT_INTERVAL_MS) {
+      lastProgressEmit = now;
+      emit();
+    }
+  };
 
   let fatal: string | undefined;
   let next = 0;
   const worker = async () => {
-    while (!fatal && !opts.signal?.aborted) {
+    while (!fatal && !controller.signal.aborted) {
       const idx = next++;
       if (idx >= todo.length) return;
       const id = todo[idx];
       try {
-        const res = await fetch(`/api/nircam-png?id=${id}`, { signal: opts.signal });
+        const res = await fetch(`/api/nircam-png?id=${id}`, { signal: controller.signal });
         if (!res.ok) {
           if (res.status !== 404) progress.failed++;
           progress.done++;
-          opts.onProgress?.({ ...progress });
+          progressed();
           continue;
         }
         const kind = res.headers.get('x-png-kind') === 'preview' ? 'preview' : 'full';
         const blob = await res.blob();
-        await putRecord({ id, kind, bytes: blob.size, storedAt: Date.now(), blob });
-        mem.set(id, { kind, url: URL.createObjectURL(blob), bytes: blob.size });
+        const storedAt = Date.now();
+        await putRecord({ id, kind, bytes: blob.size, storedAt, blob });
+        dropMemEntry(id); // replace a stale/expired leftover, if any
+        mem.set(id, { kind, url: URL.createObjectURL(blob), bytes: blob.size, storedAt });
+        announce({ type: 'stored', id });
         progress.bytes += blob.size;
         progress.done++;
-        opts.onProgress?.({ ...progress });
-        // Keep any store-stats UI roughly live without a global re-render per
-        // image; the final emit below settles the exact numbers.
-        if (progress.done % 25 === 0) emit();
+        progressed();
       } catch (err) {
-        if (opts.signal?.aborted) return;
+        if (controller.signal.aborted) return;
         if (isQuotaError(err)) {
           fatal = 'Browser storage quota exhausted — the warm stored what fit. ' +
             'Clear the cache or free disk space and re-run to continue.';
@@ -233,13 +404,15 @@ export async function warmPngStore(
         }
         progress.failed++;
         progress.done++;
-        opts.onProgress?.({ ...progress });
+        progressed();
       }
     }
   };
   await Promise.all(Array.from({ length: WARM_CONCURRENCY }, worker));
+  lastWarmResult = { ...progress, aborted: controller.signal.aborted, error: fatal };
+  activeWarm = null;
   emit();
-  return { ...progress, aborted: !!opts.signal?.aborted, error: fatal };
+  return lastWarmResult;
 }
 
 /**
@@ -260,6 +433,8 @@ export async function clearPngStore(): Promise<void> {
   }
   for (const e of mem.values()) URL.revokeObjectURL(e.url);
   mem.clear();
+  lastWarmResult = null;
+  announce({ type: 'cleared' });
   emit();
 }
 

--- a/web/lib/nircam-png-store.ts
+++ b/web/lib/nircam-png-store.ts
@@ -1,0 +1,275 @@
+/**
+ * Durable pre-downloaded exposure PNG store for the /admin/nircam triage flow:
+ * "warm a whole filter/detector pair before an inspection run, then never
+ * wait on a fetch".
+ *
+ * IndexedDB holds one Blob per exposure — the *display byte*: the full-res
+ * mask surface when the exposure has one, else the preview thumbnail. Bytes
+ * come through the same-origin /api/nircam-png proxy, because OSN serves no
+ * CORS headers: the presigned URLs the viewer streams into <img> cannot be
+ * READ by page JavaScript (the same constraint that shaped /api/nircam-fits).
+ * At render time the detail page prefers a stored blob URL over a presigned
+ * URL, so a warmed exposure paints with zero network wait — and keeps
+ * painting long after its presigned URL would have expired.
+ *
+ * IndexedDB, not localStorage, on purpose: localStorage caps out around 5 MB
+ * and stores strings; IndexedDB blobs are disk-backed and share the origin's
+ * storage quota (GBs on desktop — navigator.storage.estimate() is the truth).
+ * A thousand full-res exposures is roughly 6 GB.
+ *
+ * Lifecycle: every record carries storedAt, and ensurePngStoreReady() —
+ * called from both triage pages on mount — sweeps records older than
+ * PNG_STORE_TTL_MS, so a finished inspection's cache clears itself after the
+ * buffer window without the operator doing anything. clearPngStore() empties
+ * it on demand. Object URLs are minted once at hydration (or store time) and
+ * revoked when their record is dropped; blobs stay on disk until then, so the
+ * in-memory map costs a few strings per exposure, not the image bytes.
+ */
+
+export const PNG_STORE_TTL_MS = 24 * 60 * 60 * 1000; // inspection session + buffer
+
+const DB_NAME = 'campfire-nircam-png-store';
+const DB_VERSION = 1;
+const STORE = 'pngs';
+// Modest parallelism: each request streams ~6 MB through a serverless
+// function; 4-way keeps the pipe full without hammering the proxy.
+const WARM_CONCURRENCY = 4;
+
+interface PngRecord {
+  id: number;                    // nircam_exposures.id (the IDB key)
+  kind: 'full' | 'preview';      // which byte /api/nircam-png served
+  bytes: number;
+  storedAt: number;
+  blob: Blob;
+}
+
+export interface StoredPng {
+  kind: 'full' | 'preview';
+  url: string;                   // object URL backed by the stored blob
+  bytes: number;
+}
+
+const mem = new Map<number, StoredPng>();
+let db: IDBDatabase | null = null;
+let hydrated = false;
+let readyPromise: Promise<void> | null = null;
+
+// useSyncExternalStore plumbing (same version-counter pattern as the save
+// state in lib/nircam-exposure-cache.ts): consumers re-read the maps after
+// the version changes.
+let version = 0;
+const listeners = new Set<() => void>();
+function emit(): void {
+  version++;
+  for (const l of listeners) l();
+}
+export function subscribePngStore(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+export function getPngStoreVersion(): number {
+  return version;
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      if (!req.result.objectStoreNames.contains(STORE)) {
+        req.result.createObjectStore(STORE, { keyPath: 'id' });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error ?? new Error('IndexedDB open failed'));
+  });
+}
+
+/**
+ * Open the database, sweep expired records, and mint object URLs for the
+ * rest. Idempotent single-flight; both triage pages call it on mount. If
+ * IndexedDB is unavailable (private browsing, disabled storage) this resolves
+ * with an empty store — the pages just fall back to the presigned-URL path.
+ */
+export function ensurePngStoreReady(): Promise<void> {
+  if (readyPromise) return readyPromise;
+  readyPromise = (async () => {
+    if (typeof indexedDB === 'undefined') { hydrated = true; return; }
+    try {
+      db = await openDb();
+      const cutoff = Date.now() - PNG_STORE_TTL_MS;
+      await new Promise<void>((resolve, reject) => {
+        const tx = db!.transaction(STORE, 'readwrite');
+        const cursorReq = tx.objectStore(STORE).openCursor();
+        cursorReq.onsuccess = () => {
+          const cursor = cursorReq.result;
+          if (!cursor) return; // tx.oncomplete resolves
+          const rec = cursor.value as PngRecord;
+          if (rec.storedAt < cutoff) {
+            cursor.delete();
+          } else {
+            mem.set(rec.id, {
+              kind: rec.kind,
+              url: URL.createObjectURL(rec.blob),
+              bytes: rec.bytes,
+            });
+          }
+          cursor.continue();
+        };
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error ?? new Error('PNG store sweep failed'));
+      });
+    } catch {
+      // Store unusable — behave as empty rather than breaking triage.
+      db = null;
+      for (const e of mem.values()) URL.revokeObjectURL(e.url);
+      mem.clear();
+    }
+    hydrated = true;
+    emit();
+  })();
+  return readyPromise;
+}
+
+/** Synchronous read for the render path; undefined until warmed/hydrated. */
+export function getStoredPng(id: number): StoredPng | undefined {
+  return mem.get(id);
+}
+
+export function getPngStoreStats(): { count: number; bytes: number; hydrated: boolean } {
+  let bytes = 0;
+  for (const e of mem.values()) bytes += e.bytes;
+  return { count: mem.size, bytes, hydrated };
+}
+
+function putRecord(rec: PngRecord): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!db) { reject(new Error('PNG store unavailable')); return; }
+    const tx = db.transaction(STORE, 'readwrite');
+    tx.objectStore(STORE).put(rec);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error ?? new Error('PNG store write failed'));
+    tx.onabort = () => reject(tx.error ?? new Error('PNG store write aborted'));
+  });
+}
+
+function isQuotaError(err: unknown): boolean {
+  return err instanceof DOMException &&
+    (err.name === 'QuotaExceededError' || err.name === 'NS_ERROR_DOM_QUOTA_REACHED');
+}
+
+export interface PngWarmProgress {
+  /** Exposures processed this run (stored, skipped, or failed) out of total. */
+  done: number;
+  total: number;
+  /** Bytes downloaded this run (already-stored exposures contribute nothing). */
+  bytes: number;
+  /** Exposures whose download failed this run (re-running retries them). */
+  failed: number;
+}
+
+export interface PngWarmResult extends PngWarmProgress {
+  aborted: boolean;
+  /** Set when the warm stopped early (quota exhausted, store unusable). */
+  error?: string;
+}
+
+/**
+ * Download-and-store every id not already held, in the order given (= the
+ * list's inspection order, so the exposures the operator will hit first are
+ * warmed first — inspecting can start while the warm continues). Resumable
+ * by construction: already-stored ids are skipped, so re-running after a
+ * cancel or failure only fetches what's missing. A 404 (exposure has no PNG
+ * deployed) is a silent skip, not a failure — those render "No PNG available"
+ * in triage regardless.
+ */
+export async function warmPngStore(
+  ids: number[],
+  opts: { signal?: AbortSignal; onProgress?: (p: PngWarmProgress) => void } = {},
+): Promise<PngWarmResult> {
+  await ensurePngStoreReady();
+  const todo = ids.filter((i) => !mem.has(i));
+  const progress: PngWarmProgress = {
+    done: ids.length - todo.length,
+    total: ids.length,
+    bytes: 0,
+    failed: 0,
+  };
+  opts.onProgress?.({ ...progress });
+  if (!db && todo.length > 0) {
+    return { ...progress, aborted: false, error: 'Browser storage is unavailable (private browsing?)' };
+  }
+
+  let fatal: string | undefined;
+  let next = 0;
+  const worker = async () => {
+    while (!fatal && !opts.signal?.aborted) {
+      const idx = next++;
+      if (idx >= todo.length) return;
+      const id = todo[idx];
+      try {
+        const res = await fetch(`/api/nircam-png?id=${id}`, { signal: opts.signal });
+        if (!res.ok) {
+          if (res.status !== 404) progress.failed++;
+          progress.done++;
+          opts.onProgress?.({ ...progress });
+          continue;
+        }
+        const kind = res.headers.get('x-png-kind') === 'preview' ? 'preview' : 'full';
+        const blob = await res.blob();
+        await putRecord({ id, kind, bytes: blob.size, storedAt: Date.now(), blob });
+        mem.set(id, { kind, url: URL.createObjectURL(blob), bytes: blob.size });
+        progress.bytes += blob.size;
+        progress.done++;
+        opts.onProgress?.({ ...progress });
+        // Keep any store-stats UI roughly live without a global re-render per
+        // image; the final emit below settles the exact numbers.
+        if (progress.done % 25 === 0) emit();
+      } catch (err) {
+        if (opts.signal?.aborted) return;
+        if (isQuotaError(err)) {
+          fatal = 'Browser storage quota exhausted — the warm stored what fit. ' +
+            'Clear the cache or free disk space and re-run to continue.';
+          return;
+        }
+        progress.failed++;
+        progress.done++;
+        opts.onProgress?.({ ...progress });
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: WARM_CONCURRENCY }, worker));
+  emit();
+  return { ...progress, aborted: !!opts.signal?.aborted, error: fatal };
+}
+
+/**
+ * Drop everything now (the explicit "clear cache" affordance; the TTL sweep
+ * is the automatic path). Revokes the object URLs, so an <img> currently
+ * painting one goes blank — the detail page falls back to a presigned URL on
+ * its next step.
+ */
+export async function clearPngStore(): Promise<void> {
+  await ensurePngStoreReady();
+  if (db) {
+    await new Promise<void>((resolve, reject) => {
+      const tx = db!.transaction(STORE, 'readwrite');
+      tx.objectStore(STORE).clear();
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error ?? new Error('PNG store clear failed'));
+    });
+  }
+  for (const e of mem.values()) URL.revokeObjectURL(e.url);
+  mem.clear();
+  emit();
+}
+
+/** Origin storage headroom, for the pre-warm size hint. Null when unsupported. */
+export async function estimateStorage(): Promise<{ usage: number; quota: number } | null> {
+  if (typeof navigator === 'undefined' || !navigator.storage?.estimate) return null;
+  try {
+    const { usage = 0, quota = 0 } = await navigator.storage.estimate();
+    return { usage, quota };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a durable, IndexedDB-backed PNG pre-download system for the NIRCam admin triage workflow. Operators can now pre-cache all exposure PNGs matching the current filter set before stepping through the queue, eliminating network waits during inspection and providing resilience against presigned URL expiry.

## Key Changes

- **`lib/nircam-png-store.ts`** (new): Core IndexedDB store for caching exposure PNGs
  - Stores one Blob per exposure (full-res mask or preview thumbnail) with automatic TTL-based expiry (24h default)
  - Provides resumable, cancellable warm operation with progress tracking and quota-aware error handling
  - Mints object URLs once at hydration and revokes them on record deletion to minimize memory overhead
  - Exports `warmPngStore()`, `getStoredPng()`, `clearPngStore()`, and subscription hooks for React integration

- **`components/nircam/PngPrecacheControl.tsx`** (new): UI control for the list page
  - Sits between filter bar and table; shows cache stats and storage headroom
  - Initiates warm of filtered exposure set in list order (so operator can start inspecting while warm continues)
  - Displays real-time progress with bytes downloaded and failure count
  - Includes explicit "Clear cache" button; automatic expiry is otherwise silent

- **`app/api/nircam-png/route.ts`** (new): Same-origin proxy for readable PNG bytes
  - Admin-only endpoint that serves the display PNG (full-res mask or preview) for a given exposure id
  - Resolves storage backend (OSN or R2) server-side from the registry; never trusts client input
  - Returns `X-Png-Kind` header so the store knows which slot to fill
  - Streams response with `no-store` cache directive (caller persists bytes itself)

- **`lib/actions/nircam-exposures.ts`**: Added `getNircamExposureIds()` action
  - Fetches exposure ids in a filtered set, respecting current sort order
  - Paged internally (1000 rows per request) with 20k hard cap as runaway guard
  - Used by the warm to fetch the list of ids to download in inspection order

- **`app/admin/nircam/[id]/page.tsx`**: Integrated stored PNG preference into detail view
  - Hydrates the PNG store on mount (idempotent, module-scoped)
  - Prefers stored blob URLs over presigned URLs when available
  - Includes stored blobs in the eager prefetch window for siblings
  - Falls back to presigned URLs if no blob is cached

- **`app/admin/nircam/page.tsx`**: Added `PngPrecacheControl` to list page
  - Positioned between filter bar and table
  - Scoped to current filter/detector selection

## Implementation Details

- **Storage choice**: IndexedDB over localStorage because localStorage caps at ~5 MB and stores strings; IndexedDB is disk-backed and shares the origin's storage quota (GBs on desktop). A thousand full-res exposures is roughly 6 GB.
- **Lifecycle**: Every record carries `storedAt` timestamp. `ensurePngStoreReady()` sweeps records older than `PNG_STORE_TTL_MS` on hydration, so a finished inspection's cache clears itself automatically without operator action.
- **Concurrency**: Warm uses 4-way parallelism to keep the pipe full without hammering the proxy (each request streams ~6 MB through a serverless function).
- **Resumability**: Already-stored ids are skipped on re-run, so cancelling and resuming only fetches what's missing. 404s (exposure has no PNG deployed) are silent skips, not failures.
- **Fallback**: If IndexedDB is unavailable (private browsing, disabled storage), the store gracefully degrades to empty and pages fall back to the presigned-URL path.

https://claude.ai/code/session_018vfxTJrJq9PNY8mkpdYeiE