### PR TITLE
Add related exposures panel and zoom-to-fit for mask editor

### DIFF
--- a/web/app/admin/nircam/[id]/page.tsx
+++ b/web/app/admin/nircam/[id]/page.tsx
@@ -7,13 +7,17 @@ import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import {
   Loader2, ArrowLeft, Save, Check, ChevronLeft, ChevronRight, Keyboard,
+  ExternalLink,
 } from 'lucide-react';
 import {
   getNircamExposureById,
   getExposureNeighbors,
+  getRelatedExposures,
   saveExposureMaskRegions,
   presignExposurePngs,
   type ExposureNeighbors,
+  type RelatedExposure,
+  type RelatedExposuresResult,
 } from '@/lib/actions/nircam-exposures';
 import type { NircamExposure, MaskRegionsPayload } from '@/lib/types';
 import { stageBadgeClasses } from '@/lib/nircam-stages';
@@ -1024,6 +1028,7 @@ function ExposureDetailPageInner() {
             <div className="flex justify-between"><dt>Mark approved</dt><dd className="font-mono text-text-secondary">2</dd></div>
             <div className="flex justify-between"><dt>Mark excluded</dt><dd className="font-mono text-text-secondary">3</dd></div>
             <div className="flex justify-between"><dt>Save</dt><dd className="font-mono text-text-secondary">S</dd></div>
+            <div className="flex justify-between"><dt>Zoom to fit</dt><dd className="font-mono text-text-secondary">F</dd></div>
             <div className="flex justify-between"><dt>Help</dt><dd className="font-mono text-text-secondary">?</dd></div>
             <div className="flex justify-between"><dt>Copy masks</dt><dd className="font-mono text-text-secondary">Ctrl/⌘ C</dd></div>
             <div className="flex justify-between"><dt>Paste masks</dt><dd className="font-mono text-text-secondary">Ctrl/⌘ V</dd></div>
@@ -1318,8 +1323,141 @@ function ExposureDetailPageInner() {
               </Button>
             </div>
           </Card>
+
+          {/* Related exposures — quick jumps to siblings likely to share the
+              same artifact (mask/exclude them without hunting the table). */}
+          <RelatedExposuresPanel id={id} visit={exposure?.visit} />
         </div>
       </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Related exposures panel
+// ---------------------------------------------------------------------------
+
+const REVIEW_DOT: Record<string, string> = {
+  pending: 'bg-yellow-400',
+  approved: 'bg-green-500',
+  excluded: 'bg-red-500',
+};
+
+// Collapsed-by-default quick links to the exposures a decision here may
+// implicate: the same-module other-channel exposures read out simultaneously,
+// and the rest of the visit. Fetched lazily on first expand — server actions
+// from one client run through a serialized queue, so an eager fetch per step
+// would contend with the row/presign prefetch the triage hot loop depends on.
+// Expansion persists across prev/next; the list refetches per id while open.
+function RelatedExposuresPanel({ id, visit }: { id: number; visit: string | null | undefined }) {
+  const [open, setOpen] = useState(false);
+  // Tagged with the id it was fetched for (same pattern as navState): `id`
+  // changes instantly on a step, the fetch lands a round trip later.
+  const [state, setState] = useState<{ forId: number; data: RelatedExposuresResult } | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    getRelatedExposures(id).then(
+      (data) => { if (!cancelled) setState({ forId: id, data }); },
+      () => { if (!cancelled) setState({ forId: id, data: { simultaneous: [], sameVisit: [], error: 'Failed to load related exposures' } }); },
+    );
+    return () => { cancelled = true; };
+  }, [open, id]);
+
+  const ready = state?.forId === id ? state.data : null;
+
+  return (
+    <Card className="overflow-hidden">
+      <button
+        onClick={(e) => { blurOnMouseClick(e); setOpen((o) => !o); }}
+        aria-expanded={open}
+        className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-card-hover"
+      >
+        <span className="text-sm font-medium text-text-secondary uppercase tracking-wider">
+          Related exposures
+        </span>
+        <ChevronRight
+          className={`w-4 h-4 text-text-secondary transition-transform ${open ? 'rotate-90' : ''}`}
+        />
+      </button>
+      {open && (
+        <div className="px-4 pb-4 space-y-3">
+          {!ready ? (
+            <div className="flex justify-center py-4">
+              <Loader2 className="w-5 h-5 animate-spin text-text-secondary" />
+            </div>
+          ) : ready.error ? (
+            <p className="text-xs text-red-600 dark:text-red-400">{ready.error}</p>
+          ) : ready.simultaneous.length === 0 && ready.sameVisit.length === 0 ? (
+            <p className="text-xs text-text-secondary">
+              {visit ? 'No other exposures in this visit.' : 'No visit recorded for this exposure.'}
+            </p>
+          ) : (
+            <>
+              <RelatedList
+                title="SW/LW simultaneous"
+                hint="The same module's other-channel exposures, read out at the same moment over the same sky — artifacts here usually show in these too."
+                rows={ready.simultaneous}
+                visit={visit}
+              />
+              <RelatedList
+                title="Others in this visit"
+                rows={ready.sameVisit}
+                visit={visit}
+              />
+            </>
+          )}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function RelatedList({ title, hint, rows, visit }: {
+  title: string;
+  hint?: string;
+  rows: RelatedExposure[];
+  visit: string | null | undefined;
+}) {
+  // The shared visit prefix (and extension) carry no signal in a list that is
+  // entirely one visit — show the distinguishing tail: activity_exposure_detector.
+  const shortName = (filename: string) => {
+    const base = filename.replace(/\.fits$/, '');
+    return visit && base.startsWith(`${visit}_`) ? base.slice(visit.length + 1) : base;
+  };
+  return (
+    <div>
+      <h3 className="text-xs font-medium text-text-secondary uppercase tracking-wider mb-1" title={hint}>
+        {title}{rows.length > 0 && <span className="tabular-nums"> ({rows.length})</span>}
+      </h3>
+      {rows.length === 0 ? (
+        <p className="text-xs text-text-secondary">None</p>
+      ) : (
+        <ul className="max-h-56 overflow-y-auto">
+          {rows.map((r) => (
+            <li key={r.id}>
+              <a
+                href={`/admin/nircam/${r.id}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                title={`${r.filename} — ${r.review_status}${r.masked ? ', masked' : ''} (opens in a new tab)`}
+                className="flex items-center gap-2 -mx-1.5 px-1.5 py-1 text-xs rounded hover:bg-card-hover"
+              >
+                <span className={`w-2 h-2 rounded-full flex-shrink-0 ${REVIEW_DOT[r.review_status] ?? 'bg-surface-2'}`} />
+                <span className="font-mono text-text-primary truncate">{shortName(r.filename)}</span>
+                <span className="ml-auto flex items-center gap-1.5 flex-shrink-0 text-text-secondary">
+                  {r.masked && (
+                    <span className="text-blue-600 dark:text-blue-400">masked</span>
+                  )}
+                  <span>{r.filter}</span>
+                  <ExternalLink className="w-3 h-3" />
+                </span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/web/app/admin/nircam/page.tsx
+++ b/web/app/admin/nircam/page.tsx
@@ -83,7 +83,10 @@ function StageBadge({ stage }: { stage: string }) {
 // detector. Fields collapse (default closed) so the exposure table stays one
 // scroll away regardless of how many field/filter combinations exist. Each
 // filter row shows inspection progress (approved+excluded of total), the mask
-// count, and per-detector quick-filter links into the pending queue below.
+// count, and per-detector quick links into the exposure table below. The
+// detector chips still COUNT pending (that's the work signal) but select the
+// whole field/filter/detector set, not just pending — the already-decided
+// neighbors are useful context while triaging.
 // (The old per-stage distribution bar is gone: whole filters sit at the same
 // pipeline stage in practice, so it carried no signal. The excluded-exposures
 // copy-paste panel is gone too — `campfire pull` materializes exclusions into
@@ -143,8 +146,14 @@ function groupProgress(rows: ReductionProgress[]): FieldProgress[] {
   return out;
 }
 
-function pendingHref(field: string, filter?: string, detector?: string) {
-  const p = new URLSearchParams({ field, review: 'pending' });
+// Field-level "pending" chip: that one IS labeled pending, so it filters to it.
+function pendingHref(field: string) {
+  return `/admin/nircam?${new URLSearchParams({ field, review: 'pending' })}`;
+}
+
+// Filter/detector quick-select: scopes the table without a review filter.
+function scopeHref(field: string, filter?: string, detector?: string) {
+  const p = new URLSearchParams({ field });
   if (filter) p.set('filter', filter);
   if (detector) p.set('detector', detector);
   return `/admin/nircam?${p.toString()}`;
@@ -174,8 +183,8 @@ function InspectionMeter({ counts }: { counts: TriageCounts }) {
   );
 }
 
-// Quick-filter chip: jumps to the exposure table pre-filtered to this
-// field/filter/detector's pending queue.
+// Quick-select chip: jumps to the exposure table scoped by the href, showing
+// the count as the work signal.
 function PendingChip({ label, count, href }: { label: string; count: number; href: string }) {
   return (
     <Link
@@ -268,7 +277,7 @@ function FieldSection({ fp }: { fp: FieldProgress }) {
                             key={d.detector}
                             label={d.detector}
                             count={d.pending}
-                            href={pendingHref(fp.field, flt.filter, d.detector)}
+                            href={scopeHref(fp.field, flt.filter, d.detector)}
                           />
                         ))}
                     </div>

--- a/web/components/nircam/MaskEditor.tsx
+++ b/web/components/nircam/MaskEditor.tsx
@@ -22,7 +22,7 @@
 import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
 import {
   MousePointer2, PencilLine, Hand, Trash2, Save, Loader2, Check,
-  Copy, ClipboardPaste,
+  Copy, ClipboardPaste, Maximize,
 } from 'lucide-react';
 import { Button } from '@/components/ui/Button';
 import type { MaskPolygon, MaskRegionsPayload } from '@/lib/types';
@@ -232,8 +232,9 @@ function MaskEditor({
   const [scale, setScale] = useState(1);
   const [translate, setTranslate] = useState<[number, number]>([0, 0]);
 
-  // Fit-to-container on first mount.
-  useEffect(() => {
+  // Scale + center the image to the container — the initial view, re-invocable
+  // from the toolbar's fit button / `F` after zooming or panning away.
+  const fitToView = useCallback(() => {
     if (!containerRef.current) return;
     const cw = containerRef.current.clientWidth;
     const ch = containerRef.current.clientHeight;
@@ -244,6 +245,9 @@ function MaskEditor({
       (ch - imageHeight * s) / 2,
     ]);
   }, [imageWidth, imageHeight]);
+
+  // Fit-to-container on first mount (and when the frame dimensions change).
+  useEffect(() => { fitToView(); }, [fitToView]);
 
   // Which exposure (and frame height) the editor state currently belongs to,
   // plus event-time mirrors of `polygons`/`dirty` — the swap flush below runs
@@ -540,11 +544,19 @@ function MaskEditor({
   // ----- keyboard: Enter/Escape (draw), Backspace (vertex undo) -----
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
+      const t = e.target as HTMLElement;
+      const isInput = t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.tagName === 'SELECT';
+      // F — zoom to fit (matches the toolbar button). Plain keypress only, so
+      // it never shadows browser chords like Ctrl/⌘F.
+      if ((e.key === 'f' || e.key === 'F')
+          && !e.metaKey && !e.ctrlKey && !e.altKey && !isInput) {
+        e.preventDefault();
+        fitToView();
+        return;
+      }
       // Ctrl/⌘ C/V — mask clipboard. Skip when typing in a form field, and
       // yield Ctrl/⌘C to a real text selection anywhere on the page.
       if (clipboardSource && (e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey) {
-        const t = e.target as HTMLElement;
-        const isInput = t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.tagName === 'SELECT';
         const k = e.key.toLowerCase();
         if (k === 'c' && !isInput && !window.getSelection()?.toString()) {
           if (polygons.length > 0) { e.preventDefault(); handleCopy(); }
@@ -574,7 +586,7 @@ function MaskEditor({
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [mode, selectedId, markDirty, finalizeDraft,
+  }, [mode, selectedId, markDirty, finalizeDraft, fitToView,
       clipboardSource, polygons.length, handleCopy, handlePaste]);
 
   const handleSave = useCallback(async () => {
@@ -666,6 +678,9 @@ function MaskEditor({
           )}
           <span>{polygons.length} polygon{polygons.length === 1 ? '' : 's'}</span>
           <span>{(scale * 100).toFixed(0)}%</span>
+          <ToolButton onClick={fitToView} label="Zoom to fit (F)">
+            <Maximize className="w-4 h-4" />
+          </ToolButton>
           {saveError && <span className="text-red-500">{saveError}</span>}
           <Button
             onClick={(e) => {
@@ -847,7 +862,7 @@ function MaskEditor({
 
         {/* Help footer */}
         <div className="absolute bottom-2 left-2 right-2 text-[11px] text-white/70 pointer-events-none font-mono">
-          {mode === 'inspect' && 'drag = pan • wheel = zoom • shift+drag = pan in any mode'}
+          {mode === 'inspect' && 'drag = pan • wheel = zoom • F = zoom to fit • shift+drag = pan in any mode'}
           {mode === 'draw'    && 'click = add vertex • click first vertex / Enter = close • Esc = cancel • Backspace = undo vertex'}
           {mode === 'edit'    && 'click polygon = select • drag polygon = move • drag vertex = reshape • Delete = remove polygon'}
         </div>

--- a/web/lib/actions/nircam-exposures.ts
+++ b/web/lib/actions/nircam-exposures.ts
@@ -235,8 +235,15 @@ function parseExposureName(filename: string): { act: string; exp: string } | nul
   return parts.length >= 4 ? { act: parts[1], exp: parts[2] } : null;
 }
 
-const detectorModule = (detector: string) => detector.slice(0, 4);      // 'nrca' | 'nrcb'
-const detectorChannel = (detector: string) => detector.endsWith('long') ? 'lw' : 'sw';
+// Mirrors the pipeline's module_of/channel_of (campfire_pipeline/nircam/
+// association.py): the deployed `detector` column holds the FITS DETECTOR
+// header value verbatim, which is uppercase (NRCALONG) — and nrca5/nrcb5 are
+// aliases for the LW detectors — so normalize before classifying.
+const detectorModule = (detector: string) => detector.toLowerCase().slice(0, 4); // 'nrca' | 'nrcb'
+function detectorChannel(detector: string): 'sw' | 'lw' {
+  const d = detector.toLowerCase();
+  return d.endsWith('long') || d.endsWith('5') ? 'lw' : 'sw';
+}
 
 /**
  * The other exposures a triage decision here might implicate: everything in

--- a/web/lib/actions/nircam-exposures.ts
+++ b/web/lib/actions/nircam-exposures.ts
@@ -202,6 +202,102 @@ export async function getNircamExposureById(id: number): Promise<{
   }
 }
 
+// ---------------------------------------------------------------------------
+// Related exposures (same visit / simultaneous SW+LW)
+// ---------------------------------------------------------------------------
+
+export interface RelatedExposure {
+  id: number;
+  filename: string;
+  filter: string;
+  detector: string;
+  review_status: NircamExposure['review_status'];
+  masked: boolean;
+}
+
+export interface RelatedExposuresResult {
+  /**
+   * Exposures read out at the same moment as this one through the other
+   * channel of the same module: NIRCam's dichroic feeds a module's SW
+   * (nrc[ab]1-4) and LW (nrc[ab]long) detectors from the same sky
+   * simultaneously, so an artifact here (satellite trail, scattered light,
+   * a bright transient) usually shows up in these too.
+   */
+  simultaneous: RelatedExposure[];
+  /** Everything else sharing this exposure's visit (self + simultaneous excluded). */
+  sameVisit: RelatedExposure[];
+  error?: string;
+}
+
+// JWST filename: {visit}_{visitgroup+seq+activity}_{exposure}_{detector}[.fits]
+function parseExposureName(filename: string): { act: string; exp: string } | null {
+  const parts = filename.replace(/\.fits$/, '').split('_');
+  return parts.length >= 4 ? { act: parts[1], exp: parts[2] } : null;
+}
+
+const detectorModule = (detector: string) => detector.slice(0, 4);      // 'nrca' | 'nrcb'
+const detectorChannel = (detector: string) => detector.endsWith('long') ? 'lw' : 'sw';
+
+/**
+ * The other exposures a triage decision here might implicate: everything in
+ * the same visit (split out: the simultaneously-read other-channel exposures
+ * of the same module). Feeds the detail page's "Related exposures" panel —
+ * quick jumps to siblings that likely share the same problem.
+ */
+export async function getRelatedExposures(id: number): Promise<RelatedExposuresResult> {
+  const empty: RelatedExposuresResult = { simultaneous: [], sameVisit: [] };
+  try {
+    const supabase = await requireSession();
+
+    const { data: cur, error } = await supabase
+      .from('nircam_exposures')
+      .select('id, field, visit, filename, detector')
+      .eq('id', id)
+      .single();
+    if (error) return { ...empty, error: error.message };
+    // No visit recorded (pre-backfill row or unparseable filename) — nothing
+    // to relate on.
+    if (!cur?.visit) return empty;
+
+    const { data, error: listErr } = await supabase
+      .from('nircam_exposures')
+      .select('id, filename, filter, detector, review_status, mask_regions')
+      .eq('field', cur.field)
+      .eq('visit', cur.visit)
+      .neq('id', id)
+      .order('filename');
+    if (listErr) return { ...empty, error: listErr.message };
+
+    const curName = parseExposureName(cur.filename);
+    const curModule = detectorModule(cur.detector);
+    const curChannel = detectorChannel(cur.detector);
+
+    const out = empty;
+    for (const r of data ?? []) {
+      const rel: RelatedExposure = {
+        id: r.id,
+        filename: r.filename,
+        filter: r.filter,
+        detector: r.detector,
+        review_status: r.review_status,
+        masked: ((r.mask_regions as MaskRegionsPayload | null)?.polygons?.length ?? 0) > 0,
+      };
+      const name = parseExposureName(r.filename);
+      const simultaneous = !!curName && !!name &&
+        name.act === curName.act && name.exp === curName.exp &&
+        detectorModule(r.detector) === curModule &&
+        detectorChannel(r.detector) !== curChannel;
+      (simultaneous ? out.simultaneous : out.sameVisit).push(rel);
+    }
+    return out;
+  } catch (err) {
+    return {
+      ...empty,
+      error: err instanceof Error ? err.message : 'Failed to fetch related exposures',
+    };
+  }
+}
+
 const PNG_PRESIGN_TTL_SECONDS = 3600;
 
 export interface PresignExposurePngsResult {


### PR DESCRIPTION
## Summary
Adds a collapsible "Related exposures" panel to the NIRCam exposure detail page for quick navigation to related observations, and implements a zoom-to-fit feature for the mask editor canvas.

## Key Changes

**Related Exposures Panel**
- New `RelatedExposuresPanel` component that displays exposures from the same visit, organized into two categories:
  - **SW/LW simultaneous**: Other-channel exposures from the same module read out at the same moment (likely to share artifacts)
  - **Others in this visit**: Remaining exposures from the same visit for context
- Lazy-loads data on first expansion to avoid contending with the hot triage loop's prefetch queue
- Shows review status (pending/approved/excluded) as colored dots, filter, and masked state
- Links open in new tabs for non-disruptive navigation
- Implements `getRelatedExposures()` server action that parses JWST filenames to identify simultaneous exposures by activity/exposure number and detector module/channel

**Mask Editor Zoom-to-Fit**
- Adds `F` keyboard shortcut to zoom and center the image to the container
- Adds toolbar button with `Maximize` icon for the same action
- Refactors fit-to-view logic into a reusable `fitToView` callback
- Updates help text to document the new shortcut
- Maintains fit-to-view on mount and when frame dimensions change

**UI/UX Improvements**
- Updates keyboard help overlay to include "Zoom to fit" shortcut
- Clarifies quick-select chip behavior in the field progress section: detector chips now show pending count as a work signal but select the whole field/filter/detector set (including already-decided neighbors) rather than filtering to pending only
- Renames internal `pendingHref` to `scopeHref` to reflect the actual behavior

## Implementation Details
- Related exposures are fetched via a new `RelatedExposuresResult` interface with error handling
- Detector module/channel parsing uses simple string slicing on the detector name (e.g., 'nrca' vs 'nrcb', 'long' suffix for LW)
- Expansion state persists across prev/next navigation; the list refetches per exposure ID while open
- Mask clipboard operations and related exposures panel use the same lazy-load pattern to avoid queue contention

https://claude.ai/code/session_01UCMK26x7BGGZpbLZdiSwZR