### PR TITLE
fix(deploy): serialise token refresh; lower OSN upload concurrency

### DIFF
--- a/python/campfire/auth/tokens.py
+++ b/python/campfire/auth/tokens.py
@@ -4,6 +4,7 @@ Token management for CAMPFIRE Python client.
 Handles token refresh and validation.
 """
 
+import threading
 import time
 from datetime import datetime, timedelta
 from typing import Optional, Tuple
@@ -13,6 +14,15 @@ import requests
 from ..exceptions import AuthenticationError
 from ._jwt import get_exp
 from .credentials import CredentialManager, StoredCredentials
+
+
+class _RefreshRejected(Exception):
+    """Internal: the server rejected the refresh token we presented.
+
+    Distinct from :class:`AuthenticationError` because it is often *not* fatal —
+    a concurrent refresh (another thread or process) rotates the token, and
+    retrying with the freshly-stored one succeeds. Never escapes this module.
+    """
 
 
 class TokenManager:
@@ -51,6 +61,17 @@ class TokenManager:
         self.creds_manager = credentials_manager or CredentialManager()
         self.session = requests.Session()
         self.session.headers.update({"User-Agent": "campfire-python/0.1.0"})
+
+        # Refresh is serialised: the server ROTATES the refresh token, so two
+        # threads refreshing at once means the loser POSTs a token the winner
+        # already invalidated and gets `invalid_grant` back. Deploy runs 16
+        # concurrent upload workers off one manager, so this is reached whenever
+        # a long transfer crosses the refresh threshold (issue #474).
+        # `_refresh_generation` lets a thread that waited on the lock notice
+        # that someone else already refreshed, and use that result instead of
+        # issuing a second (doomed) refresh.
+        self._refresh_lock = threading.RLock()
+        self._refresh_generation = 0
 
         # Cache the current credentials
         self._cached_creds: Optional[StoredCredentials] = None
@@ -101,9 +122,75 @@ class TokenManager:
         except (ValueError, TypeError):
             return True
 
+    def _cached_expires_in(self) -> int:
+        """Seconds until the cached access token expires (>= 0, 0 if unknown)."""
+        creds = self._cached_creds
+        if not creds or not creds.expires_at:
+            return 0
+        try:
+            expires = datetime.fromisoformat(
+                creds.expires_at.replace("Z", "+00:00")
+            )
+            delta = (expires - datetime.now(expires.tzinfo)).total_seconds()
+            return max(0, int(delta))
+        except (ValueError, TypeError):
+            return 0
+
+    def _post_refresh(self, refresh_token: str) -> Tuple[str, str, int]:
+        """One refresh round-trip. Caller must hold ``_refresh_lock``.
+
+        Raises ``_RefreshRejected`` when the server rejects the token itself, so
+        the caller can decide whether a reload-and-retry is worth attempting;
+        every other failure raises ``AuthenticationError`` directly.
+        """
+        try:
+            response = self.session.post(
+                self.refresh_endpoint,
+                json={
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh_token,
+                },
+            )
+
+            if response.status_code == 400:
+                data = response.json()
+                error = data.get("error", "unknown_error")
+                if error in ("invalid_grant", "expired_token"):
+                    raise _RefreshRejected(error)
+                raise AuthenticationError(f"Token refresh failed: {error}")
+
+            response.raise_for_status()
+            data = response.json()
+
+            access_token = data["access_token"]
+            new_refresh_token = data["refresh_token"]
+            expires_in = data["expires_in"]
+            supabase_token = data.get("supabase_token")
+            supabase_url = data.get("supabase_url")
+            supabase_anon_key = data.get("supabase_anon_key")
+
+            # Update stored credentials
+            self.creds_manager.update_oauth_tokens(
+                access_token, new_refresh_token, expires_in,
+                supabase_token, supabase_url, supabase_anon_key,
+            )
+
+            # Reload cached credentials
+            self._load_credentials()
+            self._refresh_generation += 1
+
+            return access_token, new_refresh_token, expires_in
+
+        except requests.RequestException as e:
+            raise AuthenticationError(f"Failed to refresh token: {e}")
+
     def refresh_tokens(self) -> Tuple[str, str, int]:
         """
         Refresh the OAuth tokens.
+
+        Thread-safe: concurrent callers are serialised, and a caller that waited
+        on the lock returns the winner's freshly-rotated token rather than
+        re-refreshing with the one the winner just invalidated (issue #474).
 
         Returns
         -------
@@ -118,50 +205,47 @@ class TokenManager:
         if not self.is_oauth():
             raise AuthenticationError("Cannot refresh: not using OAuth credentials")
 
-        if not self._cached_creds or not self._cached_creds.refresh_token:
-            raise AuthenticationError("Cannot refresh: no refresh token available")
+        # Sampled before acquiring: if it moves while we wait, another thread
+        # refreshed and our view of the refresh token is stale.
+        seen_generation = self._refresh_generation
 
-        try:
-            response = self.session.post(
-                self.refresh_endpoint,
-                json={
-                    "grant_type": "refresh_token",
-                    "refresh_token": self._cached_creds.refresh_token,
-                },
-            )
-
-            if response.status_code == 400:
-                data = response.json()
-                error = data.get("error", "unknown_error")
-                if error in ("invalid_grant", "expired_token"):
-                    raise AuthenticationError(
-                        "Session expired. Please run 'campfire login' again."
+        with self._refresh_lock:
+            if self._refresh_generation != seen_generation:
+                creds = self._cached_creds
+                if creds and creds.access_token and creds.refresh_token:
+                    return (
+                        creds.access_token,
+                        creds.refresh_token,
+                        self._cached_expires_in(),
                     )
-                raise AuthenticationError(f"Token refresh failed: {error}")
 
-            response.raise_for_status()
-            data = response.json()
+            if not self._cached_creds or not self._cached_creds.refresh_token:
+                raise AuthenticationError(
+                    "Cannot refresh: no refresh token available"
+                )
 
-            access_token = data["access_token"]
-            refresh_token = data["refresh_token"]
-            expires_in = data["expires_in"]
-            supabase_token = data.get("supabase_token")
-            supabase_url = data.get("supabase_url")
-            supabase_anon_key = data.get("supabase_anon_key")
-
-            # Update stored credentials
-            self.creds_manager.update_oauth_tokens(
-                access_token, refresh_token, expires_in,
-                supabase_token, supabase_url, supabase_anon_key,
-            )
-
-            # Reload cached credentials
-            self._load_credentials()
-
-            return access_token, refresh_token, expires_in
-
-        except requests.RequestException as e:
-            raise AuthenticationError(f"Failed to refresh token: {e}")
+            try:
+                return self._post_refresh(self._cached_creds.refresh_token)
+            except _RefreshRejected:
+                # The token we sent was rejected. Another *process* may have
+                # rotated it on disk since we cached it, so reload and retry
+                # once with whatever is stored now. Only give up — and only
+                # then tell the user to log in again — if the stored token is
+                # unchanged (nothing to retry with) or is itself rejected.
+                stale = self._cached_creds.refresh_token
+                self._load_credentials()
+                current = (
+                    self._cached_creds.refresh_token
+                    if self._cached_creds else None
+                )
+                if current and current != stale:
+                    try:
+                        return self._post_refresh(current)
+                    except _RefreshRejected:
+                        pass
+                raise AuthenticationError(
+                    "Session expired. Please run 'campfire login' again."
+                )
 
     def get_valid_token(self, auto_refresh: bool = True) -> str:
         """

--- a/python/campfire/deploy/nircam.py
+++ b/python/campfire/deploy/nircam.py
@@ -681,7 +681,7 @@ def deploy_nircam(field, config, filters=None, dry_run=False, draft=False,
     # whole-file digest for download/copy verification. Registration is durable
     # per batch (registration_flusher), so an interrupted deploy resumes at file
     # granularity instead of re-uploading everything already landed.
-    upload_workers = _upload_workers()
+    upload_workers = _upload_workers(_CANONICAL_BACKEND)
     n_failed = 0
     osn_uploaded: set[str] = set()
     flusher = registration_flusher(
@@ -1116,11 +1116,11 @@ def _deploy_field_mosaics(dirs, field, config, client, filters, deployment_id,
     flusher = registration_flusher(
         client, store, plan, backend=_CANONICAL_BACKEND,
         deployment_id=deployment_id, uploaded_by=user_id,
-        max_workers=_upload_workers(), stored_sizes=stored_sizes)
+        max_workers=_upload_workers(_CANONICAL_BACKEND), stored_sizes=stored_sizes)
     if plan.to_upload:
         print(f"  Uploading {len(plan.to_upload)} mosaic file(s) to OSN...")
         success, failed, failures = upload_files_parallel(
-            config, plan.to_upload, desc='OSN mosaic uploads', max_workers=_upload_workers(),
+            config, plan.to_upload, desc='OSN mosaic uploads', max_workers=_upload_workers(_CANONICAL_BACKEND),
             succeeded_out=uploaded, backend=_CANONICAL_BACKEND,
             on_success=flusher.add, stored_sizes_out=stored_sizes)
         flusher.flush()

--- a/python/campfire/deploy/push.py
+++ b/python/campfire/deploy/push.py
@@ -68,13 +68,34 @@ _PLAN_COLUMNS = (
 REGISTRATION_BATCH = 200
 
 
-def default_upload_workers() -> int:
-    """Parallel upload streams for data pushes.
+# Parallel upload streams, per storage backend.
+#
+# OSN (uaz1.osn.mghpcc.org) rejects a large fraction of concurrent PutObject
+# requests with 500 Internal Server Error once the stream count is high. It is
+# a load response, not a per-file problem: on a 621-file pg004 deploy, 16
+# streams failed 68% of uploads and 81% on the retry, while the SAME files to
+# the SAME endpoint at 4 streams failed 0/344. A single sequential PUT of a
+# just-failed object returned 200. Size is not the discriminator — the failed
+# set's median (3.6 MB) matched the overall median (3.69 MB).
+#
+# R2 has shown no such behaviour, and the original rationale for a high count
+# still holds there: many ~20-40 MB files over a high-latency link, where extra
+# streams help fill the uplink. So the default is per-backend rather than a
+# blanket reduction.
+_UPLOAD_WORKERS_BY_BACKEND = {
+    'osn': 4,
+    'r2': 16,
+}
+_UPLOAD_WORKERS_FALLBACK = 16
 
-    Overridable via ``CAMPFIRE_DEPLOY_UPLOAD_WORKERS``. Defaults to 16: data
-    products are many ~20-40 MB files whose upload is network-bound over a
-    high-latency link, so extra concurrent streams help fill the uplink.
-    Clamped to a sane range.
+
+def default_upload_workers(backend: Optional[str] = None) -> int:
+    """Parallel upload streams for data pushes to *backend*.
+
+    ``backend`` is ``'osn'`` | ``'r2'``; ``None`` keeps the historical default.
+    Overridable for every backend via ``CAMPFIRE_DEPLOY_UPLOAD_WORKERS``, which
+    still wins when set (clamped to 1..64) — raise it deliberately if you are
+    pushing to a store that tolerates more concurrency.
     """
     raw = os.environ.get('CAMPFIRE_DEPLOY_UPLOAD_WORKERS')
     if raw:
@@ -82,7 +103,7 @@ def default_upload_workers() -> int:
             return max(1, min(64, int(raw)))
         except ValueError:
             pass
-    return 16
+    return _UPLOAD_WORKERS_BY_BACKEND.get(backend, _UPLOAD_WORKERS_FALLBACK)
 
 
 def open_reducer_store():
@@ -375,7 +396,7 @@ def push_observation(
         uploaded_by=user_id, cfpipe_version=cfpipe_version,
         stored_sizes=stored_sizes)
 
-    upload_workers = workers or default_upload_workers()
+    upload_workers = workers or default_upload_workers('osn')
     total_bytes = sum(plan.stats[t.r2_key][1] for t in plan.to_upload
                       if t.r2_key in plan.stats)
     print(f"  Pushing {len(plan.to_upload)} file(s) "
@@ -494,7 +515,7 @@ def push_field(
         uploaded_by=user_id, cfpipe_version=cfpipe_version,
         stored_sizes=stored_sizes)
 
-    upload_workers = workers or default_upload_workers()
+    upload_workers = workers or default_upload_workers('osn')
     total_bytes = sum(plan.stats[t.r2_key][1] for t in plan.to_upload
                       if t.r2_key in plan.stats)
     print(f"  Pushing {len(plan.to_upload)} file(s) "

--- a/python/tests/test_auth_token_race.py
+++ b/python/tests/test_auth_token_race.py
@@ -1,0 +1,196 @@
+"""Concurrent refresh against a rotating refresh token (issue #474).
+
+The server rotates the refresh token on every successful refresh, so a thread
+that presents a superseded token gets 400 ``invalid_grant`` back. Deploy runs
+16 concurrent upload workers off one TokenManager, so before the fix any long
+transfer that crossed the refresh threshold had most of its workers die with a
+spurious "Session expired. Please run 'campfire login' again."
+
+The fake server sleeps *before* validating. That detail is what gives these
+tests teeth: without it the refresh completes so fast that no two threads ever
+hold the same cached token, and the suite passes against the broken code.
+"""
+
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from campfire.auth.tokens import TokenManager
+from campfire.exceptions import AuthenticationError
+
+SERVER_LATENCY_S = 0.05
+N_WORKERS = 16
+
+
+class FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:  # pragma: no cover - guard only
+            raise AssertionError("raise_for_status called on an error response")
+
+
+class RotatingServer:
+    """Accepts only the current refresh token; rotates it on every success."""
+
+    def __init__(self, latency=SERVER_LATENCY_S):
+        self.current = "refresh-0"
+        self.n = 0
+        self.rejections = 0
+        self.latency = latency
+        self._lock = threading.Lock()
+
+    def post(self, url, json=None, **kwargs):
+        presented = json["refresh_token"]
+        # Latency BEFORE validation: this is what lets several threads read the
+        # same cached token and get their requests in flight concurrently.
+        time.sleep(self.latency)
+        with self._lock:
+            if presented != self.current:
+                self.rejections += 1
+                return FakeResponse(400, {"error": "invalid_grant"})
+            self.n += 1
+            self.current = f"refresh-{self.n}"
+            return FakeResponse(
+                200,
+                {
+                    "access_token": f"access-{self.n}",
+                    "refresh_token": self.current,
+                    "expires_in": 3600,
+                    "supabase_token": f"sb-{self.n}",
+                    "supabase_url": "https://example.supabase.co",
+                    "supabase_anon_key": "anon",
+                },
+            )
+
+
+class _Creds:
+    def __init__(self, access, refresh, supabase, expires_at):
+        self.access_token = access
+        self.refresh_token = refresh
+        self.supabase_token = supabase
+        self.expires_at = expires_at
+        self.api_key = None
+        self.user_email = "test@example.com"
+
+    def is_oauth(self):
+        return True
+
+    def is_api_key(self):
+        return False
+
+
+class FakeCredManager:
+    """Stands in for on-disk credential storage."""
+
+    def __init__(self):
+        self.access_token = "access-0"
+        self.refresh_token = "refresh-0"
+        self.supabase_token = "sb-0"
+        self.expires_at = _in(3600)
+        self._lock = threading.Lock()
+
+    def load(self):
+        with self._lock:
+            return _Creds(self.access_token, self.refresh_token,
+                          self.supabase_token, self.expires_at)
+
+    def update_oauth_tokens(self, access, refresh, expires_in,
+                            supabase_token=None, supabase_url=None,
+                            supabase_anon_key=None):
+        with self._lock:
+            self.access_token = access
+            self.refresh_token = refresh
+            self.expires_at = _in(expires_in)
+            if supabase_token:
+                self.supabase_token = supabase_token
+
+
+def _in(seconds):
+    return (datetime.now(timezone.utc) + timedelta(seconds=seconds)).isoformat()
+
+
+@pytest.fixture()
+def manager():
+    server = RotatingServer()
+    creds = FakeCredManager()
+    tm = TokenManager("https://example.com/api/v1", credentials_manager=creds)
+    tm.session = server
+    return tm, server, creds
+
+
+def test_concurrent_refresh_does_not_raise_session_expired(manager):
+    """16 threads refreshing at once must all succeed (issue #474)."""
+    tm, server, _ = manager
+    errors, results = [], []
+    barrier = threading.Barrier(N_WORKERS)
+
+    def worker():
+        barrier.wait()
+        try:
+            results.append(tm.refresh_tokens())
+        except AuthenticationError as exc:  # pragma: no cover - failure path
+            errors.append(str(exc))
+
+    threads = [threading.Thread(target=worker) for _ in range(N_WORKERS)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == [], f"{len(errors)} thread(s) failed: {errors[0]}"
+    assert len(results) == N_WORKERS
+    # Only the winner should have gone to the network; the rest reuse its token.
+    assert server.n == 1, f"expected 1 refresh round-trip, got {server.n}"
+    assert server.rejections == 0
+
+
+def test_concurrent_refresh_returns_the_current_token(manager):
+    """Every caller ends up holding the token that is actually current."""
+    tm, _, creds = manager
+    results = []
+    barrier = threading.Barrier(N_WORKERS)
+
+    def worker():
+        barrier.wait()
+        results.append(tm.refresh_tokens())
+
+    threads = [threading.Thread(target=worker) for _ in range(N_WORKERS)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert all(access == creds.access_token for access, _, _ in results)
+    assert all(refresh == creds.refresh_token for _, refresh, _ in results)
+
+
+def test_refresh_recovers_when_another_process_rotated_the_token(manager):
+    """A stale in-memory token is retried once against what is on disk."""
+    tm, server, creds = manager
+    # Another process refreshed: disk and server moved on, our cache did not.
+    server.current = "refresh-1"
+    creds.refresh_token = "refresh-1"
+    tm._cached_creds.refresh_token = "refresh-0"
+
+    access, refresh, _ = tm.refresh_tokens()
+
+    assert access == "access-1"
+    assert refresh == "refresh-1"
+    assert server.rejections == 1, "expected exactly one rejected attempt"
+
+
+def test_refresh_still_reports_a_genuinely_dead_session(manager):
+    """A refresh token that is dead everywhere must still surface as expired."""
+    tm, server, creds = manager
+    server.current = "refresh-nobody-has"
+
+    with pytest.raises(AuthenticationError, match="Session expired"):
+        tm.refresh_tokens()

--- a/python/tests/test_deploy_upload_workers.py
+++ b/python/tests/test_deploy_upload_workers.py
@@ -1,0 +1,48 @@
+"""Per-backend upload concurrency defaults.
+
+OSN rejects a large fraction of concurrent PutObject requests with 500 once the
+stream count is high. Measured on a 621-file pg004 deploy: 16 streams failed
+68% of uploads (81% on the retry), the same files at 4 streams failed 0/344,
+and a single sequential PUT of a just-failed object returned 200.
+"""
+
+import pytest
+
+from campfire.deploy.push import default_upload_workers
+
+ENV_VAR = "CAMPFIRE_DEPLOY_UPLOAD_WORKERS"
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    monkeypatch.delenv(ENV_VAR, raising=False)
+
+
+def test_osn_default_is_low():
+    assert default_upload_workers("osn") == 4
+
+
+def test_r2_default_is_unchanged():
+    assert default_upload_workers("r2") == 16
+
+
+def test_unknown_backend_falls_back():
+    assert default_upload_workers() == 16
+    assert default_upload_workers("something-else") == 16
+
+
+@pytest.mark.parametrize("backend", ["osn", "r2", None])
+def test_env_override_wins_for_every_backend(monkeypatch, backend):
+    monkeypatch.setenv(ENV_VAR, "9")
+    assert default_upload_workers(backend) == 9
+
+
+@pytest.mark.parametrize("raw,expected", [("0", 1), ("-5", 1), ("999", 64)])
+def test_env_override_is_clamped(monkeypatch, raw, expected):
+    monkeypatch.setenv(ENV_VAR, raw)
+    assert default_upload_workers("osn") == expected
+
+
+def test_garbage_env_falls_back_to_the_backend_default(monkeypatch):
+    monkeypatch.setenv(ENV_VAR, "not-a-number")
+    assert default_upload_workers("osn") == 4


### PR DESCRIPTION
Fixes #474.

Two independent failures that together made long NIRCam deploys unreliable. Both were found deploying `pg004` (621 files, ~23 GB, ~20 Mbps uplink) and both are reproduced by tests here.

## 1. Refresh-token race (#474)

The refresh endpoint **rotates** the refresh token, and `TokenManager` had no locking whatsoever. Deploy runs 16 concurrent upload workers off one manager, so when the access token crossed its refresh threshold mid-transfer, several threads called `refresh_tokens()` at once — one won and rotated the token, the rest POSTed the value it had just invalidated, got `400 invalid_grant`, and hit:

```python
raise AuthenticationError("Session expired. Please run 'campfire login' again.")
```

The session was **not** expired: `campfire whoami` succeeded immediately afterwards, because the winning thread's rotation had been persisted correctly. So the message sent people to a `campfire login` that fixed nothing, and the failure landed ~48 minutes into a transfer.

**Fix.** Refresh is serialised behind an `RLock` with a generation counter: a thread that waited on the lock returns the winner's freshly-stored token rather than re-refreshing with a stale one. `invalid_grant` is no longer terminal on first sight — credentials are reloaded from disk and retried once, which covers rotation by another *process*; `AuthenticationError` surfaces only if the stored token is unchanged (nothing new to try) or is itself rejected.

| 16 concurrent refreshes | before | after |
|---|---|---|
| successful | 1 / 16 | **16 / 16** |
| `AuthenticationError` | 15 | **0** |
| network round-trips | 16 | **1** |

## 2. OSN upload concurrency

OSN (`uaz1.osn.mghpcc.org`) rejects a large fraction of concurrent `PutObject` requests with `500 Internal Server Error`:

| upload workers | uploaded | failed | failure rate |
|---|---|---|---|
| 16 (default) | 198 / 621 | 423 | **68%** |
| 16 (retry) | 79 / 423 | 344 | **81%** |
| **4** | **344 / 344** | **0** | **0%** |

Same endpoint, same credentials, same files, minutes apart. It is a load response rather than a per-file problem — two hypotheses were tested and rejected first:

- *Large files timing out on slow streams*: the failed set's median is **3.6 MB** against **3.69 MB** overall, and only 13% exceed 50 MB. Size is not the discriminator.
- *OSN broadly unhealthy*: a single sequential PUT of `expmap_pg004_f356w.png`, one of the files that had just failed, returned **HTTP 200**.

**Fix.** `default_upload_workers()` now takes a backend: OSN defaults to 4, R2 stays at 16 — the original "many ~20-40 MB files over a high-latency link, extra streams help fill the uplink" rationale still holds there and no such behaviour has been observed. `CAMPFIRE_DEPLOY_UPLOAD_WORKERS` still overrides for every backend, clamped to 1..64. All three `nircam.py` call sites and both `push.py` sites upload to OSN (`_CANONICAL_BACKEND = 'osn'`), so they pass the backend through explicitly rather than relying on a changed global.

## Tests

`python/tests/test_auth_token_race.py` (4) and `python/tests/test_deploy_upload_workers.py` (10).

The race tests **fail 2/4 against the unfixed manager**, which is the point. An earlier version of the harness *passed* against broken code: the fake server answered instantly, so no two threads ever held the same cached token and the race never opened. It now sleeps before validating, which is what makes the reproduction faithful — worth preserving if anyone touches these.

`test_refresh_still_reports_a_genuinely_dead_session` guards the other direction, so a truly dead refresh token still surfaces as expired rather than being masked by the retry.

Full `python/` suite: 619 passed, 7 skipped, 1 pre-existing unrelated failure (`test_fitsgl_build.py::test_generated_viewer_block_parses_through_fitsgl`, `'ViewerSpec' object has no attribute 'weights'` — fails on `main` without these changes).

## Not fixed here

Issue #474 also notes that the deployment row is recorded *before* uploads run, so a mid-flight failure leaves a **published, publicly-visible deployment pointing at an incomplete object set**. The pg004 session produced four of them (#429, #435, #436, #437) before #438 finally completed. That is a separate change and is left open on the issue.

Generated with Claude Code

https://claude.ai/code/session_01YDPLMQty97WbBZGfgX55PX
