### PR TITLE
fix(deploy): size presign batches to the TTL, re-mint on expiry; revert OSN=4

### DIFF
--- a/python/campfire/deploy/push.py
+++ b/python/campfire/deploy/push.py
@@ -68,34 +68,21 @@ _PLAN_COLUMNS = (
 REGISTRATION_BATCH = 200
 
 
-# Parallel upload streams, per storage backend.
-#
-# OSN (uaz1.osn.mghpcc.org) rejects a large fraction of concurrent PutObject
-# requests with 500 Internal Server Error once the stream count is high. It is
-# a load response, not a per-file problem: on a 621-file pg004 deploy, 16
-# streams failed 68% of uploads and 81% on the retry, while the SAME files to
-# the SAME endpoint at 4 streams failed 0/344. A single sequential PUT of a
-# just-failed object returned 200. Size is not the discriminator — the failed
-# set's median (3.6 MB) matched the overall median (3.69 MB).
-#
-# R2 has shown no such behaviour, and the original rationale for a high count
-# still holds there: many ~20-40 MB files over a high-latency link, where extra
-# streams help fill the uplink. So the default is per-backend rather than a
-# blanket reduction.
-_UPLOAD_WORKERS_BY_BACKEND = {
-    'osn': 4,
-    'r2': 16,
-}
-_UPLOAD_WORKERS_FALLBACK = 16
-
-
 def default_upload_workers(backend: Optional[str] = None) -> int:
-    """Parallel upload streams for data pushes to *backend*.
+    """Parallel upload streams for data pushes.
 
-    ``backend`` is ``'osn'`` | ``'r2'``; ``None`` keeps the historical default.
-    Overridable for every backend via ``CAMPFIRE_DEPLOY_UPLOAD_WORKERS``, which
-    still wins when set (clamped to 1..64) — raise it deliberately if you are
-    pushing to a store that tolerates more concurrency.
+    Overridable via ``CAMPFIRE_DEPLOY_UPLOAD_WORKERS``. Defaults to 16: data
+    products are many ~20-40 MB files whose upload is network-bound over a
+    high-latency link, so extra concurrent streams help fill the uplink.
+    Clamped to a sane range.
+
+    ``backend`` is accepted (and ignored) so callers can pass the store they
+    are writing to. An earlier revision defaulted OSN to 4 on the theory that
+    concurrency was provoking 500s; that was a misdiagnosis. The 500s were
+    presigned URLs ageing out mid-batch on a slow uplink (see
+    ``PRESIGN_BATCH_SIZE`` in ``deploy/r2.py``), which is throughput-dependent
+    and entirely indifferent to stream count -- a 16-way probe against the same
+    endpoint went 16/16 while a 4-way production run failed 79%.
     """
     raw = os.environ.get('CAMPFIRE_DEPLOY_UPLOAD_WORKERS')
     if raw:
@@ -103,7 +90,7 @@ def default_upload_workers(backend: Optional[str] = None) -> int:
             return max(1, min(64, int(raw)))
         except ValueError:
             pass
-    return _UPLOAD_WORKERS_BY_BACKEND.get(backend, _UPLOAD_WORKERS_FALLBACK)
+    return 16
 
 
 def open_reducer_store():

--- a/python/campfire/deploy/r2.py
+++ b/python/campfire/deploy/r2.py
@@ -96,7 +96,19 @@ class UploadTask(NamedTuple):
 # Presigned URL mode
 # ---------------------------------------------------------------------------
 
-PRESIGN_BATCH_SIZE = 500  # Max URLs per presign request (matches the web route)
+# Max URLs per presign request. The web route accepts up to 500, but the batch
+# is also the unit that has to finish inside the 1-hour presign TTL: every URL
+# in a batch is minted at the same instant, so a batch that takes longer than
+# an hour to transfer loses its whole tail at once. At 2.16 MB/s (a domestic
+# asymmetric uplink) 500 x ~42 MB needs ~2.7 h and 438/552 files died on
+# expiry; 25 files is ~23 min there, and on a research link the extra
+# round-trips are noise against the transfer. `_PRESIGN_RETRY_ROUNDS` is the
+# real safety net -- this just makes hitting it rare.
+PRESIGN_BATCH_SIZE = 25
+# Re-mint + retry rounds for a batch's stragglers. A URL that aged out is
+# indistinguishable from a transient 5xx at this layer, and re-PUT is
+# idempotent, so retrying with fresh URLs is safe either way.
+_PRESIGN_RETRY_ROUNDS = 2
 
 
 def _get_presign_headers(config: dict) -> Optional[dict]:
@@ -518,13 +530,44 @@ def upload_files_parallel(
             # divergence. Refuse if we asked for OSN but got R2-host URLs.
             if backend == 'osn':
                 _assert_presigned_backend_osn(urls)
-            s, f, msgs = upload_files_presigned(
-                urls, batch, max_workers=max_workers, desc=desc,
-                succeeded_out=succeeded_out, session=session, on_success=on_success,
-                stored_sizes_out=stored_sizes_out,
-            )
-            total_success += s
-            total_failed += f
+            # Re-mint and retry this batch's stragglers. On a slow uplink the
+            # dominant failure is the presigned URL ageing out mid-batch, which
+            # surfaces as a 5xx indistinguishable from a transient fault --
+            # fresh URLs fix the former and cost nothing for the latter (PUT is
+            # idempotent). Only unfinished tasks are retried, so `on_success`
+            # never fires twice for the same file.
+            pending, msgs = batch, []
+            for attempt in range(1 + _PRESIGN_RETRY_ROUNDS):
+                if attempt:
+                    urls = request_presigned_urls(
+                        config, pending, bucket=bucket_id,
+                        cache_control=cache_control, backend=backend,
+                    )
+                    if not urls:
+                        break
+                    if backend == 'osn':
+                        _assert_presigned_backend_osn(urls)
+                landed: set[str] = set()
+                s, _f, msgs = upload_files_presigned(
+                    urls, pending, max_workers=max_workers,
+                    desc=(desc if not attempt else f'{desc} (retry {attempt})'),
+                    succeeded_out=landed, session=session,
+                    on_success=on_success, stored_sizes_out=stored_sizes_out,
+                )
+                total_success += s
+                if succeeded_out is not None:
+                    succeeded_out |= landed
+                if not _f:
+                    # The uploader is the authority on what failed; `landed` is
+                    # only used to decide WHICH tasks to retry. Trusting it for
+                    # "are we done" would re-upload everything against an
+                    # implementation that reports success without populating it.
+                    pending = []
+                    break
+                pending = [t for t in pending if t.r2_key not in landed]
+                if not pending:
+                    break
+            total_failed += len(pending)
             all_failures.extend(msgs)
         return total_success, total_failed, all_failures
 

--- a/python/tests/test_deploy_presign_ttl.py
+++ b/python/tests/test_deploy_presign_ttl.py
@@ -1,0 +1,132 @@
+"""Presigned URLs age out mid-batch on a slow uplink.
+
+Every URL in a presign batch is minted at the same instant with a 1-hour TTL,
+so the batch is also the unit that must finish inside that hour. At 2.16 MB/s
+(a domestic asymmetric uplink -- 267 Mbps down, ~20 Mbps up) a 500-file batch
+of ~42 MB products needs ~2.7 h, and a pg004 deploy lost 438 of 552 files in
+one go, all sharing a single X-Amz-Date.
+
+Two guards: a batch small enough that expiry is rare, and a re-mint + retry
+round so expiry is survivable regardless of link speed or file size.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from campfire.deploy import r2
+from campfire.deploy.push import default_upload_workers
+from campfire.deploy.r2 import PRESIGN_BATCH_SIZE, UploadTask
+
+
+def test_batch_fits_inside_the_presign_ttl_on_a_slow_uplink():
+    """The regression that motivated this: 500 x 42 MB at 2.16 MB/s >> 1 h."""
+    slow_bytes_per_s = 2.16e6
+    typical_product_bytes = 42e6
+    ttl_s = 3600
+    seconds = PRESIGN_BATCH_SIZE * typical_product_bytes / slow_bytes_per_s
+    assert seconds < ttl_s / 2, (
+        f"a {PRESIGN_BATCH_SIZE}-file batch needs {seconds/60:.0f} min on a "
+        f"2.16 MB/s uplink; that leaves no margin against the 1 h presign TTL"
+    )
+    # And the old value would not have.
+    assert 500 * typical_product_bytes / slow_bytes_per_s > ttl_s
+
+
+def test_worker_default_is_not_lowered_for_osn():
+    """OSN=4 was a misdiagnosis of the expiry bug; CANDIDE wants the streams."""
+    assert default_upload_workers("osn") == 16
+    assert default_upload_workers("r2") == 16
+    assert default_upload_workers() == 16
+
+
+class _Recorder:
+    """Fails every upload on the first round, succeeds once URLs are re-minted."""
+
+    def __init__(self, fail_rounds=1):
+        self.fail_rounds = fail_rounds
+        self.presign_calls = 0
+        self.upload_rounds = 0
+        self.uploaded: list[str] = []
+
+    def request_presigned_urls(self, config, tasks, **kw):
+        self.presign_calls += 1
+        return {t.r2_key: f"https://osn.example/{t.r2_key}?round={self.presign_calls}"
+                for t in tasks}
+
+    def upload_files_presigned(self, urls, tasks, **kw):
+        self.upload_rounds += 1
+        succeeded_out = kw.get("succeeded_out")
+        on_success = kw.get("on_success")
+        if self.upload_rounds <= self.fail_rounds:
+            # Everything "expires" -- nothing lands, no callbacks fire.
+            return 0, len(tasks), [f"{t.local_path.name}: 500 Server Error"
+                                   for t in tasks]
+        for t in tasks:
+            if succeeded_out is not None:
+                succeeded_out.add(t.r2_key)
+            if on_success is not None:
+                on_success(t)
+            self.uploaded.append(t.r2_key)
+        return len(tasks), 0, []
+
+
+@pytest.fixture()
+def patched(monkeypatch):
+    rec = _Recorder()
+    monkeypatch.setattr(r2, "request_presigned_urls", rec.request_presigned_urls)
+    monkeypatch.setattr(r2, "upload_files_presigned", rec.upload_files_presigned)
+    monkeypatch.setattr(r2, "create_transfer_session", lambda *a, **k: object())
+    monkeypatch.setattr(r2, "_assert_presigned_backend_osn", lambda urls: None)
+    return rec
+
+
+def _tasks(n):
+    return [UploadTask(local_path=Path(f"/tmp/f{i}.fits"),
+                       r2_key=f"data/products/x/f{i}.fits",
+                       content_type="application/fits")
+            for i in range(n)]
+
+
+def test_expired_batch_is_reminted_and_retried(patched):
+    """A wholly-expired batch must recover, not be reported as lost."""
+    tasks = _tasks(3)
+    cfg = {"supabase": {"_auth_mode": "login"}}
+    landed: set[str] = set()
+    ok, failed, msgs = r2.upload_files_parallel(
+        cfg, tasks, backend="osn", succeeded_out=landed, max_workers=4)
+
+    assert failed == 0, f"expected recovery after re-mint, got {msgs}"
+    assert ok == 3
+    assert landed == {t.r2_key for t in tasks}
+    # Re-minted rather than reusing the aged-out URLs.
+    assert patched.presign_calls == 2
+    assert patched.upload_rounds == 2
+
+
+def test_success_callback_fires_once_per_file(patched):
+    """Retries must not double-count: registry rows are built in on_success."""
+    tasks = _tasks(4)
+    seen: list[str] = []
+    r2.upload_files_parallel(
+        {"supabase": {"_auth_mode": "login"}}, tasks, backend="osn",
+        on_success=lambda t: seen.append(t.r2_key), max_workers=4)
+    assert sorted(seen) == sorted(t.r2_key for t in tasks)
+    assert len(seen) == len(set(seen))
+
+
+def test_permanent_failure_still_reported(monkeypatch):
+    """Retries are bounded -- a genuinely dead upload must still surface."""
+    rec = _Recorder(fail_rounds=99)
+    monkeypatch.setattr(r2, "request_presigned_urls", rec.request_presigned_urls)
+    monkeypatch.setattr(r2, "upload_files_presigned", rec.upload_files_presigned)
+    monkeypatch.setattr(r2, "create_transfer_session", lambda *a, **k: object())
+    monkeypatch.setattr(r2, "_assert_presigned_backend_osn", lambda urls: None)
+
+    ok, failed, msgs = r2.upload_files_parallel(
+        {"supabase": {"_auth_mode": "login"}}, _tasks(2), backend="osn",
+        max_workers=2)
+    assert ok == 0
+    assert failed == 2
+    assert msgs
+    assert rec.upload_rounds == 1 + r2._PRESIGN_RETRY_ROUNDS

--- a/python/tests/test_deploy_upload_workers.py
+++ b/python/tests/test_deploy_upload_workers.py
@@ -1,9 +1,11 @@
-"""Per-backend upload concurrency defaults.
+"""Upload concurrency defaults.
 
-OSN rejects a large fraction of concurrent PutObject requests with 500 once the
-stream count is high. Measured on a 621-file pg004 deploy: 16 streams failed
-68% of uploads (81% on the retry), the same files at 4 streams failed 0/344,
-and a single sequential PUT of a just-failed object returned 200.
+An earlier revision lowered the OSN default to 4, on the theory that
+concurrency was provoking 500s. That was a misdiagnosis: the 500s were
+presigned URLs ageing out mid-batch on a slow uplink (see
+test_deploy_presign_ttl.py), which depends on throughput and is indifferent to
+stream count -- a 16-way probe against the same endpoint went 16/16 while a
+4-way production run failed 79%. The default is 16 for every backend.
 """
 
 import pytest
@@ -18,11 +20,11 @@ def _clear_env(monkeypatch):
     monkeypatch.delenv(ENV_VAR, raising=False)
 
 
-def test_osn_default_is_low():
-    assert default_upload_workers("osn") == 4
+def test_osn_is_not_special_cased():
+    assert default_upload_workers("osn") == 16
 
 
-def test_r2_default_is_unchanged():
+def test_r2_default():
     assert default_upload_workers("r2") == 16
 
 
@@ -45,4 +47,4 @@ def test_env_override_is_clamped(monkeypatch, raw, expected):
 
 def test_garbage_env_falls_back_to_the_backend_default(monkeypatch):
     monkeypatch.setenv(ENV_VAR, "not-a-number")
-    assert default_upload_workers("osn") == 4
+    assert default_upload_workers("osn") == 16


### PR DESCRIPTION
Deploys from a domestic asymmetric uplink were losing most of their files to `500 Server Error`. The cause is **presigned URL expiry** — not OSN, not the network, not concurrency.

## The bug

Every URL in a presign batch is minted at the same instant with a **1-hour TTL**, so the batch is also the unit that must finish inside that hour. The module docstring already asserts this is handled:

> *"just-in-time presign batches (URLs are minted per 500-task batch immediately before that batch transfers, so a multi-hour push never races the 1-hour presign TTL)"*

True **per batch** — but only if a batch fits inside the TTL. At `PRESIGN_BATCH_SIZE = 500` it does not:

| link | 500 × ~42 MB | vs 1 h TTL |
|---|---|---|
| 2.16 MB/s (domestic uplink) | **~2.7 h** | loses the tail |
| ~30 MB/s (research link) | ~12 min | fine |

A `pg004` deploy lost **438 of 552 files in one stroke**, every failure carrying the same `X-Amz-Date=20260821T193826Z` — one batch, minted 10 s after start, dead at +1 h. The 114 that landed are almost exactly one hour of transfer at that rate.

This is invisible on a fast link, which is why CANDIDE pushes terabytes cleanly. Measured on the affected machine: **33.4 MB/s down vs 1.7–2.5 MB/s up**, a ~20× asymmetry, with the slow upload reproducing against an unrelated host.

## Changes

1. **`PRESIGN_BATCH_SIZE` 500 → 25** — ~23 min at 2.16 MB/s, comfortable margin. Extra presign round-trips are noise against the transfer (25 requests vs 2, ~30 s total on a multi-hour push).
2. **Re-mint + retry stragglers (2 rounds).** An aged-out URL is indistinguishable from a transient 5xx at this layer, and re-PUT is idempotent, so fresh URLs fix the former and cost nothing for the latter. **This, not the batch size, is what stops the TTL being a race** — it holds at any link speed or file size, where no fixed batch constant can.
3. **Revert the OSN=4 worker default from #475 back to 16.**

## On the revert

That change was **my misdiagnosis of this same bug**, and I should flag it plainly since it is already merged. I inferred a concurrency threshold from a single before/after pair — a 4-worker run that happened to succeed. It does not survive the evidence:

- a **4-worker** production run failed **79%** (438/552)
- a probe against the same endpoint, same credentials, same file class: **16/16 sequential, 16/16 at four, 16/16 at sixteen**

The clean 4-worker run succeeded because it had fewer files left and finished **inside the hour**, not because of the stream count. Restoring 16 also keeps CANDIDE's throughput, where extra streams genuinely help fill a fast uplink.

## Tests

`python/tests/test_deploy_presign_ttl.py` (5). **4 of 5 fail against the unfixed code**, including `test_expired_batch_is_reminted_and_retried`, which drives a wholly-expired batch through the recovery path and asserts URLs were re-minted rather than reused.

Also covered: `on_success` fires exactly once per file (registry rows are built in that callback, so a double-fire would corrupt bookkeeping), and bounded retries still surface a genuinely dead upload rather than looping.

The retry loop treats the uploader's **failure count** as authoritative for "are we done", using `succeeded_out` only to choose which tasks to retry. An implementation reporting success without populating that set would otherwise get everything re-uploaded — caught by the existing `test_deploy_osn_routing` stub, which does exactly that.

Full `python/` suite: **624 passed**, 1 pre-existing unrelated failure (`test_fitsgl_build.py`, `'ViewerSpec' object has no attribute 'weights'` — fails on `main` without these changes).

Generated with Claude Code

https://claude.ai/code/session_01YDPLMQty97WbBZGfgX55PX
