### PR TITLE
Upgrade @fitsgl/core to v0.3.2

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.932.0",
         "@aws-sdk/s3-request-presigner": "^3.932.0",
-        "@fitsgl/core": "^0.3.1",
+        "@fitsgl/core": "^0.3.2",
         "@supabase/ssr": "^0.7.0",
         "@supabase/supabase-js": "^2.81.1",
         "@tanstack/react-query": "^5.90.12",
@@ -2104,9 +2104,9 @@
       }
     },
     "node_modules/@fitsgl/core": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@fitsgl/core/-/core-0.3.1.tgz",
-      "integrity": "sha512-bUpJ/RC+tnPoCfxdXUiMt0+ZW7mYun6xKOMs14BvEljKedY+oWwobzHtKFTxwvagC69jAdfbyQ15orEz4rgtuA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@fitsgl/core/-/core-0.3.2.tgz",
+      "integrity": "sha512-iK9ffSGnhmNuIQ/0cP/hBNFsAv5f9J/zVlyuY4g2KTTCKCrJ1ocROCR6fv+h/8IWGT3VDwZprJ0VZBxtDWKnfA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": ">=18.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.932.0",
     "@aws-sdk/s3-request-presigner": "^3.932.0",
-    "@fitsgl/core": "^0.3.1",
+    "@fitsgl/core": "^0.3.2",
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.81.1",
     "@tanstack/react-query": "^5.90.12",


### PR DESCRIPTION
## Summary

Picks up the per-tile GZIP-fallback decode from [fitsgl#28](https://github.com/hollisakins/fitsgl/pull/28) — the actual root cause of the trilogy map's blocky low-res rendering over regions with partial filter coverage.

A shared-grid band's empty region is paved with all-NaN tiles, which cfitsio/astropy store via the lossless per-tile GZIP fallback (`GZIP_COMPRESSED_DATA`). `@fitsgl/core` ≤0.3.1 rejected those tiles, so the affected band never became GPU-resident there and the RGB/trilogy composite pinned to the coarsest level (with console errors on every retried fetch). 0.3.2 decodes them bit-exactly to NaN, which the shader composites as zero contribution — so partial-coverage regions now sharpen to full resolution.

## Changes

- Bumped `@fitsgl/core` to `^0.3.2` in `web/package.json` and updated `package-lock.json` (the lockfile pinned 0.3.1, so deploys kept the old renderer).

## Notes

- The server-side cutout engine (`web/lib/cutout/`) reuses `@fitsgl/core`'s `FpackFile`, so `/api/v1/cutout` over empty regions is fixed by the same upgrade.
- Verified with a full `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLongAzgPaUgdRzP77qJMX

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLongAzgPaUgdRzP77qJMX)_