### PR TITLE
Fix deploy crash on inf values in spectrum/zfit JSON generation

### DIFF
--- a/python/campfire/deploy/generate.py
+++ b/python/campfire/deploy/generate.py
@@ -152,10 +152,12 @@ def _spectrum_data_from_hdul(hdul) -> dict:
     err = hdul['ERR'].data
     prof1d = hdul['PROF1D'].data
 
-    # 1D spectrum
+    # 1D spectrum. Any non-finite flux (NaN *or* ±inf) becomes JSON null —
+    # inf is just as invalid as NaN under strict JSON, and json.dump below
+    # runs with allow_nan=False.
     wave = [round(x, 6) for x in spec1d['wave'].tolist()]
-    fnu = [None if np.isnan(x) else round(float(x), 6) for x in spec1d['fnu']]
-    fnu_err = [None if np.isnan(x) or np.isinf(x) else round(float(x), 6) for x in spec1d['fnu_err']]
+    fnu = [None if not np.isfinite(x) else round(float(x), 6) for x in spec1d['fnu']]
+    fnu_err = [None if not np.isfinite(x) else round(float(x), 6) for x in spec1d['fnu_err']]
 
     # 2D S/N
     with np.errstate(divide='ignore', invalid='ignore'):
@@ -176,7 +178,10 @@ def _spectrum_data_from_hdul(hdul) -> dict:
     else:
         cen = np.median(ypos)
 
+    # A non-finite weight (inf passes the `> 0` cut) or ypos poisons `cen`
+    # and with it the whole centered-pixel axis; coerce like the arrays above.
     pix_centered = ypos - cen
+    pix_centered = np.where(np.isfinite(pix_centered), pix_centered, 0.0)
 
     with np.errstate(divide='ignore', invalid='ignore'):
         collapsed_norm = collapsed / np.nanmax(np.abs(collapsed[valid_opt])) if np.any(valid_opt) else collapsed
@@ -263,18 +268,30 @@ def generate_zfit_json(zfit_path: Path, output_dir: Path) -> Path:
         primary = hdul['PRIMARY'].header
 
         chi2_data = hdul['CHI2'].data
-        z_grid = [round(float(z), 4) for z in chi2_data['z'].tolist()]
-        chi2_grid = [round(float(c), 2) for c in chi2_data['chi2'].tolist()]
+        z_arr = np.asarray(chi2_data['z'], dtype=float)
+        chi2_arr = np.asarray(chi2_data['chi2'], dtype=float)
+        z_grid = [round(float(z), 4) for z in z_arr.tolist()]
+        # Non-finite chi2 (masked/failed grid points) → JSON null; a bare
+        # NaN/Infinity token would make the browser reject the whole payload.
+        chi2_grid = [None if not np.isfinite(c) else round(float(c), 2) for c in chi2_arr]
 
-        min_idx = np.argmin(chi2_data['chi2'])
-        z_best = round(float(chi2_data['z'][min_idx]), 4)
-        chi2_min = round(float(chi2_data['chi2'][min_idx]), 2)
+        finite_chi2 = np.isfinite(chi2_arr)
+        if np.any(finite_chi2):
+            min_idx = int(np.argmin(np.where(finite_chi2, chi2_arr, np.inf)))
+            z_best = round(float(z_arr[min_idx]), 4)
+            chi2_min = round(float(chi2_arr[min_idx]), 2)
+        else:
+            z_best = None
+            chi2_min = None
 
-        confidence = round(float(primary.get('ZCONF', 0.0)), 1)
+        zconf = float(primary.get('ZCONF', 0.0))
+        confidence = round(zconf, 1) if np.isfinite(zconf) else None
 
         model_data = hdul['MODEL'].data
-        model_wave = [round(x, 6) for x in model_data['wav'].tolist()]
-        model_fnu = [round(x, 6) for x in model_data['fnu'].tolist()]
+        model_wave = [None if not np.isfinite(x) else round(float(x), 6)
+                      for x in model_data['wav']]
+        model_fnu = [None if not np.isfinite(x) else round(float(x), 6)
+                     for x in model_data['fnu']]
 
         data = {
             'redshift': z_best,
@@ -288,5 +305,6 @@ def generate_zfit_json(zfit_path: Path, output_dir: Path) -> Path:
 
     json_path = output_dir / (zfit_path.stem + '.json')
     with open(json_path, 'w') as f:
-        json.dump(data, f)
+        # allow_nan=False — see generate_spectrum_json.
+        json.dump(data, f, allow_nan=False)
     return json_path

--- a/python/campfire/deploy/generate.py
+++ b/python/campfire/deploy/generate.py
@@ -172,21 +172,26 @@ def _spectrum_data_from_hdul(hdul) -> dict:
     ypos = prof1d['ypos']
     opt_weight = prof1d['opt']
 
-    valid_opt = opt_weight > 0
+    # An inf weight passes a bare `> 0` cut and would poison the centroid
+    # (and with it every centered pixel), so require finiteness up front.
+    valid_opt = np.isfinite(opt_weight) & np.isfinite(ypos) & (opt_weight > 0)
     if np.any(valid_opt):
         cen = np.average(ypos[valid_opt], weights=opt_weight[valid_opt])
     else:
         cen = np.median(ypos)
 
-    # A non-finite weight (inf passes the `> 0` cut) or ypos poisons `cen`
-    # and with it the whole centered-pixel axis; coerce like the arrays above.
     pix_centered = ypos - cen
+    # Backstop for the no-valid-weight fallback (all-NaN ypos): still never
+    # let a non-finite coordinate reach the JSON.
     pix_centered = np.where(np.isfinite(pix_centered), pix_centered, 0.0)
 
     with np.errstate(divide='ignore', invalid='ignore'):
         collapsed_norm = collapsed / np.nanmax(np.abs(collapsed[valid_opt])) if np.any(valid_opt) else collapsed
         collapsed_norm = np.where(np.isfinite(collapsed_norm), collapsed_norm, 0)
-        opt_norm = opt_weight / np.nanmax(opt_weight) if np.nanmax(opt_weight) > 0 else opt_weight
+        # Normalize by the finite max — np.nanmax ignores NaN but not inf,
+        # and an inf denominator would flatten the whole profile to zero.
+        opt_max = float(np.max(opt_weight[valid_opt])) if np.any(valid_opt) else 0.0
+        opt_norm = opt_weight / opt_max if opt_max > 0 else opt_weight
         # opt weights can be non-finite at masked/edge pixels; a NaN here would
         # be serialized as the bare token `NaN` (invalid JSON) and make the
         # browser's JSON.parse reject the whole spectrum payload. Guard it the

--- a/python/tests/test_generate.py
+++ b/python/tests/test_generate.py
@@ -109,6 +109,24 @@ def test_inf_flux_becomes_null(tmp_path):
     assert "<svg" in thumbs["thumbnail_svg_fnu"]
 
 
+def test_inf_profile_weight_keeps_centered_axis(tmp_path):
+    """An inf extraction weight passes a bare `> 0` cut; it must not poison
+    the centroid (collapsing profile_pix to all zeros) nor the profile_fit
+    normalization (nanmax ignores NaN but not inf)."""
+    fits_path = tmp_path / "obj_prism_clear_4_spec.fits"
+    _write_spec_fits(fits_path, opt=[np.inf, 1.0, 2.0, 1.0, 0.5])
+
+    json_path = generate_spectrum_json(fits_path, tmp_path)
+    data = json.loads(json_path.read_text(), parse_constant=_strict_constant)
+
+    # Centroid from the finite weights only: axis stays centered, not zeroed.
+    assert any(v != 0.0 for v in data["profile_pix"])
+    assert data["profile_pix"] == sorted(data["profile_pix"])
+    # The inf weight itself is coerced to 0; the rest normalize to finite max.
+    assert data["profile_fit"][0] == 0.0
+    assert max(data["profile_fit"]) == 1.0
+
+
 def _write_zfit_fits(path, *, chi2, model_fnu, zconf=8.0):
     z = np.linspace(0.0, 10.0, len(chi2))
     model_wave = np.linspace(1.0, 5.0, len(model_fnu))

--- a/python/tests/test_generate.py
+++ b/python/tests/test_generate.py
@@ -13,7 +13,12 @@ import numpy as np
 import pytest
 from astropy.io import fits
 
-from campfire.deploy.generate import generate_spectrum_json, read_spectrum_data
+from campfire.deploy.generate import (
+    generate_spectrum_json,
+    generate_spectrum_products,
+    generate_zfit_json,
+    read_spectrum_data,
+)
 
 
 def _strict_constant(x):
@@ -83,3 +88,74 @@ def test_nonfinite_flux_becomes_null(tmp_path):
     json_path = generate_spectrum_json(fits_path, tmp_path)
     data = json.loads(json_path.read_text(), parse_constant=_strict_constant)
     assert data["fnu"][1] is None
+
+
+def test_inf_flux_becomes_null(tmp_path):
+    """Issue #482: ±inf in fnu/fnu_err crashed deploy with
+    'Out of range float values are not JSON compliant: inf'. Both must be
+    emitted as JSON null, exactly like NaN."""
+    fits_path = tmp_path / "obj_prism_clear_3_spec.fits"
+    _write_spec_fits(fits_path, opt=[1.0, 1.0, 1.0, 1.0, 0.5],
+                     fnu=[1.0, np.inf, -np.inf, 4.0])
+
+    # generate_spectrum_products is the single-read path deploy actually uses
+    # (the one that raised in the field).
+    json_path, thumbs = generate_spectrum_products(fits_path, tmp_path)
+    data = json.loads(json_path.read_text(), parse_constant=_strict_constant)
+    assert data["fnu"][1] is None
+    assert data["fnu"][2] is None
+    assert data["fnu"][0] == 1.0
+    # Thumbnails must also survive inf flux (finite points only).
+    assert "<svg" in thumbs["thumbnail_svg_fnu"]
+
+
+def _write_zfit_fits(path, *, chi2, model_fnu, zconf=8.0):
+    z = np.linspace(0.0, 10.0, len(chi2))
+    model_wave = np.linspace(1.0, 5.0, len(model_fnu))
+    hdu0 = fits.PrimaryHDU()
+    hdu0.header["ZCONF"] = zconf
+    chi2_hdu = fits.BinTableHDU.from_columns([
+        fits.Column(name="z", format="D", array=z),
+        fits.Column(name="chi2", format="D", array=np.asarray(chi2, dtype=float)),
+    ], name="CHI2")
+    model_hdu = fits.BinTableHDU.from_columns([
+        fits.Column(name="wav", format="D", array=model_wave),
+        fits.Column(name="fnu", format="D", array=np.asarray(model_fnu, dtype=float)),
+    ], name="MODEL")
+    fits.HDUList([hdu0, chi2_hdu, model_hdu]).writeto(path)
+
+
+def test_zfit_nonfinite_values_become_null(tmp_path):
+    """Issue #482 (zfit side): non-finite chi2/model values must serialize as
+    null and must not poison the best-fit selection."""
+    zfit_path = tmp_path / "obj_prism_clear_1_zfit.fits"
+    _write_zfit_fits(
+        zfit_path,
+        chi2=[np.inf, 5.0, np.nan, 2.0, 9.0],
+        model_fnu=[1.0, np.nan, np.inf, 4.0],
+    )
+
+    json_path = generate_zfit_json(zfit_path, tmp_path)
+    text = json_path.read_text()
+    data = json.loads(text, parse_constant=_strict_constant)
+
+    assert data["chi2_grid"][0] is None
+    assert data["chi2_grid"][2] is None
+    assert data["model_fnu"][1] is None
+    assert data["model_fnu"][2] is None
+    # Best fit picks the finite minimum, skipping the inf/NaN grid points.
+    assert data["chi2_min"] == 2.0
+    assert data["redshift"] == 7.5
+    assert data["confidence"] == 8.0
+
+
+def test_zfit_all_nonfinite_chi2_yields_null_best_fit(tmp_path):
+    """Degenerate zfit (no finite chi2) still writes valid JSON with null
+    best-fit scalars rather than crashing or emitting NaN."""
+    zfit_path = tmp_path / "obj_prism_clear_2_zfit.fits"
+    _write_zfit_fits(zfit_path, chi2=[np.nan, np.inf], model_fnu=[1.0, 2.0])
+
+    json_path = generate_zfit_json(zfit_path, tmp_path)
+    data = json.loads(json_path.read_text(), parse_constant=_strict_constant)
+    assert data["redshift"] is None
+    assert data["chi2_min"] is None

--- a/web/app/api/redshift-fit/route.ts
+++ b/web/app/api/redshift-fit/route.ts
@@ -3,14 +3,17 @@ import { createClient } from '@/lib/supabase/server';
 import { generateDownloadUrl } from '@/lib/r2';
 import { deriveSibling } from '@/lib/layout';
 
+// Non-finite values in the deploy-side FITS arrays are serialized as JSON
+// null (see python/campfire/deploy/generate.py); scalars are null when the
+// chi2 grid has no finite minimum. Consumers must guard before arithmetic.
 export interface RedshiftFitData {
-  redshift: number;
-  chi2_min: number;
-  confidence: number;
+  redshift: number | null;
+  chi2_min: number | null;
+  confidence: number | null;
   z_grid: number[];
-  chi2_grid: number[];
-  model_wave: number[];
-  model_fnu: number[];
+  chi2_grid: (number | null)[];
+  model_wave: (number | null)[];
+  model_fnu: (number | null)[];
 }
 
 /**

--- a/web/app/api/v1/redshift-fit/route.ts
+++ b/web/app/api/v1/redshift-fit/route.ts
@@ -5,14 +5,17 @@ import { getAccessiblePrograms, isAdminUser } from '@/lib/api-helpers';
 import { generateDownloadUrl } from '@/lib/r2';
 import { deriveSibling } from '@/lib/layout';
 
+// Non-finite values in the deploy-side FITS arrays are serialized as JSON
+// null (see python/campfire/deploy/generate.py); scalars are null when the
+// chi2 grid has no finite minimum. Consumers must guard before arithmetic.
 export interface RedshiftFitData {
-  redshift: number;
-  chi2_min: number;
-  confidence: number;
+  redshift: number | null;
+  chi2_min: number | null;
+  confidence: number | null;
   z_grid: number[];
-  chi2_grid: number[];
-  model_wave: number[];
-  model_fnu: number[];
+  chi2_grid: (number | null)[];
+  model_wave: (number | null)[];
+  model_fnu: (number | null)[];
 }
 
 /**

--- a/web/components/spectra/RedshiftFitSummary.tsx
+++ b/web/components/spectra/RedshiftFitSummary.tsx
@@ -63,9 +63,11 @@ export const RedshiftFitSummary: React.FC<RedshiftFitSummaryProps> = ({
 
           return {
             index,
-            redshift: fitData.redshift,
-            chi2Min: fitData.chi2_min,
-            confidence: fitData.confidence,
+            // Null scalars (degenerate fit with no finite chi2 minimum) map
+            // to undefined so the table's existing guards render an em dash.
+            redshift: fitData.redshift ?? undefined,
+            chi2Min: fitData.chi2_min ?? undefined,
+            confidence: fitData.confidence ?? undefined,
           };
         } catch (err) {
           return {

--- a/web/components/spectra/SpectrumPlot.tsx
+++ b/web/components/spectra/SpectrumPlot.tsx
@@ -246,16 +246,20 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
     );
 
     // Process model data if available (inspection mode)
-    let modelWave: number[] | null = null;
-    let modelFnu: number[] | null = null;
-    let modelFlambda: number[] | null = null;
+    let modelWave: (number | null)[] | null = null;
+    let modelFnu: (number | null)[] | null = null;
+    let modelFlambda: (number | null)[] | null = null;
 
     if (fitData) {
       modelWave = fitData.model_wave;
       modelFnu = fitData.model_fnu;
-      modelFlambda = fitData.model_fnu.map((f, i) =>
-        convertToFlambda(f, fitData.model_wave[i])
-      );
+      // Null samples (non-finite in the FITS) must survive as nulls — Plotly
+      // renders them as gaps, while arithmetic would coerce null to 0 and
+      // plot a false zero-flux model point.
+      modelFlambda = fitData.model_fnu.map((f, i) => {
+        const w = fitData.model_wave[i];
+        return f !== null && w !== null ? convertToFlambda(f, w) : null;
+      });
     }
 
     return { wave, fnu: fnuValues, fnuErr, flambda, flambdaErr, modelWave, modelFnu, modelFlambda };
@@ -560,9 +564,13 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
   // χ²(z) panel data — only built when the user toggles the Model overlay on.
   const chi2PlotData = useMemo(() => {
     if (!showModel || !fitData) return null;
+    // Null best-fit scalars mean the chi2 grid had no finite minimum
+    // (degenerate fit) — there is nothing meaningful to plot.
+    if (fitData.redshift === null || fitData.chi2_min === null) return null;
     let chi2Min = Infinity;
     let chi2Max = -Infinity;
     for (const v of fitData.chi2_grid) {
+      if (v === null) continue;
       if (v < chi2Min) chi2Min = v;
       if (v > chi2Max) chi2Max = v;
     }
@@ -595,7 +603,7 @@ export const SpectrumPlot: React.FC<SpectrumPlotProps> = ({
       traces,
       layout: {
         title: {
-          text: `Redshift fit · z = ${fitData.redshift.toFixed(4)}, χ²_min = ${fitData.chi2_min.toFixed(2)}, conf = ${fitData.confidence.toFixed(1)}%`,
+          text: `Redshift fit · z = ${fitData.redshift.toFixed(4)}, χ²_min = ${fitData.chi2_min.toFixed(2)}, conf = ${fitData.confidence !== null ? `${fitData.confidence.toFixed(1)}%` : '—'}`,
           font: { size: 12, color: plotColors.text },
         },
         font: { family: 'Inter, system-ui, sans-serif', color: plotColors.text },

--- a/web/components/spectra/plotting-utils.ts
+++ b/web/components/spectra/plotting-utils.ts
@@ -223,8 +223,8 @@ export function computeYRange(
   flux: number[],
   fluxErr: (number | null)[],
   options?: {
-    modelFlux?: number[] | null;
-    modelWave?: number[] | null;
+    modelFlux?: (number | null)[] | null;
+    modelWave?: (number | null)[] | null;
     dataWave?: number[];
     edgeTrim?: number;
   }
@@ -250,8 +250,12 @@ export function computeYRange(
 
     const filteredModelFlux: number[] = [];
     for (let i = 0; i < modelWave.length; i++) {
-      if (modelWave[i] >= trimmedWaveMin && modelWave[i] <= trimmedWaveMax) {
-        filteredModelFlux.push(modelFlux[i]);
+      const w = modelWave[i];
+      const f = modelFlux[i];
+      // Null samples (non-finite in the FITS) carry no range information —
+      // comparing them would coerce null to 0 and drag the range to zero.
+      if (w !== null && f !== null && w >= trimmedWaveMin && w <= trimmedWaveMax) {
+        filteredModelFlux.push(f);
       }
     }
 


### PR DESCRIPTION
Fixes #482.

`campfire deploy` crashed with `ValueError: Out of range float values are not JSON compliant: inf` when a spectrum's `fnu` contained ±inf: the sanitizer in `python/campfire/deploy/generate.py` only checked `np.isnan`, so infinities reached `json.dump(..., allow_nan=False)` and killed the deployment mid-run.

## Changes

- **`fnu` / `fnu_err`**: use a single `np.isfinite` check so NaN and ±inf are both emitted as JSON `null` (the web plot already renders `null` as a gap; the issue suggested inf→NaN, but a bare `NaN` token is itself invalid JSON, which is why `allow_nan=False` exists).
- **`profile_pix`**: coerce non-finite centered pixels to 0, matching the existing guards on `snr_2d` / `profile` / `profile_fit` — an inf extraction weight passes the `> 0` cut and poisons the centroid, taking the whole axis non-finite with it.
- **zfit JSON**: same latent bug, but worse — it ran without `allow_nan=False`, so a non-finite chi2 or model flux would have been written as a bare `NaN`/`Infinity` token and silently broken `JSON.parse` in the browser. Non-finite grid/model values now serialize as `null`, the best fit is picked from finite chi2 points only (with `null` scalars when none exist), and the `allow_nan=False` backstop is added. `redshift_auto` in the catalog is unaffected — it comes from the ECSV summary, which was already `_finite_or_none`-guarded.

## Testing

Added regression tests in `python/tests/test_generate.py`:
- ±inf flux through `generate_spectrum_products` (the exact path that crashed in the field), asserting strict-JSON validity and `null` output, plus thumbnail survival.
- Non-finite chi2/model values in the zfit JSON, including the degenerate all-non-finite-chi2 case.

All 6 tests in `test_generate.py` pass; the rest of the `python/tests` suite is green apart from pre-existing environment-only failures (missing `campfire-pipeline` install in the test venv).

No `pipeline/**` changes, so no CHANGELOG entry is needed per AGENTS.md.

Generated with Claude Code

https://claude.ai/code/session_01WwSz4v3H7KS8uFvfVxvr15

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwSz4v3H7KS8uFvfVxvr15)_