### PR TITLE
Switch presign batching from file count to total bytes

### DIFF
--- a/python/campfire/deploy/push.py
+++ b/python/campfire/deploy/push.py
@@ -80,7 +80,7 @@ def default_upload_workers(backend: Optional[str] = None) -> int:
     are writing to. An earlier revision defaulted OSN to 4 on the theory that
     concurrency was provoking 500s; that was a misdiagnosis. The 500s were
     presigned URLs ageing out mid-batch on a slow uplink (see
-    ``PRESIGN_BATCH_SIZE`` in ``deploy/r2.py``), which is throughput-dependent
+    ``PRESIGN_BATCH_MAX_BYTES`` in ``deploy/r2.py``), which is throughput-dependent
     and entirely indifferent to stream count -- a 16-way probe against the same
     endpoint went 16/16 while a 4-way production run failed 79%.
     """

--- a/python/campfire/deploy/r2.py
+++ b/python/campfire/deploy/r2.py
@@ -22,10 +22,11 @@ was the "surely this deploys to R2" trap.
 
 Transport details shared with the download side via ``campfire.storage``:
 pooled sessions with retry (PUT is idempotent, so it retries safely),
-just-in-time presign batches (URLs are minted per 500-task batch immediately
-before that batch transfers, so a multi-hour push never races the 1-hour
-presign TTL), and per-item success callbacks that run on the calling thread
-(safe for registry/mirror bookkeeping mid-transfer).
+just-in-time presign batches sized by total bytes (URLs are minted per batch
+immediately before that batch transfers, and each batch is capped at
+``PRESIGN_BATCH_MAX_BYTES`` so it finishes well inside the 1-hour presign TTL
+even on a slow uplink), and per-item success callbacks that run on the calling
+thread (safe for registry/mirror bookkeeping mid-transfer).
 """
 
 import gzip
@@ -34,7 +35,7 @@ import shutil
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Callable, NamedTuple, Optional
+from typing import Callable, Iterator, NamedTuple, Optional
 
 import requests as http_requests  # module-global: patchable seam for tests
 from urllib.parse import urlparse
@@ -96,19 +97,66 @@ class UploadTask(NamedTuple):
 # Presigned URL mode
 # ---------------------------------------------------------------------------
 
-# Max URLs per presign request. The web route accepts up to 500, but the batch
-# is also the unit that has to finish inside the 1-hour presign TTL: every URL
-# in a batch is minted at the same instant, so a batch that takes longer than
-# an hour to transfer loses its whole tail at once. At 2.16 MB/s (a domestic
-# asymmetric uplink) 500 x ~42 MB needs ~2.7 h and 438/552 files died on
-# expiry; 25 files is ~23 min there, and on a research link the extra
-# round-trips are noise against the transfer. `_PRESIGN_RETRY_ROUNDS` is the
-# real safety net -- this just makes hitting it rare.
-PRESIGN_BATCH_SIZE = 25
+# Max URLs per presign request -- the web route's hard cap. Since batching
+# went size-aware this is only the count guard (a batch of tiny files, e.g.
+# NIRSpec spectra or map tiles, tops out here); the TTL constraint is
+# PRESIGN_BATCH_MAX_BYTES below.
+PRESIGN_BATCH_SIZE = 500
+# Byte budget per presign batch. Every URL in a batch is minted at the same
+# instant with a 1-hour TTL, so the batch is also the unit that must finish
+# inside that hour -- and transfer time scales with total bytes, not file
+# count (25 NIRCam mosaics take far longer to push than 25 NIRSpec spectra,
+# which is why a fixed file-count batch was the wrong knob). At 2.16 MB/s (a
+# domestic asymmetric uplink) the old 500-file batches of ~42 MB products
+# needed ~2.7 h and lost 438/552 files to expiry in one stroke; 1 GiB is
+# ~8 min there, a comfortable margin, while a fast research link still gets
+# large batches for its many-small-file pushes. A single file bigger than the
+# budget forms its own batch: its URL is minted immediately before its PUT,
+# and S3/OSN validate expiry when the request starts, so one long PUT never
+# ages out mid-flight. `_PRESIGN_RETRY_ROUNDS` is the real safety net -- this
+# just makes hitting it rare.
+PRESIGN_BATCH_MAX_BYTES = 1 << 30
 # Re-mint + retry rounds for a batch's stragglers. A URL that aged out is
 # indistinguishable from a transient 5xx at this layer, and re-PUT is
 # idempotent, so retrying with fresh URLs is safe either way.
 _PRESIGN_RETRY_ROUNDS = 2
+
+
+def iter_presign_batches(
+    tasks: list[UploadTask],
+    *,
+    max_bytes: int = PRESIGN_BATCH_MAX_BYTES,
+    max_files: int = PRESIGN_BATCH_SIZE,
+) -> Iterator[list[UploadTask]]:
+    """Split ``tasks`` into presign batches bounded by total bytes and count.
+
+    Greedy, order-preserving accumulation: a task joins the current batch
+    unless doing so would push it past ``max_bytes`` or ``max_files``, in
+    which case the batch is yielded and a new one starts. A task larger than
+    ``max_bytes`` on its own becomes a singleton batch (its URL is minted
+    just-in-time, and expiry is checked when the PUT starts, so a single long
+    upload is TTL-safe).
+
+    Sizes come from the *local* file (compressed products upload a smaller
+    gzipped body, so this overestimates -- the safe direction for a TTL
+    budget). A file that cannot be stat'd counts as 0 bytes: the batcher's
+    job is TTL budgeting, not existence checking -- the upload itself will
+    report the missing file.
+    """
+    batch: list[UploadTask] = []
+    batch_bytes = 0
+    for task in tasks:
+        try:
+            size = task.local_path.stat().st_size
+        except OSError:
+            size = 0
+        if batch and (batch_bytes + size > max_bytes or len(batch) >= max_files):
+            yield batch
+            batch, batch_bytes = [], 0
+        batch.append(task)
+        batch_bytes += size
+    if batch:
+        yield batch
 
 
 def _get_presign_headers(config: dict) -> Optional[dict]:
@@ -463,9 +511,11 @@ def upload_files_parallel(
     In the explicit ``service_role`` / ``local`` modes it uploads directly with
     boto3 using local object-store credentials.
 
-    Presigned URLs are minted **just-in-time per batch** (500 tasks), so a push
-    that runs longer than the 1-hour presign TTL never fails late files on
-    signature expiry.
+    Presigned URLs are minted **just-in-time per batch**, and batches are
+    sized by total bytes (``PRESIGN_BATCH_MAX_BYTES``, with the web route's
+    500-URL cap as the count guard), so a push that runs longer than the
+    1-hour presign TTL never fails late files on signature expiry — however
+    large or small the individual products are.
 
     Parameters
     ----------
@@ -508,9 +558,10 @@ def upload_files_parallel(
         total_success, total_failed = 0, 0
         all_failures: list[str] = []
         # Just-in-time presigning: mint each batch's URLs immediately before
-        # that batch uploads so none can expire mid-run.
-        for i in range(0, len(tasks), PRESIGN_BATCH_SIZE):
-            batch = tasks[i:i + PRESIGN_BATCH_SIZE]
+        # that batch uploads so none can expire mid-run. Batches are bounded
+        # by total bytes (the quantity the TTL actually races), not file
+        # count.
+        for batch in iter_presign_batches(tasks):
             urls = request_presigned_urls(
                 config, batch, bucket=bucket_id, cache_control=cache_control,
                 backend=backend,

--- a/python/tests/test_deploy_presign_ttl.py
+++ b/python/tests/test_deploy_presign_ttl.py
@@ -6,8 +6,11 @@ so the batch is also the unit that must finish inside that hour. At 2.16 MB/s
 of ~42 MB products needs ~2.7 h, and a pg004 deploy lost 438 of 552 files in
 one go, all sharing a single X-Amz-Date.
 
-Two guards: a batch small enough that expiry is rare, and a re-mint + retry
-round so expiry is survivable regardless of link speed or file size.
+Two guards: batches bounded by total *bytes* (the quantity the TTL actually
+races -- 25 NIRCam mosaics take far longer to push than 25 NIRSpec spectra,
+so a file-count bound over- or under-shoots depending on product mix), and a
+re-mint + retry round so expiry is survivable regardless of link speed or
+file size.
 """
 
 from pathlib import Path
@@ -16,21 +19,75 @@ import pytest
 
 from campfire.deploy import r2
 from campfire.deploy.push import default_upload_workers
-from campfire.deploy.r2 import PRESIGN_BATCH_SIZE, UploadTask
+from campfire.deploy.r2 import (
+    PRESIGN_BATCH_MAX_BYTES, PRESIGN_BATCH_SIZE, UploadTask,
+    iter_presign_batches,
+)
 
 
-def test_batch_fits_inside_the_presign_ttl_on_a_slow_uplink():
+def test_batch_budget_fits_inside_the_presign_ttl_on_a_slow_uplink():
     """The regression that motivated this: 500 x 42 MB at 2.16 MB/s >> 1 h."""
     slow_bytes_per_s = 2.16e6
-    typical_product_bytes = 42e6
     ttl_s = 3600
-    seconds = PRESIGN_BATCH_SIZE * typical_product_bytes / slow_bytes_per_s
+    seconds = PRESIGN_BATCH_MAX_BYTES / slow_bytes_per_s
     assert seconds < ttl_s / 2, (
-        f"a {PRESIGN_BATCH_SIZE}-file batch needs {seconds/60:.0f} min on a "
-        f"2.16 MB/s uplink; that leaves no margin against the 1 h presign TTL"
+        f"a {PRESIGN_BATCH_MAX_BYTES}-byte batch needs {seconds/60:.0f} min "
+        f"on a 2.16 MB/s uplink; that leaves no margin against the 1 h "
+        f"presign TTL"
     )
-    # And the old value would not have.
-    assert 500 * typical_product_bytes / slow_bytes_per_s > ttl_s
+    # And the original unbounded 500-file batch of ~42 MB products would not
+    # have fit.
+    assert 500 * 42e6 / slow_bytes_per_s > ttl_s
+
+
+def _sized_task(tmp_path, name, size):
+    p = tmp_path / name
+    p.write_bytes(b"\0" * size)
+    return UploadTask(local_path=p, r2_key=f"data/products/x/{name}",
+                      content_type="application/fits")
+
+
+def test_batches_split_on_total_bytes_not_file_count(tmp_path):
+    """Big products form small batches, small products form big ones."""
+    tasks = [_sized_task(tmp_path, f"m{i}.fits", 400) for i in range(5)]
+    batches = list(iter_presign_batches(tasks, max_bytes=1000, max_files=500))
+    assert [len(b) for b in batches] == [2, 2, 1]
+    # Order preserved, nothing lost or duplicated.
+    assert [t.r2_key for b in batches for t in b] == [t.r2_key for t in tasks]
+
+
+def test_oversized_file_becomes_a_singleton_batch(tmp_path):
+    """A single mosaic bigger than the budget must still upload (alone)."""
+    tasks = [
+        _sized_task(tmp_path, "small1.fits", 10),
+        _sized_task(tmp_path, "huge.fits", 5000),
+        _sized_task(tmp_path, "small2.fits", 10),
+    ]
+    batches = list(iter_presign_batches(tasks, max_bytes=1000, max_files=500))
+    assert [[t.local_path.name for t in b] for b in batches] == [
+        ["small1.fits"], ["huge.fits"], ["small2.fits"]]
+
+
+def test_file_count_cap_still_bounds_tiny_file_batches(tmp_path):
+    """Many tiny files hit the presign route's URL-count cap, not the bytes."""
+    tasks = [_sized_task(tmp_path, f"s{i}.json", 1) for i in range(7)]
+    batches = list(iter_presign_batches(tasks, max_bytes=10**9, max_files=3))
+    assert [len(b) for b in batches] == [3, 3, 1]
+
+
+def test_unstatable_files_count_as_zero_bytes():
+    """Batching must not die on a missing file; the upload reports it."""
+    tasks = [UploadTask(local_path=Path(f"/nonexistent/f{i}.fits"),
+                        r2_key=f"data/products/x/f{i}.fits",
+                        content_type="application/fits")
+             for i in range(4)]
+    batches = list(iter_presign_batches(tasks, max_bytes=100, max_files=500))
+    assert [len(b) for b in batches] == [4]
+
+
+def test_default_count_cap_matches_presign_route_limit():
+    """The web /deploy/presign route accepts at most 500 URLs per request."""
+    assert PRESIGN_BATCH_SIZE == 500
 
 
 def test_worker_default_is_not_lowered_for_osn():


### PR DESCRIPTION
## Summary

Changed presign URL batching strategy from a fixed file count (25 files) to a byte-budget approach (1 GiB), making TTL expiry protection robust across different product types and sizes.

## Key Changes

- **New batching function**: Added `iter_presign_batches()` that groups tasks by total bytes rather than file count, with both a byte budget (`PRESIGN_BATCH_MAX_BYTES = 1 GiB`) and a count guard (`PRESIGN_BATCH_SIZE = 500`)
  - Greedy, order-preserving accumulation
  - Handles oversized files as singleton batches (minted just-in-time)
  - Gracefully handles missing files (counts as 0 bytes)

- **Updated constants**:
  - `PRESIGN_BATCH_SIZE`: 25 → 500 (now a count guard, not the primary constraint)
  - Added `PRESIGN_BATCH_MAX_BYTES = 1 GiB` (primary TTL budget)

- **Updated upload logic**: Replaced simple slice-based batching with `iter_presign_batches()` call in `upload_files_parallel()`

- **Documentation improvements**: 
  - Clarified that batching is now byte-aware in module docstrings and function docstrings
  - Updated comments explaining the TTL safety rationale
  - Added comprehensive docstring to `iter_presign_batches()`

## Motivation

The old fixed file-count batching (25 files) was a poor proxy for TTL risk. A batch of 25 large NIRCam mosaics takes far longer to upload than 25 small NIRSpec spectra, yet both were treated identically. This caused:
- Over-conservative batching for small files (unnecessary round-trips)
- Under-conservative batching for large files (expiry risk)

The 1 GiB byte budget directly targets the actual constraint: transfer time scales with bytes, not file count. At 2.16 MB/s (typical domestic uplink), 1 GiB takes ~8 minutes, leaving comfortable margin within the 1-hour presign TTL.

## Testing

Added comprehensive test coverage:
- TTL safety validation at slow uplink speeds
- Byte-based splitting behavior
- Oversized file handling
- File count cap enforcement for tiny files
- Missing file handling
- Constant validation

https://claude.ai/code/session_011jwH1iEt8X7EnPWoLr7Cmf