### PR TITLE
Add wildcard filename search to admin NIRCam exposure list

### DIFF
--- a/supabase/migrations/20260826120000_nircam_exposures_filename_search.sql
+++ b/supabase/migrations/20260826120000_nircam_exposures_filename_search.sql
@@ -1,0 +1,193 @@
+-- Wildcard filename search for the admin NIRCam exposure list: add p_search
+-- (an ILIKE pattern applied to filename) to get_admin_exposures and
+-- get_admin_exposure_neighbors. Callers pre-translate the operator's glob
+-- ("jw01727001*" → 'jw01727001%') in web/lib/admin/exposure-search.ts, so the
+-- list, the detail page's prev/next nav, and the PNG-manifest route all agree
+-- on what matches. Composes with every existing filter (AND semantics).
+--
+-- Adding a parameter changes the function signature, and CREATE OR REPLACE
+-- with a different argument list would create an ambiguous overload instead
+-- of replacing — so drop + recreate (house precedent: 20260817213000). The
+-- GRANTs are re-applied because they drop with the functions.
+DROP FUNCTION IF EXISTS public.get_admin_exposures(text, text, text, text, text, text, text, text, integer, integer);
+DROP FUNCTION IF EXISTS public.get_admin_exposure_neighbors(integer, text, text, text, text, text, text, text, text, integer);
+
+CREATE OR REPLACE FUNCTION public.get_admin_exposures(
+  p_field text DEFAULT NULL,
+  p_filter text DEFAULT NULL,
+  p_detector text DEFAULT NULL,
+  p_review_status text DEFAULT NULL,
+  p_stage text DEFAULT NULL,
+  p_correction text DEFAULT NULL,
+  p_sort_column text DEFAULT 'filename',   -- 'filename' = the compound (field, filter, filename) list order
+  p_sort_direction text DEFAULT 'asc',
+  p_page integer DEFAULT 1,
+  p_page_size integer DEFAULT 50,
+  p_search text DEFAULT NULL               -- ILIKE pattern on filename; callers pre-translate
+                                           -- the operator's glob (web/lib/admin/exposure-search.ts)
+)
+RETURNS TABLE (
+  id integer,
+  field text,
+  filter text,
+  detector text,
+  filename text,
+  visit text,
+  date_obs timestamp without time zone,
+  ra_center double precision,
+  dec_center double precision,
+  stage text,
+  review_status text,
+  correction text,
+  png_path text,
+  full_png_path text,
+  image_width integer,
+  image_height integer,
+  mask_regions jsonb,
+  notes text,
+  review_decided_at timestamptz,
+  created_at timestamp without time zone,
+  updated_at timestamp without time zone,
+  total_count bigint
+)
+LANGUAGE plpgsql STABLE
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_limit integer := LEAST(GREATEST(COALESCE(p_page_size, 50), 1), 200);
+  v_offset integer := GREATEST(COALESCE(p_page, 1) - 1, 0) * LEAST(GREATEST(COALESCE(p_page_size, 50), 1), 200);
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
+  IF p_sort_column NOT IN ('filename', 'field', 'filter', 'detector', 'stage',
+                           'review_status', 'date_obs', 'updated_at') THEN
+    p_sort_column := 'filename';
+  END IF;
+
+  RETURN QUERY
+  SELECT e.id, e.field, e.filter, e.detector, e.filename, e.visit, e.date_obs,
+         e.ra_center, e.dec_center, e.stage, e.review_status,
+         e.correction, e.png_path, e.full_png_path, e.image_width,
+         e.image_height, e.mask_regions, e.notes, e.review_decided_at,
+         e.created_at, e.updated_at,
+         count(*) OVER ()
+  FROM nircam_exposures e
+  WHERE (p_field IS NULL OR e.field = p_field)
+    AND (p_filter IS NULL OR e.filter = p_filter)
+    AND (p_detector IS NULL OR e.detector = p_detector)
+    AND (p_review_status IS NULL OR e.review_status = p_review_status)
+    AND (p_stage IS NULL OR e.stage = p_stage)
+    AND (p_correction IS NULL OR e.correction = p_correction)
+    AND (p_search IS NULL OR p_search = '' OR e.filename ILIKE p_search)
+  ORDER BY
+    -- Keep in lockstep with get_admin_exposure_neighbors.
+    CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'asc'  THEN e.field END ASC,
+    CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'asc'  THEN e.filter END ASC,
+    CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'asc'  THEN e.filename END ASC,
+    CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'desc' THEN e.field END DESC,
+    CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'desc' THEN e.filter END DESC,
+    CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'desc' THEN e.filename END DESC,
+    CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc'  THEN e.field END ASC,
+    CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN e.field END DESC,
+    CASE WHEN p_sort_column = 'filter' AND p_sort_direction = 'asc'  THEN e.filter END ASC,
+    CASE WHEN p_sort_column = 'filter' AND p_sort_direction = 'desc' THEN e.filter END DESC,
+    CASE WHEN p_sort_column = 'detector' AND p_sort_direction = 'asc'  THEN e.detector END ASC,
+    CASE WHEN p_sort_column = 'detector' AND p_sort_direction = 'desc' THEN e.detector END DESC,
+    CASE WHEN p_sort_column = 'stage' AND p_sort_direction = 'asc'  THEN e.stage END ASC,
+    CASE WHEN p_sort_column = 'stage' AND p_sort_direction = 'desc' THEN e.stage END DESC,
+    CASE WHEN p_sort_column = 'review_status' AND p_sort_direction = 'asc'  THEN e.review_status END ASC,
+    CASE WHEN p_sort_column = 'review_status' AND p_sort_direction = 'desc' THEN e.review_status END DESC,
+    CASE WHEN p_sort_column = 'date_obs' AND p_sort_direction = 'asc'  THEN e.date_obs END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'date_obs' AND p_sort_direction = 'desc' THEN e.date_obs END DESC NULLS LAST,
+    CASE WHEN p_sort_column = 'updated_at' AND p_sort_direction = 'asc'  THEN e.updated_at END ASC NULLS LAST,
+    CASE WHEN p_sort_column = 'updated_at' AND p_sort_direction = 'desc' THEN e.updated_at END DESC NULLS LAST,
+    e.id ASC
+  OFFSET v_offset LIMIT v_limit;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_admin_exposures TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.get_admin_exposure_neighbors(
+  p_current_id integer,
+  p_field text DEFAULT NULL,
+  p_filter text DEFAULT NULL,
+  p_detector text DEFAULT NULL,
+  p_review_status text DEFAULT NULL,
+  p_stage text DEFAULT NULL,
+  p_correction text DEFAULT NULL,
+  p_sort_column text DEFAULT 'filename',
+  p_sort_direction text DEFAULT 'asc',
+  p_window integer DEFAULT 3,
+  p_search text DEFAULT NULL   -- ILIKE pattern on filename; same contract as get_admin_exposures
+)
+RETURNS TABLE (
+  id integer,
+  nav_position bigint,   -- 1-based rank in the filtered set ("position" is reserved)
+  total_count bigint
+)
+LANGUAGE plpgsql STABLE
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_window integer := LEAST(GREATEST(COALESCE(p_window, 3), 1), 25);
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'Access denied: Admin privileges required';
+  END IF;
+  IF p_sort_direction NOT IN ('asc', 'desc') THEN p_sort_direction := 'asc'; END IF;
+  IF p_sort_column NOT IN ('filename', 'field', 'filter', 'detector', 'stage',
+                           'review_status', 'date_obs', 'updated_at') THEN
+    p_sort_column := 'filename';
+  END IF;
+
+  RETURN QUERY
+  WITH ranked AS (
+    SELECT e.id AS exp_id,
+           row_number() OVER (ORDER BY
+             -- Keep in lockstep with get_admin_exposures.
+             CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'asc'  THEN e.field END ASC,
+             CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'asc'  THEN e.filter END ASC,
+             CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'asc'  THEN e.filename END ASC,
+             CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'desc' THEN e.field END DESC,
+             CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'desc' THEN e.filter END DESC,
+             CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'desc' THEN e.filename END DESC,
+             CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'asc'  THEN e.field END ASC,
+             CASE WHEN p_sort_column = 'field' AND p_sort_direction = 'desc' THEN e.field END DESC,
+             CASE WHEN p_sort_column = 'filter' AND p_sort_direction = 'asc'  THEN e.filter END ASC,
+             CASE WHEN p_sort_column = 'filter' AND p_sort_direction = 'desc' THEN e.filter END DESC,
+             CASE WHEN p_sort_column = 'detector' AND p_sort_direction = 'asc'  THEN e.detector END ASC,
+             CASE WHEN p_sort_column = 'detector' AND p_sort_direction = 'desc' THEN e.detector END DESC,
+             CASE WHEN p_sort_column = 'stage' AND p_sort_direction = 'asc'  THEN e.stage END ASC,
+             CASE WHEN p_sort_column = 'stage' AND p_sort_direction = 'desc' THEN e.stage END DESC,
+             CASE WHEN p_sort_column = 'review_status' AND p_sort_direction = 'asc'  THEN e.review_status END ASC,
+             CASE WHEN p_sort_column = 'review_status' AND p_sort_direction = 'desc' THEN e.review_status END DESC,
+             CASE WHEN p_sort_column = 'date_obs' AND p_sort_direction = 'asc'  THEN e.date_obs END ASC NULLS LAST,
+             CASE WHEN p_sort_column = 'date_obs' AND p_sort_direction = 'desc' THEN e.date_obs END DESC NULLS LAST,
+             CASE WHEN p_sort_column = 'updated_at' AND p_sort_direction = 'asc'  THEN e.updated_at END ASC NULLS LAST,
+             CASE WHEN p_sort_column = 'updated_at' AND p_sort_direction = 'desc' THEN e.updated_at END DESC NULLS LAST,
+             e.id ASC
+           ) AS rn,
+           count(*) OVER () AS n
+    FROM nircam_exposures e
+    WHERE (p_field IS NULL OR e.field = p_field)
+      AND (p_filter IS NULL OR e.filter = p_filter)
+      AND (p_detector IS NULL OR e.detector = p_detector)
+      AND (p_review_status IS NULL OR e.review_status = p_review_status)
+      AND (p_stage IS NULL OR e.stage = p_stage)
+        AND (p_correction IS NULL OR e.correction = p_correction)
+        AND (p_search IS NULL OR p_search = '' OR e.filename ILIKE p_search)
+  ),
+  cur AS (
+    SELECT r.rn AS rn0 FROM ranked r WHERE r.exp_id = p_current_id
+  )
+  SELECT r.exp_id, r.rn, r.n
+  FROM ranked r, cur
+  WHERE r.rn BETWEEN cur.rn0 - v_window AND cur.rn0 + v_window
+  ORDER BY r.rn;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_admin_exposure_neighbors TO authenticated;

--- a/supabase/schemas/functions.sql
+++ b/supabase/schemas/functions.sql
@@ -4045,7 +4045,9 @@ CREATE OR REPLACE FUNCTION public.get_admin_exposures(
   p_sort_column text DEFAULT 'filename',   -- 'filename' = the compound (field, filter, filename) list order
   p_sort_direction text DEFAULT 'asc',
   p_page integer DEFAULT 1,
-  p_page_size integer DEFAULT 50
+  p_page_size integer DEFAULT 50,
+  p_search text DEFAULT NULL               -- ILIKE pattern on filename; callers pre-translate
+                                           -- the operator's glob (web/lib/admin/exposure-search.ts)
 )
 RETURNS TABLE (
   id integer,
@@ -4105,6 +4107,7 @@ BEGIN
     AND (p_review_status IS NULL OR e.review_status = p_review_status)
     AND (p_stage IS NULL OR e.stage = p_stage)
     AND (p_correction IS NULL OR e.correction = p_correction)
+    AND (p_search IS NULL OR p_search = '' OR e.filename ILIKE p_search)
   ORDER BY
     -- Keep in lockstep with get_admin_exposure_neighbors.
     CASE WHEN p_sort_column = 'filename' AND p_sort_direction = 'asc'  THEN e.field END ASC,
@@ -4149,7 +4152,8 @@ CREATE OR REPLACE FUNCTION public.get_admin_exposure_neighbors(
   p_correction text DEFAULT NULL,
   p_sort_column text DEFAULT 'filename',
   p_sort_direction text DEFAULT 'asc',
-  p_window integer DEFAULT 3
+  p_window integer DEFAULT 3,
+  p_search text DEFAULT NULL   -- ILIKE pattern on filename; same contract as get_admin_exposures
 )
 RETURNS TABLE (
   id integer,
@@ -4206,6 +4210,7 @@ BEGIN
       AND (p_review_status IS NULL OR e.review_status = p_review_status)
       AND (p_stage IS NULL OR e.stage = p_stage)
         AND (p_correction IS NULL OR e.correction = p_correction)
+        AND (p_search IS NULL OR p_search = '' OR e.filename ILIKE p_search)
   ),
   cur AS (
     SELECT r.rn AS rn0 FROM ranked r WHERE r.exp_id = p_current_id

--- a/web/app/admin/nircam/page.tsx
+++ b/web/app/admin/nircam/page.tsx
@@ -355,7 +355,7 @@ function ProgressSummary({ progress }: { progress: ReductionProgress[] }) {
 // see lib/nircam-exposure-nav.ts.
 // ---------------------------------------------------------------------------
 
-const FILTER_KEYS = ['field', 'filter', 'detector', 'review', 'stage', 'correction'] as const;
+const FILTER_KEYS = ['field', 'filter', 'detector', 'review', 'stage', 'correction', 'search'] as const;
 const codec = flatFilterCodec(FILTER_KEYS);
 const DEFAULT_SORT: SortState = { column: 'filename', direction: 'asc' };
 
@@ -400,6 +400,7 @@ function AdminNircamPageInner() {
         reviewStatus: f.review || undefined,
         stage: f.stage || undefined,
         correction: f.correction || undefined,
+        search: f.search || undefined,
         sortColumn: state.sort.column,
         sortDirection: state.sort.direction,
         page,
@@ -520,6 +521,9 @@ function AdminNircamPageInner() {
 
       <AdminFilterBar
         facets={[
+          // Wildcard filename search: * = any run, ? = one char; a term with
+          // no wildcard matches as a substring. Composes with the selects.
+          { kind: 'search', key: 'search', placeholder: 'Filename, e.g. jw01727001*' },
           {
             kind: 'select', key: 'field', label: 'Field',
             options: (facets?.fields ?? []).map((f) => ({ value: f, label: f })),

--- a/web/app/admin/nircam/page.tsx
+++ b/web/app/admin/nircam/page.tsx
@@ -430,10 +430,14 @@ function AdminNircamPageInner() {
   });
 
   // Row links carry the current filter+sort state so the detail page derives
-  // prev/next from the same set (see lib/nircam-exposure-nav.ts).
+  // prev/next from the same set (see lib/nircam-exposure-nav.ts). Debounced
+  // filters, matching the fetch: while the operator is mid-keystroke in the
+  // search box the rendered rows are still the debounced set, and a link
+  // carrying the un-debounced text would hand the detail page a filter its
+  // exposure doesn't match (no prev/next context).
   const navQuery = useMemo(
-    () => buildExposureNavQuery(state.filters, state.sort, DEFAULT_SORT),
-    [state.filters, state.sort],
+    () => buildExposureNavQuery(state.debouncedFilters, state.sort, DEFAULT_SORT),
+    [state.debouncedFilters, state.sort],
   );
   const detailHref = (id: number) => `/admin/nircam/${id}${navQuery ? `?${navQuery}` : ''}`;
 

--- a/web/app/api/nircam-png/manifest/route.ts
+++ b/web/app/api/nircam-png/manifest/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { EXPOSURE_SORT_KEYS } from '@/lib/admin/sort-keys';
+import { filenameSearchPattern } from '@/lib/admin/exposure-search';
 
 /**
- * GET /api/nircam-png/manifest?field=..&filter=..&detector=..&review=..&stage=..&correction=..&sort=..&dir=..
+ * GET /api/nircam-png/manifest?field=..&filter=..&detector=..&review=..&stage=..&correction=..&search=..&sort=..&dir=..
  *
  * The PNG pre-download manifest for a filtered set: which exposures have a
  * downloadable display PNG (full-res when deployed, else preview — the byte
@@ -44,6 +45,9 @@ export async function GET(request: NextRequest) {
     const v = sp.get(param);
     if (v) eq.push([column, v]);
   }
+  // Same glob → ILIKE translation as get_admin_exposures' p_search, so the
+  // manifest covers exactly the set the searched list shows.
+  const searchPattern = filenameSearchPattern(sp.get('search'));
 
   const CHUNK = 1000;   // PostgREST caps a single response at 1000 rows
   const CAP = 20000;    // runaway guard
@@ -56,6 +60,7 @@ export async function GET(request: NextRequest) {
     for (let off = 0; off < CAP; off += CHUNK) {
       let q = supabase.from('nircam_exposures').select('id, png_path, full_png_path');
       for (const [col, v] of eq) q = q.eq(col, v);
+      if (searchPattern) q = q.ilike('filename', searchPattern);
       // Mirror get_admin_exposures' ORDER BY: 'filename' is the compound
       // (field, filter, filename) list order; everything gets the id tiebreak.
       if (sortCol === 'filename') {

--- a/web/components/nircam/PngPrecacheControl.tsx
+++ b/web/components/nircam/PngPrecacheControl.tsx
@@ -109,7 +109,7 @@ export function PngPrecacheControl({ filters, sort }: PngPrecacheControlProps) {
 
   const manifestQuery = useMemo(() => {
     const sp = new URLSearchParams();
-    for (const key of ['field', 'filter', 'detector', 'review', 'stage', 'correction'] as const) {
+    for (const key of ['field', 'filter', 'detector', 'review', 'stage', 'correction', 'search'] as const) {
       if (filters[key]) sp.set(key, filters[key]);
     }
     sp.set('sort', sort.column);

--- a/web/lib/actions/nircam-exposures.ts
+++ b/web/lib/actions/nircam-exposures.ts
@@ -4,6 +4,7 @@ import { createClient } from '@/lib/supabase/server';
 import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { getS3ClientForBackend, getBucketNameForBackend, type DataBackend } from '@/lib/storage';
+import { filenameSearchPattern } from '@/lib/admin/exposure-search';
 import type { NircamExposure, MaskRegionsPayload } from '@/lib/types';
 
 export interface ExposurePngUrls {
@@ -64,6 +65,8 @@ export interface ExposureFilters {
   reviewStatus?: string;
   stage?: string;
   correction?: string;
+  /** Raw wildcard filename search ("jw01727001*"); glob → ILIKE happens at the RPC boundary. */
+  search?: string;
 }
 
 export interface ExposureSort {
@@ -83,6 +86,7 @@ function rpcExposureParams(params?: ExposureFilters & ExposureSort) {
     p_review_status: params?.reviewStatus ?? null,
     p_stage: params?.stage ?? null,
     p_correction: params?.correction ?? null,
+    p_search: filenameSearchPattern(params?.search),
     p_sort_column: params?.sortColumn ?? 'filename',
     p_sort_direction: params?.sortDirection ?? 'asc',
   };

--- a/web/lib/admin/exposure-search.ts
+++ b/web/lib/admin/exposure-search.ts
@@ -1,0 +1,26 @@
+// Wildcard filename search for the admin NIRCam exposure list. The operator
+// types glob-style patterns ("jw01727001*" = every exposure of that
+// program+obs), which are translated here — in exactly one place — into the
+// ILIKE pattern the get_admin_exposures / get_admin_exposure_neighbors RPCs
+// and the PNG-manifest route all apply to `filename`, so the list, prev/next
+// nav, and the pre-download manifest always agree on what matches.
+//
+// Semantics: `*` matches any run of characters, `?` exactly one; matching is
+// case-insensitive. A term with no wildcard is a substring match (wrapped in
+// %...%); a term with wildcards is anchored ("jw01727001*" matches from the
+// start of the filename). Literal ILIKE metacharacters in the input are
+// escaped, so a stray `%` or `_` in a pasted filename never widens the match.
+
+/** Raw search text → ILIKE pattern for `filename`, or null when empty/unset. */
+export function filenameSearchPattern(raw: string | null | undefined): string | null {
+  const term = raw?.trim();
+  if (!term) return null;
+  const hasWildcard = term.includes('*') || term.includes('?');
+  const pattern = term
+    .replace(/\\/g, '\\\\')
+    .replace(/%/g, '\\%')
+    .replace(/_/g, '\\_')
+    .replace(/\*/g, '%')
+    .replace(/\?/g, '_');
+  return hasWildcard ? pattern : `%${pattern}%`;
+}

--- a/web/lib/nircam-exposure-nav.ts
+++ b/web/lib/nircam-exposure-nav.ts
@@ -9,7 +9,7 @@ import type { ExposureFilters, ExposureSort } from '@/lib/actions/nircam-exposur
 import { EXPOSURE_SORT_KEYS } from '@/lib/admin/sort-keys';
 
 export const EXPOSURE_FILTER_PARAM_KEYS = [
-  'field', 'filter', 'detector', 'review', 'stage', 'correction',
+  'field', 'filter', 'detector', 'review', 'stage', 'correction', 'search',
 ] as const;
 
 export type ExposureFilterParams = Record<
@@ -30,6 +30,7 @@ export function parseExposureNavParams(
     reviewStatus: sp.get('review') || undefined,
     stage: sp.get('stage') || undefined,
     correction: sp.get('correction') || undefined,
+    search: sp.get('search') || undefined,
     sortColumn:
       sort && (EXPOSURE_SORT_KEYS as readonly string[]).includes(sort) ? sort : undefined,
     sortDirection: dir === 'asc' || dir === 'desc' ? dir : undefined,


### PR DESCRIPTION
## Summary
Adds glob-style wildcard filename search (`*` for any run of characters, `?` for exactly one) to the admin NIRCam exposure list, detail page navigation, and PNG pre-download manifest. The search pattern is translated once in a dedicated utility function to ensure consistent matching across all three interfaces.

## Key Changes

- **New migration** (`20260826120000_nircam_exposures_filename_search.sql`): Adds `p_search` parameter to `get_admin_exposures()` and `get_admin_exposure_neighbors()` RPC functions. Functions are dropped and recreated (rather than using `CREATE OR REPLACE`) to avoid ambiguous overloads when changing the signature. The `p_search` parameter accepts an ILIKE pattern applied to the `filename` column and composes with all existing filters using AND semantics.

- **New utility** (`web/lib/admin/exposure-search.ts`): Implements `filenameSearchPattern()` to translate operator input (glob-style: `"jw01727001*"`) into ILIKE patterns. Handles:
  - `*` → `%` (any run of characters)
  - `?` → `_` (exactly one character)
  - Escapes literal ILIKE metacharacters (`%`, `_`, `\`) so they don't widen matches
  - Unanchored terms (no wildcards) become substring matches (`%term%`)
  - Anchored terms (with wildcards) remain anchored (`pattern`)

- **Updated RPC calls**: Modified `get_admin_exposures()` and `get_admin_exposure_neighbors()` calls in:
  - `web/lib/actions/nircam-exposures.ts`: Added `search` field to `ExposureFilters` interface
  - `web/lib/nircam-exposure-nav.ts`: Added `'search'` to filter param keys
  - `web/app/admin/nircam/page.tsx`: Added search facet to filter bar and passed search parameter to RPC
  - `web/app/api/nircam-png/manifest/route.ts`: Applied same glob→ILIKE translation to manifest query so pre-download list matches the filtered view
  - `web/components/nircam/PngPrecacheControl.tsx`: Included search parameter in manifest query

- **Schema update** (`supabase/schemas/functions.sql`): Reflects the new `p_search` parameter in both functions.

## Implementation Details

The glob→ILIKE translation happens in exactly one place (`filenameSearchPattern()`) to ensure the list view, detail page prev/next navigation, and PNG manifest all agree on what matches. The search parameter is optional and composes with every existing filter (field, filter, detector, review_status, stage, correction) using AND semantics.

https://claude.ai/code/session_01EhMxtSXM8YU4uJVzWnfx3z