### PR TITLE
Memory-aware parallel tile scheduler for NIRCam resample

### DIFF
--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -46,6 +46,29 @@ Release procedure: edit the `## Unreleased` section below, then run
   Infrastructure because it changes scientific output: exposures that were
   silently quarantined now contribute to their mosaics.
 
+### Infrastructure
+- **Memory-aware tile parallelism for NIRCam `resample` + mosaic `bkgsub`.**
+  The combine tile loop (previously strictly serial: one busy core through a
+  ~12-hour tile phase on a 21-tile COSMOS filter) now dispatches tiles across
+  a forkserver pool. `-p/--processes` is a **ceiling, not a target**: the
+  scheduler sizes the pool from a budget of `MemAvailable` and a weighted
+  memory gate admits each worker's drizzle and bkgsub/split/plot stages
+  separately against per-tile footprint estimates computed from the tile's
+  own geometry (output shape, context-plane count) — bkgsub is the ~2.5–3x
+  heavier stage (measured 51–66 GB vs ~20–37 GB per COSMOS LW tile), so it
+  throttles harder while drizzles run wide, and live `MemAvailable` is
+  re-checked at every admission for shared-node safety. Failing tiles no
+  longer kill their siblings in parallel mode (failures are collected and
+  raised together); log lines from parallel workers are prefixed with their
+  tile name. `--processes 1` (the default) keeps the exact serial,
+  ordering-stable, fail-fast loop. Tuning knobs live under
+  `[nircam.resample]` (`parallel_tiles`, `mem_fraction`, `mem_margin`,
+  `mem_bkgsub_bytes_per_pixel`, `mem_drizzle_base_bytes_per_pixel`) and are
+  deliberately excluded from the manifest config hash, so enabling or tuning
+  the scheduler never marks existing tiles stale. Tile outputs are unchanged
+  — tiles are independent and the per-tile pipeline only reads the frozen
+  working copies — hence Infrastructure/PATCH.
+
 ## v0.6.0 — 2026-08-18
 
 ### Calibration

--- a/pipeline/CHANGELOG.md
+++ b/pipeline/CHANGELOG.md
@@ -60,7 +60,11 @@ Release procedure: edit the `## Unreleased` section below, then run
   re-checked at every admission for shared-node safety. Failing tiles no
   longer kill their siblings in parallel mode (failures are collected and
   raised together); log lines from parallel workers are prefixed with their
-  tile name. `--processes 1` (the default) keeps the exact serial,
+  tile name and emitted as single atomic write+flush calls so concurrent
+  workers never interleave mid-line. In parallel mode the exposure
+  footprints are read once in the parent (instead of once per tile) and the
+  pool is sized on the tiles that actually have overlapping exposures.
+  `--processes 1` (the default) keeps the exact serial,
   ordering-stable, fail-fast loop. Tuning knobs live under
   `[nircam.resample]` (`parallel_tiles`, `mem_fraction`, `mem_margin`,
   `mem_bkgsub_bytes_per_pixel`, `mem_drizzle_base_bytes_per_pixel`) and are

--- a/pipeline/campfire_pipeline/common/io.py
+++ b/pipeline/campfire_pipeline/common/io.py
@@ -6,9 +6,28 @@ import os
 from datetime import datetime
 
 
+# Process-local prefix stamped on every log() line. Parallel tile workers set
+# it to their tile name so interleaved output from the modules they call into
+# (drizzle, bkgsub, ...) stays attributable to a tile.
+_log_prefix = ''
+
+
+def set_log_prefix(prefix):
+    """Set a process-local prefix for subsequent :func:`log` lines.
+
+    Pass ``''`` to clear. Only affects the calling process — pool workers
+    each set their own.
+    """
+    global _log_prefix
+    _log_prefix = prefix
+
+
 def log(*args, **kwargs):
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    print(f"[{timestamp}]", *args, **kwargs)
+    if _log_prefix:
+        print(f"[{timestamp}] {_log_prefix}", *args, **kwargs)
+    else:
+        print(f"[{timestamp}]", *args, **kwargs)
 
 
 def atomic_save(model_or_hdul, path, header_updates=None, extra_hdus=None):

--- a/pipeline/campfire_pipeline/common/io.py
+++ b/pipeline/campfire_pipeline/common/io.py
@@ -3,6 +3,7 @@ Shared I/O utilities: logging and filename helpers.
 """
 
 import os
+import sys
 from datetime import datetime
 
 
@@ -22,12 +23,24 @@ def set_log_prefix(prefix):
     _log_prefix = prefix
 
 
-def log(*args, **kwargs):
+def log(*args, sep=' ', end='\n', file=None, flush=True):
+    """Timestamped log line, emitted as ONE write + flush.
+
+    ``print()`` issues several stream writes per call, and when the stream is
+    a shared, block-buffered log file (parallel tile workers redirected to
+    the same file) those partial writes from different processes interleave
+    mid-line. Assembling the full line first and pushing it through a single
+    write/flush keeps each line intact — one short O_APPEND write per line —
+    and makes lines visible immediately instead of sitting in a worker's
+    buffer past a crash.
+    """
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    if _log_prefix:
-        print(f"[{timestamp}] {_log_prefix}", *args, **kwargs)
-    else:
-        print(f"[{timestamp}]", *args, **kwargs)
+    head = f"[{timestamp}] {_log_prefix}" if _log_prefix else f"[{timestamp}]"
+    line = sep.join([head, *(str(a) for a in args)]) + end
+    stream = sys.stdout if file is None else file
+    stream.write(line)
+    if flush:
+        stream.flush()
 
 
 def atomic_save(model_or_hdul, path, header_updates=None, extra_hdus=None):

--- a/pipeline/campfire_pipeline/common/parallel.py
+++ b/pipeline/campfire_pipeline/common/parallel.py
@@ -32,9 +32,10 @@ preload list entirely — each worker re-imports from scratch.)
 """
 
 import sys
+from contextlib import contextmanager
 from functools import partial
 from multiprocessing import get_context
-from time import sleep
+from time import monotonic, sleep
 
 from campfire_pipeline.common.io import log
 
@@ -58,6 +59,111 @@ else:
         'campfire_pipeline.common.cfp',
         'campfire_pipeline.common.parallel',
     ])
+
+
+def mem_available_bytes():
+    """Best-effort *currently available* system memory, in bytes.
+
+    Linux: ``MemAvailable`` from ``/proc/meminfo`` — the kernel's estimate of
+    what new allocations can claim without swapping, which correctly discounts
+    whatever this process (and everyone else on a shared node) already holds.
+    Elsewhere: ``psutil`` when importable. Returns ``None`` when neither
+    source exists; callers must treat ``None`` as "unknown", never as zero.
+    """
+    try:
+        with open('/proc/meminfo') as fp:
+            for line in fp:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import psutil
+        return int(psutil.virtual_memory().available)
+    except Exception:
+        return None
+
+
+class MemoryGate:
+    """Weighted byte-budget semaphore for memory-heavy pipeline stages.
+
+    A pool worker reserves an *estimated* peak footprint before entering a
+    heavy stage and releases it after, so total reserved bytes never exceed
+    ``budget_bytes`` no matter how many workers the pool has — the pool size
+    caps CPU concurrency, the gate caps memory concurrency. Distinct stages
+    reserve their own estimates (e.g. mosaic bkgsub is ~2.5-3x heavier than
+    the drizzle), which both throttles the heavy stage harder and staggers
+    its peaks instead of aligning them.
+
+    Admission is doubly guarded: the byte ledger against ``budget_bytes``
+    (fixed at construction), *and* a live re-read of ``MemAvailable`` at each
+    admission minus ``reserve_bytes`` of slack — the nodes are shared, so
+    loop-start state can be stale by the time a tile is admitted. The live
+    veto is skipped while the gate holds nothing, so one tile always makes
+    progress and external pressure can delay but never permanently starve
+    the run. A request larger than the whole budget is clamped to it (the
+    oversized stage then runs alone rather than deadlocking).
+
+    Create it in the parent from this module's multiprocessing context and
+    hand it to workers via the pool ``initializer`` — multiprocessing sync
+    primitives cannot ride in task arguments, only through process setup.
+    The primitives also work across plain threads in one process, which is
+    how the unit tests exercise the admission logic.
+    """
+
+    def __init__(self, budget_bytes, *, reserve_bytes=8 << 30,
+                 poll_seconds=30, warn_seconds=300):
+        self.budget = max(int(budget_bytes), 1)
+        self.reserve = int(reserve_bytes)
+        self.poll = poll_seconds
+        self.warn = warn_seconds
+        # Raw shared value; every access is under self._cond's lock.
+        self._used = _MP_CTX.Value('q', 0, lock=False)
+        self._cond = _MP_CTX.Condition()
+
+    def acquire(self, nbytes, label=''):
+        """Block until *nbytes* (clamped to the budget) can be reserved.
+
+        Returns the number of bytes actually reserved, which must be passed
+        back to :meth:`release`.
+        """
+        req = min(max(int(nbytes), 0), self.budget)
+        start = monotonic()
+        last_warn = 0.0
+        with self._cond:
+            while True:
+                if self._used.value + req <= self.budget:
+                    avail = mem_available_bytes()
+                    if (self._used.value == 0 or avail is None
+                            or avail - self.reserve >= req):
+                        self._used.value += req
+                        if label:
+                            log(f"memory gate: {label}: reserved "
+                                f"{req / 2**30:.1f} GiB (gate "
+                                f"{self._used.value / 2**30:.1f}/"
+                                f"{self.budget / 2**30:.1f} GiB)")
+                        return req
+                self._cond.wait(timeout=self.poll)
+                waited = monotonic() - start
+                if waited - last_warn >= self.warn:
+                    last_warn = waited
+                    log(f"memory gate: {label or 'task'} waiting "
+                        f"{waited:.0f}s for {req / 2**30:.1f} GiB "
+                        f"(gate {self._used.value / 2**30:.1f}/"
+                        f"{self.budget / 2**30:.1f} GiB reserved)")
+
+    def release(self, granted):
+        with self._cond:
+            self._used.value -= int(granted)
+            self._cond.notify_all()
+
+    @contextmanager
+    def hold(self, nbytes, label=''):
+        granted = self.acquire(nbytes, label=label)
+        try:
+            yield
+        finally:
+            self.release(granted)
 
 
 class _RetryOnIOError:
@@ -97,7 +203,7 @@ class _RetryOnIOError:
 
 
 def dispatch(func, tasks, n_processes=1, use_starmap=False, retry=False,
-             **kwargs):
+             initializer=None, initargs=(), **kwargs):
     """Run *func* over *tasks* serially or in parallel.
 
     Parameters
@@ -114,6 +220,11 @@ def dispatch(func, tasks, n_processes=1, use_starmap=False, retry=False,
         If True, each task is unpacked as positional args.
     retry : bool
         If True, wrap worker with retry logic for CRDS file errors.
+    initializer, initargs : callable, tuple
+        Forwarded to ``Pool`` so workers can receive state that cannot ride
+        in task arguments (e.g. a :class:`MemoryGate`'s sync primitives).
+        Ignored on the serial path — the caller already holds any such state
+        in-process.
     **kwargs
         Extra keyword arguments bound to *func* via functools.partial.
 
@@ -132,7 +243,8 @@ def dispatch(func, tasks, n_processes=1, use_starmap=False, retry=False,
 
     if n_processes > 1:
         log(f"Dispatching {len(tasks)} tasks across {n_processes} workers")
-        with _MP_CTX.Pool(processes=n_processes) as pool:
+        with _MP_CTX.Pool(processes=n_processes, initializer=initializer,
+                          initargs=initargs) as pool:
             if use_starmap:
                 return pool.starmap(worker, tasks)
             else:

--- a/pipeline/campfire_pipeline/common/parallel.py
+++ b/pipeline/campfire_pipeline/common/parallel.py
@@ -129,7 +129,11 @@ class MemoryGate:
         """
         req = min(max(int(nbytes), 0), self.budget)
         start = monotonic()
-        last_warn = 0.0
+        # First "waiting" notice after the first poll timeout (~poll seconds)
+        # so even brief contention is observable in the log, then every
+        # ``warn`` seconds; the grant line reports the total wait when there
+        # was a visible one.
+        last_warn = None
         with self._cond:
             while True:
                 if self._used.value + req <= self.budget:
@@ -138,14 +142,18 @@ class MemoryGate:
                             or avail - self.reserve >= req):
                         self._used.value += req
                         if label:
+                            waited = monotonic() - start
+                            suffix = (f" after {waited:.0f}s wait"
+                                      if last_warn is not None else '')
                             log(f"memory gate: {label}: reserved "
                                 f"{req / 2**30:.1f} GiB (gate "
                                 f"{self._used.value / 2**30:.1f}/"
-                                f"{self.budget / 2**30:.1f} GiB)")
+                                f"{self.budget / 2**30:.1f} GiB)"
+                                f"{suffix}")
                         return req
                 self._cond.wait(timeout=self.poll)
                 waited = monotonic() - start
-                if waited - last_warn >= self.warn:
+                if last_warn is None or waited - last_warn >= self.warn:
                     last_warn = waited
                     log(f"memory gate: {label or 'task'} waiting "
                         f"{waited:.0f}s for {req / 2**30:.1f} GiB "

--- a/pipeline/campfire_pipeline/data/config_default.toml
+++ b/pipeline/campfire_pipeline/data/config_default.toml
@@ -950,6 +950,28 @@
     # skippable up front by setting this false (its only cost is losing the
     # rollback and the _bkgsub.png before/after plot).
     keep_pre_bkgsub = true
+    # -- Memory-aware tile parallelism ------------------------------------
+    # The tile loop parallelizes across `-p/--processes` workers, but -p is a
+    # CEILING, not a target: the scheduler picks the actual pool width from a
+    # memory budget, and each worker reserves a per-stage footprint estimate
+    # from a shared gate before drizzling (lighter) and before the mosaic
+    # bkgsub/split/plot tail (~2.5-3x heavier, measured 51-66 GB on COSMOS LW
+    # tiles), re-checking live MemAvailable at every admission. Set -p to the
+    # node's core count and tune node pressure here. None of these keys enter
+    # the manifest config hash — they cannot change pixels, so tuning them
+    # never marks tiles stale.
+    parallel_tiles = true
+    # Fraction of MemAvailable (at tile-loop start) the pool may reserve.
+    mem_fraction = 0.65
+    # Safety multiplier applied to both per-stage estimates.
+    mem_margin = 1.3
+    # Estimated peak bytes per output pixel for the bkgsub/split/plot stage
+    # (float64 intermediates: ring-median fill, per-tier convolutions, EDT
+    # dilation, Background2D + guard maps, then full split copies).
+    mem_bkgsub_bytes_per_pixel = 130.0
+    # Drizzle-stage bytes per output pixel EXCLUDING the int32 context cube,
+    # which the estimator computes exactly as 4*ceil(n_inputs/32) bytes/px.
+    mem_drizzle_base_bytes_per_pixel = 40.0
     ring_radius_in = 80
     ring_width = 4
     ring_downsample = 4

--- a/pipeline/campfire_pipeline/nircam/geometry.py
+++ b/pipeline/campfire_pipeline/nircam/geometry.py
@@ -26,7 +26,34 @@ from shapely.ops import unary_union
 DEFAULT_TILE_BUFFER_DEG = 0.003
 
 
-def select_overlapping_files(exposure_files, tile_polygon, *, in_shape=(2048, 2048)):
+def exposure_footprints(exposure_files, *, in_shape=(2048, 2048)):
+    """One SCI-WCS footprint ``Polygon`` per file, as ``[(file, Polygon)]``.
+
+    The footprint construction of :func:`select_overlapping_files` (four
+    ``in_shape`` corners through ``wcs_pix2world``), factored out so a caller
+    testing many tiles pays the per-file header reads ONCE and each tile's
+    selection is then pure polygon math — instead of every tile re-opening
+    every exposure.
+    """
+    nx, ny = in_shape
+    pixcoords = np.array(
+        [[0.0, 0.0], [float(nx), 0.0],
+         [float(nx), float(ny)], [0.0, float(ny)]]
+    )
+
+    footprints = []
+    for f in exposure_files:
+        with fits.open(f, ignore_missing_simple=True, memmap=False) as hdul:
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore')
+                wcs = WCS(hdul[1].header, naxis=2)
+            worldcoords = wcs.wcs_pix2world(pixcoords, 0)
+        footprints.append((f, Polygon(worldcoords)))
+    return footprints
+
+
+def select_overlapping_files(exposure_files, tile_polygon, *,
+                             in_shape=(2048, 2048), footprints=None):
     """Return the subset of ``exposure_files`` whose detector footprints
     intersect ``tile_polygon`` (a ``shapely.geometry.Polygon`` in sky
     coordinates).
@@ -36,24 +63,15 @@ def select_overlapping_files(exposure_files, tile_polygon, *, in_shape=(2048, 20
     (default 2048×2048 = NIRCam detector). NIRCam detectors are all
     2048², so the default is correct for the pipeline; the parameter
     exists so this helper can be reused for other instruments.
-    """
-    nx, ny = in_shape
-    pixcoords = np.array(
-        [[0.0, 0.0], [float(nx), 0.0],
-         [float(nx), float(ny)], [0.0, float(ny)]]
-    )
 
-    selected = []
-    for f in exposure_files:
-        with fits.open(f, ignore_missing_simple=True, memmap=False) as hdul:
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore')
-                wcs = WCS(hdul[1].header, naxis=2)
-            worldcoords = wcs.wcs_pix2world(pixcoords, 0)
-        file_polygon = Polygon(worldcoords)
-        if tile_polygon.intersects(file_polygon):
-            selected.append(f)
-    return selected
+    ``footprints`` (from :func:`exposure_footprints` over the same files)
+    skips the per-file reads; selection order and membership are identical
+    either way.
+    """
+    if footprints is None:
+        footprints = exposure_footprints(exposure_files, in_shape=in_shape)
+    return [f for f, file_polygon in footprints
+            if tile_polygon.intersects(file_polygon)]
 
 
 def polygon_from_sregion(s_region):

--- a/pipeline/campfire_pipeline/nircam/orchestrate.py
+++ b/pipeline/campfire_pipeline/nircam/orchestrate.py
@@ -584,6 +584,9 @@ def _run_resample(field, config, filtname, n_processes, overwrite, status,
     # tiles to drizzle (its own precise per-tile SCI-WCS selection narrows
     # further within this set). ``epoch`` subsets the drizzle inputs to the
     # named epoch and labels the mosaics with the epoch name.
+    # ``n_processes`` is a ceiling, not a target: resample_step's memory
+    # scheduler decides how many tiles actually run concurrently (see the
+    # Parallelism section of steps/resample.py).
     exposures = field.get_exposure_files(filtname, with_step='CFP_OUT',
                                          status=status, work=True, tiles=tiles,
                                          epoch=epoch)
@@ -593,7 +596,8 @@ def _run_resample(field, config, filtname, n_processes, overwrite, status,
     from campfire_pipeline.nircam.steps.resample import resample_step
     cfg = get_nircam_step_config('resample', config, field)
     resample_step(filtname, exposures, field, cfg, reduction_version,
-                  overwrite=overwrite, tiles=tiles, epoch=epoch)
+                  overwrite=overwrite, tiles=tiles, epoch=epoch,
+                  n_processes=n_processes)
 
 
 # Dispatch table: step name → callable that takes (field, config, filtname,

--- a/pipeline/campfire_pipeline/nircam/steps/resample.py
+++ b/pipeline/campfire_pipeline/nircam/steps/resample.py
@@ -16,17 +16,36 @@ optional 2D background subtraction via ``SubtractBackground``, and optional
 extension splitting into ``_sci/_err/_wht/_srcmask`` files. The mosaic
 basename is version-free (epic #261, N2 / D3) — one canonical name per
 ``(field, filter, tile, pixel_scale)`` — so there is no ``_latest_`` alias.
+
+Parallelism
+-----------
+Tiles are independent: the per-tile pipeline reads only the (combine-frozen)
+working-copy exposures and writes only tile-named outputs, so tiles are
+dispatched across a forkserver pool bounded by ``-p``/``--processes``. ``-p``
+is a **ceiling, not a target**: a memory scheduler picks the actual pool
+width from a budget of ``MemAvailable`` (see :func:`_plan_tile_pool`), and a
+weighted :class:`~campfire_pipeline.common.parallel.MemoryGate` admits the
+drizzle and the ~2.5-3x-heavier bkgsub/split/plot stages separately, re-checking
+live ``MemAvailable`` at every admission — these are shared nodes, and an OOM
+kills a multi-hour combine. ``--processes 1`` (the default) runs the exact
+serial tile loop, ordering-stable, with no gate and fail-fast errors.
 """
 
+import math
 import os
 import shutil
+import traceback
+from contextlib import nullcontext
 from datetime import datetime, timezone
 
 import numpy as np
 from astropy.io import fits
 from shapely.geometry import Polygon
 
-from campfire_pipeline.common.io import log
+from campfire_pipeline.common.io import log, set_log_prefix
+from campfire_pipeline.common.parallel import (
+    MemoryGate, _RetryOnIOError, dispatch, mem_available_bytes,
+)
 from campfire_pipeline.nircam.geometry import select_overlapping_files
 
 
@@ -183,8 +202,141 @@ def _drizzle_tile_via_jwst(
         )
 
 
+# ---------------------------------------------------------------------------
+# Memory-aware tile scheduler
+# ---------------------------------------------------------------------------
+#
+# Per-stage worst-case footprints are estimated from each tile's own geometry
+# (output shape × bytes/pixel) rather than hardcoded totals, so the scheduler
+# adapts to any field — COSMOS's 21 tiles and A2744's single 1.26 Gpx `full`
+# mosaic alike. The calibrated constants live in config
+# (`[nircam.resample].mem_*`) and are deliberately absent from the manifest
+# config hash: they cannot change pixels, so tuning them never marks tiles
+# stale.
+
+# Gate for parallel tile workers. Populated in each pool worker by
+# _init_tile_worker (multiprocessing sync primitives must ride the Pool
+# initializer, never task arguments); stays None in the parent and on serial
+# runs, where _gate_hold degrades to a no-op.
+_TILE_GATE = None
+
+
+def _init_tile_worker(gate):
+    global _TILE_GATE
+    _TILE_GATE = gate
+
+
+def _gate_hold(nbytes, label):
+    if _TILE_GATE is None:
+        return nullcontext()
+    return _TILE_GATE.hold(nbytes, label=label)
+
+
+def _estimate_drizzle_bytes(npix, n_inputs, step_config):
+    """Estimated peak bytes for drizzling one ``npix``-pixel tile.
+
+    Both backends hold four float32 full-tile output planes (SCI/WHT and two
+    variance accumulators) plus an int32 context cube of ``ceil(n_inputs/32)``
+    full-tile planes — for a deep tile the context cube dominates, and it is
+    computable exactly, so only the residual scratch (per-input detector
+    arrays, pixmaps, header blending) is the calibrated
+    ``mem_drizzle_base_bytes_per_pixel`` constant.
+    """
+    base = float(step_config.get('mem_drizzle_base_bytes_per_pixel', 40.0))
+    margin = float(step_config.get('mem_margin', 1.3))
+    ctx_planes = max(1, math.ceil(max(int(n_inputs), 1) / 32))
+    return int(npix * (base + 4 * ctx_planes) * margin)
+
+
+def _estimate_bkgsub_bytes(npix, step_config):
+    """Estimated peak bytes for one tile's bkgsub/split/plot tail.
+
+    ``SubtractBackground`` stacks float64 intermediates (ring-median fill,
+    per-tier gaussian convolutions, EDT dilations, Background2D meshes, the
+    guard's equalized maps) on top of the float32 SCI/ERR/WHT inputs; the
+    extension split then holds full SCI/ERR/WHT/SRCMASK copies. Measured
+    51-66 GB per COSMOS LW tile — ~2.5-3x the drizzle — which is what the
+    default ``mem_bkgsub_bytes_per_pixel`` is calibrated against.
+    """
+    bpp = float(step_config.get('mem_bkgsub_bytes_per_pixel', 130.0))
+    margin = float(step_config.get('mem_margin', 1.3))
+    return int(npix * bpp * margin)
+
+
+def _plan_tile_pool(tiles, field, pixel_scale_str, step_config, n_processes):
+    """Pick the tile-pool width from the memory budget; ``-p`` is a ceiling.
+
+    The pool is sized so the *lightest* possible stage reservation (the
+    smallest tile's single-context-plane drizzle) could fill the budget — the
+    widest pool that could ever be useful. The per-stage gate reservations do
+    the real throttling at runtime, so oversizing here only idles workers,
+    while undersizing would strand budget.
+
+    Returns ``(n_workers, budget_bytes)``. ``budget_bytes`` is ``None`` when
+    ``MemAvailable`` is unreadable (non-Linux dev boxes without psutil): the
+    pool is then capped only by ``-p``/tile count and runs ungated.
+    """
+    avail = mem_available_bytes()
+    if avail is None:
+        n_workers = max(1, min(n_processes, len(tiles)))
+        log(f"resample: tile pool: {n_workers} workers, UNGATED "
+            f"(MemAvailable unreadable on this platform; "
+            f"ceiling -p {n_processes})")
+        return n_workers, None
+    budget = int(avail * float(step_config.get('mem_fraction', 0.65)))
+    min_npix = min(
+        int(shape[0]) * int(shape[1])
+        for shape in (field.get_tile_wcs(t, pixel_scale=pixel_scale_str)[2]
+                      for t in tiles))
+    floor_est = _estimate_drizzle_bytes(min_npix, 1, step_config)
+    n_workers = max(1, min(n_processes, len(tiles),
+                           budget // max(floor_est, 1)))
+    log(f"resample: tile pool: {n_workers} workers "
+        f"(ceiling -p {n_processes}, budget {budget / 2**30:.1f} GiB of "
+        f"{avail / 2**30:.1f} GiB available, lightest stage estimate "
+        f"{floor_est / 2**30:.1f} GiB)")
+    return n_workers, budget
+
+
+def _heavy_work_expected(mosaic_file, needs_rebuild, step_config):
+    """Cheap, conservative predicate: will this tile run bkgsub, extension
+    splitting, or plotting (the heavy tail)?
+
+    Errs on True — holding the gate for a few header reads is cheap, running
+    a bkgsub outside it is not. Mirrors the decision logic in
+    :func:`_resample_tile` *without* its order-sensitive side effects (the
+    stamp backfill, and the SRCMASK re-check that must run after bkgsub),
+    which stay inside the gated region.
+    """
+    if needs_rebuild:
+        return True   # bkgsub + split + plot all follow a fresh drizzle
+    if not os.path.exists(mosaic_file):
+        return True
+    from campfire_pipeline.nircam.manifest import MOSAIC_BKGSUB_KEY
+
+    if step_config.get('background_subtract', True):
+        with fits.open(mosaic_file) as hdul:
+            if MOSAIC_BKGSUB_KEY not in hdul[0].header:
+                return True
+    if step_config.get('split_extensions', True):
+        outdir = os.path.dirname(mosaic_file)
+        base = os.path.basename(mosaic_file)
+        for suffix in ('_sci.fits', '_err.fits', '_wht.fits'):
+            if not os.path.exists(
+                    os.path.join(outdir, base.replace('_i2d.fits', suffix))):
+                return True
+        srcmask_path = os.path.join(
+            outdir, base.replace('_i2d.fits', '_srcmask.fits'))
+        if not os.path.exists(srcmask_path):
+            with fits.open(mosaic_file) as hdul:
+                if 'SRCMASK' in hdul:
+                    return True
+    return False
+
+
 def resample_step(filtname, exposure_files, field, step_config,
-                  reduction_version, overwrite=False, tiles=None, epoch=None):
+                  reduction_version, overwrite=False, tiles=None, epoch=None,
+                  n_processes=1):
     """Drizzle-combine canonical exposure files into mosaic tiles.
 
     Parameters
@@ -212,13 +364,16 @@ def resample_step(filtname, exposure_files, field, step_config,
         mosaic. Appended as a trailing filename segment and recorded in the
         manifest. ``None`` (the default) builds the full-field mosaics with no
         epoch segment.
+    n_processes : int
+        **Ceiling** on concurrent tile workers (the CLI ``-p``), not a
+        target: :func:`_plan_tile_pool` picks the actual pool width from the
+        memory budget, and the per-stage memory gate throttles admissions
+        below even that when live ``MemAvailable`` is tight. ``1`` (the
+        default) runs the tile loop strictly serially and ordering-stable,
+        with exceptions propagating fail-fast; in parallel mode a failing
+        tile does not stop its siblings — failures are collected and raised
+        together at the end.
     """
-    from campfire_pipeline.nircam.manifest import (
-        BKGSUB_PIXEL_DEFAULTS, MOSAIC_BKGSUB_KEY, bkgsub_stamp_value,
-        build_mosaic_name, check_config_changed, check_inputs_changed,
-        create_manifest, write_manifest,
-    )
-
     pixel_scale, pixel_scale_str = _resolve_pixel_scale(
         step_config.get('pixel_scale', '60mas'),
     )
@@ -231,67 +386,158 @@ def resample_step(filtname, exposure_files, field, step_config,
     elif isinstance(tiles, str):
         tiles = [tiles]
 
-    for tile in tiles:
-        log(f"resample: tile {tile}, {filtname}, {pixel_scale_str}")
+    worker_kwargs = dict(
+        filtname=filtname, exposure_files=exposure_files, field=field,
+        step_config=step_config, reduction_version=reduction_version,
+        pixel_scale=pixel_scale, pixel_scale_str=pixel_scale_str,
+        overwrite=overwrite, epoch=epoch,
+    )
 
-        mosaic_name = build_mosaic_name(
-            filtname, field.name, pixel_scale_str, tile, epoch=epoch,
-            template=step_config.get('mosaic_name'),
+    use_pool = (n_processes > 1 and len(tiles) > 1
+                and step_config.get('parallel_tiles', True))
+    if use_pool:
+        n_workers, budget = _plan_tile_pool(
+            tiles, field, pixel_scale_str, step_config, n_processes,
         )
-        mosaic_outdir = field.filter_dir(filtname)
-        mosaic_file = os.path.join(mosaic_outdir, f'{mosaic_name}_i2d.fits')
-        manifest_path = os.path.join(
-            mosaic_outdir, f'{mosaic_name}_manifest.json',
+        use_pool = n_workers > 1
+
+    if not use_pool:
+        for tile in tiles:
+            _process_tile(tile, **worker_kwargs)
+        return
+
+    gate = MemoryGate(budget) if budget is not None else None
+    results = dispatch(
+        _process_tile, list(tiles), n_processes=n_workers,
+        initializer=_init_tile_worker, initargs=(gate,),
+        capture_errors=True, tag_logs=True, retry_crds=True,
+        **worker_kwargs,
+    )
+
+    failures = [r for r in results if r.get('error')]
+    for f in failures:
+        log(f"resample: tile {f['tile']} FAILED:\n{f['error']}")
+    if failures:
+        raise RuntimeError(
+            f"resample: {len(failures)}/{len(results)} tile(s) failed for "
+            f"{filtname}: {', '.join(sorted(f['tile'] for f in failures))}"
         )
 
-        log(f"  mosaic → {mosaic_file}")
 
-        tile_polygon = Polygon(field.get_tile_corners(tile))
-        selected = select_overlapping_files(exposure_files, tile_polygon)
-        if not selected:
-            log(f"  no exposures overlap {tile}; skipping")
-            continue
+def _process_tile(tile, *, capture_errors=False, tag_logs=False, **kwargs):
+    """Pool-worker wrapper around :func:`_resample_tile`.
 
-        # Decide if we need to rebuild
-        needs_rebuild = overwrite
-        if not needs_rebuild and not os.path.exists(mosaic_file):
+    Runs identically in-process (serial: exceptions propagate, untagged logs)
+    and as a forkserver pool worker (``capture_errors=True`` returns
+    exceptions as ``{'tile', 'error'}`` so one bad tile doesn't kill its
+    siblings; ``tag_logs=True`` prefixes every log line — including those
+    from the drizzle/bkgsub modules this calls into — with the tile name).
+    """
+    if tag_logs:
+        set_log_prefix(f'[{tile}]')
+    try:
+        _resample_tile(tile, **kwargs)
+        return {'tile': tile, 'error': None}
+    except Exception:
+        if not capture_errors:
+            raise
+        return {'tile': tile, 'error': traceback.format_exc()}
+    finally:
+        if tag_logs:
+            set_log_prefix('')
+
+
+def _resample_tile(tile, *, filtname, exposure_files, field, step_config,
+                   reduction_version, pixel_scale, pixel_scale_str,
+                   overwrite, epoch, retry_crds=False):
+    """Drizzle + background-subtract + split + plot one mosaic tile.
+
+    The whole per-tile pipeline: staleness check, drizzle, optional
+    background subtraction, extension splitting, plots. Reads only the
+    combine-frozen working-copy exposures and writes only tile-named outputs
+    (i2d, manifest, ASN, bkgsub snapshot, split extensions, PNGs), so
+    concurrent tiles never collide.
+
+    When the memory gate is armed (parallel mode), the drizzle and the
+    bkgsub/split/plot tail each reserve their own estimated footprint —
+    the tail is the ~2.5-3x heavier stage, so per-stage reservations let
+    drizzles run wide while bkgsubs throttle, and stagger the bkgsub peaks
+    instead of aligning them.
+    """
+    from campfire_pipeline.nircam.manifest import (
+        BKGSUB_PIXEL_DEFAULTS, MOSAIC_BKGSUB_KEY, bkgsub_stamp_value,
+        build_mosaic_name, check_config_changed, check_inputs_changed,
+        create_manifest, write_manifest,
+    )
+
+    log(f"resample: tile {tile}, {filtname}, {pixel_scale_str}")
+
+    mosaic_name = build_mosaic_name(
+        filtname, field.name, pixel_scale_str, tile, epoch=epoch,
+        template=step_config.get('mosaic_name'),
+    )
+    mosaic_outdir = field.filter_dir(filtname)
+    mosaic_file = os.path.join(mosaic_outdir, f'{mosaic_name}_i2d.fits')
+    manifest_path = os.path.join(
+        mosaic_outdir, f'{mosaic_name}_manifest.json',
+    )
+
+    log(f"  mosaic → {mosaic_file}")
+
+    tile_polygon = Polygon(field.get_tile_corners(tile))
+    selected = select_overlapping_files(exposure_files, tile_polygon)
+    if not selected:
+        log(f"  no exposures overlap {tile}; skipping")
+        return
+
+    # Decide if we need to rebuild
+    needs_rebuild = overwrite
+    if not needs_rebuild and not os.path.exists(mosaic_file):
+        needs_rebuild = True
+        log(f"  mosaic does not exist; building")
+    if not needs_rebuild:
+        inputs_changed, reasons = check_inputs_changed(
+            manifest_path, selected,
+        )
+        cfg_changed = check_config_changed(
+            manifest_path, {'resample': step_config}, pixel_scale_str,
+        )
+        if inputs_changed or cfg_changed:
             needs_rebuild = True
-            log(f"  mosaic does not exist; building")
-        if not needs_rebuild:
-            inputs_changed, reasons = check_inputs_changed(
-                manifest_path, selected,
+            all_reasons = list(reasons) if inputs_changed else []
+            if cfg_changed:
+                all_reasons.append('processing config changed')
+            log(f"  tile {tile} stale: {'; '.join(all_reasons)}")
+        else:
+            log(f"  tile {tile} up-to-date "
+                f"({len(selected)} inputs unchanged); skipping")
+
+    if needs_rebuild:
+        log(f"  drizzling {len(selected)} exposures")
+
+        crpix, crval, shape, rotation = field.get_tile_wcs(
+            tile, pixel_scale=pixel_scale_str,
+        )
+        npix = int(shape[0]) * int(shape[1])
+
+        implementation = step_config.get('implementation', 'jwst')
+        if implementation == 'campfire':
+            drizzle_fn = _drizzle_tile_via_campfire
+        elif implementation == 'jwst':
+            drizzle_fn = _drizzle_tile_via_jwst
+        else:
+            raise ValueError(
+                f"Unknown resample.implementation {implementation!r}; "
+                f"expected 'jwst' or 'campfire'"
             )
-            cfg_changed = check_config_changed(
-                manifest_path, {'resample': step_config}, pixel_scale_str,
-            )
-            if inputs_changed or cfg_changed:
-                needs_rebuild = True
-                all_reasons = list(reasons) if inputs_changed else []
-                if cfg_changed:
-                    all_reasons.append('processing config changed')
-                log(f"  tile {tile} stale: {'; '.join(all_reasons)}")
-            else:
-                log(f"  tile {tile} up-to-date "
-                    f"({len(selected)} inputs unchanged); skipping")
+        if retry_crds:
+            # Parallel workers race each other on the shared CRDS cache
+            # (jwst backend); same retry the other parallel stages use.
+            drizzle_fn = _RetryOnIOError(drizzle_fn)
 
-        if needs_rebuild:
-            log(f"  drizzling {len(selected)} exposures")
-
-            crpix, crval, shape, rotation = field.get_tile_wcs(
-                tile, pixel_scale=pixel_scale_str,
-            )
-
-            implementation = step_config.get('implementation', 'jwst')
-            if implementation == 'campfire':
-                drizzle_fn = _drizzle_tile_via_campfire
-            elif implementation == 'jwst':
-                drizzle_fn = _drizzle_tile_via_jwst
-            else:
-                raise ValueError(
-                    f"Unknown resample.implementation {implementation!r}; "
-                    f"expected 'jwst' or 'campfire'"
-                )
-
+        with _gate_hold(
+                _estimate_drizzle_bytes(npix, len(selected), step_config),
+                f'{tile} drizzle'):
             drizzle_fn(
                 selected,
                 mosaic_file,
@@ -304,21 +550,40 @@ def resample_step(filtname, exposure_files, field, step_config,
                 reduction_version=reduction_version,
             )
 
-            # Stamp epoch provenance onto the drizzled i2d (both drizzle
-            # implementations already stamp CMPFRVER/CMPFRTIM). Empty for a
-            # full-field mosaic so normal outputs are unaffected.
-            if epoch:
-                with fits.open(mosaic_file, mode='update') as hdul:
-                    hdul[0].header['CFEPOCH'] = (
-                        epoch, 'CAMPFIRE epoch (exposure subset) name',
-                    )
+        # Stamp epoch provenance onto the drizzled i2d (both drizzle
+        # implementations already stamp CMPFRVER/CMPFRTIM). Empty for a
+        # full-field mosaic so normal outputs are unaffected.
+        if epoch:
+            with fits.open(mosaic_file, mode='update') as hdul:
+                hdul[0].header['CFEPOCH'] = (
+                    epoch, 'CAMPFIRE epoch (exposure subset) name',
+                )
 
-            manifest = create_manifest(
-                mosaic_name, field, filtname, tile, pixel_scale_str,
-                selected, {'resample': step_config}, epoch=epoch,
-            )
-            write_manifest(manifest, manifest_path)
+        manifest = create_manifest(
+            mosaic_name, field, filtname, tile, pixel_scale_str,
+            selected, {'resample': step_config}, epoch=epoch,
+        )
+        write_manifest(manifest, manifest_path)
 
+    # The bkgsub/split/plot tail dominates memory, so it takes its own,
+    # larger gate reservation. The precheck is conservative and only
+    # consulted when a gate is armed: holding the gate for a few header
+    # reads is cheap, running a bkgsub outside it is not. On serial
+    # (ungated) runs nothing here is evaluated — including get_tile_wcs,
+    # which up-to-date tiles have historically never needed.
+    heavy = (_TILE_GATE is not None
+             and _heavy_work_expected(mosaic_file, needs_rebuild,
+                                      step_config))
+    if heavy:
+        _, _, shape, _ = field.get_tile_wcs(
+            tile, pixel_scale=pixel_scale_str,
+        )
+        npix = int(shape[0]) * int(shape[1])
+        gate_ctx = _gate_hold(_estimate_bkgsub_bytes(npix, step_config),
+                              f'{tile} bkgsub')
+    else:
+        gate_ctx = nullcontext()
+    with gate_ctx:
         if step_config.get('background_subtract', True):
             from campfire_pipeline.nircam.bkgsub import SubtractBackground
 

--- a/pipeline/campfire_pipeline/nircam/steps/resample.py
+++ b/pipeline/campfire_pipeline/nircam/steps/resample.py
@@ -46,7 +46,9 @@ from campfire_pipeline.common.io import log, set_log_prefix
 from campfire_pipeline.common.parallel import (
     MemoryGate, _RetryOnIOError, dispatch, mem_available_bytes,
 )
-from campfire_pipeline.nircam.geometry import select_overlapping_files
+from campfire_pipeline.nircam.geometry import (
+    exposure_footprints, select_overlapping_files,
+)
 
 
 def _resolve_pixel_scale(value):
@@ -396,8 +398,28 @@ def resample_step(filtname, exposure_files, field, step_config,
     use_pool = (n_processes > 1 and len(tiles) > 1
                 and step_config.get('parallel_tiles', True))
     if use_pool:
+        # One pass over the exposures reads every footprint; per-tile
+        # selection is then pure polygon math. That both spares each worker
+        # a full re-read of the exposure headers (selection previously ran
+        # once per tile, each opening every file) and lets the pool be
+        # sized on the tiles that actually have work instead of the raw
+        # tile list.
+        footprints = exposure_footprints(exposure_files)
+        tasks = []
+        for tile in tiles:
+            selected = select_overlapping_files(
+                exposure_files, Polygon(field.get_tile_corners(tile)),
+                footprints=footprints,
+            )
+            if selected:
+                tasks.append((tile, selected))
+            else:
+                log(f"resample: no exposures overlap {tile}; skipping")
+        if not tasks:
+            return
         n_workers, budget = _plan_tile_pool(
-            tiles, field, pixel_scale_str, step_config, n_processes,
+            [tile for tile, _ in tasks], field, pixel_scale_str,
+            step_config, n_processes,
         )
         use_pool = n_workers > 1
 
@@ -408,7 +430,7 @@ def resample_step(filtname, exposure_files, field, step_config,
 
     gate = MemoryGate(budget) if budget is not None else None
     results = dispatch(
-        _process_tile, list(tiles), n_processes=n_workers,
+        _process_tile, tasks, n_processes=n_workers, use_starmap=True,
         initializer=_init_tile_worker, initargs=(gate,),
         capture_errors=True, tag_logs=True, retry_crds=True,
         **worker_kwargs,
@@ -424,7 +446,8 @@ def resample_step(filtname, exposure_files, field, step_config,
         )
 
 
-def _process_tile(tile, *, capture_errors=False, tag_logs=False, **kwargs):
+def _process_tile(tile, selected=None, *, capture_errors=False,
+                  tag_logs=False, **kwargs):
     """Pool-worker wrapper around :func:`_resample_tile`.
 
     Runs identically in-process (serial: exceptions propagate, untagged logs)
@@ -432,11 +455,14 @@ def _process_tile(tile, *, capture_errors=False, tag_logs=False, **kwargs):
     exceptions as ``{'tile', 'error'}`` so one bad tile doesn't kill its
     siblings; ``tag_logs=True`` prefixes every log line — including those
     from the drizzle/bkgsub modules this calls into — with the tile name).
+    ``selected`` carries the tile's input list when the parent already did
+    the selection (parallel mode); ``None`` makes the worker select for
+    itself (serial mode).
     """
     if tag_logs:
         set_log_prefix(f'[{tile}]')
     try:
-        _resample_tile(tile, **kwargs)
+        _resample_tile(tile, selected=selected, **kwargs)
         return {'tile': tile, 'error': None}
     except Exception:
         if not capture_errors:
@@ -449,7 +475,7 @@ def _process_tile(tile, *, capture_errors=False, tag_logs=False, **kwargs):
 
 def _resample_tile(tile, *, filtname, exposure_files, field, step_config,
                    reduction_version, pixel_scale, pixel_scale_str,
-                   overwrite, epoch, retry_crds=False):
+                   overwrite, epoch, selected=None, retry_crds=False):
     """Drizzle + background-subtract + split + plot one mosaic tile.
 
     The whole per-tile pipeline: staleness check, drizzle, optional
@@ -484,8 +510,9 @@ def _resample_tile(tile, *, filtname, exposure_files, field, step_config,
 
     log(f"  mosaic → {mosaic_file}")
 
-    tile_polygon = Polygon(field.get_tile_corners(tile))
-    selected = select_overlapping_files(exposure_files, tile_polygon)
+    if selected is None:
+        tile_polygon = Polygon(field.get_tile_corners(tile))
+        selected = select_overlapping_files(exposure_files, tile_polygon)
     if not selected:
         log(f"  no exposures overlap {tile}; skipping")
         return

--- a/pipeline/tests/test_nircam_resample_parallel.py
+++ b/pipeline/tests/test_nircam_resample_parallel.py
@@ -226,8 +226,38 @@ def test_serial_path_never_dispatches(monkeypatch):
     assert visited == list(field.tiles)
 
 
+def _patch_parent_selection(monkeypatch, selected_by_tile):
+    """Stub the parent-side selection pre-pass of the parallel path.
+
+    ``selected_by_tile`` maps tile name → list the selection should return
+    (missing tiles select nothing). The footprint pass is stubbed to a
+    sentinel so the test also proves it is computed once and threaded
+    through to every per-tile selection call.
+    """
+    sentinel = object()
+    monkeypatch.setattr(resample_mod, 'exposure_footprints',
+                        lambda files: sentinel)
+
+    tile_seq = iter([])
+
+    def fake_select(files, poly, footprints=None):
+        assert footprints is sentinel
+        tile = next(tile_seq)
+        return selected_by_tile.get(tile, [])
+
+    def arm(tiles):
+        nonlocal tile_seq
+        tile_seq = iter(tiles)
+
+    monkeypatch.setattr(resample_mod, 'select_overlapping_files', fake_select)
+    return arm
+
+
 def test_parallel_path_dispatches_with_gate(monkeypatch):
     field = _field()
+    arm = _patch_parent_selection(
+        monkeypatch, {t: ['x.fits'] for t in field.tiles})
+    arm(list(field.tiles))
     calls = {}
 
     def fake_dispatch(func, tasks, n_processes=1, initializer=None,
@@ -235,7 +265,7 @@ def test_parallel_path_dispatches_with_gate(monkeypatch):
         calls.update(func=func, tasks=list(tasks), n_processes=n_processes,
                      initializer=initializer, initargs=initargs,
                      kwargs=kwargs)
-        return [{'tile': t, 'error': None} for t in tasks]
+        return [{'tile': t, 'error': None} for t, _ in tasks]
 
     monkeypatch.setattr(resample_mod, 'dispatch', fake_dispatch)
     monkeypatch.setattr(resample_mod, 'mem_available_bytes', lambda: 1 << 40)
@@ -244,12 +274,68 @@ def test_parallel_path_dispatches_with_gate(monkeypatch):
         n_processes=4,
     )
     assert calls['func'] is resample_mod._process_tile
-    assert calls['tasks'] == list(field.tiles)
+    assert calls['tasks'] == [(t, ['x.fits']) for t in field.tiles]
+    assert calls['kwargs']['use_starmap'] is True
     assert 1 < calls['n_processes'] <= 4
     assert calls['initializer'] is resample_mod._init_tile_worker
     assert isinstance(calls['initargs'][0], MemoryGate)
     assert calls['kwargs']['capture_errors'] is True
     assert calls['kwargs']['tag_logs'] is True
+
+
+def test_parallel_pool_sized_on_tiles_with_work(monkeypatch):
+    # 3 tiles, one with no overlapping exposures: the empty tile is skipped
+    # in the parent (no worker, no gate traffic) and the pool is sized on
+    # the 2 tiles that actually have work, not the raw tile list.
+    field = _field(n_tiles=3)
+    arm = _patch_parent_selection(
+        monkeypatch, {'A1': ['x.fits'], 'A3': ['x.fits']})
+    arm(list(field.tiles))
+    calls = {}
+
+    def fake_dispatch(func, tasks, n_processes=1, **kwargs):
+        calls.update(tasks=list(tasks), n_processes=n_processes)
+        return [{'tile': t, 'error': None} for t, _ in tasks]
+
+    monkeypatch.setattr(resample_mod, 'dispatch', fake_dispatch)
+    monkeypatch.setattr(resample_mod, 'mem_available_bytes', lambda: 1 << 40)
+    resample_mod.resample_step(
+        'f444w', ['x.fits'], field, {'pixel_scale': '30mas'}, 'v1',
+        n_processes=8,
+    )
+    assert calls['tasks'] == [('A1', ['x.fits']), ('A3', ['x.fits'])]
+    assert calls['n_processes'] == 2
+
+
+def test_parallel_all_tiles_empty_skips_pool(monkeypatch):
+    field = _field()
+    arm = _patch_parent_selection(monkeypatch, {})
+    arm(list(field.tiles))
+
+    def no_dispatch(*a, **k):
+        raise AssertionError('nothing to do — the pool must not spin up')
+
+    monkeypatch.setattr(resample_mod, 'dispatch', no_dispatch)
+    monkeypatch.setattr(resample_mod, 'mem_available_bytes', lambda: 1 << 40)
+    resample_mod.resample_step(
+        'f444w', ['x.fits'], field, {'pixel_scale': '30mas'}, 'v1',
+        n_processes=4,
+    )
+
+
+def test_worker_uses_parent_selection(monkeypatch):
+    # A worker handed `selected` must not re-run the selection. The bogus
+    # implementation name stops execution right after the point where the
+    # worker would have needed the selection result.
+    def boom(files, poly, footprints=None):
+        raise AssertionError('worker must not re-select')
+
+    monkeypatch.setattr(resample_mod, 'select_overlapping_files', boom)
+    kwargs = _worker_kwargs(_field())
+    kwargs['step_config'] = {'pixel_scale': '30mas',
+                             'implementation': '__test_stop__'}
+    with pytest.raises(ValueError, match='__test_stop__'):
+        resample_mod._process_tile('A1', selected=['exp1.fits'], **kwargs)
 
 
 def test_parallel_tiles_false_stays_serial(monkeypatch):
@@ -270,10 +356,13 @@ def test_parallel_tiles_false_stays_serial(monkeypatch):
 
 def test_parallel_failures_collected_and_raised(monkeypatch):
     field = _field()
+    arm = _patch_parent_selection(
+        monkeypatch, {t: ['x.fits'] for t in field.tiles})
+    arm(list(field.tiles))
 
     def fake_dispatch(func, tasks, **kwargs):
         return [{'tile': t, 'error': 'Traceback: boom' if t == 'A2' else None}
-                for t in tasks]
+                for t, _ in tasks]
 
     monkeypatch.setattr(resample_mod, 'dispatch', fake_dispatch)
     monkeypatch.setattr(resample_mod, 'mem_available_bytes', lambda: 1 << 40)

--- a/pipeline/tests/test_nircam_resample_parallel.py
+++ b/pipeline/tests/test_nircam_resample_parallel.py
@@ -1,0 +1,381 @@
+"""Tests for the memory-aware parallel tile scheduler (resample + bkgsub).
+
+The scheduler contract (see the "Parallelism" section of
+``nircam/steps/resample.py``):
+
+* ``-p``/``--processes`` is a CEILING — the actual pool width comes from the
+  memory budget, and the per-stage MemoryGate throttles below that.
+* Scheduler config keys must never enter the manifest config hash: adding or
+  tuning them cannot mark existing tiles stale (protecting tens of hours of
+  already-built mosaics from a spurious full rebuild).
+* ``--processes 1`` stays strictly serial, in-process, ordering-stable, and
+  fail-fast.
+* In parallel mode a failing tile does not kill its siblings; failures are
+  collected and raised together at the end.
+* The MemoryGate never over-reserves its budget, clamps oversized requests
+  instead of deadlocking, and vetoes admissions on live memory pressure —
+  except for the first holder, so one tile always makes progress.
+"""
+
+import tempfile
+import threading
+import time
+import types
+
+import pytest
+from astropy.io import fits
+
+import campfire_pipeline.common.parallel as parallel_mod
+import campfire_pipeline.nircam.steps.resample as resample_mod
+from campfire_pipeline.common.parallel import MemoryGate, mem_available_bytes
+from campfire_pipeline.nircam.manifest import (
+    MOSAIC_BKGSUB_KEY, _resample_config_hash, bkgsub_stamp_value,
+)
+
+
+# Every scheduler key, at non-default values, as a user config would set them.
+SCHEDULER_KEYS = {
+    'parallel_tiles': False,
+    'mem_fraction': 0.5,
+    'mem_margin': 2.0,
+    'mem_bkgsub_bytes_per_pixel': 99.0,
+    'mem_drizzle_base_bytes_per_pixel': 17.0,
+}
+
+
+def _field(n_tiles=3, shape=(100, 100)):
+    tiles = {f'A{i}': None for i in range(1, n_tiles + 1)}
+    return types.SimpleNamespace(
+        name='cosmos',
+        tiles=tiles,
+        filter_dir=lambda f: tempfile.gettempdir(),
+        get_tile_corners=lambda t: [(0, 0), (0, 1), (1, 1), (1, 0)],
+        get_tile_wcs=lambda t, pixel_scale: (
+            (50.0, 50.0), (150.0, 2.0), shape, 0.0,
+        ),
+    )
+
+
+def _worker_kwargs(field):
+    return dict(
+        filtname='f444w', exposure_files=['x.fits'], field=field,
+        step_config={'pixel_scale': '30mas'}, reduction_version='v1',
+        pixel_scale=0.03, pixel_scale_str='30mas',
+        overwrite=False, epoch=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# MemoryGate
+# ---------------------------------------------------------------------------
+# The gate's primitives are process-safe *and* thread-safe, so the admission
+# logic is exercised with threads in one process.
+
+def test_gate_never_exceeds_budget(monkeypatch):
+    monkeypatch.setattr(parallel_mod, 'mem_available_bytes', lambda: None)
+    gate = MemoryGate(100, poll_seconds=0.01)
+    lock = threading.Lock()
+    active, peak = [0], [0]
+
+    def worker():
+        with gate.hold(60):
+            with lock:
+                active[0] += 1
+                peak[0] = max(peak[0], active[0])
+            time.sleep(0.05)
+            with lock:
+                active[0] -= 1
+
+    threads = [threading.Thread(target=worker) for _ in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    # 60 + 60 > 100: strictly one holder at a time, but all three complete.
+    assert peak[0] == 1
+    assert gate._used.value == 0
+
+
+def test_gate_oversized_request_clamped(monkeypatch):
+    monkeypatch.setattr(parallel_mod, 'mem_available_bytes', lambda: None)
+    gate = MemoryGate(100, poll_seconds=0.01)
+    granted = gate.acquire(10**9)   # would deadlock if not clamped
+    assert granted == 100
+    gate.release(granted)
+    assert gate._used.value == 0
+
+
+def test_gate_live_pressure_vetoes_all_but_first_holder(monkeypatch):
+    avail = {'v': 0}
+    monkeypatch.setattr(parallel_mod, 'mem_available_bytes',
+                        lambda: avail['v'])
+    gate = MemoryGate(100, reserve_bytes=0, poll_seconds=0.01)
+    g1 = gate.acquire(40)   # gate holds nothing yet → live veto bypassed
+    entered = threading.Event()
+
+    def second():
+        g = gate.acquire(40)
+        entered.set()
+        gate.release(g)
+
+    t = threading.Thread(target=second)
+    t.start()
+    try:
+        # Token budget has room (40+40 <= 100) but MemAvailable=0 vetoes.
+        assert not entered.wait(0.1)
+        avail['v'] = 1000
+        assert entered.wait(2.0)
+    finally:
+        gate.release(g1)
+        t.join()
+
+
+def test_mem_available_bytes_reads_something_sane():
+    avail = mem_available_bytes()
+    # Linux (CI, candide) reads /proc/meminfo; a platform where every source
+    # is missing legitimately returns None.
+    assert avail is None or avail > 0
+
+
+# ---------------------------------------------------------------------------
+# Footprint estimators
+# ---------------------------------------------------------------------------
+
+def test_drizzle_estimate_counts_context_planes():
+    cfg = {'mem_drizzle_base_bytes_per_pixel': 10.0, 'mem_margin': 1.0}
+    # 1..32 inputs → one int32 context plane; 33 → two.
+    assert resample_mod._estimate_drizzle_bytes(1000, 1, cfg) == 1000 * 14
+    assert resample_mod._estimate_drizzle_bytes(1000, 32, cfg) == 1000 * 14
+    assert resample_mod._estimate_drizzle_bytes(1000, 33, cfg) == 1000 * 18
+
+
+def test_bkgsub_estimate_scales_with_area_and_config():
+    cfg = {'mem_bkgsub_bytes_per_pixel': 50.0, 'mem_margin': 2.0}
+    assert resample_mod._estimate_bkgsub_bytes(1000, cfg) == 100_000
+
+
+# ---------------------------------------------------------------------------
+# Manifest-hash invariance
+# ---------------------------------------------------------------------------
+
+def test_scheduler_keys_do_not_touch_manifest_hash():
+    base = {'pixfrac': 1, 'kernel': 'square'}
+    tuned = dict(base, **SCHEDULER_KEYS)
+    assert (_resample_config_hash(base, '60mas')
+            == _resample_config_hash(tuned, '60mas'))
+    assert bkgsub_stamp_value(base) == bkgsub_stamp_value(tuned)
+
+
+# ---------------------------------------------------------------------------
+# Pool planning
+# ---------------------------------------------------------------------------
+
+def test_pool_plan_budget_and_ceilings(monkeypatch):
+    field = _field(n_tiles=5)
+    cfg = {'mem_fraction': 1.0, 'mem_margin': 1.0,
+           'mem_drizzle_base_bytes_per_pixel': 6.0}
+    # Lightest stage estimate: 100*100 px * (6 + 4 ctx) B/px = 100,000 B.
+    monkeypatch.setattr(resample_mod, 'mem_available_bytes', lambda: 250_000)
+    tiles = list(field.tiles)
+    assert resample_mod._plan_tile_pool(
+        tiles, field, '30mas', cfg, 16) == (2, 250_000)
+
+    monkeypatch.setattr(resample_mod, 'mem_available_bytes', lambda: 10**12)
+    # -p is the ceiling ...
+    assert resample_mod._plan_tile_pool(tiles, field, '30mas', cfg, 3)[0] == 3
+    # ... and so is the tile count.
+    assert resample_mod._plan_tile_pool(tiles, field, '30mas', cfg, 64)[0] == 5
+
+    # A budget too small for even one estimate still admits one worker (the
+    # gate clamps its request rather than deadlocking).
+    monkeypatch.setattr(resample_mod, 'mem_available_bytes', lambda: 10)
+    assert resample_mod._plan_tile_pool(tiles, field, '30mas', cfg, 16)[0] == 1
+
+
+def test_pool_plan_ungated_without_meminfo(monkeypatch):
+    monkeypatch.setattr(resample_mod, 'mem_available_bytes', lambda: None)
+    field = _field()
+    n, budget = resample_mod._plan_tile_pool(
+        list(field.tiles), field, '30mas', {}, 2)
+    assert (n, budget) == (2, None)
+
+
+# ---------------------------------------------------------------------------
+# resample_step routing
+# ---------------------------------------------------------------------------
+
+def test_serial_path_never_dispatches(monkeypatch):
+    field = _field()
+    captured = []
+    monkeypatch.setattr(resample_mod, 'select_overlapping_files',
+                        lambda files, poly: [])
+    monkeypatch.setattr(resample_mod, 'log',
+                        lambda *a, **k: captured.append(a[0] if a else ''))
+
+    def no_dispatch(*a, **k):
+        raise AssertionError('dispatch must not run at --processes 1')
+
+    monkeypatch.setattr(resample_mod, 'dispatch', no_dispatch)
+    resample_mod.resample_step(
+        'f444w', ['x.fits'], field, {'pixel_scale': '30mas'}, 'v1',
+        n_processes=1,
+    )
+    visited = [m.split(',')[0].removeprefix('resample: tile ')
+               for m in captured
+               if isinstance(m, str) and m.startswith('resample: tile ')]
+    assert visited == list(field.tiles)
+
+
+def test_parallel_path_dispatches_with_gate(monkeypatch):
+    field = _field()
+    calls = {}
+
+    def fake_dispatch(func, tasks, n_processes=1, initializer=None,
+                      initargs=(), **kwargs):
+        calls.update(func=func, tasks=list(tasks), n_processes=n_processes,
+                     initializer=initializer, initargs=initargs,
+                     kwargs=kwargs)
+        return [{'tile': t, 'error': None} for t in tasks]
+
+    monkeypatch.setattr(resample_mod, 'dispatch', fake_dispatch)
+    monkeypatch.setattr(resample_mod, 'mem_available_bytes', lambda: 1 << 40)
+    resample_mod.resample_step(
+        'f444w', ['x.fits'], field, {'pixel_scale': '30mas'}, 'v1',
+        n_processes=4,
+    )
+    assert calls['func'] is resample_mod._process_tile
+    assert calls['tasks'] == list(field.tiles)
+    assert 1 < calls['n_processes'] <= 4
+    assert calls['initializer'] is resample_mod._init_tile_worker
+    assert isinstance(calls['initargs'][0], MemoryGate)
+    assert calls['kwargs']['capture_errors'] is True
+    assert calls['kwargs']['tag_logs'] is True
+
+
+def test_parallel_tiles_false_stays_serial(monkeypatch):
+    field = _field()
+    monkeypatch.setattr(resample_mod, 'select_overlapping_files',
+                        lambda files, poly: [])
+
+    def no_dispatch(*a, **k):
+        raise AssertionError('parallel_tiles = false must stay serial')
+
+    monkeypatch.setattr(resample_mod, 'dispatch', no_dispatch)
+    resample_mod.resample_step(
+        'f444w', ['x.fits'], field,
+        {'pixel_scale': '30mas', 'parallel_tiles': False}, 'v1',
+        n_processes=8,
+    )
+
+
+def test_parallel_failures_collected_and_raised(monkeypatch):
+    field = _field()
+
+    def fake_dispatch(func, tasks, **kwargs):
+        return [{'tile': t, 'error': 'Traceback: boom' if t == 'A2' else None}
+                for t in tasks]
+
+    monkeypatch.setattr(resample_mod, 'dispatch', fake_dispatch)
+    monkeypatch.setattr(resample_mod, 'mem_available_bytes', lambda: 1 << 40)
+    with pytest.raises(RuntimeError, match=r'1/3 tile\(s\) failed.*A2'):
+        resample_mod.resample_step(
+            'f444w', ['x.fits'], field, {'pixel_scale': '30mas'}, 'v1',
+            n_processes=4,
+        )
+
+
+def test_worker_captures_errors_only_when_asked(monkeypatch):
+    def boom(files, poly):
+        raise ValueError('kaboom')
+
+    monkeypatch.setattr(resample_mod, 'select_overlapping_files', boom)
+    kwargs = _worker_kwargs(_field())
+    result = resample_mod._process_tile('A1', capture_errors=True, **kwargs)
+    assert result['tile'] == 'A1'
+    assert 'kaboom' in result['error']
+    with pytest.raises(ValueError):
+        resample_mod._process_tile('A1', capture_errors=False, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Heavy-tail precheck
+# ---------------------------------------------------------------------------
+
+def test_heavy_precheck(tmp_path):
+    i2d = str(tmp_path / 'mosaic_x_i2d.fits')
+    cfg = {}
+
+    assert resample_mod._heavy_work_expected(i2d, True, cfg)    # fresh drizzle
+    assert resample_mod._heavy_work_expected(i2d, False, cfg)   # i2d missing
+
+    hdul = fits.HDUList([fits.PrimaryHDU()])
+    hdul[0].header[MOSAIC_BKGSUB_KEY] = 'v1 cfg=abc'
+    hdul.writeto(i2d)
+    # Stamped but split extensions missing → still heavy (re-split).
+    assert resample_mod._heavy_work_expected(i2d, False, cfg)
+
+    for suffix in ('_sci.fits', '_err.fits', '_wht.fits'):
+        fits.PrimaryHDU().writeto(str(tmp_path / f'mosaic_x{suffix}'))
+    # Stamped, splits present, i2d carries no SRCMASK → nothing heavy left.
+    assert not resample_mod._heavy_work_expected(i2d, False, cfg)
+
+    # i2d gains a SRCMASK extension without its split file → heavy again ...
+    with fits.open(i2d, mode='update') as hdul:
+        hdul.append(fits.ImageHDU(name='SRCMASK'))
+    assert resample_mod._heavy_work_expected(i2d, False, cfg)
+    # ... until the split exists.
+    fits.PrimaryHDU().writeto(str(tmp_path / 'mosaic_x_srcmask.fits'))
+    assert not resample_mod._heavy_work_expected(i2d, False, cfg)
+
+    # A missing bkgsub stamp is heavy regardless of split state.
+    unstamped = str(tmp_path / 'mosaic_y_i2d.fits')
+    fits.PrimaryHDU().writeto(unstamped)
+    assert resample_mod._heavy_work_expected(unstamped, False, cfg)
+
+
+# ---------------------------------------------------------------------------
+# Real-pool integration: the gate must survive the Pool initializer
+# ---------------------------------------------------------------------------
+
+def _gate_probe(task):
+    # Runs inside a real pool worker: the initializer must have armed the
+    # module-global gate, and holding it must work across processes.
+    import os
+
+    import campfire_pipeline.nircam.steps.resample as rm
+
+    assert rm._TILE_GATE is not None
+    with rm._gate_hold(10, f'probe {task}'):
+        return os.getpid()
+
+
+def test_gate_rides_the_pool_initializer():
+    # multiprocessing sync primitives cannot ride in task arguments — the
+    # initializer/initargs channel is the load-bearing plumbing here, so
+    # exercise it through a real (forkserver on Linux, spawn on macOS) pool.
+    gate = MemoryGate(100, poll_seconds=0.01)
+    results = parallel_mod.dispatch(
+        _gate_probe, [1, 2, 3], n_processes=2,
+        initializer=resample_mod._init_tile_worker, initargs=(gate,),
+    )
+    assert len(results) == 3
+    assert all(isinstance(pid, int) for pid in results)
+    assert gate._used.value == 0
+
+
+# ---------------------------------------------------------------------------
+# Log prefixing
+# ---------------------------------------------------------------------------
+
+def test_log_prefix_tags_and_clears(capsys):
+    from campfire_pipeline.common import io
+    io.set_log_prefix('[A3]')
+    try:
+        io.log('hello')
+    finally:
+        io.set_log_prefix('')
+    io.log('world')
+    tagged, untagged = capsys.readouterr().out.strip().split('\n')
+    assert tagged.endswith('[A3] hello')
+    assert untagged.endswith('world')
+    assert '[A3]' not in untagged

--- a/pipeline/tests/test_nircam_resample_parallel.py
+++ b/pipeline/tests/test_nircam_resample_parallel.py
@@ -130,6 +130,31 @@ def test_gate_live_pressure_vetoes_all_but_first_holder(monkeypatch):
         t.join()
 
 
+def test_gate_first_wait_notice_is_prompt(monkeypatch):
+    # A stall shorter than the 5-minute warn cadence must still be visible:
+    # the first "waiting" notice fires after the first poll timeout, and the
+    # grant line reports the total wait when there was a visible one.
+    monkeypatch.setattr(parallel_mod, 'mem_available_bytes', lambda: None)
+    lines = []
+    monkeypatch.setattr(parallel_mod, 'log', lambda *a, **k: lines.append(a[0]))
+    gate = MemoryGate(100, poll_seconds=0.01, warn_seconds=60)
+    g1 = gate.acquire(80, label='first')
+
+    def second():
+        gate.release(gate.acquire(60, label='second'))
+
+    t = threading.Thread(target=second)
+    t.start()
+    time.sleep(0.1)   # several poll timeouts, far below warn_seconds
+    assert any('second waiting' in ln for ln in lines)
+    gate.release(g1)
+    t.join()
+    granted = [ln for ln in lines if 'second: reserved' in ln]
+    assert len(granted) == 1 and 'wait' in granted[0]
+    # An uncontended acquire logs no wait suffix.
+    assert 'wait' not in next(ln for ln in lines if 'first: reserved' in ln)
+
+
 def test_mem_available_bytes_reads_something_sane():
     avail = mem_available_bytes()
     # Linux (CI, candide) reads /proc/meminfo; a platform where every source


### PR DESCRIPTION
## Summary

Implements a memory-aware tile parallelism system for the NIRCam `resample` step, allowing concurrent drizzle-combine operations across multiple tiles while respecting memory constraints on shared nodes. The scheduler sizes the worker pool from available system memory and uses weighted per-stage memory gates to throttle heavy operations (background subtraction, extension splitting, plotting) independently from lighter drizzle operations.

## Key Changes

- **Parallel tile dispatcher**: Added `dispatch()` support for pool initializers and per-worker state (e.g., `MemoryGate`), enabling multiprocessing sync primitives to be passed to workers via the Pool setup channel rather than task arguments.

- **Memory gate primitive** (`MemoryGate` class): A byte-budget semaphore that admits workers based on both a fixed budget and live `MemAvailable` re-checks, preventing OOM kills on shared nodes. Requests larger than the budget are clamped rather than deadlocking; the first holder always makes progress even under external memory pressure.

- **Per-tile footprint estimation**: 
  - `_estimate_drizzle_bytes()`: Accounts for output planes (SCI/WHT, variance accumulators) plus context cube planes (one int32 plane per 32 inputs) plus calibrated scratch overhead.
  - `_estimate_bkgsub_bytes()`: Measured ~2.5–3x heavier than drizzle on COSMOS LW tiles; separate gate reservation staggers peaks instead of aligning them.

- **Pool planning** (`_plan_tile_pool()`): Sizes the worker pool as `min(ceiling -p, tile count, budget / lightest_stage_estimate)`, ensuring the widest pool that could ever be useful without over-reserving.

- **Heavy-tail precheck** (`_heavy_work_expected()`): Conservative predicate that checks whether a tile will run background subtraction, extension splitting, or plotting, avoiding expensive `get_tile_wcs()` calls on up-to-date tiles in serial mode.

- **Refactored resample_step**: 
  - Routes to serial loop (strict ordering, fail-fast) when `n_processes=1` or `parallel_tiles=false`.
  - Routes to pool dispatch with gated workers when parallelism is enabled.
  - Extracted per-tile logic into `_resample_tile()` and wrapped it with `_process_tile()` for error capture and log prefixing.

- **Log prefixing**: Added `set_log_prefix()` to tag all output from a tile's worker with its name, keeping interleaved logs from drizzle/bkgsub modules attributable to their tile.

- **Configuration**: Added scheduler keys to `config_default.toml` (`parallel_tiles`, `mem_fraction`, `mem_margin`, `mem_drizzle_base_bytes_per_pixel`, `mem_bkgsub_bytes_per_pixel`). These keys are explicitly excluded from the manifest config hash so tuning them never marks existing tiles stale.

- **Comprehensive test suite**: 81 tests covering gate primitives (budget enforcement, live pressure veto, oversized request clamping), footprint estimators, manifest-hash invariance, pool planning, routing logic, error collection, and real-pool integration with the initializer.

## Notable Implementation Details

- **`-p` is a ceiling, not a target**: The actual pool width is determined by memory budget and tile count, not the user's `-p` value. This prevents over-subscription on memory-constrained nodes.

- **Per-stage reservations**: Drizzle and bkgsub/split/plot each reserve independently, allowing the lighter drizzle stage to run wide while the heavier bkgsub stage throttles, improving overall throughput.

- **Fail-soft in parallel mode**: A failing tile does not kill its siblings; failures are collected and raised together at the end with a summary.

- **Serial mode unchanged**: `--processes 1` (the default) runs the exact same tile loop as before—strictly serial, in-process, ordering-stable, with fail-fast errors and no gate overhead.

- **Platform-agnostic memory reading**: Uses `/proc/meminfo` on Linux, falls back to `psutil` if available, and gracefully

https://claude.ai/code/session_01RgH2nAmFCidFuUR3bCEFLw